### PR TITLE
docs: frame Hive Sync as OpenClaw runtime

### DIFF
--- a/generated/issue-packets/active/adr-0014-hive-sync-rollout/01-architecture-rename-to-hive-sync.md
+++ b/generated/issue-packets/active/adr-0014-hive-sync-rollout/01-architecture-rename-to-hive-sync.md
@@ -15,7 +15,7 @@ node: honeydrunk-architecture
 # Feature: Rename `initiatives-sync` agent to `hive-sync`
 
 ## Summary
-Rename the `.claude/agents/initiatives-sync.md` agent to `.claude/agents/hive-sync.md` (verbatim copy + delete), rename the `.github/workflows/initiatives-sync.yml` scheduled workflow to `hive-sync.yml`, update the agent capability matrix to swap the row, and propagate the rename across cross-references in `CLAUDE.md`, `AGENTS.md`, and other repo-level documents. **No behavior change.** The agent still does only initiative reconciliation after this packet — Phases 2-6 add the new responsibilities. **ADR-0014 stays in `Proposed` status throughout the rollout** and auto-flips to `Accepted` via the Phase 5 auto-flip logic on the first sync run after Packet 06 closes, treated identically to every other Proposed ADR.
+Rename the `.claude/agents/initiatives-sync.md` agent to `.claude/agents/hive-sync.md` (verbatim copy + delete), retire the `.github/workflows/initiatives-sync.yml` Anthropic/Claude-Code pipeline, add an OpenClaw runbook for the scheduled/manual `hive-sync` job, update the agent capability matrix to swap the row, and propagate the rename across cross-references in `CLAUDE.md`, `AGENTS.md`, and other repo-level documents. **No behavior change.** The agent still does only initiative reconciliation after this packet — Phases 2-6 add the new responsibilities. **ADR-0014 stays in `Proposed` status throughout the rollout** and auto-flips to `Accepted` via the Phase 5 auto-flip logic on the first sync run after Packet 06 closes, treated identically to every other Proposed ADR.
 
 ## Target Repo
 `HoneyDrunkStudios/HoneyDrunk.Architecture`
@@ -24,7 +24,7 @@ Rename the `.claude/agents/initiatives-sync.md` agent to `.claude/agents/hive-sy
 
 ADR-0014 broadens the sync agent's mandate from initiative-only reconciliation to full Hive board reconciliation, packet lifecycle management, non-initiative item tracking, and Proposed-ADR queue surfacing. The rename from `initiatives-sync` to `hive-sync` is the first step — it makes the broader scope discoverable from the agent name itself, and it gives subsequent phases a stable target file (`hive-sync.md`) to build on.
 
-This packet is the entry point for the six-phase rollout. It is a **pure rename**: agent file renamed verbatim with seven targeted name-change edits, workflow file renamed verbatim with two targeted edits, capability-matrix row swapped, and cross-references propagated. No behavior change; no invariants added; ADR-0014 stays in `Proposed` status until the Phase 5 auto-flip logic fires after Packet 06 closes.
+This packet is the entry point for the six-phase rollout. It is mostly a **pure rename**, plus one intentional runtime change: `hive-sync` is run by OpenClaw as a scheduled/manual agent job instead of by a GitHub Actions workflow that calls the Anthropic API. The agent file is renamed verbatim with targeted name-change edits, the CI workflow is removed, the OpenClaw runbook is added, the capability-matrix row is swapped, and cross-references are propagated. No reconciliation behavior changes; no invariants added; ADR-0014 stays in `Proposed` status until the Phase 5 auto-flip logic fires after Packet 06 closes.
 
 ## Scope
 
@@ -40,24 +40,26 @@ All edits are in the `HoneyDrunk.Architecture` repo. No code (no `.cs` files). N
    - Change the opening paragraph from `You are the **Initiatives Sync** agent.` to `You are the **Hive Sync** agent.`
    - Change the branch-name template from `chore/initiatives-sync-$(date +%Y-%m-%d)` to `chore/hive-sync-$(date +%Y-%m-%d)`.
    - Change the PR title template from `chore: sync initiative progress ($(date +%Y-%m-%d))` to `chore: sync hive state ($(date +%Y-%m-%d))`.
-   - Change the PR-body link from `the **initiatives-sync** agent via [agent-run]` to `the **hive-sync** agent via [agent-run]`.
-   - Change the `agent-run` link in the PR body from `agent: initiatives-sync` reference to `agent: hive-sync` (the link targets the same workflow file).
+   - Change the PR-body wording from `the **initiatives-sync** agent via [agent-run]` to `the **hive-sync** agent via OpenClaw`.
    - Change the Output Summary heading from `## Initiatives Sync — {date}` to `## Hive Sync — {date}`.
 3. Delete `.claude/agents/initiatives-sync.md`. The old file is removed in the same commit; no redirect, no compatibility shim.
 
-The Workflow body, Decision Rules, Constraints, and Gather Data steps are **not modified** in this packet. Subsequent phases (02, 03, 04) add new steps; this phase is a pure rename.
+The reconciliation Workflow body, Decision Rules, Constraints, and Gather Data steps are **not modified** in this packet beyond the targeted naming/PR wording above. Subsequent phases (02, 03, 04) add new reconciliation steps; this phase is a rename plus runtime migration to OpenClaw.
 
-### Part B — Rename the workflow file
+### Part B — Retire the GitHub Actions agent-run pipeline and document the OpenClaw job
 
-1. Read `.github/workflows/initiatives-sync.yml` in full.
-2. Create `.github/workflows/hive-sync.yml` containing the same content with the following edits and **no others**:
-   - Change the top-level `name:` field from `Initiatives Sync` to `Hive Sync`.
-   - Change the `with: agent:` value from `initiatives-sync` to `hive-sync`.
-3. Delete `.github/workflows/initiatives-sync.yml`.
+1. Read `.github/workflows/initiatives-sync.yml` in full so the removed runtime is reviewable.
+2. Delete `.github/workflows/initiatives-sync.yml`. Do **not** create `.github/workflows/hive-sync.yml`.
+3. Add `infrastructure/openclaw/hive-sync.md` documenting the OpenClaw runtime contract for this job:
+   - schedule: Monday/Thursday, matching the current cadence unless Oleg later changes it in OpenClaw cron;
+   - target: isolated OpenClaw `agentTurn`, not GitHub Actions;
+   - working repo: `HoneyDrunk.Architecture`;
+   - prompt source: `.claude/agents/hive-sync.md`;
+   - allowed tools/capabilities: read/write/edit files, run `gh`, run GraphQL via `gh api graphql`, create/update the reconciliation PR;
+   - output: concise executive summary to Oleg with files changed, PR URL, and any blockers;
+   - safety: read-only with respect to The Hive board except for PR creation in Architecture; no GraphQL mutations to board fields.
 
