### PR TITLE
docs(initiatives): split active/planned from archived, add Lore

### DIFF
--- a/.claude/agents/file-issues.md
+++ b/.claude/agents/file-issues.md
@@ -1,0 +1,213 @@
+---
+name: file-issues
+description: >-
+  File GitHub issues from Architecture packet files. Handles the full pipeline:
+  create issues, add to The Hive project board, set all project fields (Status,
+  Wave, Node, Tier, Actor, Initiative), and wire blocking relationships. Use
+  after the scope agent has produced packet files.
+tools:
+  - Read
+  - Glob
+  - Bash
+---
+
+# File Issues
+
+You file GitHub issues from Architecture issue packet files and wire them fully into The Hive project board. You are the execution layer after the scope agent has designed and written packets.
+
+**You do not design or decompose work.** If packets do not exist yet, tell the user to run the scope agent first.
+
+---
+
+## Inputs
+
+You need:
+1. The initiative slug (e.g. `honeydrunk-lore-bringup`) — or a path to a standalone packet file
+2. Confirmation that packets exist under `generated/issue-packets/active/{initiative-slug}/`
+
+---
+
+## Step 1 — Load field IDs and option IDs
+
+Before filing, query The Hive for current field option IDs. Do not hardcode them — options are added over time and IDs will drift.
+
+```bash
+gh api graphql -f query='{
+  node(id: "PVT_kwDOCxPmns4BUMbi") {
+    ... on ProjectV2 {
+      fields(first: 20) {
+        nodes {
+          ... on ProjectV2SingleSelectField {
+            name id
+            options { id name }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+Build a lookup map: `{ field_name: { option_name: option_id } }`. You will need: **Status**, **Wave**, **Node**, **Tier**, **Actor**, **Initiative**.
+
+---
+
+## Step 2 — Read packets
+
+For each packet file in the initiative folder (ordered by numeric prefix):
+
+1. Read the frontmatter: `target_repo`, `tier`, `wave`, `initiative`, `node`, `labels`, `adrs`
+2. Read the title from the first `# Heading` line
+3. Identify `Actor`: if `"human-only"` is in the `labels` array → `Actor=Human`, otherwise `Actor=Agent`
+4. Identify `Dependencies`: parse the `## Dependencies` section for referenced issue numbers and repos
+
+---
+
+## Step 3 — Create issues
+
+For each packet, create the GitHub issue:
+
+```bash
+gh issue create \
+  --repo HoneyDrunkStudios/{target_repo_short} \
+  --title "{title}" \
+  --body-file "{packet_path}" \
+  --label "{comma_separated_labels}"
+```
+
+Capture the returned issue URL and extract the issue number.
+
+---
+
+## Step 4 — Add to The Hive
+
+```bash
+gh project item-add 4 --owner HoneyDrunkStudios \
+  --url "https://github.com/HoneyDrunkStudios/{repo}/issues/{number}"
+```
+
+Capture the returned item ID — you need it for field assignment.
+
+To get item IDs after adding:
+```bash
+gh api graphql -f query='{
+  node(id: "PVT_kwDOCxPmns4BUMbi") {
+    ... on ProjectV2 {
+      items(first: 50) {
+        nodes {
+          id
+          content {
+            ... on Issue { number repository { nameWithOwner } }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+---
+
+## Step 5 — Set project fields
+
+For each issue, set all six fields via `updateProjectV2ItemFieldValue`:
+
+```bash
+gh api graphql -f query='
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PVT_kwDOCxPmns4BUMbi"
+    itemId: "{item_id}"
+    fieldId: "{field_id}"
+    value: { singleSelectOptionId: "{option_id}" }
+  }) {
+    projectV2Item { id }
+  }
+}'
+```
+
+Set these fields on every issue:
+
+| Field | Value |
+|-------|-------|
+| Status | `Backlog` |
+| Wave | From packet frontmatter (`wave: 1` → `Wave 1`, `wave: N/A` → `N/A`) |
+| Node | From packet frontmatter `node:` value |
+| Tier | From packet frontmatter `tier:` value |
+| Actor | `Agent` or `Human` based on `human-only` label |
+| Initiative | From packet frontmatter `initiative:` value |
+
+If a required option does not exist (e.g. a new Initiative slug), stop and tell the user to add it manually in The Hive project settings → Fields, then re-run.
+
+---
+
+## Step 6 — Wire blocking relationships
+
+For every entry in the `## Dependencies` section of each packet, call `addBlockedBy`.
+
+First get issue node IDs:
+```bash
+gh api graphql -f query='{
+  repository(owner: "HoneyDrunkStudios", name: "{repo}") {
+    issues(first: 50) { nodes { number id } }
+  }
+}'
+```
+
+Then for each dependency pair:
+```bash
+gh api graphql -f query='
+mutation {
+  addBlockedBy(input: {
+    issueId: "{blocked_node_id}"
+    blockingIssueId: "{blocker_node_id}"
+  }) {
+    issue { number }
+    blockingIssue { number }
+  }
+}'
+```
+
+Dependencies may reference issues in different repos — fetch node IDs per repo as needed.
+
+---
+
+## Step 7 — Output summary
+
+Print a table confirming every issue was filed and all steps completed:
+
+```
+| Packet | Issue | Fields Set | Blockers Wired |
+|--------|-------|------------|----------------|
+| 01-... | Repo#N | ✓ | ✓ |
+```
+
+Flag any failures explicitly. Do not silently skip steps.
+
+---
+
+## Constraints
+
+- Never create issues without a corresponding packet file — packets are the source of truth
+- Never leave project fields unset — partial board entries cause routing failures for agents
+- Never skip blocking relationships — dependencies in packet bodies must be wired natively
+- If an Initiative option does not exist on The Hive, stop and tell the user — do not file issues with a missing Initiative
+- Standalone packets (in `active/standalone/`) follow the same steps but skip the dispatch plan check
+- Do not modify packet files — they are immutable once filed (per ADR-0008 invariant 24)
+
+---
+
+## Reference — Static IDs
+
+The Hive project ID: `PVT_kwDOCxPmns4BUMbi`
+
+These IDs are stable but always verify with Step 1 before use:
+
+| Field | Field ID |
+|-------|----------|
+| Status | `PVTSSF_lADOCxPmns4BUMbizhBWQNU` |
+| Wave | `PVTSSF_lADOCxPmns4BUMbizhBWQ88` |
+| Node | `PVTSSF_lADOCxPmns4BUMbizhBWSTA` |
+| Tier | `PVTSSF_lADOCxPmns4BUMbizhBWS1w` |
+| Actor | `PVTSSF_lADOCxPmns4BUMbizhBbxQE` |
+| Initiative | `PVTSSF_lADOCxPmns4BUMbizhBWRTQ` |

--- a/.claude/agents/scope.md
+++ b/.claude/agents/scope.md
@@ -184,10 +184,44 @@ Each handoff must be self-contained: upstream changes, new package versions, int
 
 ## Phase 5: Output
 
+### Step 1 — Create issues
 Provide `gh` CLI commands in dependency order:
 ```bash
 gh issue create --repo HoneyDrunkStudios/{repo} --title "{title}" --body-file "{packet}" --label "{labels}"
 ```
+
+### Step 2 — Add to project board
+```bash
+gh project item-add 4 --owner HoneyDrunkStudios --url "https://github.com/HoneyDrunkStudios/{repo}/issues/{number}"
+```
+
+### Step 3 — Set project fields
+Set Status, Wave, Node, Tier, Actor, and Initiative on every item via `updateProjectV2ItemFieldValue`. See field and option IDs in `infrastructure/github-projects-field-ids.md`.
+
+### Step 4 — Wire blocking relationships
+For every dependency listed in an issue's Dependencies section, call `addBlockedBy`. Get node IDs first, then wire each pair:
+
+```bash
+# Get node IDs
+gh api graphql -f query='{
+  repository(owner: "HoneyDrunkStudios", name: "{repo}") {
+    issues(first: 20) { nodes { number id } }
+  }
+}'
+
+# Wire each blocking relationship
+gh api graphql -f query='mutation {
+  addBlockedBy(input: {
+    issueId: "{blocked-node-id}"
+    blockingIssueId: "{blocker-node-id}"
+  }) {
+    issue { number }
+    blockingIssue { number }
+  }
+}'
+```
+
+Every dependency in a `Dependencies:` section must have a corresponding `addBlockedBy` call.
 
 ## Quality Checklist
 
@@ -201,6 +235,7 @@ Before outputting any issue:
 - [ ] Agent Handoff section included with constraints and key files
 - [ ] `## Human Prerequisites` section present (listing portal steps / manual actions, or explicitly "None.")
 - [ ] Actor classification explicit: default `Actor=Agent`, set `Actor=Human` and add `"human-only"` label only when the entire work item cannot be delegated
+- [ ] Blocking relationships wired via `addBlockedBy` for every dependency listed
 - [ ] No invariant violations in the proposed work
 - [ ] All referenced invariants are inlined as full text, not just cited by number
 - [ ] All ADR decisions relevant to implementation are summarized in the packet body — the agent executing in the target repo has no access to the Architecture repo

