### PR TITLE
docs: update ADR-0026 tenancy architecture contracts

### DIFF
--- a/catalogs/contracts.json
+++ b/catalogs/contracts.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "description": "Registry of public contracts (interfaces, types, HTTP endpoints, signal events) exposed by each Node. Derived from relationships.json exposes.contracts but expanded with kind, package, and status. Use this before writing code that crosses a Node boundary to find the exact interface to depend on.",
-    "updated": "2026-04-12",
+    "updated": "2026-05-04",
     "schema_version": "1.0"
   },
   "contracts": [
@@ -23,11 +23,16 @@
         { "name": "IReadinessContributor", "kind": "interface", "description": "Plugs into the readiness aggregation pipeline (/ready endpoint)." },
         { "name": "ITraceEnricher", "kind": "interface", "description": "Adds custom tags/attributes to OpenTelemetry spans." },
         { "name": "ILogScopeFactory", "kind": "interface", "description": "Creates structured log scopes enriched with GridContext." },
+        { "name": "ITenantRateLimitPolicy", "kind": "interface", "description": "Evaluates replaceable per-tenant rate-limit decisions. Kernel supplies a no-op default; product Nodes own policy." },
+        { "name": "IBillingEventEmitter", "kind": "interface", "description": "Emits normalized tenant billing events. Kernel supplies a no-op default; product Nodes own commercial integration." },
+        { "name": "BillingEvent", "kind": "type", "description": "Normalized tenant billing event envelope for commercial Nodes." },
+        { "name": "TenantRateLimitDecision", "kind": "type", "description": "Result of tenant rate-limit evaluation." },
+        { "name": "TenantRateLimitOutcome", "kind": "type", "description": "Allow/deny outcome enum for tenant rate-limit evaluation." },
         { "name": "ITelemetryActivityFactory", "kind": "interface", "description": "Creates Activity instances for trace spans, pre-enriched with GridContext." },
         { "name": "IAgentExecutionContext", "kind": "interface", "description": "LLM agent execution context — extends IOperationContext with agent identity and scope." },
         { "name": "CorrelationId", "kind": "type", "description": "ULID-based strongly-typed correlation ID. Never null in a live GridContext." },
         { "name": "NodeId", "kind": "type", "description": "ULID-based strongly-typed Node identity." },
-        { "name": "TenantId", "kind": "type", "description": "ULID-based strongly-typed tenant identity." },
+        { "name": "TenantId", "kind": "type", "description": "ULID-based strongly-typed tenant identity with `TenantId.Internal` sentinel for Grid-internal operations." },
         { "name": "ProjectId", "kind": "type", "description": "ULID-based strongly-typed project identity." },
         { "name": "RunId", "kind": "type", "description": "ULID-based strongly-typed run identity." },
         { "name": "StudioId", "kind": "type", "description": "ULID-based strongly-typed studio identity." }
@@ -55,7 +60,8 @@
         { "name": "IConfigProvider", "kind": "interface", "description": "Read typed configuration values from the shared App Configuration store." },
         { "name": "IVaultClient", "kind": "interface", "description": "Low-level Vault client. Prefer ISecretStore for application code." },
         { "name": "ISecretProvider", "kind": "interface", "description": "Provider slot interface — implement to add a new secret backend (Azure KV, AWS, File, InMemory)." },
-        { "name": "IConfigSource", "kind": "interface", "description": "Provider slot interface — implement to add a new configuration source." }
+        { "name": "IConfigSource", "kind": "interface", "description": "Provider slot interface — implement to add a new configuration source." },
+        { "name": "TenantScopedSecretResolver", "kind": "type", "description": "ADR-0026 tenant-aware resolver layered over ISecretStore. Resolves `tenant-{tenantId}-{secretName}` first for external tenants and falls back to the standard node path; internal tenants use the standard path directly." }
       ]
     },
     {
@@ -110,7 +116,8 @@
       "interfaces": [
         { "name": "ITraceSink", "kind": "interface", "description": "Receive trace spans from the OTLP collector. Implement to add a new telemetry backend." },
         { "name": "ILogSink", "kind": "interface", "description": "Receive structured log entries." },
-        { "name": "IMetricsSink", "kind": "interface", "description": "Receive metric data points." }
+        { "name": "IMetricsSink", "kind": "interface", "description": "Receive metric data points." },
+        { "name": "TelemetryTagKeys.HoneyDrunk.TenantId", "kind": "constant", "description": "Standard `honeydrunk.tenant_id` telemetry tag. Low-cardinality only; bounded by Notify Cloud cardinality criteria." }
       ]
     },
     {

--- a/catalogs/contracts.json
+++ b/catalogs/contracts.json
@@ -27,12 +27,12 @@
         { "name": "IBillingEventEmitter", "kind": "interface", "description": "Emits normalized tenant billing events. Kernel supplies a no-op default; product Nodes own commercial integration." },
         { "name": "BillingEvent", "kind": "type", "description": "Normalized tenant billing event envelope for commercial Nodes." },
         { "name": "TenantRateLimitDecision", "kind": "type", "description": "Result of tenant rate-limit evaluation." },
-        { "name": "TenantRateLimitOutcome", "kind": "type", "description": "Allow/deny outcome enum for tenant rate-limit evaluation." },
+        { "name": "TenantRateLimitOutcome", "kind": "type", "description": "Allow, Throttle, or Reject outcome enum for tenant rate-limit evaluation." },
         { "name": "ITelemetryActivityFactory", "kind": "interface", "description": "Creates Activity instances for trace spans, pre-enriched with GridContext." },
         { "name": "IAgentExecutionContext", "kind": "interface", "description": "LLM agent execution context — extends IOperationContext with agent identity and scope." },
         { "name": "CorrelationId", "kind": "type", "description": "ULID-based strongly-typed correlation ID. Never null in a live GridContext." },
         { "name": "NodeId", "kind": "type", "description": "ULID-based strongly-typed Node identity." },
-        { "name": "TenantId", "kind": "type", "description": "ULID-based strongly-typed tenant identity with `TenantId.Internal` sentinel for Grid-internal operations." },
+        { "name": "TenantId", "kind": "type", "description": "ULID-based strongly-typed tenant identity with `TenantId.Internal` sentinel and `IsInternal` predicate for Grid-internal operations." },
         { "name": "ProjectId", "kind": "type", "description": "ULID-based strongly-typed project identity." },
         { "name": "RunId", "kind": "type", "description": "ULID-based strongly-typed run identity." },
         { "name": "StudioId", "kind": "type", "description": "ULID-based strongly-typed studio identity." }
@@ -117,7 +117,7 @@
         { "name": "ITraceSink", "kind": "interface", "description": "Receive trace spans from the OTLP collector. Implement to add a new telemetry backend." },
         { "name": "ILogSink", "kind": "interface", "description": "Receive structured log entries." },
         { "name": "IMetricsSink", "kind": "interface", "description": "Receive metric data points." },
-        { "name": "TelemetryTagKeys.HoneyDrunk.TenantId", "kind": "constant", "description": "Standard `honeydrunk.tenant_id` telemetry tag. Low-cardinality only; bounded by Notify Cloud cardinality criteria." }
+        { "name": "TelemetryTagKeys.HoneyDrunk.TenantId", "kind": "type", "description": "Standard `tenant_id` telemetry tag key. Low-cardinality only; bounded by Notify Cloud cardinality criteria." }
       ]
     },
     {

--- a/constitution/invariants.md
+++ b/constitution/invariants.md
@@ -21,10 +21,10 @@ Rules that must never be violated across the HoneyDrunk Grid. Canary tests enfor
 ## Context Invariants
 
 5. **GridContext must be present in every scoped operation.**
-   Every HTTP request, message handler, and background job must have a populated `IGridContext`.
+   Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null `TenantId`.
 
-6. **CorrelationId is never null or empty in a live GridContext.**
-   It is generated at the entry point and propagated through all downstream calls.
+6. **CorrelationId and TenantId are never null or empty in a live GridContext.**
+   `CorrelationId` is generated at the entry point and propagated through all downstream calls. Missing tenant context defaults to `TenantId.Internal`; external tenant values must be valid `TenantId` ULIDs.
 
 7. **Context mappers are static and stateless.**
    `HttpContextMapper`, `MessagingContextMapper`, `JobContextMapper` — no instance state.
@@ -36,6 +36,9 @@ Rules that must never be violated across the HoneyDrunk Grid. Canary tests enfor
 
 9. **Vault is the only source of secrets.**
    No Node reads secrets directly from environment variables, config files, or provider SDKs. All access goes through `ISecretStore`.
+
+9a. **Tenant-scoped secrets are a Vault usage pattern, not an `ISecretStore` contract change.**
+   Tenant-owned secrets use `tenant-{tenantId}-{secretName}` and resolve through `TenantScopedSecretResolver`; `TenantId.Internal` uses the standard node-level secret path.
 
 10. **Auth tokens are validated, never issued.**
     HoneyDrunk.Auth validates JWT Bearer tokens. It is not an identity provider.

--- a/constitution/invariants.md
+++ b/constitution/invariants.md
@@ -23,8 +23,8 @@ Rules that must never be violated across the HoneyDrunk Grid. Canary tests enfor
 5. **GridContext must be present in every scoped operation.**
    Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null `TenantId`.
 
-6. **CorrelationId and TenantId are never null or empty in a live GridContext.**
-   `CorrelationId` is generated at the entry point and propagated through all downstream calls. Missing tenant context defaults to `TenantId.Internal`; external tenant values must be valid `TenantId` ULIDs.
+6. **CorrelationId is never null or empty, and TenantId is never absent, in a live GridContext.**
+   `CorrelationId` is generated at the entry point and propagated through all downstream calls. Missing tenant context defaults to the `TenantId.Internal` sentinel; external tenant values must be valid `TenantId` ULIDs.
 
 7. **Context mappers are static and stateless.**
    `HttpContextMapper`, `MessagingContextMapper`, `JobContextMapper` — no instance state.
@@ -139,3 +139,7 @@ _Invariants 29–30 are reserved for the Observation Layer (ADR-0010). They will
 37. **Completed issue packets are moved to `completed/`.** When a filed issue is closed on GitHub, the `hive-sync` agent moves its source packet from `generated/issue-packets/active/` to `generated/issue-packets/completed/` and updates the path key in `generated/issue-packets/filed-packets.json`. No other agent moves packets between lifecycle directories. The `hive-sync` agent may update existing entries' paths in `filed-packets.json` but may not add or remove entries (that remains the `file-issues` agent's exclusive concern). See ADR-0014 D2, D4.
 
 38. **The Architecture repo tracks all Hive board items.** Every issue on The Hive (org Project #4) is represented in either an initiative tracking file (for packet-originated work, including `active-initiatives.md`, `archived-initiatives.md`, etc.) or `initiatives/board-items.md` (for non-initiative work — nightly-security issues, grid-health-aggregator issues, and any other issue mirrored onto The Hive without a `filed-packets.json` entry). The `hive-sync` agent is responsible for maintaining this correspondence and runs through OpenClaw scheduled/manual execution. See ADR-0014 D1, D3.
+
+## Multi-Tenant Boundary Invariants
+
+39. **Tenant mechanics stay at intake and post-dispatch boundaries.** Tenant resolution, tenant rate-limit checks, billing-event emission, and tenant-scoped secret lookup must live in intake middleware/orchestration edges or post-dispatch tails. Core dispatch paths for internal Grid callers must remain tenant-agnostic and default to `TenantId.Internal` without caller-specific branches. See ADR-0026.

--- a/repos/HoneyDrunk.Kernel/boundaries.md
+++ b/repos/HoneyDrunk.Kernel/boundaries.md
@@ -7,7 +7,9 @@
 - Configuration foundation (hierarchical scoping)
 - Agent interop (serialization, execution contexts)
 - Telemetry hooks (enrichers, log scopes)
-- Identity grammar (strongly-typed ID primitives)
+- Identity grammar (strongly-typed ID primitives, including `TenantId.Internal`)
+- Multi-tenant context propagation primitives (`IGridContext.TenantId`, `IOperationContext.TenantId`)
+- Tenancy policy extension points (`ITenantRateLimitPolicy`, `IBillingEventEmitter`) with replaceable no-op defaults
 - Service discovery primitives (Node descriptors, capabilities, manifests)
 
 ## What Kernel Does NOT Own
@@ -20,6 +22,7 @@
 - **Authentication** — Token validation, authorization belong in HoneyDrunk.Auth.
 - **Telemetry backends** — Sink implementations belong in HoneyDrunk.Pulse.
 - **Business logic** — Kernel is infrastructure, not domain logic.
+- **Tenant policy decisions** — Kernel defines rate-limit/billing seams and no-op defaults; product Nodes own policy, quotas, billing plans, and enforcement behavior.
 
 ## Boundary Decision Tests
 

--- a/repos/HoneyDrunk.Kernel/invariants.md
+++ b/repos/HoneyDrunk.Kernel/invariants.md
@@ -17,8 +17,14 @@ Kernel-specific invariants (supplements `constitution/invariants.md`).
 5. **CorrelationId is never empty.**
    `CorrelationId.NewId()` always produces a valid ULID. The default value is not valid.
 
-6. **Baggage is append-only within a scope.**
+6. **TenantId is always explicit in context.**
+   `IGridContext.TenantId` and `IOperationContext.TenantId` are non-nullable `TenantId` values. Header-less internal Grid operations carry `TenantId.Internal`; malformed external tenant wire values are rejected at the boundary.
+
+7. **Kernel exposes tenancy seams, not tenant policy.**
+   Kernel owns `ITenantRateLimitPolicy`, `IBillingEventEmitter`, and no-op defaults so Nodes can compose tenancy consistently. Product Nodes own quotas, billing plans, enforcement, and commercial behavior.
+
+8. **Baggage is append-only within a scope.**
    `IGridContext.AddBaggage()` adds entries. Entries cannot be removed once added.
 
-7. **Lifecycle hooks execute in registration order.**
+9. **Lifecycle hooks execute in registration order.**
    `IStartupHook` instances run in the order they were registered in DI.


### PR DESCRIPTION
## Summary
- update Grid invariants for non-null `TenantId`, `TenantId.Internal`, and Vault tenant-scoped secret lookup
- register ADR-0026 Kernel/Vault/Pulse public surfaces in `catalogs/contracts.json`
- update HoneyDrunk.Kernel boundaries and invariants for tenancy primitives and policy seams

## Scope
Closes #59
ADR: https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0026-grid-multi-tenant-primitives.md

## Validation
- `python -m json.tool catalogs/contracts.json > $null`
