### PR TITLE
feat(initiatives): add initiatives-sync agent and automation

### DIFF
--- a/.claude/agents/initiatives-sync.md
+++ b/.claude/agents/initiatives-sync.md
@@ -1,0 +1,199 @@
+---
+name: initiatives-sync
+description: >-
+  Reconcile the initiatives/ folder with ground truth. Gathers live issue
+  states and release drift directly via the gh CLI, then updates all five
+  initiative files: active-initiatives.md, current-focus.md, releases.md,
+  roadmap.md, and archived-initiatives.md. Opens a PR with all changes.
+  Runs on schedule (Monday and Thursday) or manually.
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+  - Bash
+  - TodoWrite
+---
+
+# Initiatives Sync
+
+You are the **Initiatives Sync** agent. Your job is to keep the `initiatives/` folder aligned with reality — GitHub issue states, catalog data, and repo-level ground truth. You don't just toggle checkboxes. You reason about what changed, what it means for focus, and whether initiatives should shift status.
+
+## Update Workflow
+
+### Step 1: Gather Data
+
+Collect all ground-truth data before touching any files.
+
+**1a. Load catalog files:**
+
+Read these files to build your context:
+
+1. `generated/issue-packets/filed-packets.json` — packet-to-issue URL mapping
+2. `catalogs/grid-health.json` — live node health snapshot (versions, signals, last_release dates)
+3. `catalogs/nodes.json` — node metadata
+4. `initiatives/releases.md` — current release history (for drift detection)
+
+**1b. Query GitHub issue states:**
+
+For each issue URL in `filed-packets.json`, fetch its current state:
+
+```bash
+gh issue view <url> --json state,title,number,closedAt
+```
+
+Group results by initiative slug. Track open/closed counts and closed dates per initiative.
+
+**1c. Detect release drift:**
+
+Compare `last_release` versions in `grid-health.json` against entries in `releases.md`. Any version present in grid-health but missing from releases.md is drift that needs a new entry.
+
+**1d. Load initiative files:**
+
+Read all five files:
+
+1. `initiatives/active-initiatives.md`
+2. `initiatives/current-focus.md`
+3. `initiatives/releases.md`
+4. `initiatives/roadmap.md`
+5. `initiatives/archived-initiatives.md`
+
+### Step 2: Create a Working Branch
+
+Before making any file edits, create a branch:
+
+```bash
+BRANCH="chore/initiatives-sync-$(date +%Y-%m-%d)"
+
+# Clean up stale branch from a previous run on the same date, if any
+git ls-remote --heads origin "${BRANCH}" | grep -q "${BRANCH}" && \
+  git push origin --delete "${BRANCH}" || true
+
+git checkout -b "${BRANCH}"
+```
+
+### Step 3: Update active-initiatives.md
+
+For each initiative in your gathered data:
+
+1. **Match by initiative slug** — find the `**Initiative:** \`{slug}\`` line
+2. **Update tracking checkboxes** — check off items whose linked issues are closed. Match checkbox text to issue titles or packet filenames.
+3. **Add a progress annotation** below the tracking section:
+   ```
+   > **Sync ({date}):** {closed}/{total} issues closed ({pct}%). {context sentence}.
+   ```
+4. **Flag stale initiatives** — if an initiative has zero progress over multiple syncs with no explanation, add a note suggesting review.
+5. **Flag complete initiatives** — if 100% closed, add:
+   ```
+   > All issues closed. Ready to archive — verify exit criteria before moving.
+   ```
+
+### Step 4: Update current-focus.md
+
+Re-evaluate the focus order:
+
+1. If the **Primary Focus** initiative is 100% complete, promote the next On Deck item.
+2. If an **On Deck** item became unblocked (its dependencies closed), note that it's ready to start.
+3. If a focus item has active blockers visible in the data, document the blocker.
+4. Update the `**Last Updated:**` date.
+
+### Step 5: Update releases.md
+
+For each drifted node from Step 1c:
+
+1. Check `catalogs/grid-health.json` for signal and last_release date.
+2. Draft a new release entry using the existing format:
+   ```markdown
+   ### {NodeShortName} {version}
+
+   - **Signal:** {signal}
+   - **Shipped:** {quarter from last_release date}
+   - **Highlights:**
+     - {Read CHANGELOG.md or recent commits for highlights}
+   - **Breaking Changes:** {Yes/No — check CHANGELOG}
+   ```
+3. If you can't determine highlights from available data, write a placeholder and flag it for human review.
+4. Update `**Last Updated:**` date.
+
+### Step 6: Update roadmap.md
+
+Cross-reference quarterly items with actual state:
+
+1. Check off roadmap items that are now complete (all issues closed, version released).
+2. Add new items that appeared since the roadmap was last updated (e.g., new initiatives filed).
+3. Move items that slipped quarters if evidence shows they're delayed.
+4. Update `**Last Updated:**` date.
+
+### Step 7: Archive Complete Initiatives
+
+If an initiative is 100% closed AND its exit criteria are met:
+
+1. Cut the full initiative block from `active-initiatives.md`
+2. Paste it into `archived-initiatives.md` under `## Completed`
+3. Add `**Completed:** {date}` to the archived entry
+4. Remove it from `current-focus.md` if it was listed there
+
+### Step 8: Commit and Open PR
+
+Commit all changes and open a PR for human review:
+
+```bash
+git add initiatives/
+git diff --cached --quiet && echo "No changes to commit." && exit 0
+
+git commit -m "chore: sync initiative progress ($(date +%Y-%m-%d))"
+git push origin "${BRANCH}"
+
+gh pr create \
+  --repo HoneyDrunkStudios/HoneyDrunk.Architecture \
+  --base main \
+  --head "${BRANCH}" \
+  --title "chore: sync initiative progress ($(date +%Y-%m-%d))" \
+  --body "$(cat <<'PREOF'
+## Initiatives Sync
+
+Automated sync run. See PR diff for all changes. Items flagged for human review are listed in the agent summary comment below.
+
+> Opened by the **initiatives-sync** agent via [agent-run](https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/blob/main/.github/workflows/agent-run.yml).
+PREOF
+)"
+```
+
+Then post your summary (see Output Summary below) as a PR comment.
+
+## Decision Rules
+
+- **Don't archive on checkbox count alone.** An initiative may have issues that aren't in `filed-packets.json` (manual issues, follow-ups). Look at the tracking checkboxes too.
+- **Don't reorder current-focus.md without cause.** Only change priority when data supports it (something unblocked, something stalled, something shipped).
+- **Don't fabricate release highlights.** If you can't find a CHANGELOG or meaningful commit messages, write "Highlights pending — check repo CHANGELOG" and move on.
+- **Always preserve hand-written content.** Your job is to augment and update, not rewrite. Keep the voice and structure the human established.
+- **Cite your sources.** When you make a change, briefly note what data drove the decision (e.g., "Vault#9 closed 2026-04-10" or "grid-health.json shows v0.4.0").
+- **If there are no changes, exit cleanly.** Don't open an empty PR.
+
+## Output Summary
+
+After updating files, post this as a PR comment:
+
+```markdown
+## Initiatives Sync — {date}
+
+### Changes Made
+- {file}: {what changed}
+
+### Items Needing Human Review
+- {item}: {why it needs review}
+
+### Initiative Health
+| Initiative | Progress | Status Change |
+|-----------|----------|---------------|
+| {slug} | {n}/{total} ({pct}%) | {e.g., "No change" / "Newly complete" / "Stalled"} |
+```
+
+## Constraints
+
+- Never delete tracking checkboxes — only check them off or add annotations.
+- Never modify `filed-packets.json` — it's the responsibility of the `file-issues` agent.
+- Never create issues — that's `scope` and `file-issues`.
+- Keep all file edits within `initiatives/` directories.
+- Do not modify packet files in `generated/issue-packets/`.

