### PR TITLE
feat(architecture): accept ADR-0011 and roll out code review pipeline

### DIFF
--- a/generated/issue-packets/active/adr-0011-code-review-pipeline/01-architecture-adr-0011-acceptance.md
+++ b/generated/issue-packets/active/adr-0011-code-review-pipeline/01-architecture-adr-0011-acceptance.md
@@ -1,0 +1,310 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "docs", "adr-0011", "wave-1"]
+dependencies: []
+adrs: ["ADR-0011"]
+wave: 1
+initiative: adr-0011-code-review-pipeline
+node: honeydrunk-architecture
+---
+
+# Feature: Accept ADR-0011 — code review and merge flow, finalize invariants 31–33
+
+## Summary
+Flip ADR-0011 from `Proposed` to `Accepted`, refresh the ADR index row, drop the "(Proposed — this invariant takes effect when ADR-0011 is accepted)" qualifier on invariants 31–33, register the rollout initiative in `active-initiatives.md` and `roadmap.md`, and verify that `.claude/agents/scope.md` and `.claude/agents/review.md` already reflect the ADR's D4/D6/D7 contracts (audit pass — both files were updated in advance).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+ADR-0011 was drafted Proposed on 2026-04-12. Three things keep the current state honest but unfinished: invariants 31–33 already exist in `constitution/invariants.md` with their full text but carry a "(Proposed — this invariant takes effect when ADR-0011 is accepted)" qualifier; the ADR index row in `adrs/README.md` reads `Proposed`; and the agent definitions (`scope.md`, `review.md`) already cross-reference the ADR's decisions even though the decisions are not yet Accepted. The Grid is one PR away from a coherent state — this packet is that PR. After it lands, downstream packets in this initiative (SonarCloud workflow, agent-run amendment, label seeding, per-repo onboarding) become enforceable against live invariants rather than aspirational ones.
+
+This packet is the **single mechanically-coupled flip** that ADRs require per the scope-agent acceptance convention: status flip, index row flip, qualifier strip, and trackers all land in one merge.
+
+## Scope
+
+All edits are in the `HoneyDrunk.Architecture` repo. No code. No secrets.
+
+### Part A — ADR file flip
+
+In `adrs/ADR-0011-code-review-and-merge-flow.md`, change the front-matter line:
+
+```
+**Status:** Proposed
+```
+
+to:
+
+```
+**Status:** Accepted
+```
+
+Do not edit any other text in the ADR body. Body edits to an Accepted ADR are out-of-scope here; if the ADR text needs revision, that lives in a separate ADR amendment.
+
+### Part B — ADR index update
+
+In `adrs/README.md`, the existing row for ADR-0011:
+
+```
+| [ADR-0011](ADR-0011-code-review-and-merge-flow.md) | Code Review and Merge Flow | Proposed | 2026-04-12 | Meta | Tiered PR pipeline with named owners and artifact contracts. Review agent is local-only (cost-disciplined); SonarCloud fills the third-party static analysis slot. Invariants 31–33. |
+```
+
+Change the Status cell from `Proposed` to `Accepted`. Leave the Date column at `2026-04-12` (the original draft date — the table tracks decision date, not acceptance date, per the existing convention with ADR-0010 which kept its 2026-04-12 date through acceptance). Optionally tighten the Impact text to acknowledge what is now binding:
+
+```
+| [ADR-0011](ADR-0011-code-review-and-merge-flow.md) | Code Review and Merge Flow | Accepted | 2026-04-12 | Meta | Tiered PR pipeline (tier-1 gates required; SonarCloud tier-2 on public repos; review agent tier-3 local-only). Invariants 31–33 binding. |
+```
+
+### Part C — Strip "Proposed" qualifier from invariants 31–33
+
+In `constitution/invariants.md`, the three invariants currently read:
+
+```markdown
+31. **Every PR traverses the tier-1 gate before merge.**
+    Build, unit tests, analyzers, vulnerability scan, and secret scan are required branch-protection checks on every .NET repo in the Grid, delivered via `pr-core.yml` in `HoneyDrunk.Actions`. Bypassing tier 1 via force-push to `main` or admin override is forbidden except for `hotfix-infra` scenarios where the gate itself is broken. See ADR-0011 D2 and D5 (Proposed — this invariant takes effect when ADR-0011 is accepted).
+
+32. **Agent-authored PRs must link to their packet in the PR body.**
+    The review agent resolves the packet via this link and uses it as the primary scope anchor. Absent the link, the PR is treated as out-of-band, must carry the `out-of-band` label, and receives a degraded review in which the agent runs against the Grid context only (invariants, boundaries, relationships, diff) without a packet-scope check. See ADR-0011 D3 and D9 (Proposed — this invariant takes effect when ADR-0011 is accepted).
+
+33. **Review-agent and scope-agent context-loading contracts are coupled.**
+    The set of files loaded by the review agent (per `.claude/agents/review.md`) must be a superset of the set loaded by the scope agent (per `.claude/agents/scope.md`). Divergence is an anti-pattern; updates to either agent's context-loading section must be mirrored in the other. The coupling exists so there is no class of defect the scope agent could introduce at packet-authoring time that the review agent cannot catch at PR time for lack of information. See ADR-0011 D4 (Proposed — this invariant takes effect when ADR-0011 is accepted).
+```
+
+Strip the `(Proposed — this invariant takes effect when ADR-0011 is accepted)` qualifier from all three so they read as live rules. Final form:
+
+```markdown
+31. **Every PR traverses the tier-1 gate before merge.**
+    Build, unit tests, analyzers, vulnerability scan, and secret scan are required branch-protection checks on every .NET repo in the Grid, delivered via `pr-core.yml` in `HoneyDrunk.Actions`. Bypassing tier 1 via force-push to `main` or admin override is forbidden except for `hotfix-infra` scenarios where the gate itself is broken. See ADR-0011 D2 and D5.
+
+32. **Agent-authored PRs must link to their packet in the PR body.**
+    The review agent resolves the packet via this link and uses it as the primary scope anchor. Absent the link, the PR is treated as out-of-band, must carry the `out-of-band` label, and receives a degraded review in which the agent runs against the Grid context only (invariants, boundaries, relationships, diff) without a packet-scope check. See ADR-0011 D3 and D9.
+
+33. **Review-agent and scope-agent context-loading contracts are coupled.**
+    The set of files loaded by the review agent (per `.claude/agents/review.md`) must be a superset of the set loaded by the scope agent (per `.claude/agents/scope.md`). Divergence is an anti-pattern; updates to either agent's context-loading section must be mirrored in the other. The coupling exists so there is no class of defect the scope agent could introduce at packet-authoring time that the review agent cannot catch at PR time for lack of information. See ADR-0011 D4.
+```
+
+### Part D — Agent-definition audit (no edit expected)
+
+`.claude/agents/scope.md` and `.claude/agents/review.md` were both updated ahead of this acceptance. The ADR follow-up bullets that named them are already reflected:
+
+- **scope.md** — section "Coupling with the review agent (ADR-0011 D4, invariant 33)" is present (line 32 in the current file). No edit expected.
+- **review.md** — section "Cost Discipline" is present (currently section 8 of the Review Process, beginning at line 122). The "Governing decision: ADR-0011" callout is present. The context-loading list explicitly states "must remain a superset of the scope agent's context load … per invariant 33." No edit expected.
+
+**Verification at scope-time (2026-04-26):** the executor was confronted with a refine review claiming review.md only contained 4 of the 6 D6 items. Re-checking review.md lines 122–137 directly: all **six** items are present, in this order:
+
+1. Hot-path logging without sampling
+2. LLM calls without a cost cap
+3. Unguarded CI jobs
+4. Azure resources without SKU justification
+5. Outbound HTTP in request hot paths
+6. Unbounded catalog loops
+
+The earlier refine grep that found only 4 was incomplete — possibly searching for partial header strings rather than the bullet text inside the section. The file is correct as written and **no edit is required**. The audit acceptance criterion below remains as a tripwire — if the file has drifted by execution time, the audit catches it.
+
+**Audit task:** open both files and confirm:
+1. `scope.md` mentions ADR-0011 D4 and invariant 33 in its "Before Scoping" section.
+2. `review.md` references ADR-0011 in a top-level callout and contains a Cost Discipline section (lines 122–137 as of scope-time) listing the six checklist items from D6: hot-path logging without sampling; LLM calls without a cost cap; unguarded CI jobs; Azure resources without SKU justification; outbound HTTP in request hot paths; unbounded catalog loops.
+3. The context-loading lists in the two files are mutually consistent — review.md must be a superset of scope.md per invariant 33.
+
+If any of the three checks fails (drift since scope-time), document the gap in the PR body and add a line item to fix it as part of this PR. **No edit is expected based on the 2026-04-26 state of those files.**
+
+### Part E — Catalog: register the agent-coupling
+
+Invariant 33 establishes a real coupling between two agent definition files (`.claude/agents/scope.md` and `.claude/agents/review.md`). Today, the catalogs in `catalogs/` describe Node-to-Node coupling (`relationships.json`), public contracts (`contracts.json`), and the rest of the structural Grid map. Agent-to-agent coupling is a new relationship kind — it does not naturally fit the `nodes` array in `relationships.json` because agents are not Nodes, but it is structurally a relationship and machine-discoverability matters (the review agent's context-loading audit benefits from the catalog being authoritative).
+
+Add a sibling top-level key `agent_couplings` to `catalogs/relationships.json`. Schema:
+
+```json
+{
+  "nodes": [ ... existing ... ],
+  "agent_couplings": [
+    {
+      "id": "scope-review-context-loading",
+      "kind": "context_load_superset",
+      "agents": ["scope", "review"],
+      "rule": "review.md context-loading list must be a superset of scope.md context-loading list",
+      "governing_invariant": 33,
+      "governing_adr": "ADR-0011",
+      "rationale": "There must be no class of defect the scope agent could introduce at packet-authoring time that the review agent cannot catch at PR time for lack of information."
+    }
+  ]
+}
+```
+
+This is additive — existing tooling that reads `relationships.json` for the `nodes` key continues to work unchanged. Future agent-coupling kinds (output formats, tool-permission relationships, etc.) extend this same array.
+
+### Part F — Initiative + roadmap trackers
+
+#### `initiatives/active-initiatives.md`
+
+Add a new **In Progress** entry, ordered alphabetically/numerically alongside the existing `ADR-` entries:
+
+```markdown
+### Code Review Pipeline (ADR-0011)
+**Status:** In Progress
+**Scope:** Architecture, Actions, plus per-repo SonarCloud onboarding (Wave 3, deferred)
+**Initiative:** `adr-0011-code-review-pipeline`
+**Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)
+**Description:** Accept ADR-0011 and ship the pipeline plumbing it requires: SonarCloud reusable workflow in HoneyDrunk.Actions, packet-link injection into the cloud execution workflow's PR body (carries invariant 32), `out-of-band` label seeded across active repos, SonarCloud organization setup walkthrough, plus the first two per-repo SonarCloud onboardings as templates (Kernel and Web.Rest). Remaining .NET repos (Transport, Vault, Auth, Data, Pulse, Notify, Vault.Rotation, Actions) are tracked here but not scoped — they roll out as a follow-up wave once the templates prove out.
+
+**Tracking (Wave 1 — foundation):**
+- [ ] Architecture#NN: Accept ADR-0011 — flip status, index, invariants 31–33 qualifier strip, agent-coupling catalog entry, audit agent files, register initiative (this packet)
+- [ ] Actions#NN: Author `job-sonarcloud.yml` reusable workflow
+- [ ] Actions#NN: Amend `agent-run.yml` to inject packet link into PR body (invariant 32 enforcement — prompt-side + post-hoc workflow assert)
+- [ ] Architecture#NN: SonarCloud organization setup walkthrough doc
+- [ ] Actions#NN: Labels-as-code config + reusable `seed-labels.yml` workflow (packet 05a)
+- [ ] Actions#NN: Cross-repo fan-out — `out-of-band` label on the eleven Grid repos via `seed-labels-fanout.yml` + PAT (packet 05b, hard-blocked on 05a)
+
+**Tracking (Wave 2 — template rollout):**
+- [ ] Kernel#NN: Onboard SonarCloud (first canonical .NET template)
+- [ ] Web.Rest#NN: Onboard SonarCloud (ASP.NET Core variant template)
+
+**Deferred (Wave 3 — post-template fan-out, scope after Wave 2 lands):**
+- Transport, Vault, Auth, Data, Pulse, Notify, Vault.Rotation, Actions — eight per-repo SonarCloud onboardings, each a small (~5-line `sonar-project.properties` + branch-protection toggle + reusable-workflow call) packet
+- HoneyDrunk.Studios — TypeScript/Next.js posture, separate from the .NET fan-out; SonarCloud-JS onboarding evaluated as a one-off when Studios CI is otherwise wired
+
+**Out of scope (Unresolved Consequences in the ADR):**
+- Integration tests (Gap 1) — slot defined, no test runner yet
+- E2E / Playwright tests (Gap 3) — slot defined, no infra
+- Cost discipline tooling (Gap 4) — review agent's checklist covers it qualitatively
+- Private-repo SonarCloud (Gap 5) — opt-in per repo, no Wave-3 fan-out
+```
+
+#### `initiatives/roadmap.md`
+
+Add a Q2 2026 bullet (place near the existing ADR-0009/ADR-0015 process bullets):
+
+```markdown
+- [ ] **Code Review Pipeline (ADR-0011)** — SonarCloud reusable workflow, agent-run packet-link injection, `out-of-band` label seeding, SonarCloud org walkthrough, first two per-repo onboardings (Kernel + Web.Rest) as templates; remaining 8 .NET repos deferred to Wave 3
+```
+
+No Q3 entry — the deferred fan-out belongs in this initiative once Wave 2 lands; no new quarter is needed.
+
+## Acceptance Criteria
+
+### ADR file
+- [ ] `adrs/ADR-0011-code-review-and-merge-flow.md` line `**Status:** Proposed` flipped to `**Status:** Accepted`
+- [ ] No other text in the ADR body changed in this PR (body edits to an Accepted ADR require a separate amendment)
+
+### ADR index
+- [ ] `adrs/README.md` ADR-0011 row Status flipped to `Accepted`
+- [ ] Date column unchanged (`2026-04-12`)
+- [ ] Impact text optionally tightened to acknowledge invariants 31–33 are now binding
+
+### Invariants
+- [ ] `constitution/invariants.md`: invariant 31's `(Proposed — this invariant takes effect when ADR-0011 is accepted)` qualifier removed; rule reads as live
+- [ ] `constitution/invariants.md`: invariant 32's `(Proposed — this invariant takes effect when ADR-0011 is accepted)` qualifier removed; rule reads as live
+- [ ] `constitution/invariants.md`: invariant 33's `(Proposed — this invariant takes effect when ADR-0011 is accepted)` qualifier removed; rule reads as live
+- [ ] No other invariants edited
+
+### Agent-definition audit
+- [ ] `.claude/agents/scope.md` audit confirms ADR-0011 D4 / invariant 33 cross-reference present in "Before Scoping" section; outcome documented in PR body (`audit pass — no edits required` is the expected line)
+- [ ] `.claude/agents/review.md` audit confirms (a) ADR-0011 governing-decision callout, (b) Cost Discipline section listing the six D6 checklist items, (c) context-loading list is a superset of scope.md's per invariant 33; outcome documented in PR body
+- [ ] If any audit check fails, the gap is fixed in this PR and the fix is itself an acceptance criterion
+
+### Catalog
+- [ ] `catalogs/relationships.json`: new top-level `agent_couplings` array added (sibling to existing `nodes` array) with one entry: `id: "scope-review-context-loading"`, `kind: "context_load_superset"`, `agents: ["scope", "review"]`, `governing_invariant: 33`, `governing_adr: "ADR-0011"`. Schema is additive — existing tooling that reads `nodes` is unaffected.
+
+### Trackers
+- [ ] `initiatives/active-initiatives.md`: new "Code Review Pipeline (ADR-0011)" In Progress entry present with Wave 1 / Wave 2 / Wave 3 / out-of-scope sections
+- [ ] `initiatives/roadmap.md`: new Q2 2026 bullet for ADR-0011 present
+
+### General
+- [ ] No ADR IDs added to README-style narrative prose anywhere in this PR (per user convention: ADR IDs stay in frontmatter / index tables / dedicated invariant references, not in body narrative)
+- [ ] Repo-level `CHANGELOG.md` entry — Architecture is docs-only and currently has no `CHANGELOG.md` next to a `.slnx`; if no changelog file exists, skip per the existing Architecture-repo precedent. If one is later added, this acceptance row should ship a "ADR-0011 accepted" entry — not a blocker today.
+
+## Affected Packages
+None. Docs and constitution only.
+
+## NuGet Dependencies
+None. No .NET changes in this packet.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture` — correct repo per the routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture".
+- [x] No code changes in any other repo.
+- [x] ADR-0011 is the governing decision. Invariants 31–33 are *its* invariants, not borrowed from another ADR. The qualifier strip is mechanically coupled to the status flip.
+
+## Human Prerequisites
+None. This packet is a pure Architecture-repo edit and does not require any portal or GitHub org actions. Downstream packets (SonarCloud organization setup walkthrough — packet 04) carry the human portal work.
+
+## Dependencies
+None. This is the Wave-1 foundation packet that all downstream work in this initiative depends on.
+
+## Downstream Unblocks
+- `02-actions-job-sonarcloud-workflow.md` — `job-sonarcloud.yml` references invariants 31 and 33 by number; the qualifier strip lets the workflow's documentation describe them as live rules.
+- `03-actions-agent-run-packet-link.md` — invariant 32 ("Agent-authored PRs must link to their packet in the PR body") becomes the enforced rationale once accepted; without acceptance the workflow change is aspirational.
+- `04-architecture-sonarcloud-org-walkthrough.md` — references ADR-0011 D11 SonarCloud-as-third-party choice; the doc is more credible against an Accepted ADR.
+- `05a-actions-labels-as-code.md` and `05b-actions-out-of-band-label-fanout.md` — invariant 32's "must carry the `out-of-band` label" clause is the load-bearing reference for both packets.
+- `06-kernel-sonarcloud-onboarding.md`, `07-web-rest-sonarcloud-onboarding.md` — both reference invariant 31 (tier-1 gate) and ADR-0011 D11 (SonarCloud-as-tool); both become enforceable against a binding rule.
+- The `agent_couplings` catalog entry (Part E above) gives downstream tools (review-agent self-audit, future grid-health linters) a machine-discoverable signal of the invariant 33 coupling.
+
+## Referenced ADR Decisions
+
+**ADR-0011 (Code Review and Merge Flow):**
+- **D1:** GitHub PR is the system of record for review state. Branch protection enforces the gate.
+- **D2:** Ordered tier-1 → tier-5 review pipeline. Tier 1 = build, unit tests, analyzers, vulnerability scan, secret scan (all required). Tier 2 = integration tests + SonarCloud (SonarCloud is required on public repos). Tier 3 = LLM reviewers (Copilot automatic-cloud, review agent local-only). Tier 4 = E2E. Tier 5 = human merge.
+- **D3:** Per-stage artifact contracts. Review agent's input is non-negotiable: packet file via PR body link.
+- **D4:** Review agent's context-loading contract is the symmetric peer of the scope agent's. Coupled and bound by invariant 33.
+- **D5:** Review agent is advisory, not a required check. Tier-1 gates remain required via branch protection.
+- **D6:** Cost discipline is a named review-agent responsibility — six-item checklist baked into `.claude/agents/review.md`.
+- **D7:** Grid-alignment check is a named review-agent responsibility — packet honor, boundary respect, invariant preservation.
+- **D8:** Failure surfaces — branch protection blocks tier-1 / SonarCloud / E2E; advisory comments do not.
+- **D9:** Out-of-band PRs (no packet link) get a degraded review and must carry the `out-of-band` label.
+- **D10:** Review agent runs locally via Claude Code, invoked by the human. Deliberately not cloud-wired. The automatic LLM reviewer slot is filled by GitHub Copilot.
+- **D11:** SonarCloud is the third-party static analysis tool. Public-repos-first. Quality gate is a required branch-protection check on public repos. Private-tier opt-in only.
+
+## Referenced Invariants
+
+> **Invariant 24 (work-tracking):** Issue packets are immutable once filed as a GitHub Issue. Filing is the point of no return. State lives on the org Project board, not in the packet file.
+
+> **Invariant 31 (becoming live in this PR):** Every PR traverses the tier-1 gate before merge. Build, unit tests, analyzers, vulnerability scan, and secret scan are required branch-protection checks on every .NET repo in the Grid, delivered via `pr-core.yml` in `HoneyDrunk.Actions`. Bypassing tier 1 via force-push to `main` or admin override is forbidden except for `hotfix-infra` scenarios where the gate itself is broken.
+
+> **Invariant 32 (becoming live in this PR):** Agent-authored PRs must link to their packet in the PR body. The review agent resolves the packet via this link and uses it as the primary scope anchor. Absent the link, the PR is treated as out-of-band, must carry the `out-of-band` label, and receives a degraded review in which the agent runs against the Grid context only (invariants, boundaries, relationships, diff) without a packet-scope check.
+
+> **Invariant 33 (becoming live in this PR):** Review-agent and scope-agent context-loading contracts are coupled. The set of files loaded by the review agent (per `.claude/agents/review.md`) must be a superset of the set loaded by the scope agent (per `.claude/agents/scope.md`). Divergence is an anti-pattern; updates to either agent's context-loading section must be mirrored in the other.
+
+## Constraints
+- **Status flip is mechanically coupled to the PR.** Per the scope-agent acceptance convention, ADRs flip from `Proposed` to `Accepted` only on the PR that ships their acceptance work. Not before, not after.
+- **Do not edit ADR-0011 body text.** Only the front-matter `Status` line. Body amendments require a separate ADR or a follow-up.
+- **Do not touch invariants 1–30 or 34–36.** Only invariants 31, 32, 33 lose their qualifier in this PR.
+- **Audit-only on agent files.** `.claude/agents/scope.md` and `.claude/agents/review.md` were updated ahead of this packet. The audit acceptance criteria check that the prior updates are present and correct; do not introduce drive-by edits unless the audit fails.
+- **No ADR IDs in narrative prose.** Per user convention. ADR IDs belong in frontmatter, index tables, and dedicated invariant cross-references — not in the body narrative of `repos/*/overview.md`-style docs. This applies if any new narrative text is added; the per-section ADR references in `constitution/invariants.md` and `adrs/README.md` are *index entries*, not narrative, and remain.
+
+## Labels
+`feature`, `tier-2`, `meta`, `docs`, `adr-0011`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0011 from `Proposed` to `Accepted` in one atomic Architecture-repo PR. Strip the "(Proposed)" qualifier from invariants 31–33. Refresh the ADR index. Audit `scope.md` and `review.md` for the cross-references the ADR mandates (no edits expected). Add the `scope-review-context-loading` agent-coupling entry to `catalogs/relationships.json` (machine-discoverable invariant 33 coupling). Register the rollout initiative in the trackers.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Move ADR-0011 from Proposed to Accepted by doing the Architecture-side work it requires (status flip, invariant qualifier strip, ADR index, audit, trackers).
+- Feature: ADR-0011 Code Review and Merge Flow rollout.
+- ADRs: ADR-0011 (primary), ADR-0008 (initiative/packet conventions, cloud execution workflow context for packet 03), ADR-0009 (vulnerability scan that ADR-0011 D2 builds on), ADR-0007 (agent definitions live in `.claude/agents/`).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+- See "Constraints" section above — inlined for agent consumption.
+- Status flip is mechanically coupled to this PR; no early flip.
+- Audit-only on agent files; do not edit `scope.md` or `review.md` unless the audit fails.
+- Do not touch invariants outside 31–33.
+
+**Key Files:**
+- `adrs/ADR-0011-code-review-and-merge-flow.md` — front-matter Status line only
+- `adrs/README.md` — ADR-0011 row
+- `constitution/invariants.md` — invariants 31, 32, 33 (qualifier strip)
+- `.claude/agents/scope.md` — audit only (no edit expected)
+- `.claude/agents/review.md` — audit only (no edit expected)
+- `catalogs/relationships.json` — add `agent_couplings` sibling array with the `scope-review-context-loading` entry (invariant 33 coupling, machine-discoverable)
+- `initiatives/active-initiatives.md` — new "Code Review Pipeline (ADR-0011)" entry
+- `initiatives/roadmap.md` — Q2 2026 bullet
+
+**Contracts:** None. Docs and constitution only.

--- a/generated/issue-packets/active/adr-0011-code-review-pipeline/02-actions-job-sonarcloud-workflow.md
+++ b/generated/issue-packets/active/adr-0011-code-review-pipeline/02-actions-job-sonarcloud-workflow.md
@@ -1,0 +1,332 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ci-cd", "ops", "adr-0011", "wave-1"]
+dependencies: ["Architecture#NN — ADR-0011 acceptance (packet 01)"]
+adrs: ["ADR-0011"]
+wave: 1
+initiative: adr-0011-code-review-pipeline
+node: honeydrunk-actions
+---
+
+# Feature: Author `job-sonarcloud.yml` reusable workflow for tier-2 SonarCloud analysis
+
+## Summary
+Add a new reusable workflow `job-sonarcloud.yml` in `HoneyDrunk.Actions` that runs `dotnet-sonarscanner` against a .NET repo, publishes coverage to SonarCloud, and reports the SonarCloud quality gate as a check run. The workflow is invoked from each public repo's `pr.yml` (after that repo onboards in Wave 2 / Wave 3) and is gated to only fire on `pull_request` events and pushes to `main`.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Actions`
+
+## Motivation
+ADR-0011 D11 names SonarCloud as the third-party static analysis tool for tier-2 of the PR review pipeline. The decision contract is fully specified — the workflow plumbing is the only remaining piece. Without `job-sonarcloud.yml` in `HoneyDrunk.Actions`, every per-repo onboarding packet (Kernel, Web.Rest, and the deferred fan-out across the eight remaining .NET repos) would have to inline its own scanner invocation, which violates the existing convention that PR jobs are reusable workflows in Actions and consumer repos call them via `workflow_call`.
+
+This packet ships the workflow alone. It does **not** wire it into `pr-core.yml` and does **not** onboard any specific repo — those are downstream packets. Shipping it standalone keeps the scope tight and lets the per-repo onboarding packets (06, 07, …) reference a real workflow file at the time they author their `sonar-project.properties`.
+
+## Proposed Implementation
+
+Create `.github/workflows/job-sonarcloud.yml` in `HoneyDrunk.Actions` following the structure and conventions of the existing `job-*.yml` reusable workflows (`job-build-and-test.yml`, `job-static-analysis.yml`, `job-codeql.yml`, etc. — all in `.github/workflows/` and exposed via `workflow_call`).
+
+### Workflow shape
+
+```yaml
+# ==============================================================================
+# Job: SonarCloud Static Analysis (Tier 2)
+# ==============================================================================
+# Purpose:
+#   Run SonarCloud (Sonar Scanner for .NET) against a HoneyDrunk .NET repo,
+#   upload coverage from the unit-test run, and report the SonarCloud quality
+#   gate as a PR check.
+#
+# Tier:
+#   Tier 2 of the PR review pipeline. Required check on public repos.
+#
+# CALLER TRIGGER CONTRACT (load-bearing — read this if you are wiring a new caller):
+#   This workflow is `workflow_call`-only. It MUST only be invoked from a
+#   caller workflow whose `on:` block fires on `pull_request` events or `push`
+#   events to `main` — not on every feature-branch push, not on tags, not on
+#   schedule, not on workflow_dispatch from arbitrary refs.
+#
+#   The job below carries an `if:` guard that refuses to run when this
+#   constraint is violated, so a misconfigured caller will produce a no-op
+#   skipped job rather than burning a SonarCloud run on every feature-branch
+#   push. Per ADR-0011 D11 cost discipline.
+#
+# Cost discipline:
+#   - pull_request and push:main only — enforced by both the caller's `on:`
+#     block AND the job-level `if:` guard below
+#   - Median PR run target: under 60 seconds
+#   - Coverage report reused from job-build-and-test.yml output (no second
+#     dotnet test run)
+# ==============================================================================
+
+name: Job — SonarCloud
+
+on:
+  workflow_call:
+    inputs:
+      dotnet-version:
+        description: 'The .NET SDK version to use'
+        required: false
+        type: string
+        default: '10.0.x'
+      runs-on:
+        description: 'GitHub runner'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      working-directory:
+        description: 'Working directory'
+        required: false
+        type: string
+        default: '.'
+      project-path:
+        description: 'Solution or project path (auto-detected if blank)'
+        required: false
+        type: string
+        default: ''
+      sonar-organization:
+        description: 'SonarCloud organization key (e.g. honeydrunkstudios)'
+        required: true
+        type: string
+      sonar-project-key:
+        description: 'SonarCloud project key (e.g. honeydrunkstudios_HoneyDrunk.Vault)'
+        required: true
+        type: string
+      sonar-host-url:
+        description: 'SonarCloud host URL'
+        required: false
+        type: string
+        default: 'https://sonarcloud.io'
+      coverage-artifact-name:
+        description: 'Name of the coverage artifact uploaded by job-build-and-test.yml'
+        required: false
+        type: string
+        default: 'coverage-reports-ubuntu-latest'
+    secrets:
+      sonar-token:
+        description: 'SONAR_TOKEN — org-level secret scoped to HoneyDrunkStudios'
+        required: true
+      github-token:
+        description: 'GitHub token for PR decoration'
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  sonarcloud:
+    runs-on: ${{ inputs.runs-on }}
+    # Trigger guard — defence in depth for ADR-0011 D11 cost discipline.
+    # Refuses to run when invoked from a misconfigured caller. The expected
+    # caller `on:` block is `pull_request` and `push: branches: [main]`.
+    # If a caller wires this workflow into a feature-branch push or a tag,
+    # this guard reports a skipped job rather than spending a SonarCloud run.
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # SonarCloud needs full history for blame
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+
+      - name: Set up Java (required by Sonar Scanner)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache SonarCloud scanner
+        id: cache-sonar-scanner
+        uses: actions/cache@v4
+        with:
+          path: ./.sonar/scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+
+      - name: Install SonarCloud scanner
+        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p ./.sonar/scanner
+          dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner
+
+      - name: Download coverage artifact (if exists)
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.coverage-artifact-name }}
+          path: TestResults
+        continue-on-error: true
+
+      - name: Begin SonarCloud analysis
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          SONAR_TOKEN: ${{ secrets.sonar-token }}
+          GITHUB_TOKEN: ${{ secrets.github-token || github.token }}
+        shell: bash
+        run: |
+          ./.sonar/scanner/dotnet-sonarscanner begin \
+            /k:"${{ inputs.sonar-project-key }}" \
+            /o:"${{ inputs.sonar-organization }}" \
+            /d:sonar.host.url="${{ inputs.sonar-host-url }}" \
+            /d:sonar.token="${SONAR_TOKEN}" \
+            /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+
+      - name: Build
+        working-directory: ${{ inputs.working-directory }}
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.project-path }}" ]; then
+            dotnet build "${{ inputs.project-path }}" --configuration Release
+          else
+            dotnet build --configuration Release
+          fi
+
+      - name: End SonarCloud analysis
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          SONAR_TOKEN: ${{ secrets.sonar-token }}
+        shell: bash
+        run: |
+          ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${SONAR_TOKEN}"
+```
+
+### Notes the executor must observe
+
+- **No `actions-ref` input.** Other reusable workflows in the suite expose `actions-ref` because they consume sub-actions from `HoneyDrunk.Actions` itself. This workflow does not — its only external consumers are `actions/checkout`, `actions/setup-dotnet`, `actions/setup-java`, `actions/cache`, and `actions/download-artifact`, all of which pin to upstream versions, not to `HoneyDrunk.Actions`. Adding `actions-ref` here would be misleading. If a future revision adds a sub-action that needs a configurable ref, introduce the input then; do not reserve it speculatively.
+- **Use the existing `job-build-and-test.yml` output for coverage.** Do not re-run `dotnet test` inside this workflow. The cost-discipline budget in ADR-0011 D11 is "median PR run under 60 seconds" — running tests twice violates that. The `coverage-artifact-name` input lets the caller point at whichever artifact name `job-build-and-test.yml` published.
+- **`fetch-depth: 0` is mandatory.** SonarCloud requires full git history for blame attribution. This is documented in SonarCloud's own onboarding docs and is a frequent first-time-setup gotcha.
+- **Java is mandatory.** The Sonar Scanner CLI is JVM-based even when scanning .NET. Use Temurin 17 (current LTS); revisit if SonarCloud bumps requirements.
+- **Caching has two layers.** (1) `~/.sonar/cache` is the scanner's own download cache. (2) `./.sonar/scanner` is the scanner binary itself, installed via `dotnet tool update`. Both are needed for sub-60-second median runs.
+- **Permissions:** `contents: read`, `pull-requests: write`, `checks: write`. The PR-decoration step is part of `dotnet-sonarscanner end`'s built-in PR analysis when `GITHUB_TOKEN` is in the env.
+- **Secrets contract:** `SONAR_TOKEN` is **required**. `GITHUB_TOKEN` is optional (falls back to `github.token`).
+- **Do NOT add this workflow to `pr-core.yml`** in this packet. That wiring lives in the per-repo onboarding packets (06, 07, and the Wave-3 fan-out), because not every repo onboards at the same time.
+
+### Documentation update
+
+Add a one-line entry to `examples/` if there is a precedent (`examples/library-ci-jobs.yml`-style); otherwise add a usage example as a fenced block in the workflow's header comment block. Match whichever pattern the existing `job-codeql.yml` uses.
+
+## Affected Files
+- `.github/workflows/job-sonarcloud.yml` (new)
+- Optional: `examples/sonarcloud-usage.yml` if the existing examples convention warrants one (audit `examples/` first; if `job-codeql.yml` has no example file, mirror that and skip)
+- `CHANGELOG.md` (repo-level): append entry under in-progress version
+- `README.md` (repo-level): if there is a "Available Reusable Workflows" section listing `job-build-and-test.yml`, `job-codeql.yml`, etc., add `job-sonarcloud.yml` to it. If no such section, skip.
+
+## NuGet Dependencies
+None. The workflow installs `dotnet-sonarscanner` via `dotnet tool update` into a cache path; no project-level `<PackageReference>` is added.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Actions`. The keyword routing rule "workflow, CI, GitHub Actions, pipeline, PR check, release → HoneyDrunk.Actions" maps exactly here.
+- [x] No code change in any consuming repo. The wiring into a consumer's `pr.yml` is downstream (per-repo onboarding packets 06, 07, …).
+- [x] No new cross-Node dependency. `HoneyDrunk.Actions` continues to be a CI toolkit with no Grid runtime consumers.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/job-sonarcloud.yml` exists in `HoneyDrunk.Actions` with the shape specified above
+- [ ] Workflow exposes `workflow_call` with the inputs and secrets enumerated above
+- [ ] `SONAR_TOKEN` is the only required secret; `github-token` is optional and falls back to `github.token`
+- [ ] `fetch-depth: 0` is set on the checkout step
+- [ ] Java 17 (Temurin) is installed before the scanner runs
+- [ ] Both Sonar caches (`~/.sonar/cache` and `./.sonar/scanner`) are configured
+- [ ] Coverage artifact is downloaded from a previous job's upload (`coverage-artifact-name` input) — the workflow does not re-run `dotnet test`
+- [ ] PR decoration is enabled by passing `GITHUB_TOKEN` to the scanner steps
+- [ ] Permissions block declares `contents: read`, `pull-requests: write`, `checks: write` (no other permissions)
+- [ ] Workflow is **not** referenced from `pr-core.yml` in this PR
+- [ ] Job-level `if:` guard is present on the `sonarcloud` job: `if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}`. This is defence-in-depth for ADR-0011 D11's "pull_request and push:main only" rule, so a misconfigured caller produces a skipped job rather than a paid SonarCloud run.
+- [ ] Header comment block contains a **CALLER TRIGGER CONTRACT** section documenting the expected caller `on:` block (`pull_request`, `push: branches: [main]`) and noting that the job-level `if:` guard enforces it as defence in depth.
+- [ ] Repo-level `CHANGELOG.md`: a new in-progress version entry is created (or appended to, if the prior packet in this initiative already opened one) with a line under `Added` describing the new reusable workflow (per the rule that the first packet in a solution-initiative bumps version, subsequent packets append to the same entry — invariants 12 and 27)
+- [ ] Repo-level `README.md`: workflow-list section updated if such a section exists; otherwise skipped (invariant 12)
+- [ ] No per-package `CHANGELOG.md` updates required — this is a workflow file, not a package change
+- [ ] `.github/workflows/job-sonarcloud.yml` lints clean under `actionlint` (HoneyDrunk.Actions' own `actions-ci.yml` PR check exercises this)
+
+## Human Prerequisites
+- [ ] **`SONAR_TOKEN` org-level secret must exist** before this workflow can be exercised by a consumer. Provisioning is covered by packet 04 (SonarCloud organization setup walkthrough). Until packet 04's walkthrough is followed and the secret is provisioned at the org level, this workflow can be merged but cannot run successfully against a real PR. That is acceptable — packet 04 is on the same wave and will land alongside.
+
+## Dependencies
+- Architecture#NN — ADR-0011 acceptance (packet 01). Soft dependency: this packet's text references invariants 31 and 33 as live rules. If packet 01 lands first, the references are accurate. If this packet lands first, the references read against (Proposed)-qualifier text. Sequence with packet 01 first.
+
+## Downstream Unblocks
+- `06-kernel-sonarcloud-onboarding.md` — Kernel's `pr.yml` will call this reusable workflow.
+- `07-web-rest-sonarcloud-onboarding.md` — Web.Rest's `pr.yml` will call this reusable workflow.
+- Wave-3 deferred fan-out — Transport, Vault, Auth, Data, Pulse, Notify, Vault.Rotation, Actions all call this same workflow.
+
+## Referenced ADR Decisions
+
+**ADR-0011 (Code Review and Merge Flow):**
+- **D2 (tier model):** Tier 1 = build/tests/analyzers/vuln/secret (required). Tier 2 = integration tests + SonarCloud (SonarCloud required on public repos). Tier 3 = LLM reviewers. Tier 4 = E2E. Tier 5 = human.
+- **D11 (SonarCloud chosen):** Free for public HoneyDrunk repos. Quality gate is a required branch-protection check on public repos. Native GitHub PR decoration. `dotnet-sonarscanner` CLI used. PR decoration via `SONAR_TOKEN` org secret.
+- **D11 contract for the SonarCloud stage:**
+  - **Input:** source tree, `sonar-project.properties` at the repo root, coverage report from stage 2 (unit tests), PR diff
+  - **Output:** required PR check (quality gate status), inline PR annotations
+  - **Owner:** new `job-sonarcloud.yml` in `HoneyDrunk.Actions`, called from `pr-core.yml` tier 2 (wiring lives in per-repo onboarding packets, not in `pr-core.yml`)
+  - **Secrets:** `SONAR_TOKEN` as an org secret scoped to `HoneyDrunkStudios`
+  - **Cost discipline:** runs only on `pull_request` events and pushes to `main`. Median PR run under 60 seconds.
+
+**ADR-0009 (Package Scanning Policy)** is the precedent for "PR gate jobs are reusable workflows in HoneyDrunk.Actions, called by consumers via `workflow_call`." This packet follows that precedent exactly — `job-sonarcloud.yml` lives where `job-dependency-scan.yml` and `job-codeql.yml` already live.
+
+## Referenced Invariants
+
+> **Invariant 31:** Every PR traverses the tier-1 gate before merge. Build, unit tests, analyzers, vulnerability scan, and secret scan are required branch-protection checks on every .NET repo in the Grid, delivered via `pr-core.yml` in `HoneyDrunk.Actions`. Bypassing tier 1 via force-push to `main` or admin override is forbidden except for `hotfix-infra` scenarios where the gate itself is broken.
+
+> **Invariant 9 (secrets):** Vault is the only source of secrets. *(Reframed for CI context — `SONAR_TOKEN` lives as a GitHub org-level secret, accessed via the `secrets.` context. This is the GitHub-native equivalent of Vault for CI runtime; the invariant applies to application code reading secrets at runtime, not to CI workflows reading org-level secrets via the `secrets.` context. Calling this out so the executor does not invent a Vault read path inside CI.)*
+
+## Constraints
+- **Do not wire this workflow into `pr-core.yml`.** Wiring is per-repo, in each consuming repo's `pr.yml`. `pr-core.yml` is a per-repo orchestrator and adding SonarCloud there would force every repo (including private repos that ADR-0011 D11 explicitly excludes) to fire the workflow.
+- **Do not re-run `dotnet test` inside this workflow.** Coverage comes from `job-build-and-test.yml`'s artifact. Cost budget: under 60 seconds median.
+- **Use exact secret name `SONAR_TOKEN`.** This is the name documented in packet 04's walkthrough and in SonarCloud's own onboarding docs. Renaming creates a future-rename hazard for the org-secret.
+- **Do not commit any token, key, or organization-specific value.** The `sonar-organization` and `sonar-project-key` values are workflow inputs supplied by callers; they are not hardcoded.
+- **Permissions block stays minimal:** `contents: read`, `pull-requests: write`, `checks: write`. Anything broader is a finding.
+- **`fetch-depth: 0` is non-negotiable.** Shorter depths break SCM blame attribution and silently degrade SonarCloud's PR decoration.
+- **Job-level `if:` trigger guard is non-negotiable.** Per ADR-0011 D11, "the stage must only run on `pull_request` events and pushes to `main`. Not on every feature-branch push, not on tags." Caller-side enforcement (the consuming workflow's `on:` block) is the primary line of defence; the job-level `if:` guard is the secondary defence-in-depth line — it ensures a misconfigured caller produces a skipped no-op rather than a paid SonarCloud run on every feature-branch push.
+- **Caller trigger contract documented in header.** The CALLER TRIGGER CONTRACT block in the workflow's header comment is the contract surface for new callers; it must stay in sync with the `if:` guard expression.
+
+## Labels
+`feature`, `tier-2`, `ci-cd`, `ops`, `adr-0011`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Ship `.github/workflows/job-sonarcloud.yml` as a new reusable workflow in `HoneyDrunk.Actions` that runs SonarCloud against a .NET repo, reuses coverage from `job-build-and-test.yml`, and exposes the SonarCloud quality gate as a PR check. Do not wire it into `pr-core.yml`. Do not onboard any specific repo here.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Provide the per-repo SonarCloud onboarding packets (Wave 2 + deferred Wave 3) with a real reusable workflow to call.
+- Feature: ADR-0011 Code Review Pipeline rollout.
+- ADRs: ADR-0011 (primary, D2 tier model + D11 SonarCloud choice), ADR-0009 (precedent for "PR gate jobs are reusable workflows"), ADR-0008 (initiative/packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- Architecture#NN — ADR-0011 acceptance (packet 01). Soft dependency; sequence with 01 first to keep invariant references live.
+
+**Constraints:**
+- **Tier-1 gate is required, tier-2 SonarCloud is required only on public repos** (invariant 31, ADR-0011 D11). The workflow ships ready to run; per-repo wiring decides where it actually fires.
+- Do not re-run `dotnet test` inside this workflow — reuse coverage artifact from `job-build-and-test.yml`.
+- `fetch-depth: 0` on checkout. Java 17 Temurin. Two Sonar caches.
+- Permissions minimal: `contents: read`, `pull-requests: write`, `checks: write`.
+- `SONAR_TOKEN` is a required secret; provisioning is packet 04, not this packet.
+- Do not commit any token, organization key, or project key as a hardcoded value.
+
+**Key Files:**
+- `.github/workflows/job-sonarcloud.yml` (new)
+- `.github/workflows/job-build-and-test.yml` (existing — reference its coverage artifact name)
+- `.github/workflows/job-codeql.yml` (existing — style reference)
+- `.github/workflows/job-dependency-scan.yml` (existing — style reference)
+- `CHANGELOG.md` (root)
+- `README.md` (root) — if it has a "Reusable Workflows" listing section
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0011-code-review-pipeline/03-actions-agent-run-packet-link.md
+++ b/generated/issue-packets/active/adr-0011-code-review-pipeline/03-actions-agent-run-packet-link.md
@@ -1,0 +1,332 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ci-cd", "ops", "adr-0011", "wave-1"]
+dependencies: ["Architecture#NN — ADR-0011 acceptance (packet 01)"]
+adrs: ["ADR-0011", "ADR-0008"]
+wave: 1
+initiative: adr-0011-code-review-pipeline
+node: honeydrunk-actions
+---
+
+# Feature: Inject packet link into agent-authored PR bodies in `agent-run.yml`
+
+## Summary
+Amend the cloud agent-execution workflow `agent-run.yml` so that when an agent opens a PR for an issue packet, the PR body always contains a fully-resolved link to the packet file in `HoneyDrunk.Architecture`. This makes invariant 32 ("agent-authored PRs must link to their packet in the PR body") mechanically enforced for every agent-authored PR.
+
+The packet uses two complementary mechanisms:
+1. **Prompt-side instruction (soft, primary path).** When `packet-path` is supplied, the workflow appends a structured "Packet: <permalink>" instruction to the agent's prompt envelope so well-behaved agents include the line directly.
+2. **Workflow-side post-hoc assert (hard, mechanical guarantee).** After the agent finishes, a new "Assert PR-body packet link" step locates any PR the agent opened on the run's branch and uses `gh pr edit` to ensure the `> Packet: <permalink>` line is present in the PR body. The workflow is the source of truth — invariant 32 enforcement does not depend on the LLM remembering its instructions.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Actions`
+
+## Motivation
+Invariant 32 (now live after packet 01 lands) requires every agent-authored PR to link to its packet. The review agent uses that link to resolve the packet, which is its primary scope anchor (ADR-0011 D3). Today, whether the link appears depends on the agent's prompt discipline — it is not a property of the workflow.
+
+`agent-run.yml` is the single entrypoint for cloud-driven agent work in the Grid (per its own header comment block). It already accepts an `agent` input and resolves a prompt from `.claude/agents/{agent}.md`. What it does not do is communicate the **target packet** to the agent in a structured way that survives into the PR body. This packet closes that gap.
+
+The naive form ("just tell the agent to include the line") is a soft enforcement — it makes invariant 32 contingent on the model following instructions, which is exactly the drift mode ADR-0011 is trying to prevent. To harden it, the workflow itself asserts the line into the PR body after the agent completes. The agent's instruction is still useful (it gives the model a chance to author the link in the right place naturally) but it is no longer the only line of defence. The workflow is the mechanical guarantor of invariant 32.
+
+## Proposed Implementation
+
+### A. Add a `packet-path` input
+
+In `.github/workflows/agent-run.yml`, add a new optional input alongside `agent`, `prompt`, and `checkout-target`:
+
+```yaml
+      packet-path:
+        description: >-
+          Optional path to the issue packet file (relative to HoneyDrunk.Architecture
+          root, e.g. generated/issue-packets/active/adr-0011-code-review-pipeline/02-actions-job-sonarcloud-workflow.md).
+          When set, the workflow injects a "Packet: <permalink>" line into the
+          agent's prompt envelope so any PR opened by the agent links back to
+          the packet (per invariant 32 in HoneyDrunk.Architecture).
+        required: false
+        type: string
+        default: ''
+```
+
+### B. Resolve the packet permalink
+
+In the existing **Resolve prompt** step, before assembling the prompt, compute the GitHub permalink to the packet file. The permalink format is:
+
+```
+https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/<architecture-ref>/<packet-path>
+```
+
+Use `${{ inputs.architecture-ref }}` (which already defaults to `main`) so the link tracks the same ref the workflow checked out. Computing it in shell is safer than constructing it in `${{ }}` interpolation when `packet-path` is empty:
+
+```yaml
+      - name: Resolve packet link
+        id: packet
+        env:
+          PACKET_PATH: ${{ inputs.packet-path }}
+          ARCH_REF: ${{ inputs.architecture-ref }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${PACKET_PATH}" ]]; then
+            LINK="https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/${ARCH_REF}/${PACKET_PATH}"
+            echo "link=${LINK}" >> "$GITHUB_OUTPUT"
+            echo "has-packet=true" >> "$GITHUB_OUTPUT"
+            # Verify the file exists in the checked-out Architecture tree
+            if [[ ! -f "${PACKET_PATH}" ]]; then
+              echo "::warning::packet-path '${PACKET_PATH}' was supplied but the file does not exist at the resolved Architecture ref. The PR will still be opened, but the packet link will 404. Verify packet-path matches the on-disk path."
+            fi
+          else
+            echo "has-packet=false" >> "$GITHUB_OUTPUT"
+          fi
+```
+
+The warning case is intentional: the workflow does not fail when the packet file is missing, because that would block hotfix-style or out-of-band agent runs that legitimately have no packet. It logs a warning and continues, and the resulting PR will not link to a packet — which downstream tooling (the review agent, the human) will recognize as out-of-band per ADR-0011 D9.
+
+### C. Inject the link into the agent's prompt
+
+Modify the existing **Resolve prompt** step (it currently assembles the agent or direct-prompt envelope and writes it to `$GITHUB_OUTPUT`) so that when `packet-path` is supplied, the envelope ends with a structured instruction:
+
+```yaml
+      - name: Resolve prompt
+        id: resolve
+        env:
+          AGENT: ${{ inputs.agent }}
+          PROMPT: ${{ inputs.prompt }}
+          HAS_PACKET: ${{ steps.packet.outputs.has-packet }}
+          PACKET_LINK: ${{ steps.packet.outputs.link }}
+          PACKET_PATH: ${{ inputs.packet-path }}
+        run: |
+          set -euo pipefail
+
+          # Build the base envelope (existing logic — unchanged in shape)
+          if [[ -n "${AGENT}" ]]; then
+            BASE="You are the **${AGENT}** agent. Read your full instructions from \`.claude/agents/${AGENT}.md\` first, then execute your full workflow as described there."
+          else
+            BASE="${PROMPT}"
+          fi
+
+          # When a packet is supplied, append a structured instruction.
+          # The agent must include this exact "Packet:" line in any PR body it opens.
+          if [[ "${HAS_PACKET}" == "true" ]]; then
+            PACKET_INSTRUCTION="
+
+          ---
+
+          **Issue packet for this run:** \`${PACKET_PATH}\`
+          **Packet permalink:** ${PACKET_LINK}
+
+          When you open a pull request for this work, include the following line verbatim in the PR body (this satisfies invariant 32 in HoneyDrunk.Architecture and is what the review agent uses to resolve the packet as the primary scope anchor):
+
+          > Packet: ${PACKET_LINK}
+
+          If you cannot include the link for any reason, label the PR \`out-of-band\` and explain why in the PR body."
+            FULL_PROMPT="${BASE}${PACKET_INSTRUCTION}"
+          else
+            FULL_PROMPT="${BASE}"
+          fi
+
+          {
+            echo "prompt<<EOF_PROMPT"
+            printf '%s' "${FULL_PROMPT}"
+            echo ""
+            echo "EOF_PROMPT"
+          } >> "$GITHUB_OUTPUT"
+```
+
+The existing **Resolve prompt** step already exists in `agent-run.yml`; this is a refactor of that step, not a new step. Preserve the existing branching between `agent` and `prompt` modes — only the post-envelope packet instruction is new.
+
+### D. Optional: caller convenience hint
+
+In the workflow header comment block, add a usage example showing the new input:
+
+```yaml
+# Usage example (named agent + packet):
+#   jobs:
+#     execute:
+#       uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/agent-run.yml@main
+#       with:
+#         agent: execute
+#         packet-path: generated/issue-packets/active/adr-0011-code-review-pipeline/02-actions-job-sonarcloud-workflow.md
+#         checkout-target: HoneyDrunkStudios/HoneyDrunk.Actions
+#       secrets:
+#         anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+#         github-token: ${{ secrets.AGENT_RUN_TOKEN }}
+```
+
+Match the style of the two existing usage examples in the header.
+
+### E. Post-hoc assert step — the mechanical guarantor
+
+The prompt-injection in step C is best-effort soft enforcement. To make invariant 32 mechanically reliable regardless of LLM behaviour, add a new step **after** the agent run steps (after both `Run agent — Claude` and `Run agent — Codex`, conditional on `inputs.packet-path` being non-empty) that locates the PR the agent opened on this run's branch and asserts the `> Packet: <permalink>` line into the PR body via `gh pr edit`.
+
+Step shape:
+
+```yaml
+      - name: Assert PR-body packet link
+        if: ${{ inputs.packet-path != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
+          PACKET_LINK: ${{ steps.packet.outputs.link }}
+          PACKET_PATH: ${{ inputs.packet-path }}
+          CHECKOUT_TARGET: ${{ inputs.checkout-target }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${CHECKOUT_TARGET}" ]]; then
+            echo "::notice::No checkout-target — agent ran in Architecture-only mode; PR-body assert skipped (no target repo to inspect)."
+            exit 0
+          fi
+
+          # The agent runs in target-repo/ (set by the Checkout target repo step).
+          # Find any PR opened from the current branch on the target repo.
+          cd target-repo
+
+          BRANCH=$(git branch --show-current || true)
+          if [[ -z "${BRANCH}" || "${BRANCH}" == "main" ]]; then
+            echo "::notice::Agent did not open a feature branch (current=${BRANCH:-detached}); no PR to assert."
+            exit 0
+          fi
+
+          # Find the PR opened from this branch in the target repo.
+          PR_NUMBER=$(gh pr list --repo "${CHECKOUT_TARGET}" --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
+          if [[ -z "${PR_NUMBER}" ]]; then
+            echo "::notice::Agent did not open a PR on branch '${BRANCH}' in ${CHECKOUT_TARGET}; nothing to assert."
+            exit 0
+          fi
+
+          # Read current PR body. If the exact link line is already present, no-op.
+          BODY=$(gh pr view "${PR_NUMBER}" --repo "${CHECKOUT_TARGET}" --json body --jq '.body // ""')
+          EXPECTED_LINE="> Packet: ${PACKET_LINK}"
+
+          if printf '%s\n' "${BODY}" | grep -Fxq "${EXPECTED_LINE}"; then
+            echo "PR #${PR_NUMBER} already contains the packet link line; no edit needed."
+            exit 0
+          fi
+
+          # Otherwise, prepend the packet-link block to the PR body.
+          NEW_BODY=$(printf '%s\n\n---\n\n%s\n' "${EXPECTED_LINE}" "${BODY}")
+          echo "Asserting packet link on PR #${PR_NUMBER} in ${CHECKOUT_TARGET}."
+          gh pr edit "${PR_NUMBER}" --repo "${CHECKOUT_TARGET}" --body "${NEW_BODY}"
+```
+
+Notes on the assert step:
+
+- **Idempotent.** If the agent's PR body already contains the exact `> Packet: <permalink>` line (because the prompt-side injection worked), the step exits with no edit. If the line is missing, the step prepends a packet-link block and an `---` separator, preserving the agent's original body underneath.
+- **Soft on edge cases.** No PR found, detached HEAD, no `checkout-target`, or main-branch run all produce a `::notice::` and exit 0 — the workflow does not fail on these states. They represent legitimate non-PR-opening agent runs (governance syncs, summarisations, etc.).
+- **Permission requirements.** The step uses `gh pr edit` against `inputs.checkout-target`. The token in `secrets.github-token` must have `pull-requests: write` on the target repo. The `agent-run.yml` workflow already declares `permissions: pull-requests: write` and consumers already pass a token with this scope, so no new permission is required.
+- **Branch detection.** `git branch --show-current` returns the agent's working branch (the branch it pushed to before opening the PR). If the agent did not push or did not open a PR, the `gh pr list --head` call returns empty and the step no-ops.
+- **The line format must match exactly.** `> Packet: <permalink>` (greater-than sign, space, `Packet:`, space, full URL). The grep is `-Fxq` (literal whole-line match) — no fuzzy matching. If the agent inserts a different format (`Packet: <link>` without the quote, or `**Packet:** <link>`, etc.), the step inserts the canonical form alongside the agent's variant. The review agent's parser keys on the canonical form, so both forms coexisting is harmless.
+
+### F. No change to other callers
+
+Do **not** edit any caller of `agent-run.yml` in this packet. The `packet-path` input is optional with an empty default, so existing callers continue to work unchanged. Callers that pass a packet (the file-packets driver, future packet-execution workflows) opt in by supplying the input.
+
+## Affected Files
+- `.github/workflows/agent-run.yml` (edit — add input, resolve-packet step, prompt-envelope amendment, post-hoc assert step, header example)
+- `CHANGELOG.md` (root): append entry under in-progress version
+- `README.md` (root): no change expected; this is a new optional input + post-hoc step on an existing workflow, not a new workflow
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Actions`. Routing rule "workflow, CI, GitHub Actions, pipeline, PR check, release → HoneyDrunk.Actions" applies.
+- [x] No code changes in other repos. The Architecture-side convention ("PR bodies must link to packets") is documented; this packet enforces it on the cloud side without requiring any other repo to change.
+- [x] No new cross-Node dependency. `agent-run.yml` continues to be the single agent-execution entrypoint; this packet only adds an optional input.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/agent-run.yml` declares a new optional input `packet-path` with description and default `''`
+- [ ] A new "Resolve packet link" step exists that computes the permalink (`https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/<architecture-ref>/<packet-path>`) only when `packet-path` is non-empty
+- [ ] The "Resolve packet link" step warns (does not fail) when `packet-path` is supplied but the file is missing at the resolved ref
+- [ ] The existing "Resolve prompt" step is amended to append a structured packet instruction (the `> Packet: …` quoted line + an `out-of-band` fallback hint) only when `packet-path` is non-empty
+- [ ] The amended prompt envelope produces the exact line `> Packet: <permalink>` as a quoted markdown block — the review agent's packet-resolution logic depends on this format
+- [ ] **A new "Assert PR-body packet link" step exists**, gated `if: ${{ inputs.packet-path != '' }}`, that runs after the agent run steps. It locates the PR the agent opened on the current branch in `inputs.checkout-target` and asserts the `> Packet: <permalink>` line into the PR body via `gh pr edit`. The step is the mechanical guarantor of invariant 32 — the workflow, not the LLM, is the source of the line.
+- [ ] The assert step is **idempotent**: if the PR body already contains the exact line, no edit is performed.
+- [ ] The assert step is **soft on edge cases**: missing PR, no checkout-target, detached HEAD, or main-branch run all produce a `::notice::` and exit 0 (no failure).
+- [ ] The assert step uses `gh pr edit --body` to prepend the canonical link block; the agent's original body is preserved below an `---` separator.
+- [ ] When `packet-path` is empty, the workflow behaves identically to today (existing callers keep working — both the resolve and assert steps no-op).
+- [ ] When `packet-path` is supplied but invalid (file missing at ref), the resolve step logs `::warning::` and continues; the assert step still runs against whatever permalink was constructed.
+- [ ] Header comment block contains a new usage example that demonstrates `packet-path` and notes the post-hoc assert behaviour.
+- [ ] Permissions block is unchanged — `agent-run.yml` already declares `permissions: pull-requests: write`, which the assert step's `gh pr edit` requires; no broader permission needed.
+- [ ] Repo-level `CHANGELOG.md`: append a new line under the in-progress version's `Changed` (or `Added`) section describing the new input AND the post-hoc assert step. If packet 02 has already opened a new in-progress version entry on the same wave, append to that entry instead of opening a second one (invariants 12 and 27 — partial bumps forbidden, alignment-only entries forbidden)
+- [ ] No per-package `CHANGELOG.md` updates (this is a workflow change, not a package change)
+- [ ] `actions-ci.yml` (or whatever lints `.github/workflows/`) passes
+
+## Human Prerequisites
+None. This packet is a workflow edit in `HoneyDrunk.Actions`. No portal action, no secret seeding.
+
+The first caller that actually exercises the new input is the next packet that ships the file-packets / packet-execution driver — not in this initiative. Until then, the input remains optional and unused, which is the correct pre-rollout state.
+
+## Dependencies
+- Architecture#NN — ADR-0011 acceptance (packet 01). Soft dependency: invariant 32 is the rationale referenced in the PR-body instruction text. Sequence packet 01 first.
+
+## Downstream Unblocks
+- Future packet-execution workflows (not in this initiative) that drive `agent-run.yml` from a packet pointer can satisfy invariant 32 mechanically — the workflow asserts the line, not the LLM.
+- The review agent (local-only per ADR-0011 D10) gains a stable packet-link convention to parse — quoted markdown block starting with `Packet: `.
+- Future hardening (e.g. signed packet-link assertions, automatic `out-of-band` label application when `packet-path` is empty) can layer onto the same step structure without re-architecting.
+
+## Referenced ADR Decisions
+
+**ADR-0011 (Code Review and Merge Flow):**
+- **D3 (artifact contracts):** "Input 'packet file (via issue link)' is non-negotiable for the review agent." The PR body must link to the packet file; the review agent resolves the link, reads the packet, and uses it as the primary scope anchor. PRs whose body does not link to a packet are out-of-band per D9.
+- **D9 (out-of-band PRs):** A PR that does not link to a packet is out-of-band. Out-of-band PRs still traverse the full pipeline; the review agent's packet-loading step is skipped. They must carry the `out-of-band` label.
+- **D10 (review agent local-only):** The review agent runs locally via Claude Code, not as a cloud workflow. The packet link the review agent reads is the same link this workflow injects — local execution and cloud injection meet at the PR body.
+
+**ADR-0008 (Work Tracking and Execution Flow):**
+- **D8 (cloud agent execution):** The cloud agent execution workflow checks out both the target repo and `HoneyDrunk.Architecture`. This packet does not change that — `agent-run.yml` already does it. What this packet adds is structured packet metadata in the agent's prompt envelope so the resulting PR carries the link forward.
+
+## Referenced Invariants
+
+> **Invariant 32:** Agent-authored PRs must link to their packet in the PR body. The review agent resolves the packet via this link and uses it as the primary scope anchor. Absent the link, the PR is treated as out-of-band, must carry the `out-of-band` label, and receives a degraded review in which the agent runs against the Grid context only (invariants, boundaries, relationships, diff) without a packet-scope check.
+
+> **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. *(The link this workflow injects is to the packet file at the agent's checkout ref — stable for the duration of that execution. Post-merge, the file may be archived per ADR-0008 D10; the permalink continues to resolve via Git history.)*
+
+## Constraints
+- **Optional input, default empty.** All existing callers must keep working unchanged. Do not add a `required: true` flag.
+- **Warn, do not fail, on a missing packet file.** Failing would prevent legitimate out-of-band agent runs.
+- **Use `${{ inputs.architecture-ref }}` for the permalink branch.** Hardcoding `main` would silently break runs that pin to a tag or a specific SHA.
+- **Preserve the existing "Resolve prompt" step branching between `agent` and `prompt` modes.** The packet instruction is appended after the base envelope, regardless of which mode produced the base.
+- **The injected line format is a quoted markdown block: `> Packet: <permalink>`.** The review agent parses this exact shape. Plain text or different bullet style breaks the contract. Both the prompt-side instruction and the post-hoc assert step must produce the same canonical form.
+- **The post-hoc assert step is the mechanical guarantor.** The prompt-side instruction is best-effort soft enforcement and may be ignored by the model; the assert step ensures invariant 32 holds regardless. Do not delete the assert step in a future "simplification" — it carries the load.
+- **The assert step is idempotent and soft on edge cases.** Missing PR, no checkout-target, detached HEAD, main-branch run → `::notice::` and exit 0. Existing PR with the line already → no-op. Existing PR without the line → prepend canonical block.
+- **`gh` and `jq` are preinstalled on `ubuntu-latest`.** The assert step relies on this; do not introduce additional installation steps.
+- **Do not change the workflow's `permissions:` block.** `pull-requests: write` is already declared and is sufficient for `gh pr edit`. Adding write permissions for unrelated reasons is out of scope.
+- **No secrets read added.** This packet adds no new secret consumption — the assert step uses `secrets.github-token` which is already declared.
+
+## Labels
+`feature`, `tier-2`, `ci-cd`, `ops`, `adr-0011`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Add a `packet-path` input to `agent-run.yml` plus two complementary mechanisms: (1) a prompt-envelope injection that instructs the agent to include the `> Packet: <permalink>` line in the PR body, and (2) a post-hoc "Assert PR-body packet link" step that mechanically asserts the line into the PR body via `gh pr edit` after the agent finishes. The assert step is the load-bearing guarantor of invariant 32 — the workflow is the source of the line, not the LLM. Optional input (default empty); no failure on missing file or missing PR (notice/warn and continue); no permission changes; no caller changes.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Make invariant 32 ("agent-authored PRs must link to their packet") mechanical rather than a per-prompt convention.
+- Feature: ADR-0011 Code Review Pipeline rollout.
+- ADRs: ADR-0011 (D3 packet-as-scope-anchor, D9 out-of-band degradation, D10 local review agent reads same link), ADR-0008 (D8 cloud execution workflow context).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- Architecture#NN — ADR-0011 acceptance (packet 01). Soft dependency on invariant-32 going live.
+
+**Constraints:**
+- Optional input, default empty. Existing callers unaffected.
+- Warn (do not fail) on missing packet file. Notice (do not fail) when there is no PR to edit.
+- Use `${{ inputs.architecture-ref }}` to construct the permalink branch.
+- Preserve agent vs prompt branching in the existing "Resolve prompt" step.
+- The injected line must be exactly `> Packet: <permalink>` as a quoted markdown block — review agent parses this format. Both prompt-side and post-hoc-assert paths emit the same canonical form.
+- The post-hoc assert step is the mechanical guarantor of invariant 32; do not remove it in favour of "the prompt is enough" — the prompt is best-effort and the LLM can ignore it.
+- The assert step is idempotent — running twice on the same PR leaves it unchanged.
+- No new permissions (`pull-requests: write` already declared), no new secrets (`secrets.github-token` already declared).
+- `gh` and `jq` are preinstalled on `ubuntu-latest` — do not add install steps.
+
+**Key Files:**
+- `.github/workflows/agent-run.yml` (the only workflow file edited)
+- `CHANGELOG.md` (root)
+
+**Contracts:**
+- New convention: PR bodies opened by `agent-run.yml` runs that supply `packet-path` will contain `> Packet: <permalink>`. The review agent's packet-resolution logic in `.claude/agents/review.md` consumes this format. Do not change the format casually — it is the cloud-side half of an unwritten contract with the local-side review agent.

--- a/generated/issue-packets/active/adr-0011-code-review-pipeline/04-architecture-sonarcloud-org-walkthrough.md
+++ b/generated/issue-packets/active/adr-0011-code-review-pipeline/04-architecture-sonarcloud-org-walkthrough.md
@@ -1,0 +1,194 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "docs", "infrastructure", "adr-0011", "wave-1"]
+dependencies: ["Architecture#NN — ADR-0011 acceptance (packet 01)"]
+adrs: ["ADR-0011"]
+wave: 1
+initiative: adr-0011-code-review-pipeline
+node: honeydrunk-architecture
+---
+
+# Feature: Portal walkthrough — SonarCloud organization setup, GitHub App install, `SONAR_TOKEN` org secret
+
+## Summary
+Author a portal-first walkthrough for the one-time SonarCloud setup that ADR-0011 D11's rollout depends on: create the `honeydrunkstudios` SonarCloud organization, link it to the GitHub org, install the SonarCloud GitHub App on every existing public repo, generate the org-level `SONAR_TOKEN`, and provision it as a `HoneyDrunkStudios` GitHub org secret. Index the new walkthrough in `infrastructure/README.md`.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+ADR-0011 D11's "Follow-up Work" calls out exactly this: *"SonarCloud organization setup — create the `honeydrunkstudios` SonarCloud organization, link it to the GitHub org, install the SonarCloud GitHub App on public repos, provision `SONAR_TOKEN` as an org secret. Portal walkthrough in `HoneyDrunk.Architecture/infrastructure/` per the 'prefer portal over CLI' convention."*
+
+Per established memory and convention, infrastructure setup work is documented as a portal walkthrough — not as a CLI script. The walkthrough is the **source of truth** for the click path, and the human follows it once during initial provisioning. Per-repo onboardings (packets 06, 07, and the deferred Wave-3 fan-out) all assume the org-level setup is in place; this packet ships that walkthrough.
+
+This packet is `Actor=Agent` for the **doc-authoring** part: the agent writes the walkthrough markdown using the existing `infrastructure/*.md` style, indexes it, and adds appropriate cross-links. The actual portal clicks happen as **Human Prerequisites** — the human runs through SonarCloud's UI to create the org and seed the secret. The doc and the portal work happen on the same wave because they validate each other: the human follows the walkthrough as written, and the walkthrough is corrected if the click path is inaccurate.
+
+## Proposed Implementation
+
+Create `infrastructure/sonarcloud-organization-setup.md` matching the existing portal-first walkthrough structure used by `key-vault-creation.md`, `oidc-federated-credentials.md`, `app-configuration-provisioning.md`, etc. Sections:
+
+1. **Goal** — one paragraph: stand up SonarCloud as the third-party static analysis tool for public HoneyDrunk repos, with PR decoration via the SonarCloud GitHub App and CI authentication via an org-level `SONAR_TOKEN`. One-time per-org setup; per-repo import is a separate walkthrough/packet.
+2. **Prerequisites** — checklist:
+   - Repo admin / GitHub org owner role
+   - A SonarCloud account (free tier; sign in with GitHub recommended)
+   - The list of public Grid repos that should be imported (everything currently in `catalogs/nodes.json` with a public GitHub repo, excluding `HoneyDrunk.Studios` which is TypeScript and onboards separately as a future packet)
+3. **Portal Breadcrumb** — `https://sonarcloud.io → Sign in with GitHub → + → Create Organization → Free plan → Choose HoneyDrunkStudios`
+4. **Step-by-step** — walk through each SonarCloud screen with bullet-level guidance:
+   - **Step 1 — Sign in with GitHub.** Authorize SonarCloud's GitHub App to read the `HoneyDrunkStudios` org. Note that this is the SonarCloud OAuth grant, not the per-repo GitHub App install (that happens in step 4).
+   - **Step 2 — Create the SonarCloud organization.** Choose "Free" plan; name it `honeydrunkstudios`; bind it to the `HoneyDrunkStudios` GitHub org.
+   - **Step 3 — Verify free-tier eligibility.** SonarCloud's free tier covers public repos at zero cost. The org page should display "Free plan — public repos" with no payment method required. Confirm this before continuing.
+   - **Step 4 — Install the SonarCloud GitHub App on public repos.** From SonarCloud → Administration → Bind organization, follow the link to GitHub, install the SonarCloud app on the `HoneyDrunkStudios` org, and **explicitly select the public repos to onboard** (do not use "All repositories" — private repos are intentionally excluded per ADR-0011 D11). The list to install on, today, is:
+     - HoneyDrunk.Kernel
+     - HoneyDrunk.Transport
+     - HoneyDrunk.Vault
+     - HoneyDrunk.Vault.Rotation
+     - HoneyDrunk.Auth
+     - HoneyDrunk.Web.Rest
+     - HoneyDrunk.Data
+     - HoneyDrunk.Pulse
+     - HoneyDrunk.Notify
+     - HoneyDrunk.Actions
+     - HoneyDrunk.Architecture
+     - (any future public Grid repo — onboarded ad-hoc when added)
+     - **Excluded:** HoneyDrunk.Studios (TypeScript/Next.js — separate onboarding when needed)
+   - **Step 5 — Generate `SONAR_TOKEN`.** From SonarCloud → My Account → Security → Generate Token. Token type: **User Token** scoped to organization analysis. Set a long expiration (12 months minimum, 24 months preferred) and add a calendar reminder to rotate before expiry. Copy the token value to a temporary secure clipboard manager — SonarCloud does not show it again.
+   - **Step 6 — Provision the GitHub org secret.** Browse to `https://github.com/organizations/HoneyDrunkStudios/settings/secrets/actions → New organization secret`. Name: `SONAR_TOKEN` (exact, all caps). Value: the token from step 5. Repository access: choose **"Selected repositories"** and pick the same list as step 4. Do NOT use "All repositories" — that grants the secret to private repos, which violates ADR-0011 D11's "private-repo SonarCloud is opt-in only" posture.
+5. **Post-create hardening** — checklist:
+   - [ ] Confirm the SonarCloud org dashboard now lists every onboarded repo as "Free — public"
+   - [ ] Set a calendar reminder for the `SONAR_TOKEN` expiration date (and a second reminder 30 days before expiry to rotate)
+   - [ ] In SonarCloud Organization Settings, confirm "Default New Code definition" is set to "Number of days" → 30 (default) — this controls the New-Code analysis window for the quality gate
+   - [ ] In SonarCloud Organization Settings → Security → confirm "Two-factor authentication required" is on
+   - [ ] If a future private Grid repo wants SonarCloud coverage, that is a separate per-repo opt-in packet — do not add private repos to the SonarCloud org via "All repositories"
+6. **Quality gate posture (per ADR-0011 D11)** — short note:
+   - Default quality gate is "Sonar way" (the SonarCloud built-in). It is acceptable as a starting point.
+   - Each per-repo onboarding packet (Wave 2 + Wave 3) is responsible for adding the SonarCloud check to that repo's branch protection so the quality gate becomes enforcing per invariant 31's tier-2 reading.
+   - Quality gate failures show up as PR check failures — same surface as `pr-core.yml` checks.
+7. **Cost discipline** — explicit confirmation that this provisioning is **zero recurring cost** under SonarCloud's free public-tier pricing. Document the threshold at which costs change (private repos = paid per LOC; the free tier covers unlimited public repos). One-line note that any future private-repo SonarCloud onboarding requires a packet that justifies the cost in its own right (ADR-0011 D11 Gap 5).
+8. **References**:
+   - ADR-0011 (Code Review and Merge Flow) — D11 SonarCloud choice; this walkthrough operationalizes the "If Accepted" follow-up bullet
+   - SonarCloud documentation: `https://docs.sonarsource.com/sonarcloud/`
+   - GitHub org secrets documentation: `https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-an-organization`
+   - Cross-link to `key-vault-rbac-assignments.md` for the prefer-portal-over-CLI convention this walkthrough follows
+   - Cross-link to `azure-naming-conventions.md` for the "named org-level secret" precedent (this is GitHub, not Azure, but the discipline is the same)
+
+### Indexing
+
+In `infrastructure/README.md`, add a new entry to the Walkthrough Index in alphabetical order under a "Tooling / CI" subsection (or at the bottom of the index if no subsections exist):
+
+- `sonarcloud-organization-setup.md` — One-time SonarCloud organization creation, GitHub App install on public repos, and `SONAR_TOKEN` org-level secret provisioning. Required before per-repo SonarCloud onboarding packets can run.
+
+Add ADR-0011 to the References section if it is not already listed.
+
+## Affected Files
+- `infrastructure/sonarcloud-organization-setup.md` (new)
+- `infrastructure/README.md` (index update + ADR-0011 reference)
+
+## NuGet Dependencies
+None. Docs only.
+
+## Boundary Check
+- [x] Architecture-repo work (docs and infrastructure walkthrough). Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" applies.
+- [x] No code change in any other repo.
+- [x] The walkthrough does not encode any secret value, organization key, or token. Token generation is described step-by-step; the value is created by the human in the SonarCloud UI and pasted into the GitHub UI.
+- [x] No invariant violation: secrets stay out of the doc per invariant 8 ("Secret values never appear in logs, traces, exceptions, or telemetry") — this generalizes to documentation as well.
+
+## Acceptance Criteria
+- [ ] `infrastructure/sonarcloud-organization-setup.md` exists and follows the Goal / Prerequisites / Portal Breadcrumb / Step-by-step / Post-create hardening / Quality gate posture / Cost discipline / References structure of the existing walkthroughs (`key-vault-creation.md`, `oidc-federated-credentials.md`, etc.)
+- [ ] Step 4 explicitly enumerates the public repo onboarding list and explicitly excludes private repos and `HoneyDrunk.Studios` (TypeScript)
+- [ ] Step 6 specifies the secret name exactly as `SONAR_TOKEN` (all caps, exact)
+- [ ] Step 6 specifies "Selected repositories" — never "All repositories" — for the GitHub org secret access
+- [ ] No secret value, no token, no organization API key is committed to the doc
+- [ ] Post-create hardening checklist includes the calendar-reminder rotation step
+- [ ] Cost discipline section explicitly states: free for public repos, paid per-LOC for private repos, private opt-in is its own packet
+- [ ] `infrastructure/README.md`: new entry indexes the walkthrough; ADR-0011 listed in References if not already present
+- [ ] Repo-level `CHANGELOG.md`: append a docs entry to the in-progress version (or open one if this is the first packet in this wave to touch the Architecture repo's changelog — coordinate with packet 01's changelog stance: Architecture historically has no `CHANGELOG.md`, so this row may degrade to "skip per Architecture-repo precedent")
+- [ ] No ADR IDs added to body narrative beyond the explicit "References" section (per user convention — index/reference sections are exempt; body narrative is not)
+- [ ] The walkthrough was actually exercised by the human as part of authoring (Human Prerequisites below). If a step's wording differs from the real SonarCloud UI as of the authoring date, the doc reflects what the UI actually shows, not what the doc was originally drafted to say.
+
+## Human Prerequisites
+This packet has substantial human portal work. The agent authors the doc; the human follows the doc and corrects it. These steps must complete on the same wave:
+
+- [ ] **Step 1–2:** Sign into `https://sonarcloud.io` with the HoneyDrunk Studios GitHub identity. Create the SonarCloud organization `honeydrunkstudios` on the Free plan, bound to the `HoneyDrunkStudios` GitHub org.
+- [ ] **Step 3:** Verify the org page displays "Free plan — public repos" and no payment method is required.
+- [ ] **Step 4:** Install the SonarCloud GitHub App on the `HoneyDrunkStudios` org, with **"Selected repositories"** scoped to the public-repo list enumerated in the walkthrough (today's list: Kernel, Transport, Vault, Vault.Rotation, Auth, Web.Rest, Data, Pulse, Notify, Actions, Architecture). Do not select Studios (TypeScript). Do not select "All repositories".
+- [ ] **Step 5:** Generate a `SONAR_TOKEN` (User Token) in SonarCloud → My Account → Security. Long expiration (12+ months). Save the value to a secure password manager.
+- [ ] **Step 6:** Add `SONAR_TOKEN` as an organization secret at `https://github.com/organizations/HoneyDrunkStudios/settings/secrets/actions`. Repository access: "Selected repositories" — same list as step 4.
+- [ ] **Calendar reminder:** Set two reminders: one at the token expiration date, one 30 days before. Rotation steps will be the same as steps 5–6 with token recycling.
+- [ ] **Doc validation:** As you click through the portal, note any wording or step-ordering drift from the agent-authored doc and update the doc inline before merging the PR.
+
+**Cost note:** Free tier; zero recurring cost on the public side. Display the SonarCloud org page that shows "$0/month" before merging the PR as confirmation that the human did not accidentally onboard a private repo.
+
+## Dependencies
+- Architecture#NN — ADR-0011 acceptance (packet 01). Soft dependency on D11 being binding rather than aspirational.
+
+## Downstream Unblocks
+- `06-kernel-sonarcloud-onboarding.md` — Kernel onboarding requires the org and the secret to exist before its `pr.yml` can call `job-sonarcloud.yml` successfully.
+- `07-web-rest-sonarcloud-onboarding.md` — same.
+- All Wave-3 deferred per-repo onboardings.
+
+This packet's portal work and the `02-actions-job-sonarcloud-workflow.md` workflow file together form the prerequisite pair: workflow file + org + secret. Per-repo onboardings need both.
+
+## Referenced ADR Decisions
+
+**ADR-0011 (Code Review and Merge Flow):**
+- **D11 (SonarCloud chosen):** Free for public HoneyDrunk repos. The Grid is public by default, and the public-repo tier includes PR decoration, branch analysis, and the full C# rule set at zero cost.
+- **D11 (Public-vs-private posture):** Public repos: SonarCloud enabled by default; quality gate is a required branch-protection check. Private repos: SonarCloud not enabled by default; opt-in per repo, recorded in a packet.
+- **D11 (Contract for the SonarCloud stage):** `SONAR_TOKEN` as an org secret scoped to `HoneyDrunkStudios`. The walkthrough operationalizes this exact secret-name and scoping decision.
+- **D11 Follow-up Work:** "SonarCloud organization setup — Portal walkthrough in `HoneyDrunk.Architecture/infrastructure/` per the 'prefer portal over CLI' convention." This packet is exactly that bullet.
+
+**ADR-0005 (Configuration and Secrets Strategy)** is the precedent for "secrets are provisioned via portal walkthroughs documented in `infrastructure/`." Same pattern applies here, even though the secret store is GitHub org-level rather than Azure Key Vault.
+
+## Referenced Invariants
+
+> **Invariant 8 (secrets):** Secret values never appear in logs, traces, exceptions, or telemetry. *(Generalized: secret values do not appear in this walkthrough either. The `SONAR_TOKEN` value is generated by the human in the SonarCloud UI and pasted into the GitHub UI; neither value is committed to the repo.)*
+
+> **Invariant 31:** Every PR traverses the tier-1 gate before merge. Build, unit tests, analyzers, vulnerability scan, and secret scan are required branch-protection checks on every .NET repo in the Grid, delivered via `pr-core.yml` in `HoneyDrunk.Actions`. *(The SonarCloud quality gate is tier 2; per-repo branch-protection wiring lives in the per-repo onboarding packets, not in this walkthrough.)*
+
+## Constraints
+- **Portal-only.** Do not author this as a CLI script. The "prefer portal over CLI" convention is explicit and applies here.
+- **No secret values committed.** No `SONAR_TOKEN` value, no organization key, no project key in the doc body.
+- **Public repos only.** Step 4's repo list and Step 6's secret access list both exclude private repos and Studios. Do not loosen to "All repositories" — that contradicts ADR-0011 D11 D11's private-repo posture.
+- **Walkthrough is exercised by the human at authoring time.** This is the existing convention (per the ADR-0015 Container Apps walkthrough packet, which provisioned real `dev` resources during authoring). Drift between what the doc says and what the SonarCloud UI shows is corrected inline before merge.
+- **No ADR IDs in narrative prose.** ADR-0011 is referenced only in the explicit "References" section, not in body narrative — per user convention.
+- **Calendar reminder for token rotation is a Human Prerequisite, not a workflow.** No `nightly-cred-rotation.yml` is added; rotation is human-driven for this token.
+
+## Labels
+`feature`, `tier-2`, `meta`, `docs`, `infrastructure`, `adr-0011`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Author a portal-first walkthrough at `infrastructure/sonarcloud-organization-setup.md` that the human follows once to create the SonarCloud organization, install the SonarCloud GitHub App on public repos only, and seed `SONAR_TOKEN` as a GitHub org secret with selected-repository scope. Index the new walkthrough in `infrastructure/README.md`. The human exercises the walkthrough during authoring.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Provide the one-time SonarCloud setup that all per-repo onboarding packets depend on.
+- Feature: ADR-0011 Code Review Pipeline rollout.
+- ADRs: ADR-0011 (D11 SonarCloud choice + Follow-up Work bullet), ADR-0005 (precedent for portal walkthroughs in `infrastructure/`).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- Architecture#NN — ADR-0011 acceptance (packet 01). Soft dependency.
+
+**Constraints:**
+- Portal walkthrough format only. No CLI script.
+- No secret values committed to the doc.
+- Public repos only on the GitHub App install list (Step 4) and the GitHub org-secret access list (Step 6). "Selected repositories" — never "All repositories."
+- Excluded from Step 4: HoneyDrunk.Studios (TypeScript; separate onboarding when needed) and any private repo.
+- Free tier; zero recurring cost on the public side. Display "$0/month" confirmation before merging.
+- Cross-link to existing walkthroughs for style and convention reference (`key-vault-creation.md`, `oidc-federated-credentials.md`, `app-configuration-provisioning.md`).
+- ADR IDs only appear in the explicit References section.
+- Walkthrough is exercised by the human at authoring time; drift is corrected inline.
+
+**Key Files:**
+- `infrastructure/sonarcloud-organization-setup.md` (new)
+- `infrastructure/README.md` (index update + References section)
+- Existing walkthroughs (`key-vault-creation.md`, `key-vault-rbac-assignments.md`, `oidc-federated-credentials.md`, `app-configuration-provisioning.md`, `log-analytics-workspace-and-alerts.md`) for style matching
+
+**Contracts:**
+- Org-secret name: `SONAR_TOKEN` — exact, all caps. This name is consumed by `job-sonarcloud.yml` (packet 02) and by every per-repo onboarding (packets 06, 07, future Wave 3). Renaming is a future-rename hazard.
+- Org name in SonarCloud: `honeydrunkstudios` (lowercase, no dot) — bound to the `HoneyDrunkStudios` GitHub org. Project keys (per-repo) follow SonarCloud's auto-import format `honeydrunkstudios_{repo-name}`; the per-repo onboarding packets confirm and reference these keys.

--- a/generated/issue-packets/active/adr-0011-code-review-pipeline/05a-actions-labels-as-code.md
+++ b/generated/issue-packets/active/adr-0011-code-review-pipeline/05a-actions-labels-as-code.md
@@ -1,0 +1,246 @@
+---
+name: CI Change
+type: ci-change
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["chore", "tier-1", "ci-cd", "ops", "adr-0011", "wave-1"]
+dependencies: ["Architecture#NN — ADR-0011 acceptance (packet 01)"]
+adrs: ["ADR-0011"]
+wave: 1
+initiative: adr-0011-code-review-pipeline
+node: honeydrunk-actions
+---
+
+# Feature: Labels-as-code source-of-truth + reusable seed-labels workflow
+
+## Summary
+Establish the labels-as-code mechanism: add a `labels.yml` source-of-truth in `HoneyDrunk.Actions/.github/config/` and a `seed-labels.yml` reusable workflow that applies the label set to whatever repo invokes it. Initial label set is the single `out-of-band` label that invariant 32 references.
+
+This packet ships only the config and workflow in `HoneyDrunk.Actions`. The cross-repo apply step (running the workflow against the eleven Grid repos) lives in the sibling packet **05b**, because a cross-repo apply requires either (a) a PAT scoped to the eleven repos plus a fan-out workflow, or (b) per-repo dispatcher commits — both of which are real cross-repo work that does not belong in this single-repo packet.
+
+## Target Repo
+`HoneyDrunk.Actions` (the workflow + config). The label is then applied to each Grid repo via the workflow's manual trigger from the consumer side. This packet is filed in `HoneyDrunk.Actions` because the label-as-code source-of-truth and the apply-mechanism live there per ADR-0012's "Actions as CI/CD control plane" stance.
+
+## Motivation
+Invariant 32 (now live after packet 01) says: *"Agent-authored PRs must link to their packet in the PR body. … Absent the link, the PR is treated as out-of-band, must carry the `out-of-band` label, and receives a degraded review."*
+
+For that label-bearing path to work, **the label must exist on every repo before any PR needs it**. Today the label exists on no repo. Manually creating it via the GitHub UI on every repo is the kind of drift the Grid is built to avoid: someone creates `out-of-band` on Vault but `out_of_band` on Auth, casing differs across repos, and the review agent's "missing label" finding starts firing for the wrong reason.
+
+ADR-0011's Follow-up Work bullet names this work explicitly: *"Add the `out-of-band` label to each Grid repo's label set — trivial, automatable via a repo-setup script."*
+
+This packet is the smallest viable label-as-code system: one YAML file lists the labels, one reusable workflow applies them, and the rollout to today's repos is a manual `workflow_dispatch` per repo (matching how the existing `repo-to-node.yml` config is consumed). It does not aim to be a complete repo-bootstrap framework — that would be its own ADR and out of scope for this initiative.
+
+## Proposed Implementation
+
+### A. Label source-of-truth
+
+Create `.github/config/labels.yml` in `HoneyDrunk.Actions`. Match the YAML pattern of the existing `.github/config/repo-to-node.yml` (simple top-level keys, alphabetical, comments where useful). Initial content:
+
+```yaml
+# Grid label set
+# Source-of-truth for labels applied to every active HoneyDrunk repo.
+# Apply via the seed-labels.yml reusable workflow.
+#
+# Conventions:
+#   - kebab-case names
+#   - Lowercase
+#   - Hex colors without leading '#'
+
+labels:
+  - name: out-of-band
+    color: ed7d31
+    description: >-
+      PR was not authored from a scope-agent packet; review agent runs without
+      packet-scope context (per ADR-0011 D9, invariant 32).
+```
+
+Start with just `out-of-band`. Future labels (e.g. `human-only`, `wave-1`, sector tags) can be added in follow-up packets without changing the schema. Do not bundle an aspirational mega-list of labels into this packet — the goal is the single label invariant 32 references.
+
+### B. Reusable workflow
+
+Create `.github/workflows/seed-labels.yml` in `HoneyDrunk.Actions`. Shape:
+
+```yaml
+# ==============================================================================
+# Seed Labels
+# ==============================================================================
+# Purpose:
+#   Reusable workflow that ensures every label declared in
+#   .github/config/labels.yml exists on the calling repo with the right color
+#   and description. Idempotent — safe to re-run.
+#
+# Triggers:
+#   workflow_call (from a consuming repo's seed-labels.yml dispatcher)
+#   workflow_dispatch (in HoneyDrunk.Actions itself, for testing)
+# ==============================================================================
+
+name: Seed Labels
+
+on:
+  workflow_call:
+    inputs:
+      labels-source-ref:
+        description: 'Git ref of HoneyDrunk.Actions to read labels.yml from'
+        required: false
+        type: string
+        default: 'main'
+    secrets:
+      github-token:
+        description: 'Token with issues:write on the target repo'
+        required: true
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout HoneyDrunk.Actions (for labels.yml)
+        uses: actions/checkout@v4
+        with:
+          repository: HoneyDrunkStudios/HoneyDrunk.Actions
+          ref: ${{ inputs.labels-source-ref || 'main' }}
+          path: actions-repo
+
+      - name: Apply labels
+        env:
+          GH_TOKEN: ${{ secrets.github-token || github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Parse labels.yml using yq (preinstalled on ubuntu-latest)
+          LABELS_FILE=actions-repo/.github/config/labels.yml
+          COUNT=$(yq '.labels | length' "$LABELS_FILE")
+          echo "Applying $COUNT label(s) from $LABELS_FILE"
+
+          for i in $(seq 0 $((COUNT - 1))); do
+            NAME=$(yq ".labels[$i].name" "$LABELS_FILE")
+            COLOR=$(yq ".labels[$i].color" "$LABELS_FILE")
+            DESCRIPTION=$(yq ".labels[$i].description" "$LABELS_FILE")
+
+            # Idempotent create-or-update via gh
+            if gh label list --json name --jq '.[].name' | grep -qx "$NAME"; then
+              echo "Updating existing label: $NAME"
+              gh label edit "$NAME" --color "$COLOR" --description "$DESCRIPTION"
+            else
+              echo "Creating label: $NAME"
+              gh label create "$NAME" --color "$COLOR" --description "$DESCRIPTION"
+            fi
+          done
+```
+
+Notes:
+- `yq` is preinstalled on `ubuntu-latest` GitHub runners; no extra setup required.
+- `gh label list/create/edit` is the documented gh CLI for label management.
+- The workflow is idempotent — running it twice produces the same end state.
+- Permissions are minimal: `issues: write` is sufficient for label CRUD.
+
+### C. Index the labels file
+
+Add a one-line entry to `HoneyDrunk.Actions/README.md` (or to a `.github/config/README.md` if one exists) listing `labels.yml` under "Configuration files" alongside the existing `repo-to-node.yml`.
+
+## Affected Files
+
+In HoneyDrunk.Actions (this packet's PR — single repo):
+- `.github/config/labels.yml` (new)
+- `.github/workflows/seed-labels.yml` (new)
+- `README.md` (root): one-line addition under "Configuration files" / equivalent
+- `CHANGELOG.md` (root): append entry to the in-progress version
+
+No cross-repo work in this packet. Cross-repo apply lives in packet 05b.
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits are in `HoneyDrunk.Actions` (the CI toolkit). Routing rule "workflow, CI, GitHub Actions, pipeline, PR check, release → HoneyDrunk.Actions" applies.
+- [x] No cross-repo work in this packet. Cross-repo apply is packet 05b's scope.
+- [x] No invariant violation. The `out-of-band` label is the surface invariant 32 references.
+- [x] No secrets read or written.
+
+## Acceptance Criteria
+- [ ] `.github/config/labels.yml` exists in `HoneyDrunk.Actions` with at least the `out-of-band` label (kebab-case name, lowercase, hex color `ed7d31` without `#`, descriptive text)
+- [ ] `.github/workflows/seed-labels.yml` exists in `HoneyDrunk.Actions` and is idempotent (running twice leaves state unchanged)
+- [ ] The workflow uses `yq` (preinstalled) to parse `labels.yml` and `gh label` CRUD to apply
+- [ ] Permissions block declares only `issues: write` (no broader permissions)
+- [ ] Workflow is reusable via `workflow_call` and also invokable directly via `workflow_dispatch` in `HoneyDrunk.Actions`
+- [ ] `README.md` (root): a one-line addition references `labels.yml` as a configuration source-of-truth alongside `repo-to-node.yml`
+- [ ] Repo-level `CHANGELOG.md`: new in-progress entry (or appended to whichever entry packet 02 / 03 already opened on the same wave) describing the new config and workflow
+- [ ] No per-package `CHANGELOG.md` updates (no package changes)
+- [ ] No additional labels beyond `out-of-band` are seeded in this packet (one-label-at-a-time is intentional; future labels are future packets)
+- [ ] `actionlint` is clean on the new workflow
+- [ ] Self-test: triggering `seed-labels.yml` via `workflow_dispatch` in `HoneyDrunk.Actions` itself successfully applies the `out-of-band` label to that repo. This single-repo smoke test validates the workflow without depending on the cross-repo apply (packet 05b) being filed yet.
+
+## Human Prerequisites
+
+- [ ] After this packet's PR merges, manually trigger `seed-labels.yml` once via `workflow_dispatch` in the HoneyDrunk.Actions repo's Actions UI. This is the smoke test — it confirms the workflow runs end-to-end and applies `out-of-band` to HoneyDrunk.Actions itself before packet 05b fans the workflow out to the other ten repos.
+
+Cross-repo apply across the eleven repos is **not** in this packet — see packet 05b.
+
+## Dependencies
+- Architecture#NN — ADR-0011 acceptance (packet 01). Soft dependency on invariant 32 being live.
+
+## Downstream Unblocks
+- **Packet 05b** (cross-repo apply across the eleven Grid repos) is hard-blocked on this packet because it dispatches the workflow this packet ships.
+- The review agent's out-of-band detection (per ADR-0011 D9) can report a finding once 05b lands and the label exists on every repo.
+- Future label-as-code additions (e.g. `human-only` standardization, sector tags) become trivial extensions to `labels.yml`.
+
+## Referenced ADR Decisions
+
+**ADR-0011 (Code Review and Merge Flow):**
+- **D9 (out-of-band PRs):** A PR that does not link to a packet is out-of-band. Out-of-band PRs still traverse the full pipeline; the review agent's packet-loading step is skipped. They must carry the `out-of-band` label.
+- **Follow-up Work bullet:** "Add the `out-of-band` label to each Grid repo's label set — trivial, automatable via a repo-setup script." This packet is exactly that bullet.
+
+**ADR-0012 (HoneyDrunk.Actions as Grid CI/CD Control Plane):** Names `HoneyDrunk.Actions/.github/config/` as the right home for shared tool config. `labels.yml` follows this pattern.
+
+## Referenced Invariants
+
+> **Invariant 32:** Agent-authored PRs must link to their packet in the PR body. The review agent resolves the packet via this link and uses it as the primary scope anchor. Absent the link, the PR is treated as out-of-band, must carry the `out-of-band` label, and receives a degraded review in which the agent runs against the Grid context only (invariants, boundaries, relationships, diff) without a packet-scope check.
+
+## Constraints
+- **One label this packet, more later.** Do not pad `labels.yml` with aspirational labels. Future labels are future packets.
+- **Idempotent apply.** The workflow must produce the same end state when run twice. Run-once side effects (e.g. opening an issue when a label is created) are out of scope.
+- **Minimal permissions.** Only `issues: write`. No `contents: write`, no `pull-requests: write` here.
+- **Single-repo scope.** This packet does not reach into other repos. Cross-repo apply is packet 05b.
+- **No secrets in the workflow.** `secrets.github-token` is the only secret consumed, and it is the standard `GITHUB_TOKEN` already available in every consumer.
+- **`actionlint` clean.** Match the discipline of the other workflows in `.github/workflows/`.
+
+## Labels
+`chore`, `tier-1`, `ci-cd`, `ops`, `adr-0011`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Ship `.github/config/labels.yml` (single label `out-of-band` for now) and a reusable `.github/workflows/seed-labels.yml` workflow in `HoneyDrunk.Actions`. Single-repo packet — cross-repo apply across the eleven Grid repos lives in sibling packet 05b. The smoke test is triggering `seed-labels.yml` via `workflow_dispatch` in HoneyDrunk.Actions itself (Human Prerequisite, post-merge).
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Make invariant 32's `out-of-band` label exist consistently across the Grid.
+- Feature: ADR-0011 Code Review Pipeline rollout.
+- ADRs: ADR-0011 (D9, Follow-up Work bullet), ADR-0012 (Actions config home).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- Architecture#NN — ADR-0011 acceptance (packet 01). Soft dependency.
+
+**Constraints:**
+- Single label this packet (`out-of-band`); no aspirational fan-out into a label catalogue.
+- Idempotent workflow.
+- Permissions: `issues: write` only.
+- Single-repo scope — cross-repo apply is packet 05b.
+- The label color is `ed7d31` (orange/amber — distinct from sector colors and from `human-only` if it is later added).
+- `actionlint` clean.
+
+**Key Files:**
+- `.github/config/labels.yml` (new)
+- `.github/workflows/seed-labels.yml` (new)
+- `.github/config/repo-to-node.yml` (existing — style reference)
+- `README.md` (root)
+- `CHANGELOG.md` (root)
+
+**Contracts:**
+- `out-of-band` label name (kebab-case, lowercase). Renaming would break the review agent's expectations.

--- a/generated/issue-packets/active/adr-0011-code-review-pipeline/05b-actions-out-of-band-label-fanout.md
+++ b/generated/issue-packets/active/adr-0011-code-review-pipeline/05b-actions-out-of-band-label-fanout.md
@@ -1,0 +1,247 @@
+---
+name: CI Change
+type: ci-change
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["chore", "tier-1", "ci-cd", "ops", "adr-0011", "wave-1"]
+dependencies: ["Actions#NN — labels-as-code config + seed-labels.yml (packet 05a)", "Architecture#NN — ADR-0011 acceptance (packet 01)"]
+adrs: ["ADR-0011"]
+wave: 1
+initiative: adr-0011-code-review-pipeline
+node: honeydrunk-actions
+---
+
+# Feature: Fan out the `out-of-band` label across the eleven Grid repos
+
+## Summary
+Apply the `out-of-band` label (defined in packet 05a's `.github/config/labels.yml`) to every active Grid repo so that PRs lacking a packet link (per invariant 32) can be tagged consistently. Implementation: add a `seed-labels-fanout.yml` workflow in `HoneyDrunk.Actions` that takes a list of target repos and applies the labels-as-code config to each, using a PAT (provisioned by the human as a Human Prerequisite) authorised to write labels on the eleven repos. Trigger it once via `workflow_dispatch` to seed the initial label.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Actions` (the fan-out workflow lives where labels-as-code lives, per ADR-0012's "Actions as CI/CD control plane" stance).
+
+## Motivation
+Packet 05a ships labels-as-code (`.github/config/labels.yml`) and the per-repo `seed-labels.yml` reusable workflow. But the reusable workflow only applies labels to the **calling** repo — it cannot reach across repo boundaries on its own. To make `out-of-band` exist on every Grid repo today, something has to dispatch the workflow (or call `gh label` directly) against each of the eleven repos.
+
+Three options were considered:
+1. **Per-repo dispatcher commits.** Commit a thin `seed-labels.yml` dispatcher into each of the eleven repos. Each dispatcher is two lines and uses each repo's own `GITHUB_TOKEN`. Eleven separate one-line PRs is a lot of orchestration cost for a one-time seeding.
+2. **One-shot bash script run by the human.** The human runs `gh label create out-of-band --color ed7d31 --description "…" --repo HoneyDrunkStudios/<repo>` against each repo from their local shell. Fast for the first label but throws away the labels-as-code mechanism — every future label rerun is a new bash script, not a workflow.
+3. **A fan-out workflow in HoneyDrunk.Actions** that uses a PAT scoped to the eleven repos to call `gh label create/edit` against each. Reuses labels-as-code, agent-authorable end-to-end, future labels reuse the same workflow.
+
+This packet ships option 3. The PAT setup is the only Human Prerequisite; the workflow itself is agent work.
+
+## Proposed Implementation
+
+### A. Provision the cross-repo PAT (Human Prerequisite)
+
+The fan-out workflow needs a token that can `gh label create/edit` against the eleven Grid repos. The default `GITHUB_TOKEN` in HoneyDrunk.Actions is scoped to HoneyDrunk.Actions only. Options for the cross-repo token:
+
+- **Fine-grained PAT** (preferred) — owned by the user, scoped to the eleven repos under `HoneyDrunkStudios`, with `Contents: Read` and `Issues: Write`. One-year expiry; rotation is a future concern (ADR-0009 rotation territory).
+- **GitHub App installed on the eleven repos with `issues:write`** — more durable but heavier setup. Skip for v1; the fine-grained PAT is fine for a one-shot fan-out plus occasional reruns.
+
+Stored as a HoneyDrunk.Actions repo secret named `LABELS_FANOUT_PAT`. The Human Prerequisite section captures the click-through; this is the single portal step.
+
+### B. Fan-out workflow
+
+Create `.github/workflows/seed-labels-fanout.yml` in `HoneyDrunk.Actions`:
+
+```yaml
+# ==============================================================================
+# Seed Labels — Fan-out across the Grid
+# ==============================================================================
+# Purpose:
+#   Applies the labels declared in .github/config/labels.yml to every Grid
+#   repo enumerated below. Triggered manually via workflow_dispatch.
+#   Idempotent — re-runs are safe.
+#
+#   Cross-repo writes use the LABELS_FANOUT_PAT secret (a fine-grained PAT
+#   scoped to the eleven repos with Issues:Write). The default GITHUB_TOKEN
+#   only has access to HoneyDrunk.Actions itself and cannot reach the others.
+#
+# Triggers:
+#   workflow_dispatch only — a one-shot seeding tool, not a CI gate.
+# ==============================================================================
+
+name: Seed Labels — Fan-out
+
+on:
+  workflow_dispatch:
+    inputs:
+      target-repos:
+        description: >-
+          Comma-separated list of repo names (without owner prefix) to apply
+          labels to. Default is the eleven active Grid repos. Override to seed
+          a single repo for testing.
+        required: false
+        type: string
+        default: 'HoneyDrunk.Kernel,HoneyDrunk.Transport,HoneyDrunk.Vault,HoneyDrunk.Vault.Rotation,HoneyDrunk.Auth,HoneyDrunk.Web.Rest,HoneyDrunk.Data,HoneyDrunk.Pulse,HoneyDrunk.Notify,HoneyDrunk.Actions,HoneyDrunk.Architecture'
+
+permissions:
+  contents: read
+
+jobs:
+  fanout:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout HoneyDrunk.Actions (for labels.yml)
+        uses: actions/checkout@v4
+
+      - name: Apply labels to each target repo
+        env:
+          GH_TOKEN: ${{ secrets.LABELS_FANOUT_PAT }}
+          TARGETS: ${{ inputs.target-repos }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          LABELS_FILE=.github/config/labels.yml
+          COUNT=$(yq '.labels | length' "$LABELS_FILE")
+          echo "Applying $COUNT label(s) to repos: $TARGETS"
+
+          IFS=',' read -ra REPOS <<< "$TARGETS"
+          for REPO in "${REPOS[@]}"; do
+            REPO_TRIMMED=$(echo "$REPO" | tr -d '[:space:]')
+            FULL_REPO="HoneyDrunkStudios/${REPO_TRIMMED}"
+            echo "--- ${FULL_REPO} ---"
+
+            for i in $(seq 0 $((COUNT - 1))); do
+              NAME=$(yq ".labels[$i].name" "$LABELS_FILE")
+              COLOR=$(yq ".labels[$i].color" "$LABELS_FILE")
+              DESCRIPTION=$(yq ".labels[$i].description" "$LABELS_FILE")
+
+              if gh label list --repo "$FULL_REPO" --json name --jq '.[].name' | grep -qx "$NAME"; then
+                echo "  [update] $NAME on $FULL_REPO"
+                gh label edit "$NAME" --color "$COLOR" --description "$DESCRIPTION" --repo "$FULL_REPO"
+              else
+                echo "  [create] $NAME on $FULL_REPO"
+                gh label create "$NAME" --color "$COLOR" --description "$DESCRIPTION" --repo "$FULL_REPO"
+              fi
+            done
+          done
+
+          echo "Fan-out complete."
+```
+
+Notes:
+- The default `target-repos` value enumerates the eleven repos. The user can override it via `workflow_dispatch` to test against a single repo first.
+- The workflow uses `LABELS_FANOUT_PAT`, not `GITHUB_TOKEN`. The token has `Issues: Write` on each of the eleven repos.
+- Idempotent — running twice produces the same end state.
+- HoneyDrunk.Studios is **excluded** from the default list (it is not a .NET repo and ADR-0011 D11 / invariant 32 are scoped to the .NET PR pipeline today).
+
+### C. Document the fan-out workflow
+
+Add a one-line entry to `HoneyDrunk.Actions/README.md` under the "Workflows" or equivalent section, briefly describing `seed-labels-fanout.yml` as the cross-repo apply mechanism for `labels.yml`.
+
+## Affected Files
+- `.github/workflows/seed-labels-fanout.yml` (new)
+- `README.md` (root): one-line addition under the workflows / configuration section
+- `CHANGELOG.md` (root): append entry to the in-progress version describing the fan-out workflow
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] Workflow file lives in `HoneyDrunk.Actions`. Routing rule "workflow, CI, GitHub Actions, pipeline, PR check, release → HoneyDrunk.Actions" applies.
+- [x] The cross-repo writes go through a token (the PAT) — they do not commit code into the eleven target repos. Labels are repo-metadata, not code; this respects the per-repo code-ownership boundary.
+- [x] No invariant violation. The label is the surface invariant 32 references.
+- [x] PAT is a Human Prerequisite, scoped narrowly to `Issues: Write` on the eleven specific repos.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/seed-labels-fanout.yml` exists in `HoneyDrunk.Actions` with the shape specified above
+- [ ] Workflow is `workflow_dispatch`-only (no `pull_request` or `push` triggers — it is a one-shot seeding tool, not a CI gate)
+- [ ] Default `target-repos` input lists the eleven active Grid repos: HoneyDrunk.Kernel, HoneyDrunk.Transport, HoneyDrunk.Vault, HoneyDrunk.Vault.Rotation, HoneyDrunk.Auth, HoneyDrunk.Web.Rest, HoneyDrunk.Data, HoneyDrunk.Pulse, HoneyDrunk.Notify, HoneyDrunk.Actions, HoneyDrunk.Architecture
+- [ ] HoneyDrunk.Studios is **not** in the default list
+- [ ] Workflow uses `LABELS_FANOUT_PAT` (not `GITHUB_TOKEN`) for cross-repo writes
+- [ ] Permissions block declares only `contents: read` (the cross-repo writes happen via the PAT in env, not via the workflow's permissions)
+- [ ] Workflow is idempotent (running twice leaves state unchanged)
+- [ ] After the human triggers the workflow once, the `out-of-band` label exists with color `ed7d31` and the configured description on every one of the eleven repos in the default list
+- [ ] HoneyDrunk.Studios does NOT have the label (verify by browsing `https://github.com/HoneyDrunkStudios/HoneyDrunk.Studios/labels`)
+- [ ] Repo-level `CHANGELOG.md`: append entry to the in-progress version describing the fan-out workflow (or to whatever entry packet 02 / 03 / 05a opened on the same wave — invariants 12 and 27)
+- [ ] No per-package `CHANGELOG.md` updates (no package changes)
+- [ ] `actionlint` clean
+
+## Human Prerequisites
+
+- [ ] **Provision the `LABELS_FANOUT_PAT` PAT.** Click-through:
+  1. Go to `https://github.com/settings/personal-access-tokens/new` (fine-grained PAT settings).
+  2. Token name: `HoneyDrunk Labels Fan-out`. Expiration: 1 year.
+  3. Resource owner: `HoneyDrunkStudios`.
+  4. Repository access: "Only select repositories" → choose the eleven: HoneyDrunk.Kernel, HoneyDrunk.Transport, HoneyDrunk.Vault, HoneyDrunk.Vault.Rotation, HoneyDrunk.Auth, HoneyDrunk.Web.Rest, HoneyDrunk.Data, HoneyDrunk.Pulse, HoneyDrunk.Notify, HoneyDrunk.Actions, HoneyDrunk.Architecture. **Do not include HoneyDrunk.Studios.**
+  5. Permissions: Repository permissions → `Issues: Read and write`. Everything else default (Read-only or No access).
+  6. Generate the token. Copy the value (it is shown once).
+  7. In `HoneyDrunk.Actions`'s repo settings → Secrets and variables → Actions → New repository secret. Name: `LABELS_FANOUT_PAT`. Value: the token. Save.
+- [ ] **Trigger the fan-out workflow once.** After this packet's PR merges and the PAT secret exists:
+  1. Go to `https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/actions/workflows/seed-labels-fanout.yml`.
+  2. Click "Run workflow" → leave default `target-repos` → "Run workflow."
+  3. Wait for completion. Inspect logs for any `[create]` or `[update]` lines.
+- [ ] **Verify the eleven repos** at `https://github.com/HoneyDrunkStudios/<repo>/labels` show `out-of-band` with color `ed7d31` and the configured description.
+- [ ] **Confirm Studios excluded** at `https://github.com/HoneyDrunkStudios/HoneyDrunk.Studios/labels` does NOT show `out-of-band`.
+
+## Dependencies
+- **Actions#NN** — Packet 05a (labels-as-code config + reusable seed-labels.yml). Hard dependency: this packet's fan-out workflow reads `.github/config/labels.yml` shipped by 05a.
+- **Architecture#NN** — Packet 01 (ADR-0011 acceptance). Soft dependency: invariant 32 ("must carry the `out-of-band` label") is the rationale for fanning out the label.
+
+## Downstream Unblocks
+- The review agent's out-of-band detection (per ADR-0011 D9) can now report a finding when an out-of-band PR lacks the label, instead of having to suggest "create this label first."
+- Wave-2 onboarding packets (06, 07) can rely on the label existing on Kernel and Web.Rest from day one.
+- Future label additions in `labels.yml` re-trigger the same fan-out workflow with one click — no per-label engineering work.
+
+## Referenced ADR Decisions
+
+**ADR-0011 (Code Review and Merge Flow):**
+- **D9 (out-of-band PRs):** A PR that does not link to a packet is out-of-band. They must carry the `out-of-band` label.
+- **Follow-up Work bullet:** "Add the `out-of-band` label to each Grid repo's label set — trivial, automatable via a repo-setup script." This packet (with 05a) is exactly that bullet.
+
+**ADR-0012 (HoneyDrunk.Actions as Grid CI/CD Control Plane):** Names `HoneyDrunk.Actions/.github/config/` as the home for shared tool config and `.github/workflows/` as the home for cross-repo CI orchestration. The fan-out workflow lives where the config lives.
+
+## Referenced Invariants
+
+> **Invariant 32:** Agent-authored PRs must link to their packet in the PR body. The review agent resolves the packet via this link and uses it as the primary scope anchor. Absent the link, the PR is treated as out-of-band, must carry the `out-of-band` label, and receives a degraded review in which the agent runs against the Grid context only (invariants, boundaries, relationships, diff) without a packet-scope check.
+
+> **Invariant 9 (secrets):** Vault is the only source of secrets. *(Reframed for CI: `LABELS_FANOUT_PAT` is a CI-runtime PAT stored as a GitHub repo secret. It is not application-runtime data; the invariant applies to application code reading secrets at runtime, not to CI workflows reading repo-level secrets via the `secrets.` context.)*
+
+## Constraints
+- **`workflow_dispatch` only.** Do not add `pull_request` or `push` triggers — this is a one-shot seeding tool, not a CI gate that should run on every PR.
+- **PAT, not `GITHUB_TOKEN`.** Default `GITHUB_TOKEN` is scoped to HoneyDrunk.Actions only and cannot write labels on other repos. Do not try to use `secrets.GITHUB_TOKEN` here — it will silently fail with permission errors against other repos.
+- **PAT scope is narrow.** `Issues: Write` only, on the eleven specific repos. No org-admin scope, no `Contents: Write`, no `Pull requests: Write`. Anything broader is a security regression.
+- **Studios excluded from defaults.** Even if a future change broadens the default list, do not add Studios without a separate explicit decision.
+- **Idempotent.** The workflow must produce the same end state when run twice.
+- **`actionlint` clean.**
+
+## Labels
+`chore`, `tier-1`, `ci-cd`, `ops`, `adr-0011`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Ship `.github/workflows/seed-labels-fanout.yml` in `HoneyDrunk.Actions` — a `workflow_dispatch`-triggered cross-repo apply that uses the `LABELS_FANOUT_PAT` secret to call `gh label create/edit` against each of the eleven enumerated Grid repos, applying the labels-as-code config from packet 05a's `labels.yml`. Single PR in HoneyDrunk.Actions; the human provisions the PAT (Human Prerequisite) and triggers the workflow once after merge.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Make `out-of-band` exist on every Grid repo so invariant 32 enforcement is mechanical.
+- Feature: ADR-0011 Code Review Pipeline rollout.
+- ADRs: ADR-0011 (D9, Follow-up Work bullet), ADR-0012 (Actions config home).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- Actions#NN — Packet 05a (labels-as-code config + reusable seed-labels.yml). Hard.
+- Architecture#NN — Packet 01 (ADR-0011 acceptance). Soft.
+
+**Constraints:**
+- `workflow_dispatch` only — no `pull_request` or `push` triggers.
+- Use `LABELS_FANOUT_PAT` for cross-repo writes; the default `GITHUB_TOKEN` cannot reach other repos.
+- Default target-repos list excludes HoneyDrunk.Studios.
+- Idempotent.
+- Permissions block: `contents: read` only.
+- `actionlint` clean.
+
+**Key Files:**
+- `.github/workflows/seed-labels-fanout.yml` (new)
+- `.github/config/labels.yml` (existing — shipped by packet 05a)
+- `.github/workflows/seed-labels.yml` (existing — shipped by packet 05a; not called from the fan-out, but documented as the related sibling)
+- `README.md` (root)
+- `CHANGELOG.md` (root)
+
+**Contracts:**
+- Secret name: `LABELS_FANOUT_PAT`. Renaming would invalidate the human's PAT setup.
+- Default target-repos list: the eleven Grid repos minus Studios. Any addition or removal is a deliberate scope change that warrants a follow-up packet.

--- a/generated/issue-packets/active/adr-0011-code-review-pipeline/06-kernel-sonarcloud-onboarding.md
+++ b/generated/issue-packets/active/adr-0011-code-review-pipeline/06-kernel-sonarcloud-onboarding.md
@@ -1,0 +1,287 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Kernel
+labels: ["feature", "tier-2", "ci-cd", "core", "adr-0011", "wave-2"]
+dependencies: ["Actions#NN — job-sonarcloud.yml (packet 02)", "Architecture#NN — SonarCloud organization setup (packet 04)"]
+adrs: ["ADR-0011"]
+wave: 2
+initiative: adr-0011-code-review-pipeline
+node: honeydrunk-kernel
+---
+
+# Feature: Onboard HoneyDrunk.Kernel to SonarCloud (first canonical .NET template)
+
+## Summary
+Onboard `HoneyDrunk.Kernel` as the first repo on the Grid's SonarCloud rollout. Add `sonar-project.properties` at the repo root, wire `pr.yml` to invoke the new `job-sonarcloud.yml` reusable workflow from `HoneyDrunk.Actions` after the existing `job-build-and-test.yml` job (so coverage flows through), import the project into SonarCloud via the GitHub App, and add the SonarCloud quality gate as a required branch-protection check on `main`. This packet is the **canonical template** for downstream per-repo onboardings (Web.Rest in packet 07, Wave-3 fan-out for the remaining 8 .NET repos).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Kernel`
+
+## Motivation
+ADR-0011 D11 named SonarCloud as the third-party static analysis tool for tier 2 of the PR pipeline, and ADR-0011's Follow-up Work explicitly says "Per-repo SonarCloud onboarding — each public repo adds a `sonar-project.properties` file, imports the project into SonarCloud, and enables the SonarCloud check in branch protection. One packet per active repo."
+
+Kernel is chosen as the first onboarding for three reasons:
+1. **Foundation Node.** Kernel is at the root of the dependency graph (`relationships.json` shows zero `consumes`). Making Kernel SonarCloud-clean first means downstream Nodes inherit a clean upstream — quality gate findings on Kernel are contained to Kernel rather than propagating.
+2. **Library shape.** Kernel ships the canonical "library + Abstractions + tests" shape that most other Grid repos share. The configuration here becomes the template; Web.Rest (packet 07) covers the ASP.NET Core variant.
+3. **Stable.** Kernel is at v0.4.0 stable per `nodes.json`, with canary tests passing. Onboarding to a new tool is most informative when the codebase is not in flux.
+
+## Proposed Implementation
+
+### A. Add `sonar-project.properties`
+
+**File location is critical.** Create `sonar-project.properties` **inside the inner project subdir** at `HoneyDrunk.Kernel/sonar-project.properties` (relative to the git root). This is the same directory that contains `HoneyDrunk.Kernel.slnx`, `HoneyDrunk.Kernel/`, `HoneyDrunk.Kernel.Abstractions/`, and `HoneyDrunk.Kernel.Tests/`. It is **not** at the git repo root next to `LICENSE` and `README.md`.
+
+Why: Kernel's `pr.yml` runs the reusable workflow with `working-directory: 'HoneyDrunk.Kernel'` (verified in `.github/workflows/pr.yml`). The `dotnet-sonarscanner` discovers `sonar-project.properties` from the working directory it begins from, not from the git repo root. If the file is placed at the git root, the scanner will not find it and analysis will run with no project configuration. From inside the working-directory the scanner uses, the file path is `./sonar-project.properties`.
+
+Paths inside `sonar-project.properties` are relative to **that same working directory** (`HoneyDrunk.Kernel/` from git root). So `sonar.sources=HoneyDrunk.Kernel` resolves to the inner runtime project at `HoneyDrunk.Kernel/HoneyDrunk.Kernel/`.
+
+Content:
+
+```properties
+# SonarCloud project configuration for HoneyDrunk.Kernel.
+# Project imported via the SonarCloud GitHub App; quality gate runs in
+# job-sonarcloud.yml (HoneyDrunk.Actions) on every PR and push to main.
+#
+# This file lives at HoneyDrunk.Kernel/sonar-project.properties (inside the
+# inner project subdir, next to HoneyDrunk.Kernel.slnx). All sonar.sources /
+# sonar.tests paths are relative to that subdir, which matches the
+# working-directory the reusable job-sonarcloud.yml runs from.
+
+sonar.organization=honeydrunkstudios
+sonar.projectKey=honeydrunkstudios_HoneyDrunk.Kernel
+sonar.projectName=HoneyDrunk.Kernel
+
+# Sources — relative to the working directory (HoneyDrunk.Kernel/)
+sonar.sources=HoneyDrunk.Kernel
+# Tests — Kernel currently has only HoneyDrunk.Kernel.Tests; no .Canary project
+# exists on disk (verified). If a canary project is added later, append it here.
+sonar.tests=HoneyDrunk.Kernel.Tests
+
+# Coverage (consumed by job-sonarcloud.yml after job-build-and-test.yml uploads
+# the coverlet OpenCover report)
+sonar.cs.opencover.reportsPaths=**/coverage.opencover.xml
+
+# Exclusions — generated code and build outputs
+sonar.exclusions=**/obj/**,**/bin/**,**/*.Designer.cs
+
+# Coverage exclusions — Abstractions packages contain interfaces only
+sonar.coverage.exclusions=**/HoneyDrunk.Kernel.Abstractions/**
+
+# New Code definition — inherits from organization default (30 days)
+# Override here only if the Node has a different release cadence than default.
+```
+
+The exact source directory paths (`sonar.sources`, `sonar.tests`) must match the actual project layout. The values above were verified against the repo on `2026-04-26` — Kernel has exactly three projects (`HoneyDrunk.Kernel`, `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.Kernel.Tests`) under `HoneyDrunk.Kernel/`. If the layout has changed by execution time (e.g. a `Canary` project is added, or `src/HoneyDrunk.Kernel` reorg lands), correct the values to match the current `.slnx` and directory tree before committing.
+
+**Footnote on canary asymmetry:** Web.Rest has both a `.Tests` and `.Canary` project (packet 07 reflects this). Kernel does not have a canary project today. The two packets diverge on `sonar.tests` accordingly — this is intentional and correct. Do not add `HoneyDrunk.Kernel.Canary` to Kernel's `sonar.tests`; the path does not resolve to a project.
+
+### B. Wire `pr.yml`
+
+Kernel's existing `pr.yml` calls `pr-core.yml@main`. Add a second job that invokes `job-sonarcloud.yml` after `pr-core.yml` succeeds, so SonarCloud only runs when tier 1 has passed (per ADR-0011 D2 fail-fast cheap-first):
+
+```yaml
+name: PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-core:
+    name: PR Core
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    with:
+      dotnet-version: '10.0.x'
+      configuration: 'Release'
+      runs-on: 'ubuntu-latest'
+      working-directory: 'HoneyDrunk.Kernel'
+      project-path: 'HoneyDrunk.Kernel.slnx'
+      enable-secret-scan: true
+      enable-accessibility-check: false
+      post-pr-summary: true
+      actions-ref: 'main'
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  sonarcloud:
+    name: SonarCloud
+    needs: pr-core
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-sonarcloud.yml@main
+    with:
+      dotnet-version: '10.0.x'
+      runs-on: 'ubuntu-latest'
+      working-directory: 'HoneyDrunk.Kernel'
+      project-path: 'HoneyDrunk.Kernel.slnx'
+      sonar-organization: 'honeydrunkstudios'
+      sonar-project-key: 'honeydrunkstudios_HoneyDrunk.Kernel'
+      coverage-artifact-name: 'coverage-reports-ubuntu-latest'
+    secrets:
+      sonar-token: ${{ secrets.SONAR_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Critical wiring details:
+- `needs: pr-core` enforces tier-1-before-tier-2 fail-fast (per ADR-0011 D2). SonarCloud is skipped if `pr-core.yml` fails.
+- `coverage-artifact-name: 'coverage-reports-ubuntu-latest'` matches the artifact name `pr-core.yml` already publishes.
+- `SONAR_TOKEN` flows in from the org-level secret seeded by packet 04.
+- `actions-ref: 'main'` follows the existing convention in Kernel's `pr.yml`.
+
+### C. Import the project into SonarCloud
+
+Once the SonarCloud GitHub App is installed on `HoneyDrunkStudios/HoneyDrunk.Kernel` (per packet 04, step 4), the project should auto-appear in the SonarCloud org dashboard at `https://sonarcloud.io/organizations/honeydrunkstudios/projects`. The first-time setup steps (Human Prerequisites below):
+
+1. In SonarCloud, click "Analyze new project" → choose "GitHub" → select `HoneyDrunkStudios/HoneyDrunk.Kernel`.
+2. SonarCloud auto-detects the project and creates `honeydrunkstudios_HoneyDrunk.Kernel` as the project key.
+3. Choose "With GitHub Actions" as the analysis method (we are not using SonarCloud's own automatic analysis since `job-sonarcloud.yml` runs the scanner).
+4. Configure "New Code" definition for the project: leave at organization default (30 days).
+5. The first PR run after merging this packet's PR will populate analysis results. Initial findings against the existing v0.4.0 codebase are expected — they are not blockers for this onboarding (ADR-0011 D11 specifies the quality gate becomes enforcing on **new** code, not historical code).
+
+### D. Branch protection — add SonarCloud check (after first run, not before)
+
+This step requires GitHub repo admin and is a Human Prerequisite with **strict ordering**: branch protection can only reference a check that has run at least once. If the rule is added before SonarCloud has published its first check, GitHub rejects the rule with "this check has never run on this branch." So the sequence is:
+
+1. **Merge this packet's PR.** The `sonarcloud` job is now wired into `pr.yml`.
+2. **Wait for the first SonarCloud-enabled PR to run** (this can be a follow-up PR or any new PR after the merge). On the first run, the SonarCloud GitHub App publishes a check.
+3. **Open the PR's "Checks" tab** and read the **exact check name** the SonarCloud App is publishing. Historically this has been "SonarCloud Code Analysis" but **do not paste this string blindly** — the App's wording can drift across SonarCloud versions or organization config. Copy the literal string from the live Checks UI.
+4. Go to `https://github.com/HoneyDrunkStudios/HoneyDrunk.Kernel/settings/branches`.
+5. Edit the `main` branch protection rule (or create one if missing).
+6. Under "Require status checks to pass before merging," paste the exact check name observed in step 3.
+7. Save.
+
+The check is now required. Per ADR-0011 D11, this is the binding part of the SonarCloud onboarding for public repos.
+
+## Affected Files
+- `HoneyDrunk.Kernel/sonar-project.properties` (new — inner project subdir, next to `HoneyDrunk.Kernel.slnx`; **not** the git repo root)
+- `.github/workflows/pr.yml` (edit — add `sonarcloud` job)
+- `CHANGELOG.md` (root): docs entry under in-progress version
+- `README.md` (root): no change expected; this is CI wiring, not public API surface
+
+## NuGet Dependencies
+None. The Sonar scanner is installed as a tool by the reusable workflow at run time; no project-level `<PackageReference>` is added.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Kernel`. Routing rule "context, GridContext, NodeContext, … → HoneyDrunk.Kernel" applies (this is a CI wiring change in Kernel, even though the workflow it invokes lives in HoneyDrunk.Actions).
+- [x] The reusable workflow is the abstraction boundary. Kernel only configures inputs (project key, working dir, etc.) — it does not embed any scanner logic.
+- [x] No invariant violation. Kernel's existing tier-1 gate via `pr-core.yml` is unchanged; SonarCloud is added as a downstream tier-2 step.
+- [x] No secrets read or written in the repo. `SONAR_TOKEN` flows from the org-level GitHub secret.
+
+## Acceptance Criteria
+- [ ] `sonar-project.properties` exists at `HoneyDrunk.Kernel/sonar-project.properties` (inside the inner project subdir, next to `HoneyDrunk.Kernel.slnx`) — **not** at the git repo root. The path the scanner reads it from is `./sonar-project.properties` relative to the `working-directory: 'HoneyDrunk.Kernel'` that `pr.yml` already sets.
+- [ ] File contains the project key `honeydrunkstudios_HoneyDrunk.Kernel` and the organization key `honeydrunkstudios`
+- [ ] `sonar.sources` and `sonar.tests` reflect the actual project layout in the repo (verify against the `.slnx`); commit corrected paths if they differ from the template. As of `2026-04-26`, the verified set is `sonar.sources=HoneyDrunk.Kernel` and `sonar.tests=HoneyDrunk.Kernel.Tests` (no canary project — do **not** add `HoneyDrunk.Kernel.Canary`, it does not exist on disk).
+- [ ] `sonar.cs.opencover.reportsPaths` is `**/coverage.opencover.xml`
+- [ ] `sonar.coverage.exclusions` excludes `HoneyDrunk.Kernel.Abstractions` (interfaces-only package; coverage % is not informative)
+- [ ] `.github/workflows/pr.yml` is amended with a new `sonarcloud` job that:
+  - has `needs: pr-core` (so tier-2 only runs after tier-1 passes — fail-fast cheap-first per ADR-0011 D2)
+  - calls `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-sonarcloud.yml@main`
+  - passes `coverage-artifact-name: 'coverage-reports-ubuntu-latest'` to reuse the existing artifact
+  - passes `SONAR_TOKEN` and `GITHUB_TOKEN` as the two secrets `job-sonarcloud.yml` declares
+- [ ] The new job's permissions block declares only `contents: read`, `checks: write`, `pull-requests: write` (matching `job-sonarcloud.yml`'s declared minimum)
+- [ ] Repo-level `CHANGELOG.md`: a new entry under `Added` (or appended to the in-progress version's existing entry) describing SonarCloud onboarding (invariants 12 and 27)
+- [ ] No per-package `CHANGELOG.md` updates (CI wiring change, not a code change to any package)
+- [ ] First PR after merge produces a SonarCloud check (verify before merging the PR)
+- [ ] Branch-protection rule on `main` has the SonarCloud check name as a required check, where the check name is **the literal string observed in the first SonarCloud-enabled PR's Checks tab** (historically "SonarCloud Code Analysis" but verify before pasting). Human Prerequisite — verify before closing the issue.
+
+## Human Prerequisites
+
+The agent ships the workflow + properties file. The human handles SonarCloud-side import and GitHub branch protection:
+
+- [ ] **Confirm the SonarCloud GitHub App is installed on `HoneyDrunkStudios/HoneyDrunk.Kernel`** (this should already be true if packet 04 was followed; re-confirm at `https://github.com/organizations/HoneyDrunkStudios/settings/installations`).
+- [ ] **Confirm `SONAR_TOKEN` is accessible to `HoneyDrunkStudios/HoneyDrunk.Kernel`** — the org-level secret from packet 04 must include Kernel in its "Selected repositories" list. Check at `https://github.com/organizations/HoneyDrunkStudios/settings/secrets/actions/SONAR_TOKEN`.
+- [ ] **Import the project into SonarCloud:** `https://sonarcloud.io/organizations/honeydrunkstudios → Analyze new project → Select HoneyDrunk.Kernel → "With GitHub Actions"`. Confirm project key auto-resolves to `honeydrunkstudios_HoneyDrunk.Kernel`.
+- [ ] **Trigger the first analysis run** by pushing the PR. Verify in SonarCloud that the project page shows analysis results and a quality gate verdict.
+- [ ] **Add the SonarCloud check to branch protection on `main`** — but only **after** the first SonarCloud-enabled PR has run and published a check. GitHub rejects branch-protection rules that reference checks which have never run. Sequence: (1) open a PR after this packet's PR merges; (2) on the PR's "Checks" tab, read the literal check name the SonarCloud GitHub App publishes (historically "SonarCloud Code Analysis", but verify each time — do not paste blindly); (3) at `https://github.com/HoneyDrunkStudios/HoneyDrunk.Kernel/settings/branches`, edit the `main` rule, paste the observed check name into "Require status checks to pass before merging," save.
+- [ ] **Confirm the quality gate is passing** (or note the initial findings if it fails on legacy code). Per ADR-0011 D11, the gate enforces on new code; historical findings are not blockers for this onboarding but should be tracked for future remediation.
+
+If the first run fails for non-legacy reasons (e.g. the `coverage-artifact-name` mismatch), file a follow-up bug-fix packet rather than blocking this onboarding.
+
+## Dependencies
+- **Actions#NN** — `job-sonarcloud.yml` reusable workflow (packet 02). Hard dependency: this packet's `pr.yml` calls that workflow by name.
+- **Architecture#NN** — SonarCloud organization setup (packet 04). Hard dependency: the org, the GitHub App install on Kernel, and the `SONAR_TOKEN` org secret must all exist before the workflow can run successfully.
+- Soft dependency on packet 01 (ADR-0011 acceptance) for invariant references.
+
+## Downstream Unblocks
+- This packet is the **template** for packet 07 (Web.Rest, ASP.NET Core variant) and the Wave-3 deferred fan-out (Transport, Vault, Auth, Data, Pulse, Notify, Vault.Rotation, Actions). Each of those packets uses the same shape: `sonar-project.properties` + `pr.yml` job + project import + branch protection.
+
+## Referenced ADR Decisions
+
+**ADR-0011 (Code Review and Merge Flow):**
+- **D2 (tier model, fail-fast cheap-first):** Tier 1 (build, tests, analyzers, vuln, secret) must pass before tier 2 is worth spending money on. The `needs: pr-core` wiring enforces this.
+- **D11 (SonarCloud chosen):** Public repos: SonarCloud enabled via `job-sonarcloud.yml` called from `pr.yml`; quality gate is a required branch-protection check.
+- **D11 (Contract):** Input `sonar-project.properties` at the repo root; coverage report from stage 2 unit tests; PR diff. Output: required PR check + inline annotations. Secret: `SONAR_TOKEN` org-level. Cost discipline: median PR run under 60 seconds.
+- **D11 (Quality gate posture):** Default "Sonar way" gate at the organization level; per-repo overrides only if a Node has a documented reason. Kernel uses the org default.
+
+**ADR-0009 (Package Scanning Policy):** Established the pattern of "PR gate jobs are reusable workflows in `HoneyDrunk.Actions`; consumers call them from their `pr.yml`." This packet follows that pattern exactly.
+
+## Referenced Invariants
+
+> **Invariant 31:** Every PR traverses the tier-1 gate before merge. Build, unit tests, analyzers, vulnerability scan, and secret scan are required branch-protection checks on every .NET repo in the Grid, delivered via `pr-core.yml` in `HoneyDrunk.Actions`. *(Tier 1 is unchanged here; this packet adds tier 2 as an additional required check on top of tier 1, not as a replacement.)*
+
+> **Invariant 32:** Agent-authored PRs must link to their packet in the PR body. *(The PR opened by this packet must include the `> Packet: <permalink>` line per packet 03's mechanism. Manual confirmation if the human authors the PR locally.)*
+
+> **Invariant 27 (versioning):** All projects in a solution share one version and move together. *(This packet does not change any project's version — it adds CI wiring. No version bump required. The CHANGELOG entry is appended to whatever in-progress version Kernel currently has, or a Docs/Changed-only entry is added if no version bump is in flight.)*
+
+## Constraints
+- **Tier-1 must run first.** `needs: pr-core` is mandatory. SonarCloud must not run on a PR that already failed `dotnet build`.
+- **Reuse the coverage artifact.** Do not re-run `dotnet test` inside the SonarCloud job — pull the artifact `pr-core.yml` already publishes (`coverage-reports-ubuntu-latest`).
+- **Project key format.** `honeydrunkstudios_HoneyDrunk.Kernel` — this is the format SonarCloud auto-generates from the GitHub repo. Do not invent a different key; if SonarCloud generated a different key during import (e.g. it has used a hyphen in some auto-imports), use whatever SonarCloud actually shows on the project page.
+- **`fetch-depth: 0` is set inside `job-sonarcloud.yml`** (not in this packet's `pr.yml`). Confirm the reusable workflow already does this — it should; if it does not, the dependency on packet 02 is broken.
+- **Permissions block scoped:** `contents: read`, `checks: write`, `pull-requests: write`. Match `job-sonarcloud.yml`'s declared minimum.
+- **Working directory and project path** must match Kernel's actual layout — verify by reading the `.slnx` and directory tree before committing.
+- **Coverage exclusions:** `HoneyDrunk.Kernel.Abstractions` is excluded — it is interfaces only and coverage % does not measure anything useful there.
+- **Do not bypass the quality gate.** If the first run fails on legacy code, document the findings and either accept the New-Code-only gate (default) or open a follow-up packet to remediate. Do not relax the gate to make the gate pass.
+
+## Labels
+`feature`, `tier-2`, `ci-cd`, `core`, `adr-0011`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Onboard `HoneyDrunk.Kernel` to SonarCloud as the first canonical .NET template — `sonar-project.properties` at repo root, `sonarcloud` job in `pr.yml` chained `needs: pr-core` with the `job-sonarcloud.yml` reusable workflow, project imported into SonarCloud, branch protection updated.
+
+**Target:** `HoneyDrunk.Kernel`, branch from `main`.
+
+**Context:**
+- Goal: Establish the canonical SonarCloud onboarding pattern. Web.Rest (packet 07) replicates it for ASP.NET Core; Wave-3 fan-out replicates it for the remaining 8 .NET repos.
+- Feature: ADR-0011 Code Review Pipeline rollout.
+- ADRs: ADR-0011 (D2 tier model + D11 SonarCloud + Follow-up Work bullet), ADR-0009 (precedent for "reusable workflows in Actions, called from consumer `pr.yml`").
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- Actions#NN — `job-sonarcloud.yml` (packet 02). Hard.
+- Architecture#NN — SonarCloud organization setup walkthrough + portal work (packet 04). Hard.
+- Architecture#NN — ADR-0011 acceptance (packet 01). Soft (invariant references).
+
+**Constraints:**
+- `needs: pr-core` is mandatory — tier-1-then-tier-2 sequencing per ADR-0011 D2.
+- Reuse coverage artifact from `pr-core.yml` — never re-run `dotnet test` here.
+- Project key: `honeydrunkstudios_HoneyDrunk.Kernel` (or whatever SonarCloud actually generates on import — verify, don't invent).
+- Permissions minimal: `contents: read`, `checks: write`, `pull-requests: write`.
+- Verify `sonar.sources` and `sonar.tests` against the actual `.slnx` and directory tree.
+- Coverage exclusions for `HoneyDrunk.Kernel.Abstractions`.
+- Do not bypass or relax the quality gate to force a passing run.
+
+**Key Files:**
+- `HoneyDrunk.Kernel/sonar-project.properties` (new — inner project subdir, next to the `.slnx`; **not** at git root)
+- `.github/workflows/pr.yml` (edit)
+- `HoneyDrunk.Kernel/HoneyDrunk.Kernel.slnx` (read for layout verification)
+- `CHANGELOG.md` (root) — entry under in-progress version
+
+**Contracts:**
+- Project key `honeydrunkstudios_HoneyDrunk.Kernel`. Renaming would orphan SonarCloud history.
+- Job name `sonarcloud` in `pr.yml`. Branch protection on `main` references the SonarCloud GitHub App's check name (historically "SonarCloud Code Analysis"); the human reads the literal string from the first run's Checks tab before pasting into branch protection — do not paste blindly.
+- File location: `HoneyDrunk.Kernel/sonar-project.properties` (inner project subdir, not git root). The scanner discovers it from the working directory `pr.yml` runs in.

--- a/generated/issue-packets/active/adr-0011-code-review-pipeline/07-web-rest-sonarcloud-onboarding.md
+++ b/generated/issue-packets/active/adr-0011-code-review-pipeline/07-web-rest-sonarcloud-onboarding.md
@@ -1,0 +1,232 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Web.Rest
+labels: ["feature", "tier-2", "ci-cd", "core", "adr-0011", "wave-2"]
+dependencies: ["Actions#NN — job-sonarcloud.yml (packet 02)", "Architecture#NN — SonarCloud organization setup (packet 04)"]
+adrs: ["ADR-0011"]
+wave: 2
+initiative: adr-0011-code-review-pipeline
+node: honeydrunk-web-rest
+---
+
+# Feature: Onboard HoneyDrunk.Web.Rest to SonarCloud (ASP.NET Core variant template)
+
+## Summary
+Onboard `HoneyDrunk.Web.Rest` as the second SonarCloud template — same shape as the Kernel onboarding (packet 06) but adjusted for an ASP.NET Core middleware-and-conventions package family. Add `sonar-project.properties`, wire `pr.yml`, import the project into SonarCloud, add branch-protection check.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Web.Rest`
+
+## Motivation
+Per ADR-0011's "one packet per active repo" follow-up bullet, every public Grid repo gets its own onboarding packet. Web.Rest is chosen as the second template because:
+
+1. **Different shape from Kernel.** Kernel is a pure library + Abstractions + tests. Web.Rest ships an ASP.NET Core integration package (`HoneyDrunk.Web.Rest.AspNetCore`) that has a different surface area — middleware, exception filters, MVC conventions. The SonarCloud configuration patterns for ASP.NET Core (e.g. how to handle request-pipeline coverage, how to exclude generated `Microsoft.AspNetCore.*` glue) are slightly different from a pure library.
+2. **Two-package family.** Like several Grid repos, Web.Rest has both Abstractions and AspNetCore packages. The coverage-exclusion pattern for "Abstractions are interfaces, exclude" generalizes; the ASP.NET Core test patterns establish the second template.
+3. **Tier-2 candidate.** Web.Rest's `stability_tier` is `beta` per `nodes.json`. Sonar findings on a beta-tier Node are useful for hardening before promotion to stable.
+
+This packet is structurally identical to packet 06 — only the project key, working dir, and exclusions differ. The dispatch plan tracks them as parallel packets in Wave 2; together they cover the two dominant Grid repo shapes.
+
+## Proposed Implementation
+
+### A. Add `sonar-project.properties`
+
+**File location is critical.** Create `sonar-project.properties` **inside the inner project subdir** at `HoneyDrunk.Web.Rest/sonar-project.properties` (relative to the git root). This is the same directory that contains `HoneyDrunk.Web.Rest.slnx`, `HoneyDrunk.Web.Rest.Abstractions/`, `HoneyDrunk.Web.Rest.AspNetCore/`, `HoneyDrunk.Web.Rest.Tests/`, and `HoneyDrunk.Web.Rest.Canary/`. It is **not** at the git repo root next to `LICENSE` and `README.md`.
+
+Why: Web.Rest's `pr.yml` runs the reusable workflow with `working-directory: 'HoneyDrunk.Web.Rest'` (verified in `.github/workflows/pr.yml`). The `dotnet-sonarscanner` discovers `sonar-project.properties` from the working directory it begins from, not the git repo root. From inside the working directory the scanner uses, the file path is `./sonar-project.properties`.
+
+Paths inside `sonar-project.properties` are relative to that same working directory (`HoneyDrunk.Web.Rest/` from git root). So `sonar.sources=HoneyDrunk.Web.Rest.Abstractions,HoneyDrunk.Web.Rest.AspNetCore` resolves to the inner package directories at `HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/` and `HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/`.
+
+Content:
+
+```properties
+# SonarCloud project configuration for HoneyDrunk.Web.Rest.
+#
+# This file lives at HoneyDrunk.Web.Rest/sonar-project.properties (inside the
+# inner project subdir, next to HoneyDrunk.Web.Rest.slnx). All sonar.sources /
+# sonar.tests paths are relative to that subdir, which matches the
+# working-directory the reusable job-sonarcloud.yml runs from.
+
+sonar.organization=honeydrunkstudios
+sonar.projectKey=honeydrunkstudios_HoneyDrunk.Web.Rest
+sonar.projectName=HoneyDrunk.Web.Rest
+
+# Sources — both packages, relative to the working directory (HoneyDrunk.Web.Rest/)
+sonar.sources=HoneyDrunk.Web.Rest.Abstractions,HoneyDrunk.Web.Rest.AspNetCore
+
+# Tests — both .Tests and .Canary projects exist on disk (verified 2026-04-26).
+# Web.Rest does have a canary project, unlike Kernel; this asymmetry is intentional.
+sonar.tests=HoneyDrunk.Web.Rest.Tests,HoneyDrunk.Web.Rest.Canary
+
+# Coverage
+sonar.cs.opencover.reportsPaths=**/coverage.opencover.xml
+
+# Exclusions — generated, build artifacts, designer files
+sonar.exclusions=**/obj/**,**/bin/**,**/*.Designer.cs
+
+# Coverage exclusions:
+# - Abstractions: interfaces only, coverage % is not informative
+# - AspNetCore middleware extension methods that wrap framework calls
+sonar.coverage.exclusions=**/HoneyDrunk.Web.Rest.Abstractions/**,**/Extensions/ServiceCollectionExtensions.cs,**/Extensions/ApplicationBuilderExtensions.cs
+
+# New Code — inherit organization default (30 days)
+```
+
+The exact source / test directories were verified against the repo on `2026-04-26`: Web.Rest has four projects under `HoneyDrunk.Web.Rest/` — `HoneyDrunk.Web.Rest.Abstractions`, `HoneyDrunk.Web.Rest.AspNetCore`, `HoneyDrunk.Web.Rest.Tests`, `HoneyDrunk.Web.Rest.Canary`. If the layout has changed by execution time, correct the values to match the current `.slnx` and directory tree. The `coverage.exclusions` paths are reasonable defaults for ASP.NET Core integration packages but should be confirmed by reading the actual extension method file names — if `Extensions/ServiceCollectionExtensions.cs` is not the real path inside `HoneyDrunk.Web.Rest.AspNetCore/`, correct it.
+
+### B. Wire `pr.yml`
+
+Web.Rest's existing `pr.yml` (mirror of Kernel's pattern) calls `pr-core.yml@main`. Add the `sonarcloud` job after `pr-core.yml` succeeds, identical in shape to packet 06's wiring with Web.Rest values:
+
+```yaml
+  sonarcloud:
+    name: SonarCloud
+    needs: pr-core
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-sonarcloud.yml@main
+    with:
+      dotnet-version: '10.0.x'
+      runs-on: 'ubuntu-latest'
+      working-directory: 'HoneyDrunk.Web.Rest'   # confirm against actual layout
+      project-path: 'HoneyDrunk.Web.Rest.slnx'   # confirm against actual file name
+      sonar-organization: 'honeydrunkstudios'
+      sonar-project-key: 'honeydrunkstudios_HoneyDrunk.Web.Rest'
+      coverage-artifact-name: 'coverage-reports-ubuntu-latest'
+    secrets:
+      sonar-token: ${{ secrets.SONAR_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The `pr-core` job above is unchanged from Web.Rest's existing `pr.yml` — only the `sonarcloud` job is added.
+
+### C. Import the project into SonarCloud
+
+After the SonarCloud GitHub App is on Web.Rest (per packet 04, step 4), follow the same import flow as packet 06 with `HoneyDrunk.Web.Rest` substituted: SonarCloud → Analyze new project → GitHub → HoneyDrunkStudios/HoneyDrunk.Web.Rest → "With GitHub Actions" → confirm project key `honeydrunkstudios_HoneyDrunk.Web.Rest` → New Code default 30 days.
+
+### D. Branch protection — add SonarCloud check (after first run, not before)
+
+This step requires GitHub repo admin and is a Human Prerequisite with **strict ordering**: branch protection can only reference a check that has run at least once. If the rule is added before SonarCloud has published its first check, GitHub rejects the rule. Sequence:
+
+1. **Merge this packet's PR.** The `sonarcloud` job is now wired into `pr.yml`.
+2. **Wait for the first SonarCloud-enabled PR to run** (this can be a follow-up PR or any new PR after the merge). On the first run, the SonarCloud GitHub App publishes a check.
+3. **Open the PR's "Checks" tab** and read the **exact check name** the SonarCloud App is publishing. Historically this has been "SonarCloud Code Analysis" but **do not paste this string blindly** — copy the literal string from the live Checks UI.
+4. At `https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/settings/branches`, edit the `main` branch protection rule (or create one if missing).
+5. Under "Require status checks to pass before merging," paste the exact check name from step 3.
+6. Save.
+
+## Affected Files
+- `HoneyDrunk.Web.Rest/sonar-project.properties` (new — inner project subdir, next to `HoneyDrunk.Web.Rest.slnx`; **not** the git repo root)
+- `.github/workflows/pr.yml` (edit — add `sonarcloud` job)
+- `CHANGELOG.md` (root): entry under in-progress version
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Web.Rest`.
+- [x] Reusable workflow boundary preserved — Web.Rest only configures inputs.
+- [x] No invariant violation. Tier 1 unchanged; tier 2 SonarCloud added on top.
+- [x] No secrets read or written in the repo.
+
+## Acceptance Criteria
+- [ ] `sonar-project.properties` exists at `HoneyDrunk.Web.Rest/sonar-project.properties` (inside the inner project subdir, next to `HoneyDrunk.Web.Rest.slnx`) — **not** at the git repo root. The path the scanner reads it from is `./sonar-project.properties` relative to the `working-directory: 'HoneyDrunk.Web.Rest'` that `pr.yml` already sets.
+- [ ] File contains project key `honeydrunkstudios_HoneyDrunk.Web.Rest`
+- [ ] `sonar.sources` lists both `HoneyDrunk.Web.Rest.Abstractions` and `HoneyDrunk.Web.Rest.AspNetCore` (or whatever the actual project directory names are after verification)
+- [ ] `sonar.tests` reflects the actual test project layout
+- [ ] `sonar.coverage.exclusions` excludes the Abstractions package and any ASP.NET Core wrapper extension files (verified to exist before exclusion is added)
+- [ ] `.github/workflows/pr.yml` has a new `sonarcloud` job with `needs: pr-core` and the correct project key / working dir / project path inputs
+- [ ] Permissions block on the new job is minimal: `contents: read`, `checks: write`, `pull-requests: write`
+- [ ] Repo-level `CHANGELOG.md`: append a SonarCloud onboarding entry to the in-progress version (or open one if no in-progress version exists; per invariants 12 and 27)
+- [ ] No per-package `CHANGELOG.md` updates
+- [ ] First PR after merge produces a SonarCloud check (verify before merging)
+- [ ] Branch-protection rule on `main` has the SonarCloud check name as a required check, where the check name is **the literal string observed in the first SonarCloud-enabled PR's Checks tab** (historically "SonarCloud Code Analysis" but verify before pasting). Human Prerequisite.
+
+## Human Prerequisites
+- [ ] **Confirm SonarCloud GitHub App is on `HoneyDrunk.Web.Rest`** (covered by packet 04).
+- [ ] **Confirm `SONAR_TOKEN` org secret includes Web.Rest** in Selected repositories (covered by packet 04).
+- [ ] **Import project into SonarCloud:** SonarCloud → Analyze new project → GitHub → HoneyDrunk.Web.Rest → "With GitHub Actions". Verify project key auto-resolves to `honeydrunkstudios_HoneyDrunk.Web.Rest`.
+- [ ] **Trigger first analysis** by pushing the PR. Verify SonarCloud project page shows results.
+- [ ] **Add the SonarCloud check to branch protection on `main`** — but only **after** the first SonarCloud-enabled PR has run. GitHub rejects branch-protection rules that reference checks which have never run. Sequence: (1) open a PR after merge; (2) on the PR's "Checks" tab, read the literal check name the SonarCloud GitHub App publishes (historically "SonarCloud Code Analysis", but verify each time — do not paste blindly); (3) at `https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/settings/branches`, edit the `main` rule, paste the observed check name, save.
+- [ ] **Document any initial findings** as an issue or note for future remediation; do not relax the gate to force a pass on legacy code.
+
+## Dependencies
+- Actions#NN — `job-sonarcloud.yml` (packet 02). Hard.
+- Architecture#NN — SonarCloud organization setup (packet 04). Hard.
+- Soft dependency on packet 01 for invariant references.
+
+This packet **does not** depend on packet 06 (Kernel onboarding). The two run in parallel within Wave 2 — they are independent template repos targeted at two different repo shapes.
+
+## Downstream Unblocks
+- Together with packet 06, this packet establishes the two canonical onboarding shapes (pure library / ASP.NET Core integration). Wave-3 deferred fan-out (Transport, Vault, Auth, Data, Pulse, Notify, Vault.Rotation, Actions) replicates whichever shape applies — most are pure-library shape (use packet 06 as template); Auth.AspNetCore-style packages (if any sub-packages exist that mirror the Web.Rest split) use packet 07 as template.
+
+## Referenced ADR Decisions
+
+**ADR-0011 (Code Review and Merge Flow):**
+- **D2 (tier model, fail-fast cheap-first):** SonarCloud only runs after tier 1 passes — `needs: pr-core` enforces this.
+- **D11 (SonarCloud chosen):** Public repos: SonarCloud enabled; quality gate is a required branch-protection check.
+- **D11 (Contract):** Same as packet 06.
+
+**ADR-0009 (Package Scanning Policy):** Same precedent — reusable workflow in Actions, called from consumer `pr.yml`.
+
+## Referenced Invariants
+
+> **Invariant 31:** Every PR traverses the tier-1 gate before merge. Build, unit tests, analyzers, vulnerability scan, and secret scan are required branch-protection checks on every .NET repo in the Grid, delivered via `pr-core.yml` in `HoneyDrunk.Actions`.
+
+> **Invariant 32:** Agent-authored PRs must link to their packet in the PR body. *(The PR opened by this packet must include the `> Packet: <permalink>` line per packet 03's mechanism.)*
+
+> **Invariant 27 (versioning):** All projects in a solution share one version and move together. *(No version bump required for CI wiring; CHANGELOG entry only.)*
+
+## Constraints
+- **Tier-1 must pass first.** `needs: pr-core` is mandatory.
+- **Reuse coverage artifact.** Do not re-run `dotnet test`.
+- **Project key format:** `honeydrunkstudios_HoneyDrunk.Web.Rest` (or whatever SonarCloud auto-generates on import).
+- **Permissions minimal:** `contents: read`, `checks: write`, `pull-requests: write`.
+- **Verify project layout before committing.** Source dir, test dir, project path, and the specific extension files listed in `coverage.exclusions` must all exist.
+- **Coverage exclusions for ASP.NET Core glue.** The Abstractions exclusion is canonical; the wrapper extension exclusions are repo-specific and must be confirmed against the real file paths.
+- **Do not bypass the quality gate.** Initial findings on a beta-tier Node are expected; document and remediate, do not relax.
+
+## Labels
+`feature`, `tier-2`, `ci-cd`, `core`, `adr-0011`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Onboard `HoneyDrunk.Web.Rest` to SonarCloud as the ASP.NET Core variant template — `sonar-project.properties` covers both Abstractions and AspNetCore packages with appropriate coverage exclusions; `pr.yml` adds a `sonarcloud` job chained `needs: pr-core` calling `job-sonarcloud.yml`; project imported into SonarCloud; branch-protection check added.
+
+**Target:** `HoneyDrunk.Web.Rest`, branch from `main`.
+
+**Context:**
+- Goal: Second canonical SonarCloud onboarding template (ASP.NET Core variant; complements packet 06's pure-library variant).
+- Feature: ADR-0011 Code Review Pipeline rollout.
+- ADRs: ADR-0011 (D2 tier model + D11 SonarCloud + Follow-up Work bullet), ADR-0009 (precedent).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- Actions#NN — `job-sonarcloud.yml` (packet 02). Hard.
+- Architecture#NN — SonarCloud organization setup walkthrough + portal work (packet 04). Hard.
+- Architecture#NN — ADR-0011 acceptance (packet 01). Soft.
+
+**Constraints:**
+- `needs: pr-core` mandatory.
+- Reuse coverage artifact.
+- Project key matches SonarCloud's auto-generated value (verify; do not invent).
+- Permissions minimal: `contents: read`, `checks: write`, `pull-requests: write`.
+- Verify all paths in `sonar-project.properties` against the real `.slnx` and directory tree before committing.
+- Coverage exclusions for Abstractions (interface-only) and ASP.NET Core wrapper extension files (verify the file paths exist).
+- Do not relax the quality gate.
+
+**Key Files:**
+- `HoneyDrunk.Web.Rest/sonar-project.properties` (new — inner project subdir, next to the `.slnx`; **not** at git root)
+- `.github/workflows/pr.yml` (edit)
+- `HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.slnx` (read for layout)
+- `CHANGELOG.md` (root)
+
+**Contracts:**
+- Project key `honeydrunkstudios_HoneyDrunk.Web.Rest`. Renaming would orphan SonarCloud history.
+- Job name `sonarcloud` in `pr.yml` (matching packet 06 for consistency).
+- Branch-protection check name: literal string from the first run's Checks tab (historically "SonarCloud Code Analysis"; verify and copy, do not paste blindly).
+- File location: `HoneyDrunk.Web.Rest/sonar-project.properties` (inner project subdir, not git root). The scanner discovers it from the working directory `pr.yml` runs in.

--- a/generated/issue-packets/active/adr-0011-code-review-pipeline/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0011-code-review-pipeline/dispatch-plan.md
@@ -1,0 +1,219 @@
+# Dispatch Plan: Code Review Pipeline (ADR-0011)
+
+**Date:** 2026-04-26 (revised after refine review).
+**Trigger:** ADR-0011 (Code Review and Merge Flow) — Proposed 2026-04-12, scoped 2026-04-26.
+**Type:** Multi-repo
+**Sector:** Meta + Ops + Core (CI wiring)
+**Site sync required:** No, deferred. Today the Studios website does not surface the constitution, ADR catalogue, or PR-pipeline metadata. Site sync is **deferred** until SonarCloud quality gates and the `out-of-band` label become public-facing artifacts on the Studios site (likely tied to a future "Grid health" or "engineering practices" page). Re-evaluate when Studios CI is wired up and a public surface is decided.
+**Rollback plan:** Architecture-side edits revert cleanly via `git revert` — qualifier strip, ADR index flip, catalog `agent_couplings` add, and tracker entries are docs/text-only. The new `job-sonarcloud.yml` is additive and not yet referenced by `pr-core.yml`, so reverting it has no consumer impact. The `agent-run.yml` amendment adds a default-empty optional input plus a soft-failing post-hoc step — reverting is safe and existing callers stay green throughout. The `out-of-band` label seeding is idempotent — running an explicit `gh label delete` per repo cleans it up. Per-repo SonarCloud onboardings (06, 07) revert by removing `sonar-project.properties` from the inner project subdir, removing the `sonarcloud` job from `pr.yml`, and removing the SonarCloud check from branch protection (manual UI step).
+
+## Summary
+
+ADR-0011 names an 11-stage tiered PR review pipeline with explicit owners and artifact contracts. Most of the pipeline already exists (`pr-core.yml` ships tier 1; Copilot review fills the automatic-LLM-reviewer slot; the local `review` agent is defined in `.claude/agents/review.md`). What was missing as of the 2026-04-12 draft date:
+
+1. The ADR was Proposed, not Accepted.
+2. Invariants 31–33 were live in `constitution/invariants.md` but carried a "(Proposed — takes effect when ADR-0011 is accepted)" qualifier.
+3. The third-party static analysis stage (D11 = SonarCloud) had no reusable workflow file.
+4. The cloud agent-execution workflow (`agent-run.yml`) did not inject packet links into agent-authored PR bodies, leaving invariant 32 enforcement to per-prompt discipline.
+5. The `out-of-band` label that invariant 32 references existed on no Grid repo.
+6. The SonarCloud organization itself had not been provisioned, and per-repo onboarding had not started.
+7. `catalogs/relationships.json` did not encode the invariant-33 agent-to-agent coupling (no machine-discoverable signal of the scope/review context-loading symmetry).
+
+This initiative ships **eight packets** across two waves (revised from seven after the refine review split packet 05 into 05a + 05b for clean cross-repo apply semantics). Wave 1 is foundation work that runs in parallel after the first acceptance packet lands. Wave 2 onboards the first two repos as canonical templates. Wave 3 (the deferred fan-out across the remaining 8 .NET repos) is named here but **not scoped in this initiative** — those packets are filed when the Wave 2 templates prove out.
+
+## Important constraints (from ADR-0011 itself)
+
+- **D10 forbids cloud-wiring the review agent.** This dispatch plan does not include a `pr-review-agent.yml`. The review agent stays local-only, invoked by the human via Claude Code.
+- **The review agent is advisory (D5).** The dispatch plan does not include any "make the review agent a required check" packet. The branch-protection required-check posture stays on tier 1 + SonarCloud (per D8).
+- **Invariants 29–30 are reserved for ADR-0010** (Observation Layer, accepted 2026-04-12). New invariants in this ADR begin at 31. The acceptance packet must not touch invariants 29–30.
+- **Studios is excluded from the .NET fan-out.** SonarCloud onboarding for the TypeScript/Next.js Studios site is a separate future packet, not part of this initiative. Studios is also excluded from the `out-of-band` fan-out (no .NET PR pipeline to label against).
+
+## Wave Diagram
+
+### Wave 1 — Foundation (parallel after packet 01, with one internal hard-block)
+
+Run packet 01 first. Once it merges, packets 02, 03, 04, 05a run in parallel. Packet 05b is hard-blocked on 05a and starts after 05a merges.
+
+- [ ] `HoneyDrunk.Architecture`: **Accept ADR-0011** — flip ADR Status, ADR index, strip "(Proposed)" qualifier from invariants 31–33, audit `scope.md` and `review.md`, add `agent_couplings` to `relationships.json`, register initiative in trackers — [`01-architecture-adr-0011-acceptance.md`](01-architecture-adr-0011-acceptance.md)
+
+After packet 01 lands:
+
+- [ ] `HoneyDrunk.Actions`: Author `job-sonarcloud.yml` reusable workflow — [`02-actions-job-sonarcloud-workflow.md`](02-actions-job-sonarcloud-workflow.md)
+  - Blocked by: Wave 1 — `01-architecture-adr-0011-acceptance.md` (soft, for invariant references).
+- [ ] `HoneyDrunk.Actions`: Inject packet link into PR body via `agent-run.yml` `packet-path` input + post-hoc assert step — [`03-actions-agent-run-packet-link.md`](03-actions-agent-run-packet-link.md)
+  - Blocked by: Wave 1 — `01-architecture-adr-0011-acceptance.md` (soft, invariant 32 rationale).
+- [ ] `HoneyDrunk.Architecture`: SonarCloud organization setup walkthrough doc + portal work — [`04-architecture-sonarcloud-org-walkthrough.md`](04-architecture-sonarcloud-org-walkthrough.md)
+  - Blocked by: Wave 1 — `01-architecture-adr-0011-acceptance.md` (soft, D11 reference).
+- [ ] `HoneyDrunk.Actions`: Labels-as-code config + reusable `seed-labels.yml` workflow — [`05a-actions-labels-as-code.md`](05a-actions-labels-as-code.md)
+  - Blocked by: Wave 1 — `01-architecture-adr-0011-acceptance.md` (soft, invariant 32 rationale).
+- [ ] `HoneyDrunk.Actions`: Cross-repo fan-out — apply `out-of-band` to the eleven Grid repos via `seed-labels-fanout.yml` + PAT — [`05b-actions-out-of-band-label-fanout.md`](05b-actions-out-of-band-label-fanout.md)
+  - Blocked by: Wave 1 — `05a-actions-labels-as-code.md` (**hard** — fan-out reads the labels.yml shipped by 05a).
+  - Blocked by: Wave 1 — `01-architecture-adr-0011-acceptance.md` (soft).
+
+**Wave 1 exit criteria** (before Wave 2 starts):
+
+- ADR-0011 reads `**Status:** Accepted`; invariants 31–33 carry no "(Proposed)" qualifier; index row reflects Accepted.
+- `catalogs/relationships.json` contains the `agent_couplings` array with the `scope-review-context-loading` entry.
+- `job-sonarcloud.yml` exists in `HoneyDrunk.Actions/.github/workflows/` and is callable via `workflow_call`. Its job-level `if:` trigger guard is in place (defence-in-depth for the `pull_request` + `push:main` rule).
+- `agent-run.yml` accepts `packet-path` and (a) injects `> Packet: <permalink>` markdown into the agent's prompt envelope when supplied AND (b) runs a post-hoc "Assert PR-body packet link" step that mechanically asserts the line into any PR the agent opened. Existing callers unaffected.
+- `infrastructure/sonarcloud-organization-setup.md` exists; the `honeydrunkstudios` SonarCloud org exists; the SonarCloud GitHub App is installed on the eleven enumerated public repos (Studios excluded); `SONAR_TOKEN` is provisioned at the org level with "Selected repositories" scope.
+- `out-of-band` label exists on every active Grid repo (Studios excluded) with the configured color/description — verified by browsing each repo's `/labels` page after packet 05b's `seed-labels-fanout.yml` run.
+- `LABELS_FANOUT_PAT` exists as a HoneyDrunk.Actions repo secret, scoped to the eleven Grid repos with `Issues: Write` only.
+- `.claude/agents/scope.md` and `.claude/agents/review.md` audit pass — both already reference ADR-0011 D4/D6/D7 and the coupled context-loading contract per invariant 33.
+
+### Wave 2 — Canonical onboarding templates (parallel, with internal merge → first-run → branch-protection ordering each)
+
+Both packets run in parallel after Wave 1's exit criteria are met. Each packet has a real **internal three-step sequence** that this dispatch plan tracks explicitly because GitHub branch protection rejects rules that reference checks which have never run:
+
+1. **Merge the packet PR.** `pr.yml` now includes the `sonarcloud` job. The `sonar-project.properties` file is in place at `HoneyDrunk.<Repo>/sonar-project.properties` (inner project subdir, not git root — the scanner discovers it from the `working-directory` `pr.yml` runs in).
+2. **First SonarCloud-enabled PR runs.** This can be a follow-up PR or any new PR after the merge. On this first run, the SonarCloud GitHub App publishes its check. The exact check name is read from the live Checks tab — historically "SonarCloud Code Analysis", but verify each time and copy the literal string.
+3. **Add the SonarCloud check to branch protection on `main`.** Only after step 2 — adding the rule before the first run produces a "this check has never run on this branch" rejection from GitHub. The human pastes the check name observed in step 2.
+
+Together they establish the two dominant onboarding shapes:
+
+- [ ] `HoneyDrunk.Kernel`: Onboard SonarCloud (first canonical template — pure library + Abstractions + tests, **no canary project**) — [`06-kernel-sonarcloud-onboarding.md`](06-kernel-sonarcloud-onboarding.md)
+  - Blocked by: Wave 1 — `02-actions-job-sonarcloud-workflow.md` (hard).
+  - Blocked by: Wave 1 — `04-architecture-sonarcloud-org-walkthrough.md` (hard).
+- [ ] `HoneyDrunk.Web.Rest`: Onboard SonarCloud (ASP.NET Core variant template — Abstractions + AspNetCore + tests + canary) — [`07-web-rest-sonarcloud-onboarding.md`](07-web-rest-sonarcloud-onboarding.md)
+  - Blocked by: Wave 1 — `02-actions-job-sonarcloud-workflow.md` (hard).
+  - Blocked by: Wave 1 — `04-architecture-sonarcloud-org-walkthrough.md` (hard).
+
+Note: Kernel has no `.Canary` project on disk (verified 2026-04-26); packet 06 reflects this. Web.Rest does have a `.Canary` project; packet 07 reflects this. The two `sonar.tests` lines diverge intentionally — do not reconcile them.
+
+**Wave 2 exit criteria** (before Wave 3 fan-out is scoped):
+
+- Kernel and Web.Rest both have `sonar-project.properties` at the inner project subdir (`HoneyDrunk.Kernel/sonar-project.properties`, `HoneyDrunk.Web.Rest/sonar-project.properties`) — **not** at the git repo root — a `sonarcloud` job in `pr.yml` chained `needs: pr-core`, projects imported into SonarCloud, and the SonarCloud check (literal name observed from the first run) as a required branch-protection check on `main`.
+- The first SonarCloud quality gate run on each repo has completed (passing or with documented legacy findings).
+- Both repos' configurations have been reviewed and either (a) judged correct as written, or (b) corrected based on real layout / extension-method file paths.
+
+### Wave 3 — Deferred fan-out (NOT scoped in this initiative)
+
+Tracked here so the work does not get lost. Not filed until Wave 2 templates prove out.
+
+Eight remaining .NET repos onboard SonarCloud, each as a small packet (~5-line `sonar-project.properties` at the inner project subdir + `pr.yml` `sonarcloud` job + portal import + branch protection):
+
+- HoneyDrunk.Transport (use packet 06 as template — pure library shape)
+- HoneyDrunk.Vault (packet 06 template — Abstractions + Providers)
+- HoneyDrunk.Auth (packet 07 template — has Auth.AspNetCore sub-package)
+- HoneyDrunk.Data (packet 06 template — multi-package family)
+- HoneyDrunk.Pulse (packet 06 template)
+- HoneyDrunk.Notify (packet 06 template)
+- HoneyDrunk.Vault.Rotation (packet 06 template — Function App, but still a .NET project)
+- HoneyDrunk.Actions (packet 06 template if any .NET test projects exist; if Actions is purely YAML, defer entirely as a separate packet that reasons about whether SonarCloud applies)
+
+**Wave 3 trigger:** Wave 2 merged, Kernel and Web.Rest quality gates green for at least one PR cycle, no template-level corrections needed.
+
+**Excluded from Wave 3 entirely:**
+
+- HoneyDrunk.Studios — TypeScript/Next.js. SonarCloud-JS onboarding is a separate one-off packet (or a follow-up initiative) when Studios CI is otherwise wired up. Not part of this rollout.
+
+## Out-of-scope items from ADR-0011
+
+These ADR-0011 sections are explicitly **not** addressed by this initiative. They live as Unresolved Consequences in the ADR and are tracked there:
+
+- **Gap 1 — Integration tests (stage 6).** Slot defined; no test runner exists. No packet here.
+- **Gap 3 — E2E / Playwright tests (stage 10).** Slot defined; no infra exists. No packet here.
+- **Gap 4 — Cost discipline tooling.** Review agent's qualitative checklist (D6) covers it. No tool packet here.
+- **Gap 5 — SonarCloud on private repos.** Per-repo opt-in, no Wave-3 fan-out. No packet here.
+
+If any of these gaps becomes urgent, it is scoped via a new initiative (or appended to a future revision of this one) — but it does not block Wave 1 or Wave 2 acceptance.
+
+## `gh` CLI Commands — File All Wave 1 + Wave 2 Issues
+
+Paths are relative to the `HoneyDrunk.Architecture` repo root. All eight packets are filed in one pass; wave is execution sequencing, not a filing gate. Blocking relationships are wired afterward via `addBlockedBy`.
+
+```bash
+PACKETS="generated/issue-packets/active/adr-0011-code-review-pipeline"
+
+# --- Wave 1: Foundation ---
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture \
+  --title "Accept ADR-0011 — flip status, finalize invariants 31-33, register pipeline initiative" \
+  --body-file $PACKETS/01-architecture-adr-0011-acceptance.md \
+  --label "feature,tier-2,meta,docs,adr-0011,wave-1"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Actions \
+  --title "Author job-sonarcloud.yml reusable workflow (tier-2 SonarCloud analysis)" \
+  --body-file $PACKETS/02-actions-job-sonarcloud-workflow.md \
+  --label "feature,tier-2,ci-cd,ops,adr-0011,wave-1"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Actions \
+  --title "Inject packet link into agent-authored PR bodies in agent-run.yml" \
+  --body-file $PACKETS/03-actions-agent-run-packet-link.md \
+  --label "feature,tier-2,ci-cd,ops,adr-0011,wave-1"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture \
+  --title "Portal walkthrough — SonarCloud organization setup, GitHub App, SONAR_TOKEN" \
+  --body-file $PACKETS/04-architecture-sonarcloud-org-walkthrough.md \
+  --label "feature,tier-2,meta,docs,infrastructure,adr-0011,wave-1"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Actions \
+  --title "Labels-as-code config and reusable seed-labels workflow" \
+  --body-file $PACKETS/05a-actions-labels-as-code.md \
+  --label "chore,tier-1,ci-cd,ops,adr-0011,wave-1"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Actions \
+  --title "Fan out out-of-band label across the eleven Grid repos" \
+  --body-file $PACKETS/05b-actions-out-of-band-label-fanout.md \
+  --label "chore,tier-1,ci-cd,ops,adr-0011,wave-1"
+
+# --- Wave 2: Canonical onboarding templates ---
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Kernel \
+  --title "Onboard SonarCloud — first canonical .NET template" \
+  --body-file $PACKETS/06-kernel-sonarcloud-onboarding.md \
+  --label "feature,tier-2,ci-cd,core,adr-0011,wave-2"
+
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Web.Rest \
+  --title "Onboard SonarCloud — ASP.NET Core variant template" \
+  --body-file $PACKETS/07-web-rest-sonarcloud-onboarding.md \
+  --label "feature,tier-2,ci-cd,core,adr-0011,wave-2"
+```
+
+## After filing — board fields and blocking relationships
+
+For each issue: `gh project item-add 4 --owner HoneyDrunkStudios --url <ISSUE_URL>` then set Status=Backlog (or Ready), Wave (1 or 2), Initiative=`adr-0011-code-review-pipeline`, Node (`honeydrunk-architecture` / `honeydrunk-actions` / `honeydrunk-kernel` / `honeydrunk-web-rest`), Tier (per packet frontmatter), Actor=Agent (default — none of these packets is `Actor=Human`; packet 04 has substantial Human Prerequisites but the doc-authoring critical path is delegable; packet 05b requires a one-time human PAT setup and a one-time `workflow_dispatch` click but the workflow itself is delegable).
+
+Wire the following `addBlockedBy` relationships:
+
+- `02-actions-job-sonarcloud-workflow` blocked-by `01-architecture-adr-0011-acceptance` (soft)
+- `03-actions-agent-run-packet-link` blocked-by `01-architecture-adr-0011-acceptance` (soft)
+- `04-architecture-sonarcloud-org-walkthrough` blocked-by `01-architecture-adr-0011-acceptance` (soft)
+- `05a-actions-labels-as-code` blocked-by `01-architecture-adr-0011-acceptance` (soft)
+- `05b-actions-out-of-band-label-fanout` blocked-by `05a-actions-labels-as-code` (**hard**)
+- `05b-actions-out-of-band-label-fanout` blocked-by `01-architecture-adr-0011-acceptance` (soft)
+- `06-kernel-sonarcloud-onboarding` blocked-by `02-actions-job-sonarcloud-workflow` (hard)
+- `06-kernel-sonarcloud-onboarding` blocked-by `04-architecture-sonarcloud-org-walkthrough` (hard)
+- `07-web-rest-sonarcloud-onboarding` blocked-by `02-actions-job-sonarcloud-workflow` (hard)
+- `07-web-rest-sonarcloud-onboarding` blocked-by `04-architecture-sonarcloud-org-walkthrough` (hard)
+
+Total blocking edges: 10 (5 soft for Wave 1 sequencing; 5 hard for Wave 1 internal 05b dependency + Wave 2 dependencies).
+
+## Notes
+
+- **Acceptance precedes flip.** Per the scope-agent convention, ADR-0011 stays Proposed today. Packet 01's PR is the moment it flips to Accepted; the flip and the qualifier strip and the index row update and the catalog `agent_couplings` add all land in one merge — no early flip.
+- **The agent files (`scope.md`, `review.md`) were updated in advance.** Both already reference ADR-0011 D4 / D6 / D7 and the invariant 33 coupling. The acceptance packet's audit task confirms this and documents the audit outcome in the PR body. No edits to the agent files are expected. The Cost Discipline section in `review.md` was confirmed (2026-04-26) to contain all six D6 items: hot-path logging without sampling, LLM cost cap, unguarded CI, Azure SKU justification, outbound HTTP in hot paths, unbounded catalog loops.
+- **Invariants 31–33 are already live text in `constitution/invariants.md`** with the "(Proposed)" qualifier. The acceptance packet strips the qualifier; it does not introduce the invariants.
+- **`sonar-project.properties` lives at the inner project subdir, not the git root.** Both Wave 2 packets explicitly call this out; the scanner discovers it from the `working-directory` `pr.yml` runs in (`HoneyDrunk.Kernel/` and `HoneyDrunk.Web.Rest/`). Putting it at the git root means the scanner cannot find it and analysis runs without project configuration.
+- **Wave 2 packets each have a strict internal three-step ordering** — merge → first-run → branch-protection. GitHub rejects branch-protection rules that reference checks which have never run, so the human cannot pre-stage the branch-protection rule.
+- **Invariant 32 enforcement is mechanical.** Packet 03 ships both the prompt-side instruction (best-effort) and the post-hoc workflow assert step (mechanical guarantor). Even if the LLM ignores the prompt, the workflow asserts the line into the PR body via `gh pr edit`.
+- **The dispatch plan is the one exception to packet immutability** (per ADR-0008 D7). Updates at wave boundaries are the historical record. Packet bodies are immutable post-filing per invariant 24.
+- **Studios is the one excluded repo** across every packet that touches per-repo work (04 step 4, 05a/05b seed list, the Wave-3 fan-out). Its TypeScript posture and lack of CI today are the reasons; a future Studios SonarCloud-JS onboarding is a separate initiative. Site sync is also deferred (see "Site sync required" above).
+- **No new repo, no new ADR, no new contract.** This initiative only ships docs + workflow + per-repo CI wiring. The Grid topology (Nodes, sectors, contracts) is unchanged. The catalog gains a new agent-coupling entry but the schema extension is additive.
+- **No Azure resources are provisioned.** SonarCloud is third-party SaaS; the only "infra" is a SonarCloud organization, a GitHub org-level secret (`SONAR_TOKEN`), and a HoneyDrunk.Actions repo secret (`LABELS_FANOUT_PAT`). Cost: $0 recurring on the public-repo path.
+
+## Archival
+
+Per ADR-0008 D10, when every packet in this initiative reaches `Done` on the org Project board and the exit criteria above are met, the entire `active/adr-0011-code-review-pipeline/` folder moves to `archive/adr-0011-code-review-pipeline/` in a single commit. Partial archival is forbidden.
+
+The Wave-3 deferred fan-out, when scoped, lives in a **new** initiative folder (likely `adr-0011-sonarcloud-fanout` or similar) — not appended to this one. Initiative folders are scoped to a wave-set, not to "everything an ADR ever does."
+
+## Known Gaps (pre-existing — not owned by this initiative)
+
+- **`infrastructure/github-projects-field-ids.md` does not exist.** The "After filing" guidance above and packet 05a's per-repo workflow setup both reference it as the source of truth for board custom-field option IDs. This is a pre-existing dangling reference also relied on by the ADR-0005/0006 rollout, ADR-0010 Phase 1, and `scope.md`. **Consequence for this initiative:** the human filing the issues hand-populates Wave / Initiative / Node / Tier / Actor field values via the GitHub UI or by copy-pasting IDs from another already-filed packet's project-item state. Recommendation: ship `infrastructure/github-projects-field-ids.md` as a **separate standalone packet**, not as part of this initiative. Do not let it block Wave 1 filing.
+- **No `file-packets` driver currently consumes `agent-run.yml`'s new `packet-path` input.** Packet 03 ships the input + the post-hoc assert step; an existing or future driver workflow (out of scope for this initiative) will populate it. Until then, the input is optional and unused — which is the correct pre-rollout state per packet 03's design.
+
+## Revision history
+
+- **2026-04-26 initial scope** — seven packets across two waves.
+- **2026-04-26 refine revision** — eight packets across the same two waves. Splits packet 05 into 05a (labels-as-code config + reusable seed-labels workflow) and 05b (cross-repo fan-out via PAT + dispatcher workflow). Corrects packet 06 `sonar.tests` (Kernel has no `.Canary` project). Corrects file location for `sonar-project.properties` in packets 06 and 07 (inner project subdir, not git root). Adds branch-protection sequencing notes (merge → first-run → paste check name). Adds trigger-guard `if:` to `job-sonarcloud.yml` (packet 02). Removes unused `actions-ref` input from `job-sonarcloud.yml` (packet 02) and from packets 06/07 callers. Upgrades packet 03 from prompt-only to prompt + post-hoc workflow assert. Adds `agent_couplings` catalog entry to packet 01 (invariant 33 machine-discoverability). Site sync flag changed from "No" to "No, deferred — re-evaluate when SonarCloud / out-of-band become public-facing artifacts."

--- a/generated/issue-packets/active/adr-0011-code-review-pipeline/handoff-wave2-onboarding.md
+++ b/generated/issue-packets/active/adr-0011-code-review-pipeline/handoff-wave2-onboarding.md
@@ -1,0 +1,156 @@
+# Handoff — Wave 1 → Wave 2 (Per-repo SonarCloud Onboarding)
+
+This handoff is read **once**, at the moment Wave 1 of the ADR-0011 Code Review Pipeline initiative completes and Wave 2 (Kernel and Web.Rest SonarCloud onboardings) begins. Per ADR-0008 D7, handoffs are ephemeral baton passes — not live trackers — and are immutable under invariant 24.
+
+The agents executing Kernel#NN (packet 06) and Web.Rest#NN (packet 07) read this handoff to understand exactly what Wave 1 delivered and what stable surfaces are now in place for them to consume.
+
+## Wave 1 deliverables — what is now stable
+
+### 1. ADR-0011 is Accepted
+
+`adrs/ADR-0011-code-review-and-merge-flow.md` reads `**Status:** Accepted`. The ADR index row (`adrs/README.md`) reflects Accepted. Invariants 31, 32, 33 in `constitution/invariants.md` no longer carry the "(Proposed — this invariant takes effect when ADR-0011 is accepted)" qualifier. They are live rules.
+
+`catalogs/relationships.json` has a new `agent_couplings` array (sibling to the existing `nodes` array) with the `scope-review-context-loading` entry — invariant 33 is now machine-discoverable.
+
+The Wave 2 packets (06, 07) reference invariant 31 (tier-1 gate required), invariant 32 (PR-body packet link), and ADR-0011 D2 / D11 as binding rules — not aspirational.
+
+### 2. `job-sonarcloud.yml` exists in HoneyDrunk.Actions
+
+The reusable workflow `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-sonarcloud.yml@main` is callable via `workflow_call`. Its declared inputs:
+
+- `dotnet-version` (default `'10.0.x'`)
+- `runs-on` (default `'ubuntu-latest'`)
+- `working-directory` (default `'.'`)
+- `project-path` (default `''`)
+- `sonar-organization` (required)
+- `sonar-project-key` (required)
+- `sonar-host-url` (default `'https://sonarcloud.io'`)
+- `coverage-artifact-name` (default `'coverage-reports-ubuntu-latest'`)
+
+Declared secrets:
+- `sonar-token` (required)
+- `github-token` (optional — falls back to `github.token`)
+
+The job carries an `if:` trigger guard: `${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}`. A misconfigured caller (e.g. wired to `push` on a feature branch) produces a skipped no-op rather than a paid SonarCloud run. Wave 2 callers are correctly configured (`pr.yml` triggers on `pull_request`); the guard passes naturally.
+
+What the workflow does:
+- Checks out the consumer repo with `fetch-depth: 0` (full git history for SCM blame).
+- Carries a job-level `if:` trigger guard that refuses to run unless `github.event_name == 'pull_request'` or (`push` && `ref == refs/heads/main`). Defence-in-depth for ADR-0011 D11 cost discipline.
+- Sets up .NET (the configured version) and Java 17 Temurin (mandatory for the Sonar Scanner CLI).
+- Caches `~/.sonar/cache` and `./.sonar/scanner` for fast cold and warm runs.
+- Installs `dotnet-sonarscanner` as a tool into `./.sonar/scanner`.
+- Downloads the coverage artifact named `coverage-artifact-name` (already published by `pr-core.yml`'s `job-build-and-test.yml`) and points the scanner at `**/coverage.opencover.xml`.
+- Runs `dotnet-sonarscanner begin → dotnet build → dotnet-sonarscanner end`.
+- Reports the SonarCloud quality gate as a check run, with PR decoration via the `GITHUB_TOKEN` flowed in.
+
+Permissions block: `contents: read`, `pull-requests: write`, `checks: write`. No broader permissions.
+
+What the workflow does **not** do:
+- Re-run `dotnet test`. Coverage comes from the upstream `pr-core.yml` artifact only.
+- Wire itself into `pr-core.yml`. The wiring lives in each consuming repo's `pr.yml`.
+
+### 3. `agent-run.yml` accepts a `packet-path` input — and the workflow asserts the link
+
+`HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/agent-run.yml@main` now accepts an optional `packet-path` input. When supplied, the workflow does two things:
+
+1. **Prompt-envelope injection (soft, primary path).** Appends the following block to the agent's prompt envelope:
+   ```
+   ---
+
+   **Issue packet for this run:** `<packet-path>`
+   **Packet permalink:** <permalink>
+
+   When you open a pull request for this work, include the following line verbatim in the PR body:
+
+   > Packet: <permalink>
+
+   If you cannot include the link for any reason, label the PR `out-of-band` and explain why in the PR body.
+   ```
+
+2. **Post-hoc assert step (hard, mechanical guarantor).** After the agent run completes, a new "Assert PR-body packet link" step locates the PR the agent opened on the run's branch in `inputs.checkout-target` and uses `gh pr edit` to ensure the `> Packet: <permalink>` line is present in the PR body. Idempotent (no edit if line already present), soft on edge cases (no-PR / no-checkout-target / detached-HEAD all log a notice and exit 0).
+
+Existing callers without `packet-path` are unaffected (input default is empty; both the resolve and assert steps no-op).
+
+The `> Packet: <permalink>` quoted-block format is the contract the local review agent's packet-resolution logic in `.claude/agents/review.md` consumes. Wave 2 PRs opened by cloud agents include this line **regardless of LLM behaviour** — the workflow is the source of the line. Wave 2 PRs opened locally by the human can include it manually or rely on the local review agent reading the packet directly from disk.
+
+### 4. SonarCloud organization + GitHub App + `SONAR_TOKEN`
+
+The portal walkthrough `infrastructure/sonarcloud-organization-setup.md` was followed end-to-end during Wave 1. Resulting state:
+
+- SonarCloud organization `honeydrunkstudios` exists, bound to the `HoneyDrunkStudios` GitHub org, on the Free plan (zero recurring cost on the public-repo path).
+- The SonarCloud GitHub App is installed on **eleven public repos** with "Selected repositories" scope: HoneyDrunk.Kernel, HoneyDrunk.Transport, HoneyDrunk.Vault, HoneyDrunk.Vault.Rotation, HoneyDrunk.Auth, HoneyDrunk.Web.Rest, HoneyDrunk.Data, HoneyDrunk.Pulse, HoneyDrunk.Notify, HoneyDrunk.Actions, HoneyDrunk.Architecture. **HoneyDrunk.Studios is excluded** (TypeScript; separate future onboarding).
+- `SONAR_TOKEN` is provisioned as a GitHub organization-level secret, with "Selected repositories" scoped to the same eleven repos.
+- Default New Code definition: 30 days at the organization level. Per-repo overrides only when documented.
+- Default quality gate: "Sonar way" (SonarCloud built-in).
+
+For Wave 2:
+- Kernel and Web.Rest are both on the eleven-repo install list, and the secret is accessible to both.
+- The only remaining per-repo SonarCloud-side step is "Analyze new project → import → confirm project key" — a Human Prerequisite in each Wave 2 packet.
+
+### 5. `out-of-band` label exists across active Grid repos
+
+Two-packet split:
+- **Packet 05a** shipped `.github/config/labels.yml` and the reusable `seed-labels.yml` workflow in HoneyDrunk.Actions.
+- **Packet 05b** shipped the cross-repo fan-out workflow `seed-labels-fanout.yml` in HoneyDrunk.Actions, which uses the `LABELS_FANOUT_PAT` repo secret (fine-grained PAT scoped to the eleven Grid repos with `Issues: Write`) to call `gh label create/edit` against each repo. The human ran the fan-out workflow once via `workflow_dispatch`.
+
+Result: the label `out-of-band` (color `ed7d31`, descriptive text per ADR-0011 D9) exists on every one of the eleven public repos enumerated above. Studios excluded.
+
+For Wave 2: if a Kernel or Web.Rest PR is opened without a packet link (out-of-band), the human or the review agent flags it and applies the existing `out-of-band` label — the label does not need to be created ad hoc.
+
+### 6. Agent definitions audited
+
+`.claude/agents/scope.md` and `.claude/agents/review.md` were both audited as part of the Wave 1 acceptance packet. Both already reflect ADR-0011 D4 (coupled context-loading contracts), D6 (Cost Discipline checklist), and D7 (Grid-alignment check), and reference invariant 33. **No edits were needed; the audit recorded "no edits required" in the PR body.**
+
+For Wave 2: the local review agent invoked against a Kernel or Web.Rest PR carries the full Grid-aware review surface. No agent-side gaps to work around.
+
+## What Wave 2 must do
+
+Both Wave 2 packets (06 Kernel, 07 Web.Rest) follow the same shape:
+
+1. **Add `sonar-project.properties` at the inner project subdir** — `HoneyDrunk.Kernel/sonar-project.properties` and `HoneyDrunk.Web.Rest/sonar-project.properties` (next to the `.slnx`). **Not** at the git repo root. The scanner discovers it from the `working-directory` `pr.yml` already sets (`HoneyDrunk.Kernel` / `HoneyDrunk.Web.Rest`). Project key (`honeydrunkstudios_HoneyDrunk.<Repo>`), source dirs, test dirs, coverage report path, and exclusions inside.
+2. **Add a `sonarcloud` job to `pr.yml`** with `needs: pr-core`, calling `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-sonarcloud.yml@main`, passing the project key and `coverage-artifact-name: 'coverage-reports-ubuntu-latest'`. Do not pass `actions-ref` — that input was removed from `job-sonarcloud.yml` because it was unused.
+3. **Import the project into SonarCloud** via the GitHub App (Human Prerequisite).
+4. **Wait for the first SonarCloud-enabled PR to run** — the SonarCloud GitHub App will publish its check.
+5. **Read the literal check name from the first run's Checks tab** (historically "SonarCloud Code Analysis", but verify each time — do not paste blindly). Add it to branch protection on `main` (Human Prerequisite). GitHub rejects branch-protection rules that reference checks which have never run, so steps 4 and 5 cannot be combined.
+
+**Test asymmetry note:** Kernel has no `.Canary` project on disk (verified 2026-04-26); its `sonar.tests` line lists only `HoneyDrunk.Kernel.Tests`. Web.Rest does have a `.Canary` project; its `sonar.tests` lists both `HoneyDrunk.Web.Rest.Tests` and `HoneyDrunk.Web.Rest.Canary`. The two packets diverge intentionally on this line.
+
+Wave 2 packets must:
+- Verify project layout (source dirs, test dirs, project file paths) against the actual `.slnx` and directory tree before committing.
+- Reuse the coverage artifact — never re-run `dotnet test`.
+- Keep permissions minimal (`contents: read`, `checks: write`, `pull-requests: write`).
+- Use the project key SonarCloud actually generates on import — do not invent a different format.
+- Document any initial findings on the legacy codebase rather than relaxing the gate to force a pass.
+
+## Stable contracts Wave 2 depends on
+
+- Reusable workflow path: `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-sonarcloud.yml@main`
+- Org-level GitHub secret name: `SONAR_TOKEN` (exact, all caps)
+- Coverage artifact name: `coverage-reports-ubuntu-latest` (published by `pr-core.yml`'s `job-build-and-test.yml`)
+- SonarCloud organization key: `honeydrunkstudios` (lowercase, one word, no dot, no separator).
+- SonarCloud project key format: `honeydrunkstudios_HoneyDrunk.<Repo>` — verify against the auto-generated value during import.
+- SonarCloud GitHub App check name (for branch protection): historically "SonarCloud Code Analysis" — but this is **not** an authoritative source. Read the literal string from the first PR's check list before pasting into branch protection.
+
+## Invariants now binding for Wave 2 PRs
+
+> **Invariant 31:** Every PR traverses the tier-1 gate before merge. Build, unit tests, analyzers, vulnerability scan, and secret scan are required branch-protection checks on every .NET repo in the Grid, delivered via `pr-core.yml` in `HoneyDrunk.Actions`. *(Wave 2 packets add tier-2 SonarCloud as an additional required check — they do not weaken tier 1.)*
+
+> **Invariant 32:** Agent-authored PRs must link to their packet in the PR body. The review agent resolves the packet via this link. *(Wave 2 PRs opened via the cloud `agent-run.yml` workflow with `packet-path` will include the link automatically. Wave 2 PRs opened locally must include it manually.)*
+
+> **Invariant 33:** Review-agent and scope-agent context-loading contracts are coupled. *(Already satisfied; both agent files reflect the coupling. No Wave 2 action.)*
+
+## Acceptance criteria for the handoff itself
+
+- [x] Wave 1 packets 01, 02, 03, 04, 05a, 05b all merged.
+- [x] ADR-0011 reads Accepted; ADR index reflects Accepted; invariants 31–33 carry no "(Proposed)" qualifier.
+- [x] `catalogs/relationships.json` contains the `agent_couplings` array with the `scope-review-context-loading` entry.
+- [x] `job-sonarcloud.yml` callable from any repo via `workflow_call`; trigger guard `if:` in place.
+- [x] `agent-run.yml` accepts `packet-path`; prompt-side injection AND post-hoc assert step both in place.
+- [x] SonarCloud org `honeydrunkstudios` exists; GitHub App on the eleven repos; `SONAR_TOKEN` org secret with selected-repos scope.
+- [x] `out-of-band` label exists on the eleven repos (verified by browsing each repo's `/labels` page after the 05b fan-out run).
+- [x] `LABELS_FANOUT_PAT` exists as a HoneyDrunk.Actions repo secret.
+- [x] `scope.md` / `review.md` audit pass logged in packet 01's PR body — review.md Cost Discipline section has all six D6 items (hot-path logging, LLM cost cap, unguarded CI, Azure SKU, outbound HTTP, catalog loops).
+
+When all of the above are checked, Wave 2 starts. Packets 06 (Kernel) and 07 (Web.Rest) run in parallel.
+
+— end of handoff —


### PR DESCRIPTION
Accept ADR-0011, finalize invariants 31–33, and register the code review pipeline initiative. Add SonarCloud reusable workflow, enforce packet-linking in agent PRs, document SonarCloud org setup, and establish labels-as-code with cross-repo seeding. Onboard Kernel and Web.Rest to SonarCloud as templates. Add dispatch plan and handoff docs for initiative sequencing and onboarding.