--- a/copilot/agent-skills-map.md
+++ b/copilot/agent-skills-map.md
@@ -14,6 +14,11 @@ Maps agent capabilities to the types of work they can perform in the Grid.
 **Input:** Description of feature, bug, change, or initiative
 **Output:** Issue packets in `/generated/issue-packets/`, dispatch plans and handoff prompts in `/generated/` for multi-repo work
 
+### Issue Filing
+**Capability:** File packet files as GitHub issues and wire them fully into The Hive. Handles the entire mechanical pipeline so nothing is missed.
+**Input:** Initiative slug or path to packet files
+**Output:** GitHub issues created, added to The Hive with all fields set (Status, Wave, Node, Tier, Actor, Initiative), blocking relationships wired
+
 ### ADR Draft Generation
 **Capability:** Facilitate an architecture discussion and produce an ADR draft.
 **Input:** Design question or proposal
@@ -48,6 +53,9 @@ Maps agent capabilities to the types of work they can perform in the Grid.
 | "Break this into issues" | Issue Packet Generation |
 | "Scope this work" | Issue Packet Generation |
 | "Hand off X to Y repo" | Issue Packet Generation |
+| "File these issues" | Issue Filing |
+| "Create the issues for..." | Issue Filing |
+| "Push these packets to GitHub" | Issue Filing |
 
 ## AI Surfaces
 
@@ -68,6 +76,7 @@ Agents that run within the Claude Code / Architecture repo context:
 | **adr-composer** | Facilitate architecture decisions, produce ADRs | — |
 | **site-sync** | Sync website with architecture changes | — |
 | **scope** | Scope work into issues — auto-detects single or multi-repo, generates issue packets, dispatch plans, and handoff prompts | adr-composer, site-sync |
+| **file-issues** | File packet files as GitHub issues — creates issues, adds to The Hive, sets all project fields, wires blocking relationships | — |
 | **refine** | Challenge scoped work before execution — finds gaps, missed dependencies, boundary violations, invariant risks | — |
 | **review** | Review PRs against boundary rules, invariants, contract safety, and code conventions | — |
 | **netrunner** | Research and investigation across the Grid | — |

--- a/copilot/issue-authoring-rules.md
+++ b/copilot/issue-authoring-rules.md
@@ -14,6 +14,39 @@ Every issue must include:
 6. **Labels** — At minimum: type (`feature`, `bug`, `chore`), tier (`tier-1`, `tier-2`, `tier-3`), sector.
 7. **Dependencies** — Other issues or PRs that must complete first.
 