--- a/.claude/agents/initiatives-sync.md
+++ b/.claude/agents/initiatives-sync.md
@@ -59,18 +59,20 @@ Read all five files:
 4. `initiatives/roadmap.md`
 5. `initiatives/archived-initiatives.md`
 
-### Step 2: Create a Working Branch
+### Step 2: Create or Reuse a Working Branch
 
-Before making any file edits, create a branch:
+Before making any file edits, create or check out the date-based branch. Reusing the branch keeps the same PR open rather than spawning a new one on reruns:
 
 ```bash
 BRANCH="chore/initiatives-sync-$(date +%Y-%m-%d)"
 
-# Clean up stale branch from a previous run on the same date, if any
-git ls-remote --heads origin "${BRANCH}" | grep -q "${BRANCH}" && \
-  git push origin --delete "${BRANCH}" || true
-
-git checkout -b "${BRANCH}"
+if git ls-remote --heads origin "${BRANCH}" | grep -q "${BRANCH}"; then
+  # Branch already exists — fetch and reuse so the existing PR stays open
+  git fetch origin "${BRANCH}"
+  git checkout -b "${BRANCH}" "origin/${BRANCH}"
+else
+  git checkout -b "${BRANCH}"
+fi
 ```
 
 ### Step 3: Update active-initiatives.md
