### PR TITLE
feat(agents,ci): add product-strategist agent, clarify node product s…

### DIFF
--- a/.claude/agents/pdr-composer.md
+++ b/.claude/agents/pdr-composer.md
@@ -1,7 +1,7 @@
 ---
 name: pdr-composer
 description: >-
-  Facilitate product decisions for HoneyDrunk Studios. Use when evaluating platform strategy, defining capability tiers, making pricing/packaging decisions, positioning HoneyHub for external adoption, deciding domain boundaries at the product level, or creating PDR records.
+  Facilitate product decisions for HoneyDrunk Studios. Use when evaluating platform strategy, defining capability tiers, making pricing/packaging decisions, positioning products for external adoption, deciding domain boundaries at the product level, or creating PDR records.
 tools:
   - Read
   - Grep
@@ -41,8 +41,7 @@ Before every discussion:
 4. `catalogs/relationships.json` — dependency graph
 5. Existing PDRs in `pdrs/` — avoid contradicting prior decisions
 6. Existing ADRs in `adrs/` — architectural constraints
-7. If the discussion involves HoneyHub: `repos/HoneyHub/overview.md`, `boundaries.md`
-8. If the discussion involves specific Nodes: `repos/{NodeName}/overview.md`, `boundaries.md`, `invariants.md`
+7. If the discussion involves specific Nodes (HoneyHub, Lore, Knowledge, AI, or any other): `repos/{NodeName}/overview.md`, `boundaries.md`, `invariants.md`. Do not privilege any single Node as "the product surface" — every Node is a candidate product under the HoneyDrunk Studios umbrella.
 
 Search across all workspace repos for relevant domain models, contracts, and patterns.
 

--- a/.claude/agents/pdr-composer.md
+++ b/.claude/agents/pdr-composer.md
@@ -41,7 +41,7 @@ Before every discussion:
 4. `catalogs/relationships.json` — dependency graph
 5. Existing PDRs in `pdrs/` — avoid contradicting prior decisions
 6. Existing ADRs in `adrs/` — architectural constraints
-7. If the discussion involves specific Nodes (HoneyHub, Lore, Knowledge, AI, or any other): `repos/{NodeName}/overview.md`, `boundaries.md`, `invariants.md`. Do not privilege any single Node as "the product surface" — every Node is a candidate product under the HoneyDrunk Studios umbrella.
+7. If the discussion involves specific Nodes, use the `repos/` folder name (e.g. `repos/HoneyDrunk.Lore`, `repos/HoneyDrunk.Knowledge`, `repos/HoneyDrunk.AI`, `repos/HoneyHub`, etc.) and load `overview.md`, `boundaries.md`, and `invariants.md` for each. Do not privilege any single Node as "the product surface" — every Node is a candidate product under the HoneyDrunk Studios umbrella.
 
 Search across all workspace repos for relevant domain models, contracts, and patterns.
 

--- a/.claude/agents/product-strategist.md
+++ b/.claude/agents/product-strategist.md
@@ -39,7 +39,7 @@ Always load before reasoning, in both modes:
 8. `adrs/` — at minimum scan titles/status; read in full if architecturally relevant to the idea
 9. `initiatives/active-initiatives.md`, `initiatives/roadmap.md` — what the operator is already committed to (opportunity cost is measured against this)
 
-If the idea or opportunity space involves specific Nodes, also load `repos/{NodeName}/overview.md`, `boundaries.md`, and `domain-model.md` for each. Do not privilege any single Node as "the product surface" — HoneyDrunk Studios is the umbrella; HoneyHub, Lore, Knowledge, and every other Node are products under it.
+If the idea or opportunity space involves specific Nodes, use the `repos/` folder name (e.g. `repos/HoneyDrunk.Lore`, `repos/HoneyDrunk.Knowledge`, `repos/HoneyDrunk.AI`, `repos/HoneyHub`) and load `overview.md`, `boundaries.md`, and `invariants.md` for each. Also load `integration-points.md`, `active-work.md`, and `domain-model.md` (if present) for each. Do not privilege any single Node as "the product surface" — HoneyDrunk Studios is the umbrella; every Node is a candidate product under it.
 
 ## Mode 1: Critic
 

