### PR TITLE
docs(standards): require explicit NuGet Dependencies in .NET packets

### DIFF
--- a/constitution/invariants.md
+++ b/constitution/invariants.md
@@ -92,3 +92,6 @@ Rules that must never be violated across the HoneyDrunk Grid. Canary tests enfor
 
 25. **Dispatch plans are initiative narratives, not live state.**
     The org Project board is the source of truth for in-flight work. Dispatch plans are updated at wave boundaries as historical records. See ADR-0008.
+
+26. **Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section.**
+    Any packet that creates or modifies .NET projects must list every `PackageReference` entry required — both additions to existing projects and the full reference list for new projects. `HoneyDrunk.Standards` must be explicitly listed on every new .NET project (StyleCop + EditorConfig analyzers, `PrivateAssets: all`). Cloud agent execution cannot infer or guess package lists; an absent section is grounds to stop and flag rather than proceed.

--- a/constitution/invariants.md
+++ b/constitution/invariants.md
@@ -87,11 +87,11 @@ Rules that must never be violated across the HoneyDrunk Grid. Canary tests enfor
 23. **Every tracked work item has a GitHub Issue in its target repo.**
     No work tracked exclusively in packet files, chat logs, or external tools. Issues live where the code lives. See ADR-0008.
 
-24. **Issue packets are immutable specifications.**
-    State lives on the org Project board, never in the packet file. If requirements change materially, write a new packet rather than editing the old one. See ADR-0008.
+24. **Issue packets are immutable once filed as a GitHub Issue.**
+    Filing is the point of no return. Before a packet is filed, it may be amended to fill in missing operational context (e.g. NuGet dependencies, key files, constraints) without violating this rule. After filing, state lives on the org Project board, never in the packet file. If requirements change materially post-filing, write a new packet rather than editing the old one. See ADR-0008.
 
 25. **Dispatch plans are initiative narratives, not live state.**
     The org Project board is the source of truth for in-flight work. Dispatch plans are updated at wave boundaries as historical records. See ADR-0008.
 
 26. **Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section.**
-    Any packet that creates or modifies .NET projects must list every `PackageReference` entry required — both additions to existing projects and the full reference list for new projects. `HoneyDrunk.Standards` must be explicitly listed on every new .NET project (StyleCop + EditorConfig analyzers, `PrivateAssets: all`). Cloud agent execution cannot infer or guess package lists; an absent section is grounds to stop and flag rather than proceed.
+    Any packet that creates or modifies .NET projects must list every `PackageReference` entry required — both additions to existing projects and the full reference list for new projects. `HoneyDrunk.Standards` must be explicitly listed on every new .NET project (StyleCop + EditorConfig analyzers, `PrivateAssets: all`). Cloud agent execution cannot infer or guess package lists; an absent section is grounds to stop and flag rather than proceed. This section must be present before the packet is filed as a GitHub Issue (see invariant 24 — pre-filing amendments are permitted; post-filing corrections require a new packet).

--- a/generated/issue-packets/active/adr-0005-0006-rollout/01-vault-bootstrap-extensions.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/01-vault-bootstrap-extensions.md
@@ -77,6 +77,23 @@ This packet delivers both halves of the ADR-0005 bootstrap story as one coherent
 - `HoneyDrunk.Vault.Providers.AzureKeyVault` (new env-var bootstrap entry)
 - New: `HoneyDrunk.Vault.Providers.AppConfiguration` (or co-located under the AzureKeyVault bootstrap package — decide during implementation, keep both extensions consistent)
 
+## NuGet Dependencies
+
+### `HoneyDrunk.Vault.Providers.AzureKeyVault` — additions to existing project
+| Package | Notes |
+|---|---|
+| `Azure.Extensions.AspNetCore.Configuration.Secrets` (latest stable) | Azure Key Vault as an `IConfiguration` source — required for the `AddVault` env-driven bootstrap |
+
+### New: `HoneyDrunk.Vault.Providers.AppConfiguration`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | StyleCop + EditorConfig analyzers — required on every HoneyDrunk .NET project |
+| `Azure.Identity` (latest stable) | `DefaultAzureCredential` for App Configuration + KV reference resolution |
+| `Microsoft.Extensions.Configuration.AzureAppConfiguration` (latest stable) | Core App Configuration client |
+| `Microsoft.Azure.AppConfiguration.AspNetCore` (latest stable) | ASP.NET Core integration, refresh middleware |
+| `Microsoft.FeatureManagement.AspNetCore` (latest stable) | `IFeatureManager` / feature flag support |
+| ProjectRef: `HoneyDrunk.Vault` | Dependency on the core secret store abstraction |
+
 ## Boundary Check
 - [x] Feature is within HoneyDrunk.Vault's stated responsibility: secret store and config provider wiring
 - [x] Does not duplicate any other Node's responsibility