-The cron schedule (`0 6 * * 1,4`), `workflow_dispatch`, permissions block, the `uses:` reference to `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/agent-run.yml@main`, the `provider`, `model`, `max-turns`, and the `secrets` block are all preserved verbatim. The `INITIATIVES_SYNC_TOKEN` GitHub secret name is preserved — renaming the secret is out-of-scope and would require a coordinated org-secret update; the token's logical owner is the same agent under either name.
-
-**Cron-window note.** The schedule fires Monday/Thursday 06:00 UTC. If this PR sits open across a scheduled fire time, the run may be skipped: GitHub fires scheduled workflows from the default branch's view, and the deleted workflow on `main` is gone once merged while the new file on a feature branch does not fire on schedule. Workflows on feature branches do not fire on schedule. One missed run is acceptable; the next scheduled run after merge picks up under the new name. If you need the next sync immediately, manually dispatch `hive-sync.yml` after merge.
+The old workflow used `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/agent-run.yml@main`, `provider: claude`, and `secrets.ANTHROPIC_API_KEY`. That is intentionally retired. The GitHub Actions pipeline is no longer the brain; OpenClaw owns scheduling/manual execution, and GitHub remains the source of truth plus PR surface. If a CI file is ever reintroduced, it should be a dumb health/validation trigger, not an Anthropic API caller.
 
 ### Part C — Update the agent capability matrix
 
@@ -66,7 +68,7 @@ In `constitution/agent-capability-matrix.md`:
 1. **Replace the `initiatives-sync` row** in the main agent table (currently the last row) with a `hive-sync` row matching the structure of the other rows. The new row must read:
 
 ```markdown
-| **hive-sync** | Monday/Thursday schedule or manual dispatch | `gh` CLI issue states, `generated/issue-packets/filed-packets.json`, GraphQL Hive board state, `catalogs/grid-health.json`, `catalogs/nodes.json`, `adrs/ADR-*.md` frontmatter, initiative files | Updated `initiatives/` files via PR (new branch per run), packet moves (active → completed), `board-items.md`, `proposed-adrs.md` | Create issues, modify `filed-packets.json` entries (may update existing paths only), make architectural decisions |
+| **hive-sync** | OpenClaw Monday/Thursday schedule or manual OpenClaw dispatch | `gh` CLI issue states, `generated/issue-packets/filed-packets.json`, GraphQL Hive board state, `catalogs/grid-health.json`, `catalogs/nodes.json`, `adrs/ADR-*.md` frontmatter, initiative files | Updated `initiatives/` files via PR (new branch per run), packet moves (active → completed), `board-items.md`, `proposed-adrs.md` | Create issues, modify `filed-packets.json` entries (may update existing paths only), make architectural decisions |
 ```
 
    The "Consumes" and "Produces" columns reflect the **full** post-Phase-4 mandate, not the Phase-1 reality. Doing the capability-matrix update once at the rename avoids three subsequent matrix edits in Phases 2-4. The actual behavior at the end of this packet is still initiative-only reconciliation; the matrix forecasts the rollout.
@@ -84,14 +86,14 @@ Do initiative tracking files need reconciliation with GitHub issue states?
 
 ```
 Do Architecture-repo files need reconciliation with The Hive (initiatives, packet lifecycle, non-initiative items, Proposed-ADR queue)?
-  → yes → hive-sync (automated Monday/Thursday, or invoke manually)
+  → yes → hive-sync (OpenClaw scheduled Monday/Thursday, or invoke manually)
 ```
 
 3. **Update the Execution Rules bullet** that mentions the agent:
 
    Find: `and `initiatives-sync` (which runs via Claude Code Action in CI, creates a date-based branch, and opens or updates a PR for initiative-file reconciliation).`
 
-   Replace with: `and `hive-sync` (which runs via Claude Code Action in CI, creates a date-based branch, and opens or updates a PR for full Architecture-repo reconciliation with The Hive — initiative files, packet lifecycle, board items, and Proposed-ADR queue).`
+   Replace with: `and `hive-sync` (which runs via OpenClaw scheduled/manual agent job, creates a date-based branch, and opens or updates a PR for full Architecture-repo reconciliation with The Hive — initiative files, packet lifecycle, board items, and Proposed-ADR queue).`
 
 4. **Update the Agent-specific additional context table.** Replace the row:
 
@@ -115,7 +117,7 @@ Run a repo-wide search for the literal string `initiatives-sync` after Parts A-C
 - **Existing in-flight packets under `generated/issue-packets/active/`** — historical references to `initiatives-sync` in already-filed packets must not be edited (invariant 24: packets are immutable once filed). Leave them as-is. The set of files matching this rule includes any Wave 2+ packet of any other in-flight initiative; it is acceptable for those packets to mention `initiatives-sync` because they were filed before this rename.
 - **`CLAUDE.md`** at the repo root — if it references the agent by name, update to `hive-sync`.
 - **`AGENTS.md`** at the repo root — if it references the agent by name, update to `hive-sync`.
-- **Any `.github/workflows/*.yml` file other than the renamed one** — none should reference the agent by name today, but the search is the verifier.
+- **Any `.github/workflows/*.yml` file** — no workflow should call the sync agent after this packet. The old Anthropic-backed pipeline is intentionally removed; OpenClaw owns the runtime.
 
 The verifier command for the agent executing this packet:
 
@@ -131,7 +133,7 @@ On 2026-05-02, repo-level `CLAUDE.md`, `AGENTS.md`, and `README.md` do not conta
 
 This packet does **not** create `initiatives/board-items.md` or `initiatives/proposed-adrs.md`. Those files are introduced by Packets 03 and 04 respectively. This packet does not modify `constitution/invariants.md`. The two Hive-Sync invariants are added by Packets 02 and 03.
 
-This packet does **not** add lifecycle logic to the agent file. The Workflow steps in `hive-sync.md` after this packet are byte-identical to `initiatives-sync.md`'s Workflow steps (modulo the seven name-change edits in Part A). Validation: the Step 1 through Step 8 substantive content (the GraphQL queries, file lists, decision rules, output formats) must be unchanged after Part A.
+This packet does **not** add lifecycle logic to the agent file. The agent workflow steps in `hive-sync.md` after this packet are byte-identical to `initiatives-sync.md`'s Workflow steps (modulo the targeted name/PR wording edits in Part A). Validation: the Step 1 through Step 8 substantive content (the GraphQL queries, file lists, decision rules, output formats) must be unchanged after Part A.
 
 This packet does **not** flip ADR-0014's status. The ADR remains `Proposed` for the duration of the rollout and auto-flips on the first sync run after Packet 06 closes, via the Phase 5 auto-flip logic. Bundling the acceptance flip with any single phase was considered and rejected: an Accepted ADR with missing invariants/surfaces would misrepresent the on-disk state during the rollout. Letting the auto-flip handle ADR-0014 makes it the end-to-end validation that the new behavior works on the originating ADR.
 
@@ -162,10 +164,11 @@ In `initiatives/roadmap.md`, add an entry under the "Process & Tooling" or equiv
 
 ## Affected Files
 
-- `.claude/agents/hive-sync.md` — **new** (verbatim copy of `initiatives-sync.md` with seven targeted edits per Part A)
+- `.claude/agents/hive-sync.md` — **new** (verbatim copy of `initiatives-sync.md` with targeted name/PR wording edits per Part A)
 - `.claude/agents/initiatives-sync.md` — **deleted**
-- `.github/workflows/hive-sync.yml` — **new** (verbatim copy of `initiatives-sync.yml` with two targeted edits per Part B)
+- `infrastructure/openclaw/hive-sync.md` — **new** (OpenClaw scheduled/manual runtime contract)
 - `.github/workflows/initiatives-sync.yml` — **deleted**
+- `.github/workflows/hive-sync.yml` — **must not exist**
 - `constitution/agent-capability-matrix.md` — row swap, decision tree, execution rules, additional-context table
 - `CLAUDE.md` — if referenced
 - `AGENTS.md` — if referenced
