### PR TITLE
docs(adr): add ADR-0009 package scanning policy and rollout

### DIFF
--- a/adrs/ADR-0009-package-scanning-policy.md
+++ b/adrs/ADR-0009-package-scanning-policy.md
@@ -1,0 +1,129 @@
+# ADR-0009: Package Scanning — Vulnerability and Dependency Freshness
+
+**Status:** Proposed
+**Date:** 2026-04-11
+**Deciders:** HoneyDrunk Studios
+**Sector:** Core
+
+## Context
+
+The HoneyDrunk Grid spans 11+ repos across .NET (NuGet) and npm stacks. `HoneyDrunk.Actions` already contains the reusable workflows and actions needed for package scanning:
+
+- `security/vulnerability-scan` — runs `dotnet list package --vulnerable --include-transitive`
+- `job-static-analysis.yml` — calls the vulnerability scan on every PR, default threshold `high`
+- `nightly-security.yml` — deep nightly scan: vulnerable packages (including transitive), CodeQL SAST, gitleaks full-history secret scan, Trivy IaC misconfiguration
+- `nightly-deps.yml` — detects outdated NuGet and npm packages; optionally creates grouped update PRs
+- `deps/check-deprecated` — detects deprecated packages
+- `pr-core.yml` — orchestrates build, test, static analysis (including vulnerability scan), and secret scan on every PR
+
+As of April 2026, none of the consuming repos have any GitHub Actions workflows. The scanning infrastructure exists but is deployed nowhere.
+
+Two distinct concerns must be treated separately:
+
+1. **Vulnerability** — a package has a known CVE (reported via the NuGet advisory database / OSV). This is a security risk. Severity determines urgency.
+2. **Outdated** — a newer version exists but no CVE is reported. This is a maintenance concern, not a security emergency.
+
+Conflating them leads to either ignoring real CVEs (outdated noise drowns out signal) or unnecessary PR blocks (every version lag treated as a security issue).
+
+Repos are public. Known-vulnerable dependencies are a real and visible risk to users and downstream consumers of published NuGet packages.
+
+## Decision
+
+### 1. PR-time vulnerability scanning blocks on `high` or `critical`
+
+Every PR runs `job-static-analysis.yml` (via `pr-core.yml`) which calls `security/vulnerability-scan` with `fail-on-severity: high`. A PR with a `High` or `Critical` CVE cannot merge.
+
+`Moderate` and `Low` severity vulnerabilities do **not** block PRs. They are surfaced nightly (see below).
+
+### 2. Nightly deep vulnerability scan on all .NET repos
+
+Each .NET repo wires up a consumer workflow calling `nightly-security.yml@main` on a nightly schedule (`0 2 * * *`). This scan:
+- Runs `dotnet list package --vulnerable --include-transitive` and reports all findings including `Moderate` and `Low`
+- Runs CodeQL SAST (`security-and-quality` queries)
+- Runs gitleaks full-history secret scan
+- Runs Trivy IaC misconfiguration scan when IaC files are present
+- Uploads SARIF results to the GitHub Security tab
+- Creates a GitHub Issue when findings are present (`create-issues: true`)
+
+### 3. Nightly outdated package check on all .NET repos
+
+Each repo wires up a consumer workflow calling `nightly-deps.yml@main` on a weekly schedule (`0 3 * * 1`, Monday mornings). This scan:
+- Reports all outdated NuGet packages (`dotnet list package --outdated --include-transitive`)
+- Checks for deprecated packages
+- Does **not** block PRs — informational only
+- Does **not** auto-create update PRs by default (`create-update-prs: false`)
+
+Auto-update PRs (`create-update-prs: true`) may be enabled per-repo once the nightly dep workflow is stable, using `group-updates: true` to batch updates into a single PR.
+
+### 4. npm (Studios) out of scope for this ADR
+
+Studios will be addressed separately. This ADR covers `.NET`/`NuGet` repos only.
+
+### 5. No Dependabot
+
+Dependabot is not enabled. It creates one PR per package per repo, generating excessive noise for a solo developer with 11+ repos. The `nightly-deps.yml` grouped-update mode is the preferred automation path when auto-updates are warranted.
+
+### 6. Transitive dependencies always included
+
+All scans pass `--include-transitive`. A vulnerability in a transitive dependency is still a vulnerability in the built output.
+
+### 7. Response SLA expectations
+
+| Severity | Expected Response |
+|----------|-------------------|
+| Critical | Address before next merge to `main` |
+| High | PR blocked — must be resolved to merge |
+| Moderate | Address within current sprint (nightly issue tracks it) |
+| Low | Backlog — address during regular maintenance windows |
+| Outdated (no CVE) | Address during regular maintenance windows; no SLA |
+| Deprecated | Address before the package reaches end-of-life |
+
+## Consequences
+
+### Positive
+
+- **CVEs cannot be merged silently.** The PR gate blocks `High+` before code ships.
+- **Moderate and transitive CVEs are visible.** Nightly scan + GitHub Issues creates a paper trail without blocking day-to-day work.
+- **Outdated packages stay visible.** Weekly nightly-deps run means drift accumulates in a report, not invisibly.
+- **All scanning is automated.** Solo developer and AI agents don't need to run scans manually.
+- **SARIF results feed the GitHub Security tab.** Findings are queryable and tracked with remediation state.
+
+### Negative
+
+- **PR gate adds latency.** The `job-static-analysis.yml` step takes ~30–60 seconds per PR. Acceptable trade-off.
+- **Nightly workflows consume Actions minutes.** Minimal for public repos (free tier). Monitor if repos go private.
+- **Nightly issues can accumulate.** If findings aren't addressed, the issue count grows. Managed via the `create-issues` flag and issue de-duplication in the workflow (updates existing open issues rather than creating duplicates).
+
+## Alternatives Considered
+
+### Enable Dependabot
+
+Creates individual PRs per package per repo. With 11+ repos and dozens of dependencies each, this generates dozens of open PRs simultaneously. The `nightly-deps.yml` grouped update approach is a better fit for solo operation.
+
+### Block PRs at `moderate`
+
+Would block merges for moderate-severity CVEs that may have no applicable exploit path in the codebase. `High+` is the industry-standard threshold for PR blocking; `moderate` is surfaced nightly instead.
+
+### Block PRs on outdated packages
+
+Outdated packages without CVEs are a maintenance concern, not a security gate. Blocking PRs on version lag would create constant friction with no security benefit.
+
+### Manual scanning only
+
+Relies on the developer remembering to run `dotnet list package --vulnerable` before each release. Unacceptable given the scope of 11+ repos and AI agent collaborators who do not run ad-hoc scans.
+
+### GitHub Advanced Security / Dependabot Alerts only
+
+Available for public repos on free tier. The decision to use `dotnet list package --vulnerable` directly means scans are reproducible, logged as artifacts, and visible in CI — not just in the GitHub web UI. GHAS alerts supplement but do not replace the CI gate.
+
+## Implementation
+
+Tracked as GitHub Issues in each consuming repo under initiative `adr-0009-package-scanning-rollout`.
+
+Target repos: `HoneyDrunk.Kernel`, `HoneyDrunk.Auth`, `HoneyDrunk.Data`, `HoneyDrunk.Transport`, `HoneyDrunk.Vault`, `HoneyDrunk.Pulse`, `HoneyDrunk.Notify`, `HoneyDrunk.Web.Rest`
+
+Each repo requires three new files:
+
+1. `.github/workflows/pr.yml` — calls `pr-core.yml@main` (includes vulnerability scan gate)
+2. `.github/workflows/nightly-security.yml` — calls `nightly-security.yml@main` on nightly schedule
+3. `.github/workflows/nightly-deps.yml` — calls `nightly-deps.yml@main` on weekly schedule

