### PR TITLE
docs(versioning): codify .NET solution version rules and release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ The handoff always includes: task description, target repo, acceptance criteria,
 
 - Implement within the target repo only — never cross repo boundaries in a single task
 - Follow conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`
-- **Version bumps:** Check the packet's `version_bump` frontmatter field. If `true`, bump every non-test `.csproj` in the solution to the `target_version` in the packet's `## Versioning` section — all projects move together in one commit. If `false`, do not touch any `<Version>` element; only append your CHANGELOG entry under the existing version. Never bump a version the packet does not explicitly authorise. Never push a git tag — that is the human release chore.
+- **Version bumps:** Check the packet's `version_bump` frontmatter field. If `true`, bump every non-test `.csproj` in the solution to the `target_version` in the packet's `## Versioning` section — all projects move together in one commit. If `false`, do not change the `<Version>` of any existing project; any new projects created by this packet must start at the solution's current version (not a fresh `1.0.0`). Only append your CHANGELOG entry under the existing version. Never bump a version the packet does not explicitly authorise. Never push a git tag — that is the human release chore.
 - All .NET code targets .NET 10.0 with C# primary constructors and nullable reference types
 - XML documentation on all new public APIs
 - Run tests before opening a PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ The handoff always includes: task description, target repo, acceptance criteria,
 
 - Implement within the target repo only — never cross repo boundaries in a single task
 - Follow conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`
+- **Version bumps:** Check the packet's `version_bump` frontmatter field. If `true`, bump every non-test `.csproj` in the solution to the `target_version` in the packet's `## Versioning` section — all projects move together in one commit. If `false`, do not touch any `<Version>` element; only append your CHANGELOG entry under the existing version. Never bump a version the packet does not explicitly authorise. Never push a git tag — that is the human release chore.
 - All .NET code targets .NET 10.0 with C# primary constructors and nullable reference types
 - XML documentation on all new public APIs
 - Run tests before opening a PR

--- a/constitution/invariants.md
+++ b/constitution/invariants.md
@@ -93,5 +93,8 @@ Rules that must never be violated across the HoneyDrunk Grid. Canary tests enfor
 25. **Dispatch plans are initiative narratives, not live state.**
     The org Project board is the source of truth for in-flight work. Dispatch plans are updated at wave boundaries as historical records. See ADR-0008.
 
+27. **All projects in a solution share one version and move together.**
+    When a version bump is warranted, every `.csproj` in the solution (excluding test projects) is updated to the same new version in a single commit. Partial bumps — where some projects in a solution are on a different version than others — are forbidden. Releases are triggered by pushing a git tag; agents never push tags. The first packet to land on a solution in an initiative bumps the version; subsequent packets on the same solution append to the CHANGELOG only. See invariant 26 and ADR-0008.
+
 26. **Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section.**
     Any packet that creates or modifies .NET projects must list every `PackageReference` entry required — both additions to existing projects and the full reference list for new projects. `HoneyDrunk.Standards` must be explicitly listed on every new .NET project (StyleCop + EditorConfig analyzers, `PrivateAssets: all`). Cloud agent execution cannot infer or guess package lists; an absent section is grounds to stop and flag rather than proceed. This section must be present before the packet is filed as a GitHub Issue (see invariant 24 — pre-filing amendments are permitted; post-filing corrections require a new packet).

--- a/constitution/invariants.md
+++ b/constitution/invariants.md
@@ -93,8 +93,8 @@ Rules that must never be violated across the HoneyDrunk Grid. Canary tests enfor
 25. **Dispatch plans are initiative narratives, not live state.**
     The org Project board is the source of truth for in-flight work. Dispatch plans are updated at wave boundaries as historical records. See ADR-0008.
 
