### PR TITLE
docs: add portal-first Azure infra walkthroughs and register HoneyDrunk.Vault.Rotation node

### DIFF
--- a/adrs/ADR-0005-configuration-and-secrets-strategy.md
+++ b/adrs/ADR-0005-configuration-and-secrets-strategy.md
@@ -96,6 +96,7 @@ The following invariants must be added to `constitution/invariants.md`:
 - CI pipelines for every deployable Node must be updated to use OIDC federated credentials instead of client-secret service principals.
 - A shared `appcs-hd-shared-{env}` App Configuration resource must be provisioned per environment, with Managed Identity access granted per Node.
 - Portal walkthroughs for vault creation, RBAC, App Configuration, and OIDC wiring belong in `infrastructure/` docs, not in this ADR.
+- Walkthrough index: [Infrastructure Walkthroughs](../infrastructure/README.md).
 
 ## Alternatives Considered
 

--- a/adrs/ADR-0006-secret-rotation-and-lifecycle.md
+++ b/adrs/ADR-0006-secret-rotation-and-lifecycle.md
@@ -90,6 +90,7 @@ Scaffolding is explicitly **not** part of this ADR — this pass is documentatio
 
 - The shared Log Analytics workspace (`log-hd-shared-{env}`) becomes a cross-cutting dependency for every deployable Node. It must exist before any Node can ship to that environment.
 - Event Grid subscriptions must be provisioned per vault. This is a portal walkthrough, deferred to `infrastructure/` docs.
+- Walkthrough index: [Infrastructure Walkthroughs](../infrastructure/README.md).
 
 ### New Invariants
 

--- a/catalogs/nodes.json
+++ b/catalogs/nodes.json
@@ -12,25 +12,16 @@
     "energy": 1,
     "priority": 100,
     "flow": 45,
