### PR TITLE
fix: add target repo to reusable code packets

### DIFF
--- a/generated/issue-packets/active/standalone/2026-05-04-actions-consolidate-actions-deploy-github-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-actions-consolidate-actions-deploy-github-helpers.md
@@ -1,6 +1,7 @@
 ---
 title: "Consolidate Actions deploy and GitHub helpers"
 repo: "HoneyDrunkStudios/HoneyDrunk.Actions"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Actions"
 node: "HoneyDrunk.Actions"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-architecture-consolidate-architecture-packet-guidance-rules.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-architecture-consolidate-architecture-packet-guidance-rules.md
@@ -1,6 +1,7 @@
 ---
 title: "Consolidate Architecture packet and guidance rules"
 repo: "HoneyDrunkStudios/HoneyDrunk.Architecture"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Architecture"
 node: "HoneyDrunk.Architecture"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-builds-clarify-builds-standards-policy-ownership.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-builds-clarify-builds-standards-policy-ownership.md
@@ -1,6 +1,7 @@
 ---
 title: "Clarify Builds ownership versus Standards policy"
 repo: "HoneyDrunkStudios/HoneyDrunk.Builds"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Builds"
 node: "HoneyDrunk.Builds"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-communications-consolidate-communications-tenant-predicates.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-communications-consolidate-communications-tenant-predicates.md
@@ -1,6 +1,7 @@
 ---
 title: "Consolidate Communications tenant predicates"
 repo: "HoneyDrunkStudios/HoneyDrunk.Communications"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Communications"
 node: "HoneyDrunk.Communications"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-data-consolidate-data-ef-sql-configuration-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-data-consolidate-data-ef-sql-configuration-helpers.md
@@ -1,6 +1,7 @@
 ---
 title: "Consolidate Data EF and SQL configuration helpers"
 repo: "HoneyDrunkStudios/HoneyDrunk.Data"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Data"
 node: "HoneyDrunk.Data"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-kernel-consolidate-kernel-context-identity-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-kernel-consolidate-kernel-context-identity-helpers.md
@@ -1,6 +1,7 @@
 ---
 title: "Consolidate Kernel duplicate context and identity helpers"
 repo: "HoneyDrunkStudios/HoneyDrunk.Kernel"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Kernel"
 node: "HoneyDrunk.Kernel"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-notify-consolidate-notify-template-provider-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-notify-consolidate-notify-template-provider-helpers.md
@@ -1,6 +1,7 @@
 ---
 title: "Consolidate Notify template and provider helpers"
 repo: "HoneyDrunkStudios/HoneyDrunk.Notify"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Notify"
 node: "HoneyDrunk.Notify"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-pipelines-consolidate-pipelines-test-validation-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-pipelines-consolidate-pipelines-test-validation-helpers.md
@@ -1,6 +1,7 @@
 ---
 title: "Consolidate Pipelines test validation helpers"
 repo: "HoneyDrunkStudios/HoneyDrunk.Pipelines"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Pipelines"
 node: "HoneyDrunk.Pipelines"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-pulse-consolidate-pulse-http-otlp-sink-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-pulse-consolidate-pulse-http-otlp-sink-helpers.md
@@ -1,6 +1,7 @@
 ---
 title: "Consolidate Pulse HTTP OTLP sink helpers"
 repo: "HoneyDrunkStudios/HoneyDrunk.Pulse"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Pulse"
 node: "HoneyDrunk.Pulse"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-standards-clarify-standards-builds-policy-ownership.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-standards-clarify-standards-builds-policy-ownership.md
@@ -1,6 +1,7 @@
 ---
 title: "Clarify Standards ownership versus Builds defaults"
 repo: "HoneyDrunkStudios/HoneyDrunk.Standards"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Standards"
 node: "HoneyDrunk.Standards"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-transport-consolidate-transport-servicebus-consumer-paths.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-transport-consolidate-transport-servicebus-consumer-paths.md
@@ -1,6 +1,7 @@
 ---
 title: "Consolidate Service Bus consumer orchestration paths"
 repo: "HoneyDrunkStudios/HoneyDrunk.Transport"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Transport"
 node: "HoneyDrunk.Transport"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-vault-consolidate-vault-provider-helpers.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-vault-consolidate-vault-provider-helpers.md
@@ -1,6 +1,7 @@
 ---
 title: "Consolidate Vault provider bootstrap and store helpers"
 repo: "HoneyDrunkStudios/HoneyDrunk.Vault"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Vault"
 node: "HoneyDrunk.Vault"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-vault-rotation-consolidate-vault-rotation-placeholder-rotators.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-vault-rotation-consolidate-vault-rotation-placeholder-rotators.md
@@ -1,6 +1,7 @@
 ---
 title: "Consolidate Vault.Rotation placeholder rotators"
 repo: "HoneyDrunkStudios/HoneyDrunk.Vault.Rotation"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Vault.Rotation"
 node: "HoneyDrunk.Vault.Rotation"
 request_type: "repo-feature"
 tier: "tier-2"

--- a/generated/issue-packets/active/standalone/2026-05-04-web-rest-consolidate-web-rest-api-result-factories.md
+++ b/generated/issue-packets/active/standalone/2026-05-04-web-rest-consolidate-web-rest-api-result-factories.md
@@ -1,6 +1,7 @@
 ---
 title: "Consolidate Web.Rest API result failure factories"
 repo: "HoneyDrunkStudios/HoneyDrunk.Web.Rest"
+target_repo: "HoneyDrunkStudios/HoneyDrunk.Web.Rest"
 node: "HoneyDrunk.Web.Rest"
 request_type: "repo-feature"
 tier: "tier-2"


### PR DESCRIPTION
## Summary

Adds the required \	arget_repo\ frontmatter field to the 14 reusable-code hygiene standalone packets so the File Issue Packets workflow can parse and file them.

## Validation

- Parsed all 14 standalone packets and confirmed \	arget_repo\ is present.