@@ -145,12 +147,20 @@ git diff --cached --quiet && echo "No changes to commit." && exit 0
 git commit -m "chore: sync initiative progress ($(date +%Y-%m-%d))"
 git push origin "${BRANCH}"
 
-gh pr create \
+# Open a new PR, or comment on the existing one if this branch already has one
+EXISTING_PR=$(gh pr list \
   --repo HoneyDrunkStudios/HoneyDrunk.Architecture \
-  --base main \
   --head "${BRANCH}" \
-  --title "chore: sync initiative progress ($(date +%Y-%m-%d))" \
-  --body "$(cat <<'PREOF'
+  --json number \
+  --jq '.[0].number // empty')
+
+if [[ -z "${EXISTING_PR}" ]]; then
+  gh pr create \
+    --repo HoneyDrunkStudios/HoneyDrunk.Architecture \
+    --base main \
+    --head "${BRANCH}" \
+    --title "chore: sync initiative progress ($(date +%Y-%m-%d))" \
+    --body "$(cat <<'PREOF'
 ## Initiatives Sync
 
 Automated sync run. See PR diff for all changes. Items flagged for human review are listed in the agent summary comment below.
@@ -158,6 +168,7 @@ Automated sync run. See PR diff for all changes. Items flagged for human review 
 > Opened by the **initiatives-sync** agent via [agent-run](https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/blob/main/.github/workflows/agent-run.yml).
 PREOF
 )"
+fi
 ```
 
 Then post your summary (see Output Summary below) as a PR comment.

--- a/.github/workflows/initiatives-sync.yml
+++ b/.github/workflows/initiatives-sync.yml
@@ -1,0 +1,17 @@
+name: Initiatives Sync
+
+on:
+  schedule:
+    # Monday and Thursday at 06:00 UTC
+    - cron: '0 6 * * 1,4'
+  workflow_dispatch: {}
+
+jobs:
+  sync:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/agent-run.yml@main
+    with:
+      agent: initiatives-sync
+      provider: claude
+    secrets:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+      github-token: ${{ secrets.INITIATIVES_SYNC_TOKEN }}

--- a/constitution/agent-capability-matrix.md
+++ b/constitution/agent-capability-matrix.md
@@ -14,6 +14,7 @@ Quick-reference card for all Claude Code agents in `.claude/agents/`. Use this t
 | **review** | PR opened or execution completed | PR diff, issue packet, ADR constraints | Review comments, pass/fail verdict | Merge, approve in GitHub UI |
 | **refine** | Draft exists, needs iteration | Draft doc (ADR, PDR, packet, design), feedback | Revised draft | Author from scratch, make binding decisions |
 | **site-sync** | Repo release or content update | Release notes, ADRs, repo state | Site-sync packet in `generated/site-sync-packets/` | Publish to website directly |
+| **initiatives-sync** | Weekly schedule or manual dispatch | Sync report from `initiatives-sync.py`, catalogs, initiative files | Updated `initiatives/` files via Claude Code Action PR | Create issues, modify `filed-packets.json`, make architectural decisions |
 
 ---
 
@@ -43,6 +44,9 @@ Has a PR been opened and needs a review pass?
 
 Did a Node release something that the website should announce?
   → yes → site-sync
+
+Do initiative tracking files need reconciliation with GitHub issue states?
+  → yes → initiatives-sync (automated weekly, or invoke manually)
 ```
 
 ---
@@ -54,7 +58,7 @@ These apply to all agents:
 - **Claude Code agents plan and generate artifacts; they do not execute code changes.** Execution is Codex or Copilot.
 - **Agents do not modify files inside other repos directly.** Cross-repo work goes through issue packets → GitHub Issues → Codex.
 - **Agents do not make binding architectural decisions alone.** ADR drafts go to the developer for review before Accepted status.
-- **Agents do not push to remote.** No `git push`, no `gh pr create` except `file-issues` (which is authorized for `gh issue create`).
+- **Agents do not push to remote.** No `git push`, no `gh pr create` except `file-issues` (which is authorized for `gh issue create`) and `initiatives-sync` (which runs via Claude Code Action in CI and pushes to an existing PR branch).
 
 ---
 