--- a/generated/issue-packets/active/adr-0009-package-scanning-rollout/01-kernel-wire-up-scan-workflows.md
+++ b/generated/issue-packets/active/adr-0009-package-scanning-rollout/01-kernel-wire-up-scan-workflows.md
@@ -1,0 +1,118 @@
+---
+name: Wire up PR validation and nightly scan workflows
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Kernel
+labels: ["chore", "tier-1", "adr-0009"]
+dependencies: []
+adrs: ["ADR-0009"]
+wave: "N/A"
+initiative: adr-0009-package-scanning-rollout
+node: honeydrunk-kernel
+version_bump: false
+---
+
+# Chore: Wire up PR validation and nightly scan workflows
+
+## Summary
+
+Create three GitHub Actions consumer workflow files in `HoneyDrunk.Kernel`. No code changes. No version bump.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Kernel`
+
+## Motivation
+
+ADR-0009 establishes the package scanning policy for the Grid. `HoneyDrunk.Actions` already provides all the reusable workflows; this packet wires them up in `HoneyDrunk.Kernel`. Until these files exist, no PR validation runs and no vulnerability or outdated-package scans run for this repo.
+
+## Files to Create
+
+### `.github/workflows/pr.yml`
+
+```yaml
+name: PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pr-core:
+    name: PR Core
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-security.yml`
+
+```yaml
+name: Nightly Security
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly-security:
+    name: Nightly Security
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-security.yml@main
+    with:
+      enable-sast: true
+      enable-iac-scan: true
+      enable-secret-scan: true
+      create-issues: true
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-deps.yml`
+
+```yaml
+name: Nightly Dependencies
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  nightly-deps:
+    name: Nightly Dependencies
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main
+    with:
+      check-dotnet-deps: true
+      create-update-prs: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/pr.yml` exists and calls `pr-core.yml@main`
+- [ ] `.github/workflows/nightly-security.yml` exists and calls `nightly-security.yml@main`
+- [ ] `.github/workflows/nightly-deps.yml` exists and calls `nightly-deps.yml@main`
+- [ ] All three workflows are valid YAML (no syntax errors)
+- [ ] No other files are modified
+
+## Dependencies
+
+None.
+
+## Agent Handoff
+
+**Objective:** Create three GitHub Actions workflow files. No code changes required.
+**Target:** HoneyDrunk.Kernel, branch from `main`
+**ADRs:** ADR-0009
+
+**Constraints:**
+- Create files only — do not modify any existing source files
+- Do not add any NuGet packages or project references
+- Do not bump the version
+
+**Key Files:**
+- New: `.github/workflows/pr.yml`
+- New: `.github/workflows/nightly-security.yml`
+- New: `.github/workflows/nightly-deps.yml`

--- a/generated/issue-packets/active/adr-0009-package-scanning-rollout/02-auth-wire-up-scan-workflows.md
+++ b/generated/issue-packets/active/adr-0009-package-scanning-rollout/02-auth-wire-up-scan-workflows.md
@@ -1,0 +1,118 @@
+---
+name: Wire up PR validation and nightly scan workflows
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Auth
+labels: ["chore", "tier-1", "adr-0009"]
+dependencies: []
+adrs: ["ADR-0009"]
+wave: "N/A"
+initiative: adr-0009-package-scanning-rollout
+node: honeydrunk-auth
+version_bump: false
+---
+
+# Chore: Wire up PR validation and nightly scan workflows
+
+## Summary
+
+Create three GitHub Actions consumer workflow files in `HoneyDrunk.Auth`. No code changes. No version bump.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Auth`
+
+## Motivation
+
+ADR-0009 establishes the package scanning policy for the Grid. `HoneyDrunk.Actions` already provides all the reusable workflows; this packet wires them up in `HoneyDrunk.Auth`. Until these files exist, no PR validation runs and no vulnerability or outdated-package scans run for this repo.
+
+## Files to Create
+
+### `.github/workflows/pr.yml`
+
+```yaml
+name: PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pr-core:
+    name: PR Core
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-security.yml`
+
+```yaml
+name: Nightly Security
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly-security:
+    name: Nightly Security
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-security.yml@main
+    with:
+      enable-sast: true
+      enable-iac-scan: true
+      enable-secret-scan: true
+      create-issues: true
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-deps.yml`
+
+```yaml
+name: Nightly Dependencies
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  nightly-deps:
+    name: Nightly Dependencies
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main
+    with:
+      check-dotnet-deps: true
+      create-update-prs: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/pr.yml` exists and calls `pr-core.yml@main`
+- [ ] `.github/workflows/nightly-security.yml` exists and calls `nightly-security.yml@main`
+- [ ] `.github/workflows/nightly-deps.yml` exists and calls `nightly-deps.yml@main`
+- [ ] All three workflows are valid YAML (no syntax errors)
+- [ ] No other files are modified
+
+## Dependencies
+
+None.
+
+## Agent Handoff
+
+**Objective:** Create three GitHub Actions workflow files. No code changes required.
+**Target:** HoneyDrunk.Auth, branch from `main`
+**ADRs:** ADR-0009
+
+**Constraints:**
+- Create files only — do not modify any existing source files
+- Do not add any NuGet packages or project references
+- Do not bump the version
+
+**Key Files:**
+- New: `.github/workflows/pr.yml`
+- New: `.github/workflows/nightly-security.yml`
+- New: `.github/workflows/nightly-deps.yml`