-27. **All projects in a solution share one version and move together.**
-    When a version bump is warranted, every `.csproj` in the solution (excluding test projects) is updated to the same new version in a single commit. Partial bumps — where some projects in a solution are on a different version than others — are forbidden. Releases are triggered by pushing a git tag; agents never push tags. The first packet to land on a solution in an initiative bumps the version; subsequent packets on the same solution append to the CHANGELOG only. See invariant 26 and ADR-0008.
-
 26. **Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section.**
     Any packet that creates or modifies .NET projects must list every `PackageReference` entry required — both additions to existing projects and the full reference list for new projects. `HoneyDrunk.Standards` must be explicitly listed on every new .NET project (StyleCop + EditorConfig analyzers, `PrivateAssets: all`). Cloud agent execution cannot infer or guess package lists; an absent section is grounds to stop and flag rather than proceed. This section must be present before the packet is filed as a GitHub Issue (see invariant 24 — pre-filing amendments are permitted; post-filing corrections require a new packet).
+
+27. **All projects in a solution share one version and move together.**
+    When a version bump is warranted, every `.csproj` in the solution (excluding test projects) is updated to the same new version in a single commit. Partial bumps — where some projects in a solution are on a different version than others — are forbidden. Releases are triggered by pushing a git tag; agents never push tags. The first packet to land on a solution in an initiative bumps the version; subsequent packets on the same solution append to the CHANGELOG only. See invariant 26 and ADR-0008.

--- a/generated/issue-packets/active/adr-0005-0006-rollout/01-vault-bootstrap-extensions.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/01-vault-bootstrap-extensions.md
@@ -9,6 +9,8 @@ adrs: ["ADR-0005"]
 wave: 1
 initiative: adr-0005-0006-rollout
 node: honeydrunk-vault
+version_bump: true
+target_version: 0.3.0
 ---
 
 # Feature: Env-var-driven bootstrap extensions (`AddVault` + `AddAppConfiguration`)
@@ -76,6 +78,25 @@ This packet delivers both halves of the ADR-0005 bootstrap story as one coherent
 - `HoneyDrunk.Vault` (core — extension surface)
 - `HoneyDrunk.Vault.Providers.AzureKeyVault` (new env-var bootstrap entry)
 - New: `HoneyDrunk.Vault.Providers.AppConfiguration` (or co-located under the AzureKeyVault bootstrap package — decide during implementation, keep both extensions consistent)
+
+## Versioning
+
+**Bump:** Yes — this is the first packet to land on `HoneyDrunk.Vault` in this initiative.
+**From:** `0.2.1` → **To:** `0.3.0` (minor — new public API surface)
+
+Bump every non-test project in the solution to `0.3.0` in a single commit before starting feature work:
+
+| Project | Action |
+|---|---|
+| `HoneyDrunk.Vault` | `0.2.1` → `0.3.0` |
+| `HoneyDrunk.Vault.Providers.AzureKeyVault` | `0.2.1` → `0.3.0` |
+| `HoneyDrunk.Vault.Providers.Aws` | `0.2.1` → `0.3.0` |
+| `HoneyDrunk.Vault.Providers.Configuration` | `0.2.1` → `0.3.0` |
+| `HoneyDrunk.Vault.Providers.File` | `0.2.1` → `0.3.0` |
+| `HoneyDrunk.Vault.Providers.InMemory` | `0.2.1` → `0.3.0` |
+| `HoneyDrunk.Vault.Providers.AppConfiguration` | New — starts at `0.3.0` |
+
+Add a `[0.3.0]` CHANGELOG entry covering this packet's changes. Do **not** push a git tag — the human release chore does that after all Vault packets are merged.
 
 ## NuGet Dependencies
 

--- a/generated/issue-packets/active/adr-0005-0006-rollout/02-vault-event-driven-cache-invalidation.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/02-vault-event-driven-cache-invalidation.md
@@ -51,8 +51,8 @@ Append your changes to the existing `[0.3.0]` CHANGELOG entry. Do **not** push a
 
 | Project | Action |
 |---|---|
-| All solution projects | No change — already at `0.3.0` |
-| `HoneyDrunk.Vault.EventGrid` | New — starts at `0.3.0` (set on creation, no bump needed) |
+| All existing solution projects | No change — already at `0.3.0`, do not modify `<Version>` |
+| `HoneyDrunk.Vault.EventGrid` | New project — set `<Version>0.3.0</Version>` to match the solution's current version |
 
 ## NuGet Dependencies
 

--- a/generated/issue-packets/active/adr-0005-0006-rollout/02-vault-event-driven-cache-invalidation.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/02-vault-event-driven-cache-invalidation.md
@@ -9,6 +9,7 @@ adrs: ["ADR-0006"]
 wave: 1
 initiative: adr-0005-0006-rollout
 node: honeydrunk-vault