--- a/generated/issue-packets/active/adr-0005-0006-rollout/02-vault-event-driven-cache-invalidation.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/02-vault-event-driven-cache-invalidation.md
@@ -42,6 +42,20 @@ This must exist before per-Node migration to App Configuration + Managed Identit
 - `HoneyDrunk.Vault` (cache + invalidator contract)
 - New optional: `HoneyDrunk.Vault.EventGrid` (webhook handler package)
 
+## NuGet Dependencies
+
+### `HoneyDrunk.Vault` — additions to existing project
+No new `PackageReference` entries. The `ISecretCacheInvalidator` interface and `SecretCache` changes are within the existing dependency surface.
+
+### New: `HoneyDrunk.Vault.EventGrid`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | StyleCop + EditorConfig analyzers — required on every HoneyDrunk .NET project |
+| `Azure.Messaging.EventGrid` (latest stable) | Event Grid schema parsing — `EventGridEvent`, `CloudEvent`, subscription validation handshake |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` (latest stable) | DI registration helpers for `MapVaultInvalidationWebhook` |
+| `Microsoft.AspNetCore.Http.Abstractions` (latest stable) | `IEndpointRouteBuilder` for ASP.NET Core endpoint registration |
+| ProjectRef: `HoneyDrunk.Vault` | Resolves `ISecretCacheInvalidator` and `ISecretStore` (webhook auth) |
+
 ## Boundary Check
 - [x] Cache lives in Vault — invalidator belongs here too
 - [x] Webhook parsing is infrastructure glue, not a transport message — no Transport dependency

--- a/generated/issue-packets/active/adr-0005-0006-rollout/06-vault-rotation-scaffold.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/06-vault-rotation-scaffold.md
@@ -75,6 +75,55 @@ ADR-0006 Tier 2 introduces `HoneyDrunk.Vault.Rotation` as a brand-new sub-Node t
 - New: `HoneyDrunk.Vault.Rotation.Abstractions`
 - New: `HoneyDrunk.Vault.Rotation.Providers`
 
+## NuGet Dependencies
+
+### New: `HoneyDrunk.Vault.Rotation` (Function App host)
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | StyleCop + EditorConfig analyzers — required on every HoneyDrunk .NET project |
+| `HoneyDrunk.Kernel` (latest stable) | `IGridContext`, `AddHoneyDrunkNode` bootstrap |
+| `HoneyDrunk.Vault` (latest stable) | `ISecretStore` — for reading the Function App's own credentials |
+| `Microsoft.Azure.Functions.Worker` (latest stable) | Isolated worker model host |
+| `Microsoft.Azure.Functions.Worker.Sdk` (latest stable) | Build tooling for isolated Functions |
+| `Microsoft.Azure.Functions.Worker.Extensions.Timer` (latest stable) | Timer trigger for the rotation schedule |
+| `Microsoft.Azure.Functions.Worker.Extensions.Http` (latest stable) | HTTP trigger for the webhook invalidation endpoint |
+| `Azure.Identity` (latest stable) | `DefaultAzureCredential` / Managed Identity |
+| ProjectRef: `HoneyDrunk.Vault.Rotation.Abstractions` | `IRotator`, `RotationContext`, `RotationResult` |
+| ProjectRef: `HoneyDrunk.Vault.Rotation.Providers` | Provider stub discovery |
+
+### New: `HoneyDrunk.Vault.Rotation.Abstractions`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | StyleCop + EditorConfig analyzers — required on every HoneyDrunk .NET project |
+
+### New: `HoneyDrunk.Vault.Rotation.Providers`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | StyleCop + EditorConfig analyzers — required on every HoneyDrunk .NET project |
+| `Azure.Identity` (latest stable) | Credential chain for future provider API calls |
+| `Azure.Security.KeyVault.Secrets` (latest stable) | Writing rotated secret versions into target Key Vaults |
+| ProjectRef: `HoneyDrunk.Vault.Rotation.Abstractions` | `IRotator` contract |
+
+### New: `HoneyDrunk.Vault.Rotation.Tests`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | StyleCop + EditorConfig analyzers — required on every HoneyDrunk .NET project |
+| `xunit` (latest stable) | Test framework |
+| `xunit.runner.visualstudio` (latest stable) | VS test runner integration |
+| `Microsoft.NET.Test.Sdk` (latest stable) | Test SDK |
+| `coverlet.collector` (latest stable) | Code coverage |
+| ProjectRef: `HoneyDrunk.Vault.Rotation.Abstractions` | Unit under test |
+| ProjectRef: `HoneyDrunk.Vault.Rotation.Providers` | Unit under test |
+
+### New: `HoneyDrunk.Vault.Rotation.Canary`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | StyleCop + EditorConfig analyzers — required on every HoneyDrunk .NET project |
+| `xunit` (latest stable) | Test framework |
+| `xunit.runner.visualstudio` (latest stable) | VS test runner integration |
+| `Microsoft.NET.Test.Sdk` (latest stable) | Test SDK |
+| ProjectRef: `HoneyDrunk.Vault.Rotation.Abstractions` | Integration boundary under test |
+
 ## Boundary Check
 - [x] Rotation logic does not belong in `HoneyDrunk.Vault` (Vault is a client/cache/provider library — no outbound scheduled write responsibilities)
 - [x] Does not duplicate Azure-native rotation (Tier 1 is KV policy, not this Node)

--- a/generated/issue-packets/active/adr-0005-0006-rollout/07-auth-migrate-config-bootstrap.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/07-auth-migrate-config-bootstrap.md
@@ -36,6 +36,16 @@ ADR-0005 mandates every deployable Node bootstrap through two env vars and consu
 - `HoneyDrunk.Auth` (runtime host)
 - Any `HoneyDrunk.Auth.*` packages that currently read secrets directly
 
+## NuGet Dependencies
+
+### `HoneyDrunk.Auth` host project — additions to existing references
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | StyleCop + EditorConfig analyzers — confirm already present; add if missing |
+| `HoneyDrunk.Vault.Providers.AzureKeyVault` (preview from packet 01) | Provides the new env-driven `AddVault()` overload |
+| `HoneyDrunk.Vault.Providers.AppConfiguration` (preview from packet 01) | Provides `AddAppConfiguration()` |
+| `HoneyDrunk.Vault.EventGrid` (preview from packet 02) | Provides `MapVaultInvalidationWebhook` for the `/internal/vault/invalidate` endpoint |
+
 ## Boundary Check
 - [x] Work is purely Auth's own bootstrap surface and its secret reads — no cross-Node API changes
 - [x] Does not touch JWT validation logic (invariant 10 — Auth still validates, never issues)

--- a/generated/issue-packets/active/adr-0005-0006-rollout/08-web-rest-migrate-config-bootstrap.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/08-web-rest-migrate-config-bootstrap.md
@@ -34,6 +34,16 @@ Same as the Auth migration packet — ADR-0005 bootstrap contract + ADR-0006 rot
 - `HoneyDrunk.Web.Rest` (runtime)
 - `HoneyDrunk.Web.Rest.*` sub-packages if any read `IConfiguration` for secrets
 
+## NuGet Dependencies
+
+### `HoneyDrunk.Web.Rest` host project — additions to existing references
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | StyleCop + EditorConfig analyzers — confirm already present; add if missing |
+| `HoneyDrunk.Vault.Providers.AzureKeyVault` (preview from packet 01) | Provides the new env-driven `AddVault()` overload |
+| `HoneyDrunk.Vault.Providers.AppConfiguration` (preview from packet 01) | Provides `AddAppConfiguration()` |
+| `HoneyDrunk.Vault.EventGrid` (preview from packet 02) | Provides `MapVaultInvalidationWebhook` for the `/internal/vault/invalidate` endpoint |
+
 ## Boundary Check
 - [x] Bootstrap change is Web.Rest-internal
 - [x] Response envelope and exception mapping logic untouched (invariant-aligned)

--- a/generated/issue-packets/active/adr-0005-0006-rollout/09-data-migrate-config-bootstrap.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/09-data-migrate-config-bootstrap.md
@@ -36,6 +36,26 @@ Data is the highest-risk Node for secret leakage because it holds the SQL connec
 - `HoneyDrunk.Data.SqlServer` (provider) — verify no direct env-var reads
 - Any `HoneyDrunk.Data.*.Migrations` tooling
 
+## NuGet Dependencies
+
+### `HoneyDrunk.Data` host project — additions to existing references
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | StyleCop + EditorConfig analyzers — confirm already present; add if missing |
+| `HoneyDrunk.Vault.Providers.AzureKeyVault` (preview from packet 01) | Provides the new env-driven `AddVault()` overload |
+| `HoneyDrunk.Vault.Providers.AppConfiguration` (preview from packet 01) | Provides `AddAppConfiguration()` |
+| `HoneyDrunk.Vault.EventGrid` (preview from packet 02) | Provides `MapVaultInvalidationWebhook` for the `/internal/vault/invalidate` endpoint |
+
+### `HoneyDrunk.Data.SqlServer` — additions to existing references
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | Confirm already present; add if missing |
+
+### Migration tooling projects — additions to existing references
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Vault.Providers.AzureKeyVault` (preview from packet 01) | Migration runner must also resolve connection strings via `ISecretStore` — not from `appsettings` |
+
 ## Boundary Check
 - [x] Data's secret surface lives here; the migration is internal
 - [x] Does not alter `IRepository`/`IUnitOfWork` contracts