-    "tags": [
-      "infrastructure",
-      "primitives",
-      "context",
-      "lifecycle",
-      "telemetry",
-      "identity",
-      "health",
-      "configuration"
-    ],
+    "tags": ["infrastructure", "primitives", "context", "lifecycle", "telemetry", "identity", "health", "configuration"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Kernel"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Kernel is the semantic OS layer of HoneyDrunk.OS, the Hive. It is the foundational runtime that nodes, agents and services use to communicate, coordinate and observe themselves across the Grid. Core responsibilities: Context propagation\u2014a three tier model (GridContext, NodeContext, OperationContext) that flows across async boundaries and transports. Lifecycle orchestration\u2014startup hooks, lifecycle stages, health and readiness aggregation, graceful shutdown. Configuration and identity primitives\u2014strongly typed IDs at configuration time, string based identities at runtime, options for Grid and Node bootstrap. Telemetry integration\u2014OpenTelemetry ready activity factory, trace enrichment and log correlation wired to Grid context. Health and readiness\u2014health checks and lifecycle contributors for Kubernetes style /health and /ready endpoints. Agent interop\u2014agent execution contexts, scoped context visibility and serializers that let higher level agent runtimes safely embed LLMs into the Grid. Kernel is the part of the Grid that defines what it means to be a node.",
+      "overview": "HoneyDrunk.Kernel is the semantic OS layer of HoneyDrunk.OS, the Hive. It is the foundational runtime that nodes, agents and services use to communicate, coordinate and observe themselves across the Grid. Core responsibilities: Context propagation—a three tier model (GridContext, NodeContext, OperationContext) that flows across async boundaries and transports. Lifecycle orchestration—startup hooks, lifecycle stages, health and readiness aggregation, graceful shutdown. Configuration and identity primitives—strongly typed IDs at configuration time, string based identities at runtime, options for Grid and Node bootstrap. Telemetry integration—OpenTelemetry ready activity factory, trace enrichment and log correlation wired to Grid context. Health and readiness—health checks and lifecycle contributors for Kubernetes style /health and /ready endpoints. Agent interop—agent execution contexts, scoped context visibility and serializers that let higher level agent runtimes safely embed LLMs into the Grid. Kernel is the part of the Grid that defines what it means to be a node.",
       "why_it_exists": "To give every node the same runtime skeleton for identity, context, lifecycle and observability so those concerns are not reinvented in each service.",
       "primary_audience": "Node developers and service owners building Grid aware services. Agent runtimes and automation that need to execute with a proper Grid context.",
       "value_props": [
-        "Three tier context model\u2014Grid to Node to Operation\u2014with correlation and causation tracking",
+        "Three tier context model—Grid to Node to Operation—with correlation and causation tracking",
         "Lifecycle orchestration with startup hooks, lifecycle stages and contributor based health and readiness",
         "OpenTelemetry ready tracing, enrichment and log scopes",
         "Strongly typed identity at configuration time, string identity at runtime for performance",
@@ -41,7 +32,7 @@
       "roadmap_focus": "v0.4 is a stabilization release. Enforce the three-ID context model across all creation paths. Consolidate hosting around AddHoneyDrunkNode as the canonical API. Align lifecycle, health and readiness behavior with docs. Lock identity registries as the DNS of the Grid.",
       "grid_relationship": "Foundation for all Core nodes. Every node depends on Kernel or Kernel.Abstractions.",
       "integration_depth": "deep",
-      "demo_path": "Minimal Node setup with AddHoneyDrunkGrid and AddHoneyDrunkNode \u2192 context flow across async calls \u2192 health probe validation \u2192 graceful shutdown with lifecycle hooks.",
+      "demo_path": "Minimal Node setup with AddHoneyDrunkGrid and AddHoneyDrunkNode → context flow across async calls → health probe validation → graceful shutdown with lifecycle hooks.",
       "signal_quote": "Where everything begins.",
       "stability_tier": "critical",
       "impact_vector": "developer velocity"
@@ -66,15 +57,7 @@
     "energy": 1,
     "priority": 100,
     "flow": 45,
-    "tags": [
-      "messaging",
-      "outbox",
-      "pipeline",
-      "middleware",
-      "transport-agnostic",
-      "retry",
-      "grid-context"
-    ],
+    "tags": ["messaging", "outbox", "pipeline", "middleware", "transport-agnostic", "retry", "grid-context"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport"
     },
@@ -119,25 +102,13 @@
     "energy": 1,
     "priority": 100,
     "flow": 45,
-    "tags": [
-      "vault",
-      "secrets",
-      "configuration",
-      "provider",
-      "cache",
-      "resilience",
-      "circuit-breaker",
-      "retry",
-      "lifecycle",
-      "health",
-      "distributed-tracing"
-    ],
+    "tags": ["vault", "secrets", "configuration", "provider", "cache", "resilience", "circuit-breaker", "retry", "lifecycle", "health", "distributed-tracing"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Vault is the core secrets and configuration management library for HoneyDrunk.OS. This package provides the abstractions (ISecretStore, IConfigProvider, IVaultClient, ISecretProvider, IConfigSource), caching with TTL and sliding expiration, resilience policies (retry, circuit breaker), Kernel lifecycle integration, and distributed telemetry that all Vault providers plug into. Vault itself contains no provider implementations\u2014it defines the contract, runtime behavior, and orchestration. Providers (File, Azure Key Vault, AWS, InMemory, Configuration) supply the actual secrets while Vault handles resilience, caching, and tracing.",
-      "why_it_exists": "A unified, Kernel-aware interface for secrets and configuration\u2014no matter where those values live. Prevents inconsistent secret handling and reinvention across the Grid.",
+      "overview": "HoneyDrunk.Vault is the core secrets and configuration management library for HoneyDrunk.OS. This package provides the abstractions (ISecretStore, IConfigProvider, IVaultClient, ISecretProvider, IConfigSource), caching with TTL and sliding expiration, resilience policies (retry, circuit breaker), Kernel lifecycle integration, and distributed telemetry that all Vault providers plug into. Vault itself contains no provider implementations—it defines the contract, runtime behavior, and orchestration. Providers (File, Azure Key Vault, AWS, InMemory, Configuration) supply the actual secrets while Vault handles resilience, caching, and tracing.",
+      "why_it_exists": "A unified, Kernel-aware interface for secrets and configuration—no matter where those values live. Prevents inconsistent secret handling and reinvention across the Grid.",
       "primary_audience": "HoneyDrunk service developers and node owners who need secure, traceable access to secrets and configuration.",
       "value_props": [
         "Defines ISecretStore, IConfigProvider, IVaultClient for unified secret/config access",
@@ -152,7 +123,7 @@
       "roadmap_focus": "Pulse integration for anomaly detection, secrets-as-code manifests, autonomous credential rotation.",
       "grid_relationship": "Connects with: honeydrunk-kernel, honeydrunk-auth, honeysentinel, breachlab-exe.",
       "integration_depth": "deep",
-      "demo_path": "Register Vault with AddVault() \u2192 retrieve a secret via ISecretStore \u2192 observe caching, resilience, and telemetry.",
+      "demo_path": "Register Vault with AddVault() → retrieve a secret via ISecretStore → observe caching, resilience, and telemetry.",
       "signal_quote": "Trust, by design.",
       "stability_tier": "stable",
       "impact_vector": "security posture"
@@ -173,17 +144,38 @@
     "description": "Azure Function App that rotates third-party provider secrets (Resend, Twilio, OpenAI, ...) into per-Node Key Vaults on schedule. Sibling to HoneyDrunk.Vault; separate deployable.",
     "sector": "Core",
     "signal": "Seed",
-    "cluster": "foundation",
-    "tags": [
-      "infrastructure",
-      "rotation",
-      "secrets",
-      "functions",
-      "azure"
-    ],
+    "cluster": "security",
+    "energy": 0,
+    "priority": 0,
+    "flow": 0,
+    "tags": ["infrastructure", "rotation", "secrets", "functions", "azure"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault.Rotation"
-    }
+    },
+    "long_description": {
+      "overview": "HoneyDrunk.Vault.Rotation is a deployable Azure Function Node for ADR-0006 Tier-2 secret rotation. It rotates third-party provider credentials on schedule and writes new versions into per-Node Key Vaults.",
+      "why_it_exists": "Centralize third-party key rotation and SLA enforcement without duplicating rotator infrastructure in every Node.",
+      "primary_audience": "Platform maintainers operating HoneyDrunk secret lifecycle automation.",
+      "value_props": [
+        "Automated Tier-2 provider secret rotation",
+        "Per-vault write model aligned with Key Vault RBAC",
+        "Shared telemetry/alerting hooks for SLA monitoring"
+      ],
+      "monetization_signal": "Internal platform capability.",
+      "roadmap_focus": "Scaffold baseline Function runtime, then integrate provider adapters and observability.",
+      "grid_relationship": "Depends on Kernel and Vault, writes rotated values into deployable Node vaults.",
+      "integration_depth": "medium",
+      "demo_path": "Trigger rotation run \u2192 write new secret version \u2192 observe downstream refresh event path.",
+      "signal_quote": "Rotate once, protect everywhere.",
+      "stability_tier": "seed",
+      "impact_vector": "security posture"
+    },
+    "foundational": false,
+    "strategy_base": 10,
+    "tier": "none",
+    "time_pressure": 0,
+    "done": false,
+    "cooldown_days": 14
   },
   {
     "id": "honeydrunk-auth",
@@ -198,19 +190,12 @@
     "energy": 0,
     "priority": 43,
     "flow": 28,
-    "tags": [
-      "auth",
-      "security",
-      "jwt",
-      "policy",
-      "identity",
-      "vault"
-    ],
+    "tags": ["auth", "security", "jwt", "policy", "identity", "vault"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Auth"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Auth is a Grid node component\u2014not a standalone library\u2014that standardizes authentication and authorization decisions across nodes and entrypoints. It requires Kernel as its host runtime and provides JWT bearer token validation with Vault-backed signing keys, deterministic policy evaluation, and fail-fast startup validation. Auth ensures consistent identity checks and authorization patterns so every request entering the Grid follows the same security discipline.",
+      "overview": "HoneyDrunk.Auth is a Grid node component—not a standalone library—that standardizes authentication and authorization decisions across nodes and entrypoints. It requires Kernel as its host runtime and provides JWT bearer token validation with Vault-backed signing keys, deterministic policy evaluation, and fail-fast startup validation. Auth ensures consistent identity checks and authorization patterns so every request entering the Grid follows the same security discipline.",
       "why_it_exists": "Prevents inconsistent authentication and authorization patterns across nodes, ensuring security discipline is uniform regardless of entrypoint.",
       "primary_audience": "Service owners building HTTP APIs, gateways, and any Grid node requiring request authentication.",
       "value_props": [
@@ -249,13 +234,7 @@
     "energy": 29,
     "priority": 38,
     "flow": 35,
-    "tags": [
-      "rest",
-      "api",
-      "middleware",
-      "conventions",
-      "web"
-    ],
+    "tags": ["rest", "api", "middleware", "conventions", "web"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest"
     },
@@ -274,7 +253,7 @@
       "roadmap_focus": "OpenAPI enrichment, typed client generation, WebSocket conventions.",
       "grid_relationship": "Consumes Kernel.Abstractions (IOperationContextAccessor for correlation), Auth.AspNetCore (auth shaping), Transport.Abstractions (envelope mapping only).",
       "integration_depth": "medium",
-      "demo_path": "Call AddRest() \u2192 UseRest() \u2192 all responses automatically include correlation IDs and structured errors.",
+      "demo_path": "Call AddRest() → UseRest() → all responses automatically include correlation IDs and structured errors.",
       "signal_quote": "Speak cleanly to be understood.",
       "stability_tier": "beta",
       "impact_vector": "developer velocity"
@@ -299,17 +278,7 @@
     "energy": 0,
     "priority": 36,
     "flow": 23,
-    "tags": [
-      "database",
-      "persistence",
-      "migrations",
-      "multi-tenant",
-      "entityframework",
-      "sqlserver",
-      "outbox",
-      "contracts",
-      "testing"
-    ],
+    "tags": ["database", "persistence", "migrations", "multi-tenant", "entityframework", "sqlserver", "outbox", "contracts", "testing"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Data"
     },
@@ -327,7 +296,7 @@
       "roadmap_focus": "Advance HoneyDrunk.Data capabilities and harden contracts.",
       "grid_relationship": "Consumes Kernel (required) for GridContext, OperationContext, lifecycle hooks, and telemetry primitives. Consumes Transport (via Outbox.Dispatcher) for message publishing.",
       "integration_depth": "medium",
-      "demo_path": "Register Data with AddHoneyDrunkData() \u2192 use repositories with tenant isolation \u2192 verify outbox delivery.",
+      "demo_path": "Register Data with AddHoneyDrunkData() → use repositories with tenant isolation → verify outbox delivery.",
       "signal_quote": "Memory with meaning.",
       "stability_tier": "stable",
       "impact_vector": "developer velocity"
@@ -352,17 +321,12 @@
     "energy": 41,
     "priority": 100,
     "flow": 100,
-    "tags": [
-      "observability",
-      "monitoring",
-      "telemetry",
-      "security"
-    ],
+    "tags": ["observability", "monitoring", "telemetry", "security"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Pulse"
     },
     "long_description": {
-      "overview": "Pulse is how the Hive feels itself. It's the nervous system that collects, correlates, and interprets telemetry from every corner of the Grid \u2014 logs, traces, metrics, and signals that together form a living heartbeat. Every Node reports its state into Pulse's unified pipeline, creating a continuously updated map of operational health and system interdependence.",
+      "overview": "Pulse is how the Hive feels itself. It's the nervous system that collects, correlates, and interprets telemetry from every corner of the Grid — logs, traces, metrics, and signals that together form a living heartbeat. Every Node reports its state into Pulse's unified pipeline, creating a continuously updated map of operational health and system interdependence.",
       "why_it_exists": "In distributed systems, invisibility is the enemy. Pulse exists to prevent blindness.",
       "primary_audience": "HoneyDrunk maintainers, contributors, and service owners.",
       "value_props": [
@@ -374,7 +338,7 @@
       "roadmap_focus": "Advance Pulse capabilities and harden contracts.",
       "grid_relationship": "Connects with: honeydrunk-vault, honeydrunk-transport, honeydrunk-data.",
       "integration_depth": "medium",
-      "demo_path": "Configure Pulse sinks \u2192 emit telemetry from a Node \u2192 observe logs, traces, and metrics in unified dashboard.",
+      "demo_path": "Configure Pulse sinks → emit telemetry from a Node → observe logs, traces, and metrics in unified dashboard.",
       "signal_quote": "The Hive has a heartbeat.",
       "stability_tier": "beta",
       "impact_vector": "security posture"
@@ -399,18 +363,12 @@
     "energy": 0,
     "priority": 29,
     "flow": 29,
-    "tags": [
-      "notifications",
-      "email",
-      "sms",
-      "templates",
-      "queues"
-    ],
+    "tags": ["notifications", "email", "sms", "templates", "queues"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Notify"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Notify is the Grid's outbound notification layer \u2014 a channel-agnostic system for dispatching messages across email, SMS, and future channels. It provides a unified contract surface (INotificationSender, INotificationGateway, INotificationPolicy) with pluggable providers: SMTP and Resend for email, Twilio for SMS. Template rendering, idempotency keys, delivery tracking, and queue-based async dispatch ensure reliable, auditable delivery.",
+      "overview": "HoneyDrunk.Notify is the Grid's outbound notification layer — a channel-agnostic system for dispatching messages across email, SMS, and future channels. It provides a unified contract surface (INotificationSender, INotificationGateway, INotificationPolicy) with pluggable providers: SMTP and Resend for email, Twilio for SMS. Template rendering, idempotency keys, delivery tracking, and queue-based async dispatch ensure reliable, auditable delivery.",
       "why_it_exists": "Without unified notification infrastructure, outbound communication drifts in reliability, security, and delivery patterns across nodes.",
       "primary_audience": "Service developers and node owners needing reliable, multi-channel outbound notifications with consistent delivery semantics.",
       "value_props": [
@@ -425,7 +383,7 @@
       "roadmap_focus": "Push notification channel, webhook dispatch, adaptive send policies based on Pulse metrics.",
       "grid_relationship": "Consumes Kernel for Grid context, lifecycle hooks, and telemetry. Provider credentials are injected at deploy time via Azure Key Vault (not the HoneyDrunk.Vault package).",
       "integration_depth": "medium",
-      "demo_path": "Send a notification via INotificationSender \u2192 provider dispatches email/SMS \u2192 track delivery status.",
+      "demo_path": "Send a notification via INotificationSender → provider dispatches email/SMS → track delivery status.",
       "signal_quote": "When the Hive speaks, it's heard everywhere.",
       "stability_tier": "beta",
       "impact_vector": "communication reliability"
@@ -450,11 +408,7 @@
     "energy": 0,
     "priority": 36,
     "flow": 23,
-    "tags": [
-      "github",
-      "actions",
-      "ci-cd"
-    ],
+    "tags": ["github", "actions", "ci-cd"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions"
     },
@@ -471,7 +425,7 @@
       "roadmap_focus": "Advance HoneyDrunk.Actions capabilities and harden contracts.",
       "grid_relationship": "Connects with: honeydrunk-build.",
       "integration_depth": "medium",
-      "demo_path": "Reference a reusable workflow \u2192 observe build, test, pack, publish steps \u2192 verify artifacts.",
+      "demo_path": "Reference a reusable workflow → observe build, test, pack, publish steps → verify artifacts.",
       "signal_quote": "Automation with personality.",
       "stability_tier": "stable",
       "impact_vector": "developer velocity"
@@ -489,26 +443,19 @@
     "name": "HoneyDrunk.Architecture",
     "public_name": "HoneyDrunk.Architecture",
     "short": "Grid command center & agent hub",
-    "description": "Canonical architecture knowledge base \u2014 ADRs, catalogs, routing rules, issue templates, and agent workflows that govern how the Grid evolves.",
+    "description": "Canonical architecture knowledge base — ADRs, catalogs, routing rules, issue templates, and agent workflows that govern how the Grid evolves.",
     "sector": "Meta",
     "signal": "Live",
     "cluster": "governance",
     "energy": 50,
     "priority": 80,
     "flow": 60,
-    "tags": [
-      "architecture",
-      "adrs",
-      "governance",
-      "agents",
-      "catalogs",
-      "routing"
-    ],
+    "tags": ["architecture", "adrs", "governance", "agents", "catalogs", "routing"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Architecture is the command center of the Grid. It holds the canonical catalogs (nodes, modules, services, relationships), constitution (manifesto, invariants, sector taxonomy), architecture decision records, routing rules for agent workflows, and issue/sync packet generation. No code, no packages \u2014 pure knowledge infrastructure that agents and humans use to understand and evolve the Hive.",
+      "overview": "HoneyDrunk.Architecture is the command center of the Grid. It holds the canonical catalogs (nodes, modules, services, relationships), constitution (manifesto, invariants, sector taxonomy), architecture decision records, routing rules for agent workflows, and issue/sync packet generation. No code, no packages — pure knowledge infrastructure that agents and humans use to understand and evolve the Hive.",
       "why_it_exists": "Without a single source of architectural truth, decisions scatter across repos, agents lack context, and the Grid drifts.",
       "primary_audience": "Architecture agents, Copilot workflows, and HoneyDrunk maintainers making cross-cutting decisions.",
       "value_props": [
@@ -522,7 +469,7 @@
       "roadmap_focus": "Converge with website data. Expand agent workflows. Add initiative tracking and roadmap generation.",
       "grid_relationship": "Referenced by all agents and copilot instructions. No runtime dependencies.",
       "integration_depth": "shallow",
-      "demo_path": "Ask the ADR Composer agent a trade-off question \u2192 observe context loading from catalogs \u2192 review the generated ADR.",
+      "demo_path": "Ask the ADR Composer agent a trade-off question → observe context loading from catalogs → review the generated ADR.",
       "signal_quote": "Know the map. Tend the garden.",
       "stability_tier": "stable",
       "impact_vector": "architectural clarity"
@@ -540,26 +487,19 @@
     "name": "HoneyDrunk.Studios",
     "public_name": "HoneyDrunk.Studios",
     "short": "Public website & Grid visualizer",
-    "description": "The live front-end of The Hive \u2014 renders all Nodes, Sectors, and signals with neon-lit visualization. Next.js 16, React 19, Three.js WebGL.",
+    "description": "The live front-end of The Hive — renders all Nodes, Sectors, and signals with neon-lit visualization. Next.js 16, React 19, Three.js WebGL.",
     "sector": "Meta",
     "signal": "Live",
     "cluster": "visualization",
     "energy": 40,
     "priority": 70,
     "flow": 55,
-    "tags": [
-      "website",
-      "nextjs",
-      "react",
-      "threejs",
-      "visualization",
-      "public"
-    ],
+    "tags": ["website", "nextjs", "react", "threejs", "visualization", "public"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Studios"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Studios is the public face of the Hive \u2014 a Next.js 16 application that renders the Grid as an interactive, neon-lit visualization. It displays every Node, Sector, signal timeline entry, and relationship using static JSON data imported directly (no CMS, no database). The flagship /grid route renders an interactive Three.js WebGL scene. The site serves as both a developer portal and a build-in-public showcase.",
+      "overview": "HoneyDrunk.Studios is the public face of the Hive — a Next.js 16 application that renders the Grid as an interactive, neon-lit visualization. It displays every Node, Sector, signal timeline entry, and relationship using static JSON data imported directly (no CMS, no database). The flagship /grid route renders an interactive Three.js WebGL scene. The site serves as both a developer portal and a build-in-public showcase.",
       "why_it_exists": "To make the state of The Grid observable to contributors and the community. Transparency as a feature.",
       "primary_audience": "Developers, contributors, and anyone tracking HoneyDrunk's build-in-public roadmap.",
       "value_props": [
@@ -573,7 +513,7 @@
       "roadmap_focus": "Converge data with Architecture repo. Add live status indicators. Expand module and service detail pages.",
       "grid_relationship": "Consumes Architecture catalogs as source of truth for data/schema files. No runtime Node dependencies.",
       "integration_depth": "shallow",
-      "demo_path": "Visit honeydrunkstudios.com \u2192 explore /grid WebGL \u2192 browse /nodes \u2192 check /signal timeline.",
+      "demo_path": "Visit honeydrunkstudios.com → explore /grid WebGL → browse /nodes → check /signal timeline.",
       "signal_quote": "See the Hive breathe.",
       "stability_tier": "stable",
       "impact_vector": "community engagement"
@@ -598,16 +538,7 @@
     "energy": 0,
     "priority": 90,
     "flow": 0,
-    "tags": [
-      "inference",
-      "llm",
-      "embeddings",
-      "providers",
-      "openai",
-      "anthropic",
-      "azure-openai",
-      "telemetry"
-    ],
+    "tags": ["inference", "llm", "embeddings", "providers", "openai", "anthropic", "azure-openai", "telemetry"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.AI"
     },
@@ -626,7 +557,7 @@
       "roadmap_focus": "Initial scaffolding with OpenAI and Anthropic providers. Align with Microsoft.Extensions.AI adoption.",
       "grid_relationship": "Consumes Kernel (context, telemetry), Vault (API keys), Pulse (inference telemetry). Consumed by Agents, Memory, Knowledge, Evals, Sim.",
       "integration_depth": "deep",
-      "demo_path": "Register AI with AddHoneyDrunkAI() \u2192 configure an OpenAI provider \u2192 run a chat completion \u2192 observe Pulse telemetry with token counts and latency.",
+      "demo_path": "Register AI with AddHoneyDrunkAI() → configure an OpenAI provider → run a chat completion → observe Pulse telemetry with token counts and latency.",
       "signal_quote": "Think clearly, speak in any voice.",
       "stability_tier": "planned",
       "impact_vector": "ai capability"
@@ -651,33 +582,26 @@
     "energy": 0,
     "priority": 85,
     "flow": 0,
-    "tags": [
-      "tools",
-      "registry",
-      "permissions",
-      "discovery",
-      "agent-tools",
-      "versioning"
-    ],
+    "tags": ["tools", "registry", "permissions", "discovery", "agent-tools", "versioning"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Capabilities"
     },
     "long_description": {
       "overview": "HoneyDrunk.Capabilities is the tool registry and dispatch layer for the Grid's agents. It defines what tools exist, what parameters they accept, what they return, and who is authorized to invoke them. Tool implementations live in the Node that owns the domain (e.g., a 'query database' tool is implemented by Data). Capabilities owns discovery, schema versioning, permission checks, and execution routing.",
-      "why_it_exists": "Without a centralized tool registry, agent-tool bindings couple agent code to tool implementations. Capabilities decouples them \u2014 agents discover tools at runtime, and tool updates don't require agent redeployment.",
+      "why_it_exists": "Without a centralized tool registry, agent-tool bindings couple agent code to tool implementations. Capabilities decouples them — agents discover tools at runtime, and tool updates don't require agent redeployment.",
       "primary_audience": "Agent developers and Node owners who expose domain operations as agent-callable tools.",
       "value_props": [
         "Centralized tool registry with schema definitions",
-        "Runtime discovery \u2014 agents query available tools dynamically",
-        "Permission guards \u2014 which agents can invoke which tools",
-        "Schema versioning \u2014 tool contracts evolve without breaking consumers",
-        "Execution dispatch \u2014 route invocations to implementing Nodes"
+        "Runtime discovery — agents query available tools dynamically",
+        "Permission guards — which agents can invoke which tools",
+        "Schema versioning — tool contracts evolve without breaking consumers",
+        "Execution dispatch — route invocations to implementing Nodes"
       ],
       "monetization_signal": "Internal-first. Tool ecosystem becomes a platform capability.",
       "roadmap_focus": "Core registry contracts, permission model, initial tool descriptors for Data and Vault operations.",
       "grid_relationship": "Consumes Kernel (context, identity), Auth (authorization policies). Consumed by Agents (tool invocation).",
       "integration_depth": "medium",
-      "demo_path": "Register a tool descriptor \u2192 agent discovers it via ICapabilityRegistry \u2192 invoke with permission check \u2192 observe dispatch to implementing Node.",
+      "demo_path": "Register a tool descriptor → agent discovers it via ICapabilityRegistry → invoke with permission check → observe dispatch to implementing Node.",
       "signal_quote": "Reach for the right tool, every time.",
       "stability_tier": "planned",
       "impact_vector": "ai capability"
@@ -702,20 +626,13 @@
     "energy": 0,
     "priority": 95,
     "flow": 0,
-    "tags": [
-      "agents",
-      "lifecycle",
-      "runtime",
-      "execution-context",
-      "identity",
-      "orchestration"
-    ],
+    "tags": ["agents", "lifecycle", "runtime", "execution-context", "identity", "orchestration"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Agents"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Agents is the agent runtime for the Grid. It manages the full agent lifecycle (register \u2192 initialize \u2192 execute \u2192 complete \u2192 decommission), provides scoped execution contexts carrying GridContext, agent identity, memory references, and capability bindings. Agents defines the contracts for how agents invoke tools and access memory, with orchestration hooks for the Flow Node to coordinate multi-agent sequences.",
-      "why_it_exists": "Agents need a consistent runtime skeleton \u2014 just as Kernel gives every Node context propagation and lifecycle hooks, Agents gives every AI agent identity, execution context, and tool/memory access patterns.",
+      "overview": "HoneyDrunk.Agents is the agent runtime for the Grid. It manages the full agent lifecycle (register → initialize → execute → complete → decommission), provides scoped execution contexts carrying GridContext, agent identity, memory references, and capability bindings. Agents defines the contracts for how agents invoke tools and access memory, with orchestration hooks for the Flow Node to coordinate multi-agent sequences.",
+      "why_it_exists": "Agents need a consistent runtime skeleton — just as Kernel gives every Node context propagation and lifecycle hooks, Agents gives every AI agent identity, execution context, and tool/memory access patterns.",
       "primary_audience": "AI workflow developers building agents that operate within the Grid.",
       "value_props": [
         "Full agent lifecycle management with defined state transitions",
@@ -729,7 +646,7 @@
       "roadmap_focus": "Core lifecycle contracts, execution context, tool invoker integration with Capabilities.",
       "grid_relationship": "Consumes Kernel (context, lifecycle, identity), AI (inference), Capabilities (tool registry). Consumed by Flow (agent chaining), HoneyHub (agent execution surface).",
       "integration_depth": "deep",
-      "demo_path": "Register an agent \u2192 trigger execution \u2192 observe lifecycle stages \u2192 agent calls a tool via IToolInvoker \u2192 writes memory \u2192 completes.",
+      "demo_path": "Register an agent → trigger execution → observe lifecycle stages → agent calls a tool via IToolInvoker → writes memory → completes.",
       "signal_quote": "Autonomy with purpose.",
       "stability_tier": "planned",
       "impact_vector": "ai capability"
@@ -746,7 +663,7 @@
     "type": "node",
     "name": "HoneyDrunk.Memory",
     "public_name": "HoneyDrunk.Memory",
-    "short": "Agent memory \u2014 short-term & long-term",
+    "short": "Agent memory — short-term & long-term",
     "description": "Persistent and contextual memory system for agents. Short-term (conversation-scoped) and long-term (cross-execution) memory with scoped isolation, indexing, and summarization.",
     "sector": "AI",
     "signal": "Seed",
@@ -754,24 +671,17 @@
     "energy": 0,
     "priority": 80,
     "flow": 0,
-    "tags": [
-      "memory",
-      "agent-memory",
-      "short-term",
-      "long-term",
-      "scoping",
-      "summarization"
-    ],
+    "tags": ["memory", "agent-memory", "short-term", "long-term", "scoping", "summarization"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Memory"
     },
     "long_description": {
       "overview": "HoneyDrunk.Memory provides persistent and contextual memory for Grid agents. It manages short-term memory (conversation-scoped, cleared after execution) and long-term memory (persists across executions, scoped by tenant/project/agent). Memory storage, retrieval, search, and forgetting are all contract-driven with pluggable backends. Indexing and summarization compress memories for efficient retrieval at scale.",
-      "why_it_exists": "Agents without memory are stateless \u2014 every execution starts from scratch. Memory gives agents continuity, learning, and personalization across interactions.",
+      "why_it_exists": "Agents without memory are stateless — every execution starts from scratch. Memory gives agents continuity, learning, and personalization across interactions.",
       "primary_audience": "Agent developers who need agents to remember context across executions.",
       "value_props": [
         "Short-term and long-term memory with clear lifecycle semantics",
-        "Scoped isolation \u2014 TenantId/ProjectId/AgentId boundaries enforced at storage level",
+        "Scoped isolation — TenantId/ProjectId/AgentId boundaries enforced at storage level",
         "Pluggable backends (SQL Server, Cosmos DB, InMemory)",
         "Automatic summarization to compress old memories",
         "Similarity search via embeddings from HoneyDrunk.AI"
@@ -780,7 +690,7 @@
       "roadmap_focus": "Core contracts (IMemoryStore, IMemoryScope), InMemory provider, integration with Agents execution context.",
       "grid_relationship": "Consumes Kernel (context, scoping), Data (persistence patterns), AI (embeddings for similarity search). Consumed by Agents (memory read/write during execution).",
       "integration_depth": "medium",
-      "demo_path": "Agent writes a memory during execution \u2192 agent completes \u2192 new execution reads prior memories \u2192 observes scoped isolation.",
+      "demo_path": "Agent writes a memory during execution → agent completes → new execution reads prior memories → observes scoped isolation.",
       "signal_quote": "What was learned is never lost.",
       "stability_tier": "planned",
       "impact_vector": "ai capability"
@@ -805,15 +715,7 @@
     "energy": 0,
     "priority": 75,
     "flow": 0,
-    "tags": [
-      "knowledge",
-      "rag",
-      "embeddings",
-      "ingestion",
-      "retrieval",
-      "documents",
-      "search"
-    ],
+    "tags": ["knowledge", "rag", "embeddings", "ingestion", "retrieval", "documents", "search"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Knowledge"
     },
@@ -825,15 +727,15 @@
         "Document ingestion with pluggable parsers",
         "Chunking and embedding via HoneyDrunk.AI",
         "RAG retrieval pipelines with ranked, attributed results",
-        "Source attribution \u2014 every chunk traces to its origin",
-        "Knowledge versioning \u2014 sources update; retrieval reflects current state",
+        "Source attribution — every chunk traces to its origin",
+        "Knowledge versioning — sources update; retrieval reflects current state",
         "Pluggable backends (Azure AI Search, Postgres pgvector, InMemory)"
       ],
       "monetization_signal": "Internal-first. Knowledge infrastructure enables premium AI features.",
       "roadmap_focus": "Core contracts (IKnowledgeStore, IDocumentIngester, IRetrievalPipeline), InMemory provider, basic markdown ingestion.",
       "grid_relationship": "Consumes Kernel (context), AI (embeddings), Data (persistence patterns). Consumed by Agents (knowledge retrieval), Lore (knowledge compilation), HoneyHub (context for planning).",
       "integration_depth": "medium",
-      "demo_path": "Ingest a set of markdown files \u2192 query with a natural language question \u2192 receive ranked results with source attribution.",
+      "demo_path": "Ingest a set of markdown files → query with a natural language question → receive ranked results with source attribution.",
       "signal_quote": "Know what the world knows.",
       "stability_tier": "planned",
       "impact_vector": "ai capability"
@@ -858,14 +760,7 @@
     "energy": 0,
     "priority": 70,
     "flow": 0,
-    "tags": [
-      "workflow",
-      "orchestration",
-      "sagas",
-      "compensation",
-      "pipelines",
-      "long-running"
-    ],
+    "tags": ["workflow", "orchestration", "sagas", "compensation", "pipelines", "long-running"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Flow"
     },
@@ -877,7 +772,7 @@
         "Declarative workflow definitions with steps, transitions, and compensation",
         "Long-running process management with persistent state",
         "Retry strategies with configurable backoff",
-        "Agent chaining \u2014 output of one agent feeds the next",
+        "Agent chaining — output of one agent feeds the next",
         "Checkpoint and resume for human-in-the-loop approval via Operator",
         "Saga pattern with compensation for distributed rollback"
       ],
@@ -885,7 +780,7 @@
       "roadmap_focus": "Core contracts (IWorkflow, IWorkflowEngine, IWorkflowStep), simple sequential execution, state persistence via Data.",
       "grid_relationship": "Consumes Kernel (context, lifecycle), Agents (agent execution), Data (state persistence), Transport (async step coordination). Consumed by HoneyHub (workflow triggering).",
       "integration_depth": "deep",
-      "demo_path": "Define a two-step workflow \u2192 first step runs an agent \u2192 second step runs on agent output \u2192 observe state persistence and telemetry.",
+      "demo_path": "Define a two-step workflow → first step runs an agent → second step runs on agent output → observe state persistence and telemetry.",
       "signal_quote": "Complex work, simple steps.",
       "stability_tier": "planned",
       "impact_vector": "ai capability"
@@ -910,15 +805,7 @@
     "energy": 0,
     "priority": 65,
     "flow": 0,
-    "tags": [
-      "safety",
-      "oversight",
-      "circuit-breaker",
-      "cost-control",
-      "audit",
-      "approval",
-      "human-in-the-loop"
-    ],
+    "tags": ["safety", "oversight", "circuit-breaker", "cost-control", "audit", "approval", "human-in-the-loop"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Operator"
     },
@@ -927,18 +814,18 @@
       "why_it_exists": "The system that decides what to do must never be the system that decides whether it's allowed to do it. Operator provides independent, externally deployable safety controls that don't depend on agent runtime correctness.",
       "primary_audience": "Platform operators, security teams, and anyone responsible for AI safety and cost governance.",
       "value_props": [
-        "Approval gates \u2014 require human sign-off before high-risk actions proceed",
-        "Circuit breakers \u2014 kill switches for agents, inference, or entire workflows",
-        "Cost controls \u2014 budget limits per agent, per workflow, per time window",
-        "Safety filters \u2014 validate outputs before they leave the system",
+        "Approval gates — require human sign-off before high-risk actions proceed",
+        "Circuit breakers — kill switches for agents, inference, or entire workflows",
+        "Cost controls — budget limits per agent, per workflow, per time window",
+        "Safety filters — validate outputs before they leave the system",
         "Immutable audit trail of all AI decisions and human overrides",
-        "Decision policies \u2014 auto-approve, auto-deny, or require-human based on rules"
+        "Decision policies — auto-approve, auto-deny, or require-human based on rules"
       ],
       "monetization_signal": "Internal-first. Enterprise AI governance is a premium capability.",
       "roadmap_focus": "Core contracts (IApprovalGate, ICircuitBreaker, ICostGuard, IAuditLog), basic policy engine.",
       "grid_relationship": "Consumes Kernel (context, identity), Auth (authorization), Data (audit persistence), Pulse (operational telemetry). Consumed by Flow (approval gates), Agents (action constraints), HoneyHub (decision authority surface).",
       "integration_depth": "deep",
-      "demo_path": "Set a cost budget \u2192 agent exceeds it \u2192 Operator halts execution \u2192 observe audit trail entry.",
+      "demo_path": "Set a cost budget → agent exceeds it → Operator halts execution → observe audit trail entry.",
       "signal_quote": "Power checked. Trust earned.",
       "stability_tier": "planned",
       "impact_vector": "safety"
@@ -963,14 +850,7 @@
     "energy": 0,
     "priority": 55,
     "flow": 0,
-    "tags": [
-      "evaluation",
-      "regression",
-      "quality",
-      "scoring",
-      "model-comparison",
-      "prompts"
-    ],
+    "tags": ["evaluation", "regression", "quality", "scoring", "model-comparison", "prompts"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Evals"
     },
@@ -982,7 +862,7 @@
         "Run evaluation suites against any model/provider",
         "Structured scoring rubrics (factuality, relevance, safety, format)",
         "Regression detection across model upgrades and prompt changes",
-        "Model comparison \u2014 same eval set against multiple providers",
+        "Model comparison — same eval set against multiple providers",
         "Versioned evaluation datasets",
         "Pulse integration for quality signals and alerting"
       ],
@@ -990,7 +870,7 @@
       "roadmap_focus": "Core contracts (IEvaluator, IEvalDataset, IEvalScorer), basic model-as-judge scorer, Pulse signal emission.",
       "grid_relationship": "Consumes AI (inference for running evaluations), Pulse (emitting eval metrics). Consumed by HoneyHub (quality correlation to features).",
       "integration_depth": "medium",
-      "demo_path": "Define an eval dataset \u2192 run against two models \u2192 compare scores \u2192 observe Pulse signals for regression detection.",
+      "demo_path": "Define an eval dataset → run against two models → compare scores → observe Pulse signals for regression detection.",
       "signal_quote": "Trust, but verify.",
       "stability_tier": "planned",
       "impact_vector": "ai quality"
@@ -1015,14 +895,7 @@
     "energy": 0,
     "priority": 40,
     "flow": 0,
-    "tags": [
-      "simulation",
-      "risk",
-      "planning",
-      "dry-run",
-      "validation",
-      "scenarios"
-    ],
+    "tags": ["simulation", "risk", "planning", "dry-run", "validation", "scenarios"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Sim"
     },
@@ -1032,16 +905,16 @@
       "primary_audience": "Platform operators and workflow designers who need confidence before committing to real execution.",
       "value_props": [
         "Scenario modeling with projected outcomes",
-        "Plan evaluation \u2014 estimate results before executing",
-        "Risk analysis \u2014 failure modes, probabilities, mitigations",
-        "Pre-execution validation \u2014 dry-run against simulated state",
+        "Plan evaluation — estimate results before executing",
+        "Risk analysis — failure modes, probabilities, mitigations",
+        "Pre-execution validation — dry-run against simulated state",
         "Graduated implementation from rule-based to model-based"
       ],
       "monetization_signal": "Internal-first. Simulation is a premium enterprise safety feature.",
       "roadmap_focus": "Optional for initial AI sector delivery. Core contracts (ISimulator, IScenario, IRiskAssessment) when prioritized.",
       "grid_relationship": "Consumes AI (inference for simulation), Knowledge (context for scenarios), Agents (agent behavior models).",
       "integration_depth": "shallow",
-      "demo_path": "Define a scenario \u2192 run simulation \u2192 review projected outcomes and risk assessment \u2192 decide whether to proceed with real execution.",
+      "demo_path": "Define a scenario → run simulation → review projected outcomes and risk assessment → decide whether to proceed with real execution.",
       "signal_quote": "See before you leap.",
       "stability_tier": "planned",
       "impact_vector": "safety"
@@ -1066,35 +939,27 @@
     "energy": 0,
     "priority": 60,
     "flow": 0,
-    "tags": [
-      "knowledge-base",
-      "wiki",
-      "llm-compiled",
-      "obsidian",
-      "markdown",
-      "research",
-      "self-maintaining"
-    ],
+    "tags": ["knowledge-base", "wiki", "llm-compiled", "obsidian", "markdown", "research", "self-maintaining"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Lore is the Hive's living knowledge surface \u2014 an LLM-compiled wiki that continuously ingests raw sources (articles, papers, repos, datasets, images), compiles them into structured markdown with auto-maintained indexes, backlinks, concept articles, and summaries. It runs health checks to find inconsistencies, impute missing data, and suggest new article candidates. Queries return rendered markdown, slide shows, or visualizations, and outputs are filed back into the wiki to enhance it for further queries. The human rarely edits the wiki directly \u2014 it is the domain of the LLM.",
-      "why_it_exists": "Architecture holds governance decisions. Studios holds the public face. Lore holds the Hive's accumulated knowledge \u2014 everything the ecosystem has learned, researched, and compiled. A living knowledge base that grows smarter with every interaction.",
+      "overview": "HoneyDrunk.Lore is the Hive's living knowledge surface — an LLM-compiled wiki that continuously ingests raw sources (articles, papers, repos, datasets, images), compiles them into structured markdown with auto-maintained indexes, backlinks, concept articles, and summaries. It runs health checks to find inconsistencies, impute missing data, and suggest new article candidates. Queries return rendered markdown, slide shows, or visualizations, and outputs are filed back into the wiki to enhance it for further queries. The human rarely edits the wiki directly — it is the domain of the LLM.",
+      "why_it_exists": "Architecture holds governance decisions. Studios holds the public face. Lore holds the Hive's accumulated knowledge — everything the ecosystem has learned, researched, and compiled. A living knowledge base that grows smarter with every interaction.",
       "primary_audience": "HoneyDrunk Studios (internal research and knowledge), AI agents needing ecosystem context, and anyone querying the Hive's accumulated knowledge.",
       "value_props": [
         "Raw source ingestion into structured, browsable markdown wiki",
         "LLM-compiled with auto-maintained indexes, backlinks, and concept maps",
         "Q&A over accumulated knowledge with rendered outputs (markdown, slides, images)",
-        "Self-maintaining \u2014 health checks, consistency linting, gap detection",
+        "Self-maintaining — health checks, consistency linting, gap detection",
         "Outputs filed back into wiki for compound knowledge growth",
         "Viewable in Obsidian as a living, navigable knowledge surface"
       ],
       "monetization_signal": "Internal knowledge infrastructure. Product potential as a standalone knowledge base tool.",
-      "roadmap_focus": "Initial scaffolding \u2014 raw/ ingestion, LLM compilation pipeline, index maintenance, basic Q&A workflows.",
+      "roadmap_focus": "Initial scaffolding — raw/ ingestion, LLM compilation pipeline, index maintenance, basic Q&A workflows.",
       "grid_relationship": "Consumes Knowledge (ingestion infrastructure, retrieval), Agents (compilation and Q&A agents), AI (inference for compilation and queries), Flow (multi-step compilation workflows). Lives in Meta sector alongside Architecture and Studios.",
       "integration_depth": "medium",
-      "demo_path": "Ingest raw sources into raw/ \u2192 LLM compiles into wiki/ \u2192 browse in Obsidian \u2192 ask a complex question \u2192 receive rendered answer filed back into wiki.",
+      "demo_path": "Ingest raw sources into raw/ → LLM compiles into wiki/ → browse in Obsidian → ask a complex question → receive rendered answer filed back into wiki.",
       "signal_quote": "The Hive remembers everything.",
       "stability_tier": "planned",
       "impact_vector": "knowledge"

--- a/catalogs/nodes.json
+++ b/catalogs/nodes.json
@@ -12,16 +12,25 @@
     "energy": 1,
     "priority": 100,
     "flow": 45,
-    "tags": ["infrastructure", "primitives", "context", "lifecycle", "telemetry", "identity", "health", "configuration"],
+    "tags": [
+      "infrastructure",
+      "primitives",
+      "context",
+      "lifecycle",
+      "telemetry",
+      "identity",
+      "health",
+      "configuration"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Kernel"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Kernel is the semantic OS layer of HoneyDrunk.OS, the Hive. It is the foundational runtime that nodes, agents and services use to communicate, coordinate and observe themselves across the Grid. Core responsibilities: Context propagation—a three tier model (GridContext, NodeContext, OperationContext) that flows across async boundaries and transports. Lifecycle orchestration—startup hooks, lifecycle stages, health and readiness aggregation, graceful shutdown. Configuration and identity primitives—strongly typed IDs at configuration time, string based identities at runtime, options for Grid and Node bootstrap. Telemetry integration—OpenTelemetry ready activity factory, trace enrichment and log correlation wired to Grid context. Health and readiness—health checks and lifecycle contributors for Kubernetes style /health and /ready endpoints. Agent interop—agent execution contexts, scoped context visibility and serializers that let higher level agent runtimes safely embed LLMs into the Grid. Kernel is the part of the Grid that defines what it means to be a node.",
+      "overview": "HoneyDrunk.Kernel is the semantic OS layer of HoneyDrunk.OS, the Hive. It is the foundational runtime that nodes, agents and services use to communicate, coordinate and observe themselves across the Grid. Core responsibilities: Context propagation\u2014a three tier model (GridContext, NodeContext, OperationContext) that flows across async boundaries and transports. Lifecycle orchestration\u2014startup hooks, lifecycle stages, health and readiness aggregation, graceful shutdown. Configuration and identity primitives\u2014strongly typed IDs at configuration time, string based identities at runtime, options for Grid and Node bootstrap. Telemetry integration\u2014OpenTelemetry ready activity factory, trace enrichment and log correlation wired to Grid context. Health and readiness\u2014health checks and lifecycle contributors for Kubernetes style /health and /ready endpoints. Agent interop\u2014agent execution contexts, scoped context visibility and serializers that let higher level agent runtimes safely embed LLMs into the Grid. Kernel is the part of the Grid that defines what it means to be a node.",
       "why_it_exists": "To give every node the same runtime skeleton for identity, context, lifecycle and observability so those concerns are not reinvented in each service.",
       "primary_audience": "Node developers and service owners building Grid aware services. Agent runtimes and automation that need to execute with a proper Grid context.",
       "value_props": [
-        "Three tier context model—Grid to Node to Operation—with correlation and causation tracking",
+        "Three tier context model\u2014Grid to Node to Operation\u2014with correlation and causation tracking",
         "Lifecycle orchestration with startup hooks, lifecycle stages and contributor based health and readiness",
         "OpenTelemetry ready tracing, enrichment and log scopes",
         "Strongly typed identity at configuration time, string identity at runtime for performance",
@@ -32,7 +41,7 @@
       "roadmap_focus": "v0.4 is a stabilization release. Enforce the three-ID context model across all creation paths. Consolidate hosting around AddHoneyDrunkNode as the canonical API. Align lifecycle, health and readiness behavior with docs. Lock identity registries as the DNS of the Grid.",
       "grid_relationship": "Foundation for all Core nodes. Every node depends on Kernel or Kernel.Abstractions.",
       "integration_depth": "deep",
-      "demo_path": "Minimal Node setup with AddHoneyDrunkGrid and AddHoneyDrunkNode → context flow across async calls → health probe validation → graceful shutdown with lifecycle hooks.",
+      "demo_path": "Minimal Node setup with AddHoneyDrunkGrid and AddHoneyDrunkNode \u2192 context flow across async calls \u2192 health probe validation \u2192 graceful shutdown with lifecycle hooks.",
       "signal_quote": "Where everything begins.",
       "stability_tier": "critical",
       "impact_vector": "developer velocity"
@@ -57,7 +66,15 @@
     "energy": 1,
     "priority": 100,
     "flow": 45,
-    "tags": ["messaging", "outbox", "pipeline", "middleware", "transport-agnostic", "retry", "grid-context"],
+    "tags": [
+      "messaging",
+      "outbox",
+      "pipeline",
+      "middleware",
+      "transport-agnostic",
+      "retry",
+      "grid-context"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport"
     },
@@ -102,13 +119,25 @@
     "energy": 1,
     "priority": 100,
     "flow": 45,
-    "tags": ["vault", "secrets", "configuration", "provider", "cache", "resilience", "circuit-breaker", "retry", "lifecycle", "health", "distributed-tracing"],
+    "tags": [
+      "vault",
+      "secrets",
+      "configuration",
+      "provider",
+      "cache",
+      "resilience",
+      "circuit-breaker",
+      "retry",
+      "lifecycle",
+      "health",
+      "distributed-tracing"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Vault is the core secrets and configuration management library for HoneyDrunk.OS. This package provides the abstractions (ISecretStore, IConfigProvider, IVaultClient, ISecretProvider, IConfigSource), caching with TTL and sliding expiration, resilience policies (retry, circuit breaker), Kernel lifecycle integration, and distributed telemetry that all Vault providers plug into. Vault itself contains no provider implementations—it defines the contract, runtime behavior, and orchestration. Providers (File, Azure Key Vault, AWS, InMemory, Configuration) supply the actual secrets while Vault handles resilience, caching, and tracing.",
-      "why_it_exists": "A unified, Kernel-aware interface for secrets and configuration—no matter where those values live. Prevents inconsistent secret handling and reinvention across the Grid.",
+      "overview": "HoneyDrunk.Vault is the core secrets and configuration management library for HoneyDrunk.OS. This package provides the abstractions (ISecretStore, IConfigProvider, IVaultClient, ISecretProvider, IConfigSource), caching with TTL and sliding expiration, resilience policies (retry, circuit breaker), Kernel lifecycle integration, and distributed telemetry that all Vault providers plug into. Vault itself contains no provider implementations\u2014it defines the contract, runtime behavior, and orchestration. Providers (File, Azure Key Vault, AWS, InMemory, Configuration) supply the actual secrets while Vault handles resilience, caching, and tracing.",
+      "why_it_exists": "A unified, Kernel-aware interface for secrets and configuration\u2014no matter where those values live. Prevents inconsistent secret handling and reinvention across the Grid.",
       "primary_audience": "HoneyDrunk service developers and node owners who need secure, traceable access to secrets and configuration.",
       "value_props": [
         "Defines ISecretStore, IConfigProvider, IVaultClient for unified secret/config access",
@@ -123,7 +152,7 @@
       "roadmap_focus": "Pulse integration for anomaly detection, secrets-as-code manifests, autonomous credential rotation.",
       "grid_relationship": "Connects with: honeydrunk-kernel, honeydrunk-auth, honeysentinel, breachlab-exe.",
       "integration_depth": "deep",
-      "demo_path": "Register Vault with AddVault() → retrieve a secret via ISecretStore → observe caching, resilience, and telemetry.",
+      "demo_path": "Register Vault with AddVault() \u2192 retrieve a secret via ISecretStore \u2192 observe caching, resilience, and telemetry.",
       "signal_quote": "Trust, by design.",
       "stability_tier": "stable",
       "impact_vector": "security posture"
@@ -134,6 +163,27 @@
     "time_pressure": 2,
     "done": true,
     "cooldown_days": 14
+  },
+  {
+    "id": "honeydrunk-vault-rotation",
+    "type": "node",
+    "name": "HoneyDrunk.Vault.Rotation",
+    "public_name": "HoneyDrunk.Vault.Rotation",
+    "short": "Tier-2 third-party secret rotation Function",
+    "description": "Azure Function App that rotates third-party provider secrets (Resend, Twilio, OpenAI, ...) into per-Node Key Vaults on schedule. Sibling to HoneyDrunk.Vault; separate deployable.",
+    "sector": "Core",
+    "signal": "Seed",
+    "cluster": "foundation",
+    "tags": [
+      "infrastructure",
+      "rotation",
+      "secrets",
+      "functions",
+      "azure"
+    ],
+    "links": {
+      "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault.Rotation"
+    }
   },
   {
     "id": "honeydrunk-auth",
@@ -148,12 +198,19 @@
     "energy": 0,
     "priority": 43,
     "flow": 28,
-    "tags": ["auth", "security", "jwt", "policy", "identity", "vault"],
+    "tags": [
+      "auth",
+      "security",
+      "jwt",
+      "policy",
+      "identity",
+      "vault"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Auth"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Auth is a Grid node component—not a standalone library—that standardizes authentication and authorization decisions across nodes and entrypoints. It requires Kernel as its host runtime and provides JWT bearer token validation with Vault-backed signing keys, deterministic policy evaluation, and fail-fast startup validation. Auth ensures consistent identity checks and authorization patterns so every request entering the Grid follows the same security discipline.",
+      "overview": "HoneyDrunk.Auth is a Grid node component\u2014not a standalone library\u2014that standardizes authentication and authorization decisions across nodes and entrypoints. It requires Kernel as its host runtime and provides JWT bearer token validation with Vault-backed signing keys, deterministic policy evaluation, and fail-fast startup validation. Auth ensures consistent identity checks and authorization patterns so every request entering the Grid follows the same security discipline.",
       "why_it_exists": "Prevents inconsistent authentication and authorization patterns across nodes, ensuring security discipline is uniform regardless of entrypoint.",
       "primary_audience": "Service owners building HTTP APIs, gateways, and any Grid node requiring request authentication.",
       "value_props": [
@@ -192,7 +249,13 @@
     "energy": 29,
     "priority": 38,
     "flow": 35,
-    "tags": ["rest", "api", "middleware", "conventions", "web"],
+    "tags": [
+      "rest",
+      "api",
+      "middleware",
+      "conventions",
+      "web"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest"
     },
@@ -211,7 +274,7 @@
       "roadmap_focus": "OpenAPI enrichment, typed client generation, WebSocket conventions.",
       "grid_relationship": "Consumes Kernel.Abstractions (IOperationContextAccessor for correlation), Auth.AspNetCore (auth shaping), Transport.Abstractions (envelope mapping only).",
       "integration_depth": "medium",
-      "demo_path": "Call AddRest() → UseRest() → all responses automatically include correlation IDs and structured errors.",
+      "demo_path": "Call AddRest() \u2192 UseRest() \u2192 all responses automatically include correlation IDs and structured errors.",
       "signal_quote": "Speak cleanly to be understood.",
       "stability_tier": "beta",
       "impact_vector": "developer velocity"
@@ -236,7 +299,17 @@
     "energy": 0,
     "priority": 36,
     "flow": 23,
-    "tags": ["database", "persistence", "migrations", "multi-tenant", "entityframework", "sqlserver", "outbox", "contracts", "testing"],
+    "tags": [
+      "database",
+      "persistence",
+      "migrations",
+      "multi-tenant",
+      "entityframework",
+      "sqlserver",
+      "outbox",
+      "contracts",
+      "testing"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Data"
     },
@@ -254,7 +327,7 @@
       "roadmap_focus": "Advance HoneyDrunk.Data capabilities and harden contracts.",
       "grid_relationship": "Consumes Kernel (required) for GridContext, OperationContext, lifecycle hooks, and telemetry primitives. Consumes Transport (via Outbox.Dispatcher) for message publishing.",
       "integration_depth": "medium",
-      "demo_path": "Register Data with AddHoneyDrunkData() → use repositories with tenant isolation → verify outbox delivery.",
+      "demo_path": "Register Data with AddHoneyDrunkData() \u2192 use repositories with tenant isolation \u2192 verify outbox delivery.",
       "signal_quote": "Memory with meaning.",
       "stability_tier": "stable",
       "impact_vector": "developer velocity"
@@ -279,12 +352,17 @@
     "energy": 41,
     "priority": 100,
     "flow": 100,
-    "tags": ["observability", "monitoring", "telemetry", "security"],
+    "tags": [
+      "observability",
+      "monitoring",
+      "telemetry",
+      "security"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Pulse"
     },
     "long_description": {
-      "overview": "Pulse is how the Hive feels itself. It's the nervous system that collects, correlates, and interprets telemetry from every corner of the Grid — logs, traces, metrics, and signals that together form a living heartbeat. Every Node reports its state into Pulse's unified pipeline, creating a continuously updated map of operational health and system interdependence.",
+      "overview": "Pulse is how the Hive feels itself. It's the nervous system that collects, correlates, and interprets telemetry from every corner of the Grid \u2014 logs, traces, metrics, and signals that together form a living heartbeat. Every Node reports its state into Pulse's unified pipeline, creating a continuously updated map of operational health and system interdependence.",
       "why_it_exists": "In distributed systems, invisibility is the enemy. Pulse exists to prevent blindness.",
       "primary_audience": "HoneyDrunk maintainers, contributors, and service owners.",
       "value_props": [
@@ -296,7 +374,7 @@
       "roadmap_focus": "Advance Pulse capabilities and harden contracts.",
       "grid_relationship": "Connects with: honeydrunk-vault, honeydrunk-transport, honeydrunk-data.",
       "integration_depth": "medium",
-      "demo_path": "Configure Pulse sinks → emit telemetry from a Node → observe logs, traces, and metrics in unified dashboard.",
+      "demo_path": "Configure Pulse sinks \u2192 emit telemetry from a Node \u2192 observe logs, traces, and metrics in unified dashboard.",
       "signal_quote": "The Hive has a heartbeat.",
       "stability_tier": "beta",
       "impact_vector": "security posture"
@@ -321,12 +399,18 @@
     "energy": 0,
     "priority": 29,
     "flow": 29,
-    "tags": ["notifications", "email", "sms", "templates", "queues"],
+    "tags": [
+      "notifications",
+      "email",
+      "sms",
+      "templates",
+      "queues"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Notify"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Notify is the Grid's outbound notification layer — a channel-agnostic system for dispatching messages across email, SMS, and future channels. It provides a unified contract surface (INotificationSender, INotificationGateway, INotificationPolicy) with pluggable providers: SMTP and Resend for email, Twilio for SMS. Template rendering, idempotency keys, delivery tracking, and queue-based async dispatch ensure reliable, auditable delivery.",
+      "overview": "HoneyDrunk.Notify is the Grid's outbound notification layer \u2014 a channel-agnostic system for dispatching messages across email, SMS, and future channels. It provides a unified contract surface (INotificationSender, INotificationGateway, INotificationPolicy) with pluggable providers: SMTP and Resend for email, Twilio for SMS. Template rendering, idempotency keys, delivery tracking, and queue-based async dispatch ensure reliable, auditable delivery.",
       "why_it_exists": "Without unified notification infrastructure, outbound communication drifts in reliability, security, and delivery patterns across nodes.",
       "primary_audience": "Service developers and node owners needing reliable, multi-channel outbound notifications with consistent delivery semantics.",
       "value_props": [
@@ -341,7 +425,7 @@
       "roadmap_focus": "Push notification channel, webhook dispatch, adaptive send policies based on Pulse metrics.",
       "grid_relationship": "Consumes Kernel for Grid context, lifecycle hooks, and telemetry. Provider credentials are injected at deploy time via Azure Key Vault (not the HoneyDrunk.Vault package).",
       "integration_depth": "medium",
-      "demo_path": "Send a notification via INotificationSender → provider dispatches email/SMS → track delivery status.",
+      "demo_path": "Send a notification via INotificationSender \u2192 provider dispatches email/SMS \u2192 track delivery status.",
       "signal_quote": "When the Hive speaks, it's heard everywhere.",
       "stability_tier": "beta",
       "impact_vector": "communication reliability"
@@ -366,7 +450,11 @@
     "energy": 0,
     "priority": 36,
     "flow": 23,
-    "tags": ["github", "actions", "ci-cd"],
+    "tags": [
+      "github",
+      "actions",
+      "ci-cd"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions"
     },
@@ -383,7 +471,7 @@
       "roadmap_focus": "Advance HoneyDrunk.Actions capabilities and harden contracts.",
       "grid_relationship": "Connects with: honeydrunk-build.",
       "integration_depth": "medium",
-      "demo_path": "Reference a reusable workflow → observe build, test, pack, publish steps → verify artifacts.",
+      "demo_path": "Reference a reusable workflow \u2192 observe build, test, pack, publish steps \u2192 verify artifacts.",
       "signal_quote": "Automation with personality.",
       "stability_tier": "stable",
       "impact_vector": "developer velocity"
@@ -401,19 +489,26 @@
     "name": "HoneyDrunk.Architecture",
     "public_name": "HoneyDrunk.Architecture",
     "short": "Grid command center & agent hub",
-    "description": "Canonical architecture knowledge base — ADRs, catalogs, routing rules, issue templates, and agent workflows that govern how the Grid evolves.",
+    "description": "Canonical architecture knowledge base \u2014 ADRs, catalogs, routing rules, issue templates, and agent workflows that govern how the Grid evolves.",
     "sector": "Meta",
     "signal": "Live",
     "cluster": "governance",
     "energy": 50,
     "priority": 80,
     "flow": 60,
-    "tags": ["architecture", "adrs", "governance", "agents", "catalogs", "routing"],
+    "tags": [
+      "architecture",
+      "adrs",
+      "governance",
+      "agents",
+      "catalogs",
+      "routing"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Architecture is the command center of the Grid. It holds the canonical catalogs (nodes, modules, services, relationships), constitution (manifesto, invariants, sector taxonomy), architecture decision records, routing rules for agent workflows, and issue/sync packet generation. No code, no packages — pure knowledge infrastructure that agents and humans use to understand and evolve the Hive.",
+      "overview": "HoneyDrunk.Architecture is the command center of the Grid. It holds the canonical catalogs (nodes, modules, services, relationships), constitution (manifesto, invariants, sector taxonomy), architecture decision records, routing rules for agent workflows, and issue/sync packet generation. No code, no packages \u2014 pure knowledge infrastructure that agents and humans use to understand and evolve the Hive.",
       "why_it_exists": "Without a single source of architectural truth, decisions scatter across repos, agents lack context, and the Grid drifts.",
       "primary_audience": "Architecture agents, Copilot workflows, and HoneyDrunk maintainers making cross-cutting decisions.",
       "value_props": [
@@ -427,7 +522,7 @@
       "roadmap_focus": "Converge with website data. Expand agent workflows. Add initiative tracking and roadmap generation.",
       "grid_relationship": "Referenced by all agents and copilot instructions. No runtime dependencies.",
       "integration_depth": "shallow",
-      "demo_path": "Ask the ADR Composer agent a trade-off question → observe context loading from catalogs → review the generated ADR.",
+      "demo_path": "Ask the ADR Composer agent a trade-off question \u2192 observe context loading from catalogs \u2192 review the generated ADR.",
       "signal_quote": "Know the map. Tend the garden.",
       "stability_tier": "stable",
       "impact_vector": "architectural clarity"
@@ -445,19 +540,26 @@
     "name": "HoneyDrunk.Studios",
     "public_name": "HoneyDrunk.Studios",
     "short": "Public website & Grid visualizer",
-    "description": "The live front-end of The Hive — renders all Nodes, Sectors, and signals with neon-lit visualization. Next.js 16, React 19, Three.js WebGL.",
+    "description": "The live front-end of The Hive \u2014 renders all Nodes, Sectors, and signals with neon-lit visualization. Next.js 16, React 19, Three.js WebGL.",
     "sector": "Meta",
     "signal": "Live",
     "cluster": "visualization",
     "energy": 40,
     "priority": 70,
     "flow": 55,
-    "tags": ["website", "nextjs", "react", "threejs", "visualization", "public"],
+    "tags": [
+      "website",
+      "nextjs",
+      "react",
+      "threejs",
+      "visualization",
+      "public"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Studios"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Studios is the public face of the Hive — a Next.js 16 application that renders the Grid as an interactive, neon-lit visualization. It displays every Node, Sector, signal timeline entry, and relationship using static JSON data imported directly (no CMS, no database). The flagship /grid route renders an interactive Three.js WebGL scene. The site serves as both a developer portal and a build-in-public showcase.",
+      "overview": "HoneyDrunk.Studios is the public face of the Hive \u2014 a Next.js 16 application that renders the Grid as an interactive, neon-lit visualization. It displays every Node, Sector, signal timeline entry, and relationship using static JSON data imported directly (no CMS, no database). The flagship /grid route renders an interactive Three.js WebGL scene. The site serves as both a developer portal and a build-in-public showcase.",
       "why_it_exists": "To make the state of The Grid observable to contributors and the community. Transparency as a feature.",
       "primary_audience": "Developers, contributors, and anyone tracking HoneyDrunk's build-in-public roadmap.",
       "value_props": [
@@ -471,7 +573,7 @@
       "roadmap_focus": "Converge data with Architecture repo. Add live status indicators. Expand module and service detail pages.",
       "grid_relationship": "Consumes Architecture catalogs as source of truth for data/schema files. No runtime Node dependencies.",
       "integration_depth": "shallow",
-      "demo_path": "Visit honeydrunkstudios.com → explore /grid WebGL → browse /nodes → check /signal timeline.",
+      "demo_path": "Visit honeydrunkstudios.com \u2192 explore /grid WebGL \u2192 browse /nodes \u2192 check /signal timeline.",
       "signal_quote": "See the Hive breathe.",
       "stability_tier": "stable",
       "impact_vector": "community engagement"
@@ -496,7 +598,16 @@
     "energy": 0,
     "priority": 90,
     "flow": 0,
-    "tags": ["inference", "llm", "embeddings", "providers", "openai", "anthropic", "azure-openai", "telemetry"],
+    "tags": [
+      "inference",
+      "llm",
+      "embeddings",
+      "providers",
+      "openai",
+      "anthropic",
+      "azure-openai",
+      "telemetry"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.AI"
     },
@@ -515,7 +626,7 @@
       "roadmap_focus": "Initial scaffolding with OpenAI and Anthropic providers. Align with Microsoft.Extensions.AI adoption.",
       "grid_relationship": "Consumes Kernel (context, telemetry), Vault (API keys), Pulse (inference telemetry). Consumed by Agents, Memory, Knowledge, Evals, Sim.",
       "integration_depth": "deep",
-      "demo_path": "Register AI with AddHoneyDrunkAI() → configure an OpenAI provider → run a chat completion → observe Pulse telemetry with token counts and latency.",
+      "demo_path": "Register AI with AddHoneyDrunkAI() \u2192 configure an OpenAI provider \u2192 run a chat completion \u2192 observe Pulse telemetry with token counts and latency.",
       "signal_quote": "Think clearly, speak in any voice.",
       "stability_tier": "planned",
       "impact_vector": "ai capability"
@@ -540,26 +651,33 @@
     "energy": 0,
     "priority": 85,
     "flow": 0,
-    "tags": ["tools", "registry", "permissions", "discovery", "agent-tools", "versioning"],
+    "tags": [
+      "tools",
+      "registry",
+      "permissions",
+      "discovery",
+      "agent-tools",
+      "versioning"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Capabilities"
     },
     "long_description": {
       "overview": "HoneyDrunk.Capabilities is the tool registry and dispatch layer for the Grid's agents. It defines what tools exist, what parameters they accept, what they return, and who is authorized to invoke them. Tool implementations live in the Node that owns the domain (e.g., a 'query database' tool is implemented by Data). Capabilities owns discovery, schema versioning, permission checks, and execution routing.",
-      "why_it_exists": "Without a centralized tool registry, agent-tool bindings couple agent code to tool implementations. Capabilities decouples them — agents discover tools at runtime, and tool updates don't require agent redeployment.",
+      "why_it_exists": "Without a centralized tool registry, agent-tool bindings couple agent code to tool implementations. Capabilities decouples them \u2014 agents discover tools at runtime, and tool updates don't require agent redeployment.",
       "primary_audience": "Agent developers and Node owners who expose domain operations as agent-callable tools.",
       "value_props": [
         "Centralized tool registry with schema definitions",
-        "Runtime discovery — agents query available tools dynamically",
-        "Permission guards — which agents can invoke which tools",
-        "Schema versioning — tool contracts evolve without breaking consumers",
-        "Execution dispatch — route invocations to implementing Nodes"
+        "Runtime discovery \u2014 agents query available tools dynamically",
+        "Permission guards \u2014 which agents can invoke which tools",
+        "Schema versioning \u2014 tool contracts evolve without breaking consumers",
+        "Execution dispatch \u2014 route invocations to implementing Nodes"
       ],
       "monetization_signal": "Internal-first. Tool ecosystem becomes a platform capability.",
       "roadmap_focus": "Core registry contracts, permission model, initial tool descriptors for Data and Vault operations.",
       "grid_relationship": "Consumes Kernel (context, identity), Auth (authorization policies). Consumed by Agents (tool invocation).",
       "integration_depth": "medium",
-      "demo_path": "Register a tool descriptor → agent discovers it via ICapabilityRegistry → invoke with permission check → observe dispatch to implementing Node.",
+      "demo_path": "Register a tool descriptor \u2192 agent discovers it via ICapabilityRegistry \u2192 invoke with permission check \u2192 observe dispatch to implementing Node.",
       "signal_quote": "Reach for the right tool, every time.",
       "stability_tier": "planned",
       "impact_vector": "ai capability"
@@ -584,13 +702,20 @@
     "energy": 0,
     "priority": 95,
     "flow": 0,
-    "tags": ["agents", "lifecycle", "runtime", "execution-context", "identity", "orchestration"],
+    "tags": [
+      "agents",
+      "lifecycle",
+      "runtime",
+      "execution-context",
+      "identity",
+      "orchestration"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Agents"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Agents is the agent runtime for the Grid. It manages the full agent lifecycle (register → initialize → execute → complete → decommission), provides scoped execution contexts carrying GridContext, agent identity, memory references, and capability bindings. Agents defines the contracts for how agents invoke tools and access memory, with orchestration hooks for the Flow Node to coordinate multi-agent sequences.",
-      "why_it_exists": "Agents need a consistent runtime skeleton — just as Kernel gives every Node context propagation and lifecycle hooks, Agents gives every AI agent identity, execution context, and tool/memory access patterns.",
+      "overview": "HoneyDrunk.Agents is the agent runtime for the Grid. It manages the full agent lifecycle (register \u2192 initialize \u2192 execute \u2192 complete \u2192 decommission), provides scoped execution contexts carrying GridContext, agent identity, memory references, and capability bindings. Agents defines the contracts for how agents invoke tools and access memory, with orchestration hooks for the Flow Node to coordinate multi-agent sequences.",
+      "why_it_exists": "Agents need a consistent runtime skeleton \u2014 just as Kernel gives every Node context propagation and lifecycle hooks, Agents gives every AI agent identity, execution context, and tool/memory access patterns.",
       "primary_audience": "AI workflow developers building agents that operate within the Grid.",
       "value_props": [
         "Full agent lifecycle management with defined state transitions",
@@ -604,7 +729,7 @@
       "roadmap_focus": "Core lifecycle contracts, execution context, tool invoker integration with Capabilities.",
       "grid_relationship": "Consumes Kernel (context, lifecycle, identity), AI (inference), Capabilities (tool registry). Consumed by Flow (agent chaining), HoneyHub (agent execution surface).",
       "integration_depth": "deep",
-      "demo_path": "Register an agent → trigger execution → observe lifecycle stages → agent calls a tool via IToolInvoker → writes memory → completes.",
+      "demo_path": "Register an agent \u2192 trigger execution \u2192 observe lifecycle stages \u2192 agent calls a tool via IToolInvoker \u2192 writes memory \u2192 completes.",
       "signal_quote": "Autonomy with purpose.",
       "stability_tier": "planned",
       "impact_vector": "ai capability"
@@ -621,7 +746,7 @@
     "type": "node",
     "name": "HoneyDrunk.Memory",
     "public_name": "HoneyDrunk.Memory",
-    "short": "Agent memory — short-term & long-term",
+    "short": "Agent memory \u2014 short-term & long-term",
     "description": "Persistent and contextual memory system for agents. Short-term (conversation-scoped) and long-term (cross-execution) memory with scoped isolation, indexing, and summarization.",
     "sector": "AI",
     "signal": "Seed",
@@ -629,17 +754,24 @@
     "energy": 0,
     "priority": 80,
     "flow": 0,
-    "tags": ["memory", "agent-memory", "short-term", "long-term", "scoping", "summarization"],
+    "tags": [
+      "memory",
+      "agent-memory",
+      "short-term",
+      "long-term",
+      "scoping",
+      "summarization"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Memory"
     },
     "long_description": {
       "overview": "HoneyDrunk.Memory provides persistent and contextual memory for Grid agents. It manages short-term memory (conversation-scoped, cleared after execution) and long-term memory (persists across executions, scoped by tenant/project/agent). Memory storage, retrieval, search, and forgetting are all contract-driven with pluggable backends. Indexing and summarization compress memories for efficient retrieval at scale.",
-      "why_it_exists": "Agents without memory are stateless — every execution starts from scratch. Memory gives agents continuity, learning, and personalization across interactions.",
+      "why_it_exists": "Agents without memory are stateless \u2014 every execution starts from scratch. Memory gives agents continuity, learning, and personalization across interactions.",
       "primary_audience": "Agent developers who need agents to remember context across executions.",
       "value_props": [
         "Short-term and long-term memory with clear lifecycle semantics",
-        "Scoped isolation — TenantId/ProjectId/AgentId boundaries enforced at storage level",
+        "Scoped isolation \u2014 TenantId/ProjectId/AgentId boundaries enforced at storage level",
         "Pluggable backends (SQL Server, Cosmos DB, InMemory)",
         "Automatic summarization to compress old memories",
         "Similarity search via embeddings from HoneyDrunk.AI"
@@ -648,7 +780,7 @@
       "roadmap_focus": "Core contracts (IMemoryStore, IMemoryScope), InMemory provider, integration with Agents execution context.",
       "grid_relationship": "Consumes Kernel (context, scoping), Data (persistence patterns), AI (embeddings for similarity search). Consumed by Agents (memory read/write during execution).",
       "integration_depth": "medium",
-      "demo_path": "Agent writes a memory during execution → agent completes → new execution reads prior memories → observes scoped isolation.",
+      "demo_path": "Agent writes a memory during execution \u2192 agent completes \u2192 new execution reads prior memories \u2192 observes scoped isolation.",
       "signal_quote": "What was learned is never lost.",
       "stability_tier": "planned",
       "impact_vector": "ai capability"
@@ -673,7 +805,15 @@
     "energy": 0,
     "priority": 75,
     "flow": 0,
-    "tags": ["knowledge", "rag", "embeddings", "ingestion", "retrieval", "documents", "search"],
+    "tags": [
+      "knowledge",
+      "rag",
+      "embeddings",
+      "ingestion",
+      "retrieval",
+      "documents",
+      "search"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Knowledge"
     },
@@ -685,15 +825,15 @@
         "Document ingestion with pluggable parsers",
         "Chunking and embedding via HoneyDrunk.AI",
         "RAG retrieval pipelines with ranked, attributed results",
-        "Source attribution — every chunk traces to its origin",
-        "Knowledge versioning — sources update; retrieval reflects current state",
+        "Source attribution \u2014 every chunk traces to its origin",
+        "Knowledge versioning \u2014 sources update; retrieval reflects current state",
         "Pluggable backends (Azure AI Search, Postgres pgvector, InMemory)"
       ],
       "monetization_signal": "Internal-first. Knowledge infrastructure enables premium AI features.",
       "roadmap_focus": "Core contracts (IKnowledgeStore, IDocumentIngester, IRetrievalPipeline), InMemory provider, basic markdown ingestion.",
       "grid_relationship": "Consumes Kernel (context), AI (embeddings), Data (persistence patterns). Consumed by Agents (knowledge retrieval), Lore (knowledge compilation), HoneyHub (context for planning).",
       "integration_depth": "medium",
-      "demo_path": "Ingest a set of markdown files → query with a natural language question → receive ranked results with source attribution.",
+      "demo_path": "Ingest a set of markdown files \u2192 query with a natural language question \u2192 receive ranked results with source attribution.",
       "signal_quote": "Know what the world knows.",
       "stability_tier": "planned",
       "impact_vector": "ai capability"
@@ -718,7 +858,14 @@
     "energy": 0,
     "priority": 70,
     "flow": 0,
-    "tags": ["workflow", "orchestration", "sagas", "compensation", "pipelines", "long-running"],
+    "tags": [
+      "workflow",
+      "orchestration",
+      "sagas",
+      "compensation",
+      "pipelines",
+      "long-running"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Flow"
     },
@@ -730,7 +877,7 @@
         "Declarative workflow definitions with steps, transitions, and compensation",
         "Long-running process management with persistent state",
         "Retry strategies with configurable backoff",
-        "Agent chaining — output of one agent feeds the next",
+        "Agent chaining \u2014 output of one agent feeds the next",
         "Checkpoint and resume for human-in-the-loop approval via Operator",
         "Saga pattern with compensation for distributed rollback"
       ],
@@ -738,7 +885,7 @@
       "roadmap_focus": "Core contracts (IWorkflow, IWorkflowEngine, IWorkflowStep), simple sequential execution, state persistence via Data.",
       "grid_relationship": "Consumes Kernel (context, lifecycle), Agents (agent execution), Data (state persistence), Transport (async step coordination). Consumed by HoneyHub (workflow triggering).",
       "integration_depth": "deep",
-      "demo_path": "Define a two-step workflow → first step runs an agent → second step runs on agent output → observe state persistence and telemetry.",
+      "demo_path": "Define a two-step workflow \u2192 first step runs an agent \u2192 second step runs on agent output \u2192 observe state persistence and telemetry.",
       "signal_quote": "Complex work, simple steps.",
       "stability_tier": "planned",
       "impact_vector": "ai capability"
@@ -763,7 +910,15 @@
     "energy": 0,
     "priority": 65,
     "flow": 0,
-    "tags": ["safety", "oversight", "circuit-breaker", "cost-control", "audit", "approval", "human-in-the-loop"],
+    "tags": [
+      "safety",
+      "oversight",
+      "circuit-breaker",
+      "cost-control",
+      "audit",
+      "approval",
+      "human-in-the-loop"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Operator"
     },
@@ -772,18 +927,18 @@
       "why_it_exists": "The system that decides what to do must never be the system that decides whether it's allowed to do it. Operator provides independent, externally deployable safety controls that don't depend on agent runtime correctness.",
       "primary_audience": "Platform operators, security teams, and anyone responsible for AI safety and cost governance.",
       "value_props": [
-        "Approval gates — require human sign-off before high-risk actions proceed",
-        "Circuit breakers — kill switches for agents, inference, or entire workflows",
-        "Cost controls — budget limits per agent, per workflow, per time window",
-        "Safety filters — validate outputs before they leave the system",
+        "Approval gates \u2014 require human sign-off before high-risk actions proceed",
+        "Circuit breakers \u2014 kill switches for agents, inference, or entire workflows",
+        "Cost controls \u2014 budget limits per agent, per workflow, per time window",
+        "Safety filters \u2014 validate outputs before they leave the system",
         "Immutable audit trail of all AI decisions and human overrides",
-        "Decision policies — auto-approve, auto-deny, or require-human based on rules"
+        "Decision policies \u2014 auto-approve, auto-deny, or require-human based on rules"
       ],
       "monetization_signal": "Internal-first. Enterprise AI governance is a premium capability.",
       "roadmap_focus": "Core contracts (IApprovalGate, ICircuitBreaker, ICostGuard, IAuditLog), basic policy engine.",
       "grid_relationship": "Consumes Kernel (context, identity), Auth (authorization), Data (audit persistence), Pulse (operational telemetry). Consumed by Flow (approval gates), Agents (action constraints), HoneyHub (decision authority surface).",
       "integration_depth": "deep",
-      "demo_path": "Set a cost budget → agent exceeds it → Operator halts execution → observe audit trail entry.",
+      "demo_path": "Set a cost budget \u2192 agent exceeds it \u2192 Operator halts execution \u2192 observe audit trail entry.",
       "signal_quote": "Power checked. Trust earned.",
       "stability_tier": "planned",
       "impact_vector": "safety"
@@ -808,7 +963,14 @@
     "energy": 0,
     "priority": 55,
     "flow": 0,
-    "tags": ["evaluation", "regression", "quality", "scoring", "model-comparison", "prompts"],
+    "tags": [
+      "evaluation",
+      "regression",
+      "quality",
+      "scoring",
+      "model-comparison",
+      "prompts"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Evals"
     },
@@ -820,7 +982,7 @@
         "Run evaluation suites against any model/provider",
         "Structured scoring rubrics (factuality, relevance, safety, format)",
         "Regression detection across model upgrades and prompt changes",
-        "Model comparison — same eval set against multiple providers",
+        "Model comparison \u2014 same eval set against multiple providers",
         "Versioned evaluation datasets",
         "Pulse integration for quality signals and alerting"
       ],
@@ -828,7 +990,7 @@
       "roadmap_focus": "Core contracts (IEvaluator, IEvalDataset, IEvalScorer), basic model-as-judge scorer, Pulse signal emission.",
       "grid_relationship": "Consumes AI (inference for running evaluations), Pulse (emitting eval metrics). Consumed by HoneyHub (quality correlation to features).",
       "integration_depth": "medium",
-      "demo_path": "Define an eval dataset → run against two models → compare scores → observe Pulse signals for regression detection.",
+      "demo_path": "Define an eval dataset \u2192 run against two models \u2192 compare scores \u2192 observe Pulse signals for regression detection.",
       "signal_quote": "Trust, but verify.",
       "stability_tier": "planned",
       "impact_vector": "ai quality"
@@ -853,7 +1015,14 @@
     "energy": 0,
     "priority": 40,
     "flow": 0,
-    "tags": ["simulation", "risk", "planning", "dry-run", "validation", "scenarios"],
+    "tags": [
+      "simulation",
+      "risk",
+      "planning",
+      "dry-run",
+      "validation",
+      "scenarios"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Sim"
     },
@@ -863,16 +1032,16 @@
       "primary_audience": "Platform operators and workflow designers who need confidence before committing to real execution.",
       "value_props": [
         "Scenario modeling with projected outcomes",
-        "Plan evaluation — estimate results before executing",
-        "Risk analysis — failure modes, probabilities, mitigations",
-        "Pre-execution validation — dry-run against simulated state",
+        "Plan evaluation \u2014 estimate results before executing",
+        "Risk analysis \u2014 failure modes, probabilities, mitigations",
+        "Pre-execution validation \u2014 dry-run against simulated state",
         "Graduated implementation from rule-based to model-based"
       ],
       "monetization_signal": "Internal-first. Simulation is a premium enterprise safety feature.",
       "roadmap_focus": "Optional for initial AI sector delivery. Core contracts (ISimulator, IScenario, IRiskAssessment) when prioritized.",
       "grid_relationship": "Consumes AI (inference for simulation), Knowledge (context for scenarios), Agents (agent behavior models).",
       "integration_depth": "shallow",
-      "demo_path": "Define a scenario → run simulation → review projected outcomes and risk assessment → decide whether to proceed with real execution.",
+      "demo_path": "Define a scenario \u2192 run simulation \u2192 review projected outcomes and risk assessment \u2192 decide whether to proceed with real execution.",
       "signal_quote": "See before you leap.",
       "stability_tier": "planned",
       "impact_vector": "safety"
@@ -897,27 +1066,35 @@
     "energy": 0,
     "priority": 60,
     "flow": 0,
-    "tags": ["knowledge-base", "wiki", "llm-compiled", "obsidian", "markdown", "research", "self-maintaining"],
+    "tags": [
+      "knowledge-base",
+      "wiki",
+      "llm-compiled",
+      "obsidian",
+      "markdown",
+      "research",
+      "self-maintaining"
+    ],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Lore is the Hive's living knowledge surface — an LLM-compiled wiki that continuously ingests raw sources (articles, papers, repos, datasets, images), compiles them into structured markdown with auto-maintained indexes, backlinks, concept articles, and summaries. It runs health checks to find inconsistencies, impute missing data, and suggest new article candidates. Queries return rendered markdown, slide shows, or visualizations, and outputs are filed back into the wiki to enhance it for further queries. The human rarely edits the wiki directly — it is the domain of the LLM.",
-      "why_it_exists": "Architecture holds governance decisions. Studios holds the public face. Lore holds the Hive's accumulated knowledge — everything the ecosystem has learned, researched, and compiled. A living knowledge base that grows smarter with every interaction.",
+      "overview": "HoneyDrunk.Lore is the Hive's living knowledge surface \u2014 an LLM-compiled wiki that continuously ingests raw sources (articles, papers, repos, datasets, images), compiles them into structured markdown with auto-maintained indexes, backlinks, concept articles, and summaries. It runs health checks to find inconsistencies, impute missing data, and suggest new article candidates. Queries return rendered markdown, slide shows, or visualizations, and outputs are filed back into the wiki to enhance it for further queries. The human rarely edits the wiki directly \u2014 it is the domain of the LLM.",
+      "why_it_exists": "Architecture holds governance decisions. Studios holds the public face. Lore holds the Hive's accumulated knowledge \u2014 everything the ecosystem has learned, researched, and compiled. A living knowledge base that grows smarter with every interaction.",
       "primary_audience": "HoneyDrunk Studios (internal research and knowledge), AI agents needing ecosystem context, and anyone querying the Hive's accumulated knowledge.",
       "value_props": [
         "Raw source ingestion into structured, browsable markdown wiki",
         "LLM-compiled with auto-maintained indexes, backlinks, and concept maps",
         "Q&A over accumulated knowledge with rendered outputs (markdown, slides, images)",
-        "Self-maintaining — health checks, consistency linting, gap detection",
+        "Self-maintaining \u2014 health checks, consistency linting, gap detection",
         "Outputs filed back into wiki for compound knowledge growth",
         "Viewable in Obsidian as a living, navigable knowledge surface"
       ],
       "monetization_signal": "Internal knowledge infrastructure. Product potential as a standalone knowledge base tool.",
-      "roadmap_focus": "Initial scaffolding — raw/ ingestion, LLM compilation pipeline, index maintenance, basic Q&A workflows.",
+      "roadmap_focus": "Initial scaffolding \u2014 raw/ ingestion, LLM compilation pipeline, index maintenance, basic Q&A workflows.",
       "grid_relationship": "Consumes Knowledge (ingestion infrastructure, retrieval), Agents (compilation and Q&A agents), AI (inference for compilation and queries), Flow (multi-step compilation workflows). Lives in Meta sector alongside Architecture and Studios.",
       "integration_depth": "medium",
-      "demo_path": "Ingest raw sources into raw/ → LLM compiles into wiki/ → browse in Obsidian → ask a complex question → receive rendered answer filed back into wiki.",
+      "demo_path": "Ingest raw sources into raw/ \u2192 LLM compiles into wiki/ \u2192 browse in Obsidian \u2192 ask a complex question \u2192 receive rendered answer filed back into wiki.",
       "signal_quote": "The Hive remembers everything.",
       "stability_tier": "planned",
       "impact_vector": "knowledge"

--- a/catalogs/relationships.json
+++ b/catalogs/relationships.json
@@ -3,375 +3,144 @@
     {
       "id": "honeydrunk-kernel",
       "consumes": [],
-      "consumed_by": [
-        "honeydrunk-transport",
-        "honeydrunk-vault",
-        "honeydrunk-auth",
-        "honeydrunk-web-rest",
-        "honeydrunk-data",
-        "honeydrunk-notify",
-        "pulse",
-        "honeydrunk-vault-rotation"
-      ],
-      "consumed_by_planned": [
-        "honeydrunk-ai",
-        "honeydrunk-capabilities",
-        "honeydrunk-agents",
-        "honeydrunk-memory",
-        "honeydrunk-knowledge",
-        "honeydrunk-flow",
-        "honeydrunk-operator"
-      ],
+      "consumed_by": ["honeydrunk-transport", "honeydrunk-vault", "honeydrunk-auth", "honeydrunk-web-rest", "honeydrunk-data", "honeydrunk-notify", "pulse"],
+      "consumed_by_planned": ["honeydrunk-ai", "honeydrunk-capabilities", "honeydrunk-agents", "honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-flow", "honeydrunk-operator", "honeydrunk-vault-rotation"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "IGridContext",
-          "INodeContext",
-          "IOperationContext",
-          "IStartupHook",
-          "IShutdownHook",
-          "INodeLifecycle",
-          "IHealthContributor",
-          "IReadinessContributor",
-          "ITraceEnricher",
-          "ILogScopeFactory",
-          "IAgentExecutionContext"
-        ],
-        "packages": [
-          "HoneyDrunk.Kernel.Abstractions",
-          "HoneyDrunk.Kernel"
-        ]
+        "contracts": ["IGridContext", "INodeContext", "IOperationContext", "IStartupHook", "IShutdownHook", "INodeLifecycle", "IHealthContributor", "IReadinessContributor", "ITraceEnricher", "ILogScopeFactory", "IAgentExecutionContext"],
+        "packages": ["HoneyDrunk.Kernel.Abstractions", "HoneyDrunk.Kernel"]
       },
       "consumes_detail": {}
     },
     {
       "id": "honeydrunk-transport",
-      "consumes": [
-        "honeydrunk-kernel"
-      ],
-      "consumed_by": [
-        "honeydrunk-web-rest",
-        "honeydrunk-data"
-      ],
-      "consumed_by_planned": [
-        "honeydrunk-flow"
-      ],
+      "consumes": ["honeydrunk-kernel"],
+      "consumed_by": ["honeydrunk-web-rest", "honeydrunk-data"],
+      "consumed_by_planned": ["honeydrunk-flow"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "ITransportPublisher",
-          "ITransportConsumer",
-          "IMessageHandler",
-          "ITransportEnvelope"
-        ],
-        "packages": [
-          "HoneyDrunk.Transport",
-          "HoneyDrunk.Transport.AzureServiceBus",
-          "HoneyDrunk.Transport.StorageQueue",
-          "HoneyDrunk.Transport.InMemory"
-        ]
+        "contracts": ["ITransportPublisher", "ITransportConsumer", "IMessageHandler", "ITransportEnvelope"],
+        "packages": ["HoneyDrunk.Transport", "HoneyDrunk.Transport.AzureServiceBus", "HoneyDrunk.Transport.StorageQueue", "HoneyDrunk.Transport.InMemory"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "CorrelationId",
-          "ITelemetryActivityFactory",
-          "HoneyDrunk.Kernel.Abstractions"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "CorrelationId", "ITelemetryActivityFactory", "HoneyDrunk.Kernel.Abstractions"]
       }
     },
     {
       "id": "honeydrunk-vault",
-      "consumes": [
-        "honeydrunk-kernel"
-      ],
-      "consumed_by": [
-        "honeydrunk-auth",
-        "honeydrunk-vault-rotation"
-      ],
-      "consumed_by_planned": [
-        "honeydrunk-ai"
-      ],
+      "consumes": ["honeydrunk-kernel"],
+      "consumed_by": ["honeydrunk-auth"],
+      "consumed_by_planned": ["honeydrunk-ai", "honeydrunk-vault-rotation"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "ISecretStore",
-          "IConfigProvider",
-          "IVaultClient",
-          "ISecretProvider",
-          "IConfigSource"
-        ],
-        "packages": [
-          "HoneyDrunk.Vault",
-          "HoneyDrunk.Vault.Providers.AzureKeyVault",
-          "HoneyDrunk.Vault.Providers.Aws",
-          "HoneyDrunk.Vault.Providers.File",
-          "HoneyDrunk.Vault.Providers.Configuration",
-          "HoneyDrunk.Vault.Providers.InMemory"
-        ]
+        "contracts": ["ISecretStore", "IConfigProvider", "IVaultClient", "ISecretProvider", "IConfigSource"],
+        "packages": ["HoneyDrunk.Vault", "HoneyDrunk.Vault.Providers.AzureKeyVault", "HoneyDrunk.Vault.Providers.Aws", "HoneyDrunk.Vault.Providers.File", "HoneyDrunk.Vault.Providers.Configuration", "HoneyDrunk.Vault.Providers.InMemory"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "IOperationContext",
-          "IStartupHook",
-          "IHealthContributor",
-          "IReadinessContributor",
-          "ITraceEnricher",
-          "HoneyDrunk.Kernel"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "IOperationContext", "IStartupHook", "IHealthContributor", "IReadinessContributor", "ITraceEnricher", "HoneyDrunk.Kernel"]
       }
     },
     {
       "id": "honeydrunk-vault-rotation",
-      "consumes": [
-        "honeydrunk-kernel",
-        "honeydrunk-vault",
-        "honeydrunk-auth",
-        "honeydrunk-web-rest",
-        "honeydrunk-data",
-        "honeydrunk-notify",
-        "pulse",
-        "honeydrunk-actions",
-        "honeydrunk-studios"
-      ],
+      "consumes": ["honeydrunk-kernel", "honeydrunk-vault", "honeydrunk-auth", "honeydrunk-web-rest", "honeydrunk-data", "honeydrunk-notify", "pulse", "honeydrunk-actions", "honeydrunk-studios"],
       "consumed_by": [],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "IRotator",
-          "RotationResult"
-        ],
-        "packages": [
-          "HoneyDrunk.Vault.Rotation"
-        ]
+        "contracts": ["IRotator", "RotationResult"],
+        "packages": ["HoneyDrunk.Vault.Rotation"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "HoneyDrunk.Kernel"
-        ],
-        "honeydrunk-vault": [
-          "ISecretStore",
-          "HoneyDrunk.Vault"
-        ],
-        "honeydrunk-auth": [
-          "Target Key Vault write scope"
-        ],
-        "honeydrunk-web-rest": [
-          "Target Key Vault write scope"
-        ],
-        "honeydrunk-data": [
-          "Target Key Vault write scope"
-        ],
-        "honeydrunk-notify": [
-          "Target Key Vault write scope"
-        ],
-        "pulse": [
-          "Target Key Vault write scope"
-        ],
-        "honeydrunk-actions": [
-          "Target Key Vault write scope"
-        ],
-        "honeydrunk-studios": [
-          "Target Key Vault write scope"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "HoneyDrunk.Kernel"],
+        "honeydrunk-vault": ["ISecretStore", "HoneyDrunk.Vault"],
+        "honeydrunk-auth": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"],
+        "honeydrunk-web-rest": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"],
+        "honeydrunk-data": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"],
+        "honeydrunk-notify": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"],
+        "pulse": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"],
+        "honeydrunk-actions": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"],
+        "honeydrunk-studios": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"]
       }
     },
     {
       "id": "honeydrunk-auth",
-      "consumes": [
-        "honeydrunk-kernel",
-        "honeydrunk-vault"
-      ],
-      "consumed_by": [
-        "honeydrunk-web-rest",
-        "honeydrunk-vault-rotation"
-      ],
-      "consumed_by_planned": [
-        "honeydrunk-capabilities",
-        "honeydrunk-operator"
-      ],
+      "consumes": ["honeydrunk-kernel", "honeydrunk-vault"],
+      "consumed_by": ["honeydrunk-web-rest"],
+      "consumed_by_planned": ["honeydrunk-capabilities", "honeydrunk-operator", "honeydrunk-vault-rotation"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "IAuthenticatedIdentityAccessor",
-          "IAuthorizationPolicy",
-          "AuthenticationResult",
-          "AuthorizationDecision"
-        ],
-        "packages": [
-          "HoneyDrunk.Auth.Abstractions",
-          "HoneyDrunk.Auth",
-          "HoneyDrunk.Auth.AspNetCore"
-        ]
+        "contracts": ["IAuthenticatedIdentityAccessor", "IAuthorizationPolicy", "AuthenticationResult", "AuthorizationDecision"],
+        "packages": ["HoneyDrunk.Auth.Abstractions", "HoneyDrunk.Auth", "HoneyDrunk.Auth.AspNetCore"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "IOperationContext",
-          "IStartupHook",
-          "IHealthContributor",
-          "HoneyDrunk.Kernel"
-        ],
-        "honeydrunk-vault": [
-          "ISecretStore",
-          "HoneyDrunk.Vault"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "IOperationContext", "IStartupHook", "IHealthContributor", "HoneyDrunk.Kernel"],
+        "honeydrunk-vault": ["ISecretStore", "HoneyDrunk.Vault"]
       }
     },
     {
       "id": "honeydrunk-web-rest",
-      "consumes": [
-        "honeydrunk-kernel",
-        "honeydrunk-transport",
-        "honeydrunk-auth"
-      ],
-      "consumed_by": [
-        "honeydrunk-vault-rotation"
-      ],
-      "consumed_by_planned": [],
+      "consumes": ["honeydrunk-kernel", "honeydrunk-transport", "honeydrunk-auth"],
+      "consumed_by": [],
+      "consumed_by_planned": ["honeydrunk-vault-rotation"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "ApiResult",
-          "ApiErrorResponse"
-        ],
-        "packages": [
-          "HoneyDrunk.Web.Rest.Abstractions",
-          "HoneyDrunk.Web.Rest.AspNetCore"
-        ]
+        "contracts": ["ApiResult", "ApiErrorResponse"],
+        "packages": ["HoneyDrunk.Web.Rest.Abstractions", "HoneyDrunk.Web.Rest.AspNetCore"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IOperationContextAccessor",
-          "CorrelationId",
-          "HoneyDrunk.Kernel.Abstractions"
-        ],
-        "honeydrunk-transport": [
-          "ITransportEnvelope",
-          "HoneyDrunk.Transport"
-        ],
-        "honeydrunk-auth": [
-          "IAuthenticatedIdentityAccessor",
-          "HoneyDrunk.Auth.AspNetCore"
-        ]
+        "honeydrunk-kernel": ["IOperationContextAccessor", "CorrelationId", "HoneyDrunk.Kernel.Abstractions"],
+        "honeydrunk-transport": ["ITransportEnvelope", "HoneyDrunk.Transport"],
+        "honeydrunk-auth": ["IAuthenticatedIdentityAccessor", "HoneyDrunk.Auth.AspNetCore"]
       }
     },
     {
       "id": "honeydrunk-data",
-      "consumes": [
-        "honeydrunk-kernel",
-        "honeydrunk-transport"
-      ],
-      "consumed_by": [
-        "honeydrunk-vault-rotation"
-      ],
-      "consumed_by_planned": [
-        "honeydrunk-memory",
-        "honeydrunk-knowledge",
-        "honeydrunk-flow",
-        "honeydrunk-operator"
-      ],
+      "consumes": ["honeydrunk-kernel", "honeydrunk-transport"],
+      "consumed_by": [],
+      "consumed_by_planned": ["honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-flow", "honeydrunk-operator", "honeydrunk-vault-rotation"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "IRepository",
-          "IUnitOfWork",
-          "IOutboxStore"
-        ],
-        "packages": [
-          "HoneyDrunk.Data.Abstractions",
-          "HoneyDrunk.Data",
-          "HoneyDrunk.Data.EntityFramework",
-          "HoneyDrunk.Data.SqlServer",
-          "HoneyDrunk.Data.Outbox",
-          "HoneyDrunk.Data.Outbox.Dispatcher",
-          "HoneyDrunk.Data.Migrations",
-          "HoneyDrunk.Data.Testing"
-        ]
+        "contracts": ["IRepository", "IUnitOfWork", "IOutboxStore"],
+        "packages": ["HoneyDrunk.Data.Abstractions", "HoneyDrunk.Data", "HoneyDrunk.Data.EntityFramework", "HoneyDrunk.Data.SqlServer", "HoneyDrunk.Data.Outbox", "HoneyDrunk.Data.Outbox.Dispatcher", "HoneyDrunk.Data.Migrations", "HoneyDrunk.Data.Testing"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "IOperationContext",
-          "IStartupHook",
-          "HoneyDrunk.Kernel"
-        ],
-        "honeydrunk-transport": [
-          "ITransportPublisher",
-          "HoneyDrunk.Transport"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "IOperationContext", "IStartupHook", "HoneyDrunk.Kernel"],
+        "honeydrunk-transport": ["ITransportPublisher", "HoneyDrunk.Transport"]
       }
     },
     {
       "id": "pulse",
-      "consumes": [
-        "honeydrunk-kernel"
-      ],
-      "consumed_by": [
-        "honeydrunk-vault-rotation"
-      ],
-      "consumed_by_planned": [
-        "honeydrunk-ai",
-        "honeydrunk-evals",
-        "honeydrunk-operator"
-      ],
+      "consumes": ["honeydrunk-kernel"],
+      "consumed_by": [],
+      "consumed_by_planned": ["honeydrunk-ai", "honeydrunk-evals", "honeydrunk-operator", "honeydrunk-vault-rotation"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "ITraceSink",
-          "ILogSink",
-          "IMetricsSink"
-        ],
-        "packages": [
-          "HoneyDrunk.Pulse.Contracts",
-          "HoneyDrunk.Telemetry.Abstractions",
-          "HoneyDrunk.Telemetry.OpenTelemetry"
-        ]
+        "contracts": ["ITraceSink", "ILogSink", "IMetricsSink"],
+        "packages": ["HoneyDrunk.Pulse.Contracts", "HoneyDrunk.Telemetry.Abstractions", "HoneyDrunk.Telemetry.OpenTelemetry"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "HoneyDrunk.Kernel.Abstractions"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "HoneyDrunk.Kernel.Abstractions"]
       }
     },
     {
       "id": "honeydrunk-notify",
-      "consumes": [
-        "honeydrunk-kernel"
-      ],
-      "consumed_by": [
-        "honeydrunk-vault-rotation"
-      ],
-      "consumed_by_planned": [],
+      "consumes": ["honeydrunk-kernel"],
+      "consumed_by": [],
+      "consumed_by_planned": ["honeydrunk-vault-rotation"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "INotificationSender",
-          "INotificationGateway"
-        ],
-        "packages": [
-          "HoneyDrunk.Notify.Abstractions",
-          "HoneyDrunk.Notify"
-        ]
+        "contracts": ["INotificationSender", "INotificationGateway"],
+        "packages": ["HoneyDrunk.Notify.Abstractions", "HoneyDrunk.Notify"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "HoneyDrunk.Kernel.Abstractions"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "HoneyDrunk.Kernel.Abstractions"]
       }
     },
     {
       "id": "honeydrunk-actions",
       "consumes": [],
-      "consumed_by": [
-        "honeydrunk-vault-rotation"
-      ],
-      "consumed_by_planned": [],
+      "consumed_by": [],
+      "consumed_by_planned": ["honeydrunk-vault-rotation"],
       "blocked_by": [],
       "exposes": {
         "contracts": [],
@@ -394,10 +163,8 @@
     {
       "id": "honeydrunk-studios",
       "consumes": [],
-      "consumed_by": [
-        "honeydrunk-vault-rotation"
-      ],
-      "consumed_by_planned": [],
+      "consumed_by": [],
+      "consumed_by_planned": ["honeydrunk-vault-rotation"],
       "blocked_by": [],
       "exposes": {
         "contracts": [],
@@ -407,388 +174,151 @@
     },
     {
       "id": "honeydrunk-ai",
-      "consumes": [
-        "honeydrunk-kernel",
-        "honeydrunk-vault",
-        "pulse"
-      ],
+      "consumes": ["honeydrunk-kernel", "honeydrunk-vault", "pulse"],
       "consumed_by": [],
-      "consumed_by_planned": [
-        "honeydrunk-agents",
-        "honeydrunk-memory",
-        "honeydrunk-knowledge",
-        "honeydrunk-evals",
-        "honeydrunk-sim"
-      ],
+      "consumed_by_planned": ["honeydrunk-agents", "honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-evals", "honeydrunk-sim"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "IChatClient",
-          "IEmbeddingGenerator",
-          "IModelProvider",
-          "IInferenceResult"
-        ],
-        "packages": [
-          "HoneyDrunk.AI.Abstractions",
-          "HoneyDrunk.AI",
-          "HoneyDrunk.AI.Providers.OpenAI",
-          "HoneyDrunk.AI.Providers.Anthropic",
-          "HoneyDrunk.AI.Providers.AzureOpenAI",
-          "HoneyDrunk.AI.Providers.Local"
-        ]
+        "contracts": ["IChatClient", "IEmbeddingGenerator", "IModelProvider", "IInferenceResult"],
+        "packages": ["HoneyDrunk.AI.Abstractions", "HoneyDrunk.AI", "HoneyDrunk.AI.Providers.OpenAI", "HoneyDrunk.AI.Providers.Anthropic", "HoneyDrunk.AI.Providers.AzureOpenAI", "HoneyDrunk.AI.Providers.Local"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "IOperationContext",
-          "ITraceEnricher",
-          "HoneyDrunk.Kernel.Abstractions"
-        ],
-        "honeydrunk-vault": [
-          "ISecretStore",
-          "HoneyDrunk.Vault"
-        ],
-        "pulse": [
-          "ITraceSink",
-          "HoneyDrunk.Pulse.Contracts"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "IOperationContext", "ITraceEnricher", "HoneyDrunk.Kernel.Abstractions"],
+        "honeydrunk-vault": ["ISecretStore", "HoneyDrunk.Vault"],
+        "pulse": ["ITraceSink", "HoneyDrunk.Pulse.Contracts"]
       }
     },
     {
       "id": "honeydrunk-capabilities",
-      "consumes": [
-        "honeydrunk-kernel",
-        "honeydrunk-auth"
-      ],
+      "consumes": ["honeydrunk-kernel", "honeydrunk-auth"],
       "consumed_by": [],
-      "consumed_by_planned": [
-        "honeydrunk-agents"
-      ],
+      "consumed_by_planned": ["honeydrunk-agents"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "ICapabilityRegistry",
-          "ICapabilityDescriptor",
-          "ICapabilityInvoker",
-          "ICapabilityGuard"
-        ],
-        "packages": [
-          "HoneyDrunk.Capabilities.Abstractions",
-          "HoneyDrunk.Capabilities"
-        ]
+        "contracts": ["ICapabilityRegistry", "ICapabilityDescriptor", "ICapabilityInvoker", "ICapabilityGuard"],
+        "packages": ["HoneyDrunk.Capabilities.Abstractions", "HoneyDrunk.Capabilities"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "INodeContext",
-          "HoneyDrunk.Kernel.Abstractions"
-        ],
-        "honeydrunk-auth": [
-          "IAuthorizationPolicy",
-          "HoneyDrunk.Auth.Abstractions"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "INodeContext", "HoneyDrunk.Kernel.Abstractions"],
+        "honeydrunk-auth": ["IAuthorizationPolicy", "HoneyDrunk.Auth.Abstractions"]
       }
     },
     {
       "id": "honeydrunk-agents",
-      "consumes": [
-        "honeydrunk-kernel",
-        "honeydrunk-ai",
-        "honeydrunk-capabilities"
-      ],
+      "consumes": ["honeydrunk-kernel", "honeydrunk-ai", "honeydrunk-capabilities"],
       "consumed_by": [],
-      "consumed_by_planned": [
-        "honeydrunk-flow",
-        "honeydrunk-sim"
-      ],
+      "consumed_by_planned": ["honeydrunk-flow", "honeydrunk-sim"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "IAgent",
-          "IAgentExecutionContext",
-          "IAgentLifecycle",
-          "IToolInvoker",
-          "IAgentMemory"
-        ],
-        "packages": [
-          "HoneyDrunk.Agents.Abstractions",
-          "HoneyDrunk.Agents"
-        ]
+        "contracts": ["IAgent", "IAgentExecutionContext", "IAgentLifecycle", "IToolInvoker", "IAgentMemory"],
+        "packages": ["HoneyDrunk.Agents.Abstractions", "HoneyDrunk.Agents"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "IOperationContext",
-          "IStartupHook",
-          "IAgentExecutionContext",
-          "HoneyDrunk.Kernel"
-        ],
-        "honeydrunk-ai": [
-          "IChatClient",
-          "HoneyDrunk.AI.Abstractions"
-        ],
-        "honeydrunk-capabilities": [
-          "ICapabilityRegistry",
-          "ICapabilityInvoker",
-          "HoneyDrunk.Capabilities.Abstractions"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "IOperationContext", "IStartupHook", "IAgentExecutionContext", "HoneyDrunk.Kernel"],
+        "honeydrunk-ai": ["IChatClient", "HoneyDrunk.AI.Abstractions"],
+        "honeydrunk-capabilities": ["ICapabilityRegistry", "ICapabilityInvoker", "HoneyDrunk.Capabilities.Abstractions"]
       }
     },
     {
       "id": "honeydrunk-memory",
-      "consumes": [
-        "honeydrunk-kernel",
-        "honeydrunk-data",
-        "honeydrunk-ai"
-      ],
+      "consumes": ["honeydrunk-kernel", "honeydrunk-data", "honeydrunk-ai"],
       "consumed_by": [],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "IMemoryStore",
-          "IMemoryScope",
-          "IMemorySummarizer"
-        ],
-        "packages": [
-          "HoneyDrunk.Memory.Abstractions",
-          "HoneyDrunk.Memory",
-          "HoneyDrunk.Memory.Providers.SqlServer",
-          "HoneyDrunk.Memory.Providers.CosmosDB",
-          "HoneyDrunk.Memory.Providers.InMemory"
-        ]
+        "contracts": ["IMemoryStore", "IMemoryScope", "IMemorySummarizer"],
+        "packages": ["HoneyDrunk.Memory.Abstractions", "HoneyDrunk.Memory", "HoneyDrunk.Memory.Providers.SqlServer", "HoneyDrunk.Memory.Providers.CosmosDB", "HoneyDrunk.Memory.Providers.InMemory"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "TenantId",
-          "ProjectId",
-          "HoneyDrunk.Kernel.Abstractions"
-        ],
-        "honeydrunk-data": [
-          "IRepository",
-          "IUnitOfWork",
-          "HoneyDrunk.Data.Abstractions"
-        ],
-        "honeydrunk-ai": [
-          "IEmbeddingGenerator",
-          "HoneyDrunk.AI.Abstractions"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "TenantId", "ProjectId", "HoneyDrunk.Kernel.Abstractions"],
+        "honeydrunk-data": ["IRepository", "IUnitOfWork", "HoneyDrunk.Data.Abstractions"],
+        "honeydrunk-ai": ["IEmbeddingGenerator", "HoneyDrunk.AI.Abstractions"]
       }
     },
     {
       "id": "honeydrunk-knowledge",
-      "consumes": [
-        "honeydrunk-kernel",
-        "honeydrunk-data",
-        "honeydrunk-ai"
-      ],
+      "consumes": ["honeydrunk-kernel", "honeydrunk-data", "honeydrunk-ai"],
       "consumed_by": [],
-      "consumed_by_planned": [
-        "honeydrunk-sim",
-        "honeydrunk-lore"
-      ],
+      "consumed_by_planned": ["honeydrunk-sim", "honeydrunk-lore"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "IKnowledgeStore",
-          "IDocumentIngester",
-          "IRetrievalPipeline",
-          "IKnowledgeSource"
-        ],
-        "packages": [
-          "HoneyDrunk.Knowledge.Abstractions",
-          "HoneyDrunk.Knowledge",
-          "HoneyDrunk.Knowledge.Providers.AzureAISearch",
-          "HoneyDrunk.Knowledge.Providers.PostgresVector",
-          "HoneyDrunk.Knowledge.Providers.InMemory"
-        ]
+        "contracts": ["IKnowledgeStore", "IDocumentIngester", "IRetrievalPipeline", "IKnowledgeSource"],
+        "packages": ["HoneyDrunk.Knowledge.Abstractions", "HoneyDrunk.Knowledge", "HoneyDrunk.Knowledge.Providers.AzureAISearch", "HoneyDrunk.Knowledge.Providers.PostgresVector", "HoneyDrunk.Knowledge.Providers.InMemory"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "HoneyDrunk.Kernel.Abstractions"
-        ],
-        "honeydrunk-data": [
-          "IRepository",
-          "HoneyDrunk.Data.Abstractions"
-        ],
-        "honeydrunk-ai": [
-          "IEmbeddingGenerator",
-          "HoneyDrunk.AI.Abstractions"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "HoneyDrunk.Kernel.Abstractions"],
+        "honeydrunk-data": ["IRepository", "HoneyDrunk.Data.Abstractions"],
+        "honeydrunk-ai": ["IEmbeddingGenerator", "HoneyDrunk.AI.Abstractions"]
       }
     },
     {
       "id": "honeydrunk-flow",
-      "consumes": [
-        "honeydrunk-kernel",
-        "honeydrunk-agents",
-        "honeydrunk-data",
-        "honeydrunk-transport"
-      ],
+      "consumes": ["honeydrunk-kernel", "honeydrunk-agents", "honeydrunk-data", "honeydrunk-transport"],
       "consumed_by": [],
-      "consumed_by_planned": [
-        "honeydrunk-lore"
-      ],
+      "consumed_by_planned": ["honeydrunk-lore"],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "IWorkflow",
-          "IWorkflowEngine",
-          "IWorkflowStep",
-          "IWorkflowState",
-          "ICompensation"
-        ],
-        "packages": [
-          "HoneyDrunk.Flow.Abstractions",
-          "HoneyDrunk.Flow"
-        ]
+        "contracts": ["IWorkflow", "IWorkflowEngine", "IWorkflowStep", "IWorkflowState", "ICompensation"],
+        "packages": ["HoneyDrunk.Flow.Abstractions", "HoneyDrunk.Flow"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "IStartupHook",
-          "HoneyDrunk.Kernel"
-        ],
-        "honeydrunk-agents": [
-          "IAgent",
-          "IAgentExecutionContext",
-          "HoneyDrunk.Agents.Abstractions"
-        ],
-        "honeydrunk-data": [
-          "IRepository",
-          "IUnitOfWork",
-          "HoneyDrunk.Data.Abstractions"
-        ],
-        "honeydrunk-transport": [
-          "ITransportPublisher",
-          "HoneyDrunk.Transport"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "IStartupHook", "HoneyDrunk.Kernel"],
+        "honeydrunk-agents": ["IAgent", "IAgentExecutionContext", "HoneyDrunk.Agents.Abstractions"],
+        "honeydrunk-data": ["IRepository", "IUnitOfWork", "HoneyDrunk.Data.Abstractions"],
+        "honeydrunk-transport": ["ITransportPublisher", "HoneyDrunk.Transport"]
       }
     },
     {
       "id": "honeydrunk-operator",
-      "consumes": [
-        "honeydrunk-kernel",
-        "honeydrunk-auth",
-        "honeydrunk-data",
-        "pulse"
-      ],
+      "consumes": ["honeydrunk-kernel", "honeydrunk-auth", "honeydrunk-data", "pulse"],
       "consumed_by": [],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "IApprovalGate",
-          "ICircuitBreaker",
-          "ICostGuard",
-          "IAuditLog",
-          "IDecisionPolicy",
-          "ISafetyFilter"
-        ],
-        "packages": [
-          "HoneyDrunk.Operator.Abstractions",
-          "HoneyDrunk.Operator"
-        ]
+        "contracts": ["IApprovalGate", "ICircuitBreaker", "ICostGuard", "IAuditLog", "IDecisionPolicy", "ISafetyFilter"],
+        "packages": ["HoneyDrunk.Operator.Abstractions", "HoneyDrunk.Operator"]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": [
-          "IGridContext",
-          "HoneyDrunk.Kernel.Abstractions"
-        ],
-        "honeydrunk-auth": [
-          "IAuthorizationPolicy",
-          "HoneyDrunk.Auth.Abstractions"
-        ],
-        "honeydrunk-data": [
-          "IRepository",
-          "IUnitOfWork",
-          "HoneyDrunk.Data.Abstractions"
-        ],
-        "pulse": [
-          "ITraceSink",
-          "HoneyDrunk.Pulse.Contracts"
-        ]
+        "honeydrunk-kernel": ["IGridContext", "HoneyDrunk.Kernel.Abstractions"],
+        "honeydrunk-auth": ["IAuthorizationPolicy", "HoneyDrunk.Auth.Abstractions"],
+        "honeydrunk-data": ["IRepository", "IUnitOfWork", "HoneyDrunk.Data.Abstractions"],
+        "pulse": ["ITraceSink", "HoneyDrunk.Pulse.Contracts"]
       }
     },
     {
       "id": "honeydrunk-evals",
-      "consumes": [
-        "honeydrunk-ai",
-        "pulse"
-      ],
+      "consumes": ["honeydrunk-ai", "pulse"],
       "consumed_by": [],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "IEvaluator",
-          "IEvalDataset",
-          "IEvalScorer",
-          "IEvalReport"
-        ],
-        "packages": [
-          "HoneyDrunk.Evals.Abstractions",
-          "HoneyDrunk.Evals"
-        ]
+        "contracts": ["IEvaluator", "IEvalDataset", "IEvalScorer", "IEvalReport"],
+        "packages": ["HoneyDrunk.Evals.Abstractions", "HoneyDrunk.Evals"]
       },
       "consumes_detail": {
-        "honeydrunk-ai": [
-          "IChatClient",
-          "HoneyDrunk.AI.Abstractions"
-        ],
-        "pulse": [
-          "ITraceSink",
-          "HoneyDrunk.Pulse.Contracts"
-        ]
+        "honeydrunk-ai": ["IChatClient", "HoneyDrunk.AI.Abstractions"],
+        "pulse": ["ITraceSink", "HoneyDrunk.Pulse.Contracts"]
       }
     },
     {
       "id": "honeydrunk-sim",
-      "consumes": [
-        "honeydrunk-ai",
-        "honeydrunk-knowledge",
-        "honeydrunk-agents"
-      ],
+      "consumes": ["honeydrunk-ai", "honeydrunk-knowledge", "honeydrunk-agents"],
       "consumed_by": [],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
-        "contracts": [
-          "ISimulator",
-          "IScenario",
-          "IRiskAssessment",
-          "IPlanValidator"
-        ],
-        "packages": [
-          "HoneyDrunk.Sim.Abstractions",
-          "HoneyDrunk.Sim"
-        ]
+        "contracts": ["ISimulator", "IScenario", "IRiskAssessment", "IPlanValidator"],
+        "packages": ["HoneyDrunk.Sim.Abstractions", "HoneyDrunk.Sim"]
       },
       "consumes_detail": {
-        "honeydrunk-ai": [
-          "IChatClient",
-          "HoneyDrunk.AI.Abstractions"
-        ],
-        "honeydrunk-knowledge": [
-          "IRetrievalPipeline",
-          "HoneyDrunk.Knowledge.Abstractions"
-        ],
-        "honeydrunk-agents": [
-          "IAgent",
-          "HoneyDrunk.Agents.Abstractions"
-        ]
+        "honeydrunk-ai": ["IChatClient", "HoneyDrunk.AI.Abstractions"],
+        "honeydrunk-knowledge": ["IRetrievalPipeline", "HoneyDrunk.Knowledge.Abstractions"],
+        "honeydrunk-agents": ["IAgent", "HoneyDrunk.Agents.Abstractions"]
       }
     },
     {
       "id": "honeydrunk-lore",
-      "consumes": [
-        "honeydrunk-knowledge",
-        "honeydrunk-agents",
-        "honeydrunk-ai",
-        "honeydrunk-flow"
-      ],
+      "consumes": ["honeydrunk-knowledge", "honeydrunk-agents", "honeydrunk-ai", "honeydrunk-flow"],
       "consumed_by": [],
       "consumed_by_planned": [],
       "blocked_by": [],
@@ -797,24 +327,10 @@
         "packages": []
       },
       "consumes_detail": {
-        "honeydrunk-knowledge": [
-          "IKnowledgeStore",
-          "IDocumentIngester",
-          "IRetrievalPipeline",
-          "HoneyDrunk.Knowledge.Abstractions"
-        ],
-        "honeydrunk-agents": [
-          "IAgent",
-          "HoneyDrunk.Agents.Abstractions"
-        ],
-        "honeydrunk-ai": [
-          "IChatClient",
-          "HoneyDrunk.AI.Abstractions"
-        ],
-        "honeydrunk-flow": [
-          "IWorkflowEngine",
-          "HoneyDrunk.Flow.Abstractions"
-        ]
+        "honeydrunk-knowledge": ["IKnowledgeStore", "IDocumentIngester", "IRetrievalPipeline", "HoneyDrunk.Knowledge.Abstractions"],
+        "honeydrunk-agents": ["IAgent", "HoneyDrunk.Agents.Abstractions"],
+        "honeydrunk-ai": ["IChatClient", "HoneyDrunk.AI.Abstractions"],
+        "honeydrunk-flow": ["IWorkflowEngine", "HoneyDrunk.Flow.Abstractions"]
       }
     }
   ]

--- a/catalogs/relationships.json
+++ b/catalogs/relationships.json
@@ -3,121 +3,374 @@
     {
       "id": "honeydrunk-kernel",
       "consumes": [],
-      "consumed_by": ["honeydrunk-transport", "honeydrunk-vault", "honeydrunk-auth", "honeydrunk-web-rest", "honeydrunk-data", "honeydrunk-notify", "pulse"],
-      "consumed_by_planned": ["honeydrunk-ai", "honeydrunk-capabilities", "honeydrunk-agents", "honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-flow", "honeydrunk-operator"],
+      "consumed_by": [
+        "honeydrunk-transport",
+        "honeydrunk-vault",
+        "honeydrunk-auth",
+        "honeydrunk-web-rest",
+        "honeydrunk-data",
+        "honeydrunk-notify",
+        "pulse",
+        "honeydrunk-vault-rotation"
+      ],
+      "consumed_by_planned": [
+        "honeydrunk-ai",
+        "honeydrunk-capabilities",
+        "honeydrunk-agents",
+        "honeydrunk-memory",
+        "honeydrunk-knowledge",
+        "honeydrunk-flow",
+        "honeydrunk-operator"
+      ],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["IGridContext", "INodeContext", "IOperationContext", "IStartupHook", "IShutdownHook", "INodeLifecycle", "IHealthContributor", "IReadinessContributor", "ITraceEnricher", "ILogScopeFactory", "IAgentExecutionContext"],
-        "packages": ["HoneyDrunk.Kernel.Abstractions", "HoneyDrunk.Kernel"]
+        "contracts": [
+          "IGridContext",
+          "INodeContext",
+          "IOperationContext",
+          "IStartupHook",
+          "IShutdownHook",
+          "INodeLifecycle",
+          "IHealthContributor",
+          "IReadinessContributor",
+          "ITraceEnricher",
+          "ILogScopeFactory",
+          "IAgentExecutionContext"
+        ],
+        "packages": [
+          "HoneyDrunk.Kernel.Abstractions",
+          "HoneyDrunk.Kernel"
+        ]
       },
       "consumes_detail": {}
     },
     {
       "id": "honeydrunk-transport",
-      "consumes": ["honeydrunk-kernel"],
-      "consumed_by": ["honeydrunk-web-rest", "honeydrunk-data"],
-      "consumed_by_planned": ["honeydrunk-flow"],
+      "consumes": [
+        "honeydrunk-kernel"
+      ],
+      "consumed_by": [
+        "honeydrunk-web-rest",
+        "honeydrunk-data"
+      ],
+      "consumed_by_planned": [
+        "honeydrunk-flow"
+      ],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["ITransportPublisher", "ITransportConsumer", "IMessageHandler", "ITransportEnvelope"],
-        "packages": ["HoneyDrunk.Transport", "HoneyDrunk.Transport.AzureServiceBus", "HoneyDrunk.Transport.StorageQueue", "HoneyDrunk.Transport.InMemory"]
+        "contracts": [
+          "ITransportPublisher",
+          "ITransportConsumer",
+          "IMessageHandler",
+          "ITransportEnvelope"
+        ],
+        "packages": [
+          "HoneyDrunk.Transport",
+          "HoneyDrunk.Transport.AzureServiceBus",
+          "HoneyDrunk.Transport.StorageQueue",
+          "HoneyDrunk.Transport.InMemory"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "CorrelationId", "ITelemetryActivityFactory", "HoneyDrunk.Kernel.Abstractions"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "CorrelationId",
+          "ITelemetryActivityFactory",
+          "HoneyDrunk.Kernel.Abstractions"
+        ]
       }
     },
     {
       "id": "honeydrunk-vault",
-      "consumes": ["honeydrunk-kernel"],
-      "consumed_by": ["honeydrunk-auth"],
-      "consumed_by_planned": ["honeydrunk-ai"],
+      "consumes": [
+        "honeydrunk-kernel"
+      ],
+      "consumed_by": [
+        "honeydrunk-auth",
+        "honeydrunk-vault-rotation"
+      ],
+      "consumed_by_planned": [
+        "honeydrunk-ai"
+      ],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["ISecretStore", "IConfigProvider", "IVaultClient", "ISecretProvider", "IConfigSource"],
-        "packages": ["HoneyDrunk.Vault", "HoneyDrunk.Vault.Providers.AzureKeyVault", "HoneyDrunk.Vault.Providers.Aws", "HoneyDrunk.Vault.Providers.File", "HoneyDrunk.Vault.Providers.Configuration", "HoneyDrunk.Vault.Providers.InMemory"]
+        "contracts": [
+          "ISecretStore",
+          "IConfigProvider",
+          "IVaultClient",
+          "ISecretProvider",
+          "IConfigSource"
+        ],
+        "packages": [
+          "HoneyDrunk.Vault",
+          "HoneyDrunk.Vault.Providers.AzureKeyVault",
+          "HoneyDrunk.Vault.Providers.Aws",
+          "HoneyDrunk.Vault.Providers.File",
+          "HoneyDrunk.Vault.Providers.Configuration",
+          "HoneyDrunk.Vault.Providers.InMemory"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "IOperationContext", "IStartupHook", "IHealthContributor", "IReadinessContributor", "ITraceEnricher", "HoneyDrunk.Kernel"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "IOperationContext",
+          "IStartupHook",
+          "IHealthContributor",
+          "IReadinessContributor",
+          "ITraceEnricher",
+          "HoneyDrunk.Kernel"
+        ]
+      }
+    },
+    {
+      "id": "honeydrunk-vault-rotation",
+      "consumes": [
+        "honeydrunk-kernel",
+        "honeydrunk-vault",
+        "honeydrunk-auth",
+        "honeydrunk-web-rest",
+        "honeydrunk-data",
+        "honeydrunk-notify",
+        "pulse",
+        "honeydrunk-actions",
+        "honeydrunk-studios"
+      ],
+      "consumed_by": [],
+      "consumed_by_planned": [],
+      "blocked_by": [],
+      "exposes": {
+        "contracts": [
+          "IRotator",
+          "RotationResult"
+        ],
+        "packages": [
+          "HoneyDrunk.Vault.Rotation"
+        ]
+      },
+      "consumes_detail": {
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "HoneyDrunk.Kernel"
+        ],
+        "honeydrunk-vault": [
+          "ISecretStore",
+          "HoneyDrunk.Vault"
+        ],
+        "honeydrunk-auth": [
+          "Target Key Vault write scope"
+        ],
+        "honeydrunk-web-rest": [
+          "Target Key Vault write scope"
+        ],
+        "honeydrunk-data": [
+          "Target Key Vault write scope"
+        ],
+        "honeydrunk-notify": [
+          "Target Key Vault write scope"
+        ],
+        "pulse": [
+          "Target Key Vault write scope"
+        ],
+        "honeydrunk-actions": [
+          "Target Key Vault write scope"
+        ],
+        "honeydrunk-studios": [
+          "Target Key Vault write scope"
+        ]
       }
     },
     {
       "id": "honeydrunk-auth",
-      "consumes": ["honeydrunk-kernel", "honeydrunk-vault"],
-      "consumed_by": ["honeydrunk-web-rest"],
-      "consumed_by_planned": ["honeydrunk-capabilities", "honeydrunk-operator"],
+      "consumes": [
+        "honeydrunk-kernel",
+        "honeydrunk-vault"
+      ],
+      "consumed_by": [
+        "honeydrunk-web-rest",
+        "honeydrunk-vault-rotation"
+      ],
+      "consumed_by_planned": [
+        "honeydrunk-capabilities",
+        "honeydrunk-operator"
+      ],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["IAuthenticatedIdentityAccessor", "IAuthorizationPolicy", "AuthenticationResult", "AuthorizationDecision"],
-        "packages": ["HoneyDrunk.Auth.Abstractions", "HoneyDrunk.Auth", "HoneyDrunk.Auth.AspNetCore"]
+        "contracts": [
+          "IAuthenticatedIdentityAccessor",
+          "IAuthorizationPolicy",
+          "AuthenticationResult",
+          "AuthorizationDecision"
+        ],
+        "packages": [
+          "HoneyDrunk.Auth.Abstractions",
+          "HoneyDrunk.Auth",
+          "HoneyDrunk.Auth.AspNetCore"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "IOperationContext", "IStartupHook", "IHealthContributor", "HoneyDrunk.Kernel"],
-        "honeydrunk-vault": ["ISecretStore", "HoneyDrunk.Vault"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "IOperationContext",
+          "IStartupHook",
+          "IHealthContributor",
+          "HoneyDrunk.Kernel"
+        ],
+        "honeydrunk-vault": [
+          "ISecretStore",
+          "HoneyDrunk.Vault"
+        ]
       }
     },
     {
       "id": "honeydrunk-web-rest",
-      "consumes": ["honeydrunk-kernel", "honeydrunk-transport", "honeydrunk-auth"],
-      "consumed_by": [],
+      "consumes": [
+        "honeydrunk-kernel",
+        "honeydrunk-transport",
+        "honeydrunk-auth"
+      ],
+      "consumed_by": [
+        "honeydrunk-vault-rotation"
+      ],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["ApiResult", "ApiErrorResponse"],
-        "packages": ["HoneyDrunk.Web.Rest.Abstractions", "HoneyDrunk.Web.Rest.AspNetCore"]
+        "contracts": [
+          "ApiResult",
+          "ApiErrorResponse"
+        ],
+        "packages": [
+          "HoneyDrunk.Web.Rest.Abstractions",
+          "HoneyDrunk.Web.Rest.AspNetCore"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IOperationContextAccessor", "CorrelationId", "HoneyDrunk.Kernel.Abstractions"],
-        "honeydrunk-transport": ["ITransportEnvelope", "HoneyDrunk.Transport"],
-        "honeydrunk-auth": ["IAuthenticatedIdentityAccessor", "HoneyDrunk.Auth.AspNetCore"]
+        "honeydrunk-kernel": [
+          "IOperationContextAccessor",
+          "CorrelationId",
+          "HoneyDrunk.Kernel.Abstractions"
+        ],
+        "honeydrunk-transport": [
+          "ITransportEnvelope",
+          "HoneyDrunk.Transport"
+        ],
+        "honeydrunk-auth": [
+          "IAuthenticatedIdentityAccessor",
+          "HoneyDrunk.Auth.AspNetCore"
+        ]
       }
     },
     {
       "id": "honeydrunk-data",
-      "consumes": ["honeydrunk-kernel", "honeydrunk-transport"],
-      "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-flow", "honeydrunk-operator"],
+      "consumes": [
+        "honeydrunk-kernel",
+        "honeydrunk-transport"
+      ],
+      "consumed_by": [
+        "honeydrunk-vault-rotation"
+      ],
+      "consumed_by_planned": [
+        "honeydrunk-memory",
+        "honeydrunk-knowledge",
+        "honeydrunk-flow",
+        "honeydrunk-operator"
+      ],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["IRepository", "IUnitOfWork", "IOutboxStore"],
-        "packages": ["HoneyDrunk.Data.Abstractions", "HoneyDrunk.Data", "HoneyDrunk.Data.EntityFramework", "HoneyDrunk.Data.SqlServer", "HoneyDrunk.Data.Outbox", "HoneyDrunk.Data.Outbox.Dispatcher", "HoneyDrunk.Data.Migrations", "HoneyDrunk.Data.Testing"]
+        "contracts": [
+          "IRepository",
+          "IUnitOfWork",
+          "IOutboxStore"
+        ],
+        "packages": [
+          "HoneyDrunk.Data.Abstractions",
+          "HoneyDrunk.Data",
+          "HoneyDrunk.Data.EntityFramework",
+          "HoneyDrunk.Data.SqlServer",
+          "HoneyDrunk.Data.Outbox",
+          "HoneyDrunk.Data.Outbox.Dispatcher",
+          "HoneyDrunk.Data.Migrations",
+          "HoneyDrunk.Data.Testing"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "IOperationContext", "IStartupHook", "HoneyDrunk.Kernel"],
-        "honeydrunk-transport": ["ITransportPublisher", "HoneyDrunk.Transport"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "IOperationContext",
+          "IStartupHook",
+          "HoneyDrunk.Kernel"
+        ],
+        "honeydrunk-transport": [
+          "ITransportPublisher",
+          "HoneyDrunk.Transport"
+        ]
       }
     },
     {
       "id": "pulse",
-      "consumes": ["honeydrunk-kernel"],
-      "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-ai", "honeydrunk-evals", "honeydrunk-operator"],
+      "consumes": [
+        "honeydrunk-kernel"
+      ],
+      "consumed_by": [
+        "honeydrunk-vault-rotation"
+      ],
+      "consumed_by_planned": [
+        "honeydrunk-ai",
+        "honeydrunk-evals",
+        "honeydrunk-operator"
+      ],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["ITraceSink", "ILogSink", "IMetricsSink"],
-        "packages": ["HoneyDrunk.Pulse.Contracts", "HoneyDrunk.Telemetry.Abstractions", "HoneyDrunk.Telemetry.OpenTelemetry"]
+        "contracts": [
+          "ITraceSink",
+          "ILogSink",
+          "IMetricsSink"
+        ],
+        "packages": [
+          "HoneyDrunk.Pulse.Contracts",
+          "HoneyDrunk.Telemetry.Abstractions",
+          "HoneyDrunk.Telemetry.OpenTelemetry"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "HoneyDrunk.Kernel.Abstractions"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "HoneyDrunk.Kernel.Abstractions"
+        ]
       }
     },
     {
       "id": "honeydrunk-notify",
-      "consumes": ["honeydrunk-kernel"],
-      "consumed_by": [],
+      "consumes": [
+        "honeydrunk-kernel"
+      ],
+      "consumed_by": [
+        "honeydrunk-vault-rotation"
+      ],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["INotificationSender", "INotificationGateway"],
-        "packages": ["HoneyDrunk.Notify.Abstractions", "HoneyDrunk.Notify"]
+        "contracts": [
+          "INotificationSender",
+          "INotificationGateway"
+        ],
+        "packages": [
+          "HoneyDrunk.Notify.Abstractions",
+          "HoneyDrunk.Notify"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "HoneyDrunk.Kernel.Abstractions"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "HoneyDrunk.Kernel.Abstractions"
+        ]
       }
     },
     {
       "id": "honeydrunk-actions",
       "consumes": [],
-      "consumed_by": [],
+      "consumed_by": [
+        "honeydrunk-vault-rotation"
+      ],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
@@ -141,7 +394,9 @@
     {
       "id": "honeydrunk-studios",
       "consumes": [],
-      "consumed_by": [],
+      "consumed_by": [
+        "honeydrunk-vault-rotation"
+      ],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
@@ -152,151 +407,388 @@
     },
     {
       "id": "honeydrunk-ai",
-      "consumes": ["honeydrunk-kernel", "honeydrunk-vault", "pulse"],
+      "consumes": [
+        "honeydrunk-kernel",
+        "honeydrunk-vault",
+        "pulse"
+      ],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-agents", "honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-evals", "honeydrunk-sim"],
+      "consumed_by_planned": [
+        "honeydrunk-agents",
+        "honeydrunk-memory",
+        "honeydrunk-knowledge",
+        "honeydrunk-evals",
+        "honeydrunk-sim"
+      ],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["IChatClient", "IEmbeddingGenerator", "IModelProvider", "IInferenceResult"],
-        "packages": ["HoneyDrunk.AI.Abstractions", "HoneyDrunk.AI", "HoneyDrunk.AI.Providers.OpenAI", "HoneyDrunk.AI.Providers.Anthropic", "HoneyDrunk.AI.Providers.AzureOpenAI", "HoneyDrunk.AI.Providers.Local"]
+        "contracts": [
+          "IChatClient",
+          "IEmbeddingGenerator",
+          "IModelProvider",
+          "IInferenceResult"
+        ],
+        "packages": [
+          "HoneyDrunk.AI.Abstractions",
+          "HoneyDrunk.AI",
+          "HoneyDrunk.AI.Providers.OpenAI",
+          "HoneyDrunk.AI.Providers.Anthropic",
+          "HoneyDrunk.AI.Providers.AzureOpenAI",
+          "HoneyDrunk.AI.Providers.Local"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "IOperationContext", "ITraceEnricher", "HoneyDrunk.Kernel.Abstractions"],
-        "honeydrunk-vault": ["ISecretStore", "HoneyDrunk.Vault"],
-        "pulse": ["ITraceSink", "HoneyDrunk.Pulse.Contracts"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "IOperationContext",
+          "ITraceEnricher",
+          "HoneyDrunk.Kernel.Abstractions"
+        ],
+        "honeydrunk-vault": [
+          "ISecretStore",
+          "HoneyDrunk.Vault"
+        ],
+        "pulse": [
+          "ITraceSink",
+          "HoneyDrunk.Pulse.Contracts"
+        ]
       }
     },
     {
       "id": "honeydrunk-capabilities",
-      "consumes": ["honeydrunk-kernel", "honeydrunk-auth"],
+      "consumes": [
+        "honeydrunk-kernel",
+        "honeydrunk-auth"
+      ],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-agents"],
+      "consumed_by_planned": [
+        "honeydrunk-agents"
+      ],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["ICapabilityRegistry", "ICapabilityDescriptor", "ICapabilityInvoker", "ICapabilityGuard"],
-        "packages": ["HoneyDrunk.Capabilities.Abstractions", "HoneyDrunk.Capabilities"]
+        "contracts": [
+          "ICapabilityRegistry",
+          "ICapabilityDescriptor",
+          "ICapabilityInvoker",
+          "ICapabilityGuard"
+        ],
+        "packages": [
+          "HoneyDrunk.Capabilities.Abstractions",
+          "HoneyDrunk.Capabilities"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "INodeContext", "HoneyDrunk.Kernel.Abstractions"],
-        "honeydrunk-auth": ["IAuthorizationPolicy", "HoneyDrunk.Auth.Abstractions"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "INodeContext",
+          "HoneyDrunk.Kernel.Abstractions"
+        ],
+        "honeydrunk-auth": [
+          "IAuthorizationPolicy",
+          "HoneyDrunk.Auth.Abstractions"
+        ]
       }
     },
     {
       "id": "honeydrunk-agents",
-      "consumes": ["honeydrunk-kernel", "honeydrunk-ai", "honeydrunk-capabilities"],
+      "consumes": [
+        "honeydrunk-kernel",
+        "honeydrunk-ai",
+        "honeydrunk-capabilities"
+      ],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-flow", "honeydrunk-sim"],
+      "consumed_by_planned": [
+        "honeydrunk-flow",
+        "honeydrunk-sim"
+      ],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["IAgent", "IAgentExecutionContext", "IAgentLifecycle", "IToolInvoker", "IAgentMemory"],
-        "packages": ["HoneyDrunk.Agents.Abstractions", "HoneyDrunk.Agents"]
+        "contracts": [
+          "IAgent",
+          "IAgentExecutionContext",
+          "IAgentLifecycle",
+          "IToolInvoker",
+          "IAgentMemory"
+        ],
+        "packages": [
+          "HoneyDrunk.Agents.Abstractions",
+          "HoneyDrunk.Agents"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "IOperationContext", "IStartupHook", "IAgentExecutionContext", "HoneyDrunk.Kernel"],
-        "honeydrunk-ai": ["IChatClient", "HoneyDrunk.AI.Abstractions"],
-        "honeydrunk-capabilities": ["ICapabilityRegistry", "ICapabilityInvoker", "HoneyDrunk.Capabilities.Abstractions"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "IOperationContext",
+          "IStartupHook",
+          "IAgentExecutionContext",
+          "HoneyDrunk.Kernel"
+        ],
+        "honeydrunk-ai": [
+          "IChatClient",
+          "HoneyDrunk.AI.Abstractions"
+        ],
+        "honeydrunk-capabilities": [
+          "ICapabilityRegistry",
+          "ICapabilityInvoker",
+          "HoneyDrunk.Capabilities.Abstractions"
+        ]
       }
     },
     {
       "id": "honeydrunk-memory",
-      "consumes": ["honeydrunk-kernel", "honeydrunk-data", "honeydrunk-ai"],
+      "consumes": [
+        "honeydrunk-kernel",
+        "honeydrunk-data",
+        "honeydrunk-ai"
+      ],
       "consumed_by": [],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["IMemoryStore", "IMemoryScope", "IMemorySummarizer"],
-        "packages": ["HoneyDrunk.Memory.Abstractions", "HoneyDrunk.Memory", "HoneyDrunk.Memory.Providers.SqlServer", "HoneyDrunk.Memory.Providers.CosmosDB", "HoneyDrunk.Memory.Providers.InMemory"]
+        "contracts": [
+          "IMemoryStore",
+          "IMemoryScope",
+          "IMemorySummarizer"
+        ],
+        "packages": [
+          "HoneyDrunk.Memory.Abstractions",
+          "HoneyDrunk.Memory",
+          "HoneyDrunk.Memory.Providers.SqlServer",
+          "HoneyDrunk.Memory.Providers.CosmosDB",
+          "HoneyDrunk.Memory.Providers.InMemory"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "TenantId", "ProjectId", "HoneyDrunk.Kernel.Abstractions"],
-        "honeydrunk-data": ["IRepository", "IUnitOfWork", "HoneyDrunk.Data.Abstractions"],
-        "honeydrunk-ai": ["IEmbeddingGenerator", "HoneyDrunk.AI.Abstractions"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "TenantId",
+          "ProjectId",
+          "HoneyDrunk.Kernel.Abstractions"
+        ],
+        "honeydrunk-data": [
+          "IRepository",
+          "IUnitOfWork",
+          "HoneyDrunk.Data.Abstractions"
+        ],
+        "honeydrunk-ai": [
+          "IEmbeddingGenerator",
+          "HoneyDrunk.AI.Abstractions"
+        ]
       }
     },
     {
       "id": "honeydrunk-knowledge",
-      "consumes": ["honeydrunk-kernel", "honeydrunk-data", "honeydrunk-ai"],
+      "consumes": [
+        "honeydrunk-kernel",
+        "honeydrunk-data",
+        "honeydrunk-ai"
+      ],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-sim", "honeydrunk-lore"],
+      "consumed_by_planned": [
+        "honeydrunk-sim",
+        "honeydrunk-lore"
+      ],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["IKnowledgeStore", "IDocumentIngester", "IRetrievalPipeline", "IKnowledgeSource"],
-        "packages": ["HoneyDrunk.Knowledge.Abstractions", "HoneyDrunk.Knowledge", "HoneyDrunk.Knowledge.Providers.AzureAISearch", "HoneyDrunk.Knowledge.Providers.PostgresVector", "HoneyDrunk.Knowledge.Providers.InMemory"]
+        "contracts": [
+          "IKnowledgeStore",
+          "IDocumentIngester",
+          "IRetrievalPipeline",
+          "IKnowledgeSource"
+        ],
+        "packages": [
+          "HoneyDrunk.Knowledge.Abstractions",
+          "HoneyDrunk.Knowledge",
+          "HoneyDrunk.Knowledge.Providers.AzureAISearch",
+          "HoneyDrunk.Knowledge.Providers.PostgresVector",
+          "HoneyDrunk.Knowledge.Providers.InMemory"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "HoneyDrunk.Kernel.Abstractions"],
-        "honeydrunk-data": ["IRepository", "HoneyDrunk.Data.Abstractions"],
-        "honeydrunk-ai": ["IEmbeddingGenerator", "HoneyDrunk.AI.Abstractions"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "HoneyDrunk.Kernel.Abstractions"
+        ],
+        "honeydrunk-data": [
+          "IRepository",
+          "HoneyDrunk.Data.Abstractions"
+        ],
+        "honeydrunk-ai": [
+          "IEmbeddingGenerator",
+          "HoneyDrunk.AI.Abstractions"
+        ]
       }
     },
     {
       "id": "honeydrunk-flow",
-      "consumes": ["honeydrunk-kernel", "honeydrunk-agents", "honeydrunk-data", "honeydrunk-transport"],
+      "consumes": [
+        "honeydrunk-kernel",
+        "honeydrunk-agents",
+        "honeydrunk-data",
+        "honeydrunk-transport"
+      ],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-lore"],
+      "consumed_by_planned": [
+        "honeydrunk-lore"
+      ],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["IWorkflow", "IWorkflowEngine", "IWorkflowStep", "IWorkflowState", "ICompensation"],
-        "packages": ["HoneyDrunk.Flow.Abstractions", "HoneyDrunk.Flow"]
+        "contracts": [
+          "IWorkflow",
+          "IWorkflowEngine",
+          "IWorkflowStep",
+          "IWorkflowState",
+          "ICompensation"
+        ],
+        "packages": [
+          "HoneyDrunk.Flow.Abstractions",
+          "HoneyDrunk.Flow"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "IStartupHook", "HoneyDrunk.Kernel"],
-        "honeydrunk-agents": ["IAgent", "IAgentExecutionContext", "HoneyDrunk.Agents.Abstractions"],
-        "honeydrunk-data": ["IRepository", "IUnitOfWork", "HoneyDrunk.Data.Abstractions"],
-        "honeydrunk-transport": ["ITransportPublisher", "HoneyDrunk.Transport"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "IStartupHook",
+          "HoneyDrunk.Kernel"
+        ],
+        "honeydrunk-agents": [
+          "IAgent",
+          "IAgentExecutionContext",
+          "HoneyDrunk.Agents.Abstractions"
+        ],
+        "honeydrunk-data": [
+          "IRepository",
+          "IUnitOfWork",
+          "HoneyDrunk.Data.Abstractions"
+        ],
+        "honeydrunk-transport": [
+          "ITransportPublisher",
+          "HoneyDrunk.Transport"
+        ]
       }
     },
     {
       "id": "honeydrunk-operator",
-      "consumes": ["honeydrunk-kernel", "honeydrunk-auth", "honeydrunk-data", "pulse"],
+      "consumes": [
+        "honeydrunk-kernel",
+        "honeydrunk-auth",
+        "honeydrunk-data",
+        "pulse"
+      ],
       "consumed_by": [],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["IApprovalGate", "ICircuitBreaker", "ICostGuard", "IAuditLog", "IDecisionPolicy", "ISafetyFilter"],
-        "packages": ["HoneyDrunk.Operator.Abstractions", "HoneyDrunk.Operator"]
+        "contracts": [
+          "IApprovalGate",
+          "ICircuitBreaker",
+          "ICostGuard",
+          "IAuditLog",
+          "IDecisionPolicy",
+          "ISafetyFilter"
+        ],
+        "packages": [
+          "HoneyDrunk.Operator.Abstractions",
+          "HoneyDrunk.Operator"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-kernel": ["IGridContext", "HoneyDrunk.Kernel.Abstractions"],
-        "honeydrunk-auth": ["IAuthorizationPolicy", "HoneyDrunk.Auth.Abstractions"],
-        "honeydrunk-data": ["IRepository", "IUnitOfWork", "HoneyDrunk.Data.Abstractions"],
-        "pulse": ["ITraceSink", "HoneyDrunk.Pulse.Contracts"]
+        "honeydrunk-kernel": [
+          "IGridContext",
+          "HoneyDrunk.Kernel.Abstractions"
+        ],
+        "honeydrunk-auth": [
+          "IAuthorizationPolicy",
+          "HoneyDrunk.Auth.Abstractions"
+        ],
+        "honeydrunk-data": [
+          "IRepository",
+          "IUnitOfWork",
+          "HoneyDrunk.Data.Abstractions"
+        ],
+        "pulse": [
+          "ITraceSink",
+          "HoneyDrunk.Pulse.Contracts"
+        ]
       }
     },
     {
       "id": "honeydrunk-evals",
-      "consumes": ["honeydrunk-ai", "pulse"],
+      "consumes": [
+        "honeydrunk-ai",
+        "pulse"
+      ],
       "consumed_by": [],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["IEvaluator", "IEvalDataset", "IEvalScorer", "IEvalReport"],
-        "packages": ["HoneyDrunk.Evals.Abstractions", "HoneyDrunk.Evals"]
+        "contracts": [
+          "IEvaluator",
+          "IEvalDataset",
+          "IEvalScorer",
+          "IEvalReport"
+        ],
+        "packages": [
+          "HoneyDrunk.Evals.Abstractions",
+          "HoneyDrunk.Evals"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-ai": ["IChatClient", "HoneyDrunk.AI.Abstractions"],
-        "pulse": ["ITraceSink", "HoneyDrunk.Pulse.Contracts"]
+        "honeydrunk-ai": [
+          "IChatClient",
+          "HoneyDrunk.AI.Abstractions"
+        ],
+        "pulse": [
+          "ITraceSink",
+          "HoneyDrunk.Pulse.Contracts"
+        ]
       }
     },
     {
       "id": "honeydrunk-sim",
-      "consumes": ["honeydrunk-ai", "honeydrunk-knowledge", "honeydrunk-agents"],
+      "consumes": [
+        "honeydrunk-ai",
+        "honeydrunk-knowledge",
+        "honeydrunk-agents"
+      ],
       "consumed_by": [],
       "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["ISimulator", "IScenario", "IRiskAssessment", "IPlanValidator"],
-        "packages": ["HoneyDrunk.Sim.Abstractions", "HoneyDrunk.Sim"]
+        "contracts": [
+          "ISimulator",
+          "IScenario",
+          "IRiskAssessment",
+          "IPlanValidator"
+        ],
+        "packages": [
+          "HoneyDrunk.Sim.Abstractions",
+          "HoneyDrunk.Sim"
+        ]
       },
       "consumes_detail": {
-        "honeydrunk-ai": ["IChatClient", "HoneyDrunk.AI.Abstractions"],
-        "honeydrunk-knowledge": ["IRetrievalPipeline", "HoneyDrunk.Knowledge.Abstractions"],
-        "honeydrunk-agents": ["IAgent", "HoneyDrunk.Agents.Abstractions"]
+        "honeydrunk-ai": [
+          "IChatClient",
+          "HoneyDrunk.AI.Abstractions"
+        ],
+        "honeydrunk-knowledge": [
+          "IRetrievalPipeline",
+          "HoneyDrunk.Knowledge.Abstractions"
+        ],
+        "honeydrunk-agents": [
+          "IAgent",
+          "HoneyDrunk.Agents.Abstractions"
+        ]
       }
     },
     {
       "id": "honeydrunk-lore",
-      "consumes": ["honeydrunk-knowledge", "honeydrunk-agents", "honeydrunk-ai", "honeydrunk-flow"],
+      "consumes": [
+        "honeydrunk-knowledge",
+        "honeydrunk-agents",
+        "honeydrunk-ai",
+        "honeydrunk-flow"
+      ],
       "consumed_by": [],
       "consumed_by_planned": [],
       "blocked_by": [],
@@ -305,10 +797,24 @@
         "packages": []
       },
       "consumes_detail": {
-        "honeydrunk-knowledge": ["IKnowledgeStore", "IDocumentIngester", "IRetrievalPipeline", "HoneyDrunk.Knowledge.Abstractions"],
-        "honeydrunk-agents": ["IAgent", "HoneyDrunk.Agents.Abstractions"],
-        "honeydrunk-ai": ["IChatClient", "HoneyDrunk.AI.Abstractions"],
-        "honeydrunk-flow": ["IWorkflowEngine", "HoneyDrunk.Flow.Abstractions"]
+        "honeydrunk-knowledge": [
+          "IKnowledgeStore",
+          "IDocumentIngester",
+          "IRetrievalPipeline",
+          "HoneyDrunk.Knowledge.Abstractions"
+        ],
+        "honeydrunk-agents": [
+          "IAgent",
+          "HoneyDrunk.Agents.Abstractions"
+        ],
+        "honeydrunk-ai": [
+          "IChatClient",
+          "HoneyDrunk.AI.Abstractions"
+        ],
+        "honeydrunk-flow": [
+          "IWorkflowEngine",
+          "HoneyDrunk.Flow.Abstractions"
+        ]
       }
     }
   ]