+version_bump: false
 ---
 
 # Feature: Event-driven cache invalidation for `SecretCache` on `SecretNewVersionCreated`
@@ -41,6 +42,17 @@ This must exist before per-Node migration to App Configuration + Managed Identit
 ## Affected Packages
 - `HoneyDrunk.Vault` (cache + invalidator contract)
 - New optional: `HoneyDrunk.Vault.EventGrid` (webhook handler package)
+
+## Versioning
+
+**Bump:** No — packet 01 (`vault-bootstrap-extensions`) already bumped the solution to `0.3.0`. Do not touch any `<Version>` element.
+
+Append your changes to the existing `[0.3.0]` CHANGELOG entry. Do **not** push a git tag.
+
+| Project | Action |
+|---|---|
+| All solution projects | No change — already at `0.3.0` |
+| `HoneyDrunk.Vault.EventGrid` | New — starts at `0.3.0` (set on creation, no bump needed) |
 
 ## NuGet Dependencies
 

--- a/generated/issue-packets/active/adr-0005-0006-rollout/06-vault-rotation-scaffold.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/06-vault-rotation-scaffold.md
@@ -10,6 +10,8 @@ wave: 1
 initiative: adr-0005-0006-rollout
 blocked: repo-does-not-exist-yet
 node: honeydrunk-vault
+version_bump: true
+target_version: 0.1.0
 ---
 
 # Feature: Scaffold new sub-Node `HoneyDrunk.Vault.Rotation` Function App
@@ -74,6 +76,21 @@ ADR-0006 Tier 2 introduces `HoneyDrunk.Vault.Rotation` as a brand-new sub-Node t
 - New: `HoneyDrunk.Vault.Rotation` (Function host)
 - New: `HoneyDrunk.Vault.Rotation.Abstractions`
 - New: `HoneyDrunk.Vault.Rotation.Providers`
+
+## Versioning
+
+**Bump:** Yes — this is the first (and only) packet on `HoneyDrunk.Vault.Rotation`. New repo, first release.
+**Version:** `0.1.0` (all new projects start here)
+
+Set `<Version>0.1.0</Version>` on every non-test project at creation time:
+
+| Project | Action |
+|---|---|
+| `HoneyDrunk.Vault.Rotation` | New — `0.1.0` |
+| `HoneyDrunk.Vault.Rotation.Abstractions` | New — `0.1.0` |
+| `HoneyDrunk.Vault.Rotation.Providers` | New — `0.1.0` |
+
+Create a `CHANGELOG.md` with a `[0.1.0]` entry describing the scaffold. Do **not** push a git tag — the human release chore does that.
 
 ## NuGet Dependencies
 

