### PR TITLE
docs: add reusable code hygiene packets

### DIFF
--- a/generated/issue-packets/active/standalone/2026-05-04-actions-consolidate-actions-deploy-github-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-actions-consolidate-actions-deploy-github-helpers.md
@@ -1,0 +1,120 @@
+---
+title: "Consolidate Actions deploy and GitHub helpers"
+repo: "HoneyDrunkStudios/HoneyDrunk.Actions"
+node: "HoneyDrunk.Actions"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "ops"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "ops"]
+actor: "Agent"
+---
+
+# Consolidate Actions deploy and GitHub helpers
+
+## Summary
+
+Consolidate repeated GitHub Actions deploy orchestration, Key Vault secret parsing, actions-ref resolution, and `gh_retry` shell helpers.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Actions`
+
+Audit findings to address:
+- App Service and Function deploy composite actions repeat URL resolution, startup wait, health-check loops, slot swap, post-swap URL, and final status logic.
+- Key Vault secret mapping/parsing appears in `keyvault-fetch` and multiple deploy workflows.
+- `actions-ref` checkout fallback is repeated despite an existing `common/checkout-actions-repo` consolidation target.
+- `gh_retry` is duplicated in `scripts/file-packets.sh` and `scripts/hive-project-mirror.sh`.
+
+Likely key files:
+- `.github/actions/azure/deploy-app-service/action.yml`
+- `.github/actions/azure/deploy-function/action.yml`
+- `.github/actions/azure/keyvault-fetch/action.yml`
+- `.github/workflows/job-deploy-*.yml`
+- `.github/actions/common/checkout-actions-repo/action.yml`
+- `scripts/file-packets.sh`
+- `scripts/hive-project-mirror.sh`
+
+## Acceptance Criteria
+
+- [ ] Shared Azure deploy helper/composite/script owns URL resolution, health checks, slot swap, and deployment status where behavior is common.
+- [ ] Key Vault secret mapping parser is centralized and consumed by deploy workflows/actions.
+- [ ] `actions-ref` fallback resolution is owned by a common action/helper.
+- [ ] `gh_retry` moved to a shared shell library and sourced by both scripts.
+- [ ] Workflow/action documentation and tests/examples updated where behavior changes.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `ops`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Actions` without changing public behavior.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Shared Azure deploy helper/composite/script owns URL resolution, health checks, slot swap, and deployment status where behavior is common.
+- [ ] Key Vault secret mapping parser is centralized and consumed by deploy workflows/actions.
+- [ ] `actions-ref` fallback resolution is owned by a common action/helper.
+- [ ] `gh_retry` moved to a shared shell library and sourced by both scripts.
+- [ ] Workflow/action documentation and tests/examples updated where behavior changes.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `.github/actions/azure/deploy-app-service/action.yml`
+- `.github/actions/azure/deploy-function/action.yml`
+- `.github/actions/azure/keyvault-fetch/action.yml`
+- `.github/workflows/job-deploy-*.yml`
+- `.github/actions/common/checkout-actions-repo/action.yml`
+- `scripts/file-packets.sh`
+- `scripts/hive-project-mirror.sh`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-architecture-consolidate-architecture-packet-guidance-rules.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-architecture-consolidate-architecture-packet-guidance-rules.md
@@ -1,0 +1,139 @@
+---
+title: "Consolidate Architecture packet and guidance rules"
+repo: "HoneyDrunkStudios/HoneyDrunk.Architecture"
+node: "HoneyDrunk.Architecture"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "meta"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "meta"]
+actor: "Agent"
+---
+
+# Consolidate Architecture packet and guidance rules
+
+## Summary
+
+Centralize duplicated Architecture packet naming, structure, dependency, handoff, site-sync, agent-source, and reusable-guidance rules.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+Audit findings to address:
+- Issue packet naming is duplicated and drifted across scope agent, generated packet README, Copilot instructions, CLAUDE.md, and issue-authoring rules.
+- Packet structure/checklists repeat across scope, issue rules, and templates.
+- Dependency source-of-truth conflicts between frontmatter and body `## Dependencies` guidance.
+- Claude to Codex handoff format is duplicated and stale.
+- Site sync triggers/schema repeat with drift.
+- Copilot instructions still mention `.github/agents/` despite ADR-0007 establishing `.claude/agents/`.
+- Reusable-code/reusable-guidance rule now appears in multiple active instruction surfaces.
+
+Likely key files:
+- `.claude/agents/scope.md`
+- `generated/issue-packets/README.md`
+- `.github/copilot-instructions.md`
+- `CLAUDE.md`
+- `copilot/issue-authoring-rules.md`
+- `.claude/agents/file-issues.md`
+- `routing/sdlc.md`
+- `routing/site-sync-rules.md`
+- `.claude/agents/site-sync.md`
+- `issues/templates/*.md`
+- `AGENTS.md`
+- `copilot/global-instructions.md`
+
+## Acceptance Criteria
+
+- [ ] One canonical packet naming/lifecycle location chosen and all other docs reference it.
+- [ ] One canonical packet contract/checklist chosen and templates/agents stop restating divergent copies.
+- [ ] Dependency guidance consistently treats frontmatter `dependencies:` as machine-readable source of truth.
+- [ ] Canonical handoff schema moved to or confirmed in `routing/sdlc.md`, with surface docs referencing it.
+- [ ] Site sync trigger/schema guidance centralized.
+- [ ] Stale `.github/agents/` guidance corrected to ADR-0007 `.claude/agents/` source of truth.
+- [ ] Reusable-code guidance has one Architecture-local canonical source with references from other instruction surfaces.
+- [ ] No historical generated packets are rewritten unless they are active templates/rules.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `meta`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Architecture` without changing public behavior.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] One canonical packet naming/lifecycle location chosen and all other docs reference it.
+- [ ] One canonical packet contract/checklist chosen and templates/agents stop restating divergent copies.
+- [ ] Dependency guidance consistently treats frontmatter `dependencies:` as machine-readable source of truth.
+- [ ] Canonical handoff schema moved to or confirmed in `routing/sdlc.md`, with surface docs referencing it.
+- [ ] Site sync trigger/schema guidance centralized.
+- [ ] Stale `.github/agents/` guidance corrected to ADR-0007 `.claude/agents/` source of truth.
+- [ ] Reusable-code guidance has one Architecture-local canonical source with references from other instruction surfaces.
+- [ ] No historical generated packets are rewritten unless they are active templates/rules.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `.claude/agents/scope.md`
+- `generated/issue-packets/README.md`
+- `.github/copilot-instructions.md`
+- `CLAUDE.md`
+- `copilot/issue-authoring-rules.md`
+- `.claude/agents/file-issues.md`
+- `routing/sdlc.md`
+- `routing/site-sync-rules.md`
+- `.claude/agents/site-sync.md`
+- `issues/templates/*.md`
+- `AGENTS.md`
+- `copilot/global-instructions.md`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-builds-clarify-builds-standards-policy-ownership.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-builds-clarify-builds-standards-policy-ownership.md
@@ -1,0 +1,109 @@
+---
+title: "Clarify Builds ownership versus Standards policy"
+repo: "HoneyDrunkStudios/HoneyDrunk.Builds"
+node: "HoneyDrunk.Builds"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "ops"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "ops"]
+actor: "Agent"
+---
+
+# Clarify Builds ownership versus Standards policy
+
+## Summary
+
+Clarify and reduce overlap between build defaults in HoneyDrunk.Builds and analyzer/quality policy owned by HoneyDrunk.Standards.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Builds`
+
+Audit findings to address:
+- `HoneyDrunk.Builds/buildTransitive/HoneyDrunk.Build.props` overlaps with Standards props/targets on nullable/latest LangVersion/deterministic builds, analyzer/code-style enforcement, StyleCop/editorconfig/globalconfig wiring, and warnings-as-errors policy.
+
+Likely key files:
+- `buildTransitive/HoneyDrunk.Build.props`
+- `README.md`
+- `CHANGELOG.md`
+
+## Acceptance Criteria
+
+- [ ] Document which policies HoneyDrunk.Builds owns versus which policies HoneyDrunk.Standards owns.
+- [ ] Remove or delegate analyzer/quality policy from Builds if Standards is the canonical owner.
+- [ ] Consumer migration impact documented if props behavior changes.
+- [ ] Build validation confirms consuming repos still receive intended defaults.
+- [ ] Repo changelog updated under `Unreleased`.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `ops`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Builds` without changing public behavior.
+
+**Target:** `HoneyDrunk.Builds`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Document which policies HoneyDrunk.Builds owns versus which policies HoneyDrunk.Standards owns.
+- [ ] Remove or delegate analyzer/quality policy from Builds if Standards is the canonical owner.
+- [ ] Consumer migration impact documented if props behavior changes.
+- [ ] Build validation confirms consuming repos still receive intended defaults.
+- [ ] Repo changelog updated under `Unreleased`.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `buildTransitive/HoneyDrunk.Build.props`
+- `README.md`
+- `CHANGELOG.md`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-communications-consolidate-communications-tenant-predicates.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-communications-consolidate-communications-tenant-predicates.md
@@ -1,0 +1,107 @@
+---
+title: "Consolidate Communications tenant predicates"
+repo: "HoneyDrunkStudios/HoneyDrunk.Communications"
+node: "HoneyDrunk.Communications"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "meta"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "meta"]
+actor: "Agent"
+---
+
+# Consolidate Communications tenant predicates
+
+## Summary
+
+Consolidate duplicated internal-tenant predicate logic in Communications runtime stores/policies.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Communications`
+
+Audit findings to address:
+- `InMemoryCadencePolicy` and `InMemoryPreferenceStore` duplicate the same internal tenant check for `00000000000000000000000000` and `internal`.
+
+Likely key files:
+- `src/HoneyDrunk.Communications/Internal/InMemoryCadencePolicy.cs`
+- `src/HoneyDrunk.Communications/Internal/InMemoryPreferenceStore.cs`
+
+## Acceptance Criteria
+
+- [ ] Internal tenant detection moved to one focused internal helper/policy.
+- [ ] Cadence and preference stores both consume the shared helper.
+- [ ] Tests cover internal tenant bypass behavior for both stores/policies.
+- [ ] No public Communications contracts are changed unless explicitly justified.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `meta`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Communications` without changing public behavior.
+
+**Target:** `HoneyDrunk.Communications`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Internal tenant detection moved to one focused internal helper/policy.
+- [ ] Cadence and preference stores both consume the shared helper.
+- [ ] Tests cover internal tenant bypass behavior for both stores/policies.
+- [ ] No public Communications contracts are changed unless explicitly justified.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `src/HoneyDrunk.Communications/Internal/InMemoryCadencePolicy.cs`
+- `src/HoneyDrunk.Communications/Internal/InMemoryPreferenceStore.cs`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-data-consolidate-data-ef-sql-configuration-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-data-consolidate-data-ef-sql-configuration-helpers.md
@@ -1,0 +1,115 @@
+---
+title: "Consolidate Data EF and SQL configuration helpers"
+repo: "HoneyDrunkStudios/HoneyDrunk.Data"
+node: "HoneyDrunk.Data"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "core"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "core"]
+actor: "Agent"
+---
+
+# Consolidate Data EF and SQL configuration helpers
+
+## Summary
+
+Consolidate repeated Entity Framework registration, SQL provider configuration, and SQLite test lifecycle logic.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Data`
+
+Audit findings to address:
+- EntityFramework registration duplicates option configuration between `AddDbContextFactory<TContext>` and `AddDbContext<TContext>`.
+- SQL Server and Azure SQL registration duplicate connection resolution, retry, and command-timeout policy with only provider method/label differences.
+- SQLite test fixture/factory/canary lifecycle logic overlaps for connection creation, EF options, `EnsureCreated`, and disposal.
+
+Likely key files:
+- `HoneyDrunk.Data.EntityFramework/Registration/ServiceCollectionExtensions.cs`
+- `HoneyDrunk.Data.SqlServer/Registration/ServiceCollectionExtensions.cs`
+- `HoneyDrunk.Data.Testing/Fixtures/SqliteDbContextFixture.cs`
+- `HoneyDrunk.Data.Testing/Factories/SqliteTestDbContextFactory.cs`
+- `HoneyDrunk.Data.Canary/Infrastructure/CanarySqliteFixture.cs`
+
+## Acceptance Criteria
+
+- [ ] Common EF option configuration helper extracted and used by both DbContext registration paths.
+- [ ] Common relational SQL retry/timeout configuration extracted while preserving provider-specific calls.
+- [ ] SQLite test database lifecycle centralized with explicit in-memory keepalive and file-backed modes.
+- [ ] Tests/canaries continue to pass for EF registration, SQL configuration, and SQLite lifecycle.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `core`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Data` without changing public behavior.
+
+**Target:** `HoneyDrunk.Data`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Common EF option configuration helper extracted and used by both DbContext registration paths.
+- [ ] Common relational SQL retry/timeout configuration extracted while preserving provider-specific calls.
+- [ ] SQLite test database lifecycle centralized with explicit in-memory keepalive and file-backed modes.
+- [ ] Tests/canaries continue to pass for EF registration, SQL configuration, and SQLite lifecycle.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `HoneyDrunk.Data.EntityFramework/Registration/ServiceCollectionExtensions.cs`
+- `HoneyDrunk.Data.SqlServer/Registration/ServiceCollectionExtensions.cs`
+- `HoneyDrunk.Data.Testing/Fixtures/SqliteDbContextFixture.cs`
+- `HoneyDrunk.Data.Testing/Factories/SqliteTestDbContextFactory.cs`
+- `HoneyDrunk.Data.Canary/Infrastructure/CanarySqliteFixture.cs`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-kernel-consolidate-kernel-context-identity-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-kernel-consolidate-kernel-context-identity-helpers.md
@@ -1,0 +1,110 @@
+---
+title: "Consolidate Kernel duplicate context and identity helpers"
+repo: "HoneyDrunkStudios/HoneyDrunk.Kernel"
+node: "HoneyDrunk.Kernel"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "core"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "core"]
+actor: "Agent"
+---
+
+# Consolidate Kernel duplicate context and identity helpers
+
+## Summary
+
+Consolidate repeated Kernel parsing and identity helper logic so context extraction and strongly typed IDs do not drift.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Kernel`
+
+Audit findings to address:
+- `HttpContextMapper` and `GridContextMiddleware` duplicate `ExtractCorrelationId`, header/baggage extraction, baggage item parsing, and tenant parsing shapes; middleware-specific truncation/400 behavior should remain separate.
+- Strongly typed ID records in `HoneyDrunk.Kernel.Abstractions/Identity` repeat ULID/string constructor, parse, validation, and formatting logic across `TenantId`, `ProjectId`, `RunId`, `OperationId`, `CorrelationId`, `CausationId`, `NodeId`, `SectorId`, `EnvironmentId`, and `ErrorCode`.
+
+Likely key files:
+- `HoneyDrunk.Kernel/.../Context/Mappers/HttpContextMapper.cs`
+- `HoneyDrunk.Kernel/.../Context/Middleware/GridContextMiddleware.cs`
+- `HoneyDrunk.Kernel.Abstractions/Identity/*.cs`
+
+## Acceptance Criteria
+
+- [ ] Shared HTTP context extraction/parsing helper introduced and used by both mapper and middleware, without moving middleware-only response behavior into the mapper.
+- [ ] Shared identity parsing/validation helper or template introduced for repeated ULID/string-backed identity behavior.
+- [ ] Existing public identity types remain source/binary compatible unless an explicit breaking-change plan is added.
+- [ ] Tests cover mapper and middleware behavior after consolidation, including tenant fallback, correlation extraction, baggage parsing, and truncation/error behavior.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `core`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Kernel` without changing public behavior.
+
+**Target:** `HoneyDrunk.Kernel`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Shared HTTP context extraction/parsing helper introduced and used by both mapper and middleware, without moving middleware-only response behavior into the mapper.
+- [ ] Shared identity parsing/validation helper or template introduced for repeated ULID/string-backed identity behavior.
+- [ ] Existing public identity types remain source/binary compatible unless an explicit breaking-change plan is added.
+- [ ] Tests cover mapper and middleware behavior after consolidation, including tenant fallback, correlation extraction, baggage parsing, and truncation/error behavior.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `HoneyDrunk.Kernel/.../Context/Mappers/HttpContextMapper.cs`
+- `HoneyDrunk.Kernel/.../Context/Middleware/GridContextMiddleware.cs`
+- `HoneyDrunk.Kernel.Abstractions/Identity/*.cs`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-notify-consolidate-notify-template-provider-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-notify-consolidate-notify-template-provider-helpers.md
@@ -1,0 +1,115 @@
+---
+title: "Consolidate Notify template and provider helpers"
+repo: "HoneyDrunkStudios/HoneyDrunk.Notify"
+node: "HoneyDrunk.Notify"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "meta"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "meta"]
+actor: "Agent"
+---
+
+# Consolidate Notify template and provider helpers
+
+## Summary
+
+Consolidate duplicated Notify template loading/cache, provider secret lookup, and DI registration helper patterns.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Notify`
+
+Audit findings to address:
+- `FileTemplateRenderer` and `EmailFileTemplateRenderer` duplicate safe path resolution, TTL cache lookup/write, file existence/read, and cache-entry shape.
+- SMTP, Resend, and Twilio providers duplicate `GetSecretValueAsync` against `ISecretStore`.
+- Provider and queue DI extension classes repeat options registration, concrete singleton registration, and interface/keyed forwarding patterns.
+
+Likely key files:
+- `HoneyDrunk.Notify/Templates/FileTemplateRenderer.cs`
+- `HoneyDrunk.Notify/Templates/EmailFileTemplateRenderer.cs`
+- `HoneyDrunk.Notify.Providers.*/**/*NotificationSender.cs`
+- `**/*NotifyServiceCollectionExtensions.cs`
+- `**/*QueueServiceCollectionExtensions.cs`
+
+## Acceptance Criteria
+
+- [ ] Shared template file/path/cache loader extracted while keeping email subject/body behavior specific.
+- [ ] Provider secret value retrieval centralized through an internal helper/extension.
+- [ ] Provider/queue DI registration boilerplate consolidated without breaking SMTP backward-compatible fallback behavior.
+- [ ] Tests cover template path protection/cache behavior and provider secret lookup.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `meta`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Notify` without changing public behavior.
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Shared template file/path/cache loader extracted while keeping email subject/body behavior specific.
+- [ ] Provider secret value retrieval centralized through an internal helper/extension.
+- [ ] Provider/queue DI registration boilerplate consolidated without breaking SMTP backward-compatible fallback behavior.
+- [ ] Tests cover template path protection/cache behavior and provider secret lookup.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `HoneyDrunk.Notify/Templates/FileTemplateRenderer.cs`
+- `HoneyDrunk.Notify/Templates/EmailFileTemplateRenderer.cs`
+- `HoneyDrunk.Notify.Providers.*/**/*NotificationSender.cs`
+- `**/*NotifyServiceCollectionExtensions.cs`
+- `**/*QueueServiceCollectionExtensions.cs`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-pipelines-consolidate-pipelines-test-validation-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-pipelines-consolidate-pipelines-test-validation-helpers.md
@@ -1,0 +1,109 @@
+---
+title: "Consolidate Pipelines test validation helpers"
+repo: "HoneyDrunkStudios/HoneyDrunk.Pipelines"
+node: "HoneyDrunk.Pipelines"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "ops"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "ops"]
+actor: "Agent"
+---
+
+# Consolidate Pipelines test validation helpers
+
+## Summary
+
+Extract common PowerShell helper logic from test naming and display-name validation tasks.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Pipelines`
+
+Audit findings to address:
+- `validate-test-naming.ps1` and `validate-test-displayname.ps1` repeat recursive test-file discovery, bin/obj exclusion, summary/violation counters, warning/no-files handling, and catch/error/exit patterns.
+
+Likely key files:
+- `tasks/dotnet/validate-test-naming.ps1`
+- `tasks/dotnet/validate-test-displayname.ps1`
+- `tasks/common/*.ps1`
+
+## Acceptance Criteria
+
+- [ ] Common test discovery and Azure logging/error helpers extracted under `tasks/common/` or equivalent.
+- [ ] Both validation tasks consume shared helpers while keeping their rule-specific checks clear.
+- [ ] Existing task outputs and exit-code behavior remain compatible.
+- [ ] Add or update script-level tests/examples if this repo has a validation harness.
+- [ ] Repo changelog or release notes updated if tasks are shipped.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `ops`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Pipelines` without changing public behavior.
+
+**Target:** `HoneyDrunk.Pipelines`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Common test discovery and Azure logging/error helpers extracted under `tasks/common/` or equivalent.
+- [ ] Both validation tasks consume shared helpers while keeping their rule-specific checks clear.
+- [ ] Existing task outputs and exit-code behavior remain compatible.
+- [ ] Add or update script-level tests/examples if this repo has a validation harness.
+- [ ] Repo changelog or release notes updated if tasks are shipped.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `tasks/dotnet/validate-test-naming.ps1`
+- `tasks/dotnet/validate-test-displayname.ps1`
+- `tasks/common/*.ps1`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-pulse-consolidate-pulse-http-otlp-sink-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-pulse-consolidate-pulse-http-otlp-sink-helpers.md
@@ -1,0 +1,112 @@
+---
+title: "Consolidate Pulse HTTP OTLP sink helpers"
+repo: "HoneyDrunkStudios/HoneyDrunk.Pulse"
+node: "HoneyDrunk.Pulse"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "ops"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "ops"]
+actor: "Agent"
+---
+
+# Consolidate Pulse HTTP OTLP sink helpers
+
+## Summary
+
+Extract shared HTTP OTLP sink export/auth/options behavior used by Loki, Mimir, and Tempo sinks.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Pulse`
+
+Audit findings to address:
+- `LokiSink`, `MimirSink`, and `TempoSink` duplicate export retry loops, enabled/endpoint checks, request/content construction, exponential retry delay, header application, secret lookup, and basic-auth header construction.
+- `LokiSinkOptions`, `MimirSinkOptions`, and `TempoSinkOptions` repeat endpoint/protocol/enabled/timeout/retry/header/basic-auth secret option shapes.
+
+Likely key files:
+- `HoneyDrunk.Telemetry.Sink.Loki/Implementation/LokiSink.cs`
+- `HoneyDrunk.Telemetry.Sink.Mimir/Implementation/MimirSink.cs`
+- `HoneyDrunk.Telemetry.Sink.Tempo/Implementation/TempoSink.cs`
+- `**/*SinkOptions.cs`
+
+## Acceptance Criteria
+
+- [ ] Shared internal HTTP OTLP exporter/auth helper introduced and used by Loki, Mimir, and Tempo sinks.
+- [ ] Shared option shape or interface/base introduced where it reduces duplication without hiding sink-specific defaults.
+- [ ] Sink-specific logging, protocol names, and payload behavior remain explicit.
+- [ ] Tests cover retry/header/basic-auth behavior through the shared helper.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `ops`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Pulse` without changing public behavior.
+
+**Target:** `HoneyDrunk.Pulse`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Shared internal HTTP OTLP exporter/auth helper introduced and used by Loki, Mimir, and Tempo sinks.
+- [ ] Shared option shape or interface/base introduced where it reduces duplication without hiding sink-specific defaults.
+- [ ] Sink-specific logging, protocol names, and payload behavior remain explicit.
+- [ ] Tests cover retry/header/basic-auth behavior through the shared helper.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `HoneyDrunk.Telemetry.Sink.Loki/Implementation/LokiSink.cs`
+- `HoneyDrunk.Telemetry.Sink.Mimir/Implementation/MimirSink.cs`
+- `HoneyDrunk.Telemetry.Sink.Tempo/Implementation/TempoSink.cs`
+- `**/*SinkOptions.cs`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-standards-clarify-standards-builds-policy-ownership.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-standards-clarify-standards-builds-policy-ownership.md
@@ -1,0 +1,111 @@
+---
+title: "Clarify Standards ownership versus Builds defaults"
+repo: "HoneyDrunkStudios/HoneyDrunk.Standards"
+node: "HoneyDrunk.Standards"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "ops"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "ops"]
+actor: "Agent"
+---
+
+# Clarify Standards ownership versus Builds defaults
+
+## Summary
+
+Clarify Standards as the owner of analyzer/code-quality policy and remove ambiguity with HoneyDrunk.Builds.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Standards`
+
+Audit findings to address:
+- Standards props/targets overlap with Builds props for nullable/latest LangVersion/deterministic settings, analyzer/code-style enforcement, StyleCop/editorconfig/globalconfig wiring, and warnings-as-errors policy.
+
+Likely key files:
+- `**/buildTransitive/HoneyDrunk.Standards.props`
+- `**/HoneyDrunk.Standards.targets`
+- `README.md`
+- `CHANGELOG.md`
+
+## Acceptance Criteria
+
+- [ ] Document Standards ownership of analyzer/code-quality policy and the intended relationship to HoneyDrunk.Builds.
+- [ ] Consolidate or remove overlapping policy where appropriate, in dependency order with the Builds issue if both need code changes.
+- [ ] Validation covers a representative consuming project.
+- [ ] No analyzer enforcement is weakened.
+- [ ] Repo changelog updated under `Unreleased`.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `ops`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Standards` without changing public behavior.
+
+**Target:** `HoneyDrunk.Standards`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Document Standards ownership of analyzer/code-quality policy and the intended relationship to HoneyDrunk.Builds.
+- [ ] Consolidate or remove overlapping policy where appropriate, in dependency order with the Builds issue if both need code changes.
+- [ ] Validation covers a representative consuming project.
+- [ ] No analyzer enforcement is weakened.
+- [ ] Repo changelog updated under `Unreleased`.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `**/buildTransitive/HoneyDrunk.Standards.props`
+- `**/HoneyDrunk.Standards.targets`
+- `README.md`
+- `CHANGELOG.md`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-transport-consolidate-transport-servicebus-consumer-paths.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-transport-consolidate-transport-servicebus-consumer-paths.md
@@ -1,0 +1,105 @@
+---
+title: "Consolidate Service Bus consumer orchestration paths"
+repo: "HoneyDrunkStudios/HoneyDrunk.Transport"
+node: "HoneyDrunk.Transport"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "core"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "core"]
+actor: "Agent"
+---
+
+# Consolidate Service Bus consumer orchestration paths
+
+## Summary
+
+Consolidate duplicated standard/session Azure Service Bus consumer orchestration paths.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Transport`
+
+Audit findings to address:
+- `ServiceBusTransportConsumer` repeats standard vs session processor startup, message processing, complete/abandon/dead-letter behavior, and catch-abandon paths.
+
+Likely key files:
+- `HoneyDrunk.Transport.AzureServiceBus/ServiceBusTransportConsumer.cs`
+
+## Acceptance Criteria
+
+- [ ] Standard and session message handling share one orchestration path through a focused adapter/context abstraction or equivalent helper.
+- [ ] Type-specific Azure Service Bus SDK calls remain isolated at the edge.
+- [ ] Behavioral tests or canaries cover complete, abandon, dead-letter, and exception paths for both standard and session processors.
+- [ ] No public Transport contracts are changed unless explicitly justified.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `core`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Transport` without changing public behavior.
+
+**Target:** `HoneyDrunk.Transport`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Standard and session message handling share one orchestration path through a focused adapter/context abstraction or equivalent helper.
+- [ ] Type-specific Azure Service Bus SDK calls remain isolated at the edge.
+- [ ] Behavioral tests or canaries cover complete, abandon, dead-letter, and exception paths for both standard and session processors.
+- [ ] No public Transport contracts are changed unless explicitly justified.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `HoneyDrunk.Transport.AzureServiceBus/ServiceBusTransportConsumer.cs`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-vault-consolidate-vault-provider-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-vault-consolidate-vault-provider-helpers.md
@@ -1,0 +1,115 @@
+---
+title: "Consolidate Vault provider bootstrap and store helpers"
+repo: "HoneyDrunkStudios/HoneyDrunk.Vault"
+node: "HoneyDrunk.Vault"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "core"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "core"]
+actor: "Agent"
+---
+
+# Consolidate Vault provider bootstrap and store helpers
+
+## Summary
+
+Reduce repeated Vault provider bootstrap, secret-store facade, and config-source helper logic.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Vault`
+
+Audit findings to address:
+- App Configuration and Azure Key Vault provider bootstrap resolvers repeat `Resolve`, development checks, and endpoint/URI lookup behavior.
+- Secret-store providers repeat `FetchSecretAsync`, `TryFetchSecretAsync`, `ListVersionsAsync`, and try/get wrapper patterns across AWS, Azure Key Vault, File, InMemory, and Configuration stores.
+- `FileConfigSource` and `InMemoryConfigSource` duplicate key validation, get/try-get orchestration, and generic conversion with drift.
+
+Likely key files:
+- `HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/BootstrapConfigurationResolver.cs`
+- `HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/BootstrapConfigurationResolver.cs`
+- `**/*SecretStore.cs`
+- `FileConfigSource.cs`
+- `InMemoryConfigSource.cs`
+
+## Acceptance Criteria
+
+- [ ] Provider-neutral bootstrap configuration helper extracted or otherwise centralized without making provider packages depend on internal implementation details.
+- [ ] Common secret-store facade/try-wrapper behavior consolidated behind a base/helper while provider-specific fetch/list behavior remains explicit.
+- [ ] Config value conversion and get/try-get orchestration are unified or intentional divergence is documented.
+- [ ] Provider tests continue to pass and cover shared helper behavior.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `core`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Vault` without changing public behavior.
+
+**Target:** `HoneyDrunk.Vault`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Provider-neutral bootstrap configuration helper extracted or otherwise centralized without making provider packages depend on internal implementation details.
+- [ ] Common secret-store facade/try-wrapper behavior consolidated behind a base/helper while provider-specific fetch/list behavior remains explicit.
+- [ ] Config value conversion and get/try-get orchestration are unified or intentional divergence is documented.
+- [ ] Provider tests continue to pass and cover shared helper behavior.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/BootstrapConfigurationResolver.cs`
+- `HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/BootstrapConfigurationResolver.cs`
+- `**/*SecretStore.cs`
+- `FileConfigSource.cs`
+- `InMemoryConfigSource.cs`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-vault-rotation-consolidate-vault-rotation-placeholder-rotators.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-vault-rotation-consolidate-vault-rotation-placeholder-rotators.md
@@ -1,0 +1,109 @@
+---
+title: "Consolidate Vault.Rotation placeholder rotators"
+repo: "HoneyDrunkStudios/HoneyDrunk.Vault.Rotation"
+node: "HoneyDrunk.Vault.Rotation"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "core"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "core"]
+actor: "Agent"
+---
+
+# Consolidate Vault.Rotation placeholder rotators
+
+## Summary
+
+Replace copy/paste placeholder provider rotators with one reusable scaffold/base until real rotations land.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Vault.Rotation`
+
+Audit findings to address:
+- OpenAI, Resend, and Twilio placeholder rotators duplicate `ProviderName`, `RotateAsync`, context/cancellation validation, and skipped-result behavior with only provider names/messages differing.
+
+Likely key files:
+- `HoneyDrunk.Vault.Rotation.Providers/OpenAI/OpenAIRotator.cs`
+- `HoneyDrunk.Vault.Rotation.Providers/Resend/ResendRotator.cs`
+- `HoneyDrunk.Vault.Rotation.Providers/Twilio/TwilioRotator.cs`
+
+## Acceptance Criteria
+
+- [ ] Placeholder provider behavior consolidated into a configurable placeholder rotator or abstract scaffold base.
+- [ ] Provider registrations still expose distinct provider names for OpenAI, Resend, and Twilio.
+- [ ] Tests cover skipped placeholder behavior for each provider registration.
+- [ ] No real provider rotation behavior is implied until separately scoped.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `core`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Vault.Rotation` without changing public behavior.
+
+**Target:** `HoneyDrunk.Vault.Rotation`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Placeholder provider behavior consolidated into a configurable placeholder rotator or abstract scaffold base.
+- [ ] Provider registrations still expose distinct provider names for OpenAI, Resend, and Twilio.
+- [ ] Tests cover skipped placeholder behavior for each provider registration.
+- [ ] No real provider rotation behavior is implied until separately scoped.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `HoneyDrunk.Vault.Rotation.Providers/OpenAI/OpenAIRotator.cs`
+- `HoneyDrunk.Vault.Rotation.Providers/Resend/ResendRotator.cs`
+- `HoneyDrunk.Vault.Rotation.Providers/Twilio/TwilioRotator.cs`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.

--- a/generated/issue-packets/active/standalone/2026-05-04-web-rest-consolidate-web-rest-api-result-factories.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-web-rest-consolidate-web-rest-api-result-factories.md
@@ -1,0 +1,107 @@
+---
+title: "Consolidate Web.Rest API result failure factories"
+repo: "HoneyDrunkStudios/HoneyDrunk.Web.Rest"
+node: "HoneyDrunk.Web.Rest"
+request_type: "repo-feature"
+tier: "tier-2"
+sector: "core"
+wave: 1
+initiative: "standalone"
+adrs: []
+accepts: []
+dependencies: []
+labels: ["chore", "tier-2", "core"]
+actor: "Agent"
+---
+
+# Consolidate Web.Rest API result failure factories
+
+## Summary
+
+Consolidate duplicated generic and non-generic API result failure factory methods.
+
+## Context
+
+A cross-repo reusable-code hygiene audit found repeated helper, mapper, validator, factory, extension, or orchestration logic in this repo. Oleg added a standing rule that agents should scan for existing reusable behavior before adding one-off helpers and should consolidate repeated logic when the same shape appears twice or becomes a policy boundary.
+
+This packet is standalone and repo-scoped. It should not introduce cross-repo contract changes unless the implementation discovers that consolidation cannot be done safely within the target repo.
+
+## Scope
+
+Target repo: `HoneyDrunkStudios/HoneyDrunk.Web.Rest`
+
+Audit findings to address:
+- `ApiResult` and `ApiResult<T>` duplicate failure factories such as `Fail`, `NotFound`, `Unauthorized`, `Forbidden`, `Conflict`, and `InternalError`.
+
+Likely key files:
+- `HoneyDrunk.Web.Rest.Abstractions/Results/ApiResult.cs`
+- `HoneyDrunk.Web.Rest.Abstractions/Results/ApiResultOfT.cs`
+
+## Acceptance Criteria
+
+- [ ] Failure construction logic centralized so generic and non-generic results cannot drift.
+- [ ] Existing public factory names and behavior remain compatible.
+- [ ] Unit tests cover representative generic and non-generic failure factories.
+- [ ] XML documentation remains present on public APIs.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Implementation scans local sibling/shared locations before adding any new helper and documents intentional duplication in the PR if behavior should diverge.
+- [ ] Repo validation passes using the repo's normal tier-1 gate: build, tests, analyzers/static analysis, secret scan, and dependency/vulnerability scan where configured.
+
+## NuGet Dependencies
+
+No new `PackageReference` entries are expected. If implementation discovers a package reference is required, update this packet before filing or document the package explicitly in the filed issue/PR body before execution.
+
+## Human Prerequisites
+
+None.
+
+## Dependencies
+
+None. This is a standalone cleanup packet.
+
+## Labels
+
+- `chore`
+- `tier-2`
+- `core`
+
+## Agent Handoff
+
+**Objective:** Consolidate duplicated reusable-code patterns in `HoneyDrunk.Web.Rest` without changing public behavior.
+
+**Target:** `HoneyDrunk.Web.Rest`, branch from `main`.
+
+**Context:**
+- Goal: Apply the new reusable-code hygiene rule to existing AI-generated or near-duplicate helper/orchestration code.
+- Feature: Reduce drift risk by centralizing repeated behavior inside the owning repo.
+- ADRs: None required unless implementation needs a public contract or repo-boundary change.
+
+**Acceptance Criteria:**
+- [ ] Failure construction logic centralized so generic and non-generic results cannot drift.
+- [ ] Existing public factory names and behavior remain compatible.
+- [ ] Unit tests cover representative generic and non-generic failure factories.
+- [ ] XML documentation remains present on public APIs.
+- [ ] Repo-level and affected package changelogs updated under `Unreleased`.
+- [ ] Normal repo validation passes.
+
+**Dependencies:**
+- None.
+
+**Constraints:**
+- Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+- Provider packages depend on their parent Node's contracts, not internal implementation details; providers must only consume exported interfaces, never internal types, caches, or resilience plumbing.
+- No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+- Semantic versioning with CHANGELOG and README: update repo-level `CHANGELOG.md` for shipped behavior changes and per-package changelogs only for packages with actual functional changes.
+- All public APIs have XML documentation.
+- Tests never depend on external services; use in-memory/fake providers for isolation.
+- Issue packets are immutable once filed as a GitHub Issue; if requirements change materially after filing, write a follow-up packet rather than editing the filed packet.
+- All projects in a solution share one version and move together when a version bump is warranted; do not bump versions unless this cleanup intentionally cuts a release.
+- Agent-authored PRs must link to their packet in the PR body.
+
+**Key Files:**
+- `HoneyDrunk.Web.Rest.Abstractions/Results/ApiResult.cs`
+- `HoneyDrunk.Web.Rest.Abstractions/Results/ApiResultOfT.cs`
+
+**Contracts:**
+- Prefer internal/private consolidation. Do not change public contracts unless the PR explicitly justifies the compatibility impact.


### PR DESCRIPTION
## Summary

Adds standalone Architecture issue packets for the reusable-code hygiene audit findings, one packet per affected repo.

## Packets

- Actions
- Architecture
- Builds
- Communications
- Data
- Kernel
- Notify
- Pipelines
- Pulse
- Standards
- Transport
- Vault
- Vault.Rotation
- Web.Rest

## Notes

- Packets are standalone under `generated/issue-packets/active/standalone/`.
- No GitHub issues are filed by this PR.
- Scope comes from the duplicate/helper audit: consolidate near-duplicate helper, mapper, validator, factory, extension, and orchestration code.

## Validation

- Verified all 14 packets include required sections: Summary, Context, Scope, Acceptance Criteria, NuGet Dependencies, Human Prerequisites, Dependencies, and Agent Handoff.