+## Blocking Relationships
+
+After filing issues, wire native GitHub blocking relationships for every dependency listed in the Dependencies section. Do not leave dependencies as body text only.
+
+Use the GraphQL `addBlockedBy` mutation:
+
+```bash
+gh api graphql -f query='
+mutation {
+  addBlockedBy(input: {
+    issueId: "<blocked-issue-node-id>"
+    blockingIssueId: "<blocking-issue-node-id>"
+  }) {
+    issue { number }
+    blockingIssue { number }
+  }
+}'
+```
+
+Get issue node IDs with:
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "HoneyDrunkStudios", name: "<repo>") {
+    issues(first: 20) {
+      nodes { number id }
+    }
+  }
+}'
+```
+
+Every `Dependencies` entry in an issue body must have a corresponding `addBlockedBy` call. This surfaces the blocking chain natively in the GitHub UI and on The Hive board.
+
 ## Naming Convention for Issue Packets
 
 `{YYYY-MM-DD}-{repo-short-name}-{kebab-case-description}.md`
@@ -32,6 +65,7 @@ Before finalizing an issue packet:
 - [ ] Target repo is correct per routing rules
 - [ ] Boundary check confirms the work belongs in the target repo
 - [ ] Dependencies are listed if this is part of a cross-repo change
+- [ ] Blocking relationships wired via `addBlockedBy` for every dependency listed
 - [ ] Labels include type, tier, and sector
 - [ ] Frontmatter includes all board fields: `wave`, `initiative`, `node`, `adrs`, `tier`
 - [ ] Implementation constraints include invariant text (or a direct quoted excerpt) where the exact wording affects behavior; avoid number-only references in constraint sections

--- a/generated/issue-packets/active/honeydrunk-lore-bringup/01-lore-scaffold-and-claude-md.md
+++ b/generated/issue-packets/active/honeydrunk-lore-bringup/01-lore-scaffold-and-claude-md.md
@@ -1,0 +1,170 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Lore
+labels: ["feature", "tier-1", "scaffold"]
+dependencies: []
+adrs: []
+wave: 1
+initiative: honeydrunk-lore-bringup
+node: honeydrunk-lore
+---
+
+# Feature: Lore repo scaffold â€” directory structure + CLAUDE.md schema doc
+
+## Summary
+Stand up the foundational structure of `HoneyDrunk.Lore` as a flat-file wiki following the Karpathy LLM-wiki pattern. The repo becomes a living, agent-maintained knowledge surface: humans drop raw sources in, LLMs compile and maintain the wiki, Obsidian visualizes it.
+
+This issue covers everything needed to make the repo operational as a flat-file wiki:
+1. **Directory scaffold** â€” `raw/`, `wiki/`, `output/`, `tools/`
+2. **CLAUDE.md schema doc** â€” defines the four operations (ingest, compile, query, lint) as instructions the LLM follows when working in this repo
+3. **README.md update** â€” explains the repo purpose and how to use it
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Lore`
+
+## Motivation
+Lore is the living knowledge surface for The Grid â€” compiled research, external information, and accumulated understanding that agents and the solo developer can query. The flat-file-first implementation lets the wiki be useful immediately without depending on `HoneyDrunk.Knowledge` or `HoneyDrunk.Agents` nodes that do not yet exist.
+
+The CLAUDE.md is the most important artifact: it defines what the LLM does when operating on this wiki. Without it, the repo is just files. With it, any Claude Code session pointed at this repo knows how to ingest a source, compile a wiki page, run a lint pass, or answer a query.
+
+The directory structure mirrors Karpathy's validated pattern and matches `HoneyDrunk.Architecture/repos/HoneyDrunk.Lore/overview.md`:
+- `raw/` â€” immutable source documents (articles, papers, repos, notes, clips)
+- `wiki/` â€” LLM-compiled structured markdown
+- `output/` â€” query results (rendered markdown, visualizations)
+- `tools/` â€” CLI helpers for search and maintenance
+
+## Proposed Implementation
+
+### Directory structure
+```
+HoneyDrunk.Lore/
+â”œâ”€â”€ raw/
+â”‚   â””â”€â”€ .gitkeep
+â”œâ”€â”€ wiki/
+â”‚   â”œâ”€â”€ indexes/
+â”‚   â”‚   â””â”€â”€ .gitkeep
+â”‚   â””â”€â”€ .gitkeep
+â”œâ”€â”€ output/
+â”‚   â””â”€â”€ .gitkeep
+â”œâ”€â”€ tools/
+â”‚   â””â”€â”€ .gitkeep
+â”œâ”€â”€ CLAUDE.md
+â””â”€â”€ README.md
+```
+
+### CLAUDE.md â€” schema doc
+The CLAUDE.md defines the four operations the LLM performs in this repo. It is the only configuration the wiki needs. Structure:
+
+#### Identity
+- What Lore is: the compiled research knowledge surface for HoneyDrunk Studios
+- What it is NOT: agent memory, architecture governance, or code documentation
+
+#### Directory contract
+- `raw/` â€” never edit; source of truth for input documents
+- `wiki/` â€” LLM-maintained; structured markdown articles, concept pages, entity pages
+- `wiki/indexes/` â€” LLM-maintained auto-indexes (topic index, source index, entity index)
+- `output/` â€” query results filed here; these feed back into `wiki/` on the next compile pass
+- `tools/` â€” shell scripts for search; thin wrappers, no business logic
+
+#### Operation: Ingest
+Triggered when a new file appears in `raw/`. Steps:
+1. Read the source fully
+2. Identify key concepts, entities, and claims
+3. For each concept: check if a `wiki/` page exists; create or update it
+4. Add a source entry to `wiki/indexes/sources.md`
+5. Update topic backlinks in `wiki/indexes/topics.md`
+6. Do not delete or overwrite existing wiki content â€” always extend and reconcile
+
+#### Operation: Compile
+Triggered on demand or on a scheduled basis. Steps:
+1. Scan `raw/` for sources not yet reflected in `wiki/`
+2. Run Ingest for each unprocessed source
+3. Identify concept pages that reference the same entity â€” merge into a canonical article
+4. Rebuild `wiki/indexes/` from current wiki state
+
+#### Operation: Query
+Triggered when asked a question. Steps:
+1. Search `wiki/` for relevant pages (keyword + semantic scan)
+2. Synthesize an answer from wiki content, citing source pages
+3. Identify gaps (questions the wiki cannot answer) â€” append them to `wiki/indexes/gaps.md`
+4. File the query result in `output/` as a dated markdown file
+
+#### Operation: Lint
+Triggered on demand. Checks:
+1. Orphan pages â€” wiki pages with no backlinks or source attribution
+2. Contradictions â€” claims across wiki pages that conflict
+3. Stale sources â€” `raw/` files processed more than 90 days ago (flag for re-ingest)
+4. Gaps â€” entries in `wiki/indexes/gaps.md` that have no corresponding wiki page
+5. Output a lint report in `output/lint-YYYY-MM-DD.md`
+
+#### Conversion note (for future agents)
+The flat-file implementation is intentional and temporary. When `HoneyDrunk.Knowledge` and `HoneyDrunk.Agents` exist:
+- Ingest delegates to `IDocumentIngester`
+- Retrieval delegates to `IRetrievalPipeline`
+- Compile agents run on `HoneyDrunk.Agents` runtime
+- This CLAUDE.md becomes the agent configuration, not the implementation
+
+### README.md update
+Replace the default README with:
+- Purpose: what Lore is (one paragraph)
+- How to use: how to drop a source in `raw/` and trigger ingest, how to query, how to lint
+- Obsidian: note that `wiki/` is an Obsidian vault â€” open with Obsidian for graph view
+- Architecture context: link to `HoneyDrunk.Architecture/repos/HoneyDrunk.Lore/overview.md`
+
+## Acceptance Criteria
+- [ ] `raw/`, `wiki/`, `wiki/indexes/`, `output/`, `tools/` directories exist with `.gitkeep`
+- [ ] `CLAUDE.md` defines Identity, Directory contract, and all four operations (Ingest, Compile, Query, Lint)
+- [ ] Conversion note is present in `CLAUDE.md` explaining the flat-file-first approach
+- [ ] `README.md` explains purpose, how to use each operation, Obsidian vault note, and Architecture link
+- [ ] No `.NET` code, no NuGet references, no project files â€” flat files only
+- [ ] `wiki/indexes/` contains stub files: `sources.md`, `topics.md`, `gaps.md` (empty but with headings)
+
+## Affected Packages
+None â€” flat files only.
+
+## Boundary Check
+- [x] No infrastructure code â€” flat-file-first per design decision
+- [x] CLAUDE.md operations use the same verbs as the future Knowledge/Agents contracts (ingest, compile, query, lint)
+- [x] `wiki/` directory is Obsidian-compatible (plain markdown, no special format)
+- [x] Conversion path is documented in CLAUDE.md
+
+## Dependencies
+None. Foundational â€” unblocks Obsidian vault setup and all future wiki work.
+
+## Labels
+`feature`, `tier-1`, `scaffold`
+
+## Agent Handoff
+
+**Objective:** Create the directory scaffold and write CLAUDE.md + README.md for HoneyDrunk.Lore.
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Lore`, branch from `main`
+
+**Context:**
+- Lore is the living knowledge surface for The Grid â€” a flat-file wiki maintained by LLMs
+- Inspired by the Karpathy LLM-wiki pattern (raw sources â†’ LLM-compiled wiki â†’ query/lint)
+- Flat-file-first: no .NET, no NuGet, no infrastructure dependencies yet
+- `wiki/` will be opened as an Obsidian vault for visualization
+- Architecture context: `HoneyDrunk.Architecture/repos/HoneyDrunk.Lore/overview.md` and `boundaries.md`
+
+**Acceptance Criteria:**
+- [ ] As listed above
+
+**Constraints:**
+- No .NET code, project files, or NuGet references
+- CLAUDE.md must use the verbs: ingest, compile, query, lint â€” these will become the future contract method names
+- Do not invent wiki structure beyond what is specified â€” `wiki/indexes/` with three stubs is sufficient
+- The conversion note in CLAUDE.md must be present â€” it is a deliberate signal to future agents
+
+**Key Files:**
+- `CLAUDE.md` (new)
+- `README.md` (update)
+- `raw/.gitkeep` (new)
+- `wiki/.gitkeep` (new)
+- `wiki/indexes/sources.md` (new stub)
+- `wiki/indexes/topics.md` (new stub)
+- `wiki/indexes/gaps.md` (new stub)
+- `output/.gitkeep` (new)
+- `tools/.gitkeep` (new)

--- a/generated/issue-packets/active/honeydrunk-lore-bringup/02-architecture-catalog-registration.md
+++ b/generated/issue-packets/active/honeydrunk-lore-bringup/02-architecture-catalog-registration.md
@@ -1,0 +1,114 @@
+---
+name: Chore
+type: chore
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "meta"]
+dependencies: []
+wave: 1
+initiative: honeydrunk-lore-bringup
+node: honeydrunk-architecture
+---
+
+# Chore: Catalog registration â€” HoneyDrunk.Lore
+
+## Summary
+Register `HoneyDrunk.Lore` in the Architecture catalogs and routing rules so the Grid is aware of it. The repo now exists (`HoneyDrunkStudios/HoneyDrunk.Lore`) and is being scaffolded. This registration makes it visible to agents doing routing, dependency walks, and graph queries.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+Until Lore is in the catalogs and routing rules, agents will not know it exists. Routing rules will miss it, the node graph will not include it, and future scope passes will have no machine-readable entry point. Registration is small, independent, and unblocks all downstream work.
+
+## Proposed Implementation
+
+### `catalogs/nodes.json`
+Append a new entry matching the style of existing nodes:
+```json
+{
+  "id": "honeydrunk-lore",
+  "type": "application",
+  "name": "HoneyDrunk.Lore",
+  "public_name": "HoneyDrunk.Lore",
+  "short": "LLM-compiled living knowledge wiki",
+  "description": "Flat-file wiki maintained by LLMs. Ingests raw sources, compiles structured markdown, self-maintains indexes and backlinks, answers queries, and runs health checks. Consumed by agents and the solo developer as the ecosystem's compiled research surface.",
+  "sector": "Meta",
+  "signal": "Seed",
+  "cluster": "knowledge",
+  "tags": ["knowledge", "wiki", "lore", "ai", "flat-file", "obsidian"],
+  "links": { "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore" }
+}
+```
+Note: type is `application` not `node` â€” Lore is an application that consumes nodes, per `repos/HoneyDrunk.Lore/boundaries.md`.
+
+### `catalogs/relationships.json`
+Add planned dependency edges (use `planned` status since the nodes don't exist yet):
+- `honeydrunk-lore` â†’ `honeydrunk-knowledge` (planned: Lore will delegate ingestion/retrieval to Knowledge)
+- `honeydrunk-lore` â†’ `honeydrunk-agents` (planned: Lore will run compile/lint agents on Agents runtime)
+- `honeydrunk-lore` â†’ `honeydrunk-ai` (planned: Lore will delegate inference to AI)
+- `honeydrunk-lore` â†’ `honeydrunk-flow` (planned: Lore will use Flow for multi-step compile workflows)
+
+Check that `planned` edges are supported by the existing schema â€” if not, add a `status` field or use a comment convention that matches how other future edges are marked.
+
+### `routing/repo-discovery-rules.md`
+Add a keyword mapping row for Lore:
+```
+| lore, wiki, raw/, ingest, compile, lint, knowledge surface, living wiki | HoneyDrunk.Lore |
+```
+
+### `repos/HoneyDrunk.Lore/` stubs
+The `repos/HoneyDrunk.Lore/` directory already exists in Architecture with `overview.md`, `boundaries.md`, and `invariants.md`. Verify they exist and are complete. Add any missing files to match the standard set:
+- `active-work.md` â€” stub pointing at HoneyDrunk.Lore#1 (scaffold issue) as the active work
+- `integration-points.md` â€” stub noting that integration points are planned (Knowledge, Agents, AI, Flow) but not yet wired
+
+## Acceptance Criteria
+- [ ] `catalogs/nodes.json` has a new entry for `honeydrunk-lore`, JSON valid, style matches existing entries
+- [ ] `catalogs/relationships.json` has planned dependency edges for Knowledge, Agents, AI, and Flow
+- [ ] `relationships.json` remains a valid DAG (invariant 4) â€” planned edges to not-yet-existing nodes are acceptable if marked as planned
+- [ ] `routing/repo-discovery-rules.md` has the Lore keyword row
+- [ ] `repos/HoneyDrunk.Lore/active-work.md` exists
+- [ ] `repos/HoneyDrunk.Lore/integration-points.md` exists
+
+## Affected Packages
+None â€” catalog JSON and docs only.
+
+## Boundary Check
+- [x] Lore registered as `application` not `node` (per boundaries.md: Lore is an application, not infrastructure)
+- [x] Planned edges are marked as planned â€” no false claims about current wiring
+- [x] No code changes to any other repo
+
+## Dependencies
+None. Can be done in parallel with HoneyDrunk.Lore#1 (scaffold).
+
+## Labels
+`chore`, `tier-2`, `meta`
+
+## Agent Handoff
+
+**Objective:** Register HoneyDrunk.Lore in Architecture catalogs, routing rules, and repo stubs.
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Architecture`, branch from `main`
+
+**Context:**
+- `HoneyDrunk.Lore` is a new flat-file wiki repo (just created, being scaffolded)
+- It is an application that consumes nodes â€” not a node itself (see `repos/HoneyDrunk.Lore/boundaries.md`)
+- Sector: Meta. Signal: Seed. Cluster: knowledge.
+- The repo exists at `HoneyDrunkStudios/HoneyDrunk.Lore`
+- Flat-file-first: no .NET code yet; will eventually delegate to Knowledge/Agents/AI/Flow
+
+**Acceptance Criteria:**
+- [ ] As listed above
+
+**Constraints:**
+- Match the JSON style of existing entries in `nodes.json` exactly
+- Do not fabricate relationship edges beyond what `boundaries.md` supports (Knowledge, Agents, AI, Flow)
+- Planned edges must be clearly marked as planned â€” do not imply current wiring
+- `relationships.json` must remain a DAG after additions (invariant 4)
+
+**Key Files:**
+- `catalogs/nodes.json`
+- `catalogs/relationships.json`
+- `routing/repo-discovery-rules.md`
+- `repos/HoneyDrunk.Lore/active-work.md` (new)
+- `repos/HoneyDrunk.Lore/integration-points.md` (new)