@@ -173,7 +176,7 @@ In `initiatives/roadmap.md`, add an entry under the "Process & Tooling" or equiv
 - `initiatives/roadmap.md` — new entry under Process & Tooling
 - `CHANGELOG.md` — append entry referencing the agent rename (create the file if it does not yet exist; one bullet per phase across the rollout)
 
-The new agent file and the new workflow file are **created**; the old files are **deleted** in the same PR. Git diff for the rename is two creates + two deletes plus textual diffs in the new files where the seven/two name edits were made.
+The new agent file and the new OpenClaw runtime runbook are **created**; the old agent file and old GitHub Actions workflow are **deleted** in the same PR. Git diff for the rename is two creates + two deletes plus textual diffs in the new files where the targeted name/runtime edits were made.
 
 ## NuGet Dependencies
 
@@ -188,11 +191,11 @@ None. This is a docs/markdown/YAML change; no .NET projects touched.
 
 ## Acceptance Criteria
 
-- [ ] `.claude/agents/hive-sync.md` exists and contains the seven targeted edits described in Part A; all other content is byte-identical to the deleted `.claude/agents/initiatives-sync.md`.
+- [ ] `.claude/agents/hive-sync.md` exists and contains the targeted name/PR wording edits described in Part A; all other reconciliation logic is byte-identical to the deleted `.claude/agents/initiatives-sync.md`.
 - [ ] `.claude/agents/initiatives-sync.md` does not exist.
-- [ ] `.github/workflows/hive-sync.yml` exists with `name: Hive Sync` and `agent: hive-sync`.
 - [ ] `.github/workflows/initiatives-sync.yml` does not exist.
-- [ ] The cron schedule, permissions block, and `uses:` reference in `hive-sync.yml` are byte-identical to `initiatives-sync.yml`.
+- [ ] `.github/workflows/hive-sync.yml` does not exist.
+- [ ] `infrastructure/openclaw/hive-sync.md` exists and documents the OpenClaw scheduled/manual runtime contract.
 - [ ] `constitution/agent-capability-matrix.md` no longer contains a row for `initiatives-sync`. It contains exactly one row for `hive-sync` with the Consumes/Produces columns specified in Part C, plus the rollout-status caveat described in Part C.1.
 - [ ] `constitution/agent-capability-matrix.md` decision tree, execution rules, and Agent-specific additional context table are updated per Part C (1)-(4).
 - [ ] `git grep -n "initiatives-sync"` returns matches only inside `adrs/ADR-*.md`, `generated/issue-packets/active/**/*.md` (filed before this packet), or `generated/issue-packets/retired/**/*.md`. No matches in `.claude/`, `.github/workflows/`, `constitution/`, `CLAUDE.md`, `AGENTS.md`, or `initiatives/`.
@@ -201,14 +204,14 @@ None. This is a docs/markdown/YAML change; no .NET projects touched.
 - [ ] `initiatives/active-initiatives.md` contains a "Hive Sync Rollout (ADR-0014)" In Progress entry with the six-item Tracking list described in Part F.
 - [ ] `initiatives/roadmap.md` references `adr-0014-hive-sync-rollout`.
 - [ ] The PR diff touches only the files listed in Affected Files.
-- [ ] The Monday/Thursday scheduled workflow under the new name (`hive-sync.yml`) runs successfully on its next trigger and produces a PR identical **in structure** (same five initiative files reconciled, same PR title pattern under the new name) to what `initiatives-sync.yml` produced. The PR title text changes from `chore: sync initiative progress (...)` to `chore: sync hive state (...)`; the title pattern, branch convention, body layout, and reconciled-file set are unchanged. This criterion is verified post-merge by observing the next scheduled run; reviewers may dry-run via `workflow_dispatch` after merge to confirm.
+- [ ] The OpenClaw `hive-sync` scheduled/manual job runs successfully on its next trigger and produces a PR identical **in structure** (same five initiative files reconciled, same PR title pattern under the new name) to what `initiatives-sync.yml` produced. The PR title text changes from `chore: sync initiative progress (...)` to `chore: sync hive state (...)`; the title pattern, branch convention, body layout, and reconciled-file set are unchanged. This criterion is verified post-merge by observing the next OpenClaw run; reviewers may ask Honeyclaw/Oleg to trigger it manually if immediate validation is needed.
 - [ ] Repo-level `CHANGELOG.md` entry created or appended for this version with a one-line summary referencing the agent rename. (If `CHANGELOG.md` does not exist at the repo root, create it with a single H1 `# Changelog` and an `## Unreleased` section, then append the entry under that section. Subsequent packets append to the same file.)
 
 ## Human Prerequisites
 
 None. This packet is fully delegable.
 
-The `INITIATIVES_SYNC_TOKEN` GitHub repository secret is **not** renamed by this packet. The workflow continues to read `secrets.INITIATIVES_SYNC_TOKEN` after rename. Renaming the secret is a separate human-only chore (org-secret rename + workflow update) that does not block this rollout. If a future packet wants to rename it, it should be a standalone packet, not bundled here.
+The `ANTHROPIC_API_KEY` usage in the old GitHub Actions workflow is removed with the workflow. The `INITIATIVES_SYNC_TOKEN` secret may remain in GitHub until Oleg cleans it up, but it is no longer consumed by this runtime. OpenClaw uses the machine's authenticated `gh` context for issue/project reads and PR creation.
 
 ## Referenced Invariants
 
