### PR TITLE
chore: reconcile ADR-0019 communications architecture

### DIFF
--- a/adrs/ADR-0019-stand-up-honeydrunk-communications-node.md
+++ b/adrs/ADR-0019-stand-up-honeydrunk-communications-node.md
@@ -10,13 +10,13 @@
 
 Accepting this ADR creates catalog and cross-repo obligations that must be completed as follow-up issue packets (do not accept and leave the catalogs stale):
 
-- [ ] Create `HoneyDrunk.Communications` GitHub repo (human-only step — public default per Grid posture)
-- [ ] Scaffold packet — solution structure with `HoneyDrunk.Communications.Abstractions` and `HoneyDrunk.Communications`, HoneyDrunk.Standards wiring, CI pipeline via HoneyDrunk.Actions shared workflows, InMemory fixtures for preference store and cadence policy
-- [ ] Create `repos/HoneyDrunk.Communications/` context folder in the Architecture repo (`overview.md`, `boundaries.md`, `invariants.md`, `active-work.md`, `integration-points.md`) — matching the template used by `repos/HoneyDrunk.Agents/`
-- [ ] Reconcile `catalogs/contracts.json`: confirm the cataloged contracts (`ICommunicationOrchestrator`, `IMessageIntent`, `IRecipientResolver`, `IPreferenceStore`, `ICadencePolicy`) against the final contract shape, and add any additional records introduced by this stand-up (`MessageIntent` if promoted to a value type — see D3) plus the `ICommunicationDecisionLog` surface added in D3
-- [ ] Update `catalogs/grid-health.json` Communications entry to reflect the stood-up contract surface and scaffold expectations
-- [ ] Wire the contract-shape canary into Actions for the frozen contracts named in D8
-- [ ] **Notify refactor packet** — migrate `INotificationPolicy` conceptually into `IPreferenceStore` + `ICadencePolicy`, remove `INotificationPolicy` / `PolicyEvaluationResult` / `RejectionReason.PolicyDenied` from `HoneyDrunk.Notify.Abstractions`, delete `AllowAllPolicy` and `CompositePolicyPipeline`, remove the policy-evaluation step from `NotificationGateway.EnqueueAsync`, rename Notify's `Orchestration/` folder to `Intake/`, and update Notify's `boundaries.md`. This is part of acceptance, not a follow-up — see D11 and Consequences.
+- [x] Create `HoneyDrunk.Communications` GitHub repo (human-only step — public default per Grid posture)
+- [x] Scaffold packet — solution structure with `HoneyDrunk.Communications.Abstractions` and `HoneyDrunk.Communications`, HoneyDrunk.Standards wiring, CI pipeline via HoneyDrunk.Actions shared workflows, InMemory fixtures for preference store and cadence policy
+- [x] Create `repos/HoneyDrunk.Communications/` context folder in the Architecture repo (`overview.md`, `boundaries.md`, `invariants.md`, `active-work.md`, `integration-points.md`) — matching the template used by `repos/HoneyDrunk.Agents/`
+- [x] Reconcile `catalogs/contracts.json`: confirm the cataloged contracts (`ICommunicationOrchestrator`, `IMessageIntent`, `IRecipientResolver`, `IPreferenceStore`, `ICadencePolicy`) against the final contract shape, and add any additional records introduced by this stand-up (`MessageIntent` if promoted to a value type — see D3) plus the `ICommunicationDecisionLog` surface added in D3
+- [x] Update `catalogs/grid-health.json` Communications entry to reflect the stood-up contract surface and scaffold expectations
+- [x] Wire the contract-shape canary into Actions for the frozen contracts named in D8
+- [x] **Notify refactor packet** — migrate `INotificationPolicy` conceptually into `IPreferenceStore` + `ICadencePolicy`, remove `INotificationPolicy` / `PolicyEvaluationResult` / `RejectionReason.PolicyDenied` from `HoneyDrunk.Notify.Abstractions`, delete `AllowAllPolicy` and `CompositePolicyPipeline`, remove the policy-evaluation step from `NotificationGateway.EnqueueAsync`, rename Notify's `Orchestration/` folder to `Intake/`, and update Notify's `boundaries.md`. This is part of acceptance, not a follow-up — see D11 and Consequences.
 - [ ] Scope agent assigns final invariant numbers when flipping Status → Accepted
 
 ## Context