--- a/generated/issue-packets/active/honeydrunk-lore-bringup/03-lore-sourcing-playbook.md
+++ b/generated/issue-packets/active/honeydrunk-lore-bringup/03-lore-sourcing-playbook.md
@@ -1,0 +1,371 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Lore
+labels: ["feature", "tier-1", "docs"]
+dependencies: [1]
+wave: 2
+initiative: honeydrunk-lore-bringup
+node: honeydrunk-lore
+---
+
+# Feature: sourcing-playbook.md â€” content curation guide
+
+## Summary
+Create `sourcing-playbook.md` at the repo root. This is the human + agent guide for what content belongs in Lore, where to find it, and what relevance criteria to apply. It is the config that the OpenClaw skill and RSS agent read to decide what to clip vs. skip.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Lore`
+
+## Motivation
+The wiki compounds only if the right content goes in. Without a sourcing guide, clipping is arbitrary. The playbook makes sourcing intentional and reproducible, and gives agents enough context to source on your behalf.
+
+## Proposed Implementation
+
+Write `sourcing-playbook.md` at the repo root with the following content.
+
+---
+
+### File: `sourcing-playbook.md`
+
+```markdown
+# Lore â€” Sourcing Playbook
+
+This document defines what content belongs in Lore, where to find it, and how to decide what to clip. It is read by humans during manual curation sessions and by agents (OpenClaw skill, RSS agent) performing automated sourcing.
+
+---
+
+## How to use this playbook
+
+**Manual session (weekly):** Go through the sources listed under each category. Clip anything relevant to `raw/` using Obsidian Web Clipper. Aim for 3-10 items per session â€” quality over volume.
+
+**OpenClaw:** Say "source Lore" or "add [URL] to Lore" to trigger the skill. The skill uses this playbook to filter what is worth keeping.
+
+**RSS agent:** Polls feeds daily, filters against relevance criteria defined here, and drops qualifying items in `raw/` automatically.
+
+---
+
+## Categories
+
+### 1. AI / LLM Research & Tooling
+*Core to everything HoneyDrunk builds â€” models, agents, evals, prompting, MCP, tooling.*
+
+**What to clip:**
+- Model capability announcements and benchmark results
+- Agent architecture patterns (planning, memory, tool use, multi-agent)
+- Prompt engineering techniques and evals methodology
+- MCP (Model Context Protocol) updates and new servers
+- New AI development tools and frameworks
+- LLM infrastructure and cost optimization
+
+**What to skip:**
+- General AI hype with no technical substance
+- Product announcements with no architecture or engineering detail
+
+**Sources:**
+- Anthropic blog + research papers (anthropic.com/research)
+- Simon Willison blog (simonwillison.net)
+- Andrej Karpathy blog and GitHub
+- Hugging Face blog (huggingface.co/blog)
+- The Batch â€” Andrew Ng newsletter
+- LangChain blog
+- ArXiv cs.AI and cs.LG â€” applied agent work only
+- Hacker News â€” AI/LLM posts with substantial discussion
+
+---
+
+### 2. Software Architecture
+*Patterns that influence Grid design â€” distributed systems, event-driven, CQRS, domain modeling.*
+
+**What to clip:**
+- Event-driven and message-based architecture patterns
+- CQRS, event sourcing, outbox patterns
+- Domain-driven design and bounded contexts
+- Distributed systems fundamentals (CAP, eventual consistency, sagas)
+- API design and contract-first development
+
+**What to skip:**
+- Language-specific tutorials not applicable to .NET
+- Opinion pieces without concrete trade-off analysis
+
+**Sources:**
+- Martin Fowler blog (martinfowler.com)
+- ByteByteGo newsletter and blog
+- High Scalability (highscalability.com)
+- InfoQ architecture articles
+- The Architecture Notes newsletter
+
+---
+
+### 3. Azure & Cloud
+*Platform HoneyDrunk builds on â€” new services, best practices, pricing, identity.*
+
+**What to clip:**
+- Azure service announcements relevant to the Grid (Functions, Container Apps, App Config, Key Vault, Event Grid, AI services)
+- Azure identity and RBAC changes
+- Cost optimization strategies for Azure
+- GitHub Actions + Azure integration patterns
+- Cloud-native patterns (KEDA, Dapr)
+
+**What to skip:**
+- AWS/GCP content unless directly comparative to Azure
+- Azure services outside the Grid current or planned scope
+
+**Sources:**
+- Azure Updates blog (azure.microsoft.com/updates)
+- Azure DevBlogs (devblogs.microsoft.com/azure)
+- Azure Architecture Center (learn.microsoft.com/azure/architecture)
+- John Savill Technical Training (YouTube)
+- Azure Friday (Channel 9)
+
+---
+
+### 4. .NET Ecosystem
+*Runtime â€” framework updates, libraries, patterns, performance.*
+
+**What to clip:**
+- .NET release notes and preview features
+- ASP.NET Core and C# language updates
+- NuGet ecosystem: new libraries worth evaluating
+- Performance and benchmarking
+- Minimal API and middleware patterns
+
+**What to skip:**
+- Framework comparisons aimed at beginners
+- Content covering stable, well-understood .NET APIs already in use
+
+**Sources:**
+- .NET Blog (devblogs.microsoft.com/dotnet)
+- Andrew Lock blog (andrewlock.net)
+- Nick Chapsas (YouTube and blog)
+- Scott Hanselman blog (hanselman.com)
+- .NET Weekly newsletter
+
+---
+
+### 5. Solo Dev / Indie SaaS
+*How HoneyDrunk operates as a studio â€” product strategy, pricing, go-to-market, sustainability.*
+
+**What to clip:**
+- Build-in-public case studies and revenue milestones
+- Pricing strategy and packaging for developer tools
+- Distribution and discoverability for niche SaaS
+- Solo founder operating patterns
+- Open source + paid tier models
+
+**What to skip:**
+- VC-funded startup content focused on growth-at-all-costs
+- General entrepreneurship advice not grounded in product or technical work
+
+**Sources:**
+- Indie Hackers (indiehackers.com) â€” filter for SaaS and dev tools
+- The Bootstrapped Founder â€” Arvid Kahl
+- Pieter Levels blog and Twitter
+- Hacker News Show HN threads
+- Tiny Seed blog
+
+---
+
+### 6. Developer Tooling & AI Coding
+*Tools that improve the development workflow â€” Claude Code, MCP servers, IDEs, productivity.*
+
+**What to clip:**
+- Claude Code updates and new features
+- MCP server releases relevant to development workflows
+- IDE and editor updates (VS Code, JetBrains)
+- AI-assisted coding patterns and prompting strategies
+
+**What to skip:**
+- Tool comparisons without depth
+- Anything that does not directly improve the solo dev + AI agent workflow
+
+**Sources:**
+- Claude Code release notes and changelog
+- VS Code blog (code.visualstudio.com/updates)
+- GitHub blog (github.blog)
+- Changelog podcast
+- The Pragmatic Engineer â€” Gergely Orosz
+
+---
+
+### 7. Game Development / Unity
+*HoneyPlay sector â€” narrative, simulation, games powered by the Grid.*
+
+**What to clip:**
+- Unity engine updates (LTS releases, new features)
+- Unity + AI integration patterns
+- Procedural generation and simulation techniques
+- Narrative design and interactive storytelling
+- Game architecture patterns applicable to the Grid
+- Indie game development workflow and tooling
+
+**What to skip:**
+- Beginner Unity tutorials
+- AAA studio news with no applicable patterns
+
+**Sources:**
+- Unity Blog (blog.unity.com)
+- Game Developer Magazine (gamedeveloper.com)
+- r/gamedev â€” architecture and systems posts only
+- Game Programming Patterns (gameprogrammingpatterns.com)
+- GDC Vault free talks
+
+---
+
+### 8. DevOps & CI/CD
+*Ops sector â€” shipping reliably, observability, deployment patterns.*
+
+**What to clip:**
+- GitHub Actions updates and new features
+- Container and Docker best practices
+- Observability patterns (OpenTelemetry, distributed tracing)
+- DORA metrics and delivery performance
+- Deployment strategies (blue/green, canary, feature flags)
+
+**What to skip:**
+- DevOps culture pieces without technical substance
+- Jenkins and legacy CI content
+
+**Sources:**
+- GitHub Actions changelog
+- Docker blog (docker.com/blog)
+- OpenTelemetry blog
+- DevOps.com â€” CI/CD and observability only
+- Charity Majors blog (charity.wtf)
+
+---
+
+### 9. Workflow Automation
+*Automating the solo dev operating rhythm â€” agents, triggers, integrations.*
+
+**What to clip:**
+- No-code and low-code automation patterns (n8n, Make, Zapier)
+- Webhook-driven automation patterns
+- AI agent automation case studies
+- Scheduled and event-driven workflow patterns
+
+**What to skip:**
+- Enterprise RPA content
+- Automation platforms with no integration path to the Grid
+
+**Sources:**
+- n8n blog (n8n.io/blog)
+- Zapier blog â€” developer automation only
+- Make (make.com) updates
+- Hacker News â€” automation and workflow posts
+
+---
+
+### 10. Emerging Technology
+*Signals from adjacent fields that may influence the Grid long-term direction.*
+
+**What to clip:**
+- Robotics and embodied AI (Cyberware sector relevance)
+- WebAssembly and edge computing advances
+- New programming paradigms with architectural implications
+- Brain-computer interfaces and HCI research
+
+**What to skip:**
+- Speculative futures without engineering substance
+- Consumer technology reviews
+
+**Sources:**
+- MIT Technology Review (technologyreview.com)
+- IEEE Spectrum (spectrum.ieee.org)
+- Ars Technica â€” deep technical dives only
+- The New Stack (thenewstack.io)
+- Hacker News â€” emerging tech high signal posts
+
+---
+
+### 11. Security & Ethical Hacking
+*HoneyNet sector â€” resilience testing, digital hygiene, threat modeling.*
+
+**What to clip:**
+- Application security patterns for .NET and Azure
+- OAuth2 / OIDC security considerations
+- API security and secrets management best practices
+- CTF write-ups with applicable defensive techniques
+- Threat modeling frameworks and OWASP updates
+
+**What to skip:**
+- Malicious tooling without defensive application
+- CVE announcements for technologies outside the Grid stack
+
+**Sources:**
+- OWASP blog and updates
+- Troy Hunt blog (troyhunt.com)
+- Scott Brady blog â€” .NET identity and security
+- HackerOne Hacktivity â€” public disclosures
+- Security Weekly podcast
+
+---
+
+### 12. Creator Economy & Marketplace
+*Market sector â€” XP systems, gigs, payouts, marketplace dynamics.*
+
+**What to clip:**
+- Creator monetization models and platform economics
+- XP and gamification system design
+- Marketplace dynamics and pricing models
+- Digital goods and licensing patterns
+
+**What to skip:**
+- Influencer content without product or system depth
+- Speculative digital asset content
+
+**Sources:**
+- Lenny Newsletter â€” product and marketplace patterns
+- Hacker News â€” marketplace and economy posts
+- Stratechery â€” platform and marketplace analysis
+
+---
+
+## Relevance criteria (for agents)
+
+When deciding whether to clip something, apply these in order:
+
+1. **Actionable or instructive?** Can this be applied to HoneyDrunk design, architecture, or operation? If yes, clip.
+2. **Durable?** Will this still matter in 6 months? Patterns and trade-off analyses usually do. Current-events opinion pieces usually do not.
+3. **In scope?** Matches one of the 12 categories above? If not, skip.
+4. **Deep enough?** Has technical substance, concrete examples, or case study data? Surface-level overviews are not worth compiling.
+
+When in doubt: clip it. It is easier to lint duplicates out than to recover from missing content.
+
+---
+
+## Session rhythm
+
+| Frequency | Activity |
+|-----------|----------|
+| Daily (automated) | RSS agent and OpenClaw skill monitor feeds and clip qualifying items |
+| Weekly (manual, ~20 min) | Scan source lists for items automation missed, check `wiki/indexes/gaps.md` for open questions |
+| Monthly (manual, ~10 min) | Review this playbook â€” add new sources, remove dead ones, refine relevance criteria |
+```
+
+## Acceptance Criteria
+- [ ] `sourcing-playbook.md` exists at repo root
+- [ ] All 12 categories present with What to clip / What to skip / Sources sections
+- [ ] Relevance criteria section present
+- [ ] Session rhythm section present
+- [ ] File is valid markdown
+
+## Dependencies
+Issue #1 (scaffold) â€” repo must exist.
+
+## Labels
+`feature`, `tier-1`, `docs`
+
+## Agent Handoff
+
+**Objective:** Write `sourcing-playbook.md` at the repo root with the content specified in the Proposed Implementation section above.
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Lore`, branch from `main`
+
+**Constraints:**
+- Write the file exactly as specified â€” do not summarize or shorten any section
+- No other files should be modified
+
+**Key Files:**
+- `sourcing-playbook.md` (new)