@@ -226,7 +229,7 @@ This invariant does not directly govern the `hive-sync` agent (which is neither 
 
 **ADR-0014 D5 (Capability matrix updates):** Remove the `initiatives-sync` row. Add a `hive-sync` row with Trigger, Consumes, Produces, and Sync Responsibility describing the full broadened mandate. The agent's tool list is unchanged from `initiatives-sync` (Read, Grep, Glob, Edit, Write, Bash, TodoWrite); no new tools are required.
 
-**ADR-0014 Phase Plan, Phase 1 exit criterion:** "the agent runs on its Monday/Thursday schedule under the new name and produces the same PR it did before." This is the post-merge validation criterion in the Acceptance Criteria list.
+**ADR-0014 Phase Plan, Phase 1 exit criterion:** "the agent runs on its Monday/Thursday schedule under the new name and produces the same PR it did before." This now means the OpenClaw scheduled/manual job, not a GitHub Actions Anthropic pipeline.
 
 ## Dependencies
 
@@ -238,7 +241,7 @@ None. This packet is the entry point for the initiative.
 
 ## Agent Handoff
 
-**Objective:** Rename the `initiatives-sync` agent to `hive-sync` (verbatim copy + delete + workflow rename + capability matrix swap + cross-reference cleanup). No behavior change. ADR-0014 stays in `Proposed` throughout the rollout and auto-flips on the first sync run after Packet 06 closes, via the Phase 5 auto-flip logic.
+**Objective:** Rename the `initiatives-sync` agent to `hive-sync` (verbatim copy + delete + OpenClaw runtime migration + capability matrix swap + cross-reference cleanup). No behavior change. ADR-0014 stays in `Proposed` throughout the rollout and auto-flips on the first sync run after Packet 06 closes, via the Phase 5 auto-flip logic.
 
 **Target:** `HoneyDrunkStudios/HoneyDrunk.Architecture`, branch from `main` (suggested branch name: `chore/adr-0014-hive-sync-phase-1`).
 
@@ -254,16 +257,16 @@ None. This packet is the entry point for the initiative.
 **Constraints:**
 - **Invariant 24** (full text above) — do not edit any file under `generated/issue-packets/active/` or `generated/issue-packets/retired/`. Filed packets, including those that mention `initiatives-sync`, stay frozen.
 - **Invariant 33** (full text above) — the rename must not modify `.claude/agents/scope.md` or the context-loading section of `.claude/agents/review.md`. The capability matrix is metadata and is in scope.
-- **Pure rename, no behavior change.** The Workflow body of `hive-sync.md` after Part A must be byte-identical to `initiatives-sync.md`'s Workflow body except for the seven targeted edits (name, description, headings, branch template, PR title, PR body link, output summary heading). No new Step, no removed Step, no logic changes. The verifier is a structured diff: a reviewer should be able to look at the new file and the deleted file side-by-side and see only those seven edits.
-- **Workflow-file rename preserves the secret name.** `INITIATIVES_SYNC_TOKEN` is not renamed.
+- **Agent logic rename, no reconciliation behavior change.** The agent workflow body of `hive-sync.md` after Part A must be byte-identical to `initiatives-sync.md`'s workflow body except for the targeted name/PR wording edits. No new reconciliation Step, no removed reconciliation Step, no lifecycle logic yet. The runtime migration is isolated to deleting the GitHub Actions pipeline and documenting the OpenClaw job.
+- **Runtime migration removes the Anthropic pipeline.** The old GitHub Actions workflow is deleted; no replacement workflow calls the Anthropic API.
 - **ADR-0014 stays in Proposed.** Do not edit the ADR's Status front-matter line. Do not edit the `adrs/README.md` Status column for ADR-0014. The flip is owned by the Phase 5 auto-flip logic on the first sync run after Packet 06 closes.
 - **Accepted ADRs are immutable historical records.** Part D leaves references inside other ADR files untouched.
 
 **Key Files:**
 - `.claude/agents/initiatives-sync.md` — read in full, then delete.
-- `.claude/agents/hive-sync.md` — create with the seven targeted edits.
+- `.claude/agents/hive-sync.md` — create with the targeted name/PR wording edits.
 - `.github/workflows/initiatives-sync.yml` — read in full, then delete.
-- `.github/workflows/hive-sync.yml` — create with the two targeted edits.
+- `infrastructure/openclaw/hive-sync.md` — create with the OpenClaw scheduled/manual runtime contract.
 - `constitution/agent-capability-matrix.md` — replace four locations per Part C.
 - `adrs/README.md` — update the description column for the ADR-0014 row only; leave the Status column unchanged.
 - `initiatives/active-initiatives.md` — add new In Progress entry.

--- a/generated/issue-packets/active/adr-0014-hive-sync-rollout/02-architecture-packet-lifecycle.md
+++ b/generated/issue-packets/active/adr-0014-hive-sync-rollout/02-architecture-packet-lifecycle.md
@@ -149,7 +149,7 @@ git mv generated/issue-packets/retired generated/issue-packets/completed
 
 This is a one-time directory rename. After it lands, all backfill moves and all future agent runs use `completed/` as the destination. The pre-existing `filed-packets.json` mismatch for `2026-04-12-org-secret-gh-issue-token.md` (its key still reads `active/standalone/...`) is corrected by Step 2a's DRIFT branch later in the backfill — Step 0a only handles the directory rename, not the JSON key.
 
-**Step 0b: Hoist `/tmp/issue-states.json` generation.** The Step 1b shell pipeline (already in `hive-sync.md` from Phase 1) populates `/tmp/issue-states.json` from `filed-packets.json` plus `gh issue view` calls. Run that pipeline next — every subsequent step in the backfill reads `/tmp/issue-states.json`. A cloud agent executing this packet from a fresh checkout has no warm `/tmp` cache; if Step 1b is skipped, the backfill produces no moves and silently passes.
+**Step 0b: Hoist `/tmp/issue-states.json` generation.** The Step 1b shell pipeline (already in `hive-sync.md` from Phase 1) populates `/tmp/issue-states.json` from `filed-packets.json` plus `gh issue view` calls. Run that pipeline next — every subsequent step in the backfill reads `/tmp/issue-states.json`. An OpenClaw agent executing this packet from a fresh checkout/session has no warm `/tmp` cache; if Step 1b is skipped, the backfill produces no moves and silently passes.
 
 **Step 1: Dry-run preview (mandatory).** Before any `git mv` or `jq` rewrite runs, the agent generates a textual preview of every action the backfill would take, posts it as a PR description (or as the first commit's body), and only then proceeds:
 
@@ -237,7 +237,7 @@ mv /tmp/filed-packets.json.new generated/issue-packets/filed-packets.json
 
 **Idempotency / recovery on interruption.** If the agent crashes between Phase A and Phase B (moves done, JSON not yet updated), recovery is `git checkout -- generated/issue-packets/` to roll back. Re-run the backfill from Step 1 (dry-run preview) — the SKIP branch in Step 8.2 handles already-completed entries, and the DRIFT branch in Step 2a handles the manually-moved exception, so a re-run produces the same end state. Do not re-run partial steps; always start from the dry-run preview.
 
-**Diff noise on Windows hosts.** Per `project_windows_crlf_gotcha.md`, `jq` on the user's Windows box emits CRLF line endings. The cloud agent infra runs on Linux and emits LF, so the rewrite produced by the workflow is LF-clean. If the dry-run is performed locally on Windows for sanity, the resulting JSON's line endings will be CRLF — discard the local dry-run JSON and let the cloud workflow produce the actual commit, or pipe through `tr -d '\r'` after `jq` to normalize.
+**Diff noise on Windows hosts.** Per `project_windows_crlf_gotcha.md`, `jq` on the user's Windows box emits CRLF line endings. OpenClaw may run on Windows or Linux depending on host, so normalize generated JSON before commit. If the dry-run is performed locally on Windows for sanity, the resulting JSON's line endings may be CRLF — pipe through `tr -d '\r'`, `dos2unix`, or an equivalent normalization step before committing.
 
 **Closed-packet inventory at scoping time** (2026-05-02; a snapshot, may shift between scoping and execution):
 
@@ -370,7 +370,7 @@ Reason: this packet edits `.claude/agents/hive-sync.md`, which does not exist un
 **Acceptance Criteria:** As listed above.
 
 **Dependencies:**
-- Packet 01 (this initiative, Wave 1) must merge first. The `hive-sync.md` file and `hive-sync.yml` workflow are products of Packet 01.
+- Packet 01 (this initiative, Wave 1) must merge first. The `hive-sync.md` file and `infrastructure/openclaw/hive-sync.md` runbook are products of Packet 01.
 
 **Constraints:**
 - **Invariant 24** (full text above) — packet body content must not be edited. The lifecycle operation is a path-only move. `git mv` is the canonical command; copy + delete is forbidden because the diff would lose the rename.

--- a/generated/issue-packets/active/adr-0014-hive-sync-rollout/03-architecture-board-items-tracking.md
+++ b/generated/issue-packets/active/adr-0014-hive-sync-rollout/03-architecture-board-items-tracking.md
@@ -158,7 +158,7 @@ After this packet lands, the "Hive Sync Invariants" section contains the lifecyc
 Use this template, substituting `{N}` with the value from Step 1:
 
 ```markdown
-{N}. **The Architecture repo tracks all Hive board items.** Every issue on The Hive (org Project #4) is represented in either an initiative tracking file (for packet-originated work, including `active-initiatives.md`, `archived-initiatives.md`, etc.) or `initiatives/board-items.md` (for non-initiative work — nightly-security issues, grid-health-aggregator issues, and any other issue mirrored onto The Hive without a `filed-packets.json` entry). The `hive-sync` agent is responsible for maintaining this correspondence and runs Monday/Thursday on schedule plus manual dispatch. See ADR-0014 D1, D3.
+{N}. **The Architecture repo tracks all Hive board items.** Every issue on The Hive (org Project #4) is represented in either an initiative tracking file (for packet-originated work, including `active-initiatives.md`, `archived-initiatives.md`, etc.) or `initiatives/board-items.md` (for non-initiative work — nightly-security issues, grid-health-aggregator issues, and any other issue mirrored onto The Hive without a `filed-packets.json` entry). The `hive-sync` agent is responsible for maintaining this correspondence and runs through OpenClaw scheduled/manual execution. See ADR-0014 D1, D3.
 ```
 
 **Existing-section safety net.** If the "Hive Sync Invariants" section does not exist (because Packet 02 was reverted or has not yet landed), this packet is out of order — its dependency declaration requires Packet 02 first. Surface the error rather than creating the section here.
@@ -215,7 +215,7 @@ None. This is a docs/markdown change; no .NET projects touched.
 
 - [x] Architecture-only edits. No other repo touched.
 - [x] No new code or build artifact.
-- [x] No GraphQL **mutations** introduced — query-only access to The Hive. The `secrets.INITIATIVES_SYNC_TOKEN` must have the **`read:project`** scope (classic PAT) or the org-level **`Projects: Read-only`** permission (fine-grained PAT) for the `projectV2` query in Step 8a to succeed; verifying that scope is a Human Prerequisite below, not an assumption made by this packet.
+- [x] No GraphQL **mutations** introduced — query-only access to The Hive. The OpenClaw host's authenticated `gh` context must have the **`read:project`** scope (classic PAT) or the org-level **`Projects: Read-only`** permission (fine-grained PAT) for the `projectV2` query in Step 8a to succeed; verifying that scope is a Human Prerequisite below, not an assumption made by this packet.
 - [x] Invariant 24 preserved — no edits to existing filed packets.
 - [x] Invariant 33 preserved — `scope.md` and `review.md` context-loading sections are untouched.
 
@@ -269,7 +269,7 @@ None. This is a docs/markdown change; no .NET projects touched.
 
 **Pre-merge (BLOCKING — verify before approving the PR):**
 
-- [ ] **Verify the `INITIATIVES_SYNC_TOKEN` PAT scope.** The Step 8a GraphQL query (`organization.projectV2`) requires either the classic-PAT scope `read:project` or the fine-grained-PAT permission `Projects: Read-only` at the **organization** level. Open GitHub → Settings → Developer settings → Personal access tokens, find the token backing the `INITIATIVES_SYNC_TOKEN` repo secret, and confirm the scope is present. If absent, expand the scope before merging. **Document the verified scope in the PR body** so the merge gate is auditable.
+- [ ] **Verify the OpenClaw host `gh` auth scope.** The Step 8a GraphQL query (`organization.projectV2`) requires either the classic-PAT scope `read:project` or the fine-grained-PAT permission `Projects: Read-only` at the **organization** level. From the OpenClaw host, run `gh auth status` and the dry-run query below. If absent, update the host credential before merging. **Document the verified scope in the PR body** so the merge gate is auditable.
 - [ ] **Run the GraphQL query as a dry-run** before the agent commits the PR. From a developer machine where `gh auth status` shows authentication for `HoneyDrunkStudios`, run the exact query from Step 8a and confirm it returns at least one item (or empty results — but no permission error):
 
   ```bash
@@ -287,11 +287,11 @@ None. This is a docs/markdown change; no .NET projects touched.
   }' | jq '.data.organization.projectV2.items.nodes | length'
   ```
 
-  If the response is a number (item count) the scope is sufficient. If it is `null` or an error mentions `INSUFFICIENT_SCOPES`, the token must be expanded before merge. The dry-run uses the developer's own `gh auth` not the workflow's secret, but the same scope rules apply — if `read:project` works locally, the workflow's PAT with the same scope will work in CI.
+  If the response is a number (item count) the scope is sufficient. If it is `null` or an error mentions `INSUFFICIENT_SCOPES`, the OpenClaw host credential must be expanded before merge. The dry-run should use the same `gh auth` context that the scheduled OpenClaw job will use.
 
 **Post-merge (sanity checks, not blockers):**
 
-- [ ] After merge, observe the **next scheduled Monday/Thursday run** of `hive-sync.yml` to confirm the GraphQL query executes successfully under `INITIATIVES_SYNC_TOKEN` in CI. If the dry-run passed but the CI run fails, the workflow's secret may point at a different PAT than the one verified above — surface this as an `infrastructure/` cleanup follow-up.
+- [ ] After merge, observe the **next scheduled/manual OpenClaw run** of `hive-sync` to confirm the GraphQL query executes successfully under OpenClaw's authenticated `gh` context. If the dry-run passed but the scheduled run fails, the OpenClaw host auth differs from the verified shell auth — surface this as an `infrastructure/` cleanup follow-up.
 - [ ] Confirm that `board-items.md` is regenerated correctly on the second run as well. The first run is the seed (created by this packet's PR); the second run validates that the agent regenerates the file from live GraphQL state without leaving stale content.
 
 ## Referenced Invariants

--- a/generated/issue-packets/active/adr-0014-hive-sync-rollout/04-architecture-proposed-adrs-queue.md
+++ b/generated/issue-packets/active/adr-0014-hive-sync-rollout/04-architecture-proposed-adrs-queue.md
@@ -205,7 +205,7 @@ None. This is a docs/markdown change; no .NET projects touched.
 
 None for the agent-side code changes. Operational note for the human reviewer:
 
-- [ ] After merge, observe the **next scheduled Monday/Thursday run** of `hive-sync.yml` to confirm the agent regenerates `proposed-adrs.md` correctly from live filesystem state. The first run is the seed (this PR); the second run is the validation. Confirm ADR-0014 **does** appear in the table at this point (it's still `Proposed`); the auto-flip happens later, after Packet 06 closes.
+- [ ] After merge, observe the **next scheduled/manual OpenClaw run** of `hive-sync` to confirm the agent regenerates `proposed-adrs.md` correctly from live filesystem state. The first run is the seed (this PR); the second run is the validation. Confirm ADR-0014 **does** appear in the table at this point (it's still `Proposed`); the auto-flip happens later, after Packet 06 closes.
 
 This is a post-merge sanity check, not a blocker on PR merge. The full archival of the Hive Sync Rollout initiative is owned by Packet 06.
 

--- a/generated/issue-packets/active/adr-0014-hive-sync-rollout/05-architecture-adr-pdr-auto-acceptance.md
+++ b/generated/issue-packets/active/adr-0014-hive-sync-rollout/05-architecture-adr-pdr-auto-acceptance.md
@@ -232,7 +232,7 @@ The file `initiatives/proposed-adrs.md` was created by Packet 04 with an ADRs-on
 
 The first agent run after Packet 05 lands rewrites the file to the new structure from live state. The PR for Packet 05 itself does not pre-seed the file with the new structure — the rewrite happens on the first sync run, exactly the same way every other tracking file in this rollout is seeded.
 
-If you want the new structure visible immediately in the merge commit (e.g., for review confidence), the executing agent **may** dry-run the new logic locally and include the resulting file in the PR. This is optional — the next scheduled run will produce it regardless.
+If you want the new structure visible immediately in the merge commit (e.g., for review confidence), the executing OpenClaw agent **may** dry-run the new logic locally and include the resulting file in the PR. This is optional — the next scheduled/manual OpenClaw run will produce it regardless.
 
 ### Part E — Initiative trackers
 
@@ -296,7 +296,7 @@ None. This is a docs/markdown change; no .NET projects touched.
 - [ ] Step 9c writes sed-miss anomalies to `proposed-adrs.md` "Anomalies" section (not just PR description).
 - [ ] The Constraints block contains the bounded-authority text from Part B (replaces the prior "never modifies any ADR file" bullet) plus the new anomaly-surface bullet.
 - [ ] `.claude/agents/scope.md` is updated per Part F to instruct writing `accepts:` for new packets, with the example and convention rules described there. The `adrs:` field convention is unchanged.
-- [ ] On the first scheduled run after this PR merges:
+- [ ] On the first scheduled/manual OpenClaw run after this PR merges:
   - Every Proposed ADR with at least one packet declaring it in `accepts:` whose every issue is `closed` is flipped to `Accepted` (subject to the `MAX_FLIPS_PER_RUN` cap). The flip is a single-line `**Status:**` edit; the ADR body is unchanged.
   - Every Proposed PDR matching the same criterion is flipped.
   - `adrs/README.md` and `pdrs/README.md` index rows have Status and Date columns matching the post-flip frontmatter (rstrip applied; annotated values skipped).
@@ -313,7 +313,7 @@ None. This packet is fully delegable.
 
 **Operational note for the human reviewer:**
 
-- [ ] After merge, observe the **first scheduled Monday/Thursday run** of `hive-sync.yml`. Spot-check that any ADRs/PDRs flipped to Accepted in that run are correctly identified — i.e., their implementing packets are genuinely all closed. If a flip is wrong (rare; would indicate a packet's `adrs:` frontmatter is misleading), manually revert the ADR's Status to `Proposed` in a follow-up PR. The agent will not re-flip until at least one issue closes again, so the manual revert is stable.
+- [ ] After merge, observe the **first scheduled/manual OpenClaw run** of `hive-sync`. Spot-check that any ADRs/PDRs flipped to Accepted in that run are correctly identified — i.e., their implementing packets are genuinely all closed. If a flip is wrong (rare; would indicate a packet's `adrs:` frontmatter is misleading), manually revert the ADR's Status to `Proposed` in a follow-up PR. The agent will not re-flip until at least one issue closes again, so the manual revert is stable.
 
 ## Referenced Invariants
 

--- a/generated/issue-packets/active/adr-0014-hive-sync-rollout/06-architecture-drift-detection.md
+++ b/generated/issue-packets/active/adr-0014-hive-sync-rollout/06-architecture-drift-detection.md
@@ -353,7 +353,7 @@ Update the existing "Hive Sync Rollout (ADR-0014)" entry in `initiatives/active-
 After Packet 06 lands, the initiative is genuinely complete. Add the closing Sync annotation under the entry's tracking list:
 
 ```markdown
-> **Sync ({merge-date}):** All six packets closed. ADR-0014 will auto-flip to Accepted on the next sync run via the Phase 5 logic — the trigger is "every implementing packet's issue closed," which is now true. Initiative complete. The `hive-sync` agent now owns six reconciliation surfaces: initiative tracking files (D1), packet lifecycle (D2), board items (D3), Proposed-ADR/PDR queue (D6) with auto-acceptance (D7), README index Status/Date columns (D8), and drift report (D9). Ready to archive — the next scheduled `hive-sync` run takes ownership of the archival sequence.
+> **Sync ({merge-date}):** All six packets closed. ADR-0014 will auto-flip to Accepted on the next sync run via the Phase 5 logic — the trigger is "every implementing packet's issue closed," which is now true. Initiative complete. The `hive-sync` agent now owns six reconciliation surfaces: initiative tracking files (D1), packet lifecycle (D2), board items (D3), Proposed-ADR/PDR queue (D6) with auto-acceptance (D7), README index Status/Date columns (D8), and drift report (D9). Ready to archive — the next scheduled/manual OpenClaw `hive-sync` run takes ownership of the archival sequence.
 ```
 
 The expected post-merge archival behavior — six steps the next sync run should perform automatically:
@@ -397,13 +397,13 @@ None. This is a docs/markdown change; no .NET projects touched.
   - All five drift category sections (Invariants / Matrix Rows with No Agent File / Agent Files with No Matrix Row / Missing Repos / ADR-Named Missing Nodes), each with either a populated table or `_No drift detected._`
   - The "Auth Issues" subsection inside the Missing Repos section
   - If no drift exists in any category: the file's body is replaced with the single empty-state line from 11g
-- [ ] No catalog file (`catalogs/*.json`), no constitution file (`constitution/*.md` other than the matrix exclusion-list section being added), no agent file (`.claude/agents/*.md`), and no ADR/PDR file is modified by this PR. `git diff -- catalogs/ constitution/ .claude/ adrs/ pdrs/` after the agent runs in CI shows changes only in the matrix file's new exclusion-list section (one-time addition by this packet) and the agent file's Step 11 / Constraints additions.
+- [ ] No catalog file (`catalogs/*.json`), no constitution file (`constitution/*.md` other than the matrix exclusion-list section being added), no agent file (`.claude/agents/*.md`), and no ADR/PDR file is modified by this PR. `git diff -- catalogs/ constitution/ .claude/ adrs/ pdrs/` after the OpenClaw agent run shows changes only in the matrix file's new exclusion-list section (one-time addition by this packet) and the agent file's Step 11 / Constraints additions.
 - [ ] `constitution/agent-capability-matrix.md` contains the "Meta-Agent Exclusion List" section per Part D — a brief pointer paragraph that references `hive-sync.md` Step 11d as the canonical list, **not** a duplicate of the entries.
 - [ ] `constitution/agent-capability-matrix.md` no longer contains the rollout-status caveat that Packet 01 attached to the `hive-sync` row (per Part E). The row's Trigger / Consumes / Produces / Sync Responsibility text is unchanged.
 - [ ] The exclusion list lives only in `hive-sync.md` Step 11d. The matrix doc's snapshot listing of agent names (intended for human-readable orientation) does not have to match Step 11d byte-for-byte; the runtime list in Step 11d is authoritative.
-- [ ] On the **second** scheduled run after this PR merges, items that persisted from the first run keep their First Surfaced dates. (The first run seeds today's date everywhere; the second run validates persistence.)
+- [ ] On the **second** scheduled/manual OpenClaw run after this PR merges, items that persisted from the first run keep their First Surfaced dates. (The first run seeds today's date everywhere; the second run validates persistence.)
 - [ ] `initiatives/active-initiatives.md` "Hive Sync Rollout (ADR-0014)" entry shows Packet 06's checkbox as checked and contains the closing Sync annotation per Part F. The entry is ready to be archived by the next sync run, and ADR-0014 is queued for auto-flip on the same run.
-- [ ] **End-to-end validation criterion (post-merge, observed by the human reviewer):** after this PR merges and all six issues close, the next scheduled `hive-sync` run produces a PR in which:
+- [ ] **End-to-end validation criterion (post-merge, observed by the human reviewer):** after this PR merges and all six issues close, the next scheduled/manual OpenClaw `hive-sync` run produces a PR in which:
   1. `adrs/ADR-0014-hive-architecture-reconciliation-agent.md` Status frontmatter line reads `**Status:** Accepted` (auto-flipped by the Phase 5 logic — Packets 01-06 all carry `accepts: ["ADR-0014"]` and their issues are all closed).
   2. `adrs/README.md` ADR-0014 row Status column reads `Accepted`.
   3. `initiatives/proposed-adrs.md` "Flipped This Run" section includes ADR-0014 (or, if the file is rewritten before reading the auto-flipped ADRs, the section is regenerated correctly on the run after).
@@ -417,8 +417,8 @@ None. This is a docs/markdown change; no .NET projects touched.
 
 None for the agent-side code changes. Operational notes for the human reviewer:
 
-- [ ] After merge, observe the **first scheduled Monday/Thursday run** of `hive-sync.yml` to confirm `drift-report.md` is regenerated correctly. Expect the file to contain whatever drift exists on `main` at that moment — possibly populated, possibly empty. Spot-check a few entries against the actual repo state.
-- [ ] After the **second** scheduled run, verify First Surfaced dates persisted for any items that were present in both runs. (The persistence logic in 11h is the trickiest part of this packet to get right; the second-run check is the validator.)
+- [ ] After merge, observe the **first scheduled/manual OpenClaw run** of `hive-sync` to confirm `drift-report.md` is regenerated correctly. Expect the file to contain whatever drift exists on `main` at that moment — possibly populated, possibly empty. Spot-check a few entries against the actual repo state.
+- [ ] After the **second** scheduled/manual OpenClaw run, verify First Surfaced dates persisted for any items that were present in both runs. (The persistence logic in 11h is the trickiest part of this packet to get right; the second-run check is the validator.)
 - [ ] After merge, observe that the next sync run also performs the six-step archival described in Part F (above). If any step is missed, manually complete it and file a follow-up issue noting the gap.
 
 ## Referenced Invariants
@@ -451,7 +451,7 @@ Reason: this packet adds Step 11 after Step 10 (lifecycle, from Packet 02). Pack
 
 ## Agent Handoff
 
-**Objective:** Add Step 11 (Drift Detection) to `hive-sync`. Create `initiatives/drift-report.md` with five drift categories. Add the meta-agent exclusion list to both the agent file and the capability matrix. Remove the rollout-status caveat that Packet 01 attached to the matrix's `hive-sync` row. Close out the ADR-0014 rollout by checking off Packet 06 and adding the closing Sync annotation. ADR-0014 itself will auto-flip to Accepted on the first scheduled run after this PR merges (the trigger condition — every implementing packet's issue closed — is satisfied at that moment).
+**Objective:** Add Step 11 (Drift Detection) to `hive-sync`. Create `initiatives/drift-report.md` with five drift categories. Add the meta-agent exclusion list to both the agent file and the capability matrix. Remove the rollout-status caveat that Packet 01 attached to the matrix's `hive-sync` row. Close out the ADR-0014 rollout by checking off Packet 06 and adding the closing Sync annotation. ADR-0014 itself will auto-flip to Accepted on the first scheduled/manual OpenClaw run after this PR merges (the trigger condition — every implementing packet's issue closed — is satisfied at that moment).
 
 **Target:** `HoneyDrunkStudios/HoneyDrunk.Architecture`, branch from `main` (suggested branch name: `chore/adr-0014-hive-sync-phase-6`).
 

--- a/generated/issue-packets/active/adr-0014-hive-sync-rollout/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0014-hive-sync-rollout/dispatch-plan.md
@@ -2,13 +2,13 @@
 
 **Initiative:** `adr-0014-hive-sync-rollout`
 **Sector:** Meta
-**Governing ADR:** [ADR-0014 — Hive–Architecture Reconciliation Agent](../../../../adrs/ADR-0014-hive-architecture-reconciliation-agent.md) (Proposed 2026-04-16; this initiative flips it to Accepted via the Phase 5 auto-flip logic on the first sync run after Packet 06 closes — every implementing packet's issue is closed at that moment, satisfying the auto-flip trigger)
+**Governing ADR:** [ADR-0014 — Hive–Architecture Reconciliation Agent](../../../../adrs/ADR-0014-hive-architecture-reconciliation-agent.md) (Proposed 2026-04-16; this initiative flips it to Accepted via the Phase 5 auto-flip logic on the first OpenClaw sync run after Packet 06 closes — every implementing packet's issue is closed at that moment, satisfying the auto-flip trigger)
 **Trigger:** ADR-0014 phase plan executes the six-phase rollout for renaming `initiatives-sync` to `hive-sync`, adding the packet lifecycle, non-initiative board tracking, Proposed-ADR queue, ADR/PDR auto-acceptance + README index sync, and drift detection.
 **Single repo:** `HoneyDrunkStudios/HoneyDrunk.Architecture`
 
 ## Summary
 
-ADR-0014 redefines the agent that reconciles Architecture state with The Hive. Today, `initiatives-sync` only knows about packet-sourced issues and never moves completed packets out of `active/`. After this initiative, a renamed `hive-sync` agent owns six jobs: (1) initiative reconciliation (unchanged), (2) packet lifecycle management (`active/` → `completed/`), (3) non-initiative board tracking (`board-items.md`), (4) Proposed-ADR/PDR acceptance queue (`proposed-adrs.md`), (5) ADR/PDR auto-acceptance + README index sync, and (6) drift detection (`drift-report.md`).
+ADR-0014 redefines the agent that reconciles Architecture state with The Hive. Today, `initiatives-sync` only knows about packet-sourced issues, runs through a GitHub Actions/Anthropic pipeline, and never moves completed packets out of `active/`. After this initiative, a renamed `hive-sync` agent runs through OpenClaw scheduled/manual execution and owns six jobs: (1) initiative reconciliation (unchanged), (2) packet lifecycle management (`active/` → `completed/`), (3) non-initiative board tracking (`board-items.md`), (4) Proposed-ADR/PDR acceptance queue (`proposed-adrs.md`), (5) ADR/PDR auto-acceptance + README index sync, and (6) drift detection (`drift-report.md`).
 
 Each phase corresponds to one packet. Packets sit on a strict serial chain because every packet edits `.claude/agents/hive-sync.md` in overlapping regions — running them in parallel would force later PRs to absorb earlier renumbering. **Strict 1 → 2 → 3 → 4 → 5 → 6 serial execution is the chosen path for review-bandwidth reasons.** A solo dev reviewing one PR at a time prefers the linear order; isolated parallelization (e.g., Packets 03 and 04 after Packet 02 lands) is technically possible at the cost of one rebase but is not the planned path.
 
@@ -52,7 +52,7 @@ Wave 6: Drift detection + meta-agent exclusion list (D9)
 
 ## Phase Mapping
 
-- **Wave 1 = ADR-0014 Phase 1** — pure rename (D1, D5). Same behavior; new name. ADR-0014 stays in `Proposed`.
+- **Wave 1 = ADR-0014 Phase 1** — agent rename + runtime migration from GitHub Actions/Anthropic to OpenClaw scheduled/manual execution (D1, D5). Same reconciliation behavior; new name/runtime. ADR-0014 stays in `Proposed`.
 - **Wave 2 = ADR-0014 Phase 2** — D2 packet lifecycle, D4 single-writer rule, lifecycle invariant, one-time backfill.
 - **Wave 3 = ADR-0014 Phase 3** — D3 non-initiative tracking, board-coverage invariant, seed run from current Hive state.
 - **Wave 4 = ADR-0014 Phase 4** — D6 Proposed-ADR queue (read-only surface). Seed run from current `adrs/` Proposed entries. ADR-0014 itself appears in the seed because its Status is still `Proposed` at this point — the auto-flip happens later, after Packet 06 closes.
@@ -67,7 +67,7 @@ Wave 6: Drift detection + meta-agent exclusion list (D9)
 
 Each phase is a single PR against `HoneyDrunk.Architecture/main`. Rollback for any phase is a `git revert` on that PR.
 
-- **Phase 1 revert** restores `initiatives-sync.md`, the workflow file name, and all references. ADR-0014 stays in `Proposed` (no flip happened in Phase 1).
+- **Phase 1 revert** restores `initiatives-sync.md`, restores the retired `initiatives-sync.yml` workflow if needed, removes the OpenClaw runbook, and restores references. ADR-0014 stays in `Proposed` (no flip happened in Phase 1).
 - **Phase 2 revert** removes the lifecycle logic from `hive-sync.md`. Packets that the backfill moved to `completed/` are moved back to `active/` (the revert restores the old paths in `filed-packets.json` and `git mv`s the packets back). The agent reverts to "no lifecycle management." The lifecycle invariant added in this phase is removed from `constitution/invariants.md` in the same revert.
 - **Phase 3 revert** removes `board-items.md` and the GraphQL query logic. The board-coverage invariant added in this phase is removed from `constitution/invariants.md` in the same revert.
 - **Phase 4 revert** removes `proposed-adrs.md` and the ADR-frontmatter scan logic. Phase 4 does **not** flip ADR-0014's Status, does **not** edit `adrs/README.md`, and does **not** touch the capability-matrix caveat — those concerns moved to Phases 5 (auto-flip) and 6 (caveat removal). The Phase 4 revert is therefore a clean removal of the read-only queue surface.
@@ -78,15 +78,15 @@ Phases revert independently as long as later phases have not added cross-referen
 
 ## Acceptance Workflow Notes
 
-Per the [ADR acceptance workflow](../../../../adrs/README.md), ADRs are filed Proposed. The scope agent flips the status to Accepted **after** the implementing PR(s) merge. For ADR-0014, the implementation spans six PRs across Waves 1-6; the flip is performed **automatically** by the Phase 5 auto-flip logic (which Packet 05 introduces) on the first sync run after Packet 06 closes — at which point every implementing packet's issue is closed, and the auto-flip's trigger condition is satisfied. ADR-0014 is treated identically to every other Proposed ADR; the validation that auto-flip works correctly on the originating ADR is a deliberate end-to-end test of the new behavior.
+Per the [ADR acceptance workflow](../../../../adrs/README.md), ADRs are filed Proposed. The scope agent flips the status to Accepted **after** the implementing PR(s) merge. For ADR-0014, the implementation spans six PRs across Waves 1-6; the flip is performed **automatically** by the Phase 5 auto-flip logic (which Packet 05 introduces) on the first OpenClaw sync run after Packet 06 closes — at which point every implementing packet's issue is closed, and the auto-flip's trigger condition is satisfied. ADR-0014 is treated identically to every other Proposed ADR; the validation that auto-flip works correctly on the originating ADR is a deliberate end-to-end test of the new behavior.
 
 **Why the flip is deferred to the auto-flip after Wave 6:**
 
 - ADR-0014 mandates new invariants and surfaces across all six phases (D1-D9). If the ADR were marked `Accepted` in any earlier wave, the on-disk state would not match the ADR text for the duration of the rollout (3-6 weeks). A reader of `adrs/ADR-0014-...md` would see an Accepted ADR whose mandated behaviors did not yet exist.
 - The user-memory rule "scope agent flips status to Accepted after PR merge, never on first draft" is satisfied — and one step better, the **agent itself** flips it after every implementing PR has merged. ADR-0014 is treated identically to every other Proposed ADR.
-- This is also the **end-to-end validation** that the Phase 5 auto-flip logic works correctly. The originating ADR is the natural test case — if the auto-flip is buggy, ADR-0014 stays Proposed and the bug is loud (visible in `proposed-adrs.md`, in the ADR's frontmatter, and in `adrs/README.md`). If the auto-flip is correct, ADR-0014 lands as Accepted on the first run after Packet 06 closes — concrete proof the new behavior works.
+- This is also the **end-to-end validation** that the Phase 5 auto-flip logic works correctly under the OpenClaw scheduled/manual runtime. The originating ADR is the natural test case — if the auto-flip is buggy, ADR-0014 stays Proposed and the bug is loud (visible in `proposed-adrs.md`, in the ADR's frontmatter, and in `adrs/README.md`). If the auto-flip is correct, ADR-0014 lands as Accepted on the first OpenClaw run after Packet 06 closes — concrete proof the new behavior works.
 
-ADR-0014 itself is treated identically to every other Proposed ADR. The Phase 5 auto-flip logic (Packet 05) fires for any Proposed ADR whose implementing packets are all closed. Once Packet 06 closes, that condition is satisfied for ADR-0014 — the next sync run will auto-flip it to Accepted. No manual flip is performed mid-rollout. This validates the auto-flip logic against the originating ADR.
+ADR-0014 itself is treated identically to every other Proposed ADR. The Phase 5 auto-flip logic (Packet 05) fires for any Proposed ADR whose implementing packets are all closed. Once Packet 06 closes, that condition is satisfied for ADR-0014 — the next OpenClaw sync run will auto-flip it to Accepted. No manual flip is performed mid-rollout. This validates the auto-flip logic against the originating ADR.
 
 ## Filing Commands
 


### PR DESCRIPTION
## Summary

Reframes ADR-0014 Hive Sync rollout packets around OpenClaw/Honeyclaw scheduled/manual execution instead of a GitHub Actions workflow calling Anthropic directly.

## Changes

- Packet 01 now retires `.github/workflows/initiatives-sync.yml` and explicitly does **not** create `.github/workflows/hive-sync.yml`.
- Adds `infrastructure/openclaw/hive-sync.md` as the runtime contract expected from Packet 01.
- Replaces CI/cloud-agent/Anthropic runtime language across packets 02-06 with OpenClaw scheduled/manual job language.
- Updates auth expectations for Hive board GraphQL reads to use the OpenClaw host `gh` auth context.
- Updates dispatch plan summary, rollback notes, and auto-flip validation to name OpenClaw as the runtime.

## Validation

- `git diff --check -- generated/issue-packets/active/adr-0014-hive-sync-rollout`
- Confirmed the commit includes only ADR-0014 rollout packet files.

## Notes

Pre-existing local modifications outside ADR-0014 were intentionally left unstaged/uncommitted.