--- a/catalogs/contracts.json
+++ b/catalogs/contracts.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "description": "Registry of public contracts (interfaces, types, HTTP endpoints, signal events) exposed by each Node. Derived from relationships.json exposes.contracts but expanded with kind, package, and status. Use this before writing code that crosses a Node boundary to find the exact interface to depend on.",
-    "updated": "2026-05-04",
+    "updated": "2026-05-05",
     "schema_version": "1.0"
   },
   "contracts": [
@@ -124,23 +124,32 @@
       "node": "honeydrunk-notify",
       "node_name": "HoneyDrunk.Notify",
       "package": "HoneyDrunk.Notify.Abstractions",
-      "status": "live-undeployed",
+      "status": "live",
       "interfaces": [
-        { "name": "INotificationSender", "kind": "interface", "description": "Send a notification — channel-agnostic. Resolves to the appropriate gateway (email, SMS) based on notification type." },
-        { "name": "INotificationGateway", "kind": "interface", "description": "Provider slot — implement to add a new delivery channel (Resend, SMTP, Twilio, etc.)." }
+        { "name": "INotificationSender", "kind": "interface", "description": "Send a channel-agnostic notification through Notify intake and delivery mechanics. Decision-layer policy belongs in Communications." },
+        { "name": "INotificationGateway", "kind": "interface", "description": "Delivery gateway slot used by Notify runtime/provider implementations; it enqueues/dispatches structurally valid notifications and does not evaluate recipient preference/cadence policy." }
       ]
     },
     {
       "node": "honeydrunk-communications",
       "node_name": "HoneyDrunk.Communications",
       "package": "HoneyDrunk.Communications.Abstractions",
-      "status": "seed",
+      "status": "live",
       "interfaces": [
-        { "name": "ICommunicationOrchestrator", "kind": "interface", "description": "Top-level entry point — given a business event, decides what messages to send, to whom, and when. Delegates delivery to Notify." },
-        { "name": "IMessageIntent", "kind": "interface", "description": "Maps a business event to a message intent — captures the why and what of a communication without prescribing delivery details." },
-        { "name": "IRecipientResolver", "kind": "interface", "description": "Resolves the target audience for a message intent — determines who should receive based on context, roles, and relationships." },
-        { "name": "IPreferenceStore", "kind": "interface", "description": "User communication preferences — opt-in/out, channel preferences, quiet hours, suppression lists." },
-        { "name": "ICadencePolicy", "kind": "interface", "description": "Enforces message frequency and spacing rules per user — prevents notification fatigue and respects rate limits." }
+        { "name": "ICommunicationOrchestrator", "kind": "interface", "description": "Top-level entry point for evaluating and sending outbound communication intents. Decides send/suppress/schedule outcomes and delegates approved delivery to Notify." },
+        { "name": "IMessageIntent", "kind": "interface", "description": "Business-event message intent boundary: stable intent kind, trigger event id, recipient, and payload." },
+        { "name": "MessageIntent", "kind": "type", "description": "Immutable value-shaped implementation of IMessageIntent for simple communication flows." },
+        { "name": "IRecipientResolver", "kind": "interface", "description": "Resolves one or more recipients targeted by a communication intent." },
+        { "name": "IPreferenceStore", "kind": "interface", "description": "Tenant-scoped recipient communication preferences: opt-out, suppressed intent kinds, quiet hours, and channel preference." },
+        { "name": "ICadencePolicy", "kind": "interface", "description": "Tenant-scoped cadence policy that returns allow, suppress, or defer verdicts for recipient/intent tuples." },
+        { "name": "ICommunicationDecisionLog", "kind": "interface", "description": "Append-only audit sink for every Communications send-or-suppress decision." },
+        { "name": "CommunicationDecisionLogEntry", "kind": "type", "description": "Audit record containing decision id, timestamp, tenant, intent kind, recipient, message decision, and correlation id." },
+        { "name": "MessageDecision", "kind": "type", "description": "Result of evaluating or sending a communication intent: outcome, reason, optional scheduled time, and optional correlation key." },
+        { "name": "MessageDecisionOutcome", "kind": "type", "description": "Allowed, Sent, SuppressedByPreference, SuppressedByCadence, Scheduled, or Failed." },
+        { "name": "RecipientHandle", "kind": "type", "description": "Recipient identity plus preferred channel hint." },
+        { "name": "RecipientPreferences", "kind": "type", "description": "Tenant-scoped preference snapshot for a recipient." },
+        { "name": "CadenceVerdict", "kind": "type", "description": "Cadence policy result: outcome, optional defer time, and audit-friendly reason." },
+        { "name": "CadenceOutcome", "kind": "type", "description": "Cadence verdict outcome enum: Allow, Suppress, or Defer." }
       ]
     },
     {

--- a/catalogs/grid-health.json
+++ b/catalogs/grid-health.json
@@ -87,22 +87,22 @@
       "name": "HoneyDrunk.Notify",
       "sector": "Ops",
       "signal": "Live",
-      "version": "0.1.0",
-      "canary_status": "none",
-      "last_release": null,
-      "active_blockers": ["Azure Functions deployment pending", "Integration tests pending"],
-      "notes": "SMTP + Resend (email), Twilio (SMS), queue backends implemented. Awaiting first production deployment."
+      "version": "0.2.0",
+      "canary_status": "passing",
+      "last_release": "2026-05-05",
+      "active_blockers": [],
+      "notes": "Delivery/intake Node released at v0.2.0 after ADR-0019 refactor. Notify owns structural validation, queue-backed intake, provider dispatch, retry/delivery mechanics; preference/cadence policy moved to Communications."
     },
     {
       "id": "honeydrunk-communications",
       "name": "HoneyDrunk.Communications",
       "sector": "Ops",
-      "signal": "Seed",
-      "version": "0.0.0",
-      "canary_status": "none",
-      "last_release": null,
-      "active_blockers": ["Repo not yet scaffolded"],
-      "notes": "Message orchestration and workflow layer. Sits above Notify — decides why/when/who, delegates delivery to Notify."
+      "signal": "Live",
+      "version": "0.1.0",
+      "canary_status": "passing",
+      "last_release": "2026-05-05",
+      "active_blockers": [],
+      "notes": "v0.1.0 packages released. Contracts and welcome-flow runtime are stood up: intents, recipient resolution, preference store, cadence policy, decision log, and Notify delegation. Durable stores/testing package remain deferred."
     },
     {
       "id": "pulse",

--- a/catalogs/modules.json
+++ b/catalogs/modules.json
@@ -196,31 +196,31 @@
     "nodeId": "honeydrunk-notify",
     "name": "HoneyDrunk.Notify.Abstractions",
     "type": "abstractions",
-    "version": "0.1.0",
-    "description": "Notification channel contracts"
+    "version": "0.2.0",
+    "description": "Notification intake/delivery contracts after ADR-0019 policy-boundary cleanup"
   },
   {
     "id": "notify-runtime",
     "nodeId": "honeydrunk-notify",
     "name": "HoneyDrunk.Notify",
     "type": "runtime",
-    "version": "0.1.0",
-    "description": "Notification dispatch engine"
+    "version": "0.2.0",
+    "description": "Notification delivery runtime with intake mechanics, provider dispatch, and no recipient preference/cadence policy evaluation"
   },
   {
     "id": "communications-abstractions",
     "nodeId": "honeydrunk-communications",
     "name": "HoneyDrunk.Communications.Abstractions",
     "type": "abstractions",
-    "version": "0.0.0",
-    "description": "Communication orchestration contracts — intents, preferences, cadence, recipient resolution"
+    "version": "0.1.0",
+    "description": "Communication orchestration contracts — intents, preferences, cadence, recipient resolution, decisions, and decision logs"
   },
   {
     "id": "communications-runtime",
     "nodeId": "honeydrunk-communications",
     "name": "HoneyDrunk.Communications",
     "type": "runtime",
-    "version": "0.0.0",
-    "description": "Communication orchestration engine — workflow execution, preference enforcement, Notify delegation"
+    "version": "0.1.0",
+    "description": "Communication orchestration runtime — welcome flow, preference/cadence checks, decision logging, and Notify delegation"
   }
 ]