--- a/generated/issue-packets/active/adr-0009-package-scanning-rollout/03-data-wire-up-scan-workflows.md
+++ b/generated/issue-packets/active/adr-0009-package-scanning-rollout/03-data-wire-up-scan-workflows.md
@@ -1,0 +1,118 @@
+---
+name: Wire up PR validation and nightly scan workflows
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Data
+labels: ["chore", "tier-1", "adr-0009"]
+dependencies: []
+adrs: ["ADR-0009"]
+wave: "N/A"
+initiative: adr-0009-package-scanning-rollout
+node: honeydrunk-data
+version_bump: false
+---
+
+# Chore: Wire up PR validation and nightly scan workflows
+
+## Summary
+
+Create three GitHub Actions consumer workflow files in `HoneyDrunk.Data`. No code changes. No version bump.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Data`
+
+## Motivation
+
+ADR-0009 establishes the package scanning policy for the Grid. `HoneyDrunk.Actions` already provides all the reusable workflows; this packet wires them up in `HoneyDrunk.Data`. Until these files exist, no PR validation runs and no vulnerability or outdated-package scans run for this repo.
+
+## Files to Create
+
+### `.github/workflows/pr.yml`
+
+```yaml
+name: PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pr-core:
+    name: PR Core
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-security.yml`
+
+```yaml
+name: Nightly Security
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly-security:
+    name: Nightly Security
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-security.yml@main
+    with:
+      enable-sast: true
+      enable-iac-scan: true
+      enable-secret-scan: true
+      create-issues: true
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-deps.yml`
+
+```yaml
+name: Nightly Dependencies
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  nightly-deps:
+    name: Nightly Dependencies
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main
+    with:
+      check-dotnet-deps: true
+      create-update-prs: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/pr.yml` exists and calls `pr-core.yml@main`
+- [ ] `.github/workflows/nightly-security.yml` exists and calls `nightly-security.yml@main`
+- [ ] `.github/workflows/nightly-deps.yml` exists and calls `nightly-deps.yml@main`
+- [ ] All three workflows are valid YAML (no syntax errors)
+- [ ] No other files are modified
+
+## Dependencies
+
+None.
+
+## Agent Handoff
+
+**Objective:** Create three GitHub Actions workflow files. No code changes required.
+**Target:** HoneyDrunk.Data, branch from `main`
+**ADRs:** ADR-0009
+
+**Constraints:**
+- Create files only — do not modify any existing source files
+- Do not add any NuGet packages or project references
+- Do not bump the version
+
+**Key Files:**
+- New: `.github/workflows/pr.yml`
+- New: `.github/workflows/nightly-security.yml`
+- New: `.github/workflows/nightly-deps.yml`

--- a/generated/issue-packets/active/adr-0009-package-scanning-rollout/04-transport-wire-up-scan-workflows.md
+++ b/generated/issue-packets/active/adr-0009-package-scanning-rollout/04-transport-wire-up-scan-workflows.md
@@ -1,0 +1,118 @@
+---
+name: Wire up PR validation and nightly scan workflows
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Transport
+labels: ["chore", "tier-1", "adr-0009"]
+dependencies: []
+adrs: ["ADR-0009"]
+wave: "N/A"
+initiative: adr-0009-package-scanning-rollout
+node: honeydrunk-transport
+version_bump: false
+---
+
+# Chore: Wire up PR validation and nightly scan workflows
+
+## Summary
+
+Create three GitHub Actions consumer workflow files in `HoneyDrunk.Transport`. No code changes. No version bump.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Transport`
+
+## Motivation
+
+ADR-0009 establishes the package scanning policy for the Grid. `HoneyDrunk.Actions` already provides all the reusable workflows; this packet wires them up in `HoneyDrunk.Transport`. Until these files exist, no PR validation runs and no vulnerability or outdated-package scans run for this repo.
+
+## Files to Create
+
+### `.github/workflows/pr.yml`
+
+```yaml
+name: PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pr-core:
+    name: PR Core
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-security.yml`
+
+```yaml
+name: Nightly Security
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly-security:
+    name: Nightly Security
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-security.yml@main
+    with:
+      enable-sast: true
+      enable-iac-scan: true
+      enable-secret-scan: true
+      create-issues: true
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-deps.yml`
+
+```yaml
+name: Nightly Dependencies
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  nightly-deps:
+    name: Nightly Dependencies
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main
+    with:
+      check-dotnet-deps: true
+      create-update-prs: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/pr.yml` exists and calls `pr-core.yml@main`
+- [ ] `.github/workflows/nightly-security.yml` exists and calls `nightly-security.yml@main`
+- [ ] `.github/workflows/nightly-deps.yml` exists and calls `nightly-deps.yml@main`
+- [ ] All three workflows are valid YAML (no syntax errors)
+- [ ] No other files are modified
+
+## Dependencies
+
+None.
+
+## Agent Handoff
+
+**Objective:** Create three GitHub Actions workflow files. No code changes required.
+**Target:** HoneyDrunk.Transport, branch from `main`
+**ADRs:** ADR-0009
+
+**Constraints:**
+- Create files only — do not modify any existing source files
+- Do not add any NuGet packages or project references
+- Do not bump the version
+
+**Key Files:**
+- New: `.github/workflows/pr.yml`
+- New: `.github/workflows/nightly-security.yml`
+- New: `.github/workflows/nightly-deps.yml`

