### PR TITLE
chore(ci): pass HIVE_APP_ID + HIVE_APP_PRIVATE_KEY to file-packets caller

### DIFF
--- a/.github/workflows/file-packets.yml
+++ b/.github/workflows/file-packets.yml
@@ -11,4 +11,6 @@ jobs:
   file:
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/file-packets.yml@main
     secrets:
+      app-id: ${{ secrets.HIVE_APP_ID }}
+      app-private-key: ${{ secrets.HIVE_APP_PRIVATE_KEY }}
       hive-field-mirror-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}


### PR DESCRIPTION
Cross-repo follow-on for HoneyDrunkStudios/HoneyDrunk.Actions#57 (file-packets hardening). Must merge **after** HoneyDrunkStudios/HoneyDrunk.Actions#58.

## Summary

Adds the two new App-auth secrets to the file-packets reusable-workflow caller. The reusable workflow mints an installation token via `actions/create-github-app-token@v1` when both are present; absent App secrets it falls through to the existing `hive-field-mirror-token` PAT path.

The PAT secret stays referenced as fallback for now. Removing it is a follow-up once the GitHub App is provisioned per Actions#57's Human Prerequisites and the next run logs `Auth path: GitHub App`.

## Why a separate PR

The Actions reusable workflow has to accept the new secret names before the caller can pass them. Sequencing as two PRs avoids a transient broken state.

## Test plan

- [ ] CI passes (no behaviour change pre-Actions#58 merge — caller passes secrets the reusable workflow ignores until Actions#58 is on `main`)
- [ ] After Actions#58 merges and this PR merges: next packet hit on `main` triggers a workflow run that logs either `Auth path: GitHub App` (if App provisioned) or `Auth path: PAT fallback (hive-field-mirror-token)` (pre-provisioning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)