--- a/catalogs/nodes.json
+++ b/catalogs/nodes.json
@@ -356,7 +356,7 @@
     "name": "HoneyDrunk.Notify",
     "public_name": "HoneyDrunk.Notify",
     "short": "Unified notifications across communication channels",
-    "description": "Channel-agnostic notification dispatch system with multi-provider email (SMTP, Resend), SMS (Twilio), template rendering, and queue-based async delivery.",
+    "description": "Channel-agnostic notification intake and delivery system with multi-provider email/SMS support, template rendering, queue-backed async delivery, and retry mechanics. Recipient preference/cadence policy belongs in Communications.",
     "sector": "Ops",
     "signal": "Live",
     "cluster": "infrastructure",
@@ -368,7 +368,7 @@
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Notify"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Notify is the Grid's outbound notification layer — a channel-agnostic system for dispatching messages across email, SMS, and future channels. It provides a unified contract surface (INotificationSender, INotificationGateway, INotificationPolicy) with pluggable providers: SMTP and Resend for email, Twilio for SMS. Template rendering, idempotency keys, delivery tracking, and queue-based async dispatch ensure reliable, auditable delivery.",
+      "overview": "HoneyDrunk.Notify is the Grid delivery layer for outbound notifications. It receives structurally valid notification requests through intake contracts, handles template/render/provider/queue/retry mechanics, and deliberately does not decide recipient preference, cadence, suppression, or lifecycle workflow policy after the ADR-0019 refactor.",
       "why_it_exists": "Without unified notification infrastructure, outbound communication drifts in reliability, security, and delivery patterns across nodes.",
       "primary_audience": "Service developers and node owners needing reliable, multi-channel outbound notifications with consistent delivery semantics.",
       "value_props": [
@@ -380,10 +380,10 @@
         "Secure credential management via deploy-time Key Vault injection"
       ],
       "monetization_signal": "Internal-first; provider ecosystem may expand to push notifications, webhooks, and partner integrations.",
-      "roadmap_focus": "Push notification channel, webhook dispatch, adaptive send policies based on Pulse metrics.",
+      "roadmap_focus": "Production deployment stabilization, provider coverage, push/webhook channels, and delivery reliability. Adaptive recipient send policy belongs in Communications.",
       "grid_relationship": "Consumes Kernel for Grid context, lifecycle hooks, and telemetry. Provider credentials are injected at deploy time via Azure Key Vault (not the HoneyDrunk.Vault package).",
       "integration_depth": "medium",
-      "demo_path": "Send a notification via INotificationSender → provider dispatches email/SMS → track delivery status.",
+      "demo_path": "Receive a notification request via INotificationSender → intake validates delivery shape → provider dispatches email/SMS → track delivery status.",
       "signal_quote": "When the Hive speaks, it's heard everywhere.",
       "stability_tier": "beta",
       "impact_vector": "communication reliability"
@@ -400,10 +400,10 @@
     "type": "node",
     "name": "HoneyDrunk.Communications",
     "public_name": "HoneyDrunk.Communications",
-    "short": "Message orchestration and workflow engine",
-    "description": "Decision and orchestration layer for outbound communications. Determines why, when, and to whom messages are sent. Manages multi-step flows, campaigns, user preferences, suppression, cadence rules, and business-event-to-message-intent mapping. Delegates all delivery mechanics to Notify.",
+    "short": "Outbound message decision and orchestration substrate",
+    "description": "Decision and orchestration layer for outbound communications. Determines why, when, and to whom messages are sent; enforces preferences and cadence; records decisions; delegates delivery mechanics to Notify.",
     "sector": "Ops",
-    "signal": "Seed",
+    "signal": "Live",
     "cluster": "orchestration",
     "energy": 0,
     "priority": 25,
@@ -413,7 +413,7 @@
       "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Communications"
     },
     "long_description": {
-      "overview": "HoneyDrunk.Communications is the brain behind outbound messaging. While Notify handles the mechanics of delivery (render, send, retry, track), Communications owns the decision layer: should a message be sent, to whom, when, and as part of what workflow. It maps business events (user signed up, subscription expiring, agent completed task) to message intents, resolves recipients and their preferences, enforces suppression and cadence rules, and orchestrates multi-step communication flows (welcome sequences, re-engagement campaigns, escalation chains). Communications calls Notify's INotificationSender for every outbound message but never touches provider adapters, templates, or retry logic directly.",
+      "overview": "HoneyDrunk.Communications is the Grid decision layer for outbound messaging. It maps business events to message intents, resolves recipients, evaluates tenant-scoped preferences and cadence, records every send-or-suppress decision, and delegates approved delivery to Notify through INotificationSender. v0.1.0 ships the public contract surface and a welcome-email runtime slice.",
       "why_it_exists": "Without a dedicated orchestration layer, message-sending logic scatters across every Node that needs to communicate with users. That leads to duplicated preference checks, inconsistent cadence enforcement, and no single place to reason about a user's full communication lifecycle.",
       "primary_audience": "Node developers who need to trigger user-facing communications from business events. Product and growth workflows that require multi-step messaging sequences.",
       "value_props": [
@@ -425,12 +425,12 @@
         "Auditable decision log — every send-or-suppress decision is recorded with reasoning"
       ],
       "monetization_signal": "Internal-first. Campaign and lifecycle messaging capabilities may surface in product offerings.",
-      "roadmap_focus": "Define core abstractions (intent mapping, preference resolution, flow engine). First implementation: welcome email sequence using Notify as delivery backend.",
-      "grid_relationship": "Consumes Kernel for Grid context and lifecycle. Consumes Notify's INotificationSender for all delivery. May consume Data for preference and flow state persistence. Pulse receives telemetry on communication decisions.",
+      "roadmap_focus": "Durable preference/cadence/decision-log stores, reusable testing package, and deeper lifecycle/campaign workflows once Flow/Data integration is ready.",
+      "grid_relationship": "Consumes Kernel for tenant identity, context, health, lifecycle, and telemetry. Consumes Notify.Abstractions for delivery delegation through INotificationSender. Data/Flow/Transport edges remain deferred until durable stores or event/workflow ingress are selected.",
       "integration_depth": "medium",
-      "demo_path": "Fire a UserSignedUp event → Communications resolves intent (welcome email) → checks preferences → calls Notify → records decision.",
+      "demo_path": "Receive a UserSignedUp intent → check preferences and cadence → record MessageDecision → delegate approved welcome email to Notify.",
       "signal_quote": "The reason behind every message.",
-      "stability_tier": "experimental",
+      "stability_tier": "beta",
       "impact_vector": "communication intelligence"
     },
     "foundational": false,

