### PR TITLE
feat(ai,architecture): register ADR-0016 AI node initiative

### DIFF
--- a/copilot/issue-authoring-rules.md
+++ b/copilot/issue-authoring-rules.md
@@ -16,36 +16,24 @@ Every issue must include:
 
 ## Blocking Relationships
 
-After filing issues, wire native GitHub blocking relationships for every dependency listed in the Dependencies section. Do not leave dependencies as body text only.
+The `dependencies:` array in packet frontmatter is the **canonical, machine-readable** source of blocking relationships. The body's `## Dependencies` section is human narrative explaining *why* — it is not parsed by the filing pipeline.
 
-Use the GraphQL `addBlockedBy` mutation:
+### `dependencies:` schema
 
-```bash
-gh api graphql -f query='
-mutation {
-  addBlockedBy(input: {
-    issueId: "<blocked-issue-node-id>"
-    blockingIssueId: "<blocking-issue-node-id>"
-  }) {
-    issue { number }
-    blockingIssue { number }
-  }
-}'
-```
+Each entry must use one of two qualified reference forms:
 
-Get issue node IDs with:
-```bash
-gh api graphql -f query='
-{
-  repository(owner: "HoneyDrunkStudios", name: "<repo>") {
-    issues(first: 20) {
-      nodes { number id }
-    }
-  }
-}'
-```
+- **`"packet:NN"`** — another packet in the **same initiative folder**, identified by its two-digit ordinal prefix (or `NN` + suffix letter, e.g. `"packet:07a"`). Resolved at filing time once the referenced packet has a manifest entry.
+  - Example: `dependencies: ["packet:01", "packet:04"]`
+- **`"{Repo}#N"` or `"{owner}/{repo}#N"`** — already-filed issue in another repo. Bare `Repo` short-names expand to `HoneyDrunkStudios/HoneyDrunk.{Repo}` (so `"Architecture#9"` → `HoneyDrunkStudios/HoneyDrunk.Architecture#9`).
+  - Example: `dependencies: ["packet:01", "Architecture#9"]`
 
-Every `Dependencies` entry in an issue body must have a corresponding `addBlockedBy` call. This surfaces the blocking chain natively in the GitHub UI and on The Hive board.
+Forbidden — these were ambiguous and silently broke the wiring step:
+
+- Bare integers: `dependencies: [1, 2]`
+- Narrative strings: `dependencies: ["Issue #1 (scaffold)"]` or `dependencies: ["Architecture#NN — ADR text (packet 01)"]`
+- Filename slugs: `dependencies: ["01-foo-bar"]`
+
+The filing pipeline (`HoneyDrunk.Actions/scripts/file-packets.sh`) consumes this field, resolves each entry to an issue node ID, then calls `addBlockedBy` so the relationship surfaces natively in the GitHub UI and on The Hive board. Any unresolvable entry produces a `::warning::` in the workflow log; the build does not fail, so check the summary on every run.
 
 ## Naming Convention for Issue Packets
 

