### PR TITLE
docs(lore): register HoneyDrunk.Lore node and integration docs

### DIFF
--- a/catalogs/nodes.json
+++ b/catalogs/nodes.json
@@ -973,18 +973,18 @@
   },
   {
     "id": "honeydrunk-lore",
-    "type": "node",
+    "type": "application",
     "name": "HoneyDrunk.Lore",
     "public_name": "HoneyDrunk.Lore",
     "short": "LLM-compiled living knowledge wiki",
-    "description": "The Hive's compiled knowledge surface. Ingests raw sources, LLM-compiles into a structured browsable wiki, self-maintains indexes and backlinks, runs health checks, and answers complex queries. Living knowledge that grows with every interaction.",
+    "description": "Flat-file wiki maintained by LLMs. Ingests raw sources, compiles structured markdown, self-maintains indexes and backlinks, answers queries, and runs health checks. Consumed by agents and the solo developer as the ecosystem's compiled research surface.",
     "sector": "Meta",
     "signal": "Seed",
     "cluster": "knowledge",
     "energy": 0,
     "priority": 60,
     "flow": 0,
-    "tags": ["knowledge-base", "wiki", "llm-compiled", "obsidian", "markdown", "research", "self-maintaining"],
+    "tags": ["knowledge", "wiki", "lore", "ai", "flat-file", "obsidian"],
     "links": {
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore"
     },

--- a/catalogs/relationships.json
+++ b/catalogs/relationships.json
@@ -184,7 +184,7 @@
       "id": "honeydrunk-ai",
       "consumes": ["honeydrunk-kernel", "honeydrunk-vault"],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-agents", "honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-evals", "honeydrunk-sim"],
+      "consumed_by_planned": ["honeydrunk-agents", "honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-evals", "honeydrunk-sim", "honeydrunk-lore"],
       "blocked_by": [],
       "exposes": {
         "contracts": ["IChatClient", "IEmbeddingGenerator", "IModelProvider", "IInferenceResult", "IModelRouter", "IRoutingPolicy", "ModelCapabilityDeclaration"],
@@ -214,7 +214,7 @@
       "id": "honeydrunk-agents",
       "consumes": ["honeydrunk-kernel", "honeydrunk-ai", "honeydrunk-capabilities"],
       "consumed_by": [],
-      "consumed_by_planned": ["honeydrunk-flow", "honeydrunk-sim"],
+      "consumed_by_planned": ["honeydrunk-flow", "honeydrunk-sim", "honeydrunk-lore"],
       "blocked_by": [],
       "exposes": {
         "contracts": ["IAgent", "IAgentExecutionContext", "IAgentLifecycle", "IToolInvoker", "IAgentMemory"],

--- a/repos/HoneyDrunk.Lore/active-work.md
+++ b/repos/HoneyDrunk.Lore/active-work.md
@@ -1,0 +1,32 @@
+# HoneyDrunk.Lore — Active Work
+
+**Signal:** Seed — flat-file v1 in scaffold.
+
+## Current Status
+
+Active scaffolding under the `honeydrunk-lore-bringup` initiative. The repo exists at `HoneyDrunkStudios/HoneyDrunk.Lore` with directory layout (`raw/`, `wiki/`, `wiki/indexes/`, `output/`, `tools/`), `CLAUDE.md` schema doc, and `README.md`. No .NET code — Lore is flat-file-first by design.
+
+## Active Issues
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [HoneyDrunk.Lore#1](https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore/issues/1) | Scaffold: directory structure + CLAUDE.md schema doc | In progress (PR #2) |
+| [HoneyDrunk.Lore#2](https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore/issues/2) | Obsidian vault setup (human-only) | Open |
+| [HoneyDrunk.Lore#3](https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore/issues/3) | Scheduled ingest: daily agent to auto-compile `raw/` sources | Open |
+| [HoneyDrunk.Lore#4](https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore/issues/4) | sourcing-playbook.md — content curation guide | Open |
+| [HoneyDrunk.Lore#5](https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore/issues/5) | OpenClaw setup + Lore sourcing skill | Open |
+
+## On-Deck Work (after scaffold lands)
+
+- First real ingest pass — clip a handful of articles, let the agent compile, eyeball the output for style baseline
+- Establish a wiki page style guide once a few real pages exist (so future ingests have an example to match)
+- Wire scheduled ingest agent (HoneyDrunk.Lore#3) once Obsidian vault is producing daily input
+- Lint-pass cadence: weekly initially, scale based on volume
+
+## Initiative
+
+Part of the **honeydrunk-lore-bringup** initiative. Sequencing: scaffold (#1) → catalog registration (this packet) → Obsidian (#2) → sourcing playbook (#4) → OpenClaw (#5) → scheduled ingest (#3).
+
+## Conversion Path
+
+Lore is flat-file v1. When `HoneyDrunk.Knowledge` and `HoneyDrunk.Agents` reach Live, ingest delegates to `IDocumentIngester`, retrieval delegates to `IRetrievalPipeline`, and `CLAUDE.md` becomes agent configuration rather than the implementation. No code rewrite required — the verbs (ingest, compile, query, lint) are stable.

--- a/repos/HoneyDrunk.Lore/integration-points.md
+++ b/repos/HoneyDrunk.Lore/integration-points.md
@@ -13,7 +13,7 @@ How Lore connects to the rest of the Grid. Every item here is **planned** — Lo
 | **AI** | `IChatClient` | Inference for ingest synthesis, query answering, and lint reasoning | Planned — `AI` is Seed |
 | **Flow** | `IWorkflowEngine` | Orchestrate multi-step compile passes (ingest → consolidate → resolve contradictions → rebuild indexes) as durable workflows | Planned — `Flow` is Seed |
 
-Until those nodes exist, the operations defined in `HoneyDrunk.Lore/CLAUDE.md` are executed directly by Claude Code sessions and (eventually) a `CronCreate` scheduled trigger. There is no compile-time or runtime dependency on any Grid Node today.
+Until those nodes exist, the operations defined in [`HoneyDrunkStudios/HoneyDrunk.Lore/CLAUDE.md`](https://github.com/HoneyDrunkStudios/HoneyDrunk.Lore/blob/main/CLAUDE.md) (the schema doc inside the Lore repo, *not* this Architecture stub) are executed directly by Claude Code sessions and (eventually) a `CronCreate` scheduled trigger. There is no compile-time or runtime dependency on any Grid Node today.
 
 ## Exposes
 

--- a/repos/HoneyDrunk.Lore/integration-points.md
+++ b/repos/HoneyDrunk.Lore/integration-points.md
@@ -1,0 +1,38 @@
+# HoneyDrunk.Lore — Integration Points
+
+How Lore connects to the rest of the Grid. Every item here is **planned** — Lore is flat-file v1 and has no live integrations yet. Every row becomes a canary boundary once the corresponding upstream Node ships.
+
+## Consumes (planned)
+
+| Node | Contract | Purpose | Status |
+|------|----------|---------|--------|
+| **Knowledge** | `IDocumentIngester` | Replace flat-file ingest of `raw/` with a real document pipeline (parse, chunk, attribute) | Planned — `Knowledge` is Seed |
+| **Knowledge** | `IRetrievalPipeline` | Replace keyword scan over `wiki/` with hybrid retrieval (BM25 + embeddings + graph) | Planned — `Knowledge` is Seed |
+| **Knowledge** | `IKnowledgeStore` | Persist wiki content as a versioned knowledge store rather than raw markdown files | Planned — `Knowledge` is Seed |
+| **Agents** | `IAgent`, `IAgentExecutionContext` | Run compile / lint / query as named, lifecycle-managed agents on the Agents runtime | Planned — `Agents` is Seed |
+| **AI** | `IChatClient` | Inference for ingest synthesis, query answering, and lint reasoning | Planned — `AI` is Seed |
+| **Flow** | `IWorkflowEngine` | Orchestrate multi-step compile passes (ingest → consolidate → resolve contradictions → rebuild indexes) as durable workflows | Planned — `Flow` is Seed |
+
+Until those nodes exist, the operations defined in `HoneyDrunk.Lore/CLAUDE.md` are executed directly by Claude Code sessions and (eventually) a `CronCreate` scheduled trigger. There is no compile-time or runtime dependency on any Grid Node today.
+
+## Exposes
+
+Lore exposes no contracts. It is a leaf application — it consumes Nodes, it does not provide them.
+
+## Canary Coverage Required (when delegations land)
+
+- `Lore.Canary` → Knowledge: ingest a known source, verify a `wiki/` page is produced with attributable chunks
+- `Lore.Canary` → AI: run a query, verify `IChatClient` returns content with token-count telemetry
+- `Lore.Canary` → Agents: run a compile pass as a named agent, verify lifecycle hooks fire
+- `Lore.Canary` → Flow: run a multi-step compile workflow, verify state persists across a simulated restart
+
+## Conversion Plan
+
+The flat-file v1 keeps working while delegation lands incrementally. Order is dictated by upstream readiness, not by Lore-side priority:
+
+1. **AI Live** → swap inline LLM calls in agent prompts for `IChatClient` invocation
+2. **Knowledge Live** → swap flat `raw/` directory walk for `IDocumentIngester`; swap `wiki/` keyword scan for `IRetrievalPipeline`
+3. **Agents Live** → register compile / lint / query as `IAgent` implementations
+4. **Flow Live** → wrap multi-step compile in `IWorkflowEngine` for durability and human-in-the-loop checkpoints
+
+`CLAUDE.md` stays the single source of truth for operation semantics throughout. The verbs do not change.

--- a/repos/HoneyDrunk.Lore/overview.md
+++ b/repos/HoneyDrunk.Lore/overview.md
@@ -2,7 +2,7 @@
 
 **Sector:** Meta  
 **Version:** TBD  
-**Framework:** .NET 10.0 / Markdown  
+**Framework:** Markdown (flat-file v1; delegates to Grid Nodes when they ship — Lore itself never adds .NET code)  
 **Repo:** `HoneyDrunkStudios/HoneyDrunk.Lore`
 
 ## Purpose

--- a/routing/repo-discovery-rules.md
+++ b/routing/repo-discovery-rules.md
@@ -25,6 +25,7 @@ Rules for determining which repo(s) are affected by a given request.
 | workflow, CI, GitHub Actions, pipeline, PR check, release | `HoneyDrunk.Actions` |
 | website, Studios, Next.js, pages, blog | `HoneyDrunk.Studios` |
 | architecture, ADR, invariant, sector, catalog, routing | `HoneyDrunk.Architecture` |
+| lore, wiki, raw/, ingest, compile, lint, knowledge surface, living wiki | `HoneyDrunk.Lore` |
 
 ## Dependency Cascade Rules
 


### PR DESCRIPTION
Add HoneyDrunk.Lore to node catalog as flat-file wiki application, clarify type, description, and tags. Update relationships to reflect planned AI and Agents consumption. Add active-work.md and integration-points.md to track status, issues, and integration plans. Route lore-related requests to HoneyDrunk.Lore in repo-discovery-rules.md.