--- a/generated/issue-packets/active/honeydrunk-lore-bringup/04-lore-obsidian-vault-setup.md
+++ b/generated/issue-packets/active/honeydrunk-lore-bringup/04-lore-obsidian-vault-setup.md
@@ -1,0 +1,97 @@
+---
+name: Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Lore
+labels: ["chore", "human-only", "tier-1"]
+dependencies: [1]
+wave: 2
+initiative: honeydrunk-lore-bringup
+node: honeydrunk-lore
+---
+
+# Chore: Obsidian vault setup + Web Clipper
+
+## Summary
+Configure the repo root as an Obsidian vault and install the Obsidian Web Clipper browser extension. Together these give you a one-click path from any web article directly into `raw/`, where the scheduled ingest agent picks it up automatically.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Lore` (local clone)
+
+## Why human-only
+Obsidian is a local desktop application and Web Clipper is a browser extension. Both require UI interaction to install and configure. An agent cannot launch Obsidian or interact with browser extension settings.
+
+## Steps
+
+### 1. Install Obsidian
+Download from obsidian.md and install. No account required for local vault use.
+
+### 2. Open the repo root as a vault
+- Open Obsidian â†’ "Open folder as vault"
+- Navigate to the repo root: `HoneyDrunk.Lore/`
+- Select the **root folder** â€” not `wiki/`
+
+The vault encompasses the whole repo so Web Clipper can target `raw/`. The `wiki/` subfolder is where compiled content lives and will be the primary browsing area.
+
+### 3. Exclude non-wiki directories from the vault view
+Prevent `output/`, `tools/`, and `raw/` from cluttering the graph and file list:
+- Settings â†’ Files & Links â†’ "Excluded files": add `output`, `tools`
+- Leave `raw/` visible â€” you want to see what's waiting to be compiled
+
+### 4. Recommended settings
+
+**Files & Links**
+- "New link format": Relative path
+- "Use [[Wikilinks]]": on (enables backlink tracking across `wiki/`)
+- "Default location for new notes": `raw/` (so any new note lands in raw, not wiki)
+
+**Graph view**
+- Settings â†’ Graph view â†’ "Show attachments": off, "Show orphans": on
+- Open graph view (Ctrl+G) â€” verify `wiki/indexes/` stubs appear as nodes
+
+**Editor**
+- "Strict line breaks": off
+
+### 5. Install Obsidian Web Clipper
+- Install the browser extension: search "Obsidian Web Clipper" in your browser's extension store (Chrome, Firefox, Edge)
+- After install, click the extension icon â†’ connect it to your Obsidian vault
+
+**Configure the clipper:**
+- Vault: `HoneyDrunk.Lore`
+- Save location: `raw/`
+- Note format: Markdown
+- Filename template: `{{date}}-{{title}}` (produces dated filenames like `2026-04-11-article-title.md`)
+- Include: page URL, title, author if available, full article content
+
+Now any article you want to add to Lore is one click â€” clip it, it lands in `raw/` with a date-stamped filename, and the scheduled ingest agent handles the rest.
+
+### 6. Commit `.obsidian/` config
+After configuring, commit the `.obsidian/` directory so vault settings are preserved:
+```
+git add .obsidian/
+git commit -m "chore: add Obsidian vault config"
+```
+
+Add workspace noise to `.gitignore`:
+```
+echo ".obsidian/workspace.json" >> .gitignore
+echo ".obsidian/workspace-mobile.json" >> .gitignore
+```
+
+## Acceptance Criteria
+- [ ] Obsidian installed locally
+- [ ] Vault root is the repo root (`HoneyDrunk.Lore/`), not `wiki/`
+- [ ] `output/` and `tools/` are in excluded files
+- [ ] Default new note location is `raw/`
+- [ ] Graph view opens and shows `wiki/indexes/` stubs
+- [ ] Obsidian Web Clipper extension installed and connected to the vault
+- [ ] Clipper configured to save to `raw/` with dated markdown filenames
+- [ ] Test clip: clip one article, verify it appears in `raw/` as a `.md` file
+- [ ] `.obsidian/` config committed to repo
+- [ ] `.obsidian/workspace.json` in `.gitignore`
+
+## Dependencies
+Issue #1 (scaffold) must be complete â€” `raw/` and `wiki/` directories must exist before opening as a vault.
+
+## Labels
+`chore`, `human-only`, `tier-1`

--- a/generated/issue-packets/active/honeydrunk-lore-bringup/05-lore-scheduled-ingest-agent.md
+++ b/generated/issue-packets/active/honeydrunk-lore-bringup/05-lore-scheduled-ingest-agent.md
@@ -1,0 +1,140 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Lore
+labels: ["feature", "tier-2", "automation"]
+dependencies: [1, 2]
+wave: 3
+initiative: honeydrunk-lore-bringup
+node: honeydrunk-lore
+---
+
+# Feature: Scheduled ingest â€” daily agent to auto-compile raw/ sources
+
+## Summary
+Set up a Claude Code scheduled remote agent (via CronCreate) that runs daily, checks `raw/` for sources not yet reflected in `wiki/`, and runs the ingest operation for each. This eliminates the manual step of asking Claude to compile after clipping â€” content flows in via Web Clipper, the agent processes it overnight.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Lore`
+
+## Motivation
+The wiki compounds only if compilation is frictionless. Without automation, the workflow is: clip article â†’ remember to open Claude Code â†’ ask it to compile. That friction causes `raw/` to accumulate unprocessed sources. The scheduled agent removes the "remember to compile" step entirely â€” you clip, it compiles.
+
+Claude Code's CronCreate creates a remote trigger that runs on a cron schedule. The agent wakes up, reads `raw/` against `wiki/indexes/sources.md`, ingest any unprocessed files, and commits the result. The next time you open Obsidian, new wiki pages are already there.
+
+## How it works
+
+### Detection: what counts as "unprocessed"
+A source in `raw/` is unprocessed if its filename does not appear in `wiki/indexes/sources.md`. The ingest operation (defined in `CLAUDE.md`) is responsible for adding a source entry to `sources.md` after compiling it. This creates a simple, inspectable record: if it's in `sources.md`, it's been compiled.
+
+### Agent flow
+1. Read `wiki/indexes/sources.md` â€” build a set of processed filenames
+2. List all files in `raw/` â€” subtract processed set
+3. For each unprocessed file: run the Ingest operation as defined in `CLAUDE.md`
+4. After all ingest passes: rebuild `wiki/indexes/topics.md` and update backlinks
+5. If any new pages were created: commit to `main` with message `chore: ingest [n] new sources`
+6. If nothing new: exit silently (no empty commits)
+
+### Schedule
+Daily at 06:00 local time (or configure to preference). Running at start-of-day means new wiki pages are ready when you open Obsidian in the morning.
+
+## Proposed Implementation
+
+### Step 1: Configure the scheduled agent via CronCreate
+Use the Claude Code `/schedule` skill or CronCreate directly to create a scheduled remote trigger on `HoneyDrunkStudios/HoneyDrunk.Lore`:
+
+```
+Cron: 0 6 * * *   (daily at 06:00)
+Repo: HoneyDrunkStudios/HoneyDrunk.Lore
+Branch: main
+Prompt: (see agent prompt below)
+```
+
+### Agent prompt (to be configured in the trigger)
+```
+You are the Lore ingest agent. Your job is to compile any unprocessed sources in raw/ into the wiki.
+
+Steps:
+1. Read wiki/indexes/sources.md to get the list of already-processed files.
+2. List all files in raw/ (exclude .gitkeep).
+3. For each file in raw/ NOT present in sources.md:
+   a. Follow the Ingest operation defined in CLAUDE.md
+   b. Create or update the relevant wiki/ pages
+   c. Add the filename to wiki/indexes/sources.md
+4. After processing all new sources, rebuild wiki/indexes/topics.md backlinks.
+5. If any wiki/ files were created or modified:
+   - Stage all changes in wiki/
+   - Commit with: "chore: ingest [n] new sources (YYYY-MM-DD)"
+6. If nothing was processed, exit without committing.
+
+Read CLAUDE.md before starting â€” it defines the exact ingest behavior.
+```
+
+### Step 2: Update CLAUDE.md with a sources.md contract
+Add a note to the Ingest operation in CLAUDE.md clarifying the contract:
+> After ingesting a source, append its filename (not full path) to `wiki/indexes/sources.md` under a `## Processed` heading. This is how the scheduled agent knows it has been compiled. Do not add a source entry until ingestion is complete.
+
+### Step 3: Update wiki/indexes/sources.md stub
+Update the stub created in issue #1 to include the expected heading structure:
+```markdown
+# Sources Index
+
+## Processed
+<!-- Filenames of raw/ sources that have been compiled into wiki/ -->
+
+## Pending
+<!-- Optional: manually flag sources for priority ingest -->
+```
+
+## Acceptance Criteria
+- [ ] Scheduled remote trigger created via CronCreate, running daily at 06:00
+- [ ] Agent prompt reads CLAUDE.md before operating (not hardcoded behavior)
+- [ ] `wiki/indexes/sources.md` has the `## Processed` heading contract
+- [ ] CLAUDE.md Ingest operation updated with sources.md append contract
+- [ ] Test run: manually trigger the agent with one file in `raw/` â€” verify wiki page created + sources.md updated + commit made
+- [ ] Test run: trigger again with no new files â€” verify no empty commit
+
+## Affected Files
+- `CLAUDE.md` (update Ingest operation â€” sources.md contract)
+- `wiki/indexes/sources.md` (update stub with heading structure)
+- Claude Code settings (new scheduled trigger via CronCreate â€” not a repo file)
+
+## Boundary Check
+- [x] Agent reads CLAUDE.md for behavior â€” not hardcoded, easy to update
+- [x] sources.md is the only state the agent needs â€” simple, inspectable, no database
+- [x] Commits to main directly â€” acceptable for a solo dev wiki repo
+- [x] No .NET code, no infrastructure dependencies
+
+## Dependencies
+- Issue #1 (scaffold) â€” CLAUDE.md and `wiki/indexes/sources.md` must exist
+- Issue #2 (Obsidian + Web Clipper) â€” ingest is only useful once content flows in
+
+## Labels
+`feature`, `tier-2`, `automation`
+
+## Agent Handoff
+
+**Objective:** Configure the CronCreate scheduled trigger and update CLAUDE.md + sources.md with the sources contract.
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Lore`, branch from `main`
+
+**Context:**
+- Lore is a flat-file LLM-compiled wiki (see CLAUDE.md after issue #1 is complete)
+- The scheduled agent is the automation layer that removes friction from the ingest workflow
+- Detection of unprocessed sources is done via `wiki/indexes/sources.md` â€” simple filename list
+- CronCreate creates a Claude Code remote trigger; use the `/schedule` skill to configure it
+
+**Acceptance Criteria:**
+- [ ] As listed above
+
+**Constraints:**
+- Agent prompt must reference CLAUDE.md â€” do not hardcode ingest behavior in the prompt
+- No empty commits â€” agent exits silently if nothing new to process
+- sources.md is append-only for the agent; never delete processed entries
+- Commit message format: `chore: ingest [n] new sources (YYYY-MM-DD)`
+
+**Key Files:**
+- `CLAUDE.md` (update)
+- `wiki/indexes/sources.md` (update stub)
+- CronCreate trigger (configured via `/schedule` skill, not a repo file)

--- a/generated/issue-packets/active/honeydrunk-lore-bringup/06-lore-openclaw-setup-and-skill.md
+++ b/generated/issue-packets/active/honeydrunk-lore-bringup/06-lore-openclaw-setup-and-skill.md
@@ -1,0 +1,188 @@
+---
+name: Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Lore
+labels: ["chore", "human-only", "tier-1", "automation"]
+dependencies: [1, 2, 4]
+wave: 3
+initiative: honeydrunk-lore-bringup
+node: honeydrunk-lore
+---
+
+# Chore: OpenClaw setup + Lore sourcing skill
+
+## Summary
+Install and configure OpenClaw (openclaw.ai) as a local AI assistant connected to the Lore vault and messaging apps. Then build a custom Lore sourcing skill so you can say "add this to Lore" or "find content about X for Lore" from your phone or any connected messaging app, and the content lands in `raw/` automatically.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Lore` (local machine)
+
+## Why human-only
+OpenClaw is a local application that installs on your machine and connects to desktop apps (Obsidian) and messaging services (WhatsApp, Telegram, etc.). Installation and messaging account linking require UI interaction. The Lore skill definition is agent-writable but only useful once the runtime is installed.
+
+---
+
+## Part A â€” Install OpenClaw
+
+### 1. Install on Windows
+OpenClaw ships a bash install script. On Windows, run it in Git Bash or WSL:
+
+```bash
+curl -fsSL https://openclaw.ai/install.sh | bash
+```
+
+After installation, verify it started:
+- Check the system tray for the OpenClaw icon
+- Or run `openclaw status` in your terminal
+
+If the bash install does not work on your Windows setup, check openclaw.ai/docs for the Windows-native installer â€” they list Mac, Windows, and Linux support.
+
+### 2. Choose your AI provider
+OpenClaw supports Anthropic Claude, OpenAI, and local models. Use Claude:
+- Settings â†’ AI Provider â†’ Anthropic
+- Enter your Anthropic API key
+- Select model: claude-sonnet-4-6 (or latest Sonnet for balance of speed and quality)
+
+### 3. Connect a messaging app
+OpenClaw delivers through apps you already use. Pick one as your primary Lore interface:
+
+**Recommended: Telegram** (easiest setup, works well on mobile + desktop)
+- Create a Telegram bot via BotFather (search @BotFather in Telegram)
+- Copy the bot token
+- OpenClaw Settings â†’ Integrations â†’ Telegram â†’ paste token
+- Start a conversation with your bot â€” OpenClaw responds through it
+
+**Alternative: WhatsApp**
+- Settings â†’ Integrations â†’ WhatsApp
+- Follow the QR code pairing flow
+- Note: WhatsApp integration requires the WhatsApp app open on your phone periodically to stay connected
+
+---
+
+## Part B â€” Connect Obsidian
+
+### 4. Link Obsidian to OpenClaw
+OpenClaw has a native Obsidian integration:
+- Settings â†’ Integrations â†’ Obsidian
+- Point it at the vault root: `HoneyDrunk.Lore/`
+- Verify: send a test message "list my vault files" â€” OpenClaw should return a file listing
+
+---
+
+## Part C â€” Build the Lore sourcing skill
+
+OpenClaw skills are defined as markdown or JSON instruction files that tell OpenClaw what to do when triggered. Skills live in the ClawHub directory or a local skills folder.
+
+### 5. Create the Lore skill
+
+Create a new skill file. The skill should handle three trigger phrases:
+
+**Trigger 1: "add [URL] to Lore"**
+- Fetch the page at the URL
+- Extract: title, author (if present), publication date, full article content, source URL
+- Check `sourcing-playbook.md` relevance criteria â€” if the content matches a category, proceed; if clearly out of scope, respond "this does not match Lore sourcing criteria" and stop
+- Save to `raw/` as a markdown file named `YYYY-MM-DD-slug-of-title.md`
+- Include frontmatter: `source`, `title`, `author`, `date_clipped`, `category` (matched category from playbook)
+- Respond: "Added to Lore: [title] â†’ raw/YYYY-MM-DD-slug.md"
+
+**Trigger 2: "find content about [topic] for Lore"**
+- Search the web for recent (last 30 days) content matching the topic
+- Filter results against `sourcing-playbook.md` relevance criteria
+- For each qualifying result (max 5): save to `raw/` using the same format as Trigger 1
+- Respond with a summary: "Added N items to Lore about [topic]: [list of titles]"
+
+**Trigger 3: "what does Lore know about [topic]"**
+- Search `wiki/` for pages matching the topic
+- Summarize findings and list relevant page filenames
+- Check `wiki/indexes/gaps.md` â€” if the topic appears there, note it as a known gap
+- Respond with a brief summary
+
+### Skill file content
+
+```yaml
+name: lore-sourcing
+description: Add content to HoneyDrunk.Lore or query what Lore knows
+triggers:
+  - "add * to Lore"
+  - "add * to lore"
+  - "find content about * for Lore"
+  - "find content about * for lore"
+  - "what does Lore know about *"
+  - "what does lore know about *"
+
+vault: HoneyDrunk.Lore
+playbook_path: sourcing-playbook.md
+
+instructions: |
+  You are the Lore sourcing agent for HoneyDrunk Studios.
+  
+  Before acting, read sourcing-playbook.md from the vault root to understand
+  what content belongs in Lore and the relevance criteria.
+  
+  For "add [URL] to Lore":
+  1. Fetch the URL content
+  2. Check relevance criteria from sourcing-playbook.md
+  3. If out of scope, respond with why and stop
+  4. Save to raw/ as YYYY-MM-DD-title-slug.md with frontmatter:
+     - source: [URL]
+     - title: [article title]
+     - author: [author if available]
+     - date_clipped: [today]
+     - category: [matched category from playbook]
+  5. Confirm: "Added to Lore: [title] -> raw/[filename]"
+  
+  For "find content about [topic] for Lore":
+  1. Web search: "[topic] site:relevant-sources last month"
+  2. Filter results against sourcing-playbook.md relevance criteria
+  3. Save qualifying results (max 5) to raw/ using same format
+  4. Summarize: "Added N items to Lore about [topic]"
+  
+  For "what does Lore know about [topic]":
+  1. Search wiki/ for matching pages
+  2. Check wiki/indexes/gaps.md for the topic
+  3. Summarize findings with page references
+```
+
+### 6. Test the skill
+Send these messages to your connected bot:
+- "add [paste any relevant article URL] to Lore" â€” verify file appears in `raw/`
+- "find content about MCP servers for Lore" â€” verify 1-5 files appear in `raw/`
+- "what does Lore know about software architecture" â€” verify it searches `wiki/`
+
+---
+
+## Acceptance Criteria
+
+**Part A â€” Install**
+- [ ] OpenClaw installed and running on your machine
+- [ ] Claude (Anthropic) set as AI provider with API key configured
+- [ ] At least one messaging integration connected (Telegram recommended)
+- [ ] Test message sent and responded to
+
+**Part B â€” Obsidian**
+- [ ] Obsidian integration connected and pointing at `HoneyDrunk.Lore/` vault root
+- [ ] "list my vault files" returns a file listing via messaging app
+
+**Part C â€” Lore skill**
+- [ ] Lore sourcing skill created and loaded in OpenClaw
+- [ ] Trigger 1 test: URL clip lands in `raw/` with correct frontmatter
+- [ ] Trigger 2 test: topic search adds at least one file to `raw/`
+- [ ] Trigger 3 test: wiki query returns a meaningful response
+- [ ] Out-of-scope URL test: clearly irrelevant URL is rejected with a reason
+
+---
+
+## Dependencies
+- Issue #1 (scaffold) â€” `raw/` directory must exist
+- Issue #2 (Obsidian) â€” vault must be configured and connected
+- Issue #4 (sourcing-playbook.md) â€” skill reads the playbook for relevance criteria
+
+## Labels
+`chore`, `human-only`, `tier-1`, `automation`
+
+## Notes
+- OpenClaw documentation: openclaw.ai/docs
+- ClawHub for community skills: openclaw.ai/clawhub
+- The Lore skill reads `sourcing-playbook.md` at runtime â€” updating the playbook updates the skill behavior without reinstalling
+- If OpenClaw adds new capabilities (RSS integration, scheduled sourcing), revisit this issue to extend the skill