--- a/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/01-architecture-ai-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/01-architecture-ai-catalog-registration.md
@@ -1,0 +1,334 @@
+---
+name: Architecture Catalog Registration
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0016"]
+dependencies: []
+adrs: ["ADR-0016", "ADR-0010"]
+wave: 1
+initiative: adr-0016-honeydrunk-ai-standup
+node: honeydrunk-ai
+---
+
+# Chore: Register HoneyDrunk.AI's standup decisions in Architecture catalogs
+
+## Summary
+Reflect ADR-0016's stand-up decisions in the canonical Architecture catalogs and the AI sector architecture doc. Update `contracts.json` to match D3's seven-contract surface, register `honeydrunk-ai` in `grid-health.json`, tighten the loose "depends on Pulse" phrasing in both `nodes.json` and `constitution/ai-sector-architecture.md` to reflect the one-way telemetry direction set by D7, and complete the stale `Providers.Local` → `Providers.InMemory` rename in catalogs and AI repo docs (D2 lists `InMemory` as the fourth provider slot — `Local`/ONNX has been retired from D2).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+ADR-0016 establishes the AI Node's exposed contracts, package families, and downstream-coupling rule. None of that has reached the catalogs yet. Until it does, every downstream consumer (Capabilities, Operator, Agents, Memory, Knowledge, Evals) reads stale or inconsistent metadata when scoping their own work.
+
+Five specific drift items must be resolved in this packet:
+
+1. **`contracts.json` lists `IInferenceResult` but ADR-0016 D3 lists `ICostLedger`.** ADR-0016's "If Accepted" checklist also lists `IInferenceResult` — that is a discrepancy in the ADR itself. Per the user's explicit instruction during scoping, the **D3 table is canonical**: drop `IInferenceResult` from the catalog and add `ICostLedger`. Flag the "If Accepted" checklist as needing reconciliation in a follow-up.
+2. **`catalogs/grid-health.json`** has `honeydrunk-ai` but no per-contract surface entries. Other Live nodes have full per-Node entries; AI's is currently a stub blocked on "Repo not yet scaffolded".
+3. **`nodes.json` (line 603)** says `"Consumes Kernel (context, telemetry), Vault (API keys), Pulse (inference telemetry). Consumed by Agents, Memory, Knowledge, Evals, Sim."` — the "Pulse (inference telemetry)" phrasing implies a runtime dependency. Per ADR-0016 D7, **AI emits telemetry consumed by Pulse; there is no runtime dependency on Pulse**. The same drift exists in `constitution/ai-sector-architecture.md` ~line 114.
+4. **Stale `HoneyDrunk.AI.Providers.Local` references** appear across catalogs and AI repo docs. ADR-0016 D2 lists the fourth provider slot as **`HoneyDrunk.AI.Providers.InMemory`** (deterministic test double for Evals and CI). The previous `Local`/ONNX framing has been retired. Replace `Providers.Local` with `Providers.InMemory` everywhere it appears in catalogs/ and `repos/HoneyDrunk.AI/`. The corresponding `local`/`onnx` value-prop strings in `nodes.json` are also revised away from local/ONNX language toward the InMemory/test-double role.
+5. **ADR-0016 D2 line 42 contains its own drift** — it says `HoneyDrunk.AI.Abstractions` carries "Zero runtime dependencies beyond `HoneyDrunk.Kernel` abstractions." Repo-local invariant 1 at `repos/HoneyDrunk.AI/invariants.md:5` says zero HoneyDrunk dependencies, only `Microsoft.Extensions.*` abstractions allowed. Per the user's resolution during scoping, **the strict stance wins**: `HoneyDrunk.AI.Abstractions` ships with zero `HoneyDrunk.*` references. Kernel reference lives in the `HoneyDrunk.AI` runtime package, not Abstractions. ADR-0016 D2 line 42 is amended in this packet to match.
+
+## Proposed Implementation
+
+### `catalogs/contracts.json` — `honeydrunk-ai` block
+
+Replace the existing seven-entry interfaces array with exactly the seven contracts from ADR-0016 D3, in this order. Records lose the `I` prefix; interfaces keep it (per the Grid-wide naming rule).
+
+```json
+{
+  "node": "honeydrunk-ai",
+  "node_name": "HoneyDrunk.AI",
+  "package": "HoneyDrunk.AI.Abstractions",
+  "status": "seed",
+  "interfaces": [
+    { "name": "IChatClient", "kind": "interface", "description": "Canonical chat completion entry point. Shape-compatible with Microsoft.Extensions.AI but a distinct type under HoneyDrunk.AI.Abstractions (ADR-0016 D6)." },
+    { "name": "IEmbeddingGenerator", "kind": "interface", "description": "Canonical embedding entry point. Shape-compatible with Microsoft.Extensions.AI but a distinct type under HoneyDrunk.AI.Abstractions (ADR-0016 D6)." },
+    { "name": "IModelProvider", "kind": "interface", "description": "Provider-slot interface — implement per inference backend (OpenAI, Anthropic, Azure OpenAI, InMemory)." },
+    { "name": "IModelRouter", "kind": "interface", "description": "Capability-driven model selection. Routes inference requests to the most appropriate provider based on policy, capability, cost, and runtime constraints." },
+    { "name": "IRoutingPolicy", "kind": "interface", "description": "Pluggable routing strategy — cost-first, capability-first, latency-first, compliance-first. Sourced from Azure App Configuration via Vault's IConfigProvider." },
+    { "name": "ModelCapabilityDeclaration", "kind": "type", "description": "Record. Machine-readable model capability metadata used by IModelRouter to match requests to supported providers." },
+    { "name": "ICostLedger", "kind": "interface", "description": "Per-call token and cost accounting surface. Cost-rate tables sourced from Azure App Configuration via Vault's IConfigProvider — never hardcoded." }
+  ]
+}
+```
+
+Two surface-level changes vs current state:
+
+- **Remove** the `IInferenceResult` entry (ADR-0016 D3 does not list it). Document in the PR description that this is the deliberate D3-canonical resolution of the ADR-0016 "If Accepted" vs D3 discrepancy.
+- **Add** the `ICostLedger` entry with the App-Config-sourced rate-table description (D5).
+
+### `catalogs/relationships.json` — `honeydrunk-ai` block
+
+Two edits to this block.
+
+**(a) `exposes.contracts` array.** Currently reads:
+
+```json
+"contracts": ["IChatClient", "IEmbeddingGenerator", "IModelProvider", "IInferenceResult", "IModelRouter", "IRoutingPolicy", "ModelCapabilityDeclaration"]
+```
+
+Replace with:
+
+```json
+"contracts": ["IChatClient", "IEmbeddingGenerator", "IModelProvider", "IModelRouter", "IRoutingPolicy", "ModelCapabilityDeclaration", "ICostLedger"]
+```
+
+Same swap: drop `IInferenceResult`, add `ICostLedger`.
+
+**(b) `exposes.packages` array (line 191).** Currently reads:
+
+```json
+"packages": ["HoneyDrunk.AI.Abstractions", "HoneyDrunk.AI", "HoneyDrunk.AI.Providers.OpenAI", "HoneyDrunk.AI.Providers.Anthropic", "HoneyDrunk.AI.Providers.AzureOpenAI", "HoneyDrunk.AI.Providers.Local"]
+```
+
+Replace `"HoneyDrunk.AI.Providers.Local"` with `"HoneyDrunk.AI.Providers.InMemory"`:
+
+```json
+"packages": ["HoneyDrunk.AI.Abstractions", "HoneyDrunk.AI", "HoneyDrunk.AI.Providers.OpenAI", "HoneyDrunk.AI.Providers.Anthropic", "HoneyDrunk.AI.Providers.AzureOpenAI", "HoneyDrunk.AI.Providers.InMemory"]
+```
+
+This aligns with ADR-0016 D2 line 48 — the fourth provider slot is `InMemory`, not `Local`.
+
+### `catalogs/grid-health.json` — `honeydrunk-ai` block
+
+Replace the existing stub block with one that reflects ADR-0016 acceptance:
+
+```json
+{
+  "id": "honeydrunk-ai",
+  "name": "HoneyDrunk.AI",
+  "sector": "AI",
+  "signal": "Seed",
+  "version": "0.0.0",
+  "canary_status": "none",
+  "last_release": null,
+  "active_blockers": ["Scaffold packet (AI#NN — packet 03 of adr-0016-honeydrunk-ai-standup) not yet executed"],
+  "notes": "ADR-0016 standup ADR Proposed 2026-04-19. Catalog surface registered (7 contracts per D3). Awaiting scaffold execution: HoneyDrunk.AI.Abstractions (7 contracts), HoneyDrunk.AI runtime, four provider-slot packages (OpenAI/Anthropic/AzureOpenAI/InMemory), Standards wiring, CI with api-compatibility canary scoped to Abstractions (D8), InMemory provider for Evals/CI determinism."
+}
+```
+
+Update the `summary.blocked_nodes` list to keep `honeydrunk-ai` (it stays blocked until the scaffold packet executes) — no change needed there, just confirm the entry remains.
+
+### `catalogs/nodes.json` — `honeydrunk-ai` block
+
+Three edits to this block.
+
+**(a) `grid_relationship` field (line 603).** Current text:
+
+> `"grid_relationship": "Consumes Kernel (context, telemetry), Vault (API keys), Pulse (inference telemetry). Consumed by Agents, Memory, Knowledge, Evals, Sim."`
+
+Replace with:
+
+> `"grid_relationship": "Consumes Kernel (context, telemetry) and Vault (API keys + App Configuration for routing policies and cost-rate tables). Emits inference telemetry consumed by Pulse — no runtime dependency on Pulse. Consumed by Agents, Memory, Knowledge, Evals, Sim, Lore."`
+
+The Lore addition reflects existing relationships.json data (`honeydrunk-lore` is in `consumed_by_planned`).
+
+**(b) `value_props` line 596.** Current text:
+
+> `"Pluggable provider adapters (OpenAI, Anthropic, Azure OpenAI, local/ONNX)",`
+
+Replace with:
+
+> `"Pluggable provider adapters (OpenAI, Anthropic, Azure OpenAI, InMemory)",`
+
+This matches ADR-0016 D2's first-wave provider list. `local/ONNX` has been retired from the D2 surface.
+
+**(c) `tags` line 586.** Current text:
+
+> `"tags": ["inference", "llm", "embeddings", "providers", "openai", "anthropic", "azure-openai", "telemetry"],`
+
+The tag list as it stands has no `local` or `onnx` token to drop, but it is missing `inmemory`. Add it:
+
+> `"tags": ["inference", "llm", "embeddings", "providers", "openai", "anthropic", "azure-openai", "inmemory", "telemetry"],`
+
+If at edit time the tag list contains `local` or `onnx` (drift may have appeared since this packet was authored), drop those tokens in the same edit.
+
+Do **not** edit the line that reads `"Automatic token/latency/cost telemetry via Pulse"` (also a `value_props` entry) or line 605 (the demo path) — those describe what the telemetry does, not a dependency direction.
+
+### `constitution/ai-sector-architecture.md` — two edits
+
+**(a) Provider Slot Pattern table (lines 104–112).** Current block:
+
+```
+HoneyDrunk.AI.Abstractions          → contracts
+HoneyDrunk.AI                       → runtime, routing, telemetry
+HoneyDrunk.AI.Providers.OpenAI      → OpenAI adapter
+HoneyDrunk.AI.Providers.Anthropic   → Anthropic adapter
+HoneyDrunk.AI.Providers.AzureOpenAI → Azure OpenAI adapter
+HoneyDrunk.AI.Providers.Local       → local/ONNX models
+```
+
+Replace the `Local` row only:
+
+```
+HoneyDrunk.AI.Providers.InMemory    → deterministic test double for Evals and CI
+```
+
+Verify the rest of the block is consistent with ADR-0016 D2 — the four runtime/abstractions/providers rows above the InMemory row should remain as they are.
+
+**(b) Line 114 — dependency phrasing.** Current text:
+
+> `**Depends on:** Kernel (context, telemetry), Vault (API keys), Pulse (inference telemetry)`
+
+Replace with:
+
+> `**Depends on:** Kernel (context, telemetry), Vault (API keys + App Configuration for routing policies and cost-rate tables)`
+>
+> `**Emits to (no runtime dependency):** Pulse (inference telemetry per call — token counts, latency, model identifiers, cost estimates)`
+
+Do not change the surrounding "Note:" block about Microsoft.Extensions.AI alignment — ADR-0016 D6 keeps the alignment commitment in place.
+
+### `repos/HoneyDrunk.AI/overview.md` — line 21
+
+Replace:
+
+> `| `HoneyDrunk.AI.Providers.Local` | Provider | Local/ONNX model adapter |`
+
+with:
+
+> `| `HoneyDrunk.AI.Providers.InMemory` | Provider | Deterministic test double for Evals and CI |`
+
+### `repos/HoneyDrunk.AI/active-work.md` — lines 22–26
+
+The existing list reads:
+
+```
+- Provider adapters: OpenAI, Anthropic, Azure OpenAI (each as separate package, provider slot pattern)
+  - `HoneyDrunk.AI.Providers.OpenAI`
+  - `HoneyDrunk.AI.Providers.Anthropic`
+  - `HoneyDrunk.AI.Providers.AzureOpenAI`
+  - `HoneyDrunk.AI.Providers.Local` (ONNX — deferred)
+```
+
+Replace the trailing `Local` line so the list reads:
+
+```
+- Provider adapters: OpenAI, Anthropic, Azure OpenAI, InMemory (each as separate package, provider slot pattern)
+  - `HoneyDrunk.AI.Providers.OpenAI`
+  - `HoneyDrunk.AI.Providers.Anthropic`
+  - `HoneyDrunk.AI.Providers.AzureOpenAI`
+  - `HoneyDrunk.AI.Providers.InMemory` (deterministic test double for Evals and CI)
+```
+
+### Stale `Providers.Local` sweep
+
+Before opening the PR, grep `catalogs/` and `repos/HoneyDrunk.AI/` for any remaining `Providers.Local` or `local/ONNX` strings the explicit fix list above missed. None should remain after this packet. The grep is a hard check, not a best-effort.
+
+### `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` — D2 line 42 amendment
+
+Current text (line 42):
+
+> `- `HoneyDrunk.AI.Abstractions` — all interfaces, request/response shapes, capability declarations, cost records. Zero runtime dependencies beyond `HoneyDrunk.Kernel` abstractions.`
+
+Replace with:
+
+> `- `HoneyDrunk.AI.Abstractions` — all interfaces, request/response shapes, capability declarations, cost records. Zero runtime dependencies beyond `Microsoft.Extensions.*` abstractions.`
+
+Rationale: repo-local invariant 1 at `repos/HoneyDrunk.AI/invariants.md:5` is the strict stance ("zero HoneyDrunk dependencies. Only `Microsoft.Extensions.*` abstractions are allowed"). Per the user's resolution during scoping, the strict stance wins — `HoneyDrunk.AI.Abstractions` ships with zero `HoneyDrunk.*` references, including no `HoneyDrunk.Kernel.Abstractions`. The Kernel reference lives in the `HoneyDrunk.AI` runtime package, not Abstractions. This ADR-internal drift is reconciled in the same packet that reconciles the `IInferenceResult`/`ICostLedger` checklist drift.
+
+Document this in the PR body as the **third** "ADR drift reconciled" item alongside the existing checklist correction and the `IInferenceResult` → `ICostLedger` swap.
+
+### `CHANGELOG.md` (Architecture repo)
+Append to the Unreleased section a line: `Architecture: Register ADR-0016 standup decisions in catalogs (contracts.json swaps IInferenceResult for ICostLedger per D3; grid-health.json gets full honeydrunk-ai block; nodes.json + ai-sector-architecture.md tighten Pulse dependency phrasing per D7; Providers.Local → Providers.InMemory completed across catalogs and repos/HoneyDrunk.AI; ADR-0016 D2 line 42 amended to strict "Microsoft.Extensions.* only" Abstractions stance).`
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+- `catalogs/grid-health.json`
+- `catalogs/nodes.json`
+- `constitution/ai-sector-architecture.md`
+- `repos/HoneyDrunk.AI/overview.md`
+- `repos/HoneyDrunk.AI/active-work.md`
+- `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` (D2 line 42 amendment only)
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo — no .NET projects.
+
+## Boundary Check
+- [x] All edits are inside the `HoneyDrunk.Architecture` repo.
+- [x] No code changes anywhere; metadata only.
+- [x] No contract bodies invented in this packet — only catalog registration of ADR-0016's already-decided surface.
+- [x] The `IInferenceResult` → `ICostLedger` swap is a deliberate alignment to D3 (the canonical decision body), not a new design choice.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` `honeydrunk-ai` block lists exactly the 7 contracts from ADR-0016 D3 (no `IInferenceResult`; `ICostLedger` present). The `IModelProvider` description reads `"Provider-slot interface — implement per inference backend (OpenAI, Anthropic, Azure OpenAI, InMemory)."` (no `local`).
+- [ ] `catalogs/relationships.json` `honeydrunk-ai` `exposes.contracts` array matches the same 7-contract surface (no `IInferenceResult`; `ICostLedger` present).
+- [ ] `catalogs/relationships.json` `honeydrunk-ai` `exposes.packages` array no longer contains `HoneyDrunk.AI.Providers.Local`; contains `HoneyDrunk.AI.Providers.InMemory` instead.
+- [ ] `catalogs/grid-health.json` `honeydrunk-ai` block reflects the standup ADR with the scaffold packet noted as the active blocker.
+- [ ] `catalogs/nodes.json` `honeydrunk-ai.grid_relationship` field no longer says "Pulse (inference telemetry)" as a dependency; phrased as one-way emission per D7.
+- [ ] `catalogs/nodes.json` `honeydrunk-ai.long_description.value_props` no longer references `local/ONNX`; references `InMemory` instead.
+- [ ] `catalogs/nodes.json` `honeydrunk-ai.tags` includes `inmemory` and contains no `local`/`onnx` tokens.
+- [ ] `constitution/ai-sector-architecture.md` Provider Slot Pattern block has the `HoneyDrunk.AI.Providers.Local → local/ONNX models` row replaced with `HoneyDrunk.AI.Providers.InMemory → deterministic test double for Evals and CI`.
+- [ ] `constitution/ai-sector-architecture.md` line ~114 split into "Depends on" (no Pulse) and "Emits to (no runtime dependency): Pulse" lines.
+- [ ] `repos/HoneyDrunk.AI/overview.md` line 21 reads the new `Providers.InMemory` row instead of `Providers.Local`.
+- [ ] `repos/HoneyDrunk.AI/active-work.md` lines 22–26 list `InMemory` (deterministic test double for Evals and CI) as the fourth provider slot — no `Local` (ONNX — deferred) bullet.
+- [ ] `grep -nr "Providers.Local\|local/ONNX" catalogs/ repos/HoneyDrunk.AI/` returns no matches after edits.
+- [ ] `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` D2 line 42 amended from `Zero runtime dependencies beyond \`HoneyDrunk.Kernel\` abstractions.` to `Zero runtime dependencies beyond \`Microsoft.Extensions.*\` abstractions.`
+- [ ] `CHANGELOG.md` Unreleased section updated with all five drift reconciliations called out.
+- [ ] PR body explicitly notes the three "ADR drift reconciled" items: (1) D3-canonical resolution of the `IInferenceResult` vs `ICostLedger` checklist mismatch, (2) `Providers.Local` → `Providers.InMemory` rename completing D2's first-wave provider list, (3) D2 line 42 amendment from `HoneyDrunk.Kernel`-allowed to `Microsoft.Extensions.*`-only Abstractions stance.
+
+## Human Prerequisites
+- [ ] Reconcile the `IInferenceResult` mention in ADR-0016's "If Accepted" checklist (line 12 of `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md`). The cleanest path is to update the checklist to match D3 (`ICostLedger` instead of `IInferenceResult`) when flipping ADR-0016 to Accepted. Either resolve in this packet's PR or hold as a separate one-line edit.
+- [ ] Confirm the D2 line 42 amendment in this packet (Kernel-abstractions → `Microsoft.Extensions.*` only) is the intended stance before merge — this is the user's explicit scoping resolution but it is also the kind of decision that benefits from a final eye before it lands in the canonical ADR.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — Reinforces why `HoneyDrunk.AI.Abstractions` is the only thing downstream Nodes compile against.
+
+> **Invariant 28:** Application code must never hardcode a model name or provider. All model selection goes through `IModelRouter` in HoneyDrunk.AI. Routing policies are stored in App Configuration (ADR-0005) and are operator-configurable without a redeploy. — Reinforces D5 and the role of `ICostLedger`/`IRoutingPolicy` as App-Config-sourced.
+
+## Referenced ADR Decisions
+
+**ADR-0016 D3 (Exposed contracts):** Seven contracts form the AI Node's public boundary — `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, `IModelRouter`, `IRoutingPolicy`, `ModelCapabilityDeclaration` (record), `ICostLedger`. Records drop the `I`; interfaces keep it. **This packet treats D3 as canonical** because the user explicitly resolved the ADR-internal discrepancy with D3 in scoping.
+
+**ADR-0016 D5 (Routing policy source):** Routing policies, cost-rate tables, and capability declarations live in Azure App Configuration and are read through `IConfigProvider` from the Vault Node per ADR-0005. The `ICostLedger` description in `contracts.json` reflects this.
+
+**ADR-0016 D7 (Telemetry emission):** AI emits telemetry to Pulse via Kernel's `ITelemetryActivityFactory`. AI has **no runtime dependency on Pulse**. The catalog edits in this packet bring `nodes.json` and `ai-sector-architecture.md` into alignment with that direction.
+
+**ADR-0016 D9 (Downstream coupling):** Downstream AI-sector Nodes compile only against `HoneyDrunk.AI.Abstractions`. The `package` field on the `contracts.json` entry stays at `HoneyDrunk.AI.Abstractions` — never `HoneyDrunk.AI` or any provider package.
+
+## Dependencies
+None. This packet is the foundation of the initiative — it can land before the scaffold packet exists, because the catalog surface is design-decided already in ADR-0016. Packets 02 and 03 reference this one as `packet:01`.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0016`
+
+## Agent Handoff
+
+**Objective:** Bring `HoneyDrunk.Architecture` catalogs into alignment with ADR-0016 D3, D5, D7 — without inventing any new design choices.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Context:**
+- Goal: Catalog drift is the bottleneck that blocks downstream AI Nodes from scoping their own work. This packet removes the drift introduced by ADR-0016's acceptance.
+- Feature: ADR-0016 standup initiative.
+- ADRs: ADR-0016 (this packet implements the catalog half of "If Accepted"); ADR-0010 (already-accepted source of `IModelRouter`/`IRoutingPolicy`/`ModelCapabilityDeclaration`).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None — this packet runs first.
+
+**Constraints:**
+
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. Reinforces why the `package` field on the `honeydrunk-ai` `contracts.json` entry stays `HoneyDrunk.AI.Abstractions` — that is what downstream Nodes compile against.
+- **Invariant 28:** Application code must never hardcode a model name or provider. All model selection goes through `IModelRouter` in HoneyDrunk.AI. Routing policies are stored in App Configuration (ADR-0005) and are operator-configurable without a redeploy. Reinforces D5 and the inclusion of `IRoutingPolicy` and `ICostLedger` in the catalog surface.
+- **D3 is canonical.** The ADR's "If Accepted" checklist lists `IInferenceResult`; D3 lists `ICostLedger`. Per the user's scoping instruction, the D3 table wins. Drop `IInferenceResult` from `contracts.json` and `relationships.json`. Add `ICostLedger`.
+- **D2 first-wave provider list is canonical.** The fourth provider slot is `HoneyDrunk.AI.Providers.InMemory` (deterministic test double for Evals and CI). `Providers.Local` / local-ONNX framing is retired. Apply the rename across `catalogs/relationships.json:191`, `catalogs/contracts.json` (the `IModelProvider` description), `catalogs/nodes.json` (value_props line 596 and tags line 586), `constitution/ai-sector-architecture.md` (Provider Slot Pattern block at line 111), `repos/HoneyDrunk.AI/overview.md:21`, and `repos/HoneyDrunk.AI/active-work.md:22-26`. Final grep over `catalogs/` and `repos/HoneyDrunk.AI/` must show zero `Providers.Local` and zero `local/ONNX` matches.
+- **Strict Abstractions stance.** The repo-local invariant 1 (`repos/HoneyDrunk.AI/invariants.md:5`) and ADR-0016 D2 line 42 disagree as written; the strict stance wins. `HoneyDrunk.AI.Abstractions` ships with zero `HoneyDrunk.*` references. Amend D2 line 42 in this packet from `Zero runtime dependencies beyond \`HoneyDrunk.Kernel\` abstractions.` to `Zero runtime dependencies beyond \`Microsoft.Extensions.*\` abstractions.` Packet 03 keeps Abstractions HoneyDrunk-free; Kernel reference lives in the `HoneyDrunk.AI` runtime package.
+
+**Key Files:**
+- `catalogs/contracts.json` — replace the `honeydrunk-ai` block's interfaces array; drop `local` from `IModelProvider` description
+- `catalogs/relationships.json` — swap `IInferenceResult` for `ICostLedger` in `exposes.contracts`; swap `Providers.Local` for `Providers.InMemory` in `exposes.packages` (line 191)
+- `catalogs/grid-health.json` — replace the `honeydrunk-ai` block
+- `catalogs/nodes.json` — edit line 603 (`grid_relationship` field), line 596 (`value_props` adapters string), line 586 (`tags` — add `inmemory`, drop any `local`/`onnx` tokens)
+- `constitution/ai-sector-architecture.md` — edit Provider Slot Pattern block (line 111 row replacement) and dependency phrasing line ~114
+- `repos/HoneyDrunk.AI/overview.md` — edit line 21 provider table row
+- `repos/HoneyDrunk.AI/active-work.md` — edit lines 22–26 provider list bullets
+- `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` — amend D2 line 42 (`HoneyDrunk.Kernel` abstractions → `Microsoft.Extensions.*` abstractions)
+- `CHANGELOG.md` — Unreleased entry
+
+**Contracts:**
+- This packet does not author any new contracts. It records the seven D3 contracts in the catalog. Authoring of the actual `.cs` files happens in packet 03 (the scaffold).