--- a/generated/issue-packets/active/adr-0009-package-scanning-rollout/05-vault-wire-up-scan-workflows.md
+++ b/generated/issue-packets/active/adr-0009-package-scanning-rollout/05-vault-wire-up-scan-workflows.md
@@ -1,0 +1,118 @@
+---
+name: Wire up PR validation and nightly scan workflows
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Vault
+labels: ["chore", "tier-1", "adr-0009"]
+dependencies: []
+adrs: ["ADR-0009"]
+wave: "N/A"
+initiative: adr-0009-package-scanning-rollout
+node: honeydrunk-vault
+version_bump: false
+---
+
+# Chore: Wire up PR validation and nightly scan workflows
+
+## Summary
+
+Create three GitHub Actions consumer workflow files in `HoneyDrunk.Vault`. No code changes. No version bump.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Vault`
+
+## Motivation
+
+ADR-0009 establishes the package scanning policy for the Grid. `HoneyDrunk.Actions` already provides all the reusable workflows; this packet wires them up in `HoneyDrunk.Vault`. Until these files exist, no PR validation runs and no vulnerability or outdated-package scans run for this repo.
+
+## Files to Create
+
+### `.github/workflows/pr.yml`
+
+```yaml
+name: PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pr-core:
+    name: PR Core
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-security.yml`
+
+```yaml
+name: Nightly Security
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly-security:
+    name: Nightly Security
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-security.yml@main
+    with:
+      enable-sast: true
+      enable-iac-scan: true
+      enable-secret-scan: true
+      create-issues: true
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-deps.yml`
+
+```yaml
+name: Nightly Dependencies
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  nightly-deps:
+    name: Nightly Dependencies
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main
+    with:
+      check-dotnet-deps: true
+      create-update-prs: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/pr.yml` exists and calls `pr-core.yml@main`
+- [ ] `.github/workflows/nightly-security.yml` exists and calls `nightly-security.yml@main`
+- [ ] `.github/workflows/nightly-deps.yml` exists and calls `nightly-deps.yml@main`
+- [ ] All three workflows are valid YAML (no syntax errors)
+- [ ] No other files are modified
+
+## Dependencies
+
+None. This packet is independent of the ADR-0005/0006 Vault work (`01-vault-bootstrap-extensions.md` etc.) — it only adds CI files, it does not touch any `.csproj` or source files.
+
+## Agent Handoff
+
+**Objective:** Create three GitHub Actions workflow files. No code changes required.
+**Target:** HoneyDrunk.Vault, branch from `main`
+**ADRs:** ADR-0009
+
+**Constraints:**
+- Create files only — do not modify any existing source files
+- Do not add any NuGet packages or project references
+- Do not bump the version
+
+**Key Files:**
+- New: `.github/workflows/pr.yml`
+- New: `.github/workflows/nightly-security.yml`
+- New: `.github/workflows/nightly-deps.yml`

--- a/generated/issue-packets/active/adr-0009-package-scanning-rollout/06-pulse-wire-up-scan-workflows.md
+++ b/generated/issue-packets/active/adr-0009-package-scanning-rollout/06-pulse-wire-up-scan-workflows.md
@@ -1,0 +1,118 @@
+---
+name: Wire up PR validation and nightly scan workflows
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Pulse
+labels: ["chore", "tier-1", "adr-0009"]
+dependencies: []
+adrs: ["ADR-0009"]
+wave: "N/A"
+initiative: adr-0009-package-scanning-rollout
+node: honeydrunk-pulse
+version_bump: false
+---
+
+# Chore: Wire up PR validation and nightly scan workflows
+
+## Summary
+
+Create three GitHub Actions consumer workflow files in `HoneyDrunk.Pulse`. No code changes. No version bump.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Pulse`
+
+## Motivation
+
+ADR-0009 establishes the package scanning policy for the Grid. `HoneyDrunk.Actions` already provides all the reusable workflows; this packet wires them up in `HoneyDrunk.Pulse`. Until these files exist, no PR validation runs and no vulnerability or outdated-package scans run for this repo.
+
+## Files to Create
+
+### `.github/workflows/pr.yml`
+
+```yaml
+name: PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pr-core:
+    name: PR Core
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-security.yml`
+
+```yaml
+name: Nightly Security
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly-security:
+    name: Nightly Security
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-security.yml@main
+    with:
+      enable-sast: true
+      enable-iac-scan: true
+      enable-secret-scan: true
+      create-issues: true
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-deps.yml`
+
+```yaml
+name: Nightly Dependencies
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  nightly-deps:
+    name: Nightly Dependencies
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main
+    with:
+      check-dotnet-deps: true
+      create-update-prs: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/pr.yml` exists and calls `pr-core.yml@main`
+- [ ] `.github/workflows/nightly-security.yml` exists and calls `nightly-security.yml@main`
+- [ ] `.github/workflows/nightly-deps.yml` exists and calls `nightly-deps.yml@main`
+- [ ] All three workflows are valid YAML (no syntax errors)
+- [ ] No other files are modified
+
+## Dependencies
+
+None.
+
+## Agent Handoff
+
+**Objective:** Create three GitHub Actions workflow files. No code changes required.
+**Target:** HoneyDrunk.Pulse, branch from `main`
+**ADRs:** ADR-0009
+
+**Constraints:**
+- Create files only — do not modify any existing source files
+- Do not add any NuGet packages or project references
+- Do not bump the version
+
+**Key Files:**
+- New: `.github/workflows/pr.yml`
+- New: `.github/workflows/nightly-security.yml`
+- New: `.github/workflows/nightly-deps.yml`

