### PR TITLE
ci(initiatives-sync): grant write permissions for contents and PRs

### DIFF
--- a/.github/workflows/initiatives-sync.yml
+++ b/.github/workflows/initiatives-sync.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   sync:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/agent-run.yml@main
     with:
       agent: initiatives-sync


### PR DESCRIPTION
Add explicit write permissions for contents and pull-requests to the sync job in initiatives-sync.yml to enable workflow-driven repository and PR management