--- a/generated/issue-packets/active/honeydrunk-lore-bringup/dispatch-plan.md
+++ b/generated/issue-packets/active/honeydrunk-lore-bringup/dispatch-plan.md
@@ -1,0 +1,85 @@
+# Dispatch Plan — honeydrunk-lore-bringup
+
+**Initiative:** `honeydrunk-lore-bringup`  
+**Status:** Wave 1 ready  
+**Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)  
+**Issues filed:** Yes (Lore#1–5, Architecture#9)  
+
+---
+
+## Summary
+
+Stand up HoneyDrunk.Lore as a flat-file LLM-compiled wiki. Three waves: repo scaffold + catalog registration, then Obsidian + sourcing playbook, then the automation layer (scheduled ingest agent + OpenClaw skill).
+
+---
+
+## Wave Diagram
+
+### Wave 1 — Foundation (parallel, no dependencies)
+- [ ] `01` Lore#1 — Repo scaffold + CLAUDE.md schema doc
+- [ ] `02` Architecture#9 — Catalog registration for HoneyDrunk.Lore
+
+### Wave 2 — Content layer (parallel, depends on Wave 1)
+- [ ] `03` Lore#4 — sourcing-playbook.md
+- [ ] `04` Lore#2 — Obsidian vault setup + Web Clipper (human-only)
+  - Blocked by: Wave 1 — Lore#1
+
+### Wave 3 — Automation layer (parallel, depends on Wave 2)
+- [ ] `05` Lore#3 — Scheduled ingest agent (CronCreate)
+  - Blocked by: Wave 1 — Lore#1, Wave 2 — Lore#2
+- [ ] `06` Lore#5 — OpenClaw setup + Lore sourcing skill (human-only)
+  - Blocked by: Wave 1 — Lore#1, Wave 2 — Lore#2, Wave 2 — Lore#4
+
+---
+
+## Wave 1 Exit Criteria
+
+Before starting Wave 2:
+- [ ] Lore#1 merged — `raw/`, `wiki/`, `output/`, `tools/` exist, CLAUDE.md written
+- [ ] Architecture#9 merged — `honeydrunk-lore` in `catalogs/nodes.json`, routing rules updated
+
+---
+
+## Wave 2 Exit Criteria
+
+Before starting Wave 3:
+- [ ] Lore#4 merged — `sourcing-playbook.md` at repo root with all 12 categories
+- [ ] Lore#2 complete — Obsidian vault open, Web Clipper installed and clipping to `raw/`
+
+---
+
+## Packet Index
+
+| # | File | Target Repo | Issue | Wave | Actor |
+|---|------|-------------|-------|------|-------|
+| 01 | [01-lore-scaffold-and-claude-md.md](01-lore-scaffold-and-claude-md.md) | HoneyDrunk.Lore | [Lore#1](https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore/issues/1) | 1 | Agent |
+| 02 | [02-architecture-catalog-registration.md](02-architecture-catalog-registration.md) | HoneyDrunk.Architecture | [Architecture#9](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/9) | 1 | Agent |
+| 03 | [03-lore-sourcing-playbook.md](03-lore-sourcing-playbook.md) | HoneyDrunk.Lore | [Lore#4](https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore/issues/4) | 2 | Agent |
+| 04 | [04-lore-obsidian-vault-setup.md](04-lore-obsidian-vault-setup.md) | HoneyDrunk.Lore | [Lore#2](https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore/issues/2) | 2 | Human |
+| 05 | [05-lore-scheduled-ingest-agent.md](05-lore-scheduled-ingest-agent.md) | HoneyDrunk.Lore | [Lore#3](https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore/issues/3) | 3 | Agent |
+| 06 | [06-lore-openclaw-setup-and-skill.md](06-lore-openclaw-setup-and-skill.md) | HoneyDrunk.Lore | [Lore#5](https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore/issues/5) | 3 | Human |
+
+---
+
+## Site Sync
+
+Not required — Lore is an internal wiki, not a public-facing node. No Studios update needed at this stage.
+
+---
+
+## Rollback Plan
+
+Lore is a new repo with no downstream consumers. Any wave can be abandoned cleanly:
+- Wave 1 rollback: delete the Lore repo, revert Architecture#9 catalog changes
+- Wave 2 rollback: delete `sourcing-playbook.md`, skip Obsidian setup
+- Wave 3 rollback: remove CronCreate trigger, uninstall OpenClaw skill
+
+No core Grid nodes are affected at any wave.
+
+---
+
+## History
+
+| Date | Event |
+|------|-------|
+| 2026-04-11 | Initiative scoped, 6 issues filed on The Hive, packets written |

--- a/initiatives/active-initiatives.md
+++ b/initiatives/active-initiatives.md
@@ -66,7 +66,7 @@ Tracked initiatives currently in progress or planned. Completed and cancelled in
 ### HoneyDrunk.Lore Bring-Up
 **Status:** On Deck  
 **Scope:** Lore, Architecture  
-**Initiative:** `honeydunk-lore-bringup`  
+**Initiative:** `honeydrunk-lore-bringup`  
 **Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)  
 **Description:** Stand up HoneyDrunk.Lore as a flat-file LLM-compiled wiki. Repo scaffolded with `raw/`, `wiki/`, `output/`, `tools/` directories, CLAUDE.md schema doc, sourcing playbook, Obsidian vault configuration, Web Clipper, scheduled ingest agent, and OpenClaw sourcing skill. Inspired by the Karpathy LLM-wiki pattern. Flat-file-first — Knowledge/Agents integration deferred until those nodes exist.  
 **Tracking:**

--- a/initiatives/active-initiatives.md
+++ b/initiatives/active-initiatives.md
@@ -1,6 +1,6 @@
 # Active Initiatives
 
-Tracked initiatives across the HoneyDrunk Grid. Each initiative may span multiple repos.
+Tracked initiatives currently in progress or planned. Completed and cancelled initiatives live in [archived-initiatives.md](archived-initiatives.md).
 
 ## In Progress
 
@@ -63,20 +63,21 @@ Tracked initiatives across the HoneyDrunk Grid. Each initiative may span multipl
 
 ## Planned
 
+### HoneyDrunk.Lore Bring-Up
+**Status:** On Deck  
+**Scope:** Lore, Architecture  
+**Initiative:** `honeydunk-lore-bringup`  
+**Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)  
+**Description:** Stand up HoneyDrunk.Lore as a flat-file LLM-compiled wiki. Repo scaffolded with `raw/`, `wiki/`, `output/`, `tools/` directories, CLAUDE.md schema doc, sourcing playbook, Obsidian vault configuration, Web Clipper, scheduled ingest agent, and OpenClaw sourcing skill. Inspired by the Karpathy LLM-wiki pattern. Flat-file-first — Knowledge/Agents integration deferred until those nodes exist.  
+**Tracking:**
+- [ ] Lore#1: Repo scaffold + CLAUDE.md schema doc
+- [ ] Lore#2: Obsidian vault setup + Web Clipper (human-only)
+- [ ] Lore#3: Scheduled ingest agent (CronCreate)
+- [ ] Lore#4: sourcing-playbook.md
+- [ ] Lore#5: OpenClaw setup + Lore sourcing skill (human-only)
+- [ ] Architecture#9: Catalog registration for HoneyDrunk.Lore
+
 ### Agent Kit
 **Status:** On Deck  
 **Scope:** AI  
 **Description:** Agent execution runtime, tool abstraction, and memory. Foundation for AI-powered workflows across the Grid.  
-
-## Completed
-
-### Architecture Command Center
-**Status:** Complete  
-**Scope:** Architecture  
-**Completed:** 2026-03-28  
-**Description:** HoneyDrunk.Architecture stood up as the central command center. Catalogs, routing rules, issue templates, copilot instructions, per-repo context docs, and Azure infrastructure documentation all in place.  
-
-### ~~HoneyDrunk.Tools~~ (Scrapped)
-**Status:** Cancelled  
-**Scope:** Ops  
-**Description:** Originally planned as a separate CLI for scanning, accessibility checks, and CI automation. Decision made to implement this logic directly as composite actions within HoneyDrunk.Actions instead.  

--- a/initiatives/archived-initiatives.md
+++ b/initiatives/archived-initiatives.md
@@ -1,0 +1,22 @@
+# Archived Initiatives
+
+Completed and cancelled initiatives. Active and planned work lives in [active-initiatives.md](active-initiatives.md).
+
+---
+
+## Completed
+
+### Architecture Command Center
+**Status:** Complete  
+**Scope:** Architecture  
+**Completed:** 2026-03-28  
+**Description:** HoneyDrunk.Architecture stood up as the central command center. Catalogs, routing rules, issue templates, copilot instructions, per-repo context docs, and Azure infrastructure documentation all in place.  
+
+---
+
+## Cancelled
+
+### ~~HoneyDrunk.Tools~~ (Scrapped)
+**Status:** Cancelled  
+**Scope:** Ops  
+**Description:** Originally planned as a separate CLI for scanning, accessibility checks, and CI automation. Decision made to implement this logic directly as composite actions within HoneyDrunk.Actions instead.  

--- a/initiatives/current-focus.md
+++ b/initiatives/current-focus.md
@@ -34,7 +34,7 @@ Provision Azure infrastructure and get both services running in the development 
 
 Stand up Lore as a flat-file LLM-compiled wiki. 6 issues scoped and on The Hive under initiative `honeydrunk-lore-bringup`. Start with Lore#1 (scaffold) and Architecture#9 (catalog registration) — they are independent and can run in parallel.
 
-**See:** `initiatives/active-initiatives.md` → HoneyDrunk.Lore Bring-Up
+**See:** [active-initiatives.md](active-initiatives.md) → HoneyDrunk.Lore Bring-Up
 
 ### Agent Kit
 

--- a/initiatives/current-focus.md
+++ b/initiatives/current-focus.md
@@ -2,7 +2,7 @@
 
 What the team (human + agents) should prioritize right now.
 
-**Last Updated:** 2026-04-09
+**Last Updated:** 2026-04-11
 
 ## Primary Focus
 
@@ -29,6 +29,12 @@ Provision Azure infrastructure and get both services running in the development 
 **See:** `infrastructure/azure-provisioning-guide.md` for step-by-step instructions.
 
 ## On Deck
+
+### HoneyDrunk.Lore Bring-Up
+
+Stand up Lore as a flat-file LLM-compiled wiki. 6 issues scoped and on The Hive under initiative `honeydunk-lore-bringup`. Start with Lore#1 (scaffold) and Architecture#9 (catalog registration) — they are independent and can run in parallel.
+
+**See:** `initiatives/active-initiatives.md` → HoneyDrunk.Lore Bring-Up
 
 ### Agent Kit
 

--- a/initiatives/current-focus.md
+++ b/initiatives/current-focus.md
@@ -32,7 +32,7 @@ Provision Azure infrastructure and get both services running in the development 
 
 ### HoneyDrunk.Lore Bring-Up
 
-Stand up Lore as a flat-file LLM-compiled wiki. 6 issues scoped and on The Hive under initiative `honeydunk-lore-bringup`. Start with Lore#1 (scaffold) and Architecture#9 (catalog registration) — they are independent and can run in parallel.
+Stand up Lore as a flat-file LLM-compiled wiki. 6 issues scoped and on The Hive under initiative `honeydrunk-lore-bringup`. Start with Lore#1 (scaffold) and Architecture#9 (catalog registration) — they are independent and can run in parallel.
 
 **See:** `initiatives/active-initiatives.md` → HoneyDrunk.Lore Bring-Up
 


### PR DESCRIPTION
Refactor initiative tracking to separate active/planned from completed/cancelled (now in archived-initiatives.md). Add HoneyDrunk.Lore Bring-Up as a planned initiative with details and tracking. Update current-focus.md to reflect new priorities and clarify initiative descriptions.