--- a/catalogs/relationships.json
+++ b/catalogs/relationships.json
@@ -42,7 +42,7 @@
     },
     {
       "id": "honeydrunk-vault-rotation",
-      "consumes": ["honeydrunk-kernel", "honeydrunk-vault", "honeydrunk-auth", "honeydrunk-web-rest", "honeydrunk-data", "honeydrunk-notify", "pulse", "honeydrunk-actions", "honeydrunk-studios"],
+      "consumes": ["honeydrunk-kernel", "honeydrunk-vault"],
       "consumed_by": [],
       "consumed_by_planned": [],
       "blocked_by": [],
@@ -52,21 +52,14 @@
       },
       "consumes_detail": {
         "honeydrunk-kernel": ["IGridContext", "HoneyDrunk.Kernel"],
-        "honeydrunk-vault": ["ISecretStore", "HoneyDrunk.Vault"],
-        "honeydrunk-auth": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"],
-        "honeydrunk-web-rest": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"],
-        "honeydrunk-data": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"],
-        "honeydrunk-notify": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"],
-        "pulse": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"],
-        "honeydrunk-actions": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"],
-        "honeydrunk-studios": ["Infrastructure write scope only (target Node Key Vault ownership); not a package dependency"]
+        "honeydrunk-vault": ["ISecretStore", "HoneyDrunk.Vault"]
       }
     },
     {
       "id": "honeydrunk-auth",
       "consumes": ["honeydrunk-kernel", "honeydrunk-vault"],
       "consumed_by": ["honeydrunk-web-rest"],
-      "consumed_by_planned": ["honeydrunk-capabilities", "honeydrunk-operator", "honeydrunk-vault-rotation"],
+      "consumed_by_planned": ["honeydrunk-capabilities", "honeydrunk-operator"],
       "blocked_by": [],
       "exposes": {
         "contracts": ["IAuthenticatedIdentityAccessor", "IAuthorizationPolicy", "AuthenticationResult", "AuthorizationDecision"],
@@ -81,7 +74,7 @@
       "id": "honeydrunk-web-rest",
       "consumes": ["honeydrunk-kernel", "honeydrunk-transport", "honeydrunk-auth"],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-vault-rotation"],
+      "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
         "contracts": ["ApiResult", "ApiErrorResponse"],
@@ -97,7 +90,7 @@
       "id": "honeydrunk-data",
       "consumes": ["honeydrunk-kernel", "honeydrunk-transport"],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-flow", "honeydrunk-operator", "honeydrunk-vault-rotation"],
+      "consumed_by_planned": ["honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-flow", "honeydrunk-operator"],
       "blocked_by": [],
       "exposes": {
         "contracts": ["IRepository", "IUnitOfWork", "IOutboxStore"],
@@ -112,7 +105,7 @@
       "id": "pulse",
       "consumes": ["honeydrunk-kernel"],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-ai", "honeydrunk-evals", "honeydrunk-operator", "honeydrunk-vault-rotation"],
+      "consumed_by_planned": ["honeydrunk-ai", "honeydrunk-evals", "honeydrunk-operator"],
       "blocked_by": [],
       "exposes": {
         "contracts": ["ITraceSink", "ILogSink", "IMetricsSink"],
@@ -126,7 +119,7 @@
       "id": "honeydrunk-notify",
       "consumes": ["honeydrunk-kernel"],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-vault-rotation"],
+      "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
         "contracts": ["INotificationSender", "INotificationGateway"],
@@ -140,7 +133,7 @@
       "id": "honeydrunk-actions",
       "consumes": [],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-vault-rotation"],
+      "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
         "contracts": [],
@@ -164,7 +157,7 @@
       "id": "honeydrunk-studios",
       "consumes": [],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-vault-rotation"],
+      "consumed_by_planned": [],
       "blocked_by": [],
       "exposes": {
         "contracts": [],

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,18 @@
+# Infrastructure Walkthroughs (Portal-First)
+
+These walkthroughs are the operational runbooks for ADR-0005 and ADR-0006 rollout work. They are written for **Azure Portal first**; CLI is optional appendix material only.
+
+## Walkthrough Index
+
+- [Key Vault creation](key-vault-creation.md) — Create `kv-hd-{service}-{env}` with RBAC-only auth, naming checks, and diagnostics routing.
+- [Key Vault RBAC assignments](key-vault-rbac-assignments.md) — Assign least-privilege RBAC for runtime MI, CI OIDC identity, and Vault.Rotation MI.
+- [OIDC federated credentials](oidc-federated-credentials.md) — Create GitHub Actions federated credentials per `{repo, environment}` with no client secret.
+- [App Configuration provisioning](app-configuration-provisioning.md) — Provision shared `appcs-hd-shared-{env}` with label partitioning, KV references, and RBAC.
+- [Event Grid subscriptions on Key Vault](event-grid-subscriptions-on-keyvault.md) — Subscribe vault events for `SecretNewVersionCreated` cache-invalidation paths.
+- [Log Analytics workspace and alerts](log-analytics-workspace-and-alerts.md) — Provision `log-hd-shared-{env}` and configure SLA/security alerting.
+
+## References
+
+- [ADR-0005: Configuration and Secrets Strategy](../adrs/ADR-0005-configuration-and-secrets-strategy.md)
+- [ADR-0006: Secret Rotation and Lifecycle](../adrs/ADR-0006-secret-rotation-and-lifecycle.md)
+- [Grid Invariants](../constitution/invariants.md) — especially invariants 17–22.

--- a/infrastructure/app-configuration-provisioning.md
+++ b/infrastructure/app-configuration-provisioning.md
@@ -1,0 +1,48 @@
+# App Configuration Provisioning (Azure Portal)
+
+**Applies to:** ADR-0005, ADR-0006.  
+**Related invariants:** 18, 20, 21, 22.
+
+## Goal
+
+Provision shared App Configuration `appcs-hd-shared-{env}` for non-secret config, per-Node label partitioning, and Key Vault references.
+
+## Portal Breadcrumb
+
+**Azure Portal → App Configuration → + Create → Configuration explorer / Feature manager / Access control (IAM) / Diagnostic settings**
+
+## Step-by-step
+
+1. Create App Configuration instance:
+   - Name: `appcs-hd-shared-{env}`
+   - Scope: one shared instance per environment (not per Node).
+2. Open the instance and go to **Configuration explorer**.
+3. Create key-values for each Node using labels matching `HONEYDRUNK_NODE_ID`.
+4. Set bootstrap endpoint in app settings for consuming services:
+   - `AZURE_APPCONFIG_ENDPOINT`
+5. Configure **Feature manager** entries for runtime flags.
+6. For secret-adjacent values, create **Key Vault references**:
+   - Use “+ Create → Key Vault reference”.
+   - Reference the secret URI (unversioned preferred).
+   - Runtime resolution uses the consuming app's managed identity path.
+7. Configure diagnostics:
+   - **Diagnostic settings → + Add diagnostic setting**.
+   - Route logs/metrics to `log-hd-shared-{env}`.
+8. Configure RBAC on App Configuration:
+   - Node managed identities: **App Configuration Data Reader**.
+   - CI OIDC principals: **App Configuration Data Owner**.
+
+## Verification
+
+- Exactly one `appcs-hd-shared-{env}` exists per environment.
+- Labels align with each Node `HONEYDRUNK_NODE_ID`.
+- Feature flags visible under Feature manager.
+- Key Vault references resolve in runtime for authorized Node MI.
+- RBAC role checks confirm Reader for runtime, Owner for CI.
+- Diagnostics route to shared Log Analytics workspace.
+
+## Cross references
+
+- [ADR-0005 three-tier split](../adrs/ADR-0005-configuration-and-secrets-strategy.md)
+- [ADR-0006 Tier 4](../adrs/ADR-0006-secret-rotation-and-lifecycle.md)
+- [Invariant 18, 20–22](../constitution/invariants.md)

--- a/infrastructure/app-configuration-provisioning.md
+++ b/infrastructure/app-configuration-provisioning.md
@@ -18,6 +18,8 @@ Provision shared App Configuration `appcs-hd-shared-{env}` for non-secret config
    - Scope: one shared instance per environment (not per Node).
 2. Open the instance and go to **Configuration explorer**.
 3. Create key-values for each Node using labels matching `HONEYDRUNK_NODE_ID`.
+   - Example: key `Notify:Email:FromAddress`, value `noreply@honeydrunk.io`, label `honeydrunk-notify`.
+   - Example: key `Auth:Jwt:Issuer`, value `https://auth.honeydrunk.local`, label `honeydrunk-auth`.
 4. Set bootstrap endpoint in app settings for consuming services:
    - `AZURE_APPCONFIG_ENDPOINT`
 5. Configure **Feature manager** entries for runtime flags.

--- a/infrastructure/event-grid-subscriptions-on-keyvault.md
+++ b/infrastructure/event-grid-subscriptions-on-keyvault.md
@@ -1,0 +1,42 @@
+# Event Grid Subscriptions on Key Vault (Azure Portal)
+
+**Applies to:** ADR-0006 Tier 3.  
+**Related invariants:** 20, 21, 22.
+
+## Goal
+
+Subscribe each Key Vault to `Microsoft.KeyVault.SecretNewVersionCreated` so secret rotation events trigger cache invalidation/refresh paths.
+
+## Portal Breadcrumb
+
+**Azure Portal → Key vaults → kv-hd-{service}-{env} → Events → + Event Subscription**
+
+## Step-by-step
+
+1. Open target vault `kv-hd-{service}-{env}`.
+2. Go to **Events** → **+ Event Subscription**.
+3. Configure basics:
+   - Subscription name: `kv-secret-version-created-{service}-{env}`.
+   - Event schema: default Event Grid schema.
+4. Event types:
+   - Select only `Microsoft.KeyVault.SecretNewVersionCreated`.
+5. Endpoint:
+   - Choose webhook/Azure Function endpoint used by consuming Node invalidation path.
+   - Endpoint should be internal and authenticated (managed identity or webhook secret per rollout tiering).
+6. Dead-lettering:
+   - Enable dead-letter destination (Storage account/container).
+7. Create subscription.
+8. Complete endpoint validation handshake when prompted.
+
+## Verification
+
+- Event subscription status is **Provisioned**.
+- Only `SecretNewVersionCreated` is selected.
+- Validation handshake completed successfully.
+- Dead-letter destination configured and healthy.
+- Test secret version creation generates event delivery success.
+
+## Cross references
+
+- [ADR-0006 Tier 3](../adrs/ADR-0006-secret-rotation-and-lifecycle.md)
+- [Invariant 20–22](../constitution/invariants.md)

--- a/infrastructure/key-vault-creation.md
+++ b/infrastructure/key-vault-creation.md
@@ -20,8 +20,9 @@ Create a per-Node Key Vault named `kv-hd-{service}-{env}` in the matching resour
    - Key vault name: `kv-hd-{service}-{env}`.
 3. Validate naming before moving on:
    - Azure Key Vault name max length is **24 chars**.
-   - `kv-hd-` prefix (6 chars) + `-{env}` suffix (up to 5 chars for `stage` + separator) leaves a **13-char service budget**.
-   - If the service segment exceeds 13 chars, stop and rename the service token (Invariant 19).
+   - For `kv-hd-{service}-{env}`: `kv-hd-` uses 6 chars, the separator before `{env}` uses 1 char, and this convention requires `{env}` to be **4 chars or fewer**.
+   - Budget math: `24 - 6 - 1 - 4 = 13`, so `{service}` must be **<= 13 chars** (Invariant 19).
+   - If the service segment exceeds 13 chars, stop and rename the service token.
 4. On **Access configuration**:
    - Permission model: **Azure role-based access control**.
    - Confirm legacy access policy mode is not selected (Invariant 17).

--- a/infrastructure/key-vault-creation.md
+++ b/infrastructure/key-vault-creation.md
@@ -1,0 +1,57 @@
+# Key Vault Creation (Azure Portal)
+
+**Applies to:** ADR-0005, ADR-0006.  
+**Related invariants:** 17, 19, 22.
+
+## Goal
+
+Create a per-Node Key Vault named `kv-hd-{service}-{env}` in the matching resource group `rg-hd-{service}-{env}` with RBAC authorization, purge protection, and diagnostics routing.
+
+## Portal Breadcrumb
+
+**Azure Portal → Key vaults → + Create → Basics / Access configuration / Networking / Monitoring + tags → Review + create**
+
+## Step-by-step
+
+1. Go to **Key vaults** and select **+ Create**.
+2. On **Basics**:
+   - Subscription: choose target subscription.
+   - Resource group: select `rg-hd-{service}-{env}`.
+   - Key vault name: `kv-hd-{service}-{env}`.
+3. Validate naming before moving on:
+   - Azure Key Vault name max length is **24 chars**.
+   - `kv-hd-` prefix (6 chars) + `-{env}` suffix (up to 5 chars for `stage` + separator) leaves a **13-char service budget**.
+   - If the service segment exceeds 13 chars, stop and rename the service token (Invariant 19).
+4. On **Access configuration**:
+   - Permission model: **Azure role-based access control**.
+   - Confirm legacy access policy mode is not selected (Invariant 17).
+5. On **Networking**:
+   - Start with **Public endpoint (all networks)** and firewall defaults.
+   - Document this as temporary if Private Link migration is planned later.
+6. On **Monitoring + tags**:
+   - Add tags for `node`, `env`, and `initiative` as needed.
+7. Select **Review + create**, then **Create**.
+
+## Post-create hardening
+
+1. Open the new vault → **Properties**.
+2. Verify **Soft delete** is enabled.
+3. Verify **Purge protection** is enabled.
+4. Open **Diagnostic settings** → **+ Add diagnostic setting**:
+   - Name: `kv-audit-to-loganalytics` (or environment naming standard).
+   - Send to **Log Analytics workspace**.
+   - Workspace: `log-hd-shared-{env}`.
+   - Include audit/event categories needed by ADR-0006 monitoring.
+
+## Verification
+
+- Vault exists at `kv-hd-{service}-{env}` in `rg-hd-{service}-{env}`.
+- Access configuration shows **Azure RBAC** (not access policies).
+- Soft delete + purge protection are enabled.
+- Diagnostic setting is active and targets `log-hd-shared-{env}` (Invariant 22).
+
+## Cross references
+
+- [ADR-0005](../adrs/ADR-0005-configuration-and-secrets-strategy.md)
+- [ADR-0006](../adrs/ADR-0006-secret-rotation-and-lifecycle.md)
+- [Invariant 17–22](../constitution/invariants.md)

--- a/infrastructure/key-vault-creation.md
+++ b/infrastructure/key-vault-creation.md
@@ -20,9 +20,9 @@ Create a per-Node Key Vault named `kv-hd-{service}-{env}` in the matching resour
    - Key vault name: `kv-hd-{service}-{env}`.
 3. Validate naming before moving on:
    - Azure Key Vault name max length is **24 chars**.
-   - For `kv-hd-{service}-{env}`: `kv-hd-` uses 6 chars, the separator before `{env}` uses 1 char, and this convention requires `{env}` to be **4 chars or fewer**.
-   - Budget math: `24 - 6 - 1 - 4 = 13`, so `{service}` must be **<= 13 chars** (Invariant 19).
-   - If the service segment exceeds 13 chars, stop and rename the service token.
+   - For `kv-hd-{service}-{env}`: `kv-hd-` uses 6 chars and the separator between `{service}` and `{env}` uses 1 char.
+   - Budget math: `24 - 6 - 1 = 17`, so `{service}` and `{env}` must total **<= 17 chars** (that is, `{service}.Length + {env}.Length <= 17`) (Invariant 19).
+   - If the combined `{service}` and `{env}` segments exceed 17 chars, stop and rename one or both tokens.
 4. On **Access configuration**:
    - Permission model: **Azure role-based access control**.
    - Confirm legacy access policy mode is not selected (Invariant 17).

--- a/infrastructure/key-vault-rbac-assignments.md
+++ b/infrastructure/key-vault-rbac-assignments.md
@@ -1,0 +1,60 @@
+# Key Vault RBAC Assignments (Azure Portal)
+
+**Applies to:** ADR-0005, ADR-0006.  
+**Related invariants:** 17, 20, 21, 22.
+
+> [!WARNING]
+> **Legacy Key Vault access policies are forbidden.** Use Azure RBAC only. Do not add or retain access policies for new rollout work.
+
+## Goal
+
+Assign least-privilege Key Vault roles for runtime, CI, and rotation workflows.
+
+## Portal Breadcrumb
+
+**Azure Portal → Key vaults → kv-hd-{service}-{env} → Access control (IAM) → Add role assignment / Check access**
+
+## Step-by-step
+
+### 1) Runtime access (Node managed identity)
+
+1. Open vault `kv-hd-{service}-{env}`.
+2. Go to **Access control (IAM)** → **Add role assignment**.
+3. Role: **Key Vault Secrets User**.
+4. Assign access to: **Managed identity**.
+5. Select the Node's **system-assigned managed identity**.
+6. Scope remains this vault only.
+7. Save.
+
+### 2) CI access (GitHub Actions OIDC identity)
+
+1. In same vault IAM, add role assignment.
+2. Role: **Key Vault Secrets Officer**.
+3. Assign access to: **User, group, or service principal**.
+4. Pick the App Registration/service principal tied to the repo/environment OIDC federated credential.
+5. Keep scope at this vault only.
+6. Save.
+
+### 3) Rotation access (HoneyDrunk.Vault.Rotation MI)
+
+1. For each target vault that receives rotated third-party secrets, open **Access control (IAM)**.
+2. Add role assignment:
+   - Role: **Key Vault Secrets Officer**.
+   - Principal: **HoneyDrunk.Vault.Rotation** system-assigned managed identity.
+   - Scope: current target vault.
+3. Repeat for each deployable target vault.
+
+## Verification (required)
+
+For each principal, run **Access control (IAM) → Check access**:
+
+- Node MI resolves to **Key Vault Secrets User**.
+- CI OIDC principal resolves to **Key Vault Secrets Officer**.
+- Vault.Rotation MI resolves to **Key Vault Secrets Officer** on each target vault.
+- No legacy access policies are present.
+
+## Cross references
+
+- [ADR-0005 Access model](../adrs/ADR-0005-configuration-and-secrets-strategy.md)
+- [ADR-0006 Tier 2 + Tier 4](../adrs/ADR-0006-secret-rotation-and-lifecycle.md)
+- [Invariant 17–22](../constitution/invariants.md)

--- a/infrastructure/log-analytics-workspace-and-alerts.md
+++ b/infrastructure/log-analytics-workspace-and-alerts.md
@@ -1,0 +1,59 @@
+# Log Analytics Workspace and Alerting (Azure Portal)
+
+**Applies to:** ADR-0006 Tier 4.  
+**Related invariants:** 20, 22.
+
+## Goal
+
+Provision `log-hd-shared-{env}` and configure alerts for rotation SLA and security anomalies.
+
+## Portal Breadcrumb
+
+**Azure Portal → Log Analytics workspaces → + Create → Azure Monitor → Alerts → + Create**
+
+## Step-by-step
+
+### 1) Create shared workspace
+
+1. Go to **Log Analytics workspaces** → **+ Create**.
+2. Name: `log-hd-shared-{env}`.
+3. Pick environment-appropriate resource group and region.
+4. Create workspace.
+
+### 2) Ensure Key Vault diagnostics feed workspace
+
+1. For each `kv-hd-{service}-{env}` vault, open **Diagnostic settings**.
+2. Confirm diagnostic setting routes to `log-hd-shared-{env}`.
+3. If missing, add it (see [Key Vault creation walkthrough](key-vault-creation.md)).
+
+### 3) Create alert rules
+
+In **Azure Monitor → Alerts → + Create → Alert rule**, create rules for:
+
+1. **Secret approaching expiry** (Tier SLA threshold windows).
+2. **Rotation policy failure** (rotation jobs/errors).
+3. **Unauthorized access attempt** (failed/forbidden secret access).
+4. **Secret accessed by unexpected identity** (principal drift from expected MI).
+
+For each rule:
+- Set action group target.
+- Set severity.
+- Set evaluation frequency/window.
+- Document suppression/exception process when needed.
+
+### 4) Dashboard
+
+1. Create or import Azure Monitor workbook/dashboard for **secret age vs SLA**.
+2. Pin workspace-backed visuals for Tier-1 (<=30d) and Tier-2 (<=90d) coverage.
+
+## Verification
+
+- `log-hd-shared-{env}` exists and receives Key Vault diagnostics.
+- All four alert classes are enabled and action-group routed.
+- Dashboard/workbook shows secret-age vs SLA for current environment.
+- Exception handling path is documented for SLA breaches (Invariant 20).
+
+## Cross references
+
+- [ADR-0006 Tier 4 and SLA model](../adrs/ADR-0006-secret-rotation-and-lifecycle.md)
+- [Invariant 20 and 22](../constitution/invariants.md)

--- a/infrastructure/log-analytics-workspace-and-alerts.md
+++ b/infrastructure/log-analytics-workspace-and-alerts.md
@@ -41,6 +41,21 @@ For each rule:
 - Set evaluation frequency/window.
 - Document suppression/exception process when needed.
 
+Example starter queries (adapt table names to your diagnostic schema):
+
+- Secret approaching expiry:
+  ```kusto
+  AzureDiagnostics
+  | where ResourceType == "VAULTS" and OperationName has "SecretNearExpiry"
+  | summarize count() by Resource, bin(TimeGenerated, 1h)
+  ```
+- Unauthorized access attempt:
+  ```kusto
+  AzureDiagnostics
+  | where ResourceType == "VAULTS" and ResultType in ("Forbidden", "Unauthorized")
+  | summarize attempts = count() by identity_claim_appid_g, Resource, bin(TimeGenerated, 15m)
+  ```
+
 ### 4) Dashboard
 
 1. Create or import Azure Monitor workbook/dashboard for **secret age vs SLA**.

--- a/infrastructure/oidc-federated-credentials.md
+++ b/infrastructure/oidc-federated-credentials.md
@@ -1,0 +1,52 @@
+# OIDC Federated Credentials for GitHub Actions (Azure Portal)
+
+**Applies to:** ADR-0005.  
+**Related invariants:** 17, 18.
+
+## Goal
+
+Create Azure AD federated credentials for GitHub Actions so CI can access Azure resources without client secrets.
+
+## Portal Breadcrumb
+
+**Azure Portal → Microsoft Entra ID → App registrations → {app} → Federated credentials → + Add credential**
+
+## Step-by-step
+
+1. Open or create the App Registration used by the target repo pipeline.
+2. Go to **Federated credentials** and choose **+ Add credential**.
+3. Scenario: **GitHub Actions deploying Azure resources** preset.
+4. Configure one credential per `{repo, environment}` pair:
+   - Organization: `HoneyDrunkStudios`
+   - Repository: `{RepoName}`
+   - Environment: `{env}`
+5. Subject should resolve to:
+   - `repo:HoneyDrunkStudios/{RepoName}:environment:{env}`
+6. Save credential.
+7. Repeat for each Node/environment pair.
+
+## Critical guardrails
+
+- Do **not** create a client secret for this flow.
+- OIDC trust + federated credential replaces client-secret auth.
+
+## Wire identifiers into GitHub environment secrets
+
+In GitHub repo → **Settings → Environments → {env} → Secrets and variables → Actions**:
+
+- Add `AZURE_CLIENT_ID` (App registration client ID)
+- Add `AZURE_TENANT_ID` (Tenant ID)
+- Add `AZURE_SUBSCRIPTION_ID` (Subscription ID)
+
+These are identifiers, not sensitive secrets, but store consistently as environment secrets/variables for pipeline portability.
+
+## Verification
+
+- Federated credential exists for each intended `{repo, environment}`.
+- Subject string matches `repo:HoneyDrunkStudios/{RepoName}:environment:{env}`.
+- Pipeline login step succeeds via OIDC without client-secret material.
+
+## Cross references
+
+- [ADR-0005 Operational Consequences](../adrs/ADR-0005-configuration-and-secrets-strategy.md)
+- [Invariant 17–19](../constitution/invariants.md)

--- a/infrastructure/oidc-federated-credentials.md
+++ b/infrastructure/oidc-federated-credentials.md
@@ -49,4 +49,4 @@ These are non-sensitive identifiers and must be stored as **environment variable
 ## Cross references
 
 - [ADR-0005 Operational Consequences](../adrs/ADR-0005-configuration-and-secrets-strategy.md)
-- [Invariant 17–19](../constitution/invariants.md)
+- [Invariant 17–18](../constitution/invariants.md)

--- a/infrastructure/oidc-federated-credentials.md
+++ b/infrastructure/oidc-federated-credentials.md
@@ -30,15 +30,15 @@ Create Azure AD federated credentials for GitHub Actions so CI can access Azure 
 - Do **not** create a client secret for this flow.
 - OIDC trust + federated credential replaces client-secret auth.
 
-## Wire identifiers into GitHub environment secrets
+## Wire identifiers into GitHub environment variables
 
-In GitHub repo → **Settings → Environments → {env} → Secrets and variables → Actions**:
+In GitHub repo → **Settings → Environments → {env} → Variables**:
 
 - Add `AZURE_CLIENT_ID` (App registration client ID)
 - Add `AZURE_TENANT_ID` (Tenant ID)
 - Add `AZURE_SUBSCRIPTION_ID` (Subscription ID)
 
-These are identifiers, not sensitive secrets, but store consistently as environment secrets/variables for pipeline portability.
+These are non-sensitive identifiers and must be stored as **environment variables**, not secrets. Reserve **environment secrets** for sensitive material (e.g., `NUGET_API_KEY`, registry credentials).
 
 ## Verification
 

--- a/initiatives/active-initiatives.md
+++ b/initiatives/active-initiatives.md
@@ -23,6 +23,20 @@ Tracked initiatives currently in progress or planned. Completed and cancelled in
 - [ ] Wave 2: Per-Node bootstrap migrations (Auth, Web.Rest, Data, Notify, Pulse, Studios)
 - [ ] Wave 2: Actions direct secret removal + deploy-gate SLA check
 
+
+### Vault.Rotation Bring-Up
+**Status:** In Progress  
+**Scope:** Vault.Rotation, Architecture, Actions  
+**Initiative:** `vault-rotation-bring-up`  
+**Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)  
+**Description:** Scaffold HoneyDrunk.Vault.Rotation as a deployable Function Node, wire OIDC + RBAC, and complete ADR-0006 Tier-2 operational setup.
+**Tracking:**
+- [x] Architecture catalog registration + routing keywords
+- [x] Architecture repo stubs (`repos/HoneyDrunk.Vault.Rotation/*`)
+- [ ] Repo scaffold implementation packet execution
+- [ ] Managed identity + vault RBAC automation
+- [ ] Rotation function runtime + observability
+
 ### Grid v0.4 Stabilization
 **Status:** In Progress  
 **Scope:** Kernel, Transport, Vault, Auth, Web.Rest, Data  

--- a/initiatives/active-initiatives.md
+++ b/initiatives/active-initiatives.md
@@ -31,8 +31,8 @@ Tracked initiatives currently in progress or planned. Completed and cancelled in
 **Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)  
 **Description:** Scaffold HoneyDrunk.Vault.Rotation as a deployable Function Node, wire OIDC + RBAC, and complete ADR-0006 Tier-2 operational setup.
 **Tracking:**
-- [x] Architecture catalog registration + routing keywords
-- [x] Architecture repo stubs (`repos/HoneyDrunk.Vault.Rotation/*`)
+- [ ] Architecture catalog registration + routing keywords
+- [ ] Architecture repo stubs (`repos/HoneyDrunk.Vault.Rotation/*`)
 - [ ] Repo scaffold implementation packet execution
 - [ ] Managed identity + vault RBAC automation
 - [ ] Rotation function runtime + observability

--- a/repos/HoneyDrunk.Vault.Rotation/active-work.md
+++ b/repos/HoneyDrunk.Vault.Rotation/active-work.md
@@ -1,0 +1,14 @@
+# HoneyDrunk.Vault.Rotation — Active Work
+
+**Status:** Scaffolding in progress
+
+## Current
+
+- Architecture registration and routing integration in progress
+- Repo scaffolding packet queued under ADR-0005/0006 rollout
+
+## Next
+
+- Stand up Function App scaffold
+- Add managed identity + Key Vault RBAC automation
+- Add rotation workflows and observability wiring

--- a/repos/HoneyDrunk.Vault.Rotation/boundaries.md
+++ b/repos/HoneyDrunk.Vault.Rotation/boundaries.md
@@ -1,0 +1,17 @@
+# HoneyDrunk.Vault.Rotation — Boundaries
+
+## What Vault.Rotation Owns
+
+- Third-party secret rotation orchestration (Tier-2)
+- Writing new secret versions to target per-Node Key Vaults
+- Rotation telemetry/events needed for SLA monitoring
+
+## What Vault.Rotation Does NOT Own
+
+- Runtime secret consumption (`HoneyDrunk.Vault` owns `ISecretStore`)
+- App secret version pinning (forbidden by invariant 21)
+- Cross-repo architecture decisions beyond ADR-0006 scope
+
+## Status
+
+Scaffolding in progress; implementation details deferred to scaffold packet.

--- a/repos/HoneyDrunk.Vault.Rotation/integration-points.md
+++ b/repos/HoneyDrunk.Vault.Rotation/integration-points.md
@@ -7,11 +7,21 @@
 | **HoneyDrunk.Kernel** | Runtime patterns | Standard Node runtime dependency |
 | **HoneyDrunk.Vault** | `ISecretStore` and vault workflows | Rotator bootstrap secret access |
 
-## Downstream Touchpoints
+## Downstream Touchpoints (Operational — not package dependencies)
 
-| Node | What It Receives |
-|------|-------------------|
-| **Deployable Nodes** | Rotated third-party secrets in per-Node Key Vaults |
+The rotator holds Azure RBAC write scope on each Node's Key Vault and rotates third-party secrets in place. This is an **infrastructure relationship only**; Vault.Rotation does not take a code or package dependency on these Nodes.
+
+| Target Node | Key Vault (example, dev) | Relationship |
+|-------------|--------------------------|--------------|
+| **HoneyDrunk.Auth** | `kv-hd-auth-dev` | Writes rotated secrets |
+| **HoneyDrunk.Web.Rest** | `kv-hd-webrest-dev` | Writes rotated secrets |
+| **HoneyDrunk.Data** | `kv-hd-data-dev` | Writes rotated secrets |
+| **HoneyDrunk.Notify** | `kv-hd-notify-dev` | Writes rotated secrets |
+| **HoneyDrunk.Pulse** | `kv-hd-pulse-dev` | Writes rotated secrets |
+| **HoneyDrunk.Actions** | `kv-hd-actions-dev` | Writes rotated secrets |
+| **HoneyDrunk.Studios** | `kv-hd-studios-dev` | Writes rotated secrets |
+
+> These relationships are **not** captured in `catalogs/relationships.json` because they are operational write-scopes, not code/package dependencies. See ADR-0006 for the rotation scope model.
 
 ## Status
 

--- a/repos/HoneyDrunk.Vault.Rotation/integration-points.md
+++ b/repos/HoneyDrunk.Vault.Rotation/integration-points.md
@@ -1,0 +1,18 @@
+# HoneyDrunk.Vault.Rotation — Integration Points
+
+## Upstream Dependencies
+
+| Node | Contract | Usage |
+|------|----------|-------|
+| **HoneyDrunk.Kernel** | Runtime patterns | Standard Node runtime dependency |
+| **HoneyDrunk.Vault** | `ISecretStore` and vault workflows | Rotator bootstrap secret access |
+
+## Downstream Touchpoints
+
+| Node | What It Receives |
+|------|-------------------|
+| **Deployable Nodes** | Rotated third-party secrets in per-Node Key Vaults |
+
+## Status
+
+Scaffolding in progress; endpoint and invalidation contracts tracked by ADR-0006 rollout.

--- a/repos/HoneyDrunk.Vault.Rotation/invariants.md
+++ b/repos/HoneyDrunk.Vault.Rotation/invariants.md
@@ -1,0 +1,10 @@
+# HoneyDrunk.Vault.Rotation — Invariants
+
+1. Rotator writes secrets to Key Vault and never emits secret values to logs/traces.
+2. Rotator identity uses Azure RBAC; legacy access policies are forbidden.
+3. Rotator supports SLA enforcement targets from ADR-0006 Tier-2.
+4. Consumers resolve latest secret version via `ISecretStore`; rotator never requires version pinning.
+
+## Status
+
+Scaffolding in progress; invariants will be expanded with implementation packet.

--- a/repos/HoneyDrunk.Vault.Rotation/overview.md
+++ b/repos/HoneyDrunk.Vault.Rotation/overview.md
@@ -1,8 +1,10 @@
 # HoneyDrunk.Vault.Rotation — Overview
 
 **Sector:** Core  
+**Version:** TBD  
+**Framework:** TBD  
+**Repo:** `HoneyDrunkStudios/HoneyDrunk.Vault.Rotation`  
 **Status:** Scaffolding in progress  
-**Repo:** `HoneyDrunkStudios/HoneyDrunk.Vault.Rotation`
 
 ## Purpose
 

--- a/repos/HoneyDrunk.Vault.Rotation/overview.md
+++ b/repos/HoneyDrunk.Vault.Rotation/overview.md
@@ -1,0 +1,14 @@
+# HoneyDrunk.Vault.Rotation — Overview
+
+**Sector:** Core  
+**Status:** Scaffolding in progress  
+**Repo:** `HoneyDrunkStudios/HoneyDrunk.Vault.Rotation`
+
+## Purpose
+
+Tier-2 rotation Function that rotates third-party provider secrets into per-Node Key Vaults on schedule, as defined by ADR-0006.
+
+## References
+
+- [ADR-0006: Secret Rotation and Lifecycle](../../adrs/ADR-0006-secret-rotation-and-lifecycle.md)
+- [ADR-0005: Configuration and Secrets Strategy](../../adrs/ADR-0005-configuration-and-secrets-strategy.md)

--- a/routing/repo-discovery-rules.md
+++ b/routing/repo-discovery-rules.md
@@ -16,6 +16,7 @@ Rules for determining which repo(s) are affected by a given request.
 | context, GridContext, NodeContext, OperationContext, lifecycle, startup hook, health contributor, correlation, identity, CorrelationId, NodeId | `HoneyDrunk.Kernel` |
 | transport, message, publish, consume, envelope, middleware, outbox dispatcher, service bus, storage queue, broker | `HoneyDrunk.Transport` |
 | vault, secret, ISecretStore, key vault, aws secrets, config provider | `HoneyDrunk.Vault` |
+| rotation, secret rotation, IRotator, RotationResult, third-party rotation, Vault.Rotation | `HoneyDrunk.Vault.Rotation` |
 | auth, JWT, token, authorization, policy, signing key, claims | `HoneyDrunk.Auth` |
 | REST, API, response envelope, ApiResult, exception mapping, correlation header, pagination | `HoneyDrunk.Web.Rest` |
 | telemetry, trace, metrics, logs, sink, Loki, Tempo, Mimir, PostHog, Sentry, OTLP, Pulse, collector | `HoneyDrunk.Pulse` |


### PR DESCRIPTION
### Motivation

- Provide portal-first operational runbooks for ADR-0005 and ADR-0006 so operators can provision Key Vaults, App Configuration, OIDC, Event Grid, and Log Analytics via the Azure Portal with clear verification steps.
- Register the new HoneyDrunk.Vault.Rotation sub-Node in the Architecture catalogs so routing, dependency walks, and initiative tracking include the rotator before its scaffold and implementation.
- Create minimal repo stubs and initiative tracking to mark the Vault.Rotation scaffolding as in-progress and link it to ADR context and rollout tasks.

### Description

- Added an `infrastructure/` index and six portal-first walkthroughs (`key-vault-creation.md`, `key-vault-rbac-assignments.md`, `oidc-federated-credentials.md`, `app-configuration-provisioning.md`, `event-grid-subscriptions-on-keyvault.md`, `log-analytics-workspace-and-alerts.md`) with portal breadcrumbs, verification sections, ADR/invariant cross-links, an RBAC-only callout, and the 13-character vault service-name constraint. 
- Cross-linked the new infrastructure index from `adrs/ADR-0005-configuration-and-secrets-strategy.md` and `adrs/ADR-0006-secret-rotation-and-lifecycle.md` to surface the operational runbooks. 
- Registered `honeydrunk-vault-rotation` in `catalogs/nodes.json` and added the corresponding node plus consumes/consumed_by edges in `catalogs/relationships.json`, enumerating target vault recipients and kernel/vault dependencies while preserving graph semantics. 
- Added a routing keyword mapping for Vault.Rotation in `routing/repo-discovery-rules.md`, created `repos/HoneyDrunk.Vault.Rotation/` stubs (`overview.md`, `boundaries.md`, `active-work.md`, `invariants.md`, `integration-points.md`), and added a "Vault.Rotation Bring-Up" entry to `initiatives/active-initiatives.md`.

### Testing

- Validated JSON syntax for `catalogs/nodes.json` and `catalogs/relationships.json` with `python -m json.tool`, and both files parsed successfully. 
- Ran a topological-sort DAG check over `catalogs/relationships.json` to verify the dependency graph contains no cycles (result: `DAG_OK`).
- No unit or integration tests apply to these changes because they are documentation and catalog JSON edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daadaed1948326b7044d25b089dacb)