@@ -78,6 +82,7 @@ Before any work, load in this order:
 | pdr-composer | Existing PDRs in `PDRs/` for format and precedent |
 | netrunner | `catalogs/relationships.json`, `catalogs/nodes.json`, `routing/repo-discovery-rules.md` |
 | file-issues | `generated/issue-packets/active/` dispatch plan, `copilot/issue-authoring-rules.md` |
+| initiatives-sync | `generated/initiatives-sync-report.json`, `initiatives/`, `catalogs/grid-health.json`, `catalogs/nodes.json`, `generated/issue-packets/filed-packets.json` |
 | review | ADRs referenced in packet frontmatter, `constitution/invariants.md` |
 | refine | The draft being refined; its governing ADR/PDR if applicable |
 | site-sync | `routing/site-sync-rules.md`, `generated/site-sync-packets/` |

--- a/constitution/agent-capability-matrix.md
+++ b/constitution/agent-capability-matrix.md
@@ -14,7 +14,7 @@ Quick-reference card for all Claude Code agents in `.claude/agents/`. Use this t
 | **review** | PR opened or execution completed | PR diff, issue packet, ADR constraints | Review comments, pass/fail verdict | Merge, approve in GitHub UI |
 | **refine** | Draft exists, needs iteration | Draft doc (ADR, PDR, packet, design), feedback | Revised draft | Author from scratch, make binding decisions |
 | **site-sync** | Repo release or content update | Release notes, ADRs, repo state | Site-sync packet in `generated/site-sync-packets/` | Publish to website directly |
-| **initiatives-sync** | Weekly schedule or manual dispatch | Sync report from `initiatives-sync.py`, catalogs, initiative files | Updated `initiatives/` files via Claude Code Action PR | Create issues, modify `filed-packets.json`, make architectural decisions |
+| **initiatives-sync** | Monday/Thursday schedule or manual dispatch | `gh` CLI issue states, `generated/issue-packets/filed-packets.json`, `catalogs/grid-health.json`, `catalogs/nodes.json`, initiative files | Updated `initiatives/` files via PR (new branch per run) | Create issues, modify `filed-packets.json`, make architectural decisions |
 
 ---
 
@@ -58,7 +58,7 @@ These apply to all agents:
 - **Claude Code agents plan and generate artifacts; they do not execute code changes.** Execution is Codex or Copilot.
 - **Agents do not modify files inside other repos directly.** Cross-repo work goes through issue packets → GitHub Issues → Codex.
 - **Agents do not make binding architectural decisions alone.** ADR drafts go to the developer for review before Accepted status.
-- **Agents do not push to remote.** No `git push`, no `gh pr create` except `file-issues` (which is authorized for `gh issue create`) and `initiatives-sync` (which runs via Claude Code Action in CI and pushes to an existing PR branch).
+- **Agents do not push to remote.** No `git push`, no `gh pr create` except `file-issues` (which is authorized for `gh issue create`) and `initiatives-sync` (which runs via Claude Code Action in CI, creates a date-based branch, and opens or updates a PR for initiative-file reconciliation).
 
 ---
 
@@ -82,7 +82,7 @@ Before any work, load in this order:
 | pdr-composer | Existing PDRs in `PDRs/` for format and precedent |
 | netrunner | `catalogs/relationships.json`, `catalogs/nodes.json`, `routing/repo-discovery-rules.md` |
 | file-issues | `generated/issue-packets/active/` dispatch plan, `copilot/issue-authoring-rules.md` |
-| initiatives-sync | `generated/initiatives-sync-report.json`, `initiatives/`, `catalogs/grid-health.json`, `catalogs/nodes.json`, `generated/issue-packets/filed-packets.json` |
+| initiatives-sync | `generated/issue-packets/filed-packets.json`, `catalogs/grid-health.json`, `catalogs/nodes.json`, `initiatives/` |
 | review | ADRs referenced in packet frontmatter, `constitution/invariants.md` |
 | refine | The draft being refined; its governing ADR/PDR if applicable |
 | site-sync | `routing/site-sync-rules.md`, `generated/site-sync-packets/` |


### PR DESCRIPTION
Introduce initiatives-sync agent for automated reconciliation of initiative tracking files with GitHub issues and catalog data. Add detailed agent spec, workflow, and matrix documentation. Enable scheduled and manual sync via CI, with support for PR creation and context-driven updates.