--- a/catalogs/relationships.json
+++ b/catalogs/relationships.json
@@ -136,7 +136,7 @@
       "consumed_by_planned": ["honeydrunk-flow"],
       "blocked_by": [],
       "exposes": {
-        "contracts": ["ICommunicationOrchestrator", "IMessageIntent", "IRecipientResolver", "IPreferenceStore", "ICadencePolicy"],
+        "contracts": ["ICommunicationOrchestrator", "IMessageIntent", "MessageIntent", "IRecipientResolver", "IPreferenceStore", "ICadencePolicy", "ICommunicationDecisionLog", "CommunicationDecisionLogEntry", "MessageDecision", "RecipientHandle", "RecipientPreferences", "CadenceVerdict"],
         "packages": ["HoneyDrunk.Communications.Abstractions", "HoneyDrunk.Communications"]
       },
       "consumes_detail": {

--- a/initiatives/active-initiatives.md
+++ b/initiatives/active-initiatives.md
@@ -147,10 +147,10 @@ Tracked initiatives currently in progress or planned. Completed and cancelled in
 - [x] SMS provider (Twilio)
 - [x] Queue backends (Azure Storage, InMemory)
 - [x] Background worker
-- [ ] Azure Functions deployment
+- [x] Azure Functions deployment workflow
 - [ ] Integration tests with live providers
 
-> **Sync (2026-04-16):** 5/7 items done. Azure Functions deployment and live provider integration tests remain blocked on infrastructure provisioning. grid-health.json confirms active_blockers. No progress in 4 days; gated on deployment infrastructure.
+> **Sync (2026-05-05):** 6/7 items done. Notify v0.2.0 released and the Azure Functions deploy workflow completed. Live provider integration tests remain as production-hardening work.
 
 ### Ops: Observability Pipeline
 **Status:** In Progress  

--- a/initiatives/current-focus.md
+++ b/initiatives/current-focus.md
@@ -2,7 +2,7 @@
 
 What the team (human + agents) should prioritize right now.
 
-**Last Updated:** 2026-05-04
+**Last Updated:** 2026-05-05
 
 ## Primary Focus
 
@@ -22,11 +22,11 @@ Execute the two-wave rollout that standardizes secret and configuration manageme
 
 Provision Azure infrastructure and get both services running in the development environment.
 
-- **Notify:** Azure Function App (`func-hd-notify-dev`) — queue-triggered email/SMS dispatch
+- **Notify:** Azure Function App (`func-hd-notify-dev`) — queue-triggered email/SMS dispatch; v0.2.0 deploy workflow completed 2026-05-05.
 - **Notify.Worker:** Azure Container App (`ca-hd-notify-worker-dev`) — background worker on `cae-hd-dev` / `acrhdshareddev`
 - **Pulse:** Azure Container App (`ca-hd-pulse-dev`) — OTLP collector for observability, on `cae-hd-dev` / `acrhdshareddev`
 
-**Why now:** All Node packages are built and published. The deployment pipeline (HoneyDrunk.Actions) is ready. The Azure provisioning guide and naming conventions are documented. The only remaining work is creating the Azure resources, wiring OIDC, and running the first deploy.
+**Why now:** Notify Functions has a successful deploy workflow after the ADR-0019 boundary release. Remaining focus is Pulse deployment, Notify worker/container-app path, and live-provider hardening.
 
 **See:** `infrastructure/azure-provisioning-guide.md` for step-by-step instructions.
 

--- a/initiatives/proposed-adrs.md
+++ b/initiatives/proposed-adrs.md
@@ -4,7 +4,7 @@ Tracked automatically by the hive-sync agent. ADRs/PDRs with all implementing
 issues closed are auto-flipped to Accepted on each run; the rest are listed
 here with progress.
 
-Last synced: 2026-05-04
+Last synced: 2026-05-05
 
 ## Awaiting (no `accepts:`-declaring packets yet)
 
@@ -18,7 +18,6 @@ and remain manually-flippable until rescoped.
 |----|-------|--------|-------|------------------|
 | [ADR-0011](../adrs/ADR-0011-code-review-and-merge-flow.md) | Code Review and Merge Flow | Meta | 2026-04-12 | 22 |
 | [ADR-0012](../adrs/ADR-0012-grid-cicd-control-plane.md) | HoneyDrunk.Actions as the Grid CI/CD Control Plane | Meta | 2026-04-13 | 21 |
-| [ADR-0013](../adrs/ADR-0013-communications-orchestration-layer.md) | Communications Orchestration Layer — HoneyDrunk.Communications | Ops | 2026-04-16 | 18 |
 | [ADR-0016](../adrs/ADR-0016-stand-up-honeydrunk-ai-node.md) | Stand Up the HoneyDrunk.AI Node — Inference Substrate for the AI Sector | AI | 2026-04-19 | 15 |
 | [ADR-0017](../adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md) | Stand Up the HoneyDrunk.Capabilities Node — Tool Registry and Dispatch Substrate for the AI Sector | AI | 2026-04-19 | 15 |
 | [ADR-0018](../adrs/ADR-0018-stand-up-honeydrunk-operator-node.md) | Stand Up the HoneyDrunk.Operator Node — Human-Policy Enforcement and Audit Substrate for the AI Sector | AI | 2026-04-19 | 15 |

--- a/initiatives/releases.md
+++ b/initiatives/releases.md
@@ -2,7 +2,7 @@
 
 Centralized view of what shipped across the Grid.
 
-**Last Updated:** 2026-04-16
+**Last Updated:** 2026-05-05
 
 ---
 
@@ -51,6 +51,28 @@ Centralized view of what shipped across the Grid.
 - **Highlights:**
   - Highlights pending — repo scaffold and Function app implementation in progress (Vault.Rotation#3 open, release pending Vault.Rotation#4)
 - **Breaking Changes:** N/A (initial release)
+
+### Communications 0.1.0
+
+- **Signal:** Live
+- **Shipped:** 2026-05-05
+- **Highlights:**
+  - Initial `HoneyDrunk.Communications.Abstractions` and runtime packages released
+  - Public orchestration contracts for intents, recipient resolution, preferences, cadence, decisions, and decision logs
+  - Welcome-email runtime slice delegates approved delivery to Notify
+  - In-memory preference/cadence/decision-log implementations for bring-up
+- **Breaking Changes:** N/A (initial release)
+
+### Notify 0.2.0
+
+- **Signal:** Live
+- **Shipped:** 2026-05-05
+- **Highlights:**
+  - ADR-0019 boundary refactor: Notify now owns intake/delivery mechanics only
+  - Removed Notify-owned policy evaluation surface and default policy pipeline
+  - Renamed runtime `Orchestration/` area to `Intake/`
+  - Azure Functions deploy workflow completed after release
+- **Breaking Changes:** Yes — removed pre-1.0 policy evaluation types; no downstream users yet
 
 ---
 
@@ -148,7 +170,8 @@ See [roadmap.md](roadmap.md) for planned work.
 | Node | Next Version | Target | Key Goal |
 |------|-------------|--------|----------|
 | Pulse | 0.1.0 GA | Q2 2026 | Production hardening, Grafana dashboards |
-| Notify | 0.1.0 GA | Q2 2026 | Azure Functions deployment finalization |
+| HoneyDrunk.Communications | 0.2.0 | Q2 2026 | Durable stores/testing package if needed by first consumers |
+| Notify | 0.3.0 | Q2 2026 | Provider hardening and production smoke coverage |
 | Agent Kit | 0.1.0 | Q2 2026 | Agent execution runtime, tool abstraction |
 | Orchestrator | 0.1.0 | Q2 2026 | Workflow orchestration, multi-step pipelines |
 | HoneyHub | 0.1.0 | Q2–Q3 2026 | Project orchestration, creator dashboard |

--- a/initiatives/roadmap.md
+++ b/initiatives/roadmap.md
@@ -2,7 +2,7 @@
 
 High-level roadmap for the HoneyDrunk Grid.
 
-**Last Updated:** 2026-05-04
+**Last Updated:** 2026-05-05
 
 ## Q1 2026 (Jan–Mar)
 
@@ -23,7 +23,8 @@ High-level roadmap for the HoneyDrunk Grid.
 - [x] **Hive Sync Rollout (ADR-0014) - implementation merged** *(6/6 issues closed; ready for archive/exit-criteria review)*
 - [ ] **ADR-0015 Container Apps Rollout — underway** *(2/5 issues closed; walkthroughs + reusable deploy workflow complete; Notify/Pulse release work remains)*
 - [ ] Pulse — Production hardening, Grafana dashboard templates, finalize 0.1.0 release
-- [ ] Notify — Azure Functions deployment, finalize 0.1.0 release *(packages built, deployment blocked on Azure infrastructure)*
+- [x] Notify — v0.2.0 ADR-0019 intake-boundary release and Azure Functions deploy workflow complete
+- [x] HoneyDrunk.Communications — v0.1.0 contracts/runtime release with welcome-flow boundary slice
 - [ ] HoneyDrunk.AI — Model/provider abstraction, OpenAI + Anthropic providers, Pulse telemetry
 - [ ] **ADR-0010 Phase 1 (Observation Layer & AI Routing contracts)** *(0/3 issues closed; scoped 2026-04-18 — Observe side ready to file, AI routing deferred pending HoneyDrunk.AI standup ADR)*
 - [ ] HoneyDrunk.Capabilities — Tool registry, discovery, permissioning, initial tool descriptors

--- a/repos/HoneyDrunk.Communications/active-work.md
+++ b/repos/HoneyDrunk.Communications/active-work.md
@@ -1,0 +1,35 @@
+# HoneyDrunk.Communications - Active Work
+
+**Last Updated:** 2026-05-05  
+**Signal:** Live - v0.1.0 packages released; production durability and advanced workflows remain deferred.
+
+## Completed Bring-Up
+
+- GitHub repo created: `HoneyDrunkStudios/HoneyDrunk.Communications`.
+- Scaffold landed with `HoneyDrunk.Communications.Abstractions`, `HoneyDrunk.Communications`, HoneyDrunk.Standards wiring, CI, and NuGet release workflow.
+- Phase 1 contracts landed:
+  - `ICommunicationOrchestrator`
+  - `IMessageIntent` / `MessageIntent`
+  - `IRecipientResolver`
+  - `IPreferenceStore`
+  - `ICadencePolicy`
+  - `ICommunicationDecisionLog` / `CommunicationDecisionLogEntry`
+- Phase 2 welcome-flow runtime landed and delegates approved sends to Notify.
+- v0.1.0 released for both packages:
+  - `HoneyDrunk.Communications.Abstractions`
+  - `HoneyDrunk.Communications`
+- Notify ADR-0019 boundary refactor completed in `HoneyDrunk.Notify` v0.2.0: policy evaluation moved out of Notify and intake folder naming is now delivery-oriented.
+
+## Current Architecture Follow-Up
+
+- Reconcile Architecture source-of-truth files against the shipped 0.1.0 Communications surface.
+- Move stale ADR-0013-era tracking to ADR-0019 ownership as part of Architecture issue #82.
+
+## Deferred Work
+
+- Durable preference store.
+- Durable cadence policy state.
+- Durable decision-log storage.
+- Durable follow-up scheduler / campaign orchestration.
+- Separate `HoneyDrunk.Communications.Testing` package if downstream tests need reusable fixtures.
+- Complex multi-step campaigns using Flow when the Flow Node exists.

--- a/repos/HoneyDrunk.Communications/boundaries.md
+++ b/repos/HoneyDrunk.Communications/boundaries.md
@@ -1,0 +1,36 @@
+# HoneyDrunk.Communications - Boundaries
+
+## What Communications Owns
+
+- Business-event-to-message-intent mapping.
+- Recipient resolution for communication workflows.
+- Tenant-scoped recipient preferences, opt-outs, suppression, and quiet-hours decisions.
+- Cadence decisions: send now, suppress, or defer.
+- Multi-step communication workflow intent, starting with the welcome-email/follow-up slice.
+- Append-only decision logging for every send-or-suppress outcome.
+- Delegating approved delivery to Notify through `INotificationSender`.
+
+## What Communications Does NOT Own
+
+- **Provider adapters** - SMTP, Resend, Twilio, and future delivery providers belong in Notify.
+- **Template rendering** - template keys, rendering mechanics, and provider payload mapping belong in Notify.
+- **Queue-backed intake/delivery mechanics** - enqueueing, retry classification, workers, and dead-letter handling belong in Notify.
+- **Structural notification validation** - malformed delivery envelopes are rejected by Notify.
+- **Telemetry storage/visualization** - Communications emits decision telemetry; Pulse observes and stores telemetry.
+- **Durable workflow engine primitives** - Flow owns generalized workflow orchestration when Communications needs a durable multi-step engine.
+- **Authorization and human-policy gates** - Auth and Operator own identity/authorization/approval decisions. Communications only owns message-delivery preference/cadence decisions.
+
+## Boundary Decision Tests
+
+Before adding behavior to Communications, ask:
+
+1. Does it decide **whether this recipient should receive this message now**? Communications.
+2. Does it map a business event into **intent, audience, cadence, or suppression**? Communications.
+3. Does it render, enqueue, retry, classify provider errors, or call provider SDKs? Notify.
+4. Does it decide whether an action is authorized or requires human approval? Auth/Operator.
+5. Does it persist or query generalized application data? Data.
+6. Does it coordinate arbitrary long-running workflows beyond messaging semantics? Flow.
+
+## Notify Split Rule
+
+Notify may still be called directly for exceptional one-shot transactional delivery with no preference, cadence, or workflow requirement. User-facing lifecycle messages should enter through Communications so preferences, cadence, and decision logs stay centralized.

--- a/repos/HoneyDrunk.Communications/integration-points.md
+++ b/repos/HoneyDrunk.Communications/integration-points.md
@@ -1,0 +1,41 @@
+# HoneyDrunk.Communications - Integration Points
+
+How Communications connects to the rest of the Grid. Every cross-Node boundary needs canary coverage when the implementation changes shape.
+
+## Consumes
+
+| Node | Contract | Purpose |
+|------|----------|---------|
+| **Kernel** | `TenantId` | Tenant-scoped preference and cadence decisions; internal tenant bypass semantics. |
+| **Kernel** | Grid context / correlation primitives | Correlates the business event, Communications decision, and Notify delivery attempt. |
+| **Kernel** | lifecycle/health abstractions | Runtime startup hook and health contributor registration. |
+| **Notify** | `INotificationSender` | Approved communication decisions delegate delivery to Notify. |
+
+## Exposes
+
+| Contract | Consumer | Notes |
+|----------|----------|-------|
+| `ICommunicationOrchestrator` | Product Nodes, Operator event handlers, future lifecycle workflows | Main send/evaluate entry point. |
+| `IMessageIntent` / `MessageIntent` | Product Nodes | Intent boundary for business-event-driven communications. |
+| `IRecipientResolver` | Runtime composition and custom host integrations | Recipient resolution slot. |
+| `IPreferenceStore` | Runtime composition and future durable implementations | Tenant-scoped preference slot. |
+| `ICadencePolicy` | Runtime composition and future durable implementations | Tenant-scoped cadence/suppression slot. |
+| `ICommunicationDecisionLog` | Runtime composition and audit/observability integrations | Append-only decision log slot. |
+
+## Observed By
+
+| Node | Signal | Notes |
+|------|--------|-------|
+| **Pulse** | traces/logs/metrics | Communications emits decision telemetry; Pulse observes it. Communications has no runtime dependency on Pulse. |
+
+## Deferred / Planned Edges
+
+- **Data** - likely future durable backend for preferences, cadence, follow-up state, and decision logs.
+- **Flow** - likely future durable engine for complex campaigns and long-running sequences.
+- **Transport** - possible future ingress/event-out mechanism for business events and approval notifications.
+
+## Canary Coverage Required
+
+- Contract-shape canary for `ICommunicationOrchestrator`, `IMessageIntent`/`MessageIntent`, `IPreferenceStore`, `ICadencePolicy`, `IRecipientResolver`, and `ICommunicationDecisionLog` value surfaces.
+- Boundary canary proving the welcome-email path delegates through Notify's `INotificationSender` without taking provider dependencies.
+- Correlation canary proving the decision log and Notify envelope carry the same operation correlation.

--- a/repos/HoneyDrunk.Communications/invariants.md
+++ b/repos/HoneyDrunk.Communications/invariants.md
@@ -1,0 +1,27 @@
+# HoneyDrunk.Communications - Invariants
+
+Communications-specific invariants supplement `constitution/invariants.md`.
+
+1. **Communications owns outbound-message decisions, not delivery mechanics.**
+   Preference, cadence, suppression, recipient resolution, and workflow decisions live here. Provider dispatch stays in Notify.
+
+2. **Every send-or-suppress path records a decision.**
+   `ICommunicationDecisionLog` is the audit boundary for Communications decisions. A caller must be able to explain why a message was sent, suppressed, scheduled, or failed.
+
+3. **Tenant context gates preference and cadence state.**
+   `IPreferenceStore` and `ICadencePolicy` are scoped by `TenantId` and recipient. Internal Grid traffic uses the internal tenant bypass explicitly rather than hidden global state.
+
+4. **Delivery delegation goes through Notify abstractions.**
+   The runtime delegates approved delivery via `INotificationSender`. Communications never references provider SDKs or Notify provider implementations.
+
+5. **Business events cross the boundary as intents.**
+   Downstream Nodes should pass `IMessageIntent`/intent-specific records into Communications, not construct provider envelopes directly when preference/cadence/workflow semantics matter.
+
+6. **Correlation context survives the decision boundary.**
+   Decisions and delegated Notify sends preserve correlation keys/ids so Pulse and logs can connect business event, decision, and delivery outcome.
+
+7. **Default stores are safe but non-durable.**
+   In-memory preference, cadence, decision-log, and follow-up scheduler implementations are acceptable for bring-up and tests only. Production durability must be explicit.
+
+8. **Communications does not create a reverse dependency from safety-critical Nodes.**
+   Operator/Auth-style approval or authorization paths emit events/intents for Communications to handle; they do not depend on Communications at runtime for enforcement.

--- a/repos/HoneyDrunk.Communications/overview.md
+++ b/repos/HoneyDrunk.Communications/overview.md
@@ -1,0 +1,43 @@
+# HoneyDrunk.Communications - Overview
+
+**Sector:** Ops  
+**Version:** 0.1.0  
+**Framework:** .NET 10.0  
+**Repo:** `HoneyDrunkStudios/HoneyDrunk.Communications`
+
+## Purpose
+
+Outbound-messaging orchestration substrate above Notify. Communications decides whether a message should be sent, to whom, when, and why; Notify owns delivery mechanics.
+
+## Packages
+
+| Package | Type | Description |
+|---------|------|-------------|
+| `HoneyDrunk.Communications.Abstractions` | Abstractions | Public contracts for intents, recipient resolution, preferences, cadence, orchestration decisions, and decision logs. |
+| `HoneyDrunk.Communications` | Runtime | Default orchestrator, in-memory preference/cadence/decision-log implementations, welcome-flow intents, health/startup hooks, and DI wiring. |
+
+## Key Contracts
+
+- `ICommunicationOrchestrator` - evaluates and sends message intents through the Communications decision layer.
+- `IMessageIntent` / `MessageIntent` - interface and simple immutable value shape for business-event message intents.
+- `IRecipientResolver` - resolves one or more recipients for an intent.
+- `IPreferenceStore` - tenant-scoped recipient preference store.
+- `ICadencePolicy` - tenant-scoped cadence/suppression policy.
+- `ICommunicationDecisionLog` / `CommunicationDecisionLogEntry` - append-only audit surface for send-or-suppress decisions.
+- `MessageDecision`, `MessageDecisionOutcome`, `RecipientHandle`, `RecipientPreferences`, `CadenceVerdict`, and `CadenceOutcome` - public decision and policy value shapes.
+
+## Current Runtime Shape
+
+The first runtime slice ships the welcome-email path:
+
+1. A caller passes a `WelcomeEmailIntent` or another `IMessageIntent` to `ICommunicationOrchestrator`.
+2. Communications resolves tenant-scoped preferences and cadence.
+3. Communications records the decision.
+4. If allowed, Communications delegates delivery to Notify through `INotificationSender`.
+5. The runtime may schedule a follow-up intent via the in-memory follow-up scheduler.
+
+## Deferred Surfaces
+
+- A separate `HoneyDrunk.Communications.Testing` package from ADR-0019 is intentionally deferred; test fixtures currently live in the runtime/test project.
+- Durable preference, cadence, follow-up, and decision-log stores are deferred. The 0.1.0 runtime uses in-memory implementations.
+- Complex campaign/flow orchestration is deferred. The current slice proves the boundary through welcome-email orchestration.

--- a/repos/HoneyDrunk.Notify/active-work.md
+++ b/repos/HoneyDrunk.Notify/active-work.md
@@ -1,8 +1,8 @@
 # HoneyDrunk.Notify — Active Work
 
-**Last Updated:** 2026-03-22
+**Last Updated:** 2026-05-05
 
-- v0.1.0 released
-- Pending: Azure Functions deployment
-- Pending: Integration tests with live providers
-- Pending: Kernel 0.4.0 pattern alignment
+- v0.2.0 released after ADR-0019 intake-boundary refactor.
+- Notify-owned recipient policy evaluation removed; Communications now owns preference/cadence/workflow decisions.
+- Azure Functions deploy workflow succeeded after the v0.2.0 release pipeline.
+- Pending: deeper live-provider smoke tests and production hardening.

--- a/repos/HoneyDrunk.Notify/boundaries.md
+++ b/repos/HoneyDrunk.Notify/boundaries.md
@@ -1,14 +1,20 @@
-# HoneyDrunk.Notify — Boundaries
+# HoneyDrunk.Notify - Boundaries
 
 ## What Notify Owns
-- Channel-agnostic notification interfaces
-- Email providers (SMTP, Resend)
-- SMS providers (Twilio)
-- Template rendering
-- Queue-backed async dispatch (Azure Storage, InMemory)
-- Background notification worker
+- Channel-agnostic notification intake and delivery contracts
+- Structural validation of notification requests/envelopes
+- Queue-backed async dispatch and delivery workers/functions
+- Provider dispatch mechanics for email/SMS and future channels
+- Template/rendering mechanics and provider payload mapping
+- Retry classification, delivery result handling, and delivery observability
 
 ## What Notify Does NOT Own
-- **User preferences** — Applications manage notification preferences
-- **Transport messaging** — Notify uses its own queue system, not Transport
-- **Push notifications** — Not yet supported (future provider slot)
+- **Recipient preferences** - Communications owns opt-outs, suppressed intent kinds, quiet hours, and preferred-channel decisions.
+- **Cadence/suppression policy** - Communications decides whether a recipient should receive a message now, later, or never.
+- **Lifecycle communication workflows** - Communications owns welcome sequences, re-engagement, escalation chains, and business-event-to-message-intent mapping.
+- **Transport messaging** - Notify uses its own intake/delivery queue shape unless a future Architecture decision routes it through Transport.
+- **Push notifications** - Not yet supported (future provider slot).
+
+## Boundary Decision Test
+
+If the concern is **how to deliver a structurally valid notification**, it belongs in Notify. If the concern is **whether a recipient should receive a message, when, or as part of what workflow**, it belongs in Communications.

--- a/repos/HoneyDrunk.Notify/integration-points.md
+++ b/repos/HoneyDrunk.Notify/integration-points.md
@@ -4,4 +4,14 @@
 
 | Node | Contract | Usage |
 |------|----------|-------|
-| **Kernel** | `HoneyDrunk.Kernel.Abstractions` | Context propagation |
+| **Kernel** | `HoneyDrunk.Kernel.Abstractions` | Context propagation, lifecycle, health, telemetry. |
+
+## Consumed By
+
+| Node | Contract | Usage |
+|------|----------|-------|
+| **Communications** | `INotificationSender` | Communications delegates approved outbound messages to Notify for delivery. |
+
+## Boundary Note
+
+Notify exposes delivery contracts only. Preference, cadence, suppression, and lifecycle workflow decisions should cross through `HoneyDrunk.Communications` before Notify is called unless the caller is intentionally sending a one-shot transactional notification with no orchestration semantics.

--- a/repos/HoneyDrunk.Notify/invariants.md
+++ b/repos/HoneyDrunk.Notify/invariants.md
@@ -1,5 +1,7 @@
 # HoneyDrunk.Notify — Invariants
 
 1. **Notifications are channel-agnostic at the contract level.** Application code sends a notification, not an email or SMS.
-2. **Delivery is async via queues.** Direct synchronous send is not supported in production.
-3. **Provider failures do not crash the worker.** Failed notifications are retried with backoff.
+2. **Delivery is async via queues/intake.** Direct synchronous provider calls are not the production path.
+3. **Provider failures do not crash the worker/function.** Failed notifications are retried or surfaced as delivery outcomes.
+4. **Notify does not evaluate recipient preference or cadence policy.** Those decisions belong in Communications.
+5. **Notify validates delivery shape, not business intent.** Missing/invalid delivery fields are Notify concerns; send/suppress/workflow decisions are Communications concerns.

--- a/repos/HoneyDrunk.Notify/overview.md
+++ b/repos/HoneyDrunk.Notify/overview.md
@@ -1,23 +1,23 @@
 # HoneyDrunk.Notify — Overview
 
 **Sector:** Ops  
-**Version:** 0.1.0  
-**Framework:** .NET 10.0  
+**Version:** 0.2.0
+**Framework:** .NET 10.0
 **Repo:** `HoneyDrunkStudios/HoneyDrunk.Notify`
 
 ## Purpose
 
-Channel-agnostic notification dispatching with multi-provider support. Email (SMTP, Resend) and SMS (Twilio) with queue-backed async dispatch.
+Channel-agnostic notification intake and delivery with multi-provider support. Notify handles structural validation, queue-backed intake, provider dispatch, retries, and delivery outcomes. Recipient preference, cadence, suppression, and workflow decisions belong in HoneyDrunk.Communications.
 
 ## Key Packages
 
 | Package | Type | Description |
 |---------|------|-------------|
-| `HoneyDrunk.Notify.Abstractions` | Abstractions | Notification channel contracts |
-| `HoneyDrunk.Notify` | Runtime | Dispatch engine |
+| `HoneyDrunk.Notify.Abstractions` | Abstractions | Notification intake/delivery contracts |
+| `HoneyDrunk.Notify` | Runtime | Intake and delivery engine |
+| `HoneyDrunk.Notify.Functions` | Service | Azure Functions queue-triggered delivery host |
 | `HoneyDrunk.Notify.Hosting.AspNetCore` | Hosting | ASP.NET Core integration |
-| `HoneyDrunk.Notify.Providers.Email.Smtp` | Provider | SMTP email |
-| `HoneyDrunk.Notify.Providers.Email.Resend` | Provider | Resend email |
-| `HoneyDrunk.Notify.Providers.Sms.Twilio` | Provider | Twilio SMS |
-| `HoneyDrunk.Notify.Queue.AzureStorage` | Provider | Azure Storage queue |
-| `HoneyDrunk.Notify.Queue.InMemory` | Testing | In-memory queue |
+
+## ADR-0019 Boundary Cleanup
+
+v0.2.0 removed Notify-owned recipient policy evaluation (`INotificationPolicy`, `PolicyEvaluationResult`, `PolicyDenied`, default policy pipeline) and renamed the runtime `Orchestration/` area to `Intake/`. Notify is now the delivery Node; Communications is the decision Node.


### PR DESCRIPTION
## Summary
- Add the new `repos/HoneyDrunk.Communications/` Architecture context folder for ADR-0019.
- Reconcile Notify/Communications catalogs after Communications v0.1.0 and Notify v0.2.0.
- Update Notify repo context to reflect the intake/delivery boundary and Communications-owned policy decisions.
- Refresh release, roadmap, focus, and active initiative trackers for the completed Notify Functions deploy workflow.

## Validation
- Confirmed Notify deploy workflow `25389534399` completed successfully before reconciliation.
- Validated all `catalogs/*.json` parse successfully.
- Ran `git diff --check`.

Closes #82