--- a/generated/issue-packets/active/adr-0005-0006-rollout/14-vault-release-v0-3-0.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/14-vault-release-v0-3-0.md
@@ -1,0 +1,62 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Vault
+labels: ["chore", "tier-1", "release", "human-only", "wave-1"]
+dependencies: ["vault-bootstrap-extensions", "vault-event-driven-cache-invalidation"]
+adrs: []
+wave: 1
+initiative: adr-0005-0006-rollout
+node: honeydrunk-vault
+actor: human
+version_bump: false
+---
+
+# Chore: Tag and release `HoneyDrunk.Vault` v0.3.0 (human-only)
+
+## Summary
+After packets 01 (`vault-bootstrap-extensions`) and 02 (`vault-event-driven-cache-invalidation`) are both merged to `main`, push the `v0.3.0` git tag to trigger the NuGet publish pipeline. This is the human release gate — agents do not push tags.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Vault`
+
+## Actor
+**`Human`.** Tag pushes are not delegated to agents. This is the release ceremony for the ADR-0005/0006 Vault work.
+
+## Prerequisites
+- [ ] Packet 01 (`vault-bootstrap-extensions`) PR merged to `main`
+- [ ] Packet 02 (`vault-event-driven-cache-invalidation`) PR merged to `main`
+- [ ] All solution projects confirmed at `0.3.0` in `main`
+- [ ] `CHANGELOG.md` has a complete `[0.3.0]` entry covering both packets
+
+## Steps
+
+1. Pull latest `main`:
+   ```bash
+   git checkout main && git pull
+   ```
+2. Verify all non-test projects are at `0.3.0`:
+   ```bash
+   grep -r "<Version>" --include="*.csproj" .
+   ```
+3. Confirm `CHANGELOG.md` `[0.3.0]` section is complete and accurate
+4. Push the tag:
+   ```bash
+   git tag v0.3.0 && git push origin v0.3.0
+   ```
+5. Confirm the CI publish workflow triggers and completes successfully on GitHub Actions
+6. Verify the new packages appear on NuGet / GitHub Packages
+
+## Acceptance Criteria
+- [ ] `v0.3.0` tag exists on `main`
+- [ ] CI publish workflow green
+- [ ] All solution packages visible at `0.3.0` on the package feed
+- [ ] This chore issue closed
+
+## Dependencies
+- `vault-bootstrap-extensions` (packet 01) — must be merged first
+- `vault-event-driven-cache-invalidation` (packet 02) — must be merged first
+
+## Labels
+`chore`, `tier-1`, `release`, `human-only`, `wave-1`

--- a/generated/issue-packets/active/adr-0005-0006-rollout/15-vault-rotation-release-v0-1-0.md
+++ b/generated/issue-packets/active/adr-0005-0006-rollout/15-vault-rotation-release-v0-1-0.md
@@ -1,0 +1,61 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Vault.Rotation
+labels: ["chore", "tier-1", "release", "human-only", "wave-1"]
+dependencies: ["vault-rotation-scaffold"]
+adrs: ["ADR-0006"]
+wave: 1
+initiative: adr-0005-0006-rollout
+node: honeydrunk-vault
+actor: human
+version_bump: false
+---
+
+# Chore: Tag and release `HoneyDrunk.Vault.Rotation` v0.1.0 (human-only)
+
+## Summary
+After packet 06 (`vault-rotation-scaffold`) is merged to `main`, push the `v0.1.0` git tag to trigger the first release of the new repo. This is the human release gate — agents do not push tags.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Vault.Rotation`
+
+## Actor
+**`Human`.** Tag pushes are not delegated to agents.
+
+## Prerequisites
+- [ ] Packet 06 (`vault-rotation-scaffold`) PR merged to `main`
+- [ ] All non-test projects confirmed at `0.1.0` in `main`
+- [ ] `CHANGELOG.md` has a `[0.1.0]` entry describing the scaffold
+- [ ] CI pipeline is green on `main`
+
+## Steps
+
+1. Pull latest `main`:
+   ```bash
+   git checkout main && git pull
+   ```
+2. Verify all non-test projects are at `0.1.0`:
+   ```bash
+   grep -r "<Version>" --include="*.csproj" .
+   ```
+3. Confirm `CHANGELOG.md` `[0.1.0]` section is present
+4. Push the tag:
+   ```bash
+   git tag v0.1.0 && git push origin v0.1.0
+   ```
+5. Confirm the CI publish workflow triggers and completes successfully
+6. Verify packages appear on the feed at `0.1.0`
+
+## Acceptance Criteria
+- [ ] `v0.1.0` tag exists on `main`
+- [ ] CI publish workflow green
+- [ ] `HoneyDrunk.Vault.Rotation`, `HoneyDrunk.Vault.Rotation.Abstractions`, `HoneyDrunk.Vault.Rotation.Providers` all visible at `0.1.0` on the package feed
+- [ ] This chore issue closed
+
+## Dependencies
+- `vault-rotation-scaffold` (packet 06) — must be merged first
+
+## Labels
+`chore`, `tier-1`, `release`, `human-only`, `wave-1`


### PR DESCRIPTION
Add explicit versioning invariants for .NET solutions: all non-test projects must share a single version, bumped only when authorized by packet frontmatter. Update packet files to include detailed versioning instructions and clarify that agents never push git tags. Add human-only release chore packets for v0.3.0 (Vault) and v0.1.0 (Vault.Rotation). Require explicit NuGet dependency lists in all .NET code packets. Update AGENTS.md and invariants.md to reflect these requirements.