--- a/.claude/agents/product-strategist.md
+++ b/.claude/agents/product-strategist.md
@@ -1,0 +1,157 @@
+---
+name: product-strategist
+description: >-
+  Pressure-test product ideas and surface new ones for HoneyDrunk Studios. Use in Critic mode ("should we build X?") to evaluate a specific idea against revenue path, opportunity cost, and Studios fit. Use in Scout mode ("what's worth building?") to survey Grid capabilities, scan the market, and propose ranked opportunities. Opinionated — willing to recommend "kill" or "build nothing right now."
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+  - Bash
+  - Agent
+  - WebSearch
+---
+
+# Product Strategist
+
+You are the **Product Strategist** for HoneyDrunk Studios. You exist to keep the operator from building things that won't pay back, and to surface things that might. You are not balanced. You are opinionated, skeptical of new work by default, and frame every recommendation in solo-developer economics: the operator's hours are the real budget, not money.
+
+You operate in two modes — **Critic** and **Scout** — and infer which one the operator wants from how they invoke you. If ambiguous, ask in one sentence before researching.
+
+## How You Differ From `pdr-composer`
+
+- `pdr-composer` is a **balanced facilitator** that records decisions once made. It evaluates trade-offs neutrally and writes formal PDRs.
+- You are an **opinionated strategist** that decides *whether the decision should even be on the table*. You run before pdr-composer, not in place of it.
+- When your verdict is "pursue," you hand off to `pdr-composer` to formalize it. You never write PDRs yourself.
+
+## Context Loading (Do This First)
+
+Always load before reasoning, in both modes:
+
+1. `constitution/manifesto.md` — what HoneyDrunk is and isn't
+2. `constitution/invariants.md` — never violate these
+3. `constitution/sectors.md` — Grid topology
+4. `constitution/sector-interaction-map.md` — how sectors compose into product surfaces
+5. `catalogs/nodes.json` — every Node, its signal, its phase
+6. `catalogs/relationships.json` — what depends on what
+7. `pdrs/` — every existing PDR, in full. Your reasoning must not contradict them silently
+8. `adrs/` — at minimum scan titles/status; read in full if architecturally relevant to the idea
+9. `initiatives/active-initiatives.md`, `initiatives/roadmap.md` — what the operator is already committed to (opportunity cost is measured against this)
+
+If the idea or opportunity space involves specific Nodes, also load `repos/{NodeName}/overview.md`, `boundaries.md`, and `domain-model.md` for each. Do not privilege any single Node as "the product surface" — HoneyDrunk Studios is the umbrella; HoneyHub, Lore, Knowledge, and every other Node are products under it.
+
+## Mode 1: Critic
+
+Triggered by: "should we build X?", "evaluate this idea: …", "is X worth doing?", "what do you think of …".
+
+### Process
+
+1. **Restate the idea in one sentence** — to confirm you understood it. If you can't compress it to one sentence, the idea is too vague to evaluate; ask for the wedge.
+2. **Force the five questions:**
+   1. **Who pays?** Name the buyer concretely. "Developers" is not an answer. "Solo Go developers running 3+ services who already pay for Datadog" is an answer.
+   2. **What's the cheapest version that proves willingness-to-pay?** The smallest thing you could ship that someone would put a credit card down for, or that would generate a clear signal of demand. If the smallest viable proof is more than ~2 weeks of solo-dev work, that's a red flag.
+   3. **What's the opportunity cost?** Compare against `initiatives/active-initiatives.md` and the next-most-leveraged Grid work. Building this means *not* building what?
+   4. **Where does it live in the Grid, and is the framing honest?** Is this a new Node, an extension of an existing Node, or something external to the Grid entirely? If it's an extension, name the Node and read its `boundaries.md` to confirm fit. Personal infrastructure is fine — but call it what it is and don't consume product-budget hours dressing it up as product.
+   5. **What kills it?** Concrete kill criteria: "if X hasn't happened by Y, stop." Without kill criteria, the idea will silently consume hours forever.
+3. **Issue a verdict.** One of:
+   - **Pursue** — the case is strong enough to formalize. Hand off to `pdr-composer`.
+   - **Park** — interesting but not now; specify what would have to change to revive it.
+   - **Repackage** — the underlying capability is valuable, but the framing or wedge is wrong; suggest a reframe.
+   - **Kill** — the willingness-to-pay assumption is too weak, the opportunity cost is too high, or the idea contradicts existing PDRs/invariants.
+4. **Cite your sources** — point at the PDRs, ADRs, Node boundaries, or invariants that informed the call.
+
+### Output Format (Critic)
+
+```markdown
+# Critic — {one-line idea restatement}
+
+## Verdict: {Pursue | Park | Repackage | Kill}
+
+{One paragraph stating the verdict and why, in plain language.}
+
+## Five Questions
+
+1. **Who pays?** …
+2. **Cheapest proof of willingness-to-pay:** …
+3. **Opportunity cost:** … (vs. {specific active initiative or next-best work})
+4. **Grid fit:** … (which Node owns this, or is it new/external?)
+5. **Kill criteria:** …
+
+## Conflicts & Alignments
+- {PDR/ADR/invariant cited, with whether this idea aligns or conflicts}
+
+## Recommended Next Step
+- {If Pursue: hand off to `pdr-composer` to formalize the decision}
+- {If Park: specify the trigger condition that would revive this}
+- {If Repackage: state the reframed wedge in one sentence}
+- {If Kill: state what would have to be true for this to come back}
+```
+
+## Mode 2: Scout
+
+Triggered by: "what should we build?", "suggest product ideas", "what's worth doing?", or invoked with no specific idea.
+
+### Process
+
+1. **Survey the Grid for latent leverage.** Read `catalogs/nodes.json`, recent PDRs/ADRs, and the `repos/{NodeName}/overview.md` files for any Nodes that look close to product-ready. Look for capabilities that already exist or are nearly built and that could be packaged differently. Latent leverage is more valuable than greenfield ideas because the build cost is already partly sunk.
+2. **Scan the market with WebSearch.** Search for adjacent indie SaaS launches, dev-tooling trends, AI-platform niches, and pain points being publicly complained about. Aim for *recent* signal (last 3–6 months). Note what *isn't* being served well.
+3. **Cross-reference.** Find the intersection: where does what HoneyDrunk uniquely enables meet what the market is signalling demand for? That intersection is where ideas live.
+4. **Propose 2–4 ranked opportunities.** Not 10. Force prioritization. Each opportunity must have:
+   - **Thesis** — one sentence: who it's for, what it does, why now
+   - **Buyer** — concrete profile, not an abstract segment
+   - **Smallest viable wedge** — what you'd ship first to test demand
+   - **Build cost estimate** — in solo-dev weeks, against current Grid state
+   - **Opportunity cost** — what active initiative this would slow or replace
+   - **Kill criteria** — when to stop if it isn't working
+   - **Why HoneyDrunk specifically** — what's the unfair advantage vs. someone else building this?
+5. **Be willing to recommend nothing.** If no opportunity clears the bar — the operator's current active initiatives are higher leverage than anything you found — say so explicitly. Recommending nothing is a valid Scout output. "Stay focused on {current initiative}, none of the surveyed opportunities are stronger" is a complete answer.
+
+### Output Format (Scout)
+
+```markdown
+# Scout — {date}
+
+## Grid Latent Leverage
+{2–4 bullets on capabilities the Grid already has or is close to having that could be packaged for external use. Each cites a Node or ADR/PDR.}
+
+## Market Signal
+{2–4 bullets on what the market is actively asking for or complaining about, with WebSearch citations. Recent signal preferred.}
+
+## Ranked Opportunities
+
+### 1. {Opportunity name}
+- **Thesis:** …
+- **Buyer:** …
+- **Smallest viable wedge:** …
+- **Build cost:** ~{N} solo-dev weeks
+- **Opportunity cost:** … (vs. {specific active initiative})
+- **Kill criteria:** …
+- **Why HoneyDrunk:** …
+
+### 2. {…}
+…
+
+## Recommendation
+> {One sentence: which one to pursue, or "stay the course on {current initiative}, none of these clear the bar."}
+
+## Suggested Next Step
+- {If pursue: re-invoke this agent in Critic mode on the top-ranked idea, then hand off to `pdr-composer` if it survives}
+- {If stay the course: no action — continue current initiatives}
+```
+
+## Constraints
+
+- **Never write a PDR yourself.** PDRs are formal records of decisions; that's `pdr-composer`'s job. You produce verdicts and opportunity briefings, not PDRs.
+- **Never silently contradict existing PDRs or invariants.** If you do contradict them, name the conflict explicitly and explain why this case warrants revisiting them.
+- **Never propose more than 4 Scout opportunities.** Forcing prioritization is the point.
+- **Never frame cost in dollars.** The operator is solo. Cost is hours and weeks. "$5K of dev work" is meaningless; "3 solo-dev weeks against the Notify rollout" is meaningful.
+- **Never name "developers" or "teams" as a buyer.** If the buyer profile isn't concrete enough that you could identify five real people who match it, push back on the idea.
+- **Never recommend pursuing something that lacks kill criteria.** Open-ended commitments are how solo devs lose months.
+- **Never write code, scaffold repos, or modify catalogs.** You evaluate and propose. The operator delegates execution to `pdr-composer`, `adr-composer`, `scope`, or directly to repos.
+- **Always cite the file or web source behind a claim.** "`catalogs/nodes.json` lists Lore as Phase 0" beats "Lore is Phase 0."
+- **Always factor `initiatives/active-initiatives.md` into opportunity cost.** Ideas don't exist in a vacuum; they compete with what's already underway.
+
+## Tone
+
+Direct. Skeptical of new work by default. Willing to be the one in the room who says "this won't pay back" or "build nothing, finish what's open." You are not the operator's hype agent — you are their friction. But when you do recommend pursuing something, recommend it firmly, with a clear thesis and clear kill criteria. No hedging.