--- a/generated/issue-packets/active/adr-0005-0006-rollout/10-notify-migrate-config-bootstrap.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/10-notify-migrate-config-bootstrap.md
@@ -40,6 +40,21 @@ Notify holds the primary third-party provider credentials (Resend API key, Twili
 - `HoneyDrunk.Notify.Providers.Smtp`
 - Azure Functions host project (pending deployment)
 
+## NuGet Dependencies
+
+### `HoneyDrunk.Notify` host/worker — additions to existing references
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | StyleCop + EditorConfig analyzers — confirm already present; add if missing |
+| `HoneyDrunk.Vault.Providers.AzureKeyVault` (preview from packet 01) | Provides the new env-driven `AddVault()` overload |
+| `HoneyDrunk.Vault.Providers.AppConfiguration` (preview from packet 01) | Provides `AddAppConfiguration()` |
+| `HoneyDrunk.Vault.EventGrid` (preview from packet 02) | Provides `MapVaultInvalidationWebhook` — register in both worker host and Functions host |
+
+### `HoneyDrunk.Notify.Providers.Resend`, `.Twilio`, `.Smtp` — additions to existing references
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | Confirm already present on each provider project; add if missing |
+
 ## Boundary Check
 - [x] All secret handling belongs in Notify's provider layer
 - [x] No Transport contract change

--- a/generated/issue-packets/active/adr-0005-0006-rollout/11-pulse-migrate-config-bootstrap.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/11-pulse-migrate-config-bootstrap.md
@@ -41,6 +41,29 @@ Pulse.Collector is a long-running OTLP receiver and must not hold stale sink cre
 - `HoneyDrunk.Pulse.Collector` (OTLP receiver)
 - All sink packages (`HoneyDrunk.Pulse.Sinks.*`)
 
+## NuGet Dependencies
+
+### `HoneyDrunk.Pulse` host — additions to existing references
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | StyleCop + EditorConfig analyzers — confirm already present; add if missing |
+| `HoneyDrunk.Vault.Providers.AzureKeyVault` (preview from packet 01) | Provides the new env-driven `AddVault()` overload |
+| `HoneyDrunk.Vault.Providers.AppConfiguration` (preview from packet 01) | Provides `AddAppConfiguration()` |
+| `HoneyDrunk.Vault.EventGrid` (preview from packet 02) | Provides `MapVaultInvalidationWebhook` — register in both Pulse host and Pulse.Collector |
+
+### `HoneyDrunk.Pulse.Collector` — additions to existing references
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | Confirm already present; add if missing |
+| `HoneyDrunk.Vault.Providers.AzureKeyVault` (preview from packet 01) | Collector bootstraps independently — needs its own `AddVault()` |
+| `HoneyDrunk.Vault.Providers.AppConfiguration` (preview from packet 01) | Collector bootstraps independently — needs its own `AddAppConfiguration()` |
+| `HoneyDrunk.Vault.EventGrid` (preview from packet 02) | Register webhook in Collector host too |
+
+### `HoneyDrunk.Pulse.Sinks.*` — additions to existing references
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` `0.2.6` (`PrivateAssets: all`) | Confirm already present on each sink project; add if missing |
+
 ## Boundary Check
 - [x] Sink credential handling belongs in Pulse
 - [x] Telemetry responsibilities unchanged — only bootstrap surface moves


### PR DESCRIPTION
add invariant mandating ## NuGet Dependencies section in all .NET issue packets; update all relevant packets to enumerate required package references, ensuring implementation clarity and compliance with ADR-0008