### PR TITLE
ci(initiatives-sync): grant id-token write permission for OIDC

### DIFF
--- a/.github/workflows/initiatives-sync.yml
+++ b/.github/workflows/initiatives-sync.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/agent-run.yml@main
     with:
       agent: initiatives-sync


### PR DESCRIPTION
Add id-token: write to workflow permissions to enable OIDC authentication for external services