--- a/generated/issue-packets/active/adr-0009-package-scanning-rollout/07-notify-wire-up-scan-workflows.md
+++ b/generated/issue-packets/active/adr-0009-package-scanning-rollout/07-notify-wire-up-scan-workflows.md
@@ -1,0 +1,118 @@
+---
+name: Wire up PR validation and nightly scan workflows
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["chore", "tier-1", "adr-0009"]
+dependencies: []
+adrs: ["ADR-0009"]
+wave: "N/A"
+initiative: adr-0009-package-scanning-rollout
+node: honeydrunk-notify
+version_bump: false
+---
+
+# Chore: Wire up PR validation and nightly scan workflows
+
+## Summary
+
+Create three GitHub Actions consumer workflow files in `HoneyDrunk.Notify`. No code changes. No version bump.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Notify`
+
+## Motivation
+
+ADR-0009 establishes the package scanning policy for the Grid. `HoneyDrunk.Actions` already provides all the reusable workflows; this packet wires them up in `HoneyDrunk.Notify`. Until these files exist, no PR validation runs and no vulnerability or outdated-package scans run for this repo.
+
+## Files to Create
+
+### `.github/workflows/pr.yml`
+
+```yaml
+name: PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pr-core:
+    name: PR Core
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-security.yml`
+
+```yaml
+name: Nightly Security
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly-security:
+    name: Nightly Security
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-security.yml@main
+    with:
+      enable-sast: true
+      enable-iac-scan: true
+      enable-secret-scan: true
+      create-issues: true
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-deps.yml`
+
+```yaml
+name: Nightly Dependencies
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  nightly-deps:
+    name: Nightly Dependencies
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main
+    with:
+      check-dotnet-deps: true
+      create-update-prs: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/pr.yml` exists and calls `pr-core.yml@main`
+- [ ] `.github/workflows/nightly-security.yml` exists and calls `nightly-security.yml@main`
+- [ ] `.github/workflows/nightly-deps.yml` exists and calls `nightly-deps.yml@main`
+- [ ] All three workflows are valid YAML (no syntax errors)
+- [ ] No other files are modified
+
+## Dependencies
+
+None.
+
+## Agent Handoff
+
+**Objective:** Create three GitHub Actions workflow files. No code changes required.
+**Target:** HoneyDrunk.Notify, branch from `main`
+**ADRs:** ADR-0009
+
+**Constraints:**
+- Create files only — do not modify any existing source files
+- Do not add any NuGet packages or project references
+- Do not bump the version
+
+**Key Files:**
+- New: `.github/workflows/pr.yml`
+- New: `.github/workflows/nightly-security.yml`
+- New: `.github/workflows/nightly-deps.yml`

--- a/generated/issue-packets/active/adr-0009-package-scanning-rollout/08-web-rest-wire-up-scan-workflows.md
+++ b/generated/issue-packets/active/adr-0009-package-scanning-rollout/08-web-rest-wire-up-scan-workflows.md
@@ -1,0 +1,118 @@
+---
+name: Wire up PR validation and nightly scan workflows
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Web.Rest
+labels: ["chore", "tier-1", "adr-0009"]
+dependencies: []
+adrs: ["ADR-0009"]
+wave: "N/A"
+initiative: adr-0009-package-scanning-rollout
+node: honeydrunk-web-rest
+version_bump: false
+---
+
+# Chore: Wire up PR validation and nightly scan workflows
+
+## Summary
+
+Create three GitHub Actions consumer workflow files in `HoneyDrunk.Web.Rest`. No code changes. No version bump.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Web.Rest`
+
+## Motivation
+
+ADR-0009 establishes the package scanning policy for the Grid. `HoneyDrunk.Actions` already provides all the reusable workflows; this packet wires them up in `HoneyDrunk.Web.Rest`. Until these files exist, no PR validation runs and no vulnerability or outdated-package scans run for this repo.
+
+## Files to Create
+
+### `.github/workflows/pr.yml`
+
+```yaml
+name: PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pr-core:
+    name: PR Core
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-security.yml`
+
+```yaml
+name: Nightly Security
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly-security:
+    name: Nightly Security
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-security.yml@main
+    with:
+      enable-sast: true
+      enable-iac-scan: true
+      enable-secret-scan: true
+      create-issues: true
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### `.github/workflows/nightly-deps.yml`
+
+```yaml
+name: Nightly Dependencies
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  nightly-deps:
+    name: Nightly Dependencies
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main
+    with:
+      check-dotnet-deps: true
+      create-update-prs: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/pr.yml` exists and calls `pr-core.yml@main`
+- [ ] `.github/workflows/nightly-security.yml` exists and calls `nightly-security.yml@main`
+- [ ] `.github/workflows/nightly-deps.yml` exists and calls `nightly-deps.yml@main`
+- [ ] All three workflows are valid YAML (no syntax errors)
+- [ ] No other files are modified
+
+## Dependencies
+
+None.
+
+## Agent Handoff
+
+**Objective:** Create three GitHub Actions workflow files. No code changes required.
+**Target:** HoneyDrunk.Web.Rest, branch from `main`
+**ADRs:** ADR-0009
+
+**Constraints:**
+- Create files only — do not modify any existing source files
+- Do not add any NuGet packages or project references
+- Do not bump the version
+
+**Key Files:**
+- New: `.github/workflows/pr.yml`
+- New: `.github/workflows/nightly-security.yml`
+- New: `.github/workflows/nightly-deps.yml`

--- a/generated/issue-packets/active/adr-0009-package-scanning-rollout/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0009-package-scanning-rollout/dispatch-plan.md
@@ -1,0 +1,94 @@
+# Dispatch Plan: ADR-0009 Package Scanning Rollout
+
+**Date:** 2026-04-11
+**Trigger:** ADR-0009 (Package Scanning — Vulnerability and Dependency Freshness) proposed
+**Type:** Multi-repo
+**Sector:** Core
+**Site sync required:** No
+**Rollback plan:** Delete the three `.github/workflows/` files from any repo if a workflow causes unexpected failures. No code changes, no version bumps — fully reversible.
+
+## Summary
+
+ADR-0009 formalises the package scanning policy for the HoneyDrunk Grid. `HoneyDrunk.Actions` already contains all the necessary reusable workflows (`pr-core.yml`, `nightly-security.yml`, `nightly-deps.yml`) — the only missing piece is consumer wiring in each .NET repo.
+
+This rollout creates three workflow files in each of the 8 .NET repos:
+
+1. **`pr.yml`** — calls `pr-core.yml@main` on `pull_request` to `main`. Includes vulnerability scan gate at `High+` severity.
+2. **`nightly-security.yml`** — calls `nightly-security.yml@main` nightly at 02:00 UTC. Runs full vulnerability scan, CodeQL SAST, gitleaks secrets, Trivy IaC.
+3. **`nightly-deps.yml`** — calls `nightly-deps.yml@main` weekly on Monday at 03:00 UTC. Reports outdated and deprecated NuGet packages.
+
+No code changes. No version bumps. Tier 1.
+
+## Execution Model
+
+All 8 packets are independent and can be executed in parallel on Codex Cloud. There are no cross-repo dependencies and no wave ordering required.
+
+## Packets
+
+All packets are parallel — no wave sequencing needed:
+
+- [ ] `HoneyDrunk.Kernel` — [`01-kernel-wire-up-scan-workflows.md`](01-kernel-wire-up-scan-workflows.md)
+- [ ] `HoneyDrunk.Auth` — [`02-auth-wire-up-scan-workflows.md`](02-auth-wire-up-scan-workflows.md)
+- [ ] `HoneyDrunk.Data` — [`03-data-wire-up-scan-workflows.md`](03-data-wire-up-scan-workflows.md)
+- [ ] `HoneyDrunk.Transport` — [`04-transport-wire-up-scan-workflows.md`](04-transport-wire-up-scan-workflows.md)
+- [ ] `HoneyDrunk.Vault` — [`05-vault-wire-up-scan-workflows.md`](05-vault-wire-up-scan-workflows.md)
+- [ ] `HoneyDrunk.Pulse` — [`06-pulse-wire-up-scan-workflows.md`](06-pulse-wire-up-scan-workflows.md)
+- [ ] `HoneyDrunk.Notify` — [`07-notify-wire-up-scan-workflows.md`](07-notify-wire-up-scan-workflows.md)
+- [ ] `HoneyDrunk.Web.Rest` — [`08-web-rest-wire-up-scan-workflows.md`](08-web-rest-wire-up-scan-workflows.md)
+
+## Exit Criteria
+
+- All 8 repos have `.github/workflows/pr.yml`, `.github/workflows/nightly-security.yml`, and `.github/workflows/nightly-deps.yml`
+- PR workflow appears as a check on at least one PR in each repo
+- At least one nightly-security run completes successfully per repo (SARIF uploaded to Security tab)
+- At least one nightly-deps run completes successfully per repo (artifact uploaded)
+
+## Archival
+
+When all 8 packets reach `Done` on the org Project board and the exit criteria above are met, move the entire `active/adr-0009-package-scanning-rollout/` folder to `archive/adr-0009-package-scanning-rollout/` in one commit. Partial archival is forbidden.
+
+## `gh` CLI Commands — File All Issues At Once
+
+```bash
+PACKETS="generated/issue-packets/active/adr-0009-package-scanning-rollout"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Kernel \
+  --title "Wire up PR validation and nightly scan workflows" \
+  --body-file $PACKETS/01-kernel-wire-up-scan-workflows.md \
+  --label "chore,tier-1,adr-0009"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Auth \
+  --title "Wire up PR validation and nightly scan workflows" \
+  --body-file $PACKETS/02-auth-wire-up-scan-workflows.md \
+  --label "chore,tier-1,adr-0009"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Data \
+  --title "Wire up PR validation and nightly scan workflows" \
+  --body-file $PACKETS/03-data-wire-up-scan-workflows.md \
+  --label "chore,tier-1,adr-0009"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Transport \
+  --title "Wire up PR validation and nightly scan workflows" \
+  --body-file $PACKETS/04-transport-wire-up-scan-workflows.md \
+  --label "chore,tier-1,adr-0009"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Vault \
+  --title "Wire up PR validation and nightly scan workflows" \
+  --body-file $PACKETS/05-vault-wire-up-scan-workflows.md \
+  --label "chore,tier-1,adr-0009"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Pulse \
+  --title "Wire up PR validation and nightly scan workflows" \
+  --body-file $PACKETS/06-pulse-wire-up-scan-workflows.md \
+  --label "chore,tier-1,adr-0009"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Notify \
+  --title "Wire up PR validation and nightly scan workflows" \
+  --body-file $PACKETS/07-notify-wire-up-scan-workflows.md \
+  --label "chore,tier-1,adr-0009"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Web.Rest \
+  --title "Wire up PR validation and nightly scan workflows" \
+  --body-file $PACKETS/08-web-rest-wire-up-scan-workflows.md \
+  --label "chore,tier-1,adr-0009"
+```

--- a/generated/issue-packets/active/standalone/2026-04-11-standards-stylecop-analyzer-embedding.md
+++ b/generated/issue-packets/active/standalone/2026-04-11-standards-stylecop-analyzer-embedding.md
@@ -1,0 +1,218 @@
+---
+name: Embed StyleCop and NetAnalyzer DLLs in HoneyDrunk.Standards package
+type: bug-fix
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Standards
+labels: ["bug", "tier-2", "infrastructure"]
+dependencies: []
+adrs: []
+wave: "N/A"
+initiative: standalone
+node: honeydrunk-standards
+version_bump: true
+target_version: 0.2.7
+---
+
+# Bug Fix: StyleCop analyzer DLLs not loaded by CLI builds
+
+## Summary
+
+StyleCop SA\* rules are enforced by Visual Studio but silently ignored by `dotnet build` and CI pipelines. This is a split-brain enforcement gap: PRs pass CI with 0 SA warnings while the IDE shows errors. Fix: embed the analyzer DLLs directly in the `HoneyDrunk.Standards` `.nupkg` and wire them in the `.targets` file.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Standards`
+
+## Root Cause
+
+Two mechanisms in `0.2.6` are both broken for CLI builds:
+
+**1. `buildTransitive/HoneyDrunk.Standards.props` — PackageReference injection (lines 75–87)**
+
+```xml
+<ItemGroup Condition="'$(HD_EnableAnalyzers)' == 'true'">
+  <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" ...>
+    <PrivateAssets>all</PrivateAssets>
+    ...
+  </PackageReference>
+  <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" ...>
+    <PrivateAssets>all</PrivateAssets>
+    ...
+  </PackageReference>
+</ItemGroup>
+```
+
+NuGet restore runs **before** MSBuild imports `.props` from resolved packages. By the time this `<PackageReference>` is injected, restore is already finished. The packages are never downloaded for the consumer and the analyzer DLLs never reach the compiler's `/analyzer:` list.
+
+**2. `PrivateAssets="all"` on the Standards `.csproj`**
+
+StyleCop is a dependency of the Standards package itself with `PrivateAssets="all"`, which correctly prevents it from flowing to consumers via NuGet's dependency graph — but it also means the DLLs are only available at pack time, not at the consumer's build time.
+
+**Why Visual Studio works:** VS uses its own Roslyn host and resolves analyzers from its extension/package cache independently of MSBuild restore ordering.
+
+**Rejected fix:** Removing `PrivateAssets="all"` would force StyleCop on all consumers regardless of the `HD_UseStyleCop=false` toggle, since NuGet's dependency graph ignores MSBuild conditions.
+
+## Fix
+
+Pack the StyleCop (and NetAnalyzers) DLLs directly inside the `.nupkg` under `analyzers/dotnet/cs/`. Reference them from the `.targets` file using the existing `HD_UseStyleCop` / `HD_EnableAnalyzers` toggles.
+
+## Changes Required
+
+### 1. `HoneyDrunk.Standards.csproj` — add pack target to embed analyzer DLLs
+
+Add a `<PropertyGroup>` that declares the package versions as properties (single source of truth, must stay in sync with the `<PackageReference>` declarations), and a `BeforeTargets="GenerateNuspec"` target that includes the DLLs as pack items:
+
+```xml
+<!-- Version constants — must match the <PackageReference> declarations below -->
+<PropertyGroup>
+  <_StyleCopVersion>1.2.0-beta.556</_StyleCopVersion>
+  <_NetAnalyzersVersion>9.0.0</_NetAnalyzersVersion>
+</PropertyGroup>
+
+<Target Name="HD_EmbedAnalyzerDlls" BeforeTargets="GenerateNuspec">
+  <!-- StyleCop DLLs -->
+  <ItemGroup>
+    <None Include="$(NuGetPackageRoot)stylecop.analyzers\$(_StyleCopVersion)\analyzers\dotnet\cs\StyleCop.Analyzers.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs/StyleCop.Analyzers.dll"
+          Visible="false" />
+    <None Include="$(NuGetPackageRoot)stylecop.analyzers\$(_StyleCopVersion)\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs/StyleCop.Analyzers.CodeFixes.dll"
+          Visible="false" />
+  </ItemGroup>
+
+  <!-- NetAnalyzers DLLs -->
+  <ItemGroup>
+    <None Include="$(NuGetPackageRoot)microsoft.codeanalysis.netanalyzers\$(_NetAnalyzersVersion)\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs/Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll"
+          Visible="false" />
+    <None Include="$(NuGetPackageRoot)microsoft.codeanalysis.netanalyzers\$(_NetAnalyzersVersion)\analyzers\dotnet\cs\Microsoft.CodeAnalysis.NetAnalyzers.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs/Microsoft.CodeAnalysis.NetAnalyzers.dll"
+          Visible="false" />
+  </ItemGroup>
+</Target>
+```
+
+> **Note:** `$(NuGetPackageRoot)` resolves to the global NuGet packages cache (e.g. `~/.nuget/packages/` on Linux, `%USERPROFILE%\.nuget\packages\` on Windows). It is set by NuGet during restore and is available to MSBuild targets. Verify the actual subfolder layout for each package in the local cache if the exact DLL filenames differ.
+
+The existing `<PackageReference Include="StyleCop.Analyzers" ...>` and `<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" ...>` with `PrivateAssets="all"` **stay** in the `.csproj` — they are needed at pack time to ensure the packages are restored and the DLLs are available.
+
+### 2. `buildTransitive/HoneyDrunk.Standards.targets` — add `<Analyzer>` items
+
+Add conditional `<Analyzer>` items in a new target or `ItemGroup` so consuming projects load the embedded DLLs:
+
+```xml
+<!-- ============================================
+     Embedded Analyzer References
+     ============================================ -->
+<ItemGroup Condition="'$(HD_EnableAnalyzers)' == 'true'">
+
+  <!-- StyleCop: loaded from embedded DLLs in the package -->
+  <Analyzer
+    Condition="'$(HD_UseStyleCop)' == 'true'"
+    Include="$(MSBuildThisFileDirectory)../analyzers/dotnet/cs/StyleCop.Analyzers.dll" />
+  <Analyzer
+    Condition="'$(HD_UseStyleCop)' == 'true'"
+    Include="$(MSBuildThisFileDirectory)../analyzers/dotnet/cs/StyleCop.Analyzers.CodeFixes.dll" />
+
+  <!-- NetAnalyzers: loaded from embedded DLLs in the package -->
+  <Analyzer Include="$(MSBuildThisFileDirectory)../analyzers/dotnet/cs/Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll" />
+  <Analyzer Include="$(MSBuildThisFileDirectory)../analyzers/dotnet/cs/Microsoft.CodeAnalysis.NetAnalyzers.dll" />
+
+</ItemGroup>
+```
+
+`$(MSBuildThisFileDirectory)` is the `buildTransitive/` folder at runtime. `../analyzers/dotnet/cs/` navigates to the `analyzers/dotnet/cs/` folder packed alongside it.
+
+### 3. `buildTransitive/HoneyDrunk.Standards.props` — remove broken PackageReference injections
+
+Remove the entire `<ItemGroup>` that injects `PackageReference` items into consuming projects (the broken mechanism). This is currently the last `<ItemGroup>` in the file, containing both the StyleCop and NetAnalyzers references.
+
+**Remove (lines 75–87 in 0.2.6):**
+```xml
+<!-- ============================================
+     Analyzer Package References
+     ============================================ -->
+<ItemGroup Condition="'$(HD_EnableAnalyzers)' == 'true'">
+  <!-- StyleCop for naming and ordering conventions -->
+  <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" Condition="'$(HD_UseStyleCop)' == 'true'">
+    <PrivateAssets>all</PrivateAssets>
+    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+  </PackageReference>
+  
+  <!-- Microsoft Code Quality Analyzers -->
+  <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
+    <PrivateAssets>all</PrivateAssets>
+    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+  </PackageReference>
+</ItemGroup>
+```
+
+The `stylecop.json`, `.editorconfig`, and `HoneyDrunk.Standards.globalconfig` `<AdditionalFiles>` / `<EditorConfigFiles>` / `<GlobalAnalyzerConfigFiles>` items in `.props` are correct and must stay — they flow config to the analyzer, not the analyzer DLLs themselves.
+
+### 4. Version bump to `0.2.7`
+
+This is a **behavior change** — analyzers that were silently absent from CLI builds will now run. Consumers will see new build errors. Bump all non-test projects in the solution to `0.2.7` in a single commit before starting feature work.
+
+Add a `[0.2.7]` CHANGELOG entry:
+
+```
+## [0.2.7] — 2026-04-11
+
+### Fixed
+- StyleCop SA* analyzer DLLs now loaded by `dotnet build` and CI pipelines.
+  Previously, `PackageReference` injection from `.props` was silently skipped
+  because NuGet restore runs before `.props` from resolved packages are imported.
+  Analyzer DLLs are now embedded in the package under `analyzers/dotnet/cs/` and
+  referenced directly from `.targets`.
+
+### Breaking
+- All consumer repos will see new SA* and CA* errors on first build after upgrade.
+  These violations existed before but were invisible to CLI builds. Each repo needs
+  a cleanup pass to fix or add targeted suppressions.
+
+### Removed
+- Broken `<PackageReference>` injections from `buildTransitive/HoneyDrunk.Standards.props`.
+  These never worked for CLI builds and are replaced by embedded DLL references in `.targets`.
+```
+
+## Acceptance Criteria
+
+- [ ] `dotnet build` on any consumer project (e.g. `HoneyDrunk.Vault`) produces SA\* diagnostics matching what Visual Studio shows
+- [ ] `dotnet build` with `<HD_UseStyleCop>false</HD_UseStyleCop>` suppresses all SA\* rules in both IDE and CLI
+- [ ] `dotnet build` with `<HD_EnableAnalyzers>false</HD_EnableAnalyzers>` suppresses all analyzers (StyleCop + NetAnalyzers) in both IDE and CLI
+- [ ] `dotnet pack` produces a `.nupkg` with `analyzers/dotnet/cs/StyleCop.Analyzers.dll` and `StyleCop.Analyzers.CodeFixes.dll` inside it
+- [ ] No new transitive NuGet dependencies added to consumer package graphs (`dotnet list package` on a consumer shows no new `StyleCop.Analyzers` or `Microsoft.CodeAnalysis.NetAnalyzers` entries)
+- [ ] All projects bumped to `0.2.7`
+- [ ] CHANGELOG entry added
+
+## Downstream Impact
+
+Every consumer repo (`HoneyDrunk.Kernel`, `HoneyDrunk.Vault`, `HoneyDrunk.Transport`, `HoneyDrunk.Auth`, `HoneyDrunk.Pulse`, `HoneyDrunk.Web.Rest`, `HoneyDrunk.Notify`) will see new SA\* errors on first `dotnet build` after upgrading to `0.2.7`. This is expected — those violations already exist; they were just invisible to CI. Each repo will need a cleanup pass (separate issues, separate PRs) to resolve the newly-visible diagnostics.
+
+**Do not file those cleanup issues as part of this task.** This packet only covers the Standards package itself.
+
+## Dependencies
+
+None. Foundational fix — no upstream packages need to change.
+
+## Agent Handoff
+
+**Objective:** Fix the broken analyzer embedding in `HoneyDrunk.Standards` so that StyleCop SA\* rules are enforced by `dotnet build` / CI, not just Visual Studio. Bump to `0.2.7`.
+**Target:** HoneyDrunk.Standards, branch from `main`
+**ADRs:** None
+
+**Constraints:**
+- The existing `PrivateAssets="all"` on StyleCop and NetAnalyzers in the `.csproj` must stay — removing it would break the opt-out contract by forcing packages on all consumers
+- The `stylecop.json`, `.editorconfig`, and `.globalconfig` items in `.props` must stay — they are config, not DLL references, and they work correctly
+- Do not add any new runtime dependencies to the package (NuGet `<dependencies>` in the nuspec must remain empty for the `net10.0` target group)
+- `HD_UseStyleCop=false` must continue to completely suppress StyleCop in consumers; verify this in the `<Analyzer>` item conditions
+
+**Key Files:**
+- `HoneyDrunk.Standards.csproj` — add `HD_EmbedAnalyzerDlls` pack target
+- `buildTransitive/HoneyDrunk.Standards.props` — remove the broken `<PackageReference>` injection `<ItemGroup>`
+- `buildTransitive/HoneyDrunk.Standards.targets` — add `<Analyzer>` items referencing embedded DLLs
+- `CHANGELOG.md` — add `[0.2.7]` entry


### PR DESCRIPTION
Introduce ADR-0009 formalizing .NET package scanning policy: PR-time CVE gating, nightly security and weekly dependency checks using HoneyDrunk.Actions workflows. Add dispatch plan and 8 issue packets for workflow adoption across core repos. Include bug-fix packet for HoneyDrunk.Standards to embed analyzer DLLs, ensuring StyleCop/NetAnalyzers run in CI (v0.2.7). No consumer code changes.