--- a/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/02-architecture-ai-invariants.md
+++ b/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/02-architecture-ai-invariants.md
@@ -1,0 +1,158 @@
+---
+name: Constitution Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0016", "constitution"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0016"]
+wave: 1
+initiative: adr-0016-honeydrunk-ai-standup
+node: honeydrunk-ai
+---
+
+# Chore: Add ADR-0016's three new invariants to the Grid constitution
+
+## Summary
+Add three new invariants to `constitution/invariants.md` derived from ADR-0016 D9 (downstream coupling rule), D5 (App Configuration sourcing), and D8 (contract-shape canary). Assign them numbers 39, 40, and 41 (the next three free slots after invariant 38 — the most recent addition from ADR-0014's Hive Sync rollout).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+ADR-0016 explicitly delegates final invariant numbering to the scope agent at acceptance time. The three invariants the ADR proposes (in its "New invariants" section under Consequences) need to land in `constitution/invariants.md` so the canary infrastructure, downstream Node packets, and the review agent all have a numbered, citable rule to reference.
+
+These three rules govern the AI Node's first-shipping behavior:
+
+- **D9 — downstream coupling.** Every AI-sector Node from packet 03 onward will compile against `HoneyDrunk.AI.Abstractions` and only that package. Without an invariant, drift toward `HoneyDrunk.AI` direct references is silent until canaries catch it. Better to forbid it explicitly.
+- **D5 — App Configuration sourcing.** Cost-rate tables and routing policies in code defeat the entire reason `IRoutingPolicy` and `ICostLedger` exist. An invariant makes a hardcoded rate a build-time gating concern, not a runtime discovery.
+- **D8 — contract-shape canary.** Even with the canary wired in CI (handled by packet 03), the obligation to *keep* the canary running on the four hot-path contracts must outlive any single CI workflow file. An invariant ensures any future CI rewrite preserves the gate.
+
+## Proposed Implementation
+
+### `constitution/invariants.md` — append three new entries to the existing AI Invariants section
+
+The existing AI Invariants section (starting at line 105) already contains invariant 28 with a `(Proposed — this invariant takes effect when ADR-0010 is accepted)` qualifier and a placeholder reserving invariants 29–30 for the Observation Layer (ADR-0010). Per the active-initiatives.md sync (2026-05-03), ADR-0010 Phase 1 work is in progress; invariants 29–30 are still reserved.
+
+Add three new invariants at the **next free numbers** — currently **39, 40, 41**. Verify the highest assigned number in `constitution/invariants.md` at edit time and shift if any newly accepted ADRs have grabbed 39/40/41 between when this packet was written and when it lands.
+
+The three entries are appended directly to the existing `## AI Invariants` section, immediately after the `_Invariants 29–30 are reserved..._` line. **Do not introduce a new section header.** Non-monotonic numbering within a section (28, then 39/40/41 after the 29–30 reservation) is fine — other sections in this file already do the same kind of sparse sequencing.
+
+The current end of the AI Invariants section reads:
+
+```markdown
+## AI Invariants
+
+28. **Application code must never hardcode a model name or provider.**
+    All model selection goes through `IModelRouter` in HoneyDrunk.AI. Routing policies are stored in App Configuration (ADR-0005) and are operator-configurable without a redeploy. See ADR-0010 (Proposed — this invariant takes effect when ADR-0010 is accepted).
+
+_Invariants 29–30 are reserved for the Observation Layer (ADR-0010). They will be added here when ADR-0010 is accepted._
+
+## Code Review Invariants
+```
+
+Append the three new entries between the `_Invariants 29–30 are reserved..._` line and the `## Code Review Invariants` header so the section reads:
+
+```markdown
+## AI Invariants
+
+28. **Application code must never hardcode a model name or provider.**
+    All model selection goes through `IModelRouter` in HoneyDrunk.AI. Routing policies are stored in App Configuration (ADR-0005) and are operator-configurable without a redeploy. See ADR-0010 (Proposed — this invariant takes effect when ADR-0010 is accepted).
+
+_Invariants 29–30 are reserved for the Observation Layer (ADR-0010). They will be added here when ADR-0010 is accepted._
+
+39. **Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`.**
+    Composition against `HoneyDrunk.AI` and any `HoneyDrunk.AI.Providers.*` package is a host-time concern resolved at application startup from App Configuration. This is the same abstraction/runtime split applied for Vault and Transport, restated here because it is the specific rule that allows blocked AI-sector Nodes (Capabilities, Operator, Agents, Memory, Knowledge, Evals) to proceed on `Abstractions` alone without waiting for provider packages. See ADR-0016 D9.
+
+40. **Token cost rates, routing policies, and capability declarations are sourced from Azure App Configuration via Vault's `IConfigProvider`.**
+    Hardcoded rates, policies, or capability declarations in application code are forbidden. Rate-table refresh is operator-driven — change the config value, restart or hot-reload, no deploy required. This applies in particular to the cost-rate table consumed by `ICostLedger`: token prices per model are operator-configurable, never compiled constants. See ADR-0016 D5 and ADR-0005.
+
+41. **The HoneyDrunk.AI Node CI must include a contract-shape canary that fails the build on shape drift to `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, or `IModelRouter` without a corresponding version bump.**
+    These four are the hot-path abstractions every downstream consumer compiles against. Accidental shape drift on any of them breaks every AI-sector Node simultaneously. The canary makes this a compile-time failure at AI's own CI, not a discovery at consumer sites. The implementation may be the existing `job-api-compatibility.yml` reusable workflow scoped to `HoneyDrunk.AI.Abstractions`; the obligation is to keep the gate, not to use any specific implementation. See ADR-0016 D8.
+
+## Code Review Invariants
+```
+
+Notes for the executing agent:
+
+- The three new entries land **inside** the existing `## AI Invariants` section. Do **not** create a `## AI Invariants (continued)` or any other new heading — the section header at line 105 covers all of 28, 39, 40, 41.
+- Do not modify the existing 28's `(Proposed — this invariant takes effect when ADR-0010 is accepted)` qualifier — that is ADR-0010's concern, not this packet's.
+- Do not modify the `_Invariants 29–30 are reserved..._` placeholder line — it stays where it is, between 28 and the new 39.
+- Mark the three new invariants with the same convention used elsewhere — they should **not** carry a `(Proposed)` qualifier because ADR-0016 is being flipped to Accepted concurrently with this initiative landing (the scope agent flips Status → Accepted after this initiative's PR merges, per the user's ADR acceptance workflow).
+
+### Verify no number collision
+
+Before committing, scan `constitution/invariants.md` and confirm the highest existing number. If invariants 32–38 are present (Code Review + Container Apps + Hive Sync waves), 39 is the next free number. If any newer ADR has grabbed 39/40/41 in the interim, shift this packet's three entries to the next three free numbers and update the cross-references in:
+
+- `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` (the "New invariants (proposed for `constitution/invariants.md`)" section under Consequences) — replace the bullet text with the assigned numbers.
+- The packet 03 source file at `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md` — update any "see invariant 39/40/41" or "Invariant 39/40/41" references to match the assigned numbers. Packet 03 has not been filed yet at the time packet 02 lands (per the dispatch plan filing order), so amending its source file in place is permitted under invariant 24's pre-filing carve-out.
+
+### `CHANGELOG.md` (Architecture repo)
+Append to the Unreleased section: `Architecture: Add invariants 39 (AI downstream coupling), 40 (App Config-sourced AI rate tables and policies), and 41 (AI contract-shape canary) per ADR-0016 D9, D5, D8.`
+
+## Affected Files
+- `constitution/invariants.md`
+- `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` (only if the assigned numbers differ from 39/40/41)
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] No new design decisions — invariant text is taken verbatim from ADR-0016's "New invariants" section, with light wordsmithing for the constitution's voice.
+- [x] No existing invariants modified, only appended.
+
+## Acceptance Criteria
+- [ ] Three new invariants present in `constitution/invariants.md` with text matching ADR-0016 D9, D5, D8.
+- [ ] The three new invariants are **appended directly to the existing `## AI Invariants` section** (which begins at line 105), immediately after the `_Invariants 29–30 are reserved..._` line. No new section header is introduced — `## AI Invariants (continued)` or similar is forbidden.
+- [ ] Assigned numbers verified against the current highest number in the file (39, 40, 41 unless taken — the file's highest existing number as of 2026-05-03 is 38).
+- [ ] Each invariant's body cites its source ADR decision (D5 / D8 / D9) and any related ADRs (ADR-0005 for D5).
+- [ ] If invariant numbers shift away from 39/40/41 due to collision, packet 03's source file at `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md` is updated before that packet is filed. The dispatch plan's filing-order rule guarantees packet 03 has not been filed yet at the time packet 02 lands.
+- [ ] If numbers shifted from 39/40/41, the corresponding bullets in ADR-0016's Consequences section ("New invariants (proposed for `constitution/invariants.md`)") are updated to match, and packet 03's source file is updated to match.
+- [ ] `CHANGELOG.md` Unreleased section updated with the three invariant numbers actually assigned.
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0016 D5 (Routing policy source — App Configuration via Vault):** Routing policies, cost-rate tables, and capability declarations all live in Azure App Configuration and are read through `IConfigProvider` from the Vault Node per ADR-0005. No policies or rate tables are hardcoded in application code. — This is the source for invariant 40.
+
+**ADR-0016 D8 (Contract-shape canary):** A fifth canary is added to the AI Node's CI: a contract-shape canary that fails the build if any of `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, or `IModelRouter` change shape without a corresponding version bump. — This is the source for invariant 41.
+
+**ADR-0016 D9 (Downstream coupling rule):** Downstream AI-sector Nodes (Capabilities, Operator, Agents, Memory, Knowledge, Evals) compile only against `HoneyDrunk.AI.Abstractions`. They do not take a runtime dependency on `HoneyDrunk.AI` or any `HoneyDrunk.AI.Providers.*` package. — This is the source for invariant 39.
+
+## Dependencies
+- `packet:01` — packet 01 lands the catalog surface that invariant 41's canary will guard. Filing 02 before 01 would leave a forward-reference dangling.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0016`, `constitution`
+
+## Agent Handoff
+
+**Objective:** Land three new ADR-0016-derived invariants in the Grid constitution at the next available numbers, in a single edit.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Context:**
+- Goal: ADR-0016's "New invariants" section is a placeholder with the qualifier "Numbering is tentative — scope agent finalizes at acceptance." This packet is the finalization.
+- Feature: ADR-0016 standup initiative.
+- ADRs: ADR-0016 (sole source); ADR-0005 (referenced by invariant 40 for the App Config split).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packet 01 of this initiative (catalog registration) must merge first.
+
+**Constraints:**
+
+- **No `(Proposed)` qualifier on the new invariants.** ADR-0016 is flipping to Accepted concurrently with this initiative landing; the new invariants take effect immediately. The user's ADR acceptance workflow handles the Status flip after merge — this packet's text should read as fully active.
+- **Number collision check is a hard gate.** If 39/40/41 are taken, shift to the next free numbers and update both ADR-0016's Consequences section and packet 03 (the scaffold packet) cross-references. Do not file partial edits.
+- **Verbatim alignment with ADR-0016.** The invariant bodies should restate D5/D8/D9 with constitutional voice, not introduce new requirements. Anything novel belongs in a follow-up ADR.
+
+**Key Files:**
+- `constitution/invariants.md` — append three entries to the AI Invariants section
+- `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` — only edited if numbers shifted from 39/40/41
+- `CHANGELOG.md`
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md
@@ -1,0 +1,564 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.AI
+labels: ["feature", "tier-2", "ai", "scaffold", "adr-0016"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0016", "ADR-0010", "ADR-0005"]
+wave: 2
+initiative: adr-0016-honeydrunk-ai-standup
+node: honeydrunk-ai
+---
+
+# Feature: Stand up the HoneyDrunk.AI repo — solution, packages, contracts, CI, InMemory provider
+
+## Summary
+Bring the empty `HoneyDrunk.AI` repo from zero to first-shippable state per ADR-0016. Land the solution layout, the six package families (Abstractions + runtime + four provider slots), the seven D3 contracts inside `HoneyDrunk.AI.Abstractions`, default routing/cost/policy implementations in the `HoneyDrunk.AI` runtime, the deterministic InMemory provider, the standard CI pipeline (PR core + release + nightly), and the contract-shape canary scoped to `HoneyDrunk.AI.Abstractions` per ADR-0016 D8 / invariant 41.
+
+This is the unblocker for the six AI-sector Nodes currently waiting on AI (Capabilities, Operator, Agents, Memory, Knowledge, Evals). After this packet merges and a `0.1.0` tag lands, those Nodes can compile against `HoneyDrunk.AI.Abstractions` and start their own work in parallel.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.AI`
+
+## Motivation
+ADR-0016 establishes *what* HoneyDrunk.AI is and what contracts it exposes. The repo carries a working tree on disk but is empty — no `.slnx`, no projects, no CI, no contracts. Six AI-sector Nodes are blocked on this single repo coming online. Standing it up is the highest-leverage unblock available right now.
+
+This packet is intentionally larger than typical bring-up packets because:
+
+- The AI Node has six packages, not the usual one or two.
+- The seven D3 contracts must all land in the first commit so the contract-shape canary has a baseline.
+- The InMemory provider is required for downstream Nodes to write tests against AI without network calls.
+- Per the user's standing convention, a new Node's scaffold work bundles into one packet rather than fragmenting across many — fragmentation creates ordering hazards inside an empty repo.
+
+## Proposed Implementation
+
+### Repository layout
+
+```
+HoneyDrunk.AI/
+├── HoneyDrunk.AI.slnx
+├── CHANGELOG.md
+├── README.md
+├── .editorconfig                    (from HoneyDrunk.Standards)
+├── .gitignore
+├── .github/
+│   └── workflows/
+│       ├── pr-core.yml              (calls Actions/pr-core.yml)
+│       ├── release.yml              (calls Actions/release.yml)
+│       ├── nightly-deps.yml         (calls Actions/nightly-deps.yml)
+│       ├── nightly-security.yml     (calls Actions/nightly-security.yml)
+│       └── api-compatibility.yml    (calls Actions/job-api-compatibility.yml — D8 canary)
+├── src/
+│   ├── HoneyDrunk.AI.Abstractions/
+│   │   ├── HoneyDrunk.AI.Abstractions.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── IChatClient.cs
+│   │   ├── IEmbeddingGenerator.cs
+│   │   ├── IModelProvider.cs
+│   │   ├── IModelRouter.cs
+│   │   ├── IRoutingPolicy.cs
+│   │   ├── ModelCapabilityDeclaration.cs
+│   │   ├── ICostLedger.cs
+│   │   └── (request/response types — see "Contract details" below)
+│   ├── HoneyDrunk.AI/
+│   │   ├── HoneyDrunk.AI.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── ServiceCollectionExtensions.cs    (AddHoneyDrunkAI)
+│   │   ├── Routing/
+│   │   │   ├── DefaultModelRouter.cs
+│   │   │   └── PolicyLoader.cs               (reads policies from IConfigProvider)
+│   │   ├── Cost/
+│   │   │   └── DefaultCostLedger.cs          (reads rate-table from IConfigProvider)
+│   │   └── Telemetry/
+│   │       └── InferenceTelemetry.cs         (uses ITelemetryActivityFactory)
+│   ├── HoneyDrunk.AI.Providers.OpenAI/
+│   │   ├── HoneyDrunk.AI.Providers.OpenAI.csproj
+│   │   ├── README.md
+│   │   └── CHANGELOG.md
+│   │   (no implementation in this packet — slot only, throws NotImplementedException with TODO ADR-0016 follow-up)
+│   ├── HoneyDrunk.AI.Providers.Anthropic/      (same pattern)
+│   ├── HoneyDrunk.AI.Providers.AzureOpenAI/    (same pattern)
+│   └── HoneyDrunk.AI.Providers.InMemory/
+│       ├── HoneyDrunk.AI.Providers.InMemory.csproj
+│       ├── README.md
+│       ├── CHANGELOG.md
+│       ├── InMemoryModelProvider.cs            (deterministic — see "InMemory provider details")
+│       └── InMemoryCapabilities.cs
+└── tests/
+    ├── HoneyDrunk.AI.Abstractions.Tests/        (compile-only smoke tests)
+    ├── HoneyDrunk.AI.Tests/                     (DefaultModelRouter unit tests, DefaultCostLedger unit tests)
+    └── HoneyDrunk.AI.Providers.InMemory.Tests/  (deterministic-output assertions)
+```
+
+### Solution
+
+`HoneyDrunk.AI.slnx` references all six `src/*` projects and all three `tests/*` projects. Solution-level `Directory.Build.props` sets:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Version>0.1.0</Version>
+    <Authors>HoneyDrunk Studios</Authors>
+    <PackageProjectUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.AI</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.AI</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>
+```
+
+Per invariant 27, every project in the solution carries the same `Version` (0.1.0 for this initial release). Test projects are excluded from version-bump scope.
+
+### Contract details — `HoneyDrunk.AI.Abstractions`
+
+All seven D3 contracts. Records drop the `I` prefix; interfaces keep it. Match the **shape** of `Microsoft.Extensions.AI`'s `IChatClient` and `IEmbeddingGenerator` (D6) but declare them as distinct types under the `HoneyDrunk.AI.Abstractions` namespace.
+
+```csharp
+// IChatClient.cs
+namespace HoneyDrunk.AI.Abstractions;
+
+public interface IChatClient
+{
+    Task<ChatCompletion> CompleteAsync(
+        IReadOnlyList<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    IAsyncEnumerable<ChatCompletionUpdate> CompleteStreamingAsync(
+        IReadOnlyList<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default);
+}
+```
+
+Supporting types (`ChatMessage`, `ChatCompletion`, `ChatCompletionUpdate`, `ChatOptions`, `ChatRole`) live alongside `IChatClient.cs` in the same namespace. Match Microsoft.Extensions.AI's shapes where they are stable (the parameter shape and member set), not the literal type identities.
+
+```csharp
+// IEmbeddingGenerator.cs
+public interface IEmbeddingGenerator
+{
+    Task<IReadOnlyList<Embedding>> GenerateAsync(
+        IEnumerable<string> values,
+        EmbeddingOptions? options = null,
+        CancellationToken cancellationToken = default);
+}
+```
+
+```csharp
+// IModelProvider.cs (provider slot)
+public interface IModelProvider
+{
+    string ProviderId { get; }
+    ModelCapabilityDeclaration[] DeclaredCapabilities { get; }
+    IChatClient GetChatClient(string modelId);
+    IEmbeddingGenerator GetEmbeddingGenerator(string modelId);
+}
+```
+
+```csharp
+// IModelRouter.cs
+public interface IModelRouter
+{
+    Task<RoutedModel> RouteAsync(
+        ChatRequestSummary request,
+        IRoutingPolicy policy,
+        CancellationToken cancellationToken = default);
+}
+
+public record RoutedModel(string ProviderId, string ModelId, ModelCapabilityDeclaration Capability);
+public record ChatRequestSummary(int EstimatedInputTokens, int MaxOutputTokens, IReadOnlyList<string> RequiredCapabilities);
+```
+
+```csharp
+// IRoutingPolicy.cs
+public interface IRoutingPolicy
+{
+    string PolicyName { get; }
+    RoutingDecision Choose(IReadOnlyList<ModelCandidate> candidates, ChatRequestSummary request);
+}
+
+public record ModelCandidate(string ProviderId, string ModelId, ModelCapabilityDeclaration Capability, decimal CostPerKToken);
+public record RoutingDecision(ModelCandidate Selected, string Reason);
+```
+
+```csharp
+// ModelCapabilityDeclaration.cs (record — drops I prefix per Grid-wide naming rule)
+public record ModelCapabilityDeclaration(
+    string ProviderId,
+    string ModelId,
+    int MaxContextTokens,
+    bool SupportsStreaming,
+    bool SupportsVision,
+    bool SupportsFunctionCalling,
+    string[] SupportedRegions,
+    decimal? InputCostPerKToken,
+    decimal? OutputCostPerKToken);
+```
+
+```csharp
+// ICostLedger.cs
+public interface ICostLedger
+{
+    Task RecordAsync(InferenceCost cost, CancellationToken cancellationToken = default);
+    Task<CostSummary> GetSummaryAsync(string scope, DateTimeOffset since, CancellationToken cancellationToken = default);
+}
+
+public record InferenceCost(string ProviderId, string ModelId, int InputTokens, int OutputTokens, decimal EstimatedCost, string OperationCorrelationId);
+public record CostSummary(string Scope, DateTimeOffset Since, DateTimeOffset Until, decimal TotalCost, int TotalCalls);
+```
+
+`HoneyDrunk.AI.Abstractions` references **only** `Microsoft.Extensions.*` abstractions per invariant 1 — specifically `Microsoft.Extensions.Logging.Abstractions` for any logger contracts and `Microsoft.Extensions.Options.Abstractions` if needed. **Do not** reference any other `HoneyDrunk.*` package from Abstractions, including `HoneyDrunk.Kernel.Abstractions` — keep the AI Abstractions surface dependency-free so downstream consumers don't transit a Kernel version pin through us.
+
+**First-pass shape; subject to refinement before v0.2.0 baseline lock.** The exact member sets of `ICostLedger` (specifically the `RecordAsync`/`GetSummaryAsync` parameter shape and the `InferenceCost`/`CostSummary` records) and `IModelProvider.GetEmbeddingGenerator` are first-pass. The contract-shape canary established in this packet makes any post-v0.1.0 change a deliberate version-bump event, so the executing agent should land workable shapes here without overdesigning — refinement before downstream consumers lock against v0.2.0 is expected.
+
+**Strict Abstractions stance — deliberate, not a defect.** The `Abstractions`-has-zero-`HoneyDrunk.*`-references rule is the user's explicit scoping resolution between repo-local invariant 1 (`repos/HoneyDrunk.AI/invariants.md:5`, strict) and ADR-0016 D2 line 42 (originally permissive of Kernel.Abstractions). Packet 01 amends D2 line 42 to match the strict stance. Concretely: `InferenceCost.OperationCorrelationId` stays `string`, `ICostLedger.GetSummaryAsync(string scope, ...)` stays `string`, and any GridContext / CorrelationId propagation lives in the `HoneyDrunk.AI` runtime package (e.g. inside `InferenceTelemetry`), not in Abstractions. Abstractions does not import `HoneyDrunk.Kernel.Abstractions` to type those fields.
+
+### Runtime details — `HoneyDrunk.AI`
+
+`HoneyDrunk.AI` references:
+- `HoneyDrunk.AI.Abstractions` (project reference)
+- `HoneyDrunk.Kernel` (for `ITelemetryActivityFactory`, `IGridContext`, `IOperationContext`)
+- `HoneyDrunk.Vault` (for `IConfigProvider` to read App Config — D5)
+- `Microsoft.Extensions.DependencyInjection.Abstractions`
+- `Microsoft.Extensions.Hosting.Abstractions`
+
+Three default implementations:
+
+- **`DefaultModelRouter`** — accepts a registered set of `IModelProvider` instances via DI, builds the candidate list from `provider.DeclaredCapabilities`, hands off to the configured `IRoutingPolicy`. No baked-in policy choice — at startup, `PolicyLoader` reads `policy:active` from App Config via `IConfigProvider` and resolves the matching `IRoutingPolicy` from DI.
+- **`DefaultCostLedger`** — in-process accumulator keyed by `(ProviderId, ModelId, scope)`. Reads token prices from App Config via `IConfigProvider` at startup; refreshes on `IConfigProvider` change events. Persistence (e.g., to Data) is a follow-up — for first ship, in-memory is enough for Operator's cost-control story to start using.
+- **`InferenceTelemetry`** — wraps `IChatClient`/`IEmbeddingGenerator` calls in `ITelemetryActivityFactory`-created activities, emits per-call attributes (token in, token out, model id, provider id, latency, estimated cost). This is the "AI emits, Pulse observes" surface from D7. GridContext / CorrelationId propagation onto inference-call activities also lives here in the runtime package — not in `HoneyDrunk.AI.Abstractions`, which stays HoneyDrunk-dependency-free.
+
+**Host registration of `IConfigProvider`.** `DefaultModelRouter`, `DefaultCostLedger`, and `PolicyLoader` all depend on `IConfigProvider` being registered with an Azure App Configuration source. The deployable host (not this package) is responsible for `services.AddVault().AddAppConfigurationProvider(...)` per ADR-0005's host-composition rule. `HoneyDrunk.AI` references `HoneyDrunk.Vault` for the `IConfigProvider` contract, but it does **not** reference `HoneyDrunk.Vault.Providers.AppConfiguration` directly — that wiring is host concern. AddHoneyDrunkAI() throws a clear `InvalidOperationException` at first resolution if `IConfigProvider` is missing from the container, so a misconfigured host fails fast with a useful message.
+
+**Vault is not split into a separate Abstractions package today.** `IConfigProvider` ships from the `HoneyDrunk.Vault` runtime package (no `HoneyDrunk.Vault.Abstractions` exists yet). Referencing `HoneyDrunk.Vault` from the `HoneyDrunk.AI` runtime is therefore consistent with the existing Grid dependency pattern. If Vault later splits its abstractions out, `HoneyDrunk.AI` follows by switching the reference — that is a future-version concern, not in scope for this packet.
+
+Service registration:
+
+```csharp
+// ServiceCollectionExtensions.cs
+public static IServiceCollection AddHoneyDrunkAI(this IServiceCollection services, Action<AIOptions>? configure = null)
+{
+    services.AddSingleton<IModelRouter, DefaultModelRouter>();
+    services.AddSingleton<ICostLedger, DefaultCostLedger>();
+    // Routing policies registered by consumer or via AddRoutingPolicy<T>() helper.
+    // Providers registered by consumer or via AddModelProvider<T>() helper.
+    return services;
+}
+```
+
+### InMemory provider details — `HoneyDrunk.AI.Providers.InMemory`
+
+The InMemory provider exists for two distinct downstream consumers:
+
+- **Evals** — needs a deterministic provider whose outputs are fixture-driven, so eval runs are reproducible without spending API budget.
+- **CI / canary tests across the Grid** — needs a provider that compiles and runs without network access or secrets.
+
+Implementation:
+
+```csharp
+public sealed class InMemoryModelProvider : IModelProvider
+{
+    public string ProviderId => "inmemory";
+    public ModelCapabilityDeclaration[] DeclaredCapabilities => InMemoryCapabilities.All;
+
+    public IChatClient GetChatClient(string modelId) => new InMemoryChatClient(modelId, _scriptedResponses);
+    public IEmbeddingGenerator GetEmbeddingGenerator(string modelId) => new InMemoryEmbeddingGenerator(modelId);
+    // ...
+}
+```
+
+`InMemoryChatClient` accepts a scripted `IReadOnlyDictionary<string, ChatCompletion>` keyed by request fingerprint. Default behavior with no script: returns a fixed echo completion `"[InMemory:{modelId}] {firstUserMessageContent}"`. `InMemoryEmbeddingGenerator` returns a deterministic float vector derived from `string.GetHashCode()` over the input — enough for similarity-search correctness tests without semantic meaning.
+
+The provider declares two synthetic models in `InMemoryCapabilities`:
+- `inmemory:fast` — 8K context, no streaming, no vision, no functions, $0.00 per Ktoken
+- `inmemory:large` — 32K context, streaming, no vision, no functions, $0.00 per Ktoken
+
+### CI workflows
+
+All five workflow files are thin callers of `HoneyDrunk.Actions` reusable workflows. No bespoke CI logic in the AI repo.
+
+```yaml
+# .github/workflows/pr-core.yml
+name: PR Core
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  core:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    with:
+      dotnet-version: '10.0.x'
+```
+
+```yaml
+# .github/workflows/api-compatibility.yml — ADR-0016 D8 / invariant 41
+name: API Compatibility (Abstractions)
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/HoneyDrunk.AI.Abstractions/**'
+jobs:
+  abstractions-shape:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml@main
+    with:
+      project-path: src/HoneyDrunk.AI.Abstractions/HoneyDrunk.AI.Abstractions.csproj
+```
+
+The path filter ensures the canary only runs when Abstractions changes — keeps PR feedback fast for runtime/provider-only changes. The whole-assembly diff produced by `job-api-compatibility.yml` is sufficient to enforce D8: per D9 invariant 39, Abstractions is the only thing downstream Nodes compile against, so any shape drift in any public type in Abstractions counts.
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  release:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/release.yml@main
+    with:
+      dotnet-version: '10.0.x'
+    secrets: inherit
+```
+
+Tags are human-pushed per invariant 27 — agents do not push tags. The release workflow packs and publishes all six `src/*` projects in a single tag-driven run.
+
+`nightly-deps.yml` and `nightly-security.yml` follow the same thin-caller pattern — copy the configurations from `HoneyDrunk.Vault` or `HoneyDrunk.Auth` for reference. The exact `with:` and `secrets:` blocks should match those repos verbatim so nightly runs converge across Grid Nodes.
+
+### `HoneyDrunk.Standards` wiring
+
+Each `.csproj` references `HoneyDrunk.Standards` with `PrivateAssets="all"` per invariant 26:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="HoneyDrunk.Standards" Version="*" PrivateAssets="all" />
+</ItemGroup>
+```
+
+This pulls in the StyleCop ruleset, `.editorconfig`, and analyzer suite that every Grid repo uses.
+
+### Documentation
+
+- **Repo `README.md`** — purpose statement, package matrix, "How to consume from a downstream Node" snippet showing `AddHoneyDrunkAI()` + `AddModelProvider<InMemoryModelProvider>()`, link to ADR-0016.
+- **Repo `CHANGELOG.md`** — `## [0.1.0] - 2026-MM-DD` entry covering the entire scaffold landing.
+- **Per-package `README.md`** — purpose, public API surface summary, install command. Required by invariant 12 for new packages.
+- **Per-package `CHANGELOG.md`** — `## [0.1.0]` entry for each package introduced in this packet.
+
+## Affected Files
+Entire repo is created from this packet. Notable new files:
+- `HoneyDrunk.AI.slnx`, `Directory.Build.props`, `README.md`, `CHANGELOG.md`, `.editorconfig`, `.gitignore`
+- `src/HoneyDrunk.AI.Abstractions/` — 7 contract files + supporting record/type files + `.csproj` + `README.md` + `CHANGELOG.md`
+- `src/HoneyDrunk.AI/` — `.csproj`, `ServiceCollectionExtensions.cs`, `DefaultModelRouter.cs`, `DefaultCostLedger.cs`, `InferenceTelemetry.cs`, `PolicyLoader.cs`, `README.md`, `CHANGELOG.md`
+- `src/HoneyDrunk.AI.Providers.OpenAI/` — `.csproj`, stub provider class, `README.md`, `CHANGELOG.md`
+- `src/HoneyDrunk.AI.Providers.Anthropic/` — same
+- `src/HoneyDrunk.AI.Providers.AzureOpenAI/` — same
+- `src/HoneyDrunk.AI.Providers.InMemory/` — `.csproj`, `InMemoryModelProvider.cs`, `InMemoryChatClient.cs`, `InMemoryEmbeddingGenerator.cs`, `InMemoryCapabilities.cs`, `README.md`, `CHANGELOG.md`
+- `tests/*` — three test projects with at least smoke-test coverage
+- `.github/workflows/` — 5 workflow files
+
+## NuGet Dependencies
+
+Every new `.csproj` lists `HoneyDrunk.Standards` (`PrivateAssets="all"`) per invariant 26.
+
+### `HoneyDrunk.AI.Abstractions.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+
+(No other PackageReference. Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages, only `Microsoft.Extensions.*` abstractions are permitted, and even those only when needed. Nothing here needs them.)
+
+### `HoneyDrunk.AI.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel` | For `ITelemetryActivityFactory`, `IGridContext`, `IOperationContext` |
+| `HoneyDrunk.Vault` | For `IConfigProvider` (D5 — App Config sourcing) |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | DI registration helpers |
+| `Microsoft.Extensions.Hosting.Abstractions` | For startup hook integration |
+| `Microsoft.Extensions.Logging.Abstractions` | Logger contracts |
+| `Microsoft.Extensions.Options.ConfigurationExtensions` | Bind options from `IConfigProvider` |
+
+Project reference: `HoneyDrunk.AI.Abstractions`.
+
+### `HoneyDrunk.AI.Providers.OpenAI.csproj`, `.Anthropic.csproj`, `.AzureOpenAI.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+
+Project reference: `HoneyDrunk.AI.Abstractions` (per invariant 3 — providers depend on the parent Node's contracts package, not the runtime).
+
+(SDK packages like `OpenAI`, `Anthropic.SDK`, `Azure.AI.OpenAI` are deferred to follow-up packets that actually implement each provider. Stub classes throw `NotImplementedException("ADR-0016 follow-up — not yet implemented")`.)
+
+### `HoneyDrunk.AI.Providers.InMemory.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+
+Project reference: `HoneyDrunk.AI.Abstractions`.
+
+### Test projects
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `Microsoft.NET.Test.Sdk` | Standard |
+| `xunit` | Standard |
+| `xunit.runner.visualstudio` | Standard |
+| `Microsoft.Extensions.DependencyInjection` | For DI in router/cost ledger tests |
+
+Project references as appropriate to each `.Tests` project.
+
+## Boundary Check
+- [x] All work inside `HoneyDrunk.AI`. No edits to other Grid repos.
+- [x] `HoneyDrunk.AI.Abstractions` carries zero `HoneyDrunk.*` references — invariant 1.
+- [x] Provider packages reference `HoneyDrunk.AI.Abstractions` only — invariant 3.
+- [x] No model name or provider hardcoded anywhere in `HoneyDrunk.AI` — invariant 28. Routing reads from App Config; cost rates read from App Config.
+- [x] No secrets in code. All API keys (when provider implementations land later) flow through `ISecretStore` per invariant 9 — for this packet, the stub providers don't even take credentials.
+- [x] Abstractions' shape compatibility with `Microsoft.Extensions.AI` is structural, not type-identity (D6).
+- [x] Records (e.g. `ModelCapabilityDeclaration`, `RoutedModel`, `ModelCandidate`, `RoutingDecision`, `InferenceCost`, `CostSummary`, `Embedding`, `ChatMessage`, `ChatCompletion`) all drop the `I` prefix; interfaces keep it (Grid-wide naming rule).
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.AI.slnx` builds clean from a fresh clone via `dotnet build` with no warnings (warnings-as-errors).
+- [ ] All seven D3 contracts present in `HoneyDrunk.AI.Abstractions` with XML documentation per invariant 13.
+- [ ] `HoneyDrunk.AI.Abstractions` has zero `HoneyDrunk.*` PackageReference or ProjectReference entries (invariant 1 enforced).
+- [ ] `HoneyDrunk.AI` runtime exposes `AddHoneyDrunkAI()` extension; default `IModelRouter` and `ICostLedger` resolve from DI after registration.
+- [ ] `HoneyDrunk.AI.Providers.InMemory` is fully functional — scripted and default-echo modes both work, deterministic embedding output verified by a unit test.
+- [ ] OpenAI / Anthropic / AzureOpenAI provider stubs compile and throw `NotImplementedException` with a message naming ADR-0016 follow-up.
+- [ ] All five `.github/workflows/*.yml` files present and reference `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/*@main`.
+- [ ] `api-compatibility.yml` runs on PR. On the scaffolding PR itself the workflow runs against an absent `main` baseline and reports `status: skipped` per the `HoneyDrunk.Actions/.github/actions/api/check-compatibility/action.yml` missing-baseline path (it emits a `::warning::` and exits 0 when `git worktree add` against the baseline ref fails) — that is correct first-build behavior, not a failure. The scaffolding PR merge establishes the `main` baseline. **Verify post-merge** by opening a throwaway PR that removes a public member from `IChatClient` (or any other frozen contract); the workflow must fail with breaking-changes-detected. Revert the throwaway PR after observation.
+- [ ] `pr-core.yml` passes on the initial scaffolding PR (build + tests + analyzers + dependency scan + secret scan).
+- [ ] Repo-level `CHANGELOG.md` has a `## [0.1.0]` entry covering the scaffold; per-package `CHANGELOG.md` files each have their own `## [0.1.0]` entry naming the package's specific introductions (per invariants 12 and 27).
+- [ ] Repo-level `README.md` and per-package `README.md` files all present per invariant 12.
+- [ ] Test suite runs and passes — minimum coverage: `DefaultModelRouter` happy-path test with two providers + a cost-first policy, `DefaultCostLedger` accumulation test, `InMemoryChatClient` scripted-response test + default-echo test, `InMemoryEmbeddingGenerator` determinism test.
+- [ ] All projects in the solution carry the same `Version` (0.1.0), excluding test projects (invariant 27).
+- [ ] Manual confirmation that pushing tag `v0.1.0` triggers `release.yml` and produces NuGet packages for the six `src/*` projects (do not actually push the tag — verify the workflow exists and a tag-push trigger is configured).
+
+## Human Prerequisites
+- [ ] Confirm OIDC federated credential exists for the `HoneyDrunk.AI` repo's release workflow against the Grid's NuGet publishing identity. Cross-link: [`infrastructure/oidc-federated-credentials.md`](../../../../infrastructure/oidc-federated-credentials.md). The Grid has a standard NuGet publishing identity used by every Node — confirm `repo:HoneyDrunkStudios/HoneyDrunk.AI:ref:refs/tags/v*` is in its federated credential list.
+- [ ] After this packet's PR merges, push tag `v0.1.0` from `main` to trigger the first NuGet publish. Tags are human-pushed per invariant 27.
+- [ ] Repo settings: branch protection on `main` requires `pr-core / core` and `api-compatibility / abstractions-shape` checks, no force-pushes, signed commits not required (matches other Grid repos).
+- [ ] No Azure resource provisioning required for this packet — HoneyDrunk.AI is a library Node, not a deployable. (When a future packet stands up the cost-rate App Config keys, that packet will carry the App Config provisioning Human Prereq, not this one.)
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+
+> **Invariant 2:** Runtime packages depend on Abstractions, never on other runtime packages at the same layer. — `HoneyDrunk.AI.Providers.InMemory` references `HoneyDrunk.AI.Abstractions`, not `HoneyDrunk.AI` runtime.
+
+> **Invariant 3:** Provider packages depend on their parent Node's contracts, not internal implementation details. When a Node splits contracts into a separate package (as `HoneyDrunk.AI.Abstractions` does), providers reference that package.
+
+> **Invariant 4:** No circular dependencies. The dependency graph is a DAG. Kernel is always at the root. — `HoneyDrunk.AI` references `Kernel`; nothing in `HoneyDrunk.AI.*` is referenced back from Kernel.
+
+> **Invariant 9:** Vault is the only source of secrets. No Node reads secrets directly from environment variables, config files, or provider SDKs. All access goes through `ISecretStore`. — Provider implementations (when they land in follow-up packets) must resolve API keys via `ISecretStore`.
+
+> **Invariant 11:** One repo per Node. Each repo has its own solution, CI pipeline, and versioning. — This packet is the establishment of HoneyDrunk.AI's solution and CI pipeline.
+
+> **Invariant 12:** Semantic versioning with CHANGELOG and README. New projects must have both files from the first commit. Repo-level `CHANGELOG.md` is mandatory; per-package `CHANGELOG.md` and `README.md` required for each package.
+
+> **Invariant 13:** All public APIs have XML documentation. Enforced by HoneyDrunk.Standards analyzers. — All seven D3 contracts and their supporting types must carry `///` summaries.
+
+> **Invariant 14:** Canary tests validate cross-Node boundaries. Each Node that depends on another has a `.Canary` project verifying integration assumptions. — Future-facing: downstream Nodes will add `.Canary` projects against `HoneyDrunk.AI.Abstractions`. This packet does not author those — they belong with each downstream Node's stand-up.
+
+> **Invariant 15:** Tests never depend on external services. Use InMemory providers for isolation. — The `InMemory` provider in this packet exists specifically to satisfy this for downstream Nodes' tests.
+
+> **Invariant 16:** No test code in runtime packages. Tests live in dedicated `.Tests` or `.Canary` projects only.
+
+> **Invariant 26:** Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section. `HoneyDrunk.Standards` must be explicitly listed on every new .NET project (StyleCop + EditorConfig analyzers, `PrivateAssets: all`). — This packet's NuGet Dependencies section enumerates all six new `src/*` projects' references.
+
+> **Invariant 27:** All projects in a solution share one version and move together. When a version bump is warranted, every `.csproj` in the solution (excluding test projects) is updated to the same new version in a single commit. — Initial scaffold ships at `0.1.0` across all six packages.
+
+> **Invariant 28:** Application code must never hardcode a model name or provider. All model selection goes through `IModelRouter` in HoneyDrunk.AI. Routing policies are stored in App Configuration (ADR-0005) and are operator-configurable without a redeploy. — `DefaultModelRouter` and `DefaultCostLedger` both read from App Config via `IConfigProvider`. No `if (modelId == "gpt-4") ...` branches anywhere.
+
+> **Invariant 39 (this initiative, packet 02):** Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`. Composition against `HoneyDrunk.AI` and any `HoneyDrunk.AI.Providers.*` package is a host-time concern resolved at application startup from App Configuration. — Reinforced in this scaffold by giving `Abstractions` zero HoneyDrunk dependencies so consumers don't transit unintended pins.
+
+> **Invariant 40 (this initiative, packet 02):** Token cost rates, routing policies, and capability declarations are sourced from Azure App Configuration via Vault's `IConfigProvider`. Hardcoded rates, policies, or capability declarations in application code are forbidden. — `DefaultCostLedger` reads token prices from `IConfigProvider`; `PolicyLoader` reads `policy:active` and policy-specific config keys.
+
+> **Invariant 41 (this initiative, packet 02):** The HoneyDrunk.AI Node CI must include a contract-shape canary that fails the build on shape drift to `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, or `IModelRouter` without a corresponding version bump. — `api-compatibility.yml` calls `HoneyDrunk.Actions/job-api-compatibility.yml` scoped to `HoneyDrunk.AI.Abstractions`. The whole-assembly diff covers all four hot-path contracts plus `IRoutingPolicy`, `ModelCapabilityDeclaration`, `ICostLedger`.
+
+## Referenced ADR Decisions
+
+**ADR-0016 D1 (Inference substrate):** HoneyDrunk.AI is the AI sector's shared substrate, not an orchestrator. This scaffold ships only the substrate — no agent execution, no workflow logic, no prompt management.
+
+**ADR-0016 D2 (Package families):** Six package families — Abstractions + runtime + four provider slots (OpenAI, Anthropic, AzureOpenAI, InMemory). All six land in this packet. Provider implementations beyond InMemory are stubs awaiting follow-up packets.
+
+**ADR-0016 D3 (Exposed contracts):** Seven contracts. Records drop `I`; interfaces keep it. **D3 is the canonical surface** — `IInferenceResult` (mentioned in the ADR's "If Accepted" checklist) is **not** part of D3 and is **not** in this scaffold. `ICostLedger` is.
+
+**ADR-0016 D5 (App Configuration sourcing):** `DefaultCostLedger` and `PolicyLoader` both read from `IConfigProvider`. No rate or policy literal in code.
+
+**ADR-0016 D6 (Microsoft.Extensions.AI shape compatibility):** Method signatures and parameter shapes mirror MEAI where practical, but the types live in `HoneyDrunk.AI.Abstractions`. The `HoneyDrunk.AI.Interop.MEAI` adapter package is **deferred to Q3 2026** and is not part of this packet.
+
+**ADR-0016 D7 (Telemetry direction):** `InferenceTelemetry` emits via `ITelemetryActivityFactory` (Kernel). No Pulse package reference. Pulse consumes downstream — out of scope for this packet.
+
+**ADR-0016 D8 (Contract-shape canary):** `api-compatibility.yml` is the canary. Scoped to `HoneyDrunk.AI.Abstractions` since per D9 that is the only public-boundary package.
+
+**ADR-0016 D9 (Downstream coupling):** `Abstractions` is dependency-clean so downstream Nodes can take it without pulling Kernel or Vault transitively.
+
+**ADR-0010 (already accepted):** Source of `IModelProvider`, `IModelRouter`, `IRoutingPolicy`, `ModelCapabilityDeclaration`. Their concrete shapes are decided in this packet — ADR-0010 said "these contracts exist," ADR-0016 D3 said "they live in `HoneyDrunk.AI.Abstractions` with these member sets," and this packet authors them.
+
+**ADR-0005 (already accepted, deployable Nodes):** HoneyDrunk.AI is a **library Node**, not a deployable. Per ADR-0005, library Nodes have no Key Vault. App Config is shared across the Grid — `HoneyDrunk.AI` reads from it via `IConfigProvider` when composed into a deployable. This packet does not provision App Config — it consumes whatever the deployable host's App Config contains.
+
+## Dependencies
+- `packet:01` — catalog registration must land first so the Architecture catalogs match what this packet ships. Filing order matters for the `addBlockedBy` graph on The Hive.
+- `packet:02` — invariants 39, 40, 41 must exist in `constitution/invariants.md` before this packet's acceptance criteria reference them by number.
+
+## Labels
+`feature`, `tier-2`, `ai`, `scaffold`, `adr-0016`
+
+## Agent Handoff
+
+**Objective:** Take the empty `HoneyDrunk.AI` repo and ship version 0.1.0 with the seven D3 contracts, default runtime, four provider-slot packages (InMemory functional, three stubs), full CI, and the contract-shape canary scoped to Abstractions.
+
+**Target:** HoneyDrunk.AI, branch from `main`. (If `main` does not yet exist because the repo is fully empty, push directly to `main` for the initial commit.)
+
+**Context:**
+- Goal: Unblock six AI-sector Nodes (Capabilities, Operator, Agents, Memory, Knowledge, Evals) currently waiting for `HoneyDrunk.AI.Abstractions` to exist.
+- Feature: ADR-0016 standup initiative — this is the substrate scaffold, the third and largest packet of the initiative.
+- ADRs: ADR-0016 (sole governing ADR for the standup); ADR-0010 (already-accepted source of routing contracts); ADR-0005 (App Config split that D5 builds on).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packets 01 and 02 of this initiative must merge first.
+
+**Constraints:**
+
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — `HoneyDrunk.AI.Abstractions.csproj` must contain no `HoneyDrunk.*` PackageReference or ProjectReference. The `HoneyDrunk.Standards` reference uses `PrivateAssets="all"` so it does not propagate.
+- **Invariant 3:** Provider packages depend on their parent Node's contracts package. — All four provider `.csproj` files reference `HoneyDrunk.AI.Abstractions` (project reference), nothing else from the AI Node.
+- **Invariant 9:** Vault is the only source of secrets. All access goes through `ISecretStore`. — When future packets implement OpenAI/Anthropic/AzureOpenAI providers, they will resolve credentials via `ISecretStore`. This packet's stubs do not take credentials and do not need to reference `HoneyDrunk.Vault`.
+- **Invariant 12:** Semantic versioning with CHANGELOG and README. New projects must have both files from the first commit. — Every one of the six `src/*` projects must ship a `README.md` and `CHANGELOG.md` in the same commit it is added.
+- **Invariant 13:** All public APIs have XML documentation. — Every public type/member in `HoneyDrunk.AI.Abstractions` carries `///` summaries. StyleCop rules from `HoneyDrunk.Standards` enforce this.
+- **Invariant 26:** Packets for .NET code work must include `## NuGet Dependencies`. `HoneyDrunk.Standards` must be on every new .NET project. — Confirmed in the NuGet Dependencies section above.
+- **Invariant 27:** All projects in a solution share one version. — Every `src/*.csproj` ships at `0.1.0`. Test projects do not bump.
+- **Invariant 28:** No hardcoded model name or provider. — `DefaultModelRouter`, `DefaultCostLedger`, and `PolicyLoader` all read from App Config. The InMemory provider's two synthetic models are declared via `ModelCapabilityDeclaration` data, not branched on by string in any consumer.
+- **Invariant 39:** Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`. — Reinforced by keeping Abstractions HoneyDrunk-dependency-free.
+- **Invariant 40:** Token cost rates, routing policies, and capability declarations sourced from App Configuration via `IConfigProvider`. — `DefaultCostLedger` and `PolicyLoader` both read from `IConfigProvider`. No `decimal RatePerKToken = 0.03m` literals anywhere.
+- **Invariant 41:** AI Node CI must include the contract-shape canary on the four hot-path contracts. — `api-compatibility.yml` covers this by scoping to `HoneyDrunk.AI.Abstractions`.
+- **Canary on the scaffolding PR is expected to report `status: skipped`, not fail.** The shared `HoneyDrunk.Actions/.github/actions/api/check-compatibility/action.yml` emits `::warning::` and exits 0 with `status: skipped` when `git worktree add` against the baseline ref fails — which it always does on a first PR against an empty repo. Do not treat the skip as a misconfiguration and do not chase it. The scaffolding PR's merge establishes the `main` baseline; verification of the canary actually firing happens **post-merge** via a throwaway breaking-change PR that is reverted after observation.
+- **Strict Abstractions stance is deliberate.** `HoneyDrunk.AI.Abstractions` ships with zero `HoneyDrunk.*` references. This is the user's explicit scoping resolution — see ADR-0016 D2 line 42 (amended by packet 01 to `Microsoft.Extensions.*` only) and `repos/HoneyDrunk.AI/invariants.md:5`. Any GridContext/CorrelationId propagation belongs in the `HoneyDrunk.AI` runtime package (specifically `InferenceTelemetry`), not in Abstractions. `InferenceCost.OperationCorrelationId` is a `string`; `ICostLedger.GetSummaryAsync(string scope, ...)` takes a `string`. Do not import `HoneyDrunk.Kernel.Abstractions` in any `HoneyDrunk.AI.Abstractions` source file.
+- **D3 is canonical, not the "If Accepted" checklist.** Author exactly the seven D3 contracts. Do **not** author `IInferenceResult`. If you find a reference to `IInferenceResult` anywhere in scope (e.g. an old example in the AI sector architecture doc), that is drift to be cleaned up by packet 01 or as a follow-up — do not invent the type just because the ADR's checklist mentions it.
+- **Records drop `I`; interfaces keep it.** `ModelCapabilityDeclaration` is a record (no `I`). The other six contracts are interfaces (with `I`). Supporting record types in the same files (`RoutedModel`, `ModelCandidate`, `RoutingDecision`, `InferenceCost`, `CostSummary`, `ChatMessage`, `ChatCompletion`, `Embedding`, `EmbeddingOptions`, `ChatOptions`) all drop the `I`.
+- **Shape compatibility with `Microsoft.Extensions.AI` is structural, not type-identity.** Match the parameter shapes and member sets where they are stable. Do **not** reference any `Microsoft.Extensions.AI.*` package. The MEAI interop adapter is deferred to Q3 2026 per D6.
+
+**Key Files:**
+- `HoneyDrunk.AI.slnx`, `Directory.Build.props`
+- `src/HoneyDrunk.AI.Abstractions/IChatClient.cs`, `IEmbeddingGenerator.cs`, `IModelProvider.cs`, `IModelRouter.cs`, `IRoutingPolicy.cs`, `ModelCapabilityDeclaration.cs`, `ICostLedger.cs` and supporting record types in the same folder
+- `src/HoneyDrunk.AI/ServiceCollectionExtensions.cs`, `Routing/DefaultModelRouter.cs`, `Routing/PolicyLoader.cs`, `Cost/DefaultCostLedger.cs`, `Telemetry/InferenceTelemetry.cs`
+- `src/HoneyDrunk.AI.Providers.InMemory/InMemoryModelProvider.cs`, `InMemoryChatClient.cs`, `InMemoryEmbeddingGenerator.cs`, `InMemoryCapabilities.cs`
+- `src/HoneyDrunk.AI.Providers.{OpenAI,Anthropic,AzureOpenAI}/` — stub `.csproj` + stub `*ModelProvider.cs` throwing `NotImplementedException`
+- `.github/workflows/{pr-core,release,nightly-deps,nightly-security,api-compatibility}.yml`
+- `README.md`, `CHANGELOG.md` (repo-level), per-package `README.md` and `CHANGELOG.md`
+- `tests/HoneyDrunk.AI.Tests/`, `tests/HoneyDrunk.AI.Providers.InMemory.Tests/`
+
+**Contracts:**
+- All seven D3 contracts authored fresh in this packet inside `HoneyDrunk.AI.Abstractions`.
+- The contract-shape canary establishes its baseline against this packet's commit. Future shape changes to any public type in Abstractions trigger the canary.

--- a/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/dispatch-plan.md
@@ -1,0 +1,121 @@
+# Dispatch Plan — ADR-0016 HoneyDrunk.AI Standup
+
+**Initiative:** `adr-0016-honeydrunk-ai-standup`
+**Sector:** AI
+**Governing ADR:** [ADR-0016 — Stand Up the HoneyDrunk.AI Node](../../../../adrs/ADR-0016-stand-up-honeydrunk-ai-node.md) (Proposed 2026-04-19; flips to Accepted after this initiative's PRs merge per the user's ADR acceptance workflow — scope agent flips Status, never on first draft)
+**Trigger:** ADR-0016 accepted into the Proposed queue. Six AI-sector Nodes (Capabilities, Operator, Agents, Memory, Knowledge, Evals) are blocked on `HoneyDrunk.AI.Abstractions` existing. This initiative builds the substrate that unblocks them.
+**Type:** Multi-repo (2 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.AI`)
+**Site sync required:** No (scaffold-only; no public-API surface change needs site update yet — when 0.1.0 ships and downstream Nodes start consuming, a site-sync follow-up may be warranted)
+**Rollback plan:** Each packet is a single PR. Rollback is `git revert`. The new `HoneyDrunk.AI` repo's `0.1.0` tag is published only after the human pushes the tag — which is post-merge — so a rollback before tag push is just a revert. After tag push, NuGet packages are immutable but unconsumed at this point in the rollout (downstream Nodes haven't started yet).
+
+## Summary
+
+ADR-0016 is the standup ADR for `HoneyDrunk.AI`. It decides what the Node owns (D1), the package families (D2), the seven exposed contracts (D3), routing scope (D4), App Configuration sourcing for routing/cost (D5), Microsoft.Extensions.AI shape compatibility without type-identity coupling (D6), one-way telemetry to Pulse (D7), the contract-shape canary (D8), and the downstream coupling rule (D9). None of that has been built — the AI repo is empty.
+
+Three packets land the work:
+
+1. **Architecture catalog registration** — `contracts.json`, `relationships.json`, `grid-health.json`, `nodes.json`, `ai-sector-architecture.md`. Resolves the D3-vs-"If Accepted" checklist discrepancy by treating D3 as canonical (drops `IInferenceResult`, adds `ICostLedger`).
+2. **Constitution invariants** — three new invariants from D5, D8, D9 added to `constitution/invariants.md` at numbers 39/40/41.
+3. **HoneyDrunk.AI scaffold** — empty repo to first-shippable state. Solution, six packages, seven contracts, default runtime, four provider slots (InMemory functional, three stubs), five CI workflow files including the contract-shape canary scoped to Abstractions.
+
+## Wave Diagram
+
+```
+Wave 1: Architecture catalog + constitution updates (parallel)
+   ├─ Architecture: 01-architecture-ai-catalog-registration
+   └─ Architecture: 02-architecture-ai-invariants
+       Blocked by: 01 (so 02's invariant text aligns with the catalog surface 01 lands)
+
+Wave 2: AI repo scaffold
+   └─ HoneyDrunk.AI: 03-ai-node-scaffold
+       Blocked by: 01, 02
+```
+
+In practice 01 and 02 are both Architecture-repo packets touching different files (catalogs vs constitution), so they could be authored as a single PR. They are kept as separate packets to honor the "one logical change per packet" rule and to give the user a clean review surface for each (catalog drift is one mental model; invariant numbering is another).
+
+## Packet List
+
+| # | Packet | Repo | Wave | Depends On |
+|---|--------|------|------|------------|
+| 01 | [Catalog registration (`contracts.json`, `relationships.json`, `grid-health.json`, `nodes.json`, `ai-sector-architecture.md`)](./01-architecture-ai-catalog-registration.md) | Architecture | 1 | — |
+| 02 | [Add invariants 39/40/41 (downstream coupling, App Config sourcing, contract-shape canary)](./02-architecture-ai-invariants.md) | Architecture | 1 | 01 |
+| 03 | [Stand up `HoneyDrunk.AI` — solution, six packages, contracts, CI, InMemory provider](./03-ai-node-scaffold.md) | HoneyDrunk.AI | 2 | 01, 02 |
+
+## Phase Mapping
+
+- **Wave 1 (packets 01 + 02) = ADR-0016's "If Accepted" catalog/constitution obligations.**
+  - Packet 01 covers all four catalog/doc edits in the "If Accepted" checklist except invariants and the scaffold (catalogs/contracts.json + grid-health.json + nodes.json phrasing + ai-sector-architecture.md phrasing) and resolves the D3-vs-checklist discrepancy.
+  - Packet 02 covers the invariants ADR-0016 explicitly delegates to the scope agent at acceptance.
+- **Wave 2 (packet 03) = the standup itself.** Larger than typical bring-up packets because the AI Node carries six packages and seven contracts, all of which must land together to give the contract-shape canary a coherent baseline.
+
+## Discrepancies Flagged for the User
+
+**1. Discrepancy in ADR-0016's "If Accepted" checklist.** The ADR's checklist (line 12) lists `IInferenceResult` as one of the seven contracts. The D3 table (lines 54–62) lists `ICostLedger` instead. These cannot both be true — there are seven contracts, not eight.
+
+**Resolution:** Per the user's explicit instruction during scoping, **D3 is canonical**. This initiative ships `ICostLedger` and does **not** ship `IInferenceResult`. Packet 01 swaps the catalog entries accordingly. Packet 03 authors `ICostLedger.cs` and does not author `IInferenceResult.cs`.
+
+**Action item for the human:** When flipping ADR-0016 to Accepted (after this initiative's PRs merge), correct the "If Accepted" checklist on line 12 of the ADR to list `ICostLedger` instead of `IInferenceResult`. Packet 01's Human Prerequisites section calls this out.
+
+Also: `relationships.json` line 190 currently lists `IInferenceResult` in the `honeydrunk-ai` `exposes.contracts` array (this file existed before ADR-0016 and was authored against the now-superseded ADR-0010 inventory). Packet 01 cleans this up.
+
+**2. Stale `Providers.Local` references across catalogs and AI repo docs.** ADR-0016 D2 line 48 lists the fourth provider slot as `HoneyDrunk.AI.Providers.InMemory` (deterministic test double for Evals and CI). Earlier docs and catalogs were authored against a now-retired `Providers.Local` / local-ONNX framing. Drift is present in `catalogs/relationships.json:191`, `catalogs/contracts.json` (the `IModelProvider` description), `catalogs/nodes.json` (value_props line 596 + tags line 586), `constitution/ai-sector-architecture.md:111`, `repos/HoneyDrunk.AI/overview.md:21`, and `repos/HoneyDrunk.AI/active-work.md:22-26`.
+
+**Resolution:** Packet 01 completes the rename across all six locations. Final grep over `catalogs/` and `repos/HoneyDrunk.AI/` must show zero `Providers.Local` and zero `local/ONNX` matches.
+
+**3. Internal disagreement on `HoneyDrunk.AI.Abstractions`'s allowed dependencies.** ADR-0016 D2 line 42 says Abstractions has "Zero runtime dependencies beyond `HoneyDrunk.Kernel` abstractions" (Kernel.Abstractions allowed). Repo-local invariant 1 at `repos/HoneyDrunk.AI/invariants.md:5` says zero HoneyDrunk dependencies, only `Microsoft.Extensions.*` abstractions allowed (Kernel.Abstractions forbidden). These cannot both be true.
+
+**Resolution:** Per the user's explicit scoping resolution, the **strict stance wins**. `HoneyDrunk.AI.Abstractions` ships with zero `HoneyDrunk.*` references. Kernel reference lives in the `HoneyDrunk.AI` runtime package, not Abstractions. Rationale: keeps the hottest contract surface in the Grid dependency-clean for downstream consumers; matches the existing repo-local invariant; the runtime package is where Kernel reference belongs.
+
+Packet 01 amends ADR-0016 D2 line 42 in the same edit it lands the catalog drift fixes — replacing `Zero runtime dependencies beyond \`HoneyDrunk.Kernel\` abstractions.` with `Zero runtime dependencies beyond \`Microsoft.Extensions.*\` abstractions.` Packet 03 keeps `Abstractions` HoneyDrunk-free in code and explicitly cites this stance in its Constraints section so the executing agent does not introduce a Kernel.Abstractions reference. Practical fallout: `InferenceCost.OperationCorrelationId` stays `string`; `ICostLedger.GetSummaryAsync(string scope, ...)` keeps `string` params; GridContext/CorrelationId propagation lives in the AI runtime package's `InferenceTelemetry`, not in any Abstractions type.
+
+## Filing-order rule
+
+Packet 03 hard-codes invariant numbers 39/40/41 in its body and acceptance criteria. Filed packets are immutable (invariant 24). Therefore:
+
+**Packet 02 must be filed, its PR merged, and the assigned invariant numbers locked in `constitution/invariants.md` before packet 03 is filed.**
+
+If packet 02's collision check at edit time forces a renumber away from 39/40/41, the packet 03 source file at `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md` MUST be amended in place before push (it has not been filed yet at that point — invariant 24's pre-filing carve-out applies). **Packets 02 and 03 cannot be filed in the same push.** Concretely:
+
+1. Push packets 01 and 02 (they may travel together — packet 02's `dependencies: ["packet:01"]` wires the blocking edge automatically).
+2. Wait for packet 02's PR to merge so the assigned invariant numbers actually land in `constitution/invariants.md`.
+3. If the numbers shifted away from 39/40/41, edit `03-ai-node-scaffold.md` in place to match (pre-filing carve-out under invariant 24).
+4. Push packet 03.
+
+Packet 02's acceptance criteria call this out; packet 03's body assumes the lock has happened.
+
+## What This Initiative Does **NOT** Deliver
+
+The six downstream-blocked Nodes are **not** delivered by this initiative. The initiative unblocks them, but each gets its own bring-up:
+
+- **HoneyDrunk.Capabilities** — repo not yet scaffolded; will compile against `ModelCapabilityDeclaration`.
+- **HoneyDrunk.Operator** — repo not yet scaffolded; will wrap `IChatClient` calls with safety controls.
+- **HoneyDrunk.Agents** — repo not yet scaffolded; will compile against `IChatClient` + `IEmbeddingGenerator`.
+- **HoneyDrunk.Memory** — repo not yet scaffolded; will use `IEmbeddingGenerator` for vector recall.
+- **HoneyDrunk.Knowledge** — repo not yet scaffolded; will use `IEmbeddingGenerator` for retrieval.
+- **HoneyDrunk.Evals** — repo not yet scaffolded; will target `IModelProvider` with `InMemoryModelProvider` as the deterministic fixture.
+
+Each of these will need its own standup ADR (per the user's "new-Node scaffolding gets its own ADR/packet" rule) before scaffolding packets are written.
+
+The three OpenAI/Anthropic/AzureOpenAI provider implementations are **stubs** in this initiative. Each needs a follow-up packet to author the actual SDK integration with `ISecretStore`-backed credential resolution. Those packets are not blocked on anything in this initiative once `HoneyDrunk.AI 0.1.0` ships — they can be filed independently.
+
+The `HoneyDrunk.AI.Interop.MEAI` adapter package is deferred to Q3 2026 per ADR-0016 D6 and is not in scope for this initiative.
+
+## Archival
+
+Per ADR-0008 D10, when every packet in this initiative reaches `Done` on the org Project board and `HoneyDrunk.AI 0.1.0` is published to NuGet, the entire `active/adr-0016-honeydrunk-ai-standup/` folder moves to `archive/adr-0016-honeydrunk-ai-standup/` in a single commit. Partial archival is forbidden.
+
+The hive-sync agent moves individual closed packet files from `active/` to `completed/` per invariant 37 — that is per-packet lifecycle. Initiative-level archival is the post-completion sweep that follows after the whole folder reaches `Done`.
+
+## Notes
+
+- **Scoping insight: the contract-shape canary needs no Actions packet.** Initially scoped this initiative as four packets (with a separate Actions packet to wire the canary). Investigation showed `HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml` already exists and supports `project-path`-scoped diffing. Per ADR-0016 D9, `HoneyDrunk.AI.Abstractions` is the only public-boundary package — so scoping the canary to that one assembly satisfies D8 without per-type filtering. The wiring is a single `.github/workflows/api-compatibility.yml` file inside HoneyDrunk.AI itself, folded into packet 03's CI bring-up. No Actions repo change required.
+
+- **Why two Architecture packets in Wave 1, not one.** Catalog drift correction (packet 01) and invariant numbering (packet 02) are conceptually separate review concerns. A single mega-PR mixing them would obscure the D3-canonical resolution of the `IInferenceResult`/`ICostLedger` discrepancy. Packets 01 and 02 may be filed in the same push (their `dependencies:` frontmatter wires the `packet:01 → packet:02` blocking edge automatically); the **hard split is between 02 and 03** — see the Filing-order rule above. Packet 03 must not be filed until packet 02 has landed in `constitution/invariants.md` and the assigned numbers are confirmed, so any required amendments to packet 03's source file can happen pre-filing.
+
+- **Status flip happens after merge, not now.** ADR-0016 stays Proposed for this scoping run. The user's standing workflow says the scope agent flips Status → Accepted after the follow-up PR merges. None of the three packets in this initiative flip ADR-0016's status — that is a separate housekeeping step the scope agent handles when the initiative completes.
+
+- **No Azure provisioning in scope.** HoneyDrunk.AI is a library Node, not a deployable. There is no Key Vault, no Container App, no resource group to create. App Configuration provisioning (the Grid-shared App Config that ADR-0005 describes) is already in place from the ADR-0005/0006 rollout — packet 03 just consumes it via `IConfigProvider`. When the cost-rate keys and routing-policy keys actually need to be seeded in App Config, that is a follow-up Human Prerequisite carried by whichever packet first stands up an inference-using deployable.
+
+## Filing
+
+The `file-packets.yml` workflow in `HoneyDrunk.Architecture` triggers automatically on push to `generated/issue-packets/active/**/*.md`. No `gh issue create` commands in this dispatch plan — the pipeline handles filing, project-board addition, field population, and `addBlockedBy` wiring from the `dependencies:` frontmatter on each packet. Verify after push by checking The Hive (org Project #4) for the three new items and their blocking edges.

--- a/generated/issue-packets/completed/honeydrunk-lore-bringup/05-lore-scheduled-ingest-agent.md
+++ b/generated/issue-packets/completed/honeydrunk-lore-bringup/05-lore-scheduled-ingest-agent.md
@@ -10,18 +10,20 @@ initiative: honeydrunk-lore-bringup
 node: honeydrunk-lore
 ---
 
-# Feature: Scheduled ingest â€” daily agent to auto-compile raw/ sources
+# Feature: Scheduled ingest â€” weekly agent to auto-compile raw/ sources
 
 ## Summary
-Set up a Claude Code scheduled remote agent (via CronCreate) that runs daily, checks `raw/` for sources not yet reflected in `wiki/`, and runs the ingest operation for each. This eliminates the manual step of asking Claude to compile after clipping â€” content flows in via Web Clipper, the agent processes it overnight.
+Set up a Claude Code scheduled remote agent (via CronCreate) that runs weekly, checks `raw/` for sources not yet reflected in `wiki/`, and runs the ingest operation for each. This eliminates the manual step of asking Claude to compile after content arrives â€” content accumulates in `raw/` from multiple producers throughout the week, and the agent processes the batch in one Sunday pass.
 
 ## Target Repo
 `HoneyDrunkStudios/HoneyDrunk.Lore`
 
 ## Motivation
-The wiki compounds only if compilation is frictionless. Without automation, the workflow is: clip article â†’ remember to open Claude Code â†’ ask it to compile. That friction causes `raw/` to accumulate unprocessed sources. The scheduled agent removes the "remember to compile" step entirely â€” you clip, it compiles.
+The wiki compounds only if compilation is frictionless. Without automation, the workflow is: produce content â†’ remember to open Claude Code â†’ ask it to compile. That friction causes `raw/` to accumulate unprocessed sources. The scheduled agent removes the "remember to compile" step entirely.
 
-Claude Code's CronCreate creates a remote trigger that runs on a cron schedule. The agent wakes up, reads `raw/` against `wiki/indexes/sources.md`, ingest any unprocessed files, and commits the result. The next time you open Obsidian, new wiki pages are already there.
+`raw/` has multiple producers: OpenClaw scheduled sourcing (issue #5, runs every 1â€"2 days walking `sourcing-playbook.md`), Web Clipper (browser extension, anytime), and the on-demand "add URL to Lore" Telegram trigger (also issue #5). The weekly ingest agent does not distinguish between them â€" every file in `raw/` gets the same compile treatment. Expect 20â€"50 items to accumulate per week, processed in one Sunday batch.
+
+Claude Code's CronCreate creates a remote trigger that runs on a cron schedule. The agent wakes up, reads `raw/` against `wiki/indexes/sources.md`, ingests any unprocessed files, and commits the result. The next time you open Obsidian on Monday morning, a week's worth of new wiki pages is already there.
 
 ## How it works
 
@@ -37,7 +39,7 @@ A source in `raw/` is unprocessed if its filename does not appear in `wiki/index
 6. If nothing new: exit silently (no empty commits)
 
 ### Schedule
-Daily at 06:00 local time (or configure to preference). Running at start-of-day means new wiki pages are ready when you open Obsidian in the morning.
+Weekly on Sunday at 06:00 local time (or configure to preference). Running at the start of the week means a full week's worth of accumulated `raw/` items is processed in one batch, with new wiki pages ready when you open Obsidian on Monday morning.
 
 ### Future extensions (v2 hook layer â€” not in scope for this issue)
 The daily trigger is the first of several event-driven hooks the wiki grows toward (see the "Extensions (v2)" section in `CLAUDE.md`, sourced from https://gist.github.com/rohitg00/2067ab416f7bbe447c1977edaaa681e2). When volume or noise warrants it, file follow-up issues for:
@@ -54,7 +56,7 @@ None of these are built now. They are listed so future agents understand the tra
 Use the Claude Code `/schedule` skill or CronCreate directly to create a scheduled remote trigger on `HoneyDrunkStudios/HoneyDrunk.Lore`:
 
 ```
-Cron: 0 6 * * *   (daily at 06:00)
+Cron: 0 6 * * 0   (weekly on Sunday at 06:00)
 Repo: HoneyDrunkStudios/HoneyDrunk.Lore
 Branch: main
 Prompt: (see agent prompt below)
@@ -97,7 +99,7 @@ Update the stub created in issue #1 to include the expected heading structure:
 ```
 
 ## Acceptance Criteria
-- [ ] Scheduled remote trigger created via CronCreate, running daily at 06:00
+- [ ] Scheduled remote trigger created via CronCreate, running weekly on Sunday at 06:00
 - [ ] Agent prompt reads CLAUDE.md before operating (not hardcoded behavior)
 - [ ] `wiki/indexes/sources.md` has the `## Processed` heading contract
 - [ ] CLAUDE.md Ingest operation updated with sources.md append contract

--- a/generated/issue-packets/completed/honeydrunk-lore-bringup/06-lore-openclaw-setup-and-skill.md
+++ b/generated/issue-packets/completed/honeydrunk-lore-bringup/06-lore-openclaw-setup-and-skill.md
@@ -10,20 +10,20 @@ initiative: honeydrunk-lore-bringup
 node: honeydrunk-lore
 ---
 
-# Chore: OpenClaw setup + Lore sourcing skill
+# Chore: OpenClaw setup + scheduled Lore sourcing skill
 
 ## Summary
-Install and configure OpenClaw (openclaw.ai) as a local AI assistant connected to the Lore vault and messaging apps. Then build a custom Lore sourcing skill so you can say "add this to Lore" or "find content about X for Lore" from your phone or any connected messaging app, and the content lands in `raw/` automatically.
+Install and configure OpenClaw (openclaw.ai) as the sourcing engine for HoneyDrunk.Lore. Configure messaging (Telegram), AI provider (Claude), Obsidian vault link, browser tool (managed Chromium profile), one-time logins for login-walled sources (X, Discord), and the scheduled sourcing skill that walks `sourcing-playbook.md` and drops qualifying items in `raw/` every 1–2 days. Scheduled sourcing is the primary mechanism. Two on-demand Telegram triggers ("add [URL] to Lore", "what does Lore know about [topic]") are kept as a phone-friendly serendipitous-capture and query layer on top.
 
 ## Target Repo
 `HoneyDrunkStudios/HoneyDrunk.Lore` (local machine)
 
 ## Why human-only
-OpenClaw is a local application that installs on your machine and connects to desktop apps (Obsidian) and messaging services (WhatsApp, Telegram, etc.). Installation and messaging account linking require UI interaction. The Lore skill definition is agent-writable but only useful once the runtime is installed.
+OpenClaw installation, AI provider key entry, messaging-app pairing, and browser logins (X, Discord) all require UI interaction. The skill instruction files and OpenClaw config are agent-writable but only useful once the runtime is installed and authenticated.
 
 ---
 
-## Part A â€” Install OpenClaw
+## Part A — Install OpenClaw
 
 ### 1. Install on Windows
 OpenClaw ships a bash install script. On Windows, run it in Git Bash or WSL:
@@ -32,157 +32,262 @@ OpenClaw ships a bash install script. On Windows, run it in Git Bash or WSL:
 curl -fsSL https://openclaw.ai/install.sh | bash
 ```
 
-After installation, verify it started:
+After install:
 - Check the system tray for the OpenClaw icon
 - Or run `openclaw status` in your terminal
 
-If the bash install does not work on your Windows setup, check openclaw.ai/docs for the Windows-native installer â€” they list Mac, Windows, and Linux support.
+If the bash install fails on the Windows setup, check openclaw.ai/docs for a Windows-native installer.
 
-### 2. Choose your AI provider
-OpenClaw supports Anthropic Claude, OpenAI, and local models. Use Claude:
-- Settings â†’ AI Provider â†’ Anthropic
-- Enter your Anthropic API key
-- Select model: claude-sonnet-4-6 (or latest Sonnet for balance of speed and quality)
+---
 
-### 3. Connect a messaging app
-OpenClaw delivers through apps you already use. Pick one as your primary Lore interface:
+## Part B — Configure AI provider
 
-**Recommended: Telegram** (easiest setup, works well on mobile + desktop)
-- Create a Telegram bot via BotFather (search @BotFather in Telegram)
+### 2. Set Claude as the provider
+- Settings → AI Provider → Anthropic
+- Enter the Anthropic API key
+- Model: current Sonnet (`claude-sonnet-4-6` as of writing) — balanced speed and quality for sourcing volume
+
+---
+
+## Part C — Connect Telegram
+
+### 3. Set up the Telegram bot
+- In Telegram, search `@BotFather` and create a new bot
 - Copy the bot token
-- OpenClaw Settings â†’ Integrations â†’ Telegram â†’ paste token
-- Start a conversation with your bot â€” OpenClaw responds through it
-
-**Alternative: WhatsApp**
-- Settings â†’ Integrations â†’ WhatsApp
-- Follow the QR code pairing flow
-- Note: WhatsApp integration requires the WhatsApp app open on your phone periodically to stay connected
+- OpenClaw Settings → Integrations → Telegram → paste token
+- Send a test message to the bot — verify OpenClaw responds
 
 ---
 
-## Part B â€” Connect Obsidian
+## Part D — Connect the Obsidian vault
 
-### 4. Link Obsidian to OpenClaw
-OpenClaw has a native Obsidian integration:
-- Settings â†’ Integrations â†’ Obsidian
-- Point it at the vault root: `HoneyDrunk.Lore/`
-- Verify: send a test message "list my vault files" â€” OpenClaw should return a file listing
+### 4. Link Obsidian
+- Settings → Integrations → Obsidian
+- Point at the vault root: `HoneyDrunk.Lore/`
+- Verify: send "list my vault files" via Telegram → file listing returns
 
 ---
 
-## Part C â€” Build the Lore sourcing skill
+## Part E — Configure the browser tool
 
-OpenClaw skills are defined as markdown or JSON instruction files that tell OpenClaw what to do when triggered. Skills live in the ClawHub directory or a local skills folder.
+The browser tool drives an isolated Chromium profile that persists cookies across runs. This is what scrapes X and Discord.
 
-### 5. Create the Lore skill
+### 5. Enable browser automation
+Edit `~/.openclaw/openclaw.json`:
 
-Create a new skill file. The skill should handle three trigger phrases:
+```json
+{
+  "browser": {
+    "enabled": true,
+    "defaultProfile": "openclaw",
+    "profiles": {
+      "openclaw": {
+        "headless": true,
+        "actionTimeoutMs": 60000
+      }
+    }
+  }
+}
+```
 
-**Trigger 1: "add [URL] to Lore"**
-- Fetch the page at the URL
-- Extract: title, author (if present), publication date, full article content, source URL
-- Check `sourcing-playbook.md` relevance criteria â€” if the content matches a category, proceed; if clearly out of scope, respond "this does not match Lore sourcing criteria" and stop
-- Save to `raw/` as a markdown file named `YYYY-MM-DD-slug-of-title.md`
-- Include frontmatter: `source`, `title`, `author`, `date_clipped`, `category` (matched category from playbook)
-- Respond: "Added to Lore: [title] â†’ raw/YYYY-MM-DD-slug.md"
+Verify with the OpenClaw CLI (see docs.openclaw.ai/tools/browser for exact action syntax) that the profile is reachable and Chromium launches.
 
-**Trigger 2: "find content about [topic] for Lore"**
-- Search the web for recent (last 30 days) content matching the topic
-- Filter results against `sourcing-playbook.md` relevance criteria
-- For each qualifying result (max 5): save to `raw/` using the same format as Trigger 1
-- Respond with a summary: "Added N items to Lore about [topic]: [list of titles]"
+---
 
-**Trigger 3: "what does Lore know about [topic]"**
-- Search `wiki/` for pages matching the topic
-- Summarize findings and list relevant page filenames
-- Check `wiki/indexes/gaps.md` â€” if the topic appears there, note it as a known gap
-- Respond with a brief summary
+## Part F — One-time logins for login-walled sources
 
-### Skill file content
+The managed profile persists cookies. Log into each login-walled source once; OpenClaw reuses the session on every scheduled run.
+
+### 6. Log into X
+1. Temporarily set `"headless": false` in the browser config so the window is visible.
+2. Run an interactive browser session pointed at x.com (CLI form per OpenClaw docs).
+3. Log in with the X account; complete 2FA if prompted.
+4. Navigate to the curated private list URL specified in `sourcing-playbook.md` (X / Twitter section) — confirm it loads.
+5. Close the browser. Revert `"headless": true`.
+6. Confirm session persists: a headless `navigate` + `snapshot` against the list URL should succeed without a login redirect.
+
+### 7. Log into Discord
+For each server listed in `sourcing-playbook.md` Discord section (Anthropic, OpenAI Developer, Hugging Face, LangChain, .NET / C#):
+1. With `"headless": false`, open a browser session at `discord.com/login`.
+2. Log in (QR via mobile, or email/password).
+3. Join each server above (if not already a member).
+4. Open each server's announcement channel to confirm access.
+5. Revert `"headless": true`.
+
+---
+
+## Part G — Build the scheduled sourcing skill
+
+OpenClaw skills are markdown/YAML instruction files describing what OpenClaw does on trigger. Skills live in OpenClaw's skills directory (verify path with current docs).
+
+### 8. Create the scheduled sourcing skill
 
 ```yaml
-name: lore-sourcing
-description: Add content to HoneyDrunk.Lore or query what Lore knows
-triggers:
-  - "add * to Lore"
-  - "add * to lore"
-  - "find content about * for Lore"
-  - "find content about * for lore"
-  - "what does Lore know about *"
-  - "what does lore know about *"
+name: lore-scheduled-sourcing
+description: Walk sourcing-playbook.md and drop qualifying content in HoneyDrunk.Lore/raw/
 
 vault: HoneyDrunk.Lore
 playbook_path: sourcing-playbook.md
 
+triggers:
+  - schedule: "0 3 * * *"   # daily at 03:00 local; change to "0 3 */2 * *" for every 2 days
+
 instructions: |
-  You are the Lore sourcing agent for HoneyDrunk Studios.
-  
-  Before acting, read sourcing-playbook.md from the vault root to understand
-  what content belongs in Lore and the relevance criteria.
-  
-  For "add [URL] to Lore":
-  1. Fetch the URL content
-  2. Check relevance criteria from sourcing-playbook.md
-  3. If out of scope, respond with why and stop
-  4. Save to raw/ as YYYY-MM-DD-title-slug.md with frontmatter:
-     - source: [URL]
-     - title: [article title]
-     - author: [author if available]
-     - date_clipped: [today]
-     - category: [matched category from playbook]
-  5. Confirm: "Added to Lore: [title] -> raw/[filename]"
-  
-  For "find content about [topic] for Lore":
-  1. Web search: "[topic] site:relevant-sources last month"
-  2. Filter results against sourcing-playbook.md relevance criteria
-  3. Save qualifying results (max 5) to raw/ using same format
-  4. Summarize: "Added N items to Lore about [topic]"
-  
-  For "what does Lore know about [topic]":
-  1. Search wiki/ for matching pages
-  2. Check wiki/indexes/gaps.md for the topic
-  3. Summarize findings with page references
+  You are the Lore scheduled sourcing agent.
+
+  Before sourcing, read sourcing-playbook.md from the vault root. It defines:
+  - 12 topic categories, each with What-to-clip / What-to-skip / Sources
+  - The "Sources requiring browser or audio tooling" section for login-walled and audio sources
+  - Relevance criteria — apply in order: actionable, durable, in scope, deep enough
+
+  Walk every source listed in the playbook. Mechanism by source type:
+
+  RSS-friendly sources (most of cats 1–12):
+  1. Resolve the feed URL — try common endpoints (/rss, /feed, /atom.xml) or auto-discover
+     via <link rel="alternate" type="application/rss+xml"> in the source homepage <head>.
+  2. Fetch the feed.
+  3. For each entry newer than the last run, apply relevance criteria from the playbook.
+  4. Qualifying entries: fetch full article, save to raw/ using the Output format below.
+
+  X / Twitter (login-walled, browser tool):
+  1. Use the openclaw browser profile.
+  2. Navigate to the private X list URL specified in the playbook's X / Twitter section.
+  3. Snapshot the timeline; collect tweets/threads newer than the last run.
+  4. Apply relevance criteria. Qualifying items: save to raw/ with source_type=x.
+
+  Discord (login-walled, browser tool):
+  1. Use the openclaw browser profile.
+  2. For each Discord server in the playbook, navigate to its announcement channel.
+  3. Snapshot recent messages.
+  4. Apply relevance criteria. Save qualifying messages to raw/ with source_type=discord
+     and the channel + server name in frontmatter.
+
+  Podcasts (audio):
+  1. Fetch each podcast's RSS feed.
+  2. For each new episode: download audio, transcribe via Whisper (or equivalent
+     transcription path available to the runtime).
+  3. Save transcript to raw/ with source_type=podcast and the original audio URL in
+     frontmatter.
+
+  Output format for every raw/ file:
+    Filename: YYYY-MM-DD-source_type-slug.md
+      (e.g., 2026-05-04-rss-fowler-microservices.md)
+    Frontmatter:
+      source:         [original URL]
+      title:          [original title]
+      author:         [if available]
+      date_published: [original publish date if available]
+      date_clipped:   [today YYYY-MM-DD]
+      category:       [matched playbook category]
+      source_type:    rss | x | discord | podcast
+    Body: full extracted content (article, thread, message, or transcript)
+
+  Deduplication: skip items whose source URL already appears in:
+  - any existing raw/ file's frontmatter, OR
+  - wiki/indexes/sources.md (already-ingested set)
+
+  Reliability: if a single source fails (network error, expired login, parse error),
+  log the failure and continue. Do NOT abort the entire run.
+
+  Logging: at end of run, write a summary line to stdout —
+  "Sourced N items: A rss, B x, C discord, D podcast" —
+  for cron capture.
 ```
 
-### 6. Test the skill
-Send these messages to your connected bot:
-- "add [paste any relevant article URL] to Lore" â€” verify file appears in `raw/`
-- "find content about MCP servers for Lore" â€” verify 1-5 files appear in `raw/`
-- "what does Lore know about software architecture" â€” verify it searches `wiki/`
+### 9. Create the on-demand override skills
+
+Two secondary skills for phone-triggered actions:
+
+```yaml
+name: lore-add-url
+description: Manual single-URL clip from Telegram
+triggers:
+  - "add * to Lore"
+  - "add * to lore"
+instructions: |
+  Extract the URL from the message. Fetch the page. Apply sourcing-playbook.md
+  relevance criteria. If out of scope, respond with the reason and stop. If in scope,
+  save to raw/ using the same Output format as lore-scheduled-sourcing
+  (source_type=clipper).
+  Confirm via Telegram: "Added to Lore: [title] → raw/[filename]"
+```
+
+```yaml
+name: lore-query
+description: Query the Lore wiki from Telegram
+triggers:
+  - "what does Lore know about *"
+  - "what does lore know about *"
+instructions: |
+  Search wiki/ for pages matching the topic. Check wiki/indexes/gaps.md for the topic.
+  Respond via Telegram with a brief summary referencing relevant page filenames. If the
+  topic is in gaps.md, note it as a known gap.
+```
+
+---
+
+## Part H — Verify the schedule
+
+### 10. Confirm cron registration
+After the scheduled sourcing skill loads, confirm OpenClaw has registered the cron trigger (CLI form per current docs — typically a `schedule list` action or equivalent). The expected entry: `lore-scheduled-sourcing` running `0 3 * * *`.
+
+If `0 3 */2 * *` (every 2 days) is preferred, edit the skill and reload.
+
+---
+
+## Part I — End-to-end test
+
+### 11. Dry run the scheduled skill
+- Manually trigger one run (CLI: `schedule run lore-scheduled-sourcing` or equivalent)
+- Expect a summary like "Sourced 12 items: 8 rss, 3 x, 0 discord, 1 podcast"
+- Inspect `raw/` — confirm filenames follow the format and frontmatter is complete
+
+### 12. Test the on-demand triggers
+- Telegram → "add [paste any relevant article URL] to Lore" — confirm a file appears in `raw/`
+- Telegram → "what does Lore know about MCP" — confirm a meaningful response (will be sparse before the ingest agent has run; success here means the mechanism works, not that the wiki is full)
 
 ---
 
 ## Acceptance Criteria
 
-**Part A â€” Install**
-- [ ] OpenClaw installed and running on your machine
+**Part A–D (runtime + integrations)**
+- [ ] OpenClaw installed and running on the user's machine
 - [ ] Claude (Anthropic) set as AI provider with API key configured
-- [ ] At least one messaging integration connected (Telegram recommended)
-- [ ] Test message sent and responded to
+- [ ] Telegram bot connected and responsive
+- [ ] Obsidian integration pointed at the `HoneyDrunk.Lore/` vault root
 
-**Part B â€” Obsidian**
-- [ ] Obsidian integration connected and pointing at `HoneyDrunk.Lore/` vault root
-- [ ] "list my vault files" returns a file listing via messaging app
+**Part E–F (browser + logins)**
+- [ ] Browser tool enabled in `~/.openclaw/openclaw.json` with managed `openclaw` profile
+- [ ] Logged into X — private list URL accessible without login redirect when headless
+- [ ] Logged into Discord — all servers in the playbook accessible
 
-**Part C â€” Lore skill**
-- [ ] Lore sourcing skill created and loaded in OpenClaw
-- [ ] Trigger 1 test: URL clip lands in `raw/` with correct frontmatter
-- [ ] Trigger 2 test: topic search adds at least one file to `raw/`
-- [ ] Trigger 3 test: wiki query returns a meaningful response
-- [ ] Out-of-scope URL test: clearly irrelevant URL is rejected with a reason
+**Part G–H (skills + schedule)**
+- [ ] `lore-scheduled-sourcing` skill created and registered
+- [ ] `lore-add-url` and `lore-query` on-demand skills created
+- [ ] Cron schedule registered (`0 3 * * *` daily, or `0 3 */2 * *` every 2 days)
+
+**Part I (end-to-end)**
+- [ ] Dry run produces files in `raw/` covering at least RSS + X (Discord/podcast may be empty if no new content that day)
+- [ ] Dry run logs the summary line
+- [ ] On-demand "add URL to Lore" trigger places a file in `raw/` with correct frontmatter
+- [ ] On-demand "what does Lore know about X" trigger returns a meaningful response
+- [ ] Out-of-scope URL test: clearly irrelevant URL is rejected via the on-demand trigger with a reason
 
 ---
 
 ## Dependencies
-- Issue #1 (scaffold) â€” `raw/` directory must exist
-- Issue #2 (Obsidian) â€” vault must be configured and connected
-- Issue #4 (sourcing-playbook.md) â€” skill reads the playbook for relevance criteria
+- Issue #1 (scaffold) — `raw/`, `wiki/indexes/sources.md` must exist
+- Issue #2 (Obsidian) — vault must be configured and connected
+- Issue #4 (sourcing-playbook.md) — skill reads the playbook for sources and relevance criteria
 
 ## Labels
 `chore`, `human-only`, `tier-1`, `automation`
 
 ## Notes
-- OpenClaw documentation: openclaw.ai/docs
-- ClawHub for community skills: openclaw.ai/clawhub
-- The Lore skill reads `sourcing-playbook.md` at runtime â€” updating the playbook updates the skill behavior without reinstalling
-- If OpenClaw adds new capabilities (RSS integration, scheduled sourcing), revisit this issue to extend the skill
+- OpenClaw docs: openclaw.ai/docs
+- Browser tool docs: docs.openclaw.ai/tools/browser
+- ClawHub: openclaw.ai/clawhub
+- The scheduled sourcing skill reads `sourcing-playbook.md` at runtime — updating the playbook (adding sources, refining relevance criteria) updates skill behavior without re-installing the skill
+- When the playbook adds a new login-walled source, repeat Part F to log in via the managed browser
+- If X (or any other login-walled source) reskins their UI and scraping breaks, re-prompt the skill instructions rather than maintaining selector code — the browser tool works on snapshots, not CSS selectors, so the skill adapts via natural-language re-prompting
+- The sourcing skill is the producer; the weekly Claude Code ingest agent (packet 05) is the consumer. Both target `raw/` — neither cares which produced a file


### PR DESCRIPTION
add packets for HoneyDrunk.AI standup: catalog registration, new AI invariants, and repo scaffold per ADR-0016; update dispatch plan and dependencies schema; clarify Lore sourcing schedule and acceptance criteria; resolve catalog/ADR drift and formalize downstream AI-sector unblock