### PR TITLE
docs: document OpenClaw skill pairing for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ When you receive a task:
 - **PRs:** Implementation must align with acceptance criteria in the issue
 - **Tests:** All code changes include tests unless the issue explicitly says otherwise
 - **Boundaries:** Code that belongs in another Node must not leak into the target repo
+- **Reusable logic:** Before adding a new helper, mapper, validator, factory, extension method, or orchestration method, scan the current type, sibling types, and repo-level shared locations for existing behavior to reuse or extend. Prefer cohesive shared methods over one-off near-duplicates; justify intentional duplication when behavior should diverge.
 
 ## Context Files You May Need
 

--- a/adrs/ADR-0007-claude-agents-as-source-of-truth.md
+++ b/adrs/ADR-0007-claude-agents-as-source-of-truth.md
@@ -62,6 +62,21 @@ If a second tool ever emerges that requires a genuinely different file format an
 - **Adding a third tool that needs a different format requires reintroducing generation.** Accepted. We'll build the generator when we actually have two targets, not in anticipation of having them.
 - **ADR-0004's "survives vendor format changes" argument is lost.** True in theory, but Claude Code's format has been stable and the cost of a future migration is bounded.
 
+## Operational Addendum: OpenClaw Skills
+
+OpenClaw does not consume `.claude/agents/*.md` as first-class named agents. It can still **read those files as source instructions** and use OpenClaw's own runtime primitives (`sessions_spawn`, scheduled tasks, tools, and workspace skills), but that is not equivalent to Claude Code invoking `@scope` or `@adr-composer` directly.
+
+Therefore, `.claude/agents/*.md` remains the source of truth for Claude Code and Copilot agent definitions, and any newly added Architecture agent must also be mirrored by an **OpenClaw skill** when the behavior is expected to be reusable from OpenClaw.
+
+Required maintenance rule:
+
+1. When adding or materially changing `.claude/agents/{name}.md`, decide whether OpenClaw should be able to reuse that workflow.
+2. If yes, create or update the matching OpenClaw skill with the same routing intent, core workflow, context-loading contract, and handoff/output expectations.
+3. Keep the OpenClaw skill concise and adapted to OpenClaw primitives rather than copying Claude-specific tool names verbatim.
+4. Update `copilot/agent-skills-map.md` so the agent inventory records the OpenClaw skill pairing.
+
+This is intentionally a **companion-skill rule**, not a new canonical generation layer. The Architecture repo already chose direct `.claude/agents/` maintenance over a generator; OpenClaw compatibility is maintained by explicit paired skills for workflows that need it.
+
 ## Alternatives Considered
 
 ### Keep ADR-0004 as-is

--- a/adrs/ADR-0007-claude-agents-as-source-of-truth.md
+++ b/adrs/ADR-0007-claude-agents-as-source-of-truth.md
@@ -73,7 +73,8 @@ Required maintenance rule:
 1. When adding or materially changing `.claude/agents/{name}.md`, decide whether OpenClaw should be able to reuse that workflow.
 2. If yes, create or update the matching OpenClaw skill with the same routing intent, core workflow, context-loading contract, and handoff/output expectations.
 3. Keep the OpenClaw skill concise and adapted to OpenClaw primitives rather than copying Claude-specific tool names verbatim.
-4. Update `copilot/agent-skills-map.md` so the agent inventory records the OpenClaw skill pairing.
+4. Update `copilot/agent-skills-map.md` so the agent inventory records the OpenClaw skill pairing by skill identifier.
+5. Runtime skill files live in the OpenClaw host workspace `skills/` directory; in-repo operational runbooks or scheduled-work contracts may live under `infrastructure/openclaw/` when the workflow needs auditable Architecture-repo context.
 
 This is intentionally a **companion-skill rule**, not a new canonical generation layer. The Architecture repo already chose direct `.claude/agents/` maintenance over a generator; OpenClaw compatibility is maintained by explicit paired skills for workflows that need it.
 

--- a/copilot/agent-skills-map.md
+++ b/copilot/agent-skills-map.md
@@ -67,19 +67,39 @@ Work flows through three AI surfaces. See `/routing/sdlc.md` for the full lifecy
 | **Codex** | Execute tasks autonomously in the cloud | Single repo per task | Autonomous implementation from well-scoped issues |
 | **GitHub Copilot** | In-IDE coding, debugging, exploration | Single repo (open in editor) | Line-by-line precision, interactive iteration |
 
+OpenClaw is an operator/runtime surface around these workflows. It does not load `.claude/agents/*.md` as native named agents, but it can read them as instruction sources and delegate work through OpenClaw sub-sessions. For repeatable Architecture workflows, pair the Claude/Copilot agent with an OpenClaw skill instead of relying on ad hoc prompt copying.
+
 ## Agent Inventory (Claude Code Surface)
 
 Agents that run within the Claude Code / Architecture repo context:
 
-| Agent | Purpose | Invokes |
-|-------|---------|---------|
-| **adr-composer** | Facilitate architecture decisions, produce ADRs | — |
-| **site-sync** | Sync website with architecture changes | — |
-| **scope** | Scope work into issues — auto-detects single or multi-repo, generates issue packets, dispatch plans, and handoff prompts | adr-composer, site-sync |
-| **file-issues** | File packet files as GitHub issues — creates issues, adds to The Hive, sets all project fields, wires blocking relationships | — |
-| **refine** | Challenge scoped work before execution — finds gaps, missed dependencies, boundary violations, invariant risks | — |
-| **review** | Review PRs against boundary rules, invariants, contract safety, and code conventions | — |
-| **netrunner** | Research and investigation across the Grid | — |
+| Agent | Purpose | Invokes | OpenClaw skill |
+|-------|---------|---------|----------------|
+| **adr-composer** | Facilitate architecture decisions, produce ADRs | — | `honeydrunk-adr-composer` |
+| **pdr-composer** | Facilitate product decisions, produce PDRs | — | `honeydrunk-pdr-composer` |
+| **product-strategist** | Product strategy, positioning, roadmap, and commercialization analysis | — | `honeydrunk-product-strategist` |
+| **site-sync** | Sync website with architecture changes | — | `honeydrunk-site-sync` |
+| **scope** | Scope work into issues — auto-detects single or multi-repo, generates issue packets, dispatch plans, and handoff prompts | adr-composer, site-sync | `honeydrunk-scope` |
+| **file-issues** | File packet files as GitHub issues — creates issues, adds to The Hive, sets all project fields, wires blocking relationships | — | `honeydrunk-file-issues` |
+| **refine** | Challenge scoped work before execution — finds gaps, missed dependencies, boundary violations, invariant risks | — | `honeydrunk-refine` |
+| **review** | Review PRs against boundary rules, invariants, contract safety, and code conventions | — | `honeydrunk-review` |
+| **netrunner** | Research and investigation across the Grid | — | `honeydrunk-netrunner` |
+| **node-audit** | Audit Node boundary, invariant, catalog, and release-hygiene alignment | — | `honeydrunk-node-audit` |
+| **hive-sync** | Reconcile Architecture repo state with The Hive and initiative tracking | — | `honeydrunk-hive-sync` |
+
+## OpenClaw Skill Pairing Rule
+
+When adding a new Architecture agent under `.claude/agents/`, also add or update the corresponding OpenClaw skill if OpenClaw should invoke that workflow repeatedly.
+
+The OpenClaw skill should preserve:
+
+- Routing intent: when the workflow should trigger.
+- Required context files and research order.
+- Decision boundaries and stop/ask conditions.
+- Output contract: ADR draft, PDR draft, issue packets, review notes, filed issues, etc.
+- Delegation expectations, translated to OpenClaw primitives such as sub-sessions rather than Claude-specific `Agent` tool language.
+
+Do not create a new canonical agent directory or generator for this. ADR-0007 keeps `.claude/agents/` as the source of truth for Claude/Copilot; OpenClaw compatibility is maintained through paired skills documented here.
 
 ## Codex Execution Model
 

--- a/copilot/agent-skills-map.md
+++ b/copilot/agent-skills-map.md
@@ -67,11 +67,11 @@ Work flows through three AI surfaces. See `/routing/sdlc.md` for the full lifecy
 | **Codex** | Execute tasks autonomously in the cloud | Single repo per task | Autonomous implementation from well-scoped issues |
 | **GitHub Copilot** | In-IDE coding, debugging, exploration | Single repo (open in editor) | Line-by-line precision, interactive iteration |
 
-OpenClaw is an operator/runtime surface around these workflows. It does not load `.claude/agents/*.md` as native named agents, but it can read them as instruction sources and delegate work through OpenClaw sub-sessions. For repeatable Architecture workflows, pair the Claude/Copilot agent with an OpenClaw skill instead of relying on ad hoc prompt copying.
+OpenClaw is an operator/runtime surface around these workflows. It does not load `.claude/agents/*.md` as native named agents, but it can read them as instruction sources and delegate work through OpenClaw `sessions_spawn` sub-agent sessions. For repeatable Architecture workflows, pair the Claude/Copilot agent with an OpenClaw skill instead of relying on ad hoc prompt copying.
 
 ## Agent Inventory (Claude Code Surface)
 
-Agents that run within the Claude Code / Architecture repo context:
+Complete inventory of agents under `.claude/agents/` that run within the Claude Code / Architecture repo context. OpenClaw skill names refer to companion skills in the OpenClaw workspace `skills/` directory; use `—` only when no reusable OpenClaw pairing exists yet.
 
 | Agent | Purpose | Invokes | OpenClaw skill |
 |-------|---------|---------|----------------|
@@ -89,7 +89,7 @@ Agents that run within the Claude Code / Architecture repo context:
 
 ## OpenClaw Skill Pairing Rule
 
-When adding a new Architecture agent under `.claude/agents/`, also add or update the corresponding OpenClaw skill if OpenClaw should invoke that workflow repeatedly.
+When adding a new Architecture agent under `.claude/agents/`, or materially changing an existing agent's routing intent, context contract, or output contract, also add or update the corresponding OpenClaw skill if OpenClaw should invoke that workflow repeatedly.
 
 The OpenClaw skill should preserve:
 

--- a/copilot/global-instructions.md
+++ b/copilot/global-instructions.md
@@ -25,6 +25,10 @@ These rules apply to all agents operating within the HoneyDrunk Grid.
 - XML documentation on all public APIs
 - Conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`
 - HoneyDrunk.Standards analyzers enforced
+- Before creating a new helper, mapper, validator, factory, extension method, or orchestration method, scan the current type, sibling types, and repo-level shared locations for existing behavior to reuse or extend.
+- Prefer cohesive shared methods over one-off near-duplicates; extract repeated logic once the same shape appears twice or when the behavior is becoming a policy boundary.
+- Do not create generic utility dumping grounds. Keep shared code close to its domain unless it is clearly cross-cutting.
+- If duplication is intentional because two paths are expected to diverge, call that out in the PR or a short code comment.
 
 ## Communication
 

--- a/copilot/pr-review-rules.md
+++ b/copilot/pr-review-rules.md
@@ -23,6 +23,8 @@ Rules for agents when reviewing pull requests.
 - [ ] HoneyDrunk.Standards analyzers pass (no suppressions added)
 - [ ] Primary constructors used where appropriate
 - [ ] Nullable reference types respected (no `!` suppression without justification)
+- [ ] New helper/mapper/validator/orchestration methods were checked against existing reusable methods before adding one-off logic
+- [ ] Repeated logic is consolidated into cohesive shared methods, or intentional duplication is justified because behavior should diverge
 - [ ] Tests added for new behavior
 - [ ] CHANGELOG.md updated
 


### PR DESCRIPTION
## Summary
- documents that OpenClaw can read Claude agents as instructions but does not invoke them as native named agents
- adds the paired OpenClaw skill maintenance rule to ADR-0007 and the agent skills map
- avoids introducing a new canonical agent directory or generator

## Validation
- docs-only change; inspected diff