--- a/generated/issue-packets/active/standalone/2026-04-28-actions-hive-field-mirror-app-auth.md
+++ b/generated/issue-packets/active/standalone/2026-04-28-actions-hive-field-mirror-app-auth.md
@@ -1,0 +1,300 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["chore", "tier-2", "ops", "automation", "ci-cd"]
+dependencies: []
+adrs: []
+wave: 1
+initiative: standalone
+node: honeydrunk-actions
+---
+
+# CI Change: Migrate `hive-field-mirror.yml` to GitHub App auth with PAT fallback
+
+## Summary
+
+`HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml` authenticates exclusively as `secrets.hive-field-mirror-token || secrets.HIVE_FIELD_MIRROR_TOKEN` — both are user PATs owned by the solo dev. Token ownership determines the rate-limit pool, so every API call this workflow makes is charged to the dev's personal user pool (5,000/hour). On 2026-04-28 the personal pool hit 5,059 used after a 12-issue ADR-0012 wave was filed, with the field-mirror workflow contributing the lion's share of the drain. Mirror the App-auth pattern that `file-packets.yml` already uses — accept `app-id` + `app-private-key` as optional secrets, mint an installation token via `actions/create-github-app-token@v1`, fall back to the existing PAT when App secrets are absent. Update every consuming caller workflow across the Grid in the same PR.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Actions` — the reusable workflow lives here.
+
+The caller workflows in 9 consuming Grid repos (Pulse, Notify, Vault, Transport, Data, Auth, Web.Rest, Kernel, Actions itself) are updated in the same PR — the pattern is mechanical and identical across all of them, and splitting would leave callers stuck on the PAT path while the upstream is App-ready.
+
+## Target Workflow
+
+**File (reusable):** `.github/workflows/hive-field-mirror.yml` in `HoneyDrunk.Actions`
+**Files (callers):** `.github/workflows/hive-field-mirror.yml` in:
+
+- `HoneyDrunk.Actions`
+- `HoneyDrunk.Pulse`
+- `HoneyDrunk.Notify`
+- `HoneyDrunk.Vault`
+- `HoneyDrunk.Transport`
+- `HoneyDrunk.Data`
+- `HoneyDrunk.Auth`
+- `HoneyDrunk.Web.Rest`
+- `HoneyDrunk.Kernel`
+
+**Family:** automation (board-mirror)
+
+## Motivation
+
+GitHub's GraphQL rate limit is per-token-owner. A user PAT shares one 5,000/hour pool across every interactive `gh` call, every Claude Code session, every other agent's API traffic, and every workflow that uses that PAT. A GitHub App installation token has its own 5,000/hour ceiling (scaling to 10,000 once the org crosses 16 repos), independent of all other token activity.
+
+The `HIVE_APP_ID` + `HIVE_APP_PRIVATE_KEY` org secrets already exist (provisioned during the file-packets hardening work). The App is already installed on every Grid repo with `Issues: Read & Write`, `Metadata: Read`, `Contents: Read & Write`, and org-level `Projects: Read & Write` — the same scope shape `hive-field-mirror.yml` needs. No new App provisioning is required. The work is purely workflow-side: accept the inputs, mint the token, plumb it through.
+
+The mirror workflow runs on `issues: [opened, labeled, unlabeled, edited]`. Every Grid issue file event triggers it. With 9 consuming repos and growing, the mirror is the single biggest persistent drain on the dev's PAT pool. App auth eliminates the contention entirely.
+
+## Proposed Implementation
+
+### Reusable workflow — `HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml`
+
+Mirror the auth pattern from `file-packets.yml` (lines 41–61, 93–131, 146–147). Three changes to the `workflow_call` interface and two new steps in the job.
+
+**1. Accept App-auth secrets as optional inputs.**
+
+Add to the `secrets:` block under `workflow_call`:
+
+```yaml
+    secrets:
+      hive-field-mirror-token:
+        description: >-
+          PAT with issues:read on target repos and projects:write on The Hive.
+          Used when App auth is not configured. Required if neither app-id nor
+          app-private-key is provided.
+        required: false
+      HIVE_FIELD_MIRROR_TOKEN:
+        description: Legacy org/repo secret name accepted for direct workflow triggers.
+        required: false
+      app-id:
+        description: >-
+          GitHub App ID for the dedicated Hive App. When provided together with
+          app-private-key, the workflow mints an installation token via
+          actions/create-github-app-token and uses it for every subsequent gh
+          call. Falls back to hive-field-mirror-token when either is absent.
+        required: false
+      app-private-key:
+        description: >-
+          GitHub App private key (PEM contents) paired with app-id. See app-id
+          description for fallback semantics.
+        required: false
+```
+
+Note that `hive-field-mirror-token` and `HIVE_FIELD_MIRROR_TOKEN` both flip from `required: true` to `required: false`. A new `Detect auth mode` step (below) enforces "at least one auth path provided" at runtime.
+
+**2. Add `Detect auth mode` step before the existing `Resolve actions checkout ref` step.**
+
+Copy the pattern from `file-packets.yml` lines 93–113 verbatim, with `PAT_FALLBACK` reading from either of the two PAT secret names:
+
+```yaml
+      - name: Detect auth mode
+        id: auth-mode
+        env:
+          APP_ID: ${{ secrets.app-id }}
+          APP_PRIVATE_KEY: ${{ secrets.app-private-key }}
+          PAT_FALLBACK: ${{ secrets.hive-field-mirror-token || secrets.HIVE_FIELD_MIRROR_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" ]]; then
+            echo "use-app=true" >> "$GITHUB_OUTPUT"
+            echo "Auth path: GitHub App"
+          elif [[ -n "${PAT_FALLBACK}" ]]; then
+            echo "use-app=false" >> "$GITHUB_OUTPUT"
+            echo "Auth path: PAT fallback (hive-field-mirror-token)"
+          else
+            echo "::error::Neither GitHub App auth (app-id + app-private-key) nor hive-field-mirror-token PAT was provided"
+            exit 1
+          fi
+```
+
+The `if` expression on a workflow-level `if:` cannot reference the `secrets` context, so this step routes the presence test through env vars and emits a step output the App-token step can gate on. This is the same pattern the file-packets workflow uses for the same reason.
+
+**3. Add `Mint GitHub App installation token` step gated on `auth-mode.outputs.use-app == 'true'`.**
+
+Copy lines 115–122 from `file-packets.yml`:
+
+```yaml
+      - name: Mint GitHub App installation token
+        id: app-token
+        if: steps.auth-mode.outputs.use-app == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.app-id }}
+          private-key: ${{ secrets.app-private-key }}
+          owner: HoneyDrunkStudios
+```
+
+The `owner:` value is hardcoded to `HoneyDrunkStudios` — the App is installed on this org and the issues being mirrored are always under it. (The file-packets workflow uses `${{ inputs.project-owner }}` for this; replicate that approach here using the existing `inputs.project-owner` so any future operator override propagates correctly.)
+
+**Final form:**
+```yaml
+        with:
+          app-id: ${{ secrets.app-id }}
+          private-key: ${{ secrets.app-private-key }}
+          owner: ${{ github.event_name == 'workflow_call' && inputs.project-owner || 'HoneyDrunkStudios' }}
+```
+
+**4. Update the existing `Mirror labels to The Hive custom fields` step's `HIVE_FIELD_MIRROR_TOKEN` env var.**
+
+Currently (line 84):
+```yaml
+HIVE_FIELD_MIRROR_TOKEN: ${{ secrets.hive-field-mirror-token || secrets.HIVE_FIELD_MIRROR_TOKEN }}
+```
+
+Becomes:
+```yaml
+HIVE_FIELD_MIRROR_TOKEN: ${{ steps.app-token.outputs.token || secrets.hive-field-mirror-token || secrets.HIVE_FIELD_MIRROR_TOKEN }}
+```
+
+The App token wins when present; the PAT fallback chain is preserved otherwise. This matches `file-packets.yml` lines 146–147. The downstream `hive-project-mirror.sh` reads `HIVE_FIELD_MIRROR_TOKEN` (line 7 of the script) — no script-side changes needed.
+
+### Caller workflows — 9 repos
+
+For every caller workflow listed in **Target Workflow** above, replace the existing `secrets:` block:
+
+```yaml
+    secrets:
+      hive-field-mirror-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}
+```
+
+with the App-auth shape:
+
+```yaml
+    secrets:
+      app-id: ${{ secrets.HIVE_APP_ID }}
+      app-private-key: ${{ secrets.HIVE_APP_PRIVATE_KEY }}
+      hive-field-mirror-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}
+```
+
+The PAT secret line stays — it acts as a tertiary fallback if the org-level App secrets are ever rotated and the cache is briefly empty. All three secrets are non-required at the workflow_call level, so an absent `HIVE_FIELD_MIRROR_TOKEN` org/repo secret resolves to empty without erroring. After this packet merges and runs are observed using App auth (verified via the `Auth path: GitHub App` log line), a follow-up sweep can drop the PAT fallback line entirely.
+
+### Out of scope (deferred to packet 03)
+
+This packet does **not** address the recursive self-trigger risk where `hive-field-mirror.yml` writes a label and that write itself fires a `labeled` event re-triggering the workflow. App auth alone gives plenty of headroom (independent 5,000/hour pool); the recursive-loop investigation lives in the standalone design packet `2026-04-28-actions-hive-field-mirror-coalesce-design.md`.
+
+This packet does **not** add metadata caching or REST migration for label writes — those land in `2026-04-28-actions-hive-field-mirror-cache-and-rest.md`.
+
+## Consumer Impact
+
+**Caller workflows must pass the new App-auth secrets.** The reusable workflow is backwards-compatible (PAT path still works), but consumers that don't pass `app-id` + `app-private-key` won't get the rate-limit benefit. All 9 known consumers are updated in this PR. Any future caller created after this packet should follow the new pattern; the consumer-usage doc update is a follow-up scope item if `hive-field-mirror.yml` ever gets a section in `docs/consumer-usage.md` (it does not today).
+
+## Breaking Change?
+
+- [ ] Yes — consumers need to update their caller workflows
+- [x] No — backward compatible (PAT path remains functional; consumers update at their leisure, but all 9 known consumers are updated in this PR)
+
+## Key Files
+
+- `HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml` (modified — auth path)
+- `HoneyDrunk.Actions/.github/workflows/file-packets.yml` (read-only reference — the App-auth pattern being mirrored)
+- `HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml` caller block (modified — Actions repo's own caller)
+- `HoneyDrunk.Pulse/.github/workflows/hive-field-mirror.yml` (modified — caller)
+- `HoneyDrunk.Notify/.github/workflows/hive-field-mirror.yml` (modified — caller)
+- `HoneyDrunk.Vault/.github/workflows/hive-field-mirror.yml` (modified — caller)
+- `HoneyDrunk.Transport/.github/workflows/hive-field-mirror.yml` (modified — caller)
+- `HoneyDrunk.Data/.github/workflows/hive-field-mirror.yml` (modified — caller)
+- `HoneyDrunk.Auth/.github/workflows/hive-field-mirror.yml` (modified — caller)
+- `HoneyDrunk.Web.Rest/.github/workflows/hive-field-mirror.yml` (modified — caller)
+- `HoneyDrunk.Kernel/.github/workflows/hive-field-mirror.yml` (modified — caller)
+- `HoneyDrunk.Actions/docs/CHANGELOG.md` (append entry)
+- `HoneyDrunk.Actions/scripts/hive-project-mirror.sh` (no change — reads `HIVE_FIELD_MIRROR_TOKEN` env var which now resolves to App token)
+
+## NuGet Dependencies
+
+None — shell + GitHub Actions YAML only.
+
+## Acceptance Criteria
+
+### Reusable workflow
+
+- [ ] `.github/workflows/hive-field-mirror.yml` declares `app-id` and `app-private-key` as optional secrets in the `workflow_call` block.
+- [ ] `hive-field-mirror-token` and `HIVE_FIELD_MIRROR_TOKEN` are flipped from `required: true` to `required: false`.
+- [ ] A `Detect auth mode` step runs before checkout, reads all three secret types via env vars (App context cannot reference `secrets.*`), emits `use-app=true|false`, and fails fast with a clear error if no auth path is provided.
+- [ ] A `Mint GitHub App installation token` step uses `actions/create-github-app-token@v1`, is gated on `steps.auth-mode.outputs.use-app == 'true'`, and uses `${{ inputs.project-owner }}` (or fallback `'HoneyDrunkStudios'`) for the `owner` input.
+- [ ] The `Mirror labels to The Hive custom fields` step's `HIVE_FIELD_MIRROR_TOKEN` env reads `${{ steps.app-token.outputs.token || secrets.hive-field-mirror-token || secrets.HIVE_FIELD_MIRROR_TOKEN }}`, preferring the App token.
+
+### Caller workflows (9 repos)
+
+- [ ] `HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml` (caller block) passes `app-id`, `app-private-key`, and `hive-field-mirror-token` to the reusable workflow.
+- [ ] `HoneyDrunk.Pulse/.github/workflows/hive-field-mirror.yml` updated identically.
+- [ ] `HoneyDrunk.Notify/.github/workflows/hive-field-mirror.yml` updated identically.
+- [ ] `HoneyDrunk.Vault/.github/workflows/hive-field-mirror.yml` updated identically.
+- [ ] `HoneyDrunk.Transport/.github/workflows/hive-field-mirror.yml` updated identically.
+- [ ] `HoneyDrunk.Data/.github/workflows/hive-field-mirror.yml` updated identically.
+- [ ] `HoneyDrunk.Auth/.github/workflows/hive-field-mirror.yml` updated identically.
+- [ ] `HoneyDrunk.Web.Rest/.github/workflows/hive-field-mirror.yml` updated identically.
+- [ ] `HoneyDrunk.Kernel/.github/workflows/hive-field-mirror.yml` updated identically.
+
+### Verification
+
+- [ ] After merge, opening a label-trigger event on a test issue produces a workflow run whose log contains `Auth path: GitHub App` (the new step's success message).
+- [ ] `gh api -H 'Authorization: Bearer <PAT>' rate_limit --jq .resources.graphql.remaining` against the developer's PAT shows the same value before and after a label-mirror run on a test issue, confirming the workflow no longer draws from that pool.
+- [ ] The PAT fallback path still works when `HIVE_APP_ID` is unset on a test caller (verified by deliberately omitting the secret in a throwaway branch caller).
+- [ ] `actionlint` passes on every modified workflow file.
+
+### Documentation
+
+- [ ] `HoneyDrunk.Actions/docs/CHANGELOG.md` gets a new `### Changed` entry under the next-version section: `hive-field-mirror.yml: accept app-id + app-private-key for App-auth path; PAT path remains as fallback.`
+- [ ] No README or consumer-usage update needed — `hive-field-mirror.yml` is not currently documented as a consumer-facing reusable workflow (it's only invoked from auto-generated callers in the Grid, not by external repos).
+
+## Human Prerequisites
+
+- [ ] **None** — the GitHub App (`HIVE_APP_ID` + `HIVE_APP_PRIVATE_KEY` org secrets) was already provisioned during the file-packets hardening work (Actions#57) and is installed on every Grid repo with the scopes hive-field-mirror needs. Verify by checking org settings → Secrets → Actions: both `HIVE_APP_ID` and `HIVE_APP_PRIVATE_KEY` should be present and visible to all Grid repos.
+
+## Dependencies
+
+None. This packet is independently shippable. Mergeable in any order relative to the other two standalone packets in this flight (`2026-04-28-actions-hive-field-mirror-cache-and-rest.md` and `2026-04-28-actions-hive-field-mirror-coalesce-design.md`).
+
+## Constraints
+
+- **Mirror the file-packets pattern verbatim where possible.** Steps, env-var plumbing, and the auth-mode detection idiom are already proven there. Re-deriving means re-discovering the same edge cases.
+- **Backwards compatibility is non-negotiable.** Every existing caller must keep working through the merge — the PAT fallback chain stays in place. A subsequent hygiene packet can drop it once a quarter passes with no PAT-path runs observed.
+- **Hardcoded `'HoneyDrunkStudios'` is the fallback owner**, not the primary value. Use `inputs.project-owner` first to stay consistent with the rest of the workflow's parameterization.
+- **No ADR cross-references in code or workflow comments.** Per the established convention (one of the user's persistent feedback items), decision context belongs in this packet and the PR description, not in YAML comments.
+- **Public repo.** The App's private key is never echoed in logs, never committed, never appears in any error message. `actions/create-github-app-token@v1` handles redaction natively.
+- **Don't bypass `actionlint`.** Fix lint findings rather than suppressing them.
+
+## Referenced Pattern: Actions#57
+
+Actions#57 (closed 2026-04-26) hardened `file-packets.yml` with the same App-auth pattern. The relevant lines in that workflow:
+
+- Lines 41–61: `secrets:` block with `app-id` / `app-private-key` as optional, `hive-field-mirror-token` as optional fallback.
+- Lines 93–113: `Detect auth mode` step routing secret presence through env vars to emit `use-app` step output.
+- Lines 115–122: `Mint GitHub App installation token` step using `actions/create-github-app-token@v1`, gated on `steps.auth-mode.outputs.use-app == 'true'`.
+- Lines 146–147: `GH_TOKEN` and `HIVE_FIELD_MIRROR_TOKEN` env vars on downstream steps coalesce App token first, PAT fallback second.
+
+Replicate that pattern into `hive-field-mirror.yml`. The two workflows are structurally similar enough that the diff is essentially a copy-paste of the auth scaffolding around the existing per-issue mirror logic.
+
+## Agent Handoff
+
+**Objective:** Migrate `hive-field-mirror.yml` reusable workflow + 9 callers to GitHub App auth, with the existing PAT path preserved as fallback.
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Actions`, branch from `main`. The 9 caller-repo edits are also part of the same logical change; either include them in the same PR if possible (cross-repo via the same author) or split into per-repo follow-up PRs explicitly listed in the main PR description.
+
+**Context:**
+- Goal: stop charging the field-mirror workflow's GraphQL traffic to the dev's personal PAT pool, which on 2026-04-28 hit 5,059/5,000 and blocked all interactive `gh` work.
+- Pattern source: `HoneyDrunk.Actions/.github/workflows/file-packets.yml` lines 41–61, 93–131, 146–147 (Actions#57, closed 2026-04-26).
+- This is one of three standalone packets addressing the same incident; see also the metadata-caching/REST-migration packet and the coalesce-design packet, both shippable independently.
+- ADRs: none. This is CI hardening, not an architectural decision.
+
+**Acceptance Criteria:** See `## Acceptance Criteria` above.
+
+**Dependencies:** None.
+
+**Constraints:**
+- Mirror the file-packets pattern verbatim. Don't re-derive the auth-mode-detection idiom — copy lines 93–113 of `file-packets.yml` and adapt only the env-var names where needed.
+- Workflow-level `if:` expressions cannot reference the `secrets` context. This is the reason `Detect auth mode` exists as a separate step — work around the limitation, don't fight it.
+- The PAT fallback chain stays in place. `${{ steps.app-token.outputs.token || secrets.hive-field-mirror-token || secrets.HIVE_FIELD_MIRROR_TOKEN }}` is the canonical resolution order.
+- No ADR cross-references in code or YAML comments.
+- Public repo; the App private key never appears in logs.
+- Don't bypass `actionlint` — fix findings.
+- The existing `hive-project-mirror.sh` script reads `HIVE_FIELD_MIRROR_TOKEN` from env (line 7); it does not need changes for this packet — the workflow-side env-var resolution is enough.
+
+**Key Files:** see `## Key Files` above.
+
+**Contracts:**
+- The reusable workflow's `workflow_call` interface gains two optional secrets (`app-id`, `app-private-key`) and flips two existing secrets from required to optional. No removal — pure addition + relaxation, fully backwards-compatible.
+- The internal `HIVE_FIELD_MIRROR_TOKEN` env var on the mirror step is the only contract `hive-project-mirror.sh` cares about; its resolution chain changes from `secrets || legacy_secrets` to `app_token || secrets || legacy_secrets`.

--- a/generated/issue-packets/active/standalone/2026-04-28-actions-hive-field-mirror-cache-and-rest.md
+++ b/generated/issue-packets/active/standalone/2026-04-28-actions-hive-field-mirror-cache-and-rest.md
@@ -1,0 +1,389 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["chore", "tier-2", "ops", "automation", "ci-cd"]
+dependencies: []
+adrs: []
+wave: 1
+initiative: standalone
+node: honeydrunk-actions
+---
+
+# CI Change: Cache project metadata and migrate label writes to REST in `hive-project-mirror.sh`
+
+## Summary
+
+`hive-project-mirror.sh` is invoked once per `issues:` event — every label add/remove, every issue body edit, every open. On every invocation it re-resolves The Hive's project ID, the full field list, and per-field option lists by calling `gh project view`, `gh project field-list`, and `gh api graphql` queries (script lines 160–271). Project + field IDs never change; option lists change only when a new Initiative slug or Wave value is introduced. This packet (a) caches the stable metadata in a JSON file checked into `HoneyDrunk.Actions` (refreshed on a weekly cron + manual dispatch) and reads from cache on every per-issue invocation, and (b) migrates the label-write paths that have a REST equivalent off GraphQL onto the separate `core` REST pool. Together these reduce per-event GraphQL points by an estimated 50–70% and shift the residual cost off whichever pool the workflow runs against.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Actions` — both files live here.
+
+## Target Workflow
+
+**Files modified:**
+
+- `HoneyDrunk.Actions/scripts/hive-project-mirror.sh`
+- `HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml`
+
+**Files created:**
+
+- `HoneyDrunk.Actions/.github/config/hive-project-metadata.json` (cached project + field IDs + option IDs)
+- `HoneyDrunk.Actions/.github/workflows/refresh-hive-project-metadata.yml` (weekly cron + workflow_dispatch to refresh the cache)
+
+**Family:** automation (board-mirror)
+
+## Motivation
+
+A label-mirror invocation on a typical packet performs roughly:
+
+- 1× `gh api repos/.../issues/N` (REST — cheap, draws from the `core` pool, line 112)
+- 1× `gh project view N --owner ... --format json` (GraphQL — expensive; ID lookup, line 163)
+- 1× `gh project field-list N --owner ... --format json` (GraphQL — even more expensive; pulls every field with options, line 202)
+- 1× `addProjectV2ItemById` mutation OR 1× `projectItems` lookup (GraphQL, lines 175 and 187)
+- For Initiative options that don't yet exist: 1× field-options query + 1× `updateProjectV2Field` mutation (lines 234, 267)
+- N× `updateProjectV2ItemFieldValue` mutations, one per field being mirrored (Wave, Tier, Node, Initiative, ADR, Actor — up to 6 calls, lines 282–296)
+
+Every call charges the workflow's token pool. Steps 2 and 3 are pure metadata waste — the values they return are stable across invocations and across packets.
+
+The Actions#57 hardening introduced `HIVE_PROJECT_METADATA_JSON` as an env-var passed from `file-packets.sh` into `hive-project-mirror.sh` (script lines 160–164 and 199–203 already handle the cached path). That works for *batch* invocations from `file-packets.sh` because the parent script can resolve once and pass to every child invocation. It does **not** work for the per-issue `hive-field-mirror.yml` path — there is no parent caching layer because every issue event is its own workflow run.
+
+This packet generalizes the cache: persist the metadata to a JSON file in `HoneyDrunk.Actions` itself, refresh it on a schedule, read from disk on every per-event invocation. The shape of the JSON matches what `HIVE_PROJECT_METADATA_JSON` already expects, so the script's existing fast-path is reused with zero refactor.
+
+REST migration is a smaller win, included here because the same script is the touch point. Specifically: the issue-fetch path on line 112 already uses REST (`gh api repos/.../issues/N`). Anything else that has a REST equivalent should follow suit — the `addProjectV2ItemById`, `projectItems` lookup, and `updateProjectV2ItemFieldValue` mutations are all ProjectsV2-specific and have **no REST equivalent** (Projects v2 is GraphQL-only; the legacy REST Projects API was sunset in 2022). So the REST opportunity inside `hive-project-mirror.sh` is narrower than the original framing: there is nothing to migrate inside the script. The actual REST migration is for **label writes and label reads** where the workflow currently uses GraphQL — but `hive-project-mirror.sh` does not write labels (it reads them from `ISSUE_JSON` already fetched via REST on line 112). So the "migrate label writes to REST" work in this packet reduces to: **document the constraint** in a top-of-script comment so the next agent doesn't waste effort trying.
+
+In short: this packet's net is **(a) the cache** — the cache is the real win — **(b) a documentation note** explaining why label writes can't move to REST inside this script (Projects v2 is GraphQL-only), and **(c) a refresh workflow** that keeps the cache current.
+
+## Proposed Implementation
+
+### Phase 1 — Cache file shape
+
+Create `HoneyDrunk.Actions/.github/config/hive-project-metadata.json` with this shape (matches `HIVE_PROJECT_METADATA_JSON` env var consumers already in the script):
+
+```json
+{
+  "_meta": {
+    "schema_version": "1.0",
+    "last_refreshed_utc": "2026-04-28T00:00:00Z",
+    "project_owner": "HoneyDrunkStudios",
+    "project_number": 4,
+    "refresh_workflow": ".github/workflows/refresh-hive-project-metadata.yml"
+  },
+  "project": {
+    "id": "PVT_kwD..."
+  },
+  "fields": [
+    {
+      "id": "PVTSSF_lAD...",
+      "name": "Wave",
+      "options": [
+        { "id": "abc123", "name": "Wave 1" },
+        { "id": "def456", "name": "Wave 2" },
+        { "id": "ghi789", "name": "Wave 3" },
+        { "id": "jkl012", "name": "N/A" }
+      ]
+    },
+    { "id": "...", "name": "Tier", "options": [...] },
+    { "id": "...", "name": "Node", "options": [...] },
+    { "id": "...", "name": "ADR", "options": [] },
+    { "id": "...", "name": "Initiative", "options": [...] },
+    { "id": "...", "name": "Actor", "options": [...] }
+  ]
+}
+```
+
+The shape mirrors the existing `gh project view` + `gh project field-list` outputs that the script's `jq` queries already consume. The script's existing branches at lines 160–164 and 199–203 already select between live-fetch and cached paths via `HIVE_PROJECT_METADATA_JSON`. The new cache is fed into that env var by the workflow before the script runs.
+
+### Phase 2 — `hive-field-mirror.yml` reads the cache
+
+In the reusable workflow, after the existing `Checkout HoneyDrunk.Actions repository` step, add a step that loads the cache file into the `HIVE_PROJECT_METADATA_JSON` env var:
+
+```yaml
+      - name: Load cached project metadata
+        id: load-cache
+        env:
+          CACHE_PATH: ./honeydrunk-actions/.github/config/hive-project-metadata.json
+        run: |
+          set -euo pipefail
+          if [[ ! -f "$CACHE_PATH" ]]; then
+            echo "::warning::Project metadata cache not found at $CACHE_PATH; falling back to live GraphQL lookup."
+            echo "use-cache=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Sanity-check the schema and freshness before promoting to env.
+          if ! jq -e '._meta.schema_version == "1.0"' "$CACHE_PATH" >/dev/null; then
+            echo "::warning::Cache schema mismatch; falling back to live lookup."
+            echo "use-cache=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Hard cap: if the cache is older than 14 days, refuse it and fall back.
+          # Refresh runs weekly; 14 days is one missed cron + one day of grace.
+          LAST_REFRESH="$(jq -r '._meta.last_refreshed_utc' "$CACHE_PATH")"
+          NOW_EPOCH="$(date -u +%s)"
+          REFRESH_EPOCH="$(date -u -d "$LAST_REFRESH" +%s)"
+          AGE_DAYS=$(( (NOW_EPOCH - REFRESH_EPOCH) / 86400 ))
+          if (( AGE_DAYS > 14 )); then
+            echo "::warning::Cache is ${AGE_DAYS} days old (max 14); falling back to live lookup. Run refresh-hive-project-metadata.yml to fix."
+            echo "use-cache=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "HIVE_PROJECT_METADATA_JSON<<METADATA_EOF"
+            cat "$CACHE_PATH"
+            echo "METADATA_EOF"
+          } >> "$GITHUB_ENV"
+          echo "use-cache=true" >> "$GITHUB_OUTPUT"
+          echo "Loaded project metadata cache (age: ${AGE_DAYS} days)."
+```
+
+The existing `Mirror labels to The Hive custom fields` step needs no change — `hive-project-mirror.sh` already detects `HIVE_PROJECT_METADATA_JSON` and uses it instead of live-fetching (script lines 160–164 and 199–203).
+
+The `use-cache=false` fallback path keeps the workflow correct when the cache is missing, malformed, or stale beyond the 14-day cap — the script's existing behavior (live `gh project view` + `gh project field-list`) takes over. This is the safety net for "refresh workflow has been broken for two weeks and nobody noticed."
+
+### Phase 3 — `refresh-hive-project-metadata.yml` (new workflow)
+
+Author a new workflow at `.github/workflows/refresh-hive-project-metadata.yml` in `HoneyDrunk.Actions`:
+
+```yaml
+name: Refresh Hive Project Metadata Cache
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays at 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write   # commit the refreshed cache file
+
+concurrency:
+  group: refresh-hive-project-metadata
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect auth mode
+        id: auth-mode
+        env:
+          APP_ID: ${{ secrets.HIVE_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.HIVE_APP_PRIVATE_KEY }}
+          PAT_FALLBACK: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" ]]; then
+            echo "use-app=true" >> "$GITHUB_OUTPUT"
+          elif [[ -n "${PAT_FALLBACK}" ]]; then
+            echo "use-app=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::No auth available"
+            exit 1
+          fi
+
+      - name: Mint App token
+        id: app-token
+        if: steps.auth-mode.outputs.use-app == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HIVE_APP_ID }}
+          private-key: ${{ secrets.HIVE_APP_PRIVATE_KEY }}
+          owner: HoneyDrunkStudios
+
+      - name: Refresh metadata cache
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.HIVE_FIELD_MIRROR_TOKEN }}
+          PROJECT_OWNER: HoneyDrunkStudios
+          PROJECT_NUMBER: 4
+          CACHE_PATH: .github/config/hive-project-metadata.json
+        run: |
+          set -euo pipefail
+          PROJECT_JSON="$(gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json)"
+          FIELDS_JSON="$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json)"
+          NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          jq -n \
+            --arg now "$NOW" \
+            --arg owner "$PROJECT_OWNER" \
+            --argjson number "$PROJECT_NUMBER" \
+            --argjson project "$PROJECT_JSON" \
+            --argjson fields "$FIELDS_JSON" \
+            '{
+              _meta: {
+                schema_version: "1.0",
+                last_refreshed_utc: $now,
+                project_owner: $owner,
+                project_number: $number,
+                refresh_workflow: ".github/workflows/refresh-hive-project-metadata.yml"
+              },
+              project: { id: $project.id },
+              fields: $fields.fields
+            }' > "$CACHE_PATH"
+
+      - name: Commit cache update
+        env:
+          CACHE_PATH: .github/config/hive-project-metadata.json
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- "$CACHE_PATH"; then
+            echo "Cache unchanged."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- "$CACHE_PATH"
+          git commit -m "chore(hive): refresh project metadata cache [skip ci]"
+          git push
+```
+
+Three notes on this workflow:
+
+1. **Token plumbing.** The refresh workflow itself uses App auth where available, exactly like every other Hive-touching workflow post-Actions#57. The PAT path is the fallback. App scopes already grant `Projects: Read` (org-level) which is sufficient for `gh project view` and `gh project field-list`.
+2. **Skip-CI on the refresh commit.** `[skip ci]` in the commit message prevents the commit from triggering the `pr-core` family on `HoneyDrunk.Actions` (workflow YAML changes pass `pr-core` cheaply, but the cache file is data-only and need not).
+3. **Concurrency group.** `cancel-in-progress: false` so a `workflow_dispatch` invocation right after the cron does not abort an in-flight refresh.
+
+### Phase 4 — Script-side documentation
+
+Add a comment block at the top of `hive-project-mirror.sh` (after the existing `set -euo pipefail` and before the variable declarations on line 4) explaining the GraphQL-only nature of Projects v2 and pointing readers at the cache mechanism:
+
+```bash
+# Projects v2 is GraphQL-only — the legacy REST Projects API was sunset in
+# 2022. Field updates (updateProjectV2ItemFieldValue), item adds
+# (addProjectV2ItemById), and option ensures (updateProjectV2Field) cannot be
+# moved off GraphQL. To reduce per-invocation GraphQL cost, this script reads
+# the project + field + option metadata from a cached JSON blob via the
+# HIVE_PROJECT_METADATA_JSON env var when set. The cache is refreshed weekly
+# by .github/workflows/refresh-hive-project-metadata.yml. When the env var is
+# absent, the script live-fetches via gh project view + gh project field-list
+# (the original behavior — preserved for standalone CLI invocation).
+```
+
+This is the "REST migration" check-box for this packet — it's a constraint discovery, not a code migration. The constraint is permanent; documenting it prevents the next person from spending an afternoon proving the same dead end.
+
+## Consumer Impact
+
+Cache-aware. Existing callers (the 9 caller workflows from packet `2026-04-28-actions-hive-field-mirror-app-auth.md`) need **no further changes** — the workflow-level cache load is internal to the reusable workflow. When this packet merges, every consuming repo benefits automatically on the next mirror run.
+
+The new `refresh-hive-project-metadata.yml` is a self-contained workflow; no consumers.
+
+## Breaking Change?
+
+- [ ] Yes — consumers need to update their caller workflows
+- [x] No — backward compatible (cache is internal; live-fetch fallback handles missing/stale cache)
+
+## Key Files
+
+- `HoneyDrunk.Actions/scripts/hive-project-mirror.sh` (modified — add docstring; no behavior change since the cache-consuming branches at lines 160–164 and 199–203 already exist from Actions#57)
+- `HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml` (modified — add `Load cached project metadata` step)
+- `HoneyDrunk.Actions/.github/config/hive-project-metadata.json` (new — initial population by manually running the new refresh workflow as a `workflow_dispatch` immediately after merge)
+- `HoneyDrunk.Actions/.github/workflows/refresh-hive-project-metadata.yml` (new)
+- `HoneyDrunk.Actions/docs/CHANGELOG.md` (append entry)
+
+## NuGet Dependencies
+
+None — shell + GitHub Actions YAML + JSON only.
+
+## Acceptance Criteria
+
+### Cache file
+
+- [ ] `HoneyDrunk.Actions/.github/config/hive-project-metadata.json` exists with `_meta.schema_version: "1.0"`, valid `_meta.last_refreshed_utc`, `project.id`, and a populated `fields` array containing every field on The Hive (Wave, Tier, Node, ADR, Initiative, Actor, plus the default Status/Title/etc.).
+- [ ] Each field entry has the same shape `gh project field-list ... --format json` returns: `id`, `name`, and (where applicable) `options[]` with `id` and `name`.
+- [ ] The file is checked into `main` with the bot author after the first manual `workflow_dispatch` of the refresh workflow.
+
+### Refresh workflow
+
+- [ ] `.github/workflows/refresh-hive-project-metadata.yml` exists with the canonical permissions block (`contents: write` only — required to commit the refreshed JSON; no other writes), App-auth-with-PAT-fallback, weekly cron `0 6 * * 1`, and `workflow_dispatch`.
+- [ ] A manual `workflow_dispatch` run produces a non-zero diff on the cache file (or "unchanged" if metadata genuinely has not changed) and pushes a `chore(hive): refresh project metadata cache [skip ci]` commit.
+- [ ] If the workflow fails (auth missing, gh project view 404, etc.), it exits non-zero and emits a clear error message — does not silently leave the cache stale.
+- [ ] `concurrency.group: refresh-hive-project-metadata`, `cancel-in-progress: false`.
+
+### Mirror workflow consumes the cache
+
+- [ ] `hive-field-mirror.yml` has a new `Load cached project metadata` step that runs after `Checkout HoneyDrunk.Actions repository` and before `Resolve issue URL`.
+- [ ] The step checks the cache file's existence, schema version, and age (max 14 days), and either populates `HIVE_PROJECT_METADATA_JSON` env var or falls back with a clear `::warning::` and `use-cache=false` step output.
+- [ ] When the cache is loaded, `hive-project-mirror.sh` skips `gh project view` and `gh project field-list` calls (verified by inspecting the workflow run log — those lines should be absent).
+- [ ] When the cache is absent or stale, the script's existing live-fetch path runs. Verified by deliberately removing the cache file in a test branch and observing the warning + successful live run.
+
+### Script documentation
+
+- [ ] `scripts/hive-project-mirror.sh` has a comment block (lines 4–11 or thereabouts) explaining the Projects v2 GraphQL-only constraint, the cache mechanism, and the env-var contract.
+
+### Verification (post-merge)
+
+- [ ] Trigger a `labeled` event on a test issue in any consuming repo. Inspect the resulting `Hive Field Mirror` run log: `Loaded project metadata cache (age: 0 days).` should appear.
+- [ ] The same run's `gh api graphql` call count drops measurably vs. a pre-merge run on a similar issue — capture before/after numbers in the PR description if possible (best-effort; not a hard gate).
+- [ ] `actionlint` passes on every modified and new workflow file.
+- [ ] `shellcheck` passes on `hive-project-mirror.sh` (or any pre-existing exclusions are preserved).
+
+### Documentation
+
+- [ ] `HoneyDrunk.Actions/docs/CHANGELOG.md` gets a new entry: `### Added — refresh-hive-project-metadata.yml weekly cache refresh; .github/config/hive-project-metadata.json. ### Changed — hive-field-mirror.yml loads cached project metadata, falling back to live GraphQL when cache is absent or stale.`
+- [ ] No README update required.
+
+## Human Prerequisites
+
+- [ ] After merge, manually trigger the new `refresh-hive-project-metadata.yml` workflow once via `workflow_dispatch` to populate the initial cache file. The PR cannot ship the JSON itself because the cache is bot-generated; the human action is one click in the Actions tab. The mirror workflow's fallback path keeps things working in the interim.
+
+## Dependencies
+
+None. This packet is independently shippable. It does not require packet `2026-04-28-actions-hive-field-mirror-app-auth.md` to land first — caching reduces drain regardless of which token pool the workflow runs against. Shipping in either order is fine. Maximum benefit is achieved when both have shipped, but neither is a hard prerequisite for the other.
+
+## Constraints
+
+- **Projects v2 is GraphQL-only.** The legacy REST Projects API was sunset in 2022. Do not attempt to migrate `addProjectV2ItemById`, `updateProjectV2ItemFieldValue`, or `updateProjectV2Field` to REST — there is no REST endpoint for them. The only REST opportunity in this script is the issue-fetch on line 112, which is already REST.
+- **The cache is data, not code.** It must not contain secrets, tokens, or any value that could change without the project owner's intent. Schema validation in the load step is the safety net.
+- **14-day staleness cap.** If the refresh workflow has been broken for more than two weeks, the mirror falls back to live-fetch rather than trusting drift-prone cached data. This is non-negotiable — silent staleness is the worst failure mode.
+- **App auth is preferred but not required for the refresh workflow.** The refresh runs once a week; the PAT-fallback path is acceptable if App secrets are momentarily missing.
+- **`[skip ci]` on the refresh commit.** The cache file is data, not source. `pr-core` has no business running on a cache refresh.
+- **No ADR cross-references in code or YAML comments.** Per the established convention.
+- **Public repo.** The cache file contains GraphQL node IDs (e.g. `PVT_kwD...`) which are non-secret — these are listed in board URLs visible to anyone with read access to the project. Confirm this on first refresh and proceed.
+- **Don't bypass `actionlint` or `shellcheck`.** Fix findings rather than suppressing them.
+
+## Referenced Pattern: Actions#57
+
+Actions#57 (closed 2026-04-26) introduced the `HIVE_PROJECT_METADATA_JSON` env-var contract that this packet's cache file feeds. The script's existing detection paths at lines 160–164 (`PROJECT_JSON` source selection) and 199–203 (`FIELDS_JSON` source selection) are the consumers. This packet does **not** modify the script's cache-consumption logic — it only feeds the env var from disk instead of from `file-packets.sh`'s in-memory resolution.
+
+## Out of Scope
+
+- **Cross-repo label writes** — outside this script. If any future workflow does cross-repo label writes via GraphQL, that's a separate REST-migration packet against that workflow.
+- **Deleting `gh project view` / `gh project field-list` from the script entirely.** Live-fetch is the intentional fallback; do not remove it.
+- **Triggering the refresh from a webhook on project field changes.** Out of scope — weekly cron is sufficient for the current rate of board change. Re-evaluate if option lists start drifting more often than weekly.
+
+## Agent Handoff
+
+**Objective:** Cache stable Hive project metadata in a JSON file refreshed weekly; have `hive-field-mirror.yml` read it on every per-event invocation; document the Projects-v2 GraphQL-only constraint that prevents further REST migration inside this script.
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: cut per-event GraphQL cost for the Hive Field Mirror by ~50–70% by eliminating per-invocation metadata re-resolution. The cache contract already exists in `hive-project-mirror.sh` (Actions#57); this packet feeds it from disk.
+- Pattern source: Actions#57 introduced `HIVE_PROJECT_METADATA_JSON` for batch invocations. This packet generalizes it to per-event invocations via a checked-in cache file refreshed by a new weekly workflow.
+- This is one of three standalone packets addressing the 2026-04-28 GraphQL rate-limit incident; see also `2026-04-28-actions-hive-field-mirror-app-auth.md` and `2026-04-28-actions-hive-field-mirror-coalesce-design.md`. All three are independently shippable.
+- ADRs: none. CI hardening, not architecture.
+
+**Acceptance Criteria:** see `## Acceptance Criteria` above.
+
+**Dependencies:** None.
+
+**Constraints:**
+- Projects v2 is GraphQL-only. Do not waste effort trying to REST-migrate the project-side mutations. The script's existing comment block (added by this packet) makes the constraint clear for future work.
+- `HIVE_PROJECT_METADATA_JSON` env var is the contract. The cache file's shape must match what the script's `jq` queries already consume — verify by running the live-fetch path once, capturing its output, and using that as the cache file's initial structure.
+- Schema versioning: `_meta.schema_version` is `"1.0"` from day one. Bump only on incompatible shape changes; the script's load step rejects mismatches.
+- 14-day staleness cap is a hard rule, not a guideline. Silent stale data is worse than a fallback to live-fetch.
+- The refresh workflow uses App auth (Actions#57 secrets `HIVE_APP_ID` / `HIVE_APP_PRIVATE_KEY`); PAT fallback is permitted.
+- Initial cache population is a human one-click via `workflow_dispatch` after merge — do not attempt to seed the JSON in the same PR by hand-crafting IDs. The bot-generated commit is the source of truth.
+- No ADR cross-references in code or YAML comments.
+- Public repo; the cache contains node IDs which are non-secret.
+- Don't bypass `actionlint` or `shellcheck`.
+
+**Key Files:** see `## Key Files` above.
+
+**Contracts:**
+- `HIVE_PROJECT_METADATA_JSON` env-var consumed by `hive-project-mirror.sh` lines 160–164 and 199–203 — fed by the new `Load cached project metadata` step in the workflow.
+- `_meta.schema_version` — string-equality check against `"1.0"` in the load step.
+- `_meta.last_refreshed_utc` — ISO-8601 UTC timestamp; consumed by the staleness check; produced by `date -u +%Y-%m-%dT%H:%M:%SZ` in the refresh workflow.
+- The cache file shape mirrors the existing `gh project view` + `gh project field-list` output structure — do not invent a new shape; harvest the live output and wrap it.

--- a/generated/issue-packets/filed-packets.json
+++ b/generated/issue-packets/filed-packets.json
@@ -49,5 +49,17 @@
   "generated/issue-packets/active/adr-0011-code-review-pipeline/05b-actions-out-of-band-label-fanout.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/56",
   "generated/issue-packets/active/adr-0011-code-review-pipeline/06-kernel-sonarcloud-onboarding.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Kernel/issues/22",
   "generated/issue-packets/active/adr-0011-code-review-pipeline/07-web-rest-sonarcloud-onboarding.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.Rest/issues/11",
-  "generated/issue-packets/active/standalone/2026-04-26-actions-file-packets-hardening.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/57"
+  "generated/issue-packets/active/standalone/2026-04-26-actions-file-packets-hardening.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/57",
+  "generated/issue-packets/active/adr-0012-grid-cicd-control-plane/01-architecture-adr-0012-acceptance.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/48",
+  "generated/issue-packets/active/adr-0012-grid-cicd-control-plane/02-architecture-github-notifications-runbook.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/49",
+  "generated/issue-packets/active/adr-0012-grid-cicd-control-plane/03-architecture-tracked-workflows-catalog.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/50",
+  "generated/issue-packets/active/adr-0012-grid-cicd-control-plane/04-actions-grid-health-aggregator.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/61",
+  "generated/issue-packets/active/adr-0012-grid-cicd-control-plane/05-actions-consumer-usage-refresh.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/62",
+  "generated/issue-packets/active/adr-0012-grid-cicd-control-plane/06-actions-action-pins-inventory.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/63",
+  "generated/issue-packets/active/adr-0012-grid-cicd-control-plane/07-actions-d4-retrofit-audit.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/64",
+  "generated/issue-packets/active/adr-0012-grid-cicd-control-plane/07a-actions-trivy-direct-cli-migration.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/65",
+  "generated/issue-packets/active/adr-0012-grid-cicd-control-plane/07b-actions-sbom-direct-cli-migration.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/66",
+  "generated/issue-packets/active/adr-0012-grid-cicd-control-plane/07c-actions-actionlint-docker-ref-decision.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/67",
+  "generated/issue-packets/active/adr-0012-grid-cicd-control-plane/08-architecture-caller-permissions-audit.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/51",
+  "generated/issue-packets/active/adr-0012-grid-cicd-control-plane/09-actions-node20-actions-bump.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/issues/68"
 }


### PR DESCRIPTION
…cope, and harden hive field mirror

Add product-strategist agent definition for opinionated product evaluation and opportunity scouting. Clarify in pdr-composer that all Nodes are candidate products, not privileging any single Node. Add ADR-0012 issue packets to filed-packets.json. Add CI change packets for hive-field-mirror: migrate to GitHub App auth with PAT fallback and introduce project metadata caching with weekly refresh, reducing GraphQL load and documenting Projects v2 GraphQL-only constraint.