### PR TITLE
chore(capabilities): add ADR-0017 standup plan, catalogs, invariants

### DIFF
--- a/adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md
+++ b/adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md
@@ -40,7 +40,7 @@ Tool *implementations* live in the Node that owns the domain (a "query database"
 
 The Capabilities Node ships the following package families, mirroring ADR-0016's package-family pattern for AI:
 
-- `HoneyDrunk.Capabilities.Abstractions` — all interfaces, the `CapabilityDescriptor` record, and the invocation request/response shapes. Zero runtime dependencies beyond `HoneyDrunk.Kernel` abstractions.
+- `HoneyDrunk.Capabilities.Abstractions` — all interfaces, the `CapabilityDescriptor` record, and the invocation request/response shapes. Zero runtime dependencies beyond `Microsoft.Extensions.*` abstractions.
 - `HoneyDrunk.Capabilities` — runtime composition: default `ICapabilityRegistry`, default `ICapabilityInvoker`, DI wiring.
 - `HoneyDrunk.Capabilities.Testing` — opt-in testing fixture package carrying an in-memory registry and dispatcher implementation for deterministic unit and integration tests. Consumed by downstream Nodes in test projects, never in production composition.
 

--- a/adrs/ADR-0028-event-driven-architecture-and-messaging.md
+++ b/adrs/ADR-0028-event-driven-architecture-and-messaging.md
@@ -1,0 +1,254 @@
+# ADR-0028: Event-Driven Architecture and Messaging — Use-Case-First Backing Selection
+
+**Status:** Proposed
+**Date:** 2026-05-04
+**Deciders:** HoneyDrunk Studios
+**Sector:** Core (Transport) · Ops (Communications, Notify, Pulse, Actions) · cross-cutting
+
+## If Accepted — Required Follow-Up Work in Architecture Repo
+
+Accepting this ADR creates catalog and cross-repo obligations that must be completed as follow-up issue packets (do not accept and leave the catalogs stale):
+
+- [ ] Add the use-case → backing matrix (D2 below) to `repos/HoneyDrunk.Transport/integration-points.md` so the Transport repo is the authoritative reference for "which backing for which use case"
+- [ ] Update `repos/HoneyDrunk.Transport/boundaries.md` to clarify that Transport is the abstraction layer for **async commands and durable pub/sub** only — telemetry signals (Pulse), CI cron (Actions), and reactive resource events (Event Grid system topics) are out of Transport's scope
+- [ ] Update `repos/HoneyDrunk.Pulse/boundaries.md` to add the "Pulse signals are not domain events" disambiguation introduced in D3
+- [ ] Add a follow-up packet against Communications to specify the concrete `INotificationSender` → `INotifyQueueWriter` boundary and confirm that Communications dispatches to Notify in-process (not via Transport) — D4 settles the principle; the implementation packet wires it
+- [ ] Update `catalogs/contracts.json` if `IEventPublisher` (custom-topic shape, deferred per D6) gains a concrete contract in a future implementation packet — not at this ADR's acceptance
+- [ ] Scope agent flips Status → Accepted after the Transport repo's integration-points and boundaries reflect this ADR
+
+## Context
+
+The Grid has accumulated several messaging-shaped surfaces over the last fourteen ADRs without a single decision document explaining **which backing serves which use case**. The shapes that exist today, audited at the time of this ADR:
+
+1. **`HoneyDrunk.Transport`** — a transport-agnostic abstraction (`ITransportPublisher`, `ITransportConsumer`, `IMessageHandler<T>`) with three working providers (Azure Service Bus, Azure Storage Queue, InMemory), a middleware pipeline, GridContext propagation, transactional outbox contracts, and blob fallback. **Transport is not a backing — it is the abstraction over backings.** It already enumerates Service Bus vs. Storage Queue trade-offs in its README. v0.1.0 ships.
+2. **`HoneyDrunk.Notify.Queue.*`** — Notify's *own* queue abstraction, separate from Transport, with `Queue.Abstractions`, `Queue.AzureStorage`, and `Queue.InMemory` packages. The Transport boundaries doc explicitly disclaims this surface: "Queue-based notifications — Queue management for notifications belongs in Notify." Notify intake → Notify worker is an internal queue, not a Transport hop.
+3. **`HoneyDrunk.Pulse` + `PulseIngested` Transport event** — Pulse already publishes a `PulseIngested` Transport event after each ingestion batch, treating Transport as the downstream signal fanout channel. This is the one production event in the Grid that cleanly fits Transport's pub/sub shape today, and it predates this ADR.
+4. **`HoneyDrunk.Data.Outbox`** — a transactional outbox that bridges database commits to Transport publishes. Already implemented; the seam where domain commits become outgoing messages.
+5. **`HoneyDrunk.Communications` (Proposed, ADR-0019)** — sits above Notify and orchestrates outbound messaging. The Communications → Notify hop is the single most-trafficked cross-Node messaging seam the Grid is about to ship. Where it lives — in-process call, Transport hop, Service Bus topic — has not been decided.
+6. **`HoneyDrunk.Actions`** — CI/CD control plane (ADR-0012). Schedules nightly-deps, nightly-security, grid-health aggregator, and the hive-sync loop via `cron:`. None of those use Transport, Service Bus, or Event Grid; the schedule lives in GitHub Actions itself.
+7. **Lore ingestion two-stage workflow** — daily OpenClaw sourcing into `raw/`, weekly Claude skill ingests `raw/` → `wiki/`. Cron-driven; no broker today.
+8. **Vault rotation cache invalidation (ADR-0006)** — relies on Event Grid for secret-version-changed reactive events. Event Grid is mentioned in Invariant 21 ("pinning breaks Event Grid cache invalidation") but the system-topic plumbing is referenced, not formally decided as a Grid pattern.
+9. **Notify Cloud (ADR-0027)** — emits `BillingEvent` per delivery; the Stripe billing adapter writes to "an Azure Storage queue that a Stripe webhook bridge consumes" per ADR-0026 D6. That decision is implicit in the consumer-Node ADRs but never elevated to a Grid pattern.
+
+The Grid's hosting platform (ADR-0015) is **Azure Container Apps**, which has native KEDA scalers for Service Bus, Event Grid, and Storage Queues. Container App revisions can scale-to-zero on Service Bus queue depth, Event Grid event arrival, or Storage Queue length. That changes the operational calculus: a Service Bus topic is no longer "another running thing" — it is a scaler input that lets a Container App stay at zero replicas until a message arrives.
+
+The user's prompt scopes this ADR carefully: **use cases first, mechanism second.** Different patterns warrant different backings. A blanket "the Grid uses Service Bus" decision would over-spend on a workload that fits a Storage Queue (cents/month) and under-spend on a workload that needs Event Grid's pub/sub fanout. The specific question this ADR answers is: **for each event-driven use case the Grid has today or is about to have, which backing is the right default, and why.**
+
+This ADR does **not** replace Transport. Transport stays the abstraction for the use cases where async messaging crosses a Node boundary. This ADR pairs use cases with backings *underneath* the Transport abstraction (Service Bus, Storage Queue) or *outside* it (Event Grid, in-process MediatR-style, GitHub Actions cron, direct HTTP) where Transport is the wrong shape.
+
+## Decision
+
+The Grid does not have one event-driven backing — it has **six**, each chosen for the use case it serves best. The decisions below are the use-case → backing matrix and the rules for picking among them.
+
+### D1. Transport remains the abstraction for cross-Node async messaging — not a backing decision
+
+`HoneyDrunk.Transport` is not in scope for re-decision. It stays the broker-agnostic abstraction for any message that crosses a Node boundary asynchronously. Below the abstraction, two backings are first-class today (Service Bus, Storage Queue) and one (InMemory) for tests. This ADR does not add or remove providers; it pins **which backing Transport uses for which Grid use case**, and which use cases bypass Transport entirely.
+
+The principle: every use case picks a backing on its own merits. Transport is the abstraction *for the use cases that fit it*, not a forced front for every messaging concern.
+
+### D2. Use-case → backing matrix
+
+This is the load-bearing table. Each row is a Grid use case enumerated from the Context audit, with a primary backing, ordering/durability properties, cost posture, and a one-sentence justification.
+
+| # | Use Case | Primary Backing | Ordering | Durability | Idle Cost | Why this backing |
+|---|---|---|---|---|---|---|
+| 1 | Async commands across Nodes (one sender, one logical recipient — e.g. Flow workflow engine async step boundaries per ADR-0024, Communications → Notify post-split (currently in-process per D4; Service Bus when split), long-running Container App hand-offs from Actions per D8 (Action-to-Action coordination stays GitHub-native)) | **Azure Service Bus queue** via `HoneyDrunk.Transport.AzureServiceBus` | FIFO with sessions when grouped; otherwise best-effort | Durable; dead-letter queue native; duplicate detection native | ~$10/mo Standard tier per namespace (one shared namespace per environment, not per use case) | Sessions, DLQ, duplicate detection, transactions — none of which Storage Queue offers — are all relevant to "send this command exactly once, in order if grouped, with a recovery surface when it fails." |
+| 2 | Pub/sub fanout (one event, many in-Grid consumers — e.g. Pulse `PulseIngested`, future `UserSignedUp`-style domain events with welcome-email + analytics + provisioning consumers) | **Azure Service Bus topic** via `HoneyDrunk.Transport.AzureServiceBus` (same namespace as #1) | Per-subscription FIFO with sessions | Durable per subscription; per-subscription DLQ | Shared namespace cost from #1 — topics are free incremental | Service Bus topics give per-subscriber durability and DLQ. Event Grid (D6) is the wrong shape here — Event Grid is best for *infrastructure* events (blob written, secret rotated), not for in-Grid domain pub/sub where consumers want guaranteed delivery and replay. |
+| 3 | High-volume commodity work queues (notification dispatch, batch background work — e.g. Notify intake → Notify worker, Notify Cloud `BillingEvent` → Stripe webhook bridge) | **Azure Storage Queue** via `HoneyDrunk.Transport.StorageQueue` (Notify Cloud's billing path uses Storage Queue per ADR-0026 D6 implicit decision; this ADR pins the pattern) | Best-effort, no FIFO | Durable; manual poison-queue pattern (no built-in DLQ) | Cents per month at the Grid's volume (10K ops = $0.0004) | When the workload is "many small messages, ordering doesn't matter, transient failures retry up to N times then go to a poison queue I write myself," Storage Queue is two orders of magnitude cheaper than Service Bus and the feature gap doesn't matter. |
+| 4 | High-volume telemetry / observability signals (Pulse OTLP ingest path) | **Direct OTLP via HTTP/gRPC, then Pulse Collector → backends (Tempo, Loki, Mimir, Sentry, PostHog, Azure Monitor)** | None — best-effort | Best-effort, sink-by-sink failure isolation | Pay-per-ingestion to backends; no broker between Node and Pulse Collector | Telemetry is **not a domain event**. It rides OpenTelemetry, not Transport. The single Transport hop Pulse uses today (`PulseIngested` after a batch lands) is a domain pub/sub event that says "telemetry ingested," not the telemetry itself. D3 disambiguates. |
+| 5 | Scheduled / time-triggered work (cron — nightly-deps, nightly-security, grid-health aggregator, hive-sync, Vault rotation policy schedule, Lore ingestion) | **GitHub Actions `schedule:` cron** for CI-shaped schedules; **Azure Container Apps scheduled jobs** (KEDA cron scaler) for Node-internal schedules where the workload is too heavy for Actions runners | Per-trigger; no message ordering concern | The scheduler retries on the next trigger | Free at the Grid's volume — Actions minutes are free for public repos; Container Apps cron jobs scale to zero between triggers | Cron is not a queue. The scheduler **is** the broker. Adding Service Bus or Event Grid between "the schedule fired" and "the work runs" is rebuilding cron's job. Lore's two-stage flow stays cron-driven (D7). |
+| 6 | Reactive resource events (Azure-emitted system events — blob written, Key Vault secret rotated, Container Registry image pushed — and any future Grid-internal "something changed" event a system topic can publish) | **Azure Event Grid system topics** for Azure-resource-emitted events; **Azure Event Grid custom topics deferred** until a concrete consumer materializes | Best-effort, at-least-once | Durable retry up to 24h, then dead-lettered to Storage | Pay-per-event ($0.60/M events at Basic tier); zero idle cost | Event Grid is the only Azure surface that emits secret-rotated, blob-written, image-pushed events as a managed system topic. The Vault rotation cache-invalidation pathway already implicitly relies on it (Invariant 21). Custom topics are deferred (D6) — no Grid-internal use case justifies the operational weight today. |
+| 7 | In-process / same-Node domain events (mediator-style command/handler decoupling within a single Node — e.g. `IMessageIntent` resolution → preference check → cadence check → send delegation, all within Communications) | **In-process MediatR-style or simple `IServiceProvider.GetService<IDomainEventHandler>` fan-out** — not Transport, not a broker | N/A — synchronous in-process | N/A — no durability needed; failure is a thrown exception | Zero | If sender and receiver share a process and a transaction, putting a broker between them adds latency, failure modes, and cost for nothing. The "make it async to be safe" instinct is wrong when the work is synchronous by domain. |
+| 8 | Dead-letter / poison-message handling | **Service Bus native DLQ** for use cases #1, #2; **manual poison-queue pattern** for use case #3 (Storage Queue); **Event Grid dead-lettering to Storage** for use case #6 | Per-backing | Per-backing | Negligible | Dead-letter strategy is per-backing, not Grid-wide. Service Bus has it native; Storage Queue does not and a poison-queue convention substitutes; Event Grid dead-letters to Storage with a configured destination. |
+
+Use cases #5 (cron) and #7 (in-process) **do not use Transport**. Use case #4 (Pulse telemetry) uses OpenTelemetry, not Transport, except for the single `PulseIngested` domain pub/sub event which rides Transport per #2. Use cases #1, #2, #3, and #6 are the four genuinely-event-driven backings the Grid commits to.
+
+### D3. Pulse signals are not domain events — explicit disambiguation
+
+This is the single most-conflated concept the Grid's existing surfaces blur. Pulse is observability — traces, logs, metrics, errors, analytics. Domain events are facts about the business — `UserSignedUp`, `OrderShipped`, `BillingEventEmitted`. The two are not interchangeable backings, and this ADR pins the rule:
+
+- **Telemetry signals ride OpenTelemetry over the OTLP wire format.** Nodes emit traces/metrics/logs to the Pulse Collector via HTTP or gRPC. The Pulse Collector fans out to backends (Tempo, Loki, Mimir, Sentry, PostHog, Azure Monitor). No Transport hop, no Service Bus topic, no Event Grid involvement. The pipeline already works.
+- **Domain events ride Transport.** `PulseIngested` is a domain event ("telemetry was ingested for batch X") that happens to be emitted by Pulse — it is *not* the telemetry. It rides Transport per use case #2 above.
+- **Pulse never receives domain events as a consumer.** Pulse observes; it does not subscribe. If a Node wants Pulse to see something, it emits a span / metric / log via the existing OTel pipeline, not a Transport message.
+
+The negative form: do not put metrics on Service Bus topics. Do not put domain events through OTLP. Do not subscribe Pulse to Transport topics to "make it learn what happened." The two channels are intentionally separate and stay separate.
+
+`repos/HoneyDrunk.Pulse/boundaries.md` already lists "Transport — Message publishing for events belongs in Transport" under "What Pulse Does NOT Own." This ADR's follow-up extends that to the explicit signals-vs-events sentence.
+
+### D4. Communications → Notify is in-process at v1, Service Bus when scale demands it
+
+The most-trafficked cross-Node messaging seam the Grid is about to ship is `ICommunicationOrchestrator` → `INotificationSender`. ADR-0019 D5 made Communications take a first-class runtime dependency on `HoneyDrunk.Notify.Abstractions` — meaning the call is in-process by default, not over a broker. This ADR confirms that decision against the use-case matrix:
+
+- **At v1 (single Container App per Node, low/bursty traffic), the call is in-process.** Communications resolves intent, checks preferences and cadence, then synchronously invokes Notify's `INotificationSender`. Notify's *own internal* queue (Notify intake → Notify worker, use case #3) is the first async hop. This matches the existing design and the behavior Notify already ships.
+- **The seam to Service Bus opens when Notify Cloud's tier ceiling pressures it.** PDR-0002 names tens of paying tenants at v1 and low hundreds at the Pro ceiling. If Notify Cloud sustains a load where Communications and Notify benefit from being independently scaled — different replica counts, different Container Apps — the path is to introduce a Service Bus queue between them via the existing `ITransportPublisher` / `ITransportConsumer` abstraction. **Communications already composes Transport in its planned dependencies** (Communications → Transport is implied by orchestration over a queue); the abstractions are in place. The change is a host-time composition, not a code rewrite.
+- **Notify Cloud's external API → Communications is also in-process at v1.** The whole Notify Cloud Container App composes Notify Cloud + Communications + Notify in the same process. The split-by-Container-App question is deferred to a future ADR if the v1 deployment shows scaling pressure.
+
+This is the "no eventing — direct call" choice for use case #1's Communications-shaped subset. It is not a permanent decision; it is the right choice at the Grid's current scale, with a known migration path through Transport when scale demands it.
+
+### D5. Service Bus is the default broker; one shared namespace per environment
+
+When use cases #1 and #2 hit production, the backing is Service Bus, and the namespace shape is shared per environment (consistent with ADR-0015's shared Container Apps Environment and shared ACR per environment):
+
+- **`sbns-hd-shared-{env}`** — one Service Bus namespace per environment (`dev`, `stg`, `prod`). All Grid-internal queues and topics live in this namespace.
+- **Tier:** Standard for all environments at v1 (~$10/mo per namespace per environment). Premium is rejected — its features (dedicated capacity, geo-DR, larger message size) do not apply at the Grid's scale and would multiply cost ~10x.
+- **Naming:** queues are `sbq-{purpose}-{env}` (e.g. `sbq-notify-cloud-billing-stg`); topics are `sbt-{purpose}-{env}` with subscriptions named after the consumer Node (e.g. `sbt-pulse-ingested-stg/sub-analytics`).
+- **Per-Node namespace rejected.** Same logic as ADR-0015's per-Node-environment rejection: namespace is not a security boundary (Managed Identity scopes per queue/topic), namespaces have a fixed per-namespace cost, and a shared namespace simplifies cross-Node observability. If a single Node ever generates enough traffic to warrant its own namespace, that's a future ADR — not the v1 default.
+
+The cost posture: at the Grid's current scale, the namespace itself costs ~$10/mo per environment (so ~$30/mo across `dev`/`stg`/`prod`); message volume is well within the Standard tier's included throughput. This is the price of having pub/sub topics at all — Storage Queue does not offer them. For use cases where pub/sub is not needed (use case #3), Storage Queue at cents/month remains the right choice.
+
+**Provisioning is just-in-time.** Per memory ("provision Azure resources when first needed"), the namespace is not provisioned until the **first cross-Node async pub/sub consumer ships** — which may or may not coincide with Pulse Collector's deploy. `PulseIngested` is published today but has no subscribers; if Pulse Collector ships with no `PulseIngested` consumers, it can run with the `InMemory` Transport provider in non-prod and the namespace creation defers further. The trigger is "first real consumer," not "first publisher." When that consumer lands, the namespace is shared across all use cases #1 and #2 in that environment, holding the cost figure (~$10/mo per environment, ~$30/mo across `dev`/`stg`/`prod`).
+
+### D6. Event Grid custom topics deferred — system topics only at v1
+
+Event Grid has two surfaces: **system topics** (Azure emits — secret rotated, blob written, image pushed) and **custom topics** (you publish — your own events).
+
+- **System topics are accepted at v1.** They are the only mechanism that delivers Azure-emitted reactive events. The Vault rotation cache-invalidation flow already implicitly depends on Event Grid system topics (Invariant 21). This ADR pins the pattern: when a Grid-internal flow needs to react to an Azure-resource event, the wiring is Event Grid system topic → consumer (Container App via webhook, Logic App, or Function). No Transport, no Service Bus.
+- **Custom topics are deferred.** No Grid-internal use case today justifies the cost of "publish your own event to Event Grid" over the Service Bus topic alternative (use case #2). Service Bus topics give durable per-subscription delivery; Event Grid custom topics are at-most-once-with-retry and route by event-type filter, which is the wrong shape for in-Grid domain events. If a future use case emerges where Event Grid's filter/fanout-to-disparate-consumers shape is genuinely needed (e.g. webhook fanout to external customer endpoints), it gets its own follow-up ADR. Until then, custom topics are not provisioned.
+
+### D7. Lore ingestion stays cron, not event-driven
+
+The Lore two-stage workflow — daily OpenClaw sourcing into `raw/`, weekly Claude skill ingests `raw/` → `wiki/` — is a candidate for event-driven (e.g. `raw/` blob write → Event Grid → ingest trigger). This ADR rejects that conversion at v1:
+
+- **The cron model fits.** Daily and weekly cadences are explicit, predictable, and the right granularity for an LLM-compiled wiki. There is no value in compiling sub-daily.
+- **OpenClaw is the scheduler.** OpenClaw already runs the daily sourcing pass on its own cron. Replacing that with a blob-write trigger would require running a Container App for the ingest stage and inverting the schedule's source of truth from OpenClaw to Azure.
+- **The wiki compilation is single-threaded by design.** Lore explicitly compiles `raw/` → `wiki/` as a deliberate, slower-than-real-time pass. Event-driven would tempt sub-batch compilation, which fights the design.
+
+Lore's flow stays cron. If a future workflow on Lore genuinely needs sub-daily reactivity, that's a per-flow ADR.
+
+### D8. Actions stays GitHub-Actions-native — no queue layer
+
+`HoneyDrunk.Actions` (CI/CD control plane per ADR-0012) schedules the nightly-deps, nightly-security, grid-health aggregator, hive-sync, and the future grid-wide pipeline observability via `schedule:` cron in YAML. This ADR rejects adding a queue or eventing layer between Actions and the Nodes those workflows touch:
+
+- **The use case is "trigger a CI job on a schedule."** GitHub Actions provides this directly. Adding Service Bus, Event Grid, or anything else between the cron trigger and the workflow runner is rebuilding what GitHub already provides.
+- **Cross-Node fanout is already idiomatic in Actions.** Where one Action needs to trigger work in another repo, the pattern is `gh workflow run` from the calling workflow, or the existing `repository_dispatch` event. No broker is needed; GitHub is the broker.
+- **The grid-health aggregator (ADR-0012 D6) is a periodic pull, not an event-driven push.** It runs on cron, queries each Grid repo's CI state via the GitHub API, and assembles the aggregate. Inverting this to "every CI run pushes its result to a Grid topic" is more moving parts for the same outcome.
+
+If a future Actions-driven workflow needs to durably hand off work to a long-running Container App (e.g. a multi-hour data migration), that workflow uses the use-case #1 pattern (Service Bus queue) at the seam. Actions-to-Action coordination stays GitHub-native.
+
+### D9. Outbox pattern is the bridge from domain commits to Transport publishes
+
+`HoneyDrunk.Data.Outbox` (already implemented, per ADR-0008-era work and Transport's `IOutboxStore` / `IOutboxDispatcher` contracts) is the standard bridge for any use case where a database commit and a Transport publish must be atomic — the classic "I saved the user but failed to send the welcome email" problem.
+
+This ADR confirms outbox as the **only** correct pattern for committing-then-publishing across Transport. Direct publishes from inside a database transaction are forbidden — Transport has no way to roll back a Service Bus send if the transaction commits and the send fails (or vice versa). The outbox writes the message into the same database transaction; `IOutboxDispatcher` polls and publishes asynchronously, with at-least-once delivery semantics.
+
+Use cases #1 and #2 are the consumers of outbox. Use case #3 (Storage Queue commodity work) may also use outbox, but the cost-vs-value calculation is per-flow — for Notify intake → Notify worker, where Notify owns both ends in the same Container App, the queue is durable enough on its own.
+
+### D10. KEDA scaling on Container Apps is the consumer-side runtime model
+
+ADR-0015 settled Container Apps with KEDA. This ADR confirms the consumer-side rule:
+
+- **Service Bus queue/topic consumers** scale on KEDA's `azure-servicebus` scaler (queue length / subscription length).
+- **Storage Queue consumers** scale on KEDA's `azure-queue` scaler (queue length).
+- **Event Grid consumers** scale on KEDA's `azure-eventgrid-topic` scaler if a Container App is the destination, or run as a webhook endpoint if the workload is bursty.
+- **Cron-driven Container Apps** (use case #5's heavy variant) use KEDA's `cron` scaler to scale to one replica during the scheduled window and back to zero.
+
+The corollary: every consumer Container App for an event-driven use case is configured to scale to zero between events. This is the cost-defining decision — at the Grid's traffic, Container Apps Consumption + scale-to-zero is the difference between "messaging is cents per month" and "messaging is the line item that swallows the budget."
+
+### D11. What this ADR explicitly does **not** decide
+
+To keep the scope tight and avoid the trap of bundling every event-shaped concern into one ADR:
+
+- **Per-flow message schema versioning.** Transport's README already names schema-registry as out of scope for v0.1.0. When schema evolution becomes a real concern (a v2 of `PulseIngested`, etc.), the per-Node ADR for that flow handles it.
+- **Specific dead-letter consumer wiring.** Service Bus queues and topics get a DLQ by default; what runs against the DLQ (a manual replay tool, a Container App that auto-retries, a Pulse signal that fires) is a per-flow operational concern.
+- **Cross-region replication.** All current use cases are single-region (East US per ADR-0027). Multi-region eventing is a future ADR if and when a workload needs it.
+- **Webhook delivery to external customers.** Notify Cloud's customer-facing webhook story is in PDR-0002's open-questions list. When it gets specified, it likely uses Event Grid custom topics or a webhook-specific service — the question is opened by D6's deferral, not closed.
+- **AI agent inter-message coordination.** Flow's workflow engine (ADR-0024) coordinates multi-step AI work over `ITransportPublisher` for async step boundaries — that's use case #1. The Flow-specific saga semantics are scoped by ADR-0024, not by this ADR.
+- **Queue-vs-topic for Notify Cloud's billing path.** ADR-0026 D6 mentions Storage Queue as the implementation; this ADR D2 row 3 confirms the pattern. The exact wiring (queue name, retention, idempotency keys) is the Stripe billing integration ADR, not this one.
+- **Outbox dispatcher hosting and scaling.** `HoneyDrunk.Data.Outbox.Dispatcher` runs as a long-lived poller; whether it lives as a sidecar to each producing Node, as a single shared Container App per environment, or with KEDA cron-driven activation is a per-deployment question. The first flow that ships an outbox-fed Transport publish settles the host shape.
+
+## Consequences
+
+### Implementation — Done When
+
+This ADR is "Done" when all of the following are true:
+
+- [ ] `repos/HoneyDrunk.Transport/integration-points.md` carries the use-case → backing matrix from D2 verbatim or by reference.
+- [ ] `repos/HoneyDrunk.Transport/boundaries.md` reflects D3's signals-vs-events disambiguation (Transport is for domain events; telemetry rides OTel).
+- [ ] `repos/HoneyDrunk.Pulse/boundaries.md` adds the explicit "Pulse signals are not domain events" sentence per D3.
+- [ ] No Grid Node has been deployed to production yet that violates the matrix in D2 — the audit is clean. (If a violation is found, it is a follow-up packet, not a blocker for this ADR.)
+- [ ] Scope agent flips Status → Accepted.
+
+### New invariants (proposed for `constitution/invariants.md`)
+
+Numbering is tentative — scope agent finalizes at acceptance. Two invariants are proposed; both are deliberately small.
+
+- **Telemetry signals ride OpenTelemetry; domain events ride Transport.** Pulse is not subscribed to Transport topics. Nodes do not emit metrics or traces over Transport. The two channels stay separate. (See D3.)
+- **Cross-Node async messaging crosses Transport — never raw broker SDK calls.** Even when the chosen backing is Service Bus or Storage Queue, the call site is `ITransportPublisher` / `ITransportConsumer`. Direct `ServiceBusClient.SendAsync` from application code is forbidden — the abstraction exists so that backing swaps are host-time composition changes, not code rewrites. (See D1.)
+
+### Unblocks
+
+Accepting this ADR unblocks the following:
+
+- **Pulse Collector production deployment.** The `PulseIngested` Transport pub/sub flow has a named backing (Service Bus topic per D2 row 2, in `sbns-hd-shared-{env}` per D5), so the production deploy can provision the namespace alongside the first Container App.
+- **Notify Cloud Stripe billing integration ADR.** The Storage Queue → Stripe webhook bridge pattern is pinned (D2 row 3); the integration ADR scopes the wiring, not the choice.
+- **Communications → Notify production deployment.** D4 confirms the in-process call at v1 with a known migration path, so the deployment doesn't need to provision a Service Bus queue prematurely.
+- **Future event-driven use cases.** Any new Node introducing async messaging consults D2 first, picks a row that fits, and either reuses the existing backing or files a follow-up ADR if no row fits.
+
+### Negative
+
+- **Two queue abstractions remain in the Grid.** `HoneyDrunk.Transport` (cross-Node) and `HoneyDrunk.Notify.Queue.*` (intra-Notify) coexist. Notify's queue is not Transport because the boundary doc explicitly disclaims it, and merging them would force every Notify intake message through Transport's middleware pipeline — which is wasteful for the in-Node case. The cost is one more abstraction to maintain; the benefit is each one fits its scope. Mitigation: this is documented in D1 and in Transport's boundaries doc; new Nodes default to Transport unless they have a strict in-Node queue justification.
+- **Service Bus Standard at ~$10/mo per environment is a fixed cost the Grid pays once Pulse Collector deploys.** At three environments, that is ~$30/mo of broker idle cost before any messages flow. Mitigation: the namespace is shared across all use cases #1 and #2 in the Grid for that environment, so the cost is amortized across every consumer. The alternative (per-use-case namespaces) would multiply the cost without commensurate benefit.
+- **The use-case → backing matrix in D2 is opinionated and may need revision as new use cases emerge.** Mitigation: the matrix lives in this ADR (the source of truth) and is mirrored into `repos/HoneyDrunk.Transport/integration-points.md` (the developer-facing reference). New rows are added by follow-up ADRs that name a use case the matrix does not currently cover.
+- **Deferring Event Grid custom topics may need revisiting sooner than expected.** If Notify Cloud's customer-facing webhook story (PDR-0002 open question) lands within the next two ADR cycles and clearly wants Event Grid custom topics, D6 will need a follow-up ADR. Mitigation: the deferral is named explicitly so the next ADR knows where to look; it is not a permanent rejection.
+- **Outbox is not free — it requires a database table, a polling dispatcher, and operational discipline (lease timeouts, dead-letter handling on the dispatcher side).** The pattern is non-trivial. Mitigation: `HoneyDrunk.Data.Outbox` and `HoneyDrunk.Data.Outbox.Dispatcher` already implement the pattern; new consumers compose them rather than reinventing.
+
+### Catalog obligations
+
+`catalogs/contracts.json` — no immediate change. If a future implementation packet introduces an `IEventPublisher`-shaped contract for Event Grid custom topics (D6 deferred), that packet adds the entry. The four Transport contracts (`ITransportPublisher`, `ITransportConsumer`, `IMessageHandler`, `ITransportEnvelope`) are already cataloged.
+
+`catalogs/relationships.json` — no immediate change. The use-case matrix is descriptive of how existing Node-to-Node edges are realized, not new edges.
+
+`catalogs/grid-health.json` — no immediate change. Pulse, Transport, Notify, Communications, and Notify Cloud entries already capture their messaging surfaces.
+
+`constitution/sectors.md` — no change.
+
+`constitution/invariants.md` — adds the two invariants from the section above.
+
+## Alternatives Considered
+
+### One backing for the whole Grid (e.g. "all messaging is Service Bus")
+
+Rejected. This is the framing the user explicitly turned down in the prompt and the Context section evidences why: a blanket Service Bus decision over-spends on commodity-work-queue use cases (use case #3, billing events to Stripe — Storage Queue at cents) and under-spends on reactive resource events (use case #6 — only Event Grid emits Azure-system signals as a managed channel). One-backing decisions are easy to write but produce wrong-tool-for-the-job costs across the matrix.
+
+### Use Event Grid (custom topics) as the Grid's primary pub/sub instead of Service Bus topics
+
+Rejected at v1. Event Grid custom topics are filter-routed, at-most-once-with-retry, and shine when the consumer set is heterogeneous (some HTTP webhooks, some Azure Functions, some Container Apps). The Grid's pub/sub use cases today (use case #2 — `PulseIngested`, future domain events) are homogeneous (Container App consumers that want guaranteed per-subscription delivery and replay). Service Bus topics fit that shape; Event Grid does not. Custom topics may be revisited if/when an external-webhook-fanout use case lands.
+
+### Use Storage Queue for everything (cost-first)
+
+Rejected. Storage Queue lacks topics (no fanout), sessions (no FIFO grouping), DLQ (manual poison-queue convention required), transactions, and duplicate detection. Use cases #1 and #2 need at least three of those features; use case #3 needs none of them. The right answer is to use Storage Queue where its trade-offs fit (use case #3) and Service Bus where they do not (#1, #2).
+
+### Treat Pulse as a Transport consumer and route domain events through it for "free observability"
+
+Rejected. This is the conflation D3 names explicitly. Pulse is observability infrastructure; domain events are business state. Subscribing Pulse to Transport topics would (a) couple observability to event schema, (b) put telemetry processing in the path of domain delivery, (c) blur the architectural seam between OTel-shaped signals and Transport-shaped events. The two channels stay separate; Pulse instruments domain events from inside the Nodes that emit them, via OpenTelemetry.
+
+### Replace Notify's internal queue (`HoneyDrunk.Notify.Queue.*`) with Transport
+
+Rejected at v1. Notify intake → Notify worker is an in-Node hop where the producer and consumer share the same Container App and the same `kv-hd-notify-{env}` Vault. Routing the message through Transport's middleware pipeline adds latency and complexity for no boundary-crossing benefit. The Transport boundaries doc already disclaims this surface for the same reason. If Notify ever splits intake and worker into separate Container Apps, the seam migrates to Transport via the abstraction that already exists; until then, the in-Node queue stays Notify-internal.
+
+### Add a queue layer between GitHub Actions and Grid Nodes (Actions → Service Bus → Node consumer)
+
+Rejected. The use case is "trigger a CI job on a schedule," and GitHub Actions does that natively with `schedule:` cron. Adding a broker between the cron trigger and the workflow runner is rebuilding what GitHub already provides. Cross-Action coordination uses `gh workflow run` or `repository_dispatch`. If a future Actions-driven flow needs durable hand-off to a long-running Container App, that flow uses the use-case-#1 Service Bus pattern at the hand-off seam — but Actions-to-Actions coordination stays GitHub-native.
+
+### Convert Lore's two-stage workflow to event-driven (raw/ blob write → ingest trigger)
+
+Rejected at v1, per D7. Daily and weekly cadences are explicit, predictable, and right-sized for an LLM-compiled wiki. OpenClaw is already the scheduler; converting to event-driven would invert the source of truth and tempt sub-batch compilation that fights Lore's design. If a Lore-specific workflow ever genuinely needs sub-daily reactivity, that's a per-flow ADR.
+
+### Make Service Bus per-Node instead of one shared namespace per environment
+
+Rejected. Same reasoning as ADR-0015's per-Node-environment rejection: namespace is not a security boundary (Managed Identity scopes per queue/topic), per-namespace cost is fixed (~$10/mo Standard), and a shared namespace simplifies cross-Node observability. If a single Node ever generates traffic that warrants its own namespace (Notify Cloud at 10K+ tenants, hypothetically), that is a future ADR — not the v1 default.
+
+### Skip Event Grid system topics and roll cache invalidation into a Transport flow
+
+Rejected. Event Grid system topics are the **only** mechanism Azure provides for emitting "this resource changed" events as a managed channel. Vault rotation cache invalidation already implicitly relies on this (Invariant 21 calls out version pinning as breaking Event Grid invalidation). Replacing it with a polling Transport flow would mean every Vault consumer polls Key Vault for the latest version on every request — which is exactly what the cache exists to avoid. System topics are accepted; custom topics are deferred.
+
+## Open Questions
+
+Items that should become their own ADRs or packets later:
+
+- **Notify Cloud customer-facing webhooks.** PDR-0002 §Open Questions defers this. When it lands, it likely needs Event Grid custom topics (the deferred half of D6) or a webhook-specific service. Specific shape unknown.
+- **Cross-region replication for Service Bus / Event Grid.** Notify Cloud v1 is single-region per PDR-0002 §B. Multi-region eventing is a future ADR when a workload needs it.
+- **Schema registry for Transport messages.** Transport's README disclaims this for v0.1.0. When schema evolution causes pain (a v2 of `PulseIngested`, an evolving `BillingEvent`), a follow-up packet adds a registry — likely as a thin convention rather than a heavy schema-registry service.
+- **Static analyzer enforcing the "no raw broker SDK calls" invariant.** A `HoneyDrunk.Standards` analyzer that flags `Azure.Messaging.ServiceBus.ServiceBusClient` or `Azure.Storage.Queues.QueueClient` references outside `HoneyDrunk.Transport.*` packages. Useful but not gating; future packet.
+- **Event Grid → Container App webhook authentication.** When the first Container App consumes Event Grid system topic events (Vault rotation cache invalidation is the most likely first), the auth shape (Event Grid signed delivery, plus Auth's existing JWT validation, plus per-Node Managed Identity) needs settling. Future packet, likely under the Vault rotation flow.
+- **Outbox dispatcher operational tuning.** Lease timeouts, batch sizes, polling intervals — all currently default values in `HoneyDrunk.Data.Outbox.Dispatcher`. Will need tuning once the first production outbox-fed flow ships. Not gating for this ADR; surfaces as operational telemetry on Pulse.

--- a/generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/01-architecture-capabilities-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/01-architecture-capabilities-catalog-registration.md
@@ -1,0 +1,467 @@
+---
+name: Architecture Catalog Registration
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0017"]
+dependencies: []
+adrs: ["ADR-0017"]
+wave: 1
+initiative: adr-0017-honeydrunk-capabilities-standup
+node: honeydrunk-capabilities
+---
+
+# Chore: Register HoneyDrunk.Capabilities's standup decisions in Architecture catalogs
+
+## Summary
+Reflect ADR-0017's stand-up decisions in the canonical Architecture catalogs and the AI sector architecture doc. Reconcile `contracts.json` to drop the placeholder `ICapability` and `ICapabilityPermission` entries and add the four D3 contracts (`ICapabilityRegistry`, `CapabilityDescriptor`, `ICapabilityInvoker`, `ICapabilityGuard`); update `relationships.json` exposes; refresh `grid-health.json` to reflect the standup; refresh `nodes.json` and `constitution/ai-sector-architecture.md` so Capabilities's contract list matches D3 (the existing `ICapabilityDescriptor` interface entry is replaced by `CapabilityDescriptor` record per the Grid-wide naming rule); refresh `repos/HoneyDrunk.Capabilities/overview.md` for the same naming rule; and add a new `repos/HoneyDrunk.Capabilities/integration-points.md` matching the template used by `repos/HoneyDrunk.Agents/integration-points.md`.
+
+ADR-0017 stays at `Status: Proposed` for this packet — the Status flip is a separate post-merge housekeeping step the scope agent handles after the entire initiative completes, per the user's standing ADR acceptance workflow. This packet's body does not edit the ADR header.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+ADR-0017 establishes the Capabilities Node's exposed contracts, package families, downstream-coupling rule, and the four invariants the scope agent finalizes at acceptance. None of that has reached the catalogs yet. Until it does, every downstream consumer (Agents, Operator, Memory, Knowledge, Evals) and every domain Node planning to register a callable tool reads stale or inconsistent metadata when scoping their own work.
+
+Five specific drift items must be resolved in this packet:
+
+1. **`contracts.json` lists `ICapability` and `ICapabilityPermission` as placeholders.** ADR-0017 D3 supersedes them with four separated surfaces — `ICapabilityRegistry`, `CapabilityDescriptor` (record, no `I` prefix), `ICapabilityInvoker`, `ICapabilityGuard`. The placeholder entries must be removed; the four D3 entries must be added.
+2. **`catalogs/relationships.json`** currently lists `honeydrunk-capabilities`'s `exposes.contracts` as four entries: `ICapabilityRegistry`, `ICapabilityDescriptor` (interface form), `ICapabilityInvoker`, `ICapabilityGuard`. The middle entry must change to `CapabilityDescriptor` (record form, no `I` prefix). The downstream `honeydrunk-agents` entry's `consumes_detail.honeydrunk-capabilities` array must be re-checked against the new names.
+3. **`catalogs/grid-health.json`** has a `honeydrunk-capabilities` block but only as a stub (`active_blockers: ["Repo not yet scaffolded"]`, `notes: "Tool registry, discovery, permissioning, versioning."`). It should reflect the standup ADR with the scaffold packet noted as the active blocker, the integration-points doc as filed, and the four D3 contracts as registered surface.
+4. **`constitution/ai-sector-architecture.md`** Capabilities section (line 219+) lists `ICapabilityDescriptor` (interface) as a Key Contract. That must be replaced by `CapabilityDescriptor` (record) to match D3 and the Grid-wide naming rule.
+5. **`repos/HoneyDrunk.Capabilities/overview.md`** lists `ICapabilityDescriptor` as a Key Interface. Same rename to `CapabilityDescriptor` (record).
+
+In addition this packet:
+
+- Adds a new `repos/HoneyDrunk.Capabilities/integration-points.md` because ADR-0017's "If Accepted" checklist explicitly requires it. The template is the existing `repos/HoneyDrunk.Agents/integration-points.md`.
+- Updates `initiatives/active-initiatives.md` to add an "ADR-0017 HoneyDrunk.Capabilities Standup" entry under "In Progress".
+
+The strict-Abstractions stance for `HoneyDrunk.Capabilities.Abstractions` (zero `HoneyDrunk.*` references; only `Microsoft.Extensions.*`) is already in the ADR text — D2 line 43 was edited directly to read `Zero runtime dependencies beyond \`Microsoft.Extensions.*\` abstractions.` before this packet was filed, and `repos/HoneyDrunk.Capabilities/invariants.md:5` already declares the same rule locally. No ADR amendment is needed here.
+
+The ADR Status flip (Proposed → Accepted) is intentionally **not** in this packet. Per the user's standing ADR acceptance workflow, the scope agent flips Status only after the entire initiative's PRs have merged. This is a separate housekeeping step that runs after packets 01 / 02 / 03 / 04 are all closed — not a line-edit on this packet.
+
+## Proposed Implementation
+
+### `catalogs/contracts.json` — `honeydrunk-capabilities` block
+
+The current block (lines 209-217 of `catalogs/contracts.json`) reads:
+
+```json
+{
+  "node": "honeydrunk-capabilities",
+  "node_name": "HoneyDrunk.Capabilities",
+  "package": "HoneyDrunk.Capabilities.Abstractions",
+  "status": "seed",
+  "interfaces": [
+    { "name": "ICapabilityRegistry", "kind": "interface", "description": "Discover and resolve available tools by name and version." },
+    { "name": "ICapability", "kind": "interface", "description": "A registered tool — schema, version, executor, permission requirements." },
+    { "name": "ICapabilityPermission", "kind": "interface", "description": "Authorization gate for a capability — checked before execution." }
+  ]
+}
+```
+
+Replace the `interfaces` array with exactly the four D3 contracts. Records lose the `I` prefix; interfaces keep it (Grid-wide naming rule). The block becomes:
+
+```json
+{
+  "node": "honeydrunk-capabilities",
+  "node_name": "HoneyDrunk.Capabilities",
+  "package": "HoneyDrunk.Capabilities.Abstractions",
+  "status": "seed",
+  "interfaces": [
+    { "name": "ICapabilityRegistry", "kind": "interface", "description": "Register, discover, and resolve tool descriptors by `(name, version)`. Versioning is required (ADR-0017 D6); registry lookup is version-aware." },
+    { "name": "CapabilityDescriptor", "kind": "type", "description": "Record. Machine-readable tool metadata — name, version, parameter schema, return schema, owning Node, permission requirements. Value type, no `I` prefix per the Grid-wide naming rule." },
+    { "name": "ICapabilityInvoker", "kind": "interface", "description": "Dispatch a resolved capability invocation to its implementing Node and return the result. The invoker is gated by `ICapabilityGuard` before dispatch." },
+    { "name": "ICapabilityGuard", "kind": "interface", "description": "Authorization gate — checked by the invoker before dispatch. Default implementation delegates to `HoneyDrunk.Auth` policy (ADR-0017 D5/D10); Capabilities does not maintain an independent permission model." }
+  ]
+}
+```
+
+Two surface-level changes vs current state:
+
+- **Remove** `ICapability` and `ICapabilityPermission` (placeholder entries superseded by D3).
+- **Add** `CapabilityDescriptor` (record) and `ICapabilityInvoker` (interface) and `ICapabilityGuard` (interface). `ICapabilityRegistry` stays but its description tightens to mention versioning per D6.
+
+### `catalogs/relationships.json` — `honeydrunk-capabilities` block
+
+Two edits to the block at lines 198-212.
+
+**(a) `exposes.contracts` array (line 205).** Currently reads:
+
+```json
+"contracts": ["ICapabilityRegistry", "ICapabilityDescriptor", "ICapabilityInvoker", "ICapabilityGuard"]
+```
+
+Replace with:
+
+```json
+"contracts": ["ICapabilityRegistry", "CapabilityDescriptor", "ICapabilityInvoker", "ICapabilityGuard"]
+```
+
+The single-character change is the I-prefix drop on the descriptor record. The other three entries stay byte-for-byte identical.
+
+**(b) `exposes.packages` array (line 206).** Currently reads:
+
+```json
+"packages": ["HoneyDrunk.Capabilities.Abstractions", "HoneyDrunk.Capabilities"]
+```
+
+Replace with:
+
+```json
+"packages": ["HoneyDrunk.Capabilities.Abstractions", "HoneyDrunk.Capabilities", "HoneyDrunk.Capabilities.Testing"]
+```
+
+This adds the `Testing` fixture package (ADR-0017 D2) — a separate NuGet artifact, not a `Providers.*` slot. Production composition references the runtime package; test projects reference `Testing` for the in-memory registry/dispatcher fixture per D9.
+
+**(c) Downstream consumer entry — `honeydrunk-agents.consumes_detail.honeydrunk-capabilities`.** At line 226 the array currently reads:
+
+```json
+"honeydrunk-capabilities": ["ICapabilityRegistry", "ICapabilityInvoker", "HoneyDrunk.Capabilities.Abstractions"]
+```
+
+Verify it stays consistent with the four D3 contracts. The Agents Node does not necessarily consume `CapabilityDescriptor` directly (Agents consumes `IToolInvoker` from its own `Agents.Abstractions`, which internally resolves through `ICapabilityRegistry` per `repos/HoneyDrunk.Agents/integration-points.md`). No edit required to this array unless a future audit shows Agents reaches `CapabilityDescriptor` directly — that is a follow-up concern, not in scope for this packet.
+
+### `catalogs/grid-health.json` — `honeydrunk-capabilities` block
+
+The current block (lines 217-227) reads:
+
+```json
+{
+  "id": "honeydrunk-capabilities",
+  "name": "HoneyDrunk.Capabilities",
+  "sector": "AI",
+  "signal": "Seed",
+  "version": "0.0.0",
+  "canary_status": "none",
+  "last_release": null,
+  "active_blockers": ["Repo not yet scaffolded"],
+  "notes": "Tool registry, discovery, permissioning, versioning."
+}
+```
+
+Replace with:
+
+```json
+{
+  "id": "honeydrunk-capabilities",
+  "name": "HoneyDrunk.Capabilities",
+  "sector": "AI",
+  "signal": "Seed",
+  "version": "0.0.0",
+  "canary_status": "none",
+  "last_release": null,
+  "active_blockers": ["GitHub repo not yet created (Architecture#NN — packet 03 of adr-0017-honeydrunk-capabilities-standup)", "Scaffold packet (Capabilities#NN — packet 04 of adr-0017-honeydrunk-capabilities-standup) not yet executed"],
+  "notes": "ADR-0017 standup ADR Proposed 2026-04-19 (Status flip to Accepted is a separate post-merge housekeeping step after the initiative completes). Catalog surface registered (4 contracts per D3: ICapabilityRegistry, CapabilityDescriptor, ICapabilityInvoker, ICapabilityGuard). Integration-points doc filed at repos/HoneyDrunk.Capabilities/integration-points.md. Awaiting GitHub repo creation (human-only) and scaffold execution: HoneyDrunk.Capabilities.Abstractions (4 contracts, zero HoneyDrunk dependencies), HoneyDrunk.Capabilities runtime (default registry, invoker, Auth-backed guard), HoneyDrunk.Capabilities.Testing (in-memory registry/dispatcher fixture), Standards wiring, CI with contract-shape canary scoped to Abstractions (D8)."
+}
+```
+
+The `summary.blocked_nodes` list at lines 269-270 keeps `honeydrunk-capabilities` (it stays blocked until the scaffold packet executes) — no edit needed there, just confirm the entry remains.
+
+### `catalogs/nodes.json` — `honeydrunk-capabilities` block
+
+Two edits to this block.
+
+**(a) `tags` (line 630).** Current text:
+
+> `"tags": ["tools", "registry", "permissions", "discovery", "agent-tools", "versioning"],`
+
+Replace with:
+
+> `"tags": ["tools", "registry", "permissions", "discovery", "agent-tools", "versioning", "dispatch", "guard"],`
+
+The `dispatch` and `guard` tokens reflect the D3 surface — the Node owns dispatch (`ICapabilityInvoker`) and authorization gating (`ICapabilityGuard`), not just registry and permissions.
+
+**(b) `grid_relationship` (line 647).** Current text:
+
+> `"grid_relationship": "Consumes Kernel (context, identity), Auth (authorization policies). Consumed by Agents (tool invocation).",`
+
+Replace with:
+
+> `"grid_relationship": "Consumes Kernel (context, identity) and Auth (authorization policy via ICapabilityGuard's default implementation). Emits registration/resolution/invocation telemetry consumed by Pulse — no runtime dependency on Pulse (ADR-0017 D7). Consumed by Agents (tool invocation), Operator (gating decisions before agent actions), Evals (deterministic test tools via HoneyDrunk.Capabilities.Testing), and any domain Node that registers a callable tool (Data, Notify, Vault, etc.).",`
+
+Do not edit any line that describes telemetry as a value prop — the dependency-direction rule applies to `grid_relationship`, not to value-prop strings about what telemetry does.
+
+### `constitution/ai-sector-architecture.md` — Capabilities section (lines 219-243)
+
+Two edits to the Capabilities Node Definition.
+
+**(a) Key Contracts list (lines 235-239).** Current block:
+
+```
+- `ICapabilityRegistry` — register, discover, resolve tools
+- `ICapabilityDescriptor` — tool schema (name, parameters, return type, permissions)
+- `ICapabilityInvoker` — execute a tool invocation
+- `ICapabilityGuard` — permission check before invocation
+```
+
+Replace with:
+
+```
+- `ICapabilityRegistry` — register, discover, resolve tool descriptors by `(name, version)` (versioning required per ADR-0017 D6)
+- `CapabilityDescriptor` — record. Tool schema (name, version, parameter schema, return schema, owning Node, permission requirements). Value type, no `I` prefix per the Grid-wide naming rule.
+- `ICapabilityInvoker` — dispatch a resolved capability invocation to its implementing Node, gated by `ICapabilityGuard` before dispatch
+- `ICapabilityGuard` — authorization gate. Default implementation delegates to `HoneyDrunk.Auth` policy; Capabilities does not maintain an independent permission model
+```
+
+**(b) Depends on phrasing (line 241).** Current text:
+
+> `**Depends on:** Kernel (context, identity for permission checks), Auth (authorization policies)`
+
+Replace with:
+
+> `**Depends on:** Kernel (context, identity), Auth (authorization policy — `ICapabilityGuard`'s default delegates here per ADR-0017 D5/D10)`
+>
+> `**Emits to (no runtime dependency):** Pulse (registration, resolution, and invocation telemetry via Kernel's `ITelemetryActivityFactory` — ADR-0017 D7)`
+
+Same one-way emission split as the AI sector doc applies to AI per ADR-0016 D7.
+
+### `repos/HoneyDrunk.Capabilities/overview.md` — Key Interfaces table (lines 21-25)
+
+Current block:
+
+```
+- `ICapabilityRegistry` — Register, discover, resolve tools
+- `ICapabilityDescriptor` — Tool schema (name, parameters, return type, permissions)
+- `ICapabilityInvoker` — Execute a tool invocation
+- `ICapabilityGuard` — Permission check before invocation
+```
+
+Replace with:
+
+```
+- `ICapabilityRegistry` — Register, discover, resolve tool descriptors by `(name, version)`
+- `CapabilityDescriptor` — Record. Tool metadata (name, version, parameter schema, return schema, owning Node, permission requirements). Value type, no `I` prefix.
+- `ICapabilityInvoker` — Dispatch a resolved capability invocation to its implementing Node
+- `ICapabilityGuard` — Authorization gate. Default implementation delegates to `HoneyDrunk.Auth` policy.
+```
+
+Also rename the section heading on line 19 from `## Key Interfaces` to `## Key Contracts` — the section now mixes interfaces and one record.
+
+The Packages table (lines 13-17) currently lists two packages:
+
+```
+| `HoneyDrunk.Capabilities.Abstractions` | Abstractions | Zero-dependency tool contracts |
+| `HoneyDrunk.Capabilities` | Runtime | Registry, discovery, dispatch, permission enforcement |
+```
+
+Add a third row for the `Testing` fixture package:
+
+```
+| `HoneyDrunk.Capabilities.Testing` | Testing fixture | Opt-in NuGet package — in-memory registry and dispatcher for downstream Nodes' deterministic unit and integration tests. Never composed into production hosts. |
+```
+
+The Design Notes paragraph at line 26 also mentions `IToolInvoker` (which lives in `Agents.Abstractions`, not Capabilities). That phrasing is correct as written — leave it alone.
+
+### `repos/HoneyDrunk.Capabilities/integration-points.md` — new file
+
+Create this file matching the template used by `repos/HoneyDrunk.Agents/integration-points.md`. The full content:
+
+```markdown
+# HoneyDrunk.Capabilities — Integration Points
+
+How Capabilities connects to the rest of the Grid. Every item here represents a cross-Node boundary that requires a canary test.
+
+## Consumes
+
+| Node | Contract | Purpose |
+|------|----------|---------|
+| **Kernel** | `IGridContext`, `INodeContext`, `IOperationContext` | Every registry, resolution, and invocation operation runs inside a Grid context. CorrelationId flows through dispatch. |
+| **Kernel** | `IStartupHook`, `IShutdownHook` | Registry initialization at startup; graceful drain on shutdown. |
+| **Kernel** | `ITelemetryActivityFactory` | Emits per-call activities for registration, resolution, and invocation. Pulse consumes these — see Emits below. |
+| **Auth** | `IAuthorizationPolicy`, `AuthorizationDecision` | The default `ICapabilityGuard` implementation delegates allow/deny decisions to Auth policy. Capabilities does not maintain an independent permission model.
+
+## Exposes
+
+| Contract | Consumer | Notes |
+|----------|---------|-------|
+| `ICapabilityRegistry` | Agents, Operator, Evals, domain Nodes registering tools | Register descriptors at startup; resolve by `(name, version)` at agent runtime. |
+| `CapabilityDescriptor` | All consumers | Record carrying tool metadata. Travels through the registry, the invoker, and the guard. |
+| `ICapabilityInvoker` | Agents (via `IToolInvoker`), Operator | Dispatch a resolved invocation. The default invoker checks `ICapabilityGuard` before dispatching. |
+| `ICapabilityGuard` | Agents, Operator | Authorization gate. Production composition uses the Auth-backed default; tests use the `HoneyDrunk.Capabilities.Testing` in-memory permissive guard. |
+
+## Emits (no runtime dependency)
+
+| Signal | Consumer | Notes |
+|--------|----------|-------|
+| Registration / resolution / invocation activities | **Pulse** | Emitted via Kernel's `ITelemetryActivityFactory`. Capabilities has no runtime dependency on Pulse — direction is one-way by contract. |
+
+## Canary Coverage Required
+
+Before any Capabilities code can be considered production-ready:
+
+- `Capabilities.Canary` → Kernel: verifies `IGridContext` flows through registry/resolver/invoker, CorrelationId is propagated to invoked tools.
+- `Capabilities.Canary` → Auth: verifies `ICapabilityGuard`'s default implementation rejects when Auth policy denies, allows when Auth policy permits.
+- `Capabilities.Canary` → contract-shape: contract-shape canary in CI fails the build if `ICapabilityRegistry`, `CapabilityDescriptor`, `ICapabilityInvoker`, or `ICapabilityGuard` change shape without a version bump (ADR-0017 D8 / invariant — number assigned at acceptance).
+
+## Dependency Order for Bring-Up
+
+Capabilities cannot be scaffolded until these Nodes have published their Abstractions packages:
+
+1. Kernel (already Live — `HoneyDrunk.Kernel.Abstractions` stable)
+2. Auth (already Live — `HoneyDrunk.Auth.Abstractions` stable)
+
+Capabilities is itself a hard prerequisite for:
+
+1. Agents (`HoneyDrunk.Agents.Abstractions` — Seed, blocked on Capabilities for `ICapabilityRegistry` resolution from `IToolInvoker`)
+2. Operator (`HoneyDrunk.Operator.Abstractions` — Seed, blocked on Capabilities for guard composition)
+3. Evals (`HoneyDrunk.Evals.Abstractions` — Seed, blocked on Capabilities for `Testing`-based deterministic tool fixtures)
+4. Memory, Knowledge — soft prerequisite (each may register their query surfaces as tools post-stand-up)
+5. Domain Nodes (Data, Notify, Vault) — soft prerequisite (each may register agent-callable tools post-stand-up)
+```
+
+The exact `_meta` layout, header levels, and table format mirror `repos/HoneyDrunk.Agents/integration-points.md` so the two files are diff-readable side-by-side.
+
+### `adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md` — no edit in this packet
+
+The ADR file is **not** edited in this packet:
+
+- D2 line 43 already reads `Zero runtime dependencies beyond \`Microsoft.Extensions.*\` abstractions.` — that edit landed directly on the ADR file before this packet was filed (rationale: cleaner to fix the still-Proposed ADR text in place than to carry a one-line amendment in a catalog packet).
+- The Status flip (Proposed → Accepted) is **not** part of this packet. Per the user's standing rule, the scope agent flips Status only after the entire initiative's PRs have merged. That is a separate post-merge housekeeping step. ADR-0017 stays Proposed throughout this run.
+
+### `adrs/README.md` — no edit
+
+The Status flip lands in a separate post-merge step, so the index needs no update from this packet either. If the index does carry a per-ADR Status column, the post-merge housekeeping step that flips the ADR file to Accepted also updates the index in the same commit.
+
+### `initiatives/active-initiatives.md` — new entry
+
+Add a new entry under `## In Progress`, immediately after the "ADR-0010 Observation Layer & AI Routing — Phase 1" block (so it sits next to the other in-progress AI-sector standup). The entry:
+
+```markdown
+### ADR-0017 HoneyDrunk.Capabilities Standup
+**Status:** In Progress
+**Scope:** Architecture, HoneyDrunk.Capabilities (new repo)
+**Initiative:** `adr-0017-honeydrunk-capabilities-standup`
+**Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)
+**Description:** Stand up `HoneyDrunk.Capabilities` as the AI sector's tool-registry and dispatch substrate per ADR-0017. Catalog reconciliation (drop placeholder `ICapability`/`ICapabilityPermission`, add four D3 contracts), four new invariants for D9 / D6 / D5+D10 / D8, human-only repo creation, and the scaffold packet (three packages: `Abstractions`, runtime, `Testing` fixture). Unblocks Agents, Operator, Memory, Knowledge, Evals, and any domain Node that registers a callable tool.
+
+**Tracking:**
+- [ ] Architecture#NN: Catalog registration + integration-points (packet 01)
+- [ ] Architecture#NN: Add four new invariants for D9 / D6 / D5+D10 / D8 (packet 02)
+- [ ] Architecture#NN: Create HoneyDrunk.Capabilities GitHub repo (human-only — packet 03)
+- [ ] Capabilities#NN: Scaffold HoneyDrunk.Capabilities — solution, three packages, contracts, CI, in-memory testing fixture (packet 04)
+
+> **Sync (2026-MM-DD):** Initiative scoped today. Packets 01-03 ready to file in Wave 1/2; packet 04 (Capabilities scaffold) parked on packets 02 + 03 landing — packet 02 because the scaffold body cites assigned invariant numbers, packet 03 because the repo must exist before file-packets.sh can target it.
+```
+
+Replace `2026-MM-DD` in the sync line with the date this packet's PR merges.
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the Unreleased section:
+
+`Architecture: Register ADR-0017 standup decisions in catalogs (contracts.json drops placeholder ICapability/ICapabilityPermission and adds four D3 contracts; relationships.json swaps ICapabilityDescriptor → CapabilityDescriptor and adds HoneyDrunk.Capabilities.Testing to exposes.packages; grid-health.json gets the standup block; nodes.json grid_relationship gets one-way Pulse phrasing per D7; ai-sector-architecture.md Capabilities section gets D3 contract names + emits-to split; repos/HoneyDrunk.Capabilities/overview.md adopts CapabilityDescriptor record; new repos/HoneyDrunk.Capabilities/integration-points.md filed; active-initiatives.md gets the new initiative block). ADR-0017 stays Proposed in this packet — the Status flip is a separate post-merge housekeeping step.`
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+- `catalogs/grid-health.json`
+- `catalogs/nodes.json`
+- `constitution/ai-sector-architecture.md`
+- `repos/HoneyDrunk.Capabilities/overview.md`
+- `repos/HoneyDrunk.Capabilities/integration-points.md` (new file)
+- `initiatives/active-initiatives.md`
+- `CHANGELOG.md`
+
+`adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md` is **not** edited by this packet. Its D2 line 43 strict-Abstractions phrasing is already in the file (edited directly before filing). Its Status header stays `Proposed` — the flip is a separate post-merge housekeeping step.
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo — no .NET projects.
+
+## Boundary Check
+- [x] All edits are inside the `HoneyDrunk.Architecture` repo.
+- [x] No code changes anywhere; metadata only.
+- [x] No contract bodies invented in this packet — only catalog registration of ADR-0017's already-decided D3 surface.
+- [x] The `ICapabilityDescriptor` (interface) → `CapabilityDescriptor` (record) rename is a deliberate Grid-wide-naming-rule alignment, not a new design choice.
+- [x] No edits to `adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md` in this packet. The Status flip is a separate post-merge housekeeping step per the user's standing ADR acceptance workflow.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` `honeydrunk-capabilities` block lists exactly the four D3 contracts (`ICapabilityRegistry`, `CapabilityDescriptor`, `ICapabilityInvoker`, `ICapabilityGuard`) — no `ICapability`, no `ICapabilityPermission`.
+- [ ] `CapabilityDescriptor` is recorded with `kind: "type"` (record), not `kind: "interface"`.
+- [ ] `catalogs/relationships.json` `honeydrunk-capabilities` `exposes.contracts` array contains `CapabilityDescriptor` (no `I` prefix); other three entries unchanged.
+- [ ] `catalogs/relationships.json` `honeydrunk-capabilities` `exposes.packages` array includes `HoneyDrunk.Capabilities.Testing` as the third entry.
+- [ ] `catalogs/grid-health.json` `honeydrunk-capabilities` block reflects the standup ADR with the GitHub repo creation and the scaffold packet noted as the active blockers; `notes` field names the four D3 contracts and references `integration-points.md`.
+- [ ] `catalogs/nodes.json` `honeydrunk-capabilities.tags` includes `dispatch` and `guard`.
+- [ ] `catalogs/nodes.json` `honeydrunk-capabilities.grid_relationship` field describes the Auth dependency via `ICapabilityGuard`'s default and emits to Pulse one-way per D7; consumers list includes Operator, Evals, and "any domain Node that registers a callable tool".
+- [ ] `constitution/ai-sector-architecture.md` Capabilities section Key Contracts list reads with `CapabilityDescriptor` (record), not `ICapabilityDescriptor` (interface).
+- [ ] `constitution/ai-sector-architecture.md` Capabilities section dependency phrasing split into "Depends on" (no Pulse) and "Emits to (no runtime dependency): Pulse" lines per D7.
+- [ ] `repos/HoneyDrunk.Capabilities/overview.md` Key Contracts section reads with `CapabilityDescriptor` (record); section heading changed from "Key Interfaces" to "Key Contracts"; Packages table includes a third row for `HoneyDrunk.Capabilities.Testing`.
+- [ ] `repos/HoneyDrunk.Capabilities/integration-points.md` exists and matches the structure of `repos/HoneyDrunk.Agents/integration-points.md` (Consumes / Exposes / Emits / Canary Coverage Required / Dependency Order for Bring-Up).
+- [ ] `adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md` is **not** modified by this packet. (Verify the file is unchanged in the diff. D2 line 43's strict-Abstractions phrasing is already in place from a pre-filing direct edit; the Status flip is deferred to post-merge housekeeping.)
+- [ ] `initiatives/active-initiatives.md` includes a new "ADR-0017 HoneyDrunk.Capabilities Standup" block under `## In Progress`.
+- [ ] `CHANGELOG.md` Unreleased section updated with the catalog reconciliations. The CHANGELOG entry must **not** claim a Status flip — the ADR stays Proposed in this packet's diff.
+- [ ] PR body explicitly notes the catalog drift reconciled: drop placeholder `ICapability`/`ICapabilityPermission` in favor of the four D3 contracts (with `CapabilityDescriptor` as a record per the Grid-wide naming rule). PR body also explicitly notes that ADR-0017 stays at `Status: Proposed` in this packet — the flip is a separate post-merge housekeeping step.
+- [ ] No file under `catalogs/` or `repos/HoneyDrunk.Capabilities/` references `ICapability` or `ICapabilityPermission` after the edits — verify with `grep -nr "ICapabilityPermission\|ICapability\b" catalogs/ repos/HoneyDrunk.Capabilities/ constitution/ai-sector-architecture.md` and confirm zero matches (note: `ICapabilityRegistry`, `ICapabilityInvoker`, `ICapabilityGuard`, `ICapabilityDescriptor` are different names; the `\b` boundary in `ICapability\b` excludes them. Manually re-verify if any tooling does word-boundary differently).
+
+## Human Prerequisites
+None. ADR-0017's D2 line 43 strict-Abstractions phrasing is already in the file (pre-filing direct edit). The Status flip is deferred to post-merge housekeeping.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — Reinforces why ADR-0017 D2 line 43 already reads `Zero runtime dependencies beyond \`Microsoft.Extensions.*\` abstractions.` (pre-filing direct edit) and why the catalog `package` field on the `honeydrunk-capabilities` `contracts.json` entry stays `HoneyDrunk.Capabilities.Abstractions`.
+
+> **Invariant 4:** No circular dependencies. The dependency graph is a DAG. Kernel is always at the root. — Capabilities consumes Kernel and Auth; nothing in `HoneyDrunk.Capabilities.*` is referenced back from Kernel or Auth.
+
+> **Invariant 11:** One repo per Node (or tightly coupled Node family). Each repo has its own solution, CI pipeline, and versioning. — Capabilities is its own Node, hence its own repo (created by packet 03).
+
+## Referenced ADR Decisions
+
+**ADR-0017 D2 (Package families):** Three package families — `HoneyDrunk.Capabilities.Abstractions`, `HoneyDrunk.Capabilities`, `HoneyDrunk.Capabilities.Testing`. The `Testing` package is a separate NuGet artifact (not a `Providers.*` slot) carrying the in-memory registry/dispatcher fixture for downstream Nodes' deterministic tests. The `relationships.json exposes.packages` array reflects all three.
+
+**ADR-0017 D3 (Exposed contracts):** Four contracts form the Capabilities Node's public boundary — `ICapabilityRegistry`, `CapabilityDescriptor` (record), `ICapabilityInvoker`, `ICapabilityGuard`. The existing `ICapability` and `ICapabilityPermission` placeholder entries are superseded. Records drop the `I`; interfaces keep it.
+
+**ADR-0017 D5 (Authorization through Auth):** `ICapabilityGuard` resolves authorization decisions by consulting Auth policy via the already-established `HoneyDrunk.Auth` contracts. No new edge in `relationships.json` is added; the Capabilities → Auth dependency already exists. The catalog edits here align the descriptions to call this out explicitly.
+
+**ADR-0017 D7 (Telemetry direction):** Capabilities emits registration, resolution, and invocation telemetry via Kernel's `ITelemetryActivityFactory`. Pulse consumes downstream. **Capabilities has no runtime dependency on Pulse.** The catalog edits in this packet bring `nodes.json` and `ai-sector-architecture.md` into alignment with that direction — same one-way phrasing as ADR-0016 D7 applied to AI.
+
+**ADR-0017 D9 (Downstream coupling):** Downstream Nodes compile only against `HoneyDrunk.Capabilities.Abstractions`. The `package` field on the `contracts.json` entry stays at `Abstractions` — never the runtime or the `Testing` fixture.
+
+## Dependencies
+None. This packet is the foundation of the initiative — it can land before the scaffold packet exists, because the catalog surface is design-decided already in ADR-0017. Packets 02, 03, and 04 reference this one as `packet:01`.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0017`
+
+## Agent Handoff
+
+**Objective:** Bring `HoneyDrunk.Architecture` catalogs into alignment with ADR-0017 D3, D5, D7, D9 — without inventing any new design choices. Add the new `integration-points.md`. Add the initiative entry to `active-initiatives.md`. **Do not edit `adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md` in this packet** — its D2 line 43 amendment is already in place (pre-filing direct edit), and the Status flip is a separate post-merge housekeeping step.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Context:**
+- Goal: Catalog drift is the bottleneck that blocks downstream AI-sector Nodes (Agents, Operator, Memory, Knowledge, Evals) and tool-registering domain Nodes from scoping their own work. This packet removes the drift introduced by ADR-0017's acceptance.
+- Feature: ADR-0017 standup initiative, Wave 1, Packet 01.
+- ADRs: ADR-0017 (this packet implements the catalog half of "If Accepted").
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None — this packet runs first.
+
+**Constraints:**
+
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — Reinforces why D2 line 43 must read `Microsoft.Extensions.*` only and why the catalog `package` field on the `honeydrunk-capabilities` `contracts.json` entry stays `HoneyDrunk.Capabilities.Abstractions`.
+- **Invariant 11:** One repo per Node. — Capabilities is a separate Node and gets its own repo. Packet 03 creates it.
+- **D3 is canonical.** Drop `ICapability` and `ICapabilityPermission` (placeholders). Add `ICapabilityRegistry` (description tightened to mention versioning), `CapabilityDescriptor` (record, no `I`), `ICapabilityInvoker`, `ICapabilityGuard` (default delegates to Auth).
+- **Records drop `I`; interfaces keep it.** `CapabilityDescriptor` is a record. The other three contracts are interfaces. Apply the rename across `contracts.json`, `relationships.json`, `ai-sector-architecture.md`, and `repos/HoneyDrunk.Capabilities/overview.md`. Verify with grep that no remaining `ICapabilityDescriptor` (with the I prefix) exists in `catalogs/`, `constitution/ai-sector-architecture.md`, or `repos/HoneyDrunk.Capabilities/` after edits.
+- **Strict Abstractions stance is already in the ADR text.** ADR-0017 D2 line 43 already reads `Zero runtime dependencies beyond \`Microsoft.Extensions.*\` abstractions.` (pre-filing direct edit). `repos/HoneyDrunk.Capabilities/invariants.md:5` declares the same rule locally. Do **not** modify the ADR file in this packet.
+- **Auth is a first-class runtime dependency.** ADR-0017 D10 makes this explicit. The catalog already has the edge; no new edge to add. The `nodes.json grid_relationship` and `ai-sector-architecture.md Depends on` text describe the dependency in terms of `ICapabilityGuard`'s default delegating to Auth — that is the precise framing.
+- **Pulse is one-way.** Same direction rule as ADR-0016 D7 applied to AI. Edit `grid_relationship` and `ai-sector-architecture.md` accordingly. Do not add Pulse to `consumes` or `consumes_detail` in `relationships.json`.
+- **No ADR Status flip in this packet.** ADR-0017 stays at `Status: Proposed`. The flip is a separate post-merge housekeeping step the scope agent runs after the entire initiative completes, per the user's standing ADR acceptance workflow. Do not edit the ADR header in this PR.
+- **Naming-collision note (D4).** Two collisions are disambiguated: ADR-0004's `capabilities:` YAML frontmatter on agent definition files, and HoneyDrunk.Actions (Ops Node for CI/CD). Neither is a code change. While editing `repos/HoneyDrunk.Capabilities/`, do not introduce the word "actions" to mean tool invocations and do not borrow the `capabilities:` frontmatter word for runtime concepts.
+
+**Key Files:**
+- `catalogs/contracts.json` — replace the `honeydrunk-capabilities` block's interfaces array
+- `catalogs/relationships.json` — line 205 `exposes.contracts` (rename `ICapabilityDescriptor` → `CapabilityDescriptor`); line 206 `exposes.packages` (add `HoneyDrunk.Capabilities.Testing`)
+- `catalogs/grid-health.json` — replace the `honeydrunk-capabilities` block (lines 217-227)
+- `catalogs/nodes.json` — edit line 630 (`tags`) and line 647 (`grid_relationship`)
+- `constitution/ai-sector-architecture.md` — Capabilities section Key Contracts list (lines 235-239) and Depends-on phrasing (line 241)
+- `repos/HoneyDrunk.Capabilities/overview.md` — Key Interfaces → Key Contracts heading + body (lines 19-25); add `Testing` row to Packages table (lines 13-17)
+- `repos/HoneyDrunk.Capabilities/integration-points.md` — new file
+- `initiatives/active-initiatives.md` — new entry under `## In Progress`
+- `CHANGELOG.md` — Unreleased entry
+
+`adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md` and `adrs/README.md` are explicitly **not** edited in this packet.
+
+**Contracts:**
+- This packet does not author any new contracts. It records the four D3 contracts in the catalog. Authoring of the actual `.cs` files happens in packet 04 (the scaffold).

--- a/generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/02-architecture-capabilities-invariants.md
+++ b/generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/02-architecture-capabilities-invariants.md
@@ -1,0 +1,193 @@
+---
+name: Constitution Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0017", "constitution"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0017"]
+wave: 1
+initiative: adr-0017-honeydrunk-capabilities-standup
+node: honeydrunk-capabilities
+---
+
+# Chore: Add ADR-0017's four new invariants to the Grid constitution
+
+## Summary
+Add four new invariants to `constitution/invariants.md` derived from ADR-0017's Consequences section: D9 (downstream coupling rule), D6 (descriptor versioning), D5+D10 (authorization through Auth), and D8 (contract-shape canary). Assign them numbers **43, 44, 45, 46** — the next four free numbers assuming ADR-0016's invariants pack (proposed 39/40/41 originally, expected to renumber to 40/41/42 since ADR-0026 already took 39) lands first. Collision check at edit time decides the actual numbers.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+ADR-0017 explicitly delegates final invariant numbering to the scope agent at acceptance time. The four invariants the ADR proposes (in its "New invariants" section under Consequences) need to land in `constitution/invariants.md` so the canary infrastructure, downstream Node packets, and the review agent all have a numbered, citable rule to reference.
+
+These four rules govern the Capabilities Node's first-shipping behavior:
+
+- **D9 — downstream coupling.** Every AI-sector consumer from packet 04 onward will compile against `HoneyDrunk.Capabilities.Abstractions` and only that package. Without an invariant, drift toward `HoneyDrunk.Capabilities` direct references or `HoneyDrunk.Capabilities.Testing` references in production composition is silent until canaries catch it. Better to forbid it explicitly.
+- **D6 — descriptor versioning.** A registry where descriptors can be unversioned breaks the entire "tools evolve without breaking consumers" promise. An invariant makes unversioned registration a build-time gating concern.
+- **D5/D10 — Auth as the authorization root.** A second permission model in the Grid is a second trust boundary, and the two models drift. An invariant locks the rule that `ICapabilityGuard` projects Auth's policy, never invents its own.
+- **D8 — contract-shape canary.** Even with the canary wired in CI (handled by packet 04), the obligation to *keep* the canary running on the four hot-path contracts must outlive any single CI workflow file. An invariant ensures any future CI rewrite preserves the gate.
+
+## Proposed Implementation
+
+### `constitution/invariants.md` — append four new entries
+
+The current state of the file (verified 2026-05-04):
+
+- Highest assigned number is **39** (ADR-0026's "Tenant mechanics stay at intake and post-dispatch boundaries.")
+- Numbers 29-30 are reserved for ADR-0010 (the placeholder line is still present at line 113)
+- ADR-0016's standup initiative also files three new invariants. ADR-0016 packet 02's source file at `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/02-architecture-ai-invariants.md` proposes 39/40/41; that packet's collision-check language acknowledges it must shift if 39 is taken. Since ADR-0026 has already landed and grabbed 39, ADR-0016's packet 02 is expected to file at 40/41/42 (its collision-check logic handles this automatically when it executes).
+
+Working assumption: ADR-0016 packet 02 lands first (it is also Wave 1 and depends on its own packet 01). It claims 40/41/42. ADR-0017 packet 02 (this one) claims **43, 44, 45, 46**.
+
+**Collision-check rule for the executing agent:** Before committing, scan `constitution/invariants.md` and confirm the highest existing number. If the highest is 42, claim 43-46. If the highest is something else (e.g. 39 because ADR-0016 has not yet landed, or 46 because some other initiative grabbed slots in the interim), claim the next four free numbers. This is a hard gate, not a best-effort.
+
+If the assigned numbers shift away from 43-46:
+
+- The corresponding bullets in ADR-0017's Consequences section ("New invariants (proposed for `constitution/invariants.md`)") at lines 128-131 are updated to state the assigned numbers.
+- The packet 04 source file at `generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md` is amended in place before push. Per the dispatch plan's filing-order rule, packet 04 is not filed until this packet has merged, so the pre-filing carve-out under invariant 24 applies.
+- `repos/HoneyDrunk.Capabilities/integration-points.md` (created in packet 01) references the canary invariant by phrase ("number assigned at acceptance") rather than by number, so no edit is required there. If for some reason a number has been baked into that file already, update it.
+
+### Where the four entries land in `constitution/invariants.md`
+
+The current file ends with:
+
+```markdown
+## Multi-Tenant Boundary Invariants
+
+39. **Tenant mechanics stay at intake and post-dispatch boundaries.** ...
+```
+
+There is no AI-Capabilities-specific section header. The four new invariants belong logically alongside the AI invariants but are about Capabilities specifically. Two acceptable layouts:
+
+- **Option A (preferred): introduce a new `## AI Sector — Capabilities Invariants` section after `## Multi-Tenant Boundary Invariants`.** Mirrors the structure ADR-0016 packet 02 set: ADR-0016 added its three invariants under the existing `## AI Invariants` section because that section was already labeled generically. ADR-0017's invariants are specifically about the Capabilities Node, so a sibling section is clearer than overloading `AI Invariants` with substrate-specific rules.
+- **Option B (acceptable): append the four entries inside the existing `## AI Invariants` section, right after the three ADR-0016-derived entries (40/41/42).** This matches ADR-0016 packet 02's choice of "no new section header — stay inside `## AI Invariants`". Acceptable but it stretches that section into two logical groupings (substrate inference rules vs substrate tool-registry rules) under one header.
+
+The executing agent picks based on what the file looks like at edit time:
+
+- If `## AI Invariants` already contains 28 + the three ADR-0016-derived entries, **Option A** is preferred — start a new `## AI Sector — Capabilities Invariants` section to keep each substrate's rules visually clustered.
+- If the file structure has otherwise drifted in unexpected ways, fall back to **Option B** (append inside `## AI Invariants`) and mention the deviation in the PR body.
+
+### Invariant text — assuming numbers 43, 44, 45, 46
+
+Append the four entries as:
+
+```markdown
+## AI Sector — Capabilities Invariants
+
+43. **Downstream Nodes take a runtime dependency only on `HoneyDrunk.Capabilities.Abstractions`.**
+    Composition against `HoneyDrunk.Capabilities` and `HoneyDrunk.Capabilities.Testing` is a host-time (and test-time) concern, resolved at application startup. Test projects may reference `HoneyDrunk.Capabilities.Testing` to pick up the in-memory registry/dispatcher fixture. Production projects must not. This is the same abstraction/runtime split applied for AI, Vault, and Transport, restated here because it is the specific rule that allows Agents, Operator, Memory, Knowledge, Evals, and tool-registering domain Nodes to proceed on `Abstractions` alone without waiting for the runtime or pulling the testing fixture into production composition. See ADR-0017 D9 (Proposed — this invariant takes effect when ADR-0017 is accepted).
+
+44. **Every registered capability descriptor carries an explicit version; the registry key is `(name, version)`.**
+    Unversioned registration is a build failure. Version-aware lookup is required of the registry implementation. The specific version *format* (name-suffixed string, strict semver, hybrid) is decided by the scaffold packet that ships the first registry implementation, but the principle that descriptors are versioned is fixed at acceptance. See ADR-0017 D6 (Proposed — this invariant takes effect when ADR-0017 is accepted).
+
+45. **Authorization for capability invocation is resolved through `HoneyDrunk.Auth` policy via `ICapabilityGuard`.**
+    Capabilities does not maintain an independent permission model. The `ICapabilityGuard` interface is the local surface a downstream Node compiles against; its default implementation delegates to Auth. Invocation paths must always pass through the guard before dispatch — no bypass surface exists. See ADR-0017 D5 and D10 (Proposed — this invariant takes effect when ADR-0017 is accepted).
+
+46. **The HoneyDrunk.Capabilities Node CI must include a contract-shape canary that fails the build on shape drift to `ICapabilityRegistry`, `CapabilityDescriptor`, `ICapabilityInvoker`, or `ICapabilityGuard` without a corresponding version bump.**
+    These four are the hot-path abstractions every downstream consumer compiles against. Accidental shape drift on any of them breaks every AI-sector Node and every tool-registering domain Node simultaneously. The canary makes this a compile-time failure at Capabilities's own CI, not a discovery at consumer sites. The implementation may be the existing `job-api-compatibility.yml` reusable workflow scoped to `HoneyDrunk.Capabilities.Abstractions`; the obligation is to keep the gate, not to use any specific implementation. See ADR-0017 D8 (Proposed — this invariant takes effect when ADR-0017 is accepted).
+```
+
+If Option B is chosen instead (append inside `## AI Invariants`), drop the `## AI Sector — Capabilities Invariants` heading and place the four entries after ADR-0016's three.
+
+### Notes for the executing agent
+
+- **Each new invariant entry MUST be marked `(Proposed — this invariant takes effect when ADR-0017 is accepted)`** at the end of its body. ADR-0017 is still at `Status: Proposed` at the time this packet's PR lands — none of the four packets in this initiative flip ADR-0017's status. The status flip is a separate post-merge housekeeping step. Until that flip happens, the four new invariants are themselves Proposed. This matches the existing pattern: invariant 28 (ADR-0010), invariants 31/32/33 (ADR-0011) all carry `(Proposed — this invariant takes effect when ADR-XXXX is accepted)` qualifiers — replicate that exact qualifier shape verbatim, substituting `ADR-0017`.
+- Do not modify the existing entries (28, 31-39) or the `_Invariants 29–30 are reserved..._` placeholder.
+- If ADR-0016 packet 02 has not yet merged at the time this packet executes, the highest number is still 39 and the four new entries claim 40/41/42/43. In that case the executing agent for this packet does the renumber, updates ADR-0017's Consequences bullets accordingly, and amends packet 04's source file (per the lockstep-rename criterion below). The dispatch plan's filing-order rule and invariant 24's pre-filing carve-out cover the packet-04 amendment.
+
+### Lockstep renumber of packet 04 source file
+
+Packet 04 (the scaffold) hard-codes the assumed invariant numbers 43-46 in roughly ten places. If the collision check shifts the numbers away from 43-46, every reference in `04-capabilities-node-scaffold.md` must update in lockstep before that packet is filed.
+
+After determining the actually-assigned numbers, run:
+
+```bash
+rg -n '\b4[3-6]\b' generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md
+```
+
+Use ripgrep (`rg`), not `grep` — Windows Git Bash's `grep` boundary semantics differ subtly from ripgrep's. For each match, replace the old number with the assigned one. The matches are concentrated in the Constraints and Referenced Invariants sections; verify by re-running the rg query and confirming zero hits at the old numbers and the expected count at the new numbers. Where a reference is purely narrative ("the Capabilities downstream-coupling invariant"), the number does not need to be there at all — those phrase-keyed references are preferred per the packet's existing pattern. The numbers stay in places where they are genuinely needed (e.g. parenthetical "default 43" annotations, the actual `constitution/invariants.md` insertion).
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the Unreleased section: `Architecture: Add invariants 43 (Capabilities downstream coupling), 44 (descriptor versioning), 45 (Auth as authorization root for ICapabilityGuard), and 46 (Capabilities contract-shape canary) per ADR-0017 D9, D6, D5+D10, D8. (Numbers shift to next-available if collision check finds 43-46 taken.)`
+
+If renumbered, update the changelog line to state the actually-assigned numbers.
+
+## Affected Files
+- `constitution/invariants.md`
+- `adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md` (only if the assigned numbers differ from 43/44/45/46 — update the Consequences "New invariants" bullets)
+- `generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md` (only if the assigned numbers differ from 43/44/45/46 — pre-filing amendment per invariant 24's carve-out)
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] No new design decisions — invariant text is taken from ADR-0017's "New invariants" section, with light wordsmithing for the constitution's voice.
+- [x] No existing invariants modified, only appended.
+- [x] Pre-filing amendment to packet 04's source file is permitted under invariant 24's carve-out; post-filing amendment is forbidden, so the dispatch plan's filing-order rule (packet 04 not filed until this packet's PR has merged) is the structural protection.
+
+## Acceptance Criteria
+- [ ] Four new invariants present in `constitution/invariants.md` with text matching ADR-0017 D9, D6, D5+D10, D8.
+- [ ] Assigned numbers verified against the current highest number in the file. Default assumption is 43-46; renumber to next-available if 43-46 are taken (most likely 40-43 if ADR-0016 has not yet landed; possibly higher if other initiatives have grabbed slots in the interim).
+- [ ] Each invariant's body cites its source ADR decision.
+- [ ] **Each new invariant entry carries the qualifier `(Proposed — this invariant takes effect when ADR-0017 is accepted)`** at the end of its body. ADR-0017 stays at `Status: Proposed` for this entire initiative — the Status flip is a separate post-merge housekeeping step. This pattern matches existing entries 28 (ADR-0010), 31, 32, 33 (ADR-0011) which all carry the same qualifier shape.
+- [ ] Existing entries (28, 29-30 reservation, 31-39) are unmodified.
+- [ ] If invariant numbers shifted away from 43-46, the corresponding bullets in ADR-0017's Consequences section ("New invariants (proposed for `constitution/invariants.md`)") at lines 128-131 are updated to match.
+- [ ] If invariant numbers shifted away from 43-46, the packet 04 source file at `generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md` is amended before that packet is filed. After determining the assigned numbers, run `rg -n '\b4[3-6]\b' generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md` and update each match to the actually-assigned number. Use ripgrep (`rg`), not `grep`, for predictable boundary semantics on Windows Git Bash. After replacement, re-run the rg query and confirm zero hits at the old numbers. The dispatch plan's filing-order rule guarantees packet 04 has not been filed yet at the time this packet's PR merges.
+- [ ] `CHANGELOG.md` Unreleased section updated with the four invariant numbers actually assigned.
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0017 D5 (Authorization routes through Auth):** `ICapabilityGuard` resolves authorization decisions by consulting Auth policy via the already-established `HoneyDrunk.Auth` contracts. No new edge in `relationships.json` is added; the Capabilities → Auth dependency already exists. — Source for invariant 45.
+
+**ADR-0017 D6 (Tool-schema versioning principle):** Every registered tool descriptor carries an explicit `version` field. The public registry key is the pair `(name, version)`. The specific versioning *model* is deferred to the scaffold packet, but the principle is fixed at acceptance. — Source for invariant 44.
+
+**ADR-0017 D8 (Contract-shape canary):** A contract-shape canary is added to the Capabilities Node's CI: it fails the build if any of `ICapabilityRegistry`, `CapabilityDescriptor`, `ICapabilityInvoker`, `ICapabilityGuard` change shape without a corresponding version bump. — Source for invariant 46.
+
+**ADR-0017 D9 (Downstream coupling rule):** Downstream Nodes (Agents, Operator, Memory, Knowledge, Evals, and domain Nodes that *expose* tools) compile only against `HoneyDrunk.Capabilities.Abstractions`. They do not take a runtime dependency on `HoneyDrunk.Capabilities` or on `HoneyDrunk.Capabilities.Testing` in production composition. — Source for invariant 43.
+
+**ADR-0017 D10 (Auth dependency is first-class):** Capabilities takes a first-class runtime dependency on HoneyDrunk.Auth for authorization resolution. The default `ICapabilityGuard` implementation cannot produce an allow/deny decision without Auth. — Reinforces invariant 45.
+
+## Dependencies
+- `packet:01` — packet 01 lands the catalog surface (especially the four D3 contract names) that invariant 46's canary will guard. Filing 02 before 01 would leave a forward-reference dangling.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0017`, `constitution`
+
+## Agent Handoff
+
+**Objective:** Land four new ADR-0017-derived invariants in the Grid constitution at the next four available numbers, in a single edit. Update ADR-0017 Consequences bullets and packet 04's source file if the assigned numbers shift away from 43-46.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Context:**
+- Goal: ADR-0017's "New invariants" section is a placeholder with the qualifier "Numbering is tentative — scope agent finalizes at acceptance." This packet is the finalization.
+- Feature: ADR-0017 standup initiative, Wave 1, Packet 02.
+- ADRs: ADR-0017 (sole source).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packet 01 of this initiative (catalog registration + integration-points + Status flip) must merge first.
+
+**Constraints:**
+
+- **Each new invariant carries `(Proposed — this invariant takes effect when ADR-0017 is accepted)`.** ADR-0017 stays at `Status: Proposed` across the entire initiative — none of the four packets flip its status. Mirror the qualifier pattern from invariants 28 (ADR-0010) and 31/32/33 (ADR-0011) verbatim, substituting `ADR-0017`.
+- **Number collision check is a hard gate.** Default 43-46. Verify against the file's highest number at edit time. If shifted, update both ADR-0017's Consequences section (lines 128-131) and packet 04's source file. Do not file partial edits — either all four invariants land at consistent numbers across all three files, or none of them.
+- **Section choice (Option A vs Option B) is a stylistic call, not a correctness one.** Pick based on what the file looks like at edit time. Default to Option A (new `## AI Sector — Capabilities Invariants` section).
+- **Verbatim alignment with ADR-0017.** The invariant bodies should restate D9/D6/D5+D10/D8 with constitutional voice, not introduce new requirements. Anything novel belongs in a follow-up ADR.
+- **Pre-filing amendment to packet 04 is the mechanism** for handling number shifts. Invariant 24: filed packets are immutable, but pre-filing edits are permitted. The dispatch plan's filing-order rule (packet 04 not filed until this packet's PR has merged) is what makes the carve-out applicable.
+
+**Key Files:**
+- `constitution/invariants.md` — append four entries (Option A: under a new `## AI Sector — Capabilities Invariants` section; Option B: inside `## AI Invariants`)
+- `adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md` — only edited if numbers shifted from 43/44/45/46 (lines 128-131 in the Consequences section)
+- `generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md` — only edited if numbers shifted from 43/44/45/46
+- `CHANGELOG.md`
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/03-architecture-create-capabilities-repo.md
+++ b/generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/03-architecture-create-capabilities-repo.md
@@ -1,0 +1,120 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "new-node", "adr-0017", "human-only", "wave-2"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0017"]
+wave: 2
+initiative: adr-0017-honeydrunk-capabilities-standup
+node: honeydrunk-architecture
+actor: human
+---
+
+# Chore: Create `HoneyDrunk.Capabilities` GitHub repo (human-only)
+
+## Summary
+Create the `HoneyDrunkStudios/HoneyDrunk.Capabilities` repo on GitHub with the Grid's standard per-repo settings. This is an org-admin action that cannot be delegated to an agent — it gates the `04-capabilities-node-scaffold.md` packet, which is blocked until the repo exists.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture` (this is where the tracking issue lives; the actual work happens on GitHub at the org level)
+
+## Actor
+**`Human`.** This entire work item is human-only. Org-admin rights on `HoneyDrunkStudios` are required to create a new repo, and repo creation is not delegated to agents. Frontmatter sets `actor: human` and labels include `human-only`; the filing pipeline mirrors `Actor=Human` onto The Hive.
+
+## Motivation
+`04-capabilities-node-scaffold.md` defines the solution, three packages, four contracts, default registry/invoker/guard implementations, in-memory testing fixture, and CI pipeline for `HoneyDrunk.Capabilities` but cannot be filed as a GitHub issue until the target repo exists. Surfacing this as an explicit Wave-2 work item keeps it visible on The Hive board as a human-only blocker instead of an implicit prerequisite. Same pattern as `02-architecture-create-communications-repo.md` from the ADR-0013 initiative.
+
+## Steps (portal)
+
+1. Navigate to https://github.com/organizations/HoneyDrunkStudios/repositories/new
+2. **Repository name:** `HoneyDrunk.Capabilities`
+3. **Description:** `Tool-registry and dispatch substrate for the AI sector — registers tool descriptors, dispatches invocations, gates them through Auth policy via ICapabilityGuard. The "how a tool becomes callable" half of the AI sector base (paired with HoneyDrunk.AI for the inference half).`
+4. **Visibility:** Public — matches the HoneyDrunk Grid default. The registry/dispatcher logic is design-pattern code and is openly shareable. Secrets never live in code; the only credentials Capabilities touches are at composition time (the host wires in Auth's policy resolver) and there is no per-repo secret to seed at creation. Do not commit tenant IDs, subscription IDs, or any environment-specific identifiers.
+5. **Initialize with:**
+   - [x] Add a README file
+   - [x] Add `.gitignore` → `VisualStudio` template
+   - [x] Choose a license → match what the other HoneyDrunk.* repos use (check `HoneyDrunk.Auth/LICENSE` since Capabilities is most similar to Auth in shape — pure abstractions + runtime + zero external SDK dependencies)
+6. Click **Create repository**
+7. After creation, apply org defaults:
+   - Branch protection on `main` (mirror `HoneyDrunk.Auth` settings — require PR, require checks, no force push, no deletion)
+   - Default branch = `main`
+   - Actions enabled
+   - Secrets and variables → nothing to seed yet (Capabilities is a library Node with no Azure footprint; future deployable hosts compose it in but the repo itself ships NuGet packages only)
+
+## Acceptance Criteria
+- [ ] `HoneyDrunkStudios/HoneyDrunk.Capabilities` exists and is accessible
+- [ ] Visibility is Public (matches HoneyDrunk default)
+- [ ] Default branch is `main` with a README committed
+- [ ] Branch protection rules match the Grid standard (mirror `HoneyDrunk.Auth`'s settings)
+- [ ] `.gitignore` and LICENSE committed
+- [ ] "Next Steps" script below has been run, filing `04-capabilities-node-scaffold.md` as an issue on the new repo (assuming packet 02 has merged and any required invariant-number amendments to packet 04 have been applied)
+- [ ] This chore issue is closed after the Next Steps script completes
+
+## Next Steps (run immediately after the repo exists *and* packet 02 has merged)
+
+These commands seed labels on the new repo, file `04-capabilities-node-scaffold.md` against it, add the resulting issue to The Hive, and prepare for the board-field population step. Run from the `HoneyDrunk.Architecture` repo root.
+
+**Important order-of-operations:** Per the dispatch plan's filing-order rule, packet 04 cannot be filed until packet 02's PR has merged (so the assigned invariant numbers are locked in `constitution/invariants.md`) and any required pre-filing amendments to `04-capabilities-node-scaffold.md` have been applied. If packet 02 has not yet merged at the time this chore is being closed, file packet 04 **after** packet 02 lands — not now.
+
+```bash
+PACKETS="generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup"
+
+# 1. Seed the new repo with the labels the filing command needs.
+#    Color choices follow the existing convention used by other Grid repos:
+#    feature=green, tier-2=yellow, tier-3=purple, new-node=light-blue, ai=magenta,
+#    scaffolding=pale-cyan, adr-0017=mid-blue, wave-3=yellow.
+for label in "feature:0E8A16" "tier-2:FBCA04" "tier-3:5319E7" "new-node:C5DEF5" "ai:D946EF" "scaffolding:BFDADC" "adr-0017:1D76DB" "wave-3:FBCA04"; do
+  name="${label%:*}"; color="${label#*:}"
+  gh label create "$name" --repo HoneyDrunkStudios/HoneyDrunk.Capabilities --color "$color" 2>/dev/null
+done
+
+# 2. File the scaffold packet as an issue on the new repo
+ISSUE_URL=$(gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Capabilities \
+  --title "Scaffold HoneyDrunk.Capabilities repo, solution, three packages, contracts, CI, in-memory testing fixture" \
+  --body-file "$PACKETS/04-capabilities-node-scaffold.md" \
+  --label "feature,tier-2,new-node,ai,scaffolding,adr-0017,wave-3")
+echo "Filed: $ISSUE_URL"
+
+# 3. Add to The Hive — field IDs per infrastructure/github-projects-field-ids.md
+gh project item-add 4 --owner HoneyDrunkStudios --url "$ISSUE_URL"
+
+# 4. Set board fields (Wave 3 / Initiative adr-0017-honeydrunk-capabilities-standup / Node honeydrunk-capabilities / Tier 2 / Actor Agent)
+# See infrastructure/github-projects-field-ids.md for current option IDs; apply via `gh project item-edit`.
+# (If that file does not exist yet, copy field option IDs from another already-filed packet's project-item state, e.g. an ADR-0016 or ADR-0026 issue.)
+```
+
+After this runs, `04-capabilities-node-scaffold.md` is filed against the new repo and is the next Wave-3 agent-eligible work item. Close this chore issue afterwards.
+
+## Human Prerequisites
+- [ ] Org-admin role on `HoneyDrunkStudios` (required to create new repos under the org)
+- [ ] Browser with GitHub session logged in as the org owner
+- [ ] `gh` CLI installed locally and authenticated as the org owner (for the Next Steps script)
+- [ ] Confirm packet 02 (invariants) has merged before running the Next Steps script — if not, defer the script run until it has
+
+## Dependencies
+- `packet:01` — catalog registration packet must merge first so the catalogs and `repos/HoneyDrunk.Capabilities/integration-points.md` already point at the eventual repo. Sequenced after Wave 1 by dispatch plan; the actual portal action could run in parallel with Wave 1, but the tracking issue is filed in Wave 2.
+
+## Downstream Unblocks
+- `04-capabilities-node-scaffold.md` — becomes fileable and executable the moment this chore is Done **and** packet 02 has merged (whichever happens later)
+
+## Referenced ADR Decisions
+
+**ADR-0017 (Stand Up the HoneyDrunk.Capabilities Node):**
+- **§Decision / D1:** HoneyDrunk.Capabilities is a new Node in the AI sector. New Node ⇒ new repo per invariant 11.
+- **§Decision / D2:** Three package families (`HoneyDrunk.Capabilities.Abstractions`, `HoneyDrunk.Capabilities`, `HoneyDrunk.Capabilities.Testing`) — all three live in this single repo per invariant 11.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node (or tightly coupled Node family). Each repo has its own solution, CI pipeline, and versioning.
+
+## Labels
+`chore`, `tier-1`, `meta`, `new-node`, `adr-0017`, `human-only`, `wave-2`
+
+## Notes for the human executing this chore
+
+- This is a 3-minute portal task. No scripts beyond the Next Steps block, which is a quick CLI run after the portal click — and only after packet 02 has merged.
+- After the repo is created, run the Next Steps script above to file `04-capabilities-node-scaffold.md`, then close this chore issue.
+- Do not provision any Azure resources (Key Vault, App Configuration, Container App). HoneyDrunk.Capabilities is a library Node with no Azure footprint. Future deployable hosts that compose Capabilities will provision their own resources per the host's own bring-up; that is not this packet's concern.
+- If you decide to defer Capabilities standup, close this as "not planned" with a note pointing at the deferral decision — do not delete the packet. A future acceptance can revive it.

--- a/generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md
@@ -1,0 +1,595 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Capabilities
+labels: ["feature", "tier-2", "ai", "scaffolding", "new-node", "adr-0017"]
+dependencies: ["packet:01", "packet:02", "packet:03"]
+adrs: ["ADR-0017"]
+wave: 3
+initiative: adr-0017-honeydrunk-capabilities-standup
+node: honeydrunk-capabilities
+---
+
+# Feature: Stand up the HoneyDrunk.Capabilities repo — solution, three packages, contracts, CI, in-memory testing fixture
+
+## Summary
+Bring the empty `HoneyDrunk.Capabilities` repo from zero to first-shippable state per ADR-0017. Land the solution layout, the three package families (`Abstractions`, runtime, `Testing` fixture), the four D3 contracts inside `HoneyDrunk.Capabilities.Abstractions`, default registry/invoker/Auth-backed guard implementations in the runtime, the in-memory registry/dispatcher/permissive guard fixture in `HoneyDrunk.Capabilities.Testing`, the standard CI pipeline (PR core + release + nightly + secrets + contract-shape canary), and the contract-shape canary scoped to `HoneyDrunk.Capabilities.Abstractions` per ADR-0017 D8 and the Capabilities canary invariant (number assigned by packet 02 — see Constraints below).
+
+This is the unblocker for the five AI-sector Nodes that consume Capabilities (Agents, Operator, Memory, Knowledge, Evals) and for any domain Node that registers an agent-callable tool (Data, Notify, Vault). After this packet merges and a `0.1.0` tag lands, those Nodes can compile against `HoneyDrunk.Capabilities.Abstractions` and start their own work in parallel.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Capabilities`
+
+## Motivation
+ADR-0017 establishes *what* HoneyDrunk.Capabilities is and what contracts it exposes. The repo is created by packet 03 but is otherwise empty — no `.slnx`, no projects, no CI, no contracts. Five AI-sector Nodes plus every tool-registering domain Node are blocked on this single repo coming online. Standing it up is the highest-leverage unblock available after packet 03 closes.
+
+This packet bundles the full stand-up:
+
+- The Node has three packages (`Abstractions`, runtime, `Testing` fixture), not the typical two.
+- The four D3 contracts must all land in the first commit so the contract-shape canary has a baseline.
+- The `Testing` fixture is required for downstream Nodes (especially Evals) to write deterministic tests against Capabilities without standing up a full Auth policy resolver.
+- Per the user's standing convention, a new Node's scaffold work bundles into one packet rather than fragmenting across many — fragmentation creates ordering hazards inside an empty repo.
+
+## Proposed Implementation
+
+### Repository layout
+
+```
+HoneyDrunk.Capabilities/
+├── HoneyDrunk.Capabilities.slnx
+├── Directory.Build.props
+├── CHANGELOG.md
+├── README.md
+├── .editorconfig                    (from HoneyDrunk.Standards)
+├── .gitignore
+├── .github/
+│   └── workflows/
+│       ├── pr-core.yml              (calls Actions/pr-core.yml)
+│       ├── release.yml              (calls Actions/release.yml)
+│       ├── nightly-deps.yml         (calls Actions/nightly-deps.yml)
+│       ├── nightly-security.yml     (calls Actions/nightly-security.yml)
+│       └── api-compatibility.yml    (calls Actions/job-api-compatibility.yml — D8 canary)
+├── src/
+│   ├── HoneyDrunk.Capabilities.Abstractions/
+│   │   ├── HoneyDrunk.Capabilities.Abstractions.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── ICapabilityRegistry.cs
+│   │   ├── CapabilityDescriptor.cs
+│   │   ├── ICapabilityInvoker.cs
+│   │   ├── ICapabilityGuard.cs
+│   │   └── (request/response types — see "Contract details" below)
+│   ├── HoneyDrunk.Capabilities/
+│   │   ├── HoneyDrunk.Capabilities.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── ServiceCollectionExtensions.cs    (AddHoneyDrunkCapabilities)
+│   │   ├── Registry/
+│   │   │   └── DefaultCapabilityRegistry.cs  (in-process versioned registry)
+│   │   ├── Dispatch/
+│   │   │   └── DefaultCapabilityInvoker.cs   (guard + dispatch pipeline)
+│   │   ├── Authorization/
+│   │   │   └── AuthBackedCapabilityGuard.cs  (delegates to HoneyDrunk.Auth)
+│   │   └── Telemetry/
+│   │       └── CapabilityTelemetry.cs        (uses ITelemetryActivityFactory)
+│   └── HoneyDrunk.Capabilities.Testing/
+│       ├── HoneyDrunk.Capabilities.Testing.csproj
+│       ├── README.md
+│       ├── CHANGELOG.md
+│       ├── InMemoryCapabilityRegistry.cs
+│       ├── InMemoryCapabilityInvoker.cs
+│       └── PermissiveCapabilityGuard.cs       (allow-all guard for tests)
+└── tests/
+    ├── HoneyDrunk.Capabilities.Abstractions.Tests/  (compile-only smoke tests)
+    ├── HoneyDrunk.Capabilities.Tests/               (DefaultCapabilityRegistry, DefaultCapabilityInvoker, AuthBackedCapabilityGuard tests)
+    └── HoneyDrunk.Capabilities.Testing.Tests/       (InMemory* fixtures verified against Abstractions contracts)
+```
+
+### Solution
+
+`HoneyDrunk.Capabilities.slnx` references the three `src/*` projects and the three `tests/*` projects. Solution-level `Directory.Build.props` sets:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Authors>HoneyDrunk Studios</Authors>
+    <PackageProjectUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Capabilities</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Capabilities</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Version applies to shipping projects only. Test projects are excluded from
+       the solution-shared-version rule per invariant 27. The IsTestProject
+       MSBuild property is set to true by Microsoft.NET.Test.Sdk's targets when
+       a test project imports it; the negative condition therefore matches src/* but not tests/*. -->
+  <PropertyGroup Condition="'$(IsTestProject)' != 'true'">
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+</Project>
+```
+
+Per invariant 27 — "All projects in a solution share one version and move together. Every `.csproj` in the solution (excluding test projects) is updated to the same new version in a single commit." — every src project carries the same `Version` (0.1.0 for this initial release). Test projects are excluded from version-bump scope; the `Condition="'$(IsTestProject)' != 'true'"` wrapper on the `<Version>` PropertyGroup enforces this so test projects do not pick up the version from `Directory.Build.props`.
+
+### Contract details — `HoneyDrunk.Capabilities.Abstractions`
+
+All four D3 contracts. Records drop the `I` prefix; interfaces keep it (Grid-wide naming rule).
+
+```csharp
+// ICapabilityRegistry.cs
+namespace HoneyDrunk.Capabilities.Abstractions;
+
+public interface ICapabilityRegistry
+{
+    Task RegisterAsync(CapabilityDescriptor descriptor, CancellationToken cancellationToken = default);
+    Task<CapabilityDescriptor?> ResolveAsync(string name, string version, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<CapabilityDescriptor>> ListAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<CapabilityDescriptor>> ListVersionsAsync(string name, CancellationToken cancellationToken = default);
+}
+```
+
+The registry key is the pair `(name, version)` per ADR-0017 D6. Unversioned registration is forbidden — the descriptor record requires a non-null/non-empty `Version` field, and `RegisterAsync` validates this and throws on violation. `ListVersionsAsync(name)` returns every registered version of a named tool so callers can iterate available versions when policy permits.
+
+```csharp
+// CapabilityDescriptor.cs (record — drops I prefix per Grid-wide naming rule)
+public sealed record CapabilityDescriptor(
+    string Name,
+    string Version,
+    string OwningNodeId,             // string, not NodeId — Abstractions stays HoneyDrunk-dependency-free
+    string Description,
+    CapabilityParameter[] Parameters,
+    CapabilityReturnType ReturnType,
+    string[] RequiredPermissions);   // policy names resolved by ICapabilityGuard
+
+public sealed record CapabilityParameter(
+    string Name,
+    string SchemaJson,                // JSON-schema fragment for the parameter
+    bool Required,
+    string? Description);
+
+public sealed record CapabilityReturnType(
+    string SchemaJson,                // JSON-schema fragment for the return value
+    string? Description);
+```
+
+**Tool-schema versioning model — fixed at scaffold per D6.** ADR-0017 D6 said "every registered tool descriptor carries an explicit `version` field" and "the specific versioning *model* is deferred to the scaffold packet." This packet picks **plain semantic-version strings** (`"1.0.0"`, `"1.1.0"`, `"2.0.0"`) as the format — `Version` is a `string`, validated by the registry as non-empty (parsing rules, e.g. SemVer compliance, are enforced by analyzer or runtime guard rather than by the type system, to avoid pulling a `SemanticVersion` library into Abstractions). The decision tradeoff: SemVer strings are familiar, mechanical to compare, and avoid coupling the descriptor to a third-party version type. Future packets can tighten parsing if needed.
+
+```csharp
+// ICapabilityInvoker.cs
+public interface ICapabilityInvoker
+{
+    Task<CapabilityInvocationResult> InvokeAsync(
+        CapabilityInvocationRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record CapabilityInvocationRequest(
+    string CapabilityName,
+    string CapabilityVersion,
+    string ArgumentsJson,                  // JSON-encoded arguments matching CapabilityDescriptor.Parameters
+    string CallerCorrelationId);           // string, not CorrelationId — Abstractions stays HoneyDrunk-dependency-free
+
+public sealed record CapabilityInvocationResult(
+    bool Success,
+    string? ResultJson,                    // JSON-encoded result matching CapabilityDescriptor.ReturnType
+    CapabilityInvocationError? Error);
+
+public sealed record CapabilityInvocationError(
+    CapabilityErrorCode Code,
+    string Message,
+    string? DetailsJson);
+
+public enum CapabilityErrorCode
+{
+    /// <summary>The named capability is not registered with the registry.</summary>
+    NotRegistered = 0,
+    /// <summary>The named capability is registered but the requested version is not.</summary>
+    VersionNotFound = 1,
+    /// <summary>The capability guard denied the invocation.</summary>
+    Unauthorized = 2,
+    /// <summary>Argument JSON does not validate against the descriptor's parameter schema.</summary>
+    InvalidArguments = 3,
+    /// <summary>The handler ran but threw or returned a failure.</summary>
+    ExecutionFailed = 4,
+    /// <summary>The invocation was cancelled before the handler completed.</summary>
+    Cancelled = 5,
+    /// <summary>Caller-supplied CallerCorrelationId disagrees with the ambient IGridContext.CorrelationId.</summary>
+    InvalidCorrelationId = 6,
+}
+```
+
+The `Code` field is a typed `CapabilityErrorCode` enum, not a string — adding or removing a value is a public-symbol diff that the contract-shape canary catches. This is intentional: a string with a comment listing legal values would let value removals slip through silently, which the canary's enforcement model is supposed to prevent. Each enum member carries XML doc summarizing when the runtime emits it.
+
+`CapabilityErrorCode` is part of the four-frozen-contracts surface monitored by the contract-shape canary — even though it is a value type rather than a hot-path interface, its stable shape matters because every consumer's error-handling path branches on its values. Removing or reordering a value is a breaking change. The canary scope set in `api-compatibility.yml` is the whole `HoneyDrunk.Capabilities.Abstractions` assembly, so the enum is covered without additional configuration.
+
+```csharp
+// ICapabilityGuard.cs
+public interface ICapabilityGuard
+{
+    Task<CapabilityGuardDecision> CheckAsync(
+        CapabilityDescriptor descriptor,
+        CapabilityInvocationRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record CapabilityGuardDecision(
+    bool Allow,
+    string? DenyReason,
+    string[] EvaluatedPolicies);
+```
+
+The guard returns a structured decision (allow + evaluated-policy list, or deny + reason + evaluated-policy list). The default `AuthBackedCapabilityGuard` (in the runtime package) translates `descriptor.RequiredPermissions` into Auth's `IAuthorizationPolicy` evaluations and aggregates the results.
+
+`HoneyDrunk.Capabilities.Abstractions` references **only** `Microsoft.Extensions.*` abstractions per invariant 1 — specifically `Microsoft.Extensions.Logging.Abstractions` for any logger contracts and `Microsoft.Extensions.Options.Abstractions` if needed. **Do not** reference any other `HoneyDrunk.*` package from Abstractions, including `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.Auth.Abstractions`. This keeps the strict-Abstractions stance per `repos/HoneyDrunk.Capabilities/invariants.md:5` and ADR-0017 D2 (which already reads `Zero runtime dependencies beyond \`Microsoft.Extensions.*\` abstractions.`).
+
+**Strict Abstractions stance is deliberate, not a defect.** Concretely:
+
+- `CapabilityDescriptor.OwningNodeId` is `string`, not `HoneyDrunk.Kernel.Abstractions.NodeId`.
+- `CapabilityInvocationRequest.CallerCorrelationId` is `string`, not `HoneyDrunk.Kernel.Abstractions.CorrelationId`.
+- `ICapabilityGuard` does not transit any Auth type — it works in `descriptor.RequiredPermissions` (string array of policy names). The runtime guard in the `HoneyDrunk.Capabilities` package is what imports `HoneyDrunk.Auth` and translates strings into `IAuthorizationPolicy` evaluations.
+
+GridContext propagation onto invocation activities lives in the runtime package's `CapabilityTelemetry` (which uses Kernel's `ITelemetryActivityFactory`) — not in any Abstractions type.
+
+**First-pass shape; subject to refinement before v0.2.0 baseline lock.** The exact member sets of `CapabilityInvocationRequest`/`Result`/`Error` and the `CapabilityErrorCode` enum are first-pass. The contract-shape canary established in this packet makes any post-v0.1.0 change a deliberate version-bump event, so the executing agent should land workable shapes here without overdesigning — refinement before downstream consumers lock against v0.2.0 is expected.
+
+**Known shape question for v0.2.0:** `CapabilityParameter.Required` is potentially redundant with what a JSON Schema `SchemaJson` already encodes (the standard `required` keyword on object schemas). The two are kept independent in v0.1.0 to avoid pre-committing to a JSON-Schema parser at the boundary, but the duplication invites drift (a parameter could be marked `Required: true` while its schema permits omission, or vice versa). Revisit this before v0.2.0 — either remove `Required` and require callers to read it out of `SchemaJson`, or document an authoritative-source rule. Out of scope for this packet.
+
+### Runtime details — `HoneyDrunk.Capabilities`
+
+`HoneyDrunk.Capabilities` references:
+- `HoneyDrunk.Capabilities.Abstractions` (project reference)
+- `HoneyDrunk.Kernel` (for `ITelemetryActivityFactory`, `IGridContext`, `IOperationContext`)
+- `HoneyDrunk.Auth` (for `IAuthorizationPolicy` evaluation in `AuthBackedCapabilityGuard` per ADR-0017 D5/D10)
+- `Microsoft.Extensions.DependencyInjection.Abstractions`
+- `Microsoft.Extensions.Hosting.Abstractions`
+- `Microsoft.Extensions.Logging.Abstractions`
+
+Three default implementations:
+
+- **`DefaultCapabilityRegistry`** — in-process, thread-safe, version-aware. Uses a `ConcurrentDictionary<string, ConcurrentDictionary<string, CapabilityDescriptor>>` keyed by `(name → version → descriptor)`. `RegisterAsync` validates that `descriptor.Name` and `descriptor.Version` are non-empty and that `(name, version)` is not already registered. `ResolveAsync` returns null for missing entries; `ListVersionsAsync` returns the inner dictionary's values for the named tool.
+- **`DefaultCapabilityInvoker`** — pipeline:
+  1. **Reconcile correlation IDs.** Read the ambient `IGridContext.CorrelationId` via `IGridContextAccessor` (Kernel) and compare against `request.CallerCorrelationId`. If `request.CallerCorrelationId` is non-empty and does not match the ambient `CorrelationId.ToString()` value, return `CapabilityInvocationResult(Success: false, Error: { Code: InvalidCorrelationId })`. If `request.CallerCorrelationId` is empty, accept the ambient value silently. The runtime treats the ambient `IGridContext.CorrelationId` as authoritative; `CallerCorrelationId` is the *string mirror for Abstractions parity* (Abstractions cannot reference `Kernel.CorrelationId`), not an independent ID source.
+  2. Resolve descriptor from registry (return `CapabilityErrorCode.NotRegistered` for an unknown name, `CapabilityErrorCode.VersionNotFound` for a known name with an unknown version)
+  3. Call `ICapabilityGuard.CheckAsync` (return `Unauthorized` if denied, including the deny reason and evaluated policies)
+  4. Open a `CapabilityInvocation` activity via `CapabilityTelemetry`, propagating the ambient `IGridContext` (CorrelationId, CausationId) onto the activity tags.
+  5. Dispatch to the registered handler — handler resolution for v0.1.0 uses a simple `IServiceProvider`-based lookup keyed by `(name, version)`, registered via DI helpers from `ServiceCollectionExtensions`. Handlers throwing produce `ExecutionFailed`; cancellation produces `Cancelled`.
+  6. Close the activity with success/error attributes
+- **`AuthBackedCapabilityGuard`** — depends on `HoneyDrunk.Auth`'s `IAuthorizationPolicy` resolver. For each `descriptor.RequiredPermissions[i]` (string), resolves the matching policy via Auth and evaluates it against the current `IGridContext`'s authenticated identity. Aggregates: all-allow ⇒ allow, any-deny ⇒ deny with the first deny reason. The list of evaluated policy names is returned in `CapabilityGuardDecision.EvaluatedPolicies`.
+- **`CapabilityTelemetry`** — wraps `RegisterAsync`/`ResolveAsync`/`InvokeAsync` calls in `ITelemetryActivityFactory`-created activities, emits per-call attributes (capability name, version, owning node, decision, deny reason if any, latency). This is the "Capabilities emits, Pulse observes" surface from D7. GridContext / CorrelationId propagation onto activity tags also lives here in the runtime package — not in `HoneyDrunk.Capabilities.Abstractions`, which stays HoneyDrunk-dependency-free.
+
+Service registration:
+
+```csharp
+// ServiceCollectionExtensions.cs
+public static IServiceCollection AddHoneyDrunkCapabilities(
+    this IServiceCollection services,
+    Action<CapabilitiesOptions>? configure = null)
+{
+    services.AddSingleton<ICapabilityRegistry, DefaultCapabilityRegistry>();
+    services.AddScoped<ICapabilityInvoker, DefaultCapabilityInvoker>();
+    services.AddScoped<ICapabilityGuard, AuthBackedCapabilityGuard>();
+    // Tool handlers registered by consumer via AddCapabilityHandler<TDescriptorMatch, THandler>()
+    return services;
+}
+```
+
+`AddCapabilityHandler` is a small extension that takes the descriptor `(name, version)` pair and a delegate or `ICapabilityHandler` implementation, registers both, and registers the descriptor with the registry at `IStartupHook` time.
+
+### Testing fixture details — `HoneyDrunk.Capabilities.Testing`
+
+The `Testing` fixture exists for two distinct downstream consumers:
+
+- **Evals** — needs a deterministic registry/invoker/guard chain for reproducible test runs without spinning up real Auth policy resolution.
+- **Other AI-sector and domain Nodes' unit tests** — need to compose `ICapabilityRegistry`/`Invoker`/`Guard` without referencing the runtime package or pulling in Auth.
+
+Implementation:
+
+```csharp
+// InMemoryCapabilityRegistry.cs
+public sealed class InMemoryCapabilityRegistry : ICapabilityRegistry
+{
+    // identical-shape, simpler implementation than DefaultCapabilityRegistry —
+    // backed by a plain Dictionary, single-threaded assumption, no telemetry
+}
+
+// InMemoryCapabilityInvoker.cs
+public sealed class InMemoryCapabilityInvoker : ICapabilityInvoker
+{
+    // takes a registry + a guard + a handler delegate dictionary, dispatches synchronously
+}
+
+// PermissiveCapabilityGuard.cs
+public sealed class PermissiveCapabilityGuard : ICapabilityGuard
+{
+    // always returns CapabilityGuardDecision(Allow: true, DenyReason: null, EvaluatedPolicies: [])
+    // intended for unit tests where the guard surface is not under test
+}
+```
+
+`HoneyDrunk.Capabilities.Testing` references **only** `HoneyDrunk.Capabilities.Abstractions` (project reference) and the test-relevant `Microsoft.Extensions.*` packages — no `HoneyDrunk.Kernel`, no `HoneyDrunk.Auth`. Per invariant 3 (provider/companion packages depend on the parent Node's contracts package, not the runtime), `Testing` references `Abstractions`, never the runtime. This is the same pattern Vault uses for `HoneyDrunk.Vault.Providers.InMemory` referencing `HoneyDrunk.Vault.Abstractions`-equivalent.
+
+### CI workflows
+
+All five workflow files are thin callers of `HoneyDrunk.Actions` reusable workflows. No bespoke CI logic in the Capabilities repo.
+
+```yaml
+# .github/workflows/pr-core.yml
+name: PR Core
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  core:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    with:
+      dotnet-version: '10.0.x'
+```
+
+```yaml
+# .github/workflows/api-compatibility.yml — ADR-0017 D8 / Capabilities canary invariant
+name: API Compatibility (Abstractions)
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/HoneyDrunk.Capabilities.Abstractions/**'
+jobs:
+  abstractions-shape:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml@main
+    with:
+      project-path: src/HoneyDrunk.Capabilities.Abstractions/HoneyDrunk.Capabilities.Abstractions.csproj
+```
+
+The path filter ensures the canary only runs when Abstractions changes — keeps PR feedback fast for runtime/testing-only changes. The whole-assembly diff produced by `job-api-compatibility.yml` is sufficient to enforce D8: per the Capabilities downstream-coupling invariant, Abstractions is the only thing downstream Nodes compile against, so any shape drift in any public type in Abstractions counts.
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  release:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/release.yml@main
+    with:
+      dotnet-version: '10.0.x'
+    secrets: inherit
+```
+
+Tags are human-pushed per invariant 27 — agents do not push tags. The release workflow packs and publishes all three `src/*` projects in a single tag-driven run.
+
+`nightly-deps.yml` and `nightly-security.yml` follow the same thin-caller pattern — copy the configurations from `HoneyDrunk.Auth` or `HoneyDrunk.Vault` for reference. The exact `with:` and `secrets:` blocks should match those repos verbatim so nightly runs converge across Grid Nodes.
+
+### `HoneyDrunk.Standards` wiring
+
+Each `.csproj` references `HoneyDrunk.Standards` with `PrivateAssets="all"` per invariant 26:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="HoneyDrunk.Standards" Version="*" PrivateAssets="all" />
+</ItemGroup>
+```
+
+This pulls in the StyleCop ruleset, `.editorconfig`, and analyzer suite that every Grid repo uses.
+
+### Documentation
+
+- **Repo `README.md`** — purpose statement, package matrix, "How to consume from a downstream Node" snippet showing `AddHoneyDrunkCapabilities()` + `AddCapabilityHandler<...>()`, link to ADR-0017.
+- **Repo `CHANGELOG.md`** — `## [0.1.0] - 2026-MM-DD` entry covering the entire scaffold landing.
+- **Per-package `README.md`** — purpose, public API surface summary, install command. Required by invariant 12 for new packages.
+- **Per-package `CHANGELOG.md`** — `## [0.1.0]` entry for each package introduced in this packet.
+
+## Affected Files
+Entire repo is created from this packet. Notable new files:
+- `HoneyDrunk.Capabilities.slnx`, `Directory.Build.props`, `README.md`, `CHANGELOG.md`, `.editorconfig`, `.gitignore`
+- `src/HoneyDrunk.Capabilities.Abstractions/` — 4 contract files + supporting record/type files + `.csproj` + `README.md` + `CHANGELOG.md`
+- `src/HoneyDrunk.Capabilities/` — `.csproj`, `ServiceCollectionExtensions.cs`, `Registry/DefaultCapabilityRegistry.cs`, `Dispatch/DefaultCapabilityInvoker.cs`, `Authorization/AuthBackedCapabilityGuard.cs`, `Telemetry/CapabilityTelemetry.cs`, `README.md`, `CHANGELOG.md`
+- `src/HoneyDrunk.Capabilities.Testing/` — `.csproj`, `InMemoryCapabilityRegistry.cs`, `InMemoryCapabilityInvoker.cs`, `PermissiveCapabilityGuard.cs`, `README.md`, `CHANGELOG.md`
+- `tests/*` — three test projects with at least smoke-test coverage
+- `.github/workflows/` — 5 workflow files
+
+## NuGet Dependencies
+
+Every new `.csproj` lists `HoneyDrunk.Standards` (`PrivateAssets="all"`) per invariant 26.
+
+### `HoneyDrunk.Capabilities.Abstractions.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+
+(No other PackageReference. Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages, only `Microsoft.Extensions.*` abstractions are permitted, and even those only when needed. Nothing here needs them.)
+
+### `HoneyDrunk.Capabilities.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel` | For `ITelemetryActivityFactory`, `IGridContext`, `IOperationContext` |
+| `HoneyDrunk.Auth` | For `IAuthorizationPolicy` evaluation in `AuthBackedCapabilityGuard` (ADR-0017 D5/D10) |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | DI registration helpers |
+| `Microsoft.Extensions.Hosting.Abstractions` | For startup hook integration |
+| `Microsoft.Extensions.Logging.Abstractions` | Logger contracts |
+
+Project reference: `HoneyDrunk.Capabilities.Abstractions`.
+
+### `HoneyDrunk.Capabilities.Testing.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | for DI helper registration in test fixtures |
+
+Project reference: `HoneyDrunk.Capabilities.Abstractions`. **No reference to `HoneyDrunk.Capabilities` runtime, no reference to `HoneyDrunk.Kernel`, no reference to `HoneyDrunk.Auth`.** The `Testing` package depends on the contract surface only (invariant 3 applied to a non-provider companion package).
+
+### Test projects
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `Microsoft.NET.Test.Sdk` | Standard |
+| `xunit` | Standard |
+| `xunit.runner.visualstudio` | Standard |
+| `Microsoft.Extensions.DependencyInjection` | For DI in registry/invoker/guard tests |
+| `NSubstitute` | For mocking `IAuthorizationPolicy` evaluation in `AuthBackedCapabilityGuard` tests |
+
+Project references as appropriate to each `.Tests` project.
+
+## Boundary Check
+- [x] All work inside `HoneyDrunk.Capabilities`. No edits to other Grid repos.
+- [x] `HoneyDrunk.Capabilities.Abstractions` carries zero `HoneyDrunk.*` references — invariant 1.
+- [x] `HoneyDrunk.Capabilities.Testing` references only `HoneyDrunk.Capabilities.Abstractions` — invariant 3 applied to the Testing fixture.
+- [x] No tool implementations live in any Capabilities package — `repos/HoneyDrunk.Capabilities/invariants.md:14` ("Tool implementations never live in the Capabilities package"). The scaffold ships registry, invoker, guard, telemetry only.
+- [x] Every invocation passes through `ICapabilityGuard` via `DefaultCapabilityInvoker` — `repos/HoneyDrunk.Capabilities/invariants.md:8` ("Every tool invocation passes through a permission check"). No bypass surface.
+- [x] Tool descriptors require non-empty `Version`; `RegisterAsync` validates and throws — D6 enforced.
+- [x] No secrets in code. The Auth dependency in `AuthBackedCapabilityGuard` resolves policy by name via `HoneyDrunk.Auth`'s already-stable contracts; no credentials touched.
+- [x] Records (`CapabilityDescriptor`, `CapabilityParameter`, `CapabilityReturnType`, `CapabilityInvocationRequest`, `CapabilityInvocationResult`, `CapabilityInvocationError`, `CapabilityGuardDecision`) all drop the `I` prefix; interfaces (`ICapabilityRegistry`, `ICapabilityInvoker`, `ICapabilityGuard`) keep it (Grid-wide naming rule).
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Capabilities.slnx` builds clean from a fresh clone via `dotnet build` with no warnings (warnings-as-errors).
+- [ ] All four D3 contracts present in `HoneyDrunk.Capabilities.Abstractions` with XML documentation per invariant 13.
+- [ ] `HoneyDrunk.Capabilities.Abstractions` has zero `HoneyDrunk.*` PackageReference or ProjectReference entries (invariant 1 enforced).
+- [ ] `HoneyDrunk.Capabilities.Testing` has zero references to `HoneyDrunk.Capabilities` (the runtime), `HoneyDrunk.Kernel`, or `HoneyDrunk.Auth`. Only `HoneyDrunk.Capabilities.Abstractions` and Microsoft.Extensions.*.
+- [ ] `HoneyDrunk.Capabilities` runtime exposes `AddHoneyDrunkCapabilities()` extension; `ICapabilityRegistry`, `ICapabilityInvoker`, `ICapabilityGuard` all resolve from DI after registration.
+- [ ] `DefaultCapabilityRegistry.RegisterAsync` rejects descriptors with null/empty `Version` (per ADR-0017 D6 / the descriptor-versioning invariant). A unit test covers this.
+- [ ] `DefaultCapabilityInvoker` calls `ICapabilityGuard.CheckAsync` before dispatch on every invocation. A unit test verifies the guard is called and that an `Unauthorized` result short-circuits dispatch.
+- [ ] `DefaultCapabilityInvoker` reconciles `request.CallerCorrelationId` against the ambient `IGridContext.CorrelationId` (resolved via Kernel's `IGridContextAccessor`). If `CallerCorrelationId` is non-empty and disagrees with the ambient value, the invoker returns `CapabilityInvocationResult(Success: false, Error: { Code: InvalidCorrelationId })`. Empty `CallerCorrelationId` is accepted silently and the ambient value is used. Unit tests cover all three cases (empty caller, matching caller, mismatched caller).
+- [ ] `AuthBackedCapabilityGuard` translates `descriptor.RequiredPermissions` into Auth policy evaluations via `IAuthorizationPolicy` (mocked in tests). All-allow ⇒ allow; any-deny ⇒ deny.
+- [ ] `CapabilityTelemetry` emits a `Capability.Register` activity on every `RegisterAsync` call, tagged with `capability.name`, `capability.version`, `capability.owning_node`. Verified by a test using a `TestActivityListener`-style fixture against `ITelemetryActivityFactory`.
+- [ ] `CapabilityTelemetry` emits a `Capability.Resolve` activity on every `ResolveAsync` call, tagged with `capability.name`, `capability.version`, and `capability.resolved` (bool). Verified by a test.
+- [ ] `CapabilityTelemetry` emits a `Capability.Invoke` activity on every `InvokeAsync` call, tagged with `capability.name`, `capability.version`, `capability.guard_decision` (Allow/Deny), `capability.outcome` (Success/error code), and the ambient `correlation_id` and `causation_id` from `IGridContext`. Verified by a test that runs a full happy-path invocation and asserts the emitted activity tags.
+- [ ] `HoneyDrunk.Capabilities.Testing` ships `InMemoryCapabilityRegistry`, `InMemoryCapabilityInvoker`, and `PermissiveCapabilityGuard`. Each is fully functional and verified by unit tests against the four D3 contracts.
+- [ ] All five `.github/workflows/*.yml` files present and reference `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/*@main`.
+- [ ] `api-compatibility.yml` runs on PR. On the scaffolding PR itself the workflow runs against an absent `main` baseline and reports `status: skipped` per the `HoneyDrunk.Actions/.github/actions/api/check-compatibility/action.yml` missing-baseline path (it emits a `::warning::` and exits 0 when `git worktree add` against the baseline ref fails) — that is correct first-build behavior, not a failure. The scaffolding PR merge establishes the `main` baseline. **Verify post-merge** by opening a throwaway PR that removes a public member from `ICapabilityRegistry` (or any other frozen contract); the workflow must fail with breaking-changes-detected. Revert the throwaway PR after observation.
+- [ ] `pr-core.yml` passes on the initial scaffolding PR (build + tests + analyzers + dependency scan + secret scan).
+- [ ] Repo-level `CHANGELOG.md` has a `## [0.1.0]` entry covering the scaffold; per-package `CHANGELOG.md` files each have their own `## [0.1.0]` entry naming the package's specific introductions (per invariants 12 and 27).
+- [ ] Repo-level `README.md` and per-package `README.md` files all present per invariant 12.
+- [ ] Test suite runs and passes — minimum coverage: `DefaultCapabilityRegistry` register/resolve/list-versions happy path + version-validation rejection test, `DefaultCapabilityInvoker` guard-allow + guard-deny tests, `AuthBackedCapabilityGuard` all-allow + first-deny tests using mocked `IAuthorizationPolicy`, `InMemoryCapabilityRegistry`/`Invoker`/`PermissiveCapabilityGuard` smoke tests.
+- [ ] All projects in the solution carry the same `Version` (0.1.0), excluding test projects (invariant 27).
+- [ ] Manual confirmation that pushing tag `v0.1.0` triggers `release.yml` and produces NuGet packages for the three `src/*` projects (do not actually push the tag — verify the workflow exists and a tag-push trigger is configured).
+
+## Human Prerequisites
+- [ ] Confirm OIDC federated credential exists for the `HoneyDrunk.Capabilities` repo's release workflow against the Grid's NuGet publishing identity. Cross-link: [`infrastructure/oidc-federated-credentials.md`](../../../../infrastructure/oidc-federated-credentials.md). The Grid has a standard NuGet publishing identity used by every Node — confirm `repo:HoneyDrunkStudios/HoneyDrunk.Capabilities:ref:refs/tags/v*` is in its federated credential list.
+- [ ] After this packet's PR merges, push tag `v0.1.0` from `main` to trigger the first NuGet publish. Tags are human-pushed per invariant 27.
+- [ ] Repo settings: branch protection on `main` requires `pr-core / core` and `api-compatibility / abstractions-shape` checks, no force-pushes, signed commits not required (matches other Grid repos). Most of these are seeded by packet 03's repo-creation steps; confirm they are still in place at this point.
+- [ ] No Azure resource provisioning required for this packet — HoneyDrunk.Capabilities is a library Node, not a deployable.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+
+> **Invariant 2:** Runtime packages depend on Abstractions, never on other runtime packages at the same layer. — `HoneyDrunk.Capabilities.Testing` references `HoneyDrunk.Capabilities.Abstractions`, not `HoneyDrunk.Capabilities` runtime.
+
+> **Invariant 3:** Provider packages depend on their parent Node's contracts, not internal implementation details. When a Node splits contracts into a separate package (as `HoneyDrunk.Capabilities.Abstractions` does), companion packages reference that package. — Applied here to the `Testing` fixture as well: it references `Abstractions`, never the runtime.
+
+> **Invariant 4:** No circular dependencies. The dependency graph is a DAG. Kernel is always at the root. — `HoneyDrunk.Capabilities` references `Kernel` and `Auth`; nothing in `HoneyDrunk.Capabilities.*` is referenced back from Kernel or Auth.
+
+> **Invariant 11:** One repo per Node. Each repo has its own solution, CI pipeline, and versioning. — This packet is the establishment of HoneyDrunk.Capabilities's solution and CI pipeline.
+
+> **Invariant 12:** Semantic versioning with CHANGELOG and README. New projects must have both files from the first commit. Repo-level `CHANGELOG.md` is mandatory; per-package `CHANGELOG.md` and `README.md` required for each package.
+
+> **Invariant 13:** All public APIs have XML documentation. Enforced by HoneyDrunk.Standards analyzers. — All four D3 contracts and their supporting types must carry `///` summaries.
+
+> **Invariant 14:** Canary tests validate cross-Node boundaries. Each Node that depends on another has a `.Canary` project verifying integration assumptions. — Future-facing: downstream Nodes will add `.Canary` projects against `HoneyDrunk.Capabilities.Abstractions`. This packet does not author those — they belong with each downstream Node's stand-up. The Capabilities-side Canary covers Auth integration for `AuthBackedCapabilityGuard` and Kernel integration for context propagation; both can be added in a follow-up packet once Capabilities's runtime is exercising them in a deployable host.
+
+> **Invariant 15:** Tests never depend on external services. Use InMemory providers for isolation. — `HoneyDrunk.Capabilities.Testing` exists specifically to satisfy this for downstream Nodes' tests.
+
+> **Invariant 16:** No test code in runtime packages. Tests live in dedicated `.Tests` or `.Canary` projects only. — `HoneyDrunk.Capabilities.Testing` is **not** test code. It is a production-quality fixture *used by* tests. The package itself is not a test project; consumers reference it from their test projects.
+
+> **Invariant 26:** Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section. `HoneyDrunk.Standards` must be explicitly listed on every new .NET project (StyleCop + EditorConfig analyzers, `PrivateAssets: all`). — This packet's NuGet Dependencies section enumerates all three new `src/*` projects' references plus test project references.
+
+> **Invariant 27:** All projects in a solution share one version and move together. When a version bump is warranted, every `.csproj` in the solution (excluding test projects) is updated to the same new version in a single commit. — Initial scaffold ships at `0.1.0` across all three packages.
+
+> **Capabilities downstream-coupling invariant (number assigned by packet 02):** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Capabilities.Abstractions`. Composition against `HoneyDrunk.Capabilities` and `HoneyDrunk.Capabilities.Testing` is a host-time (and test-time) concern, resolved at application startup. Test projects may reference `HoneyDrunk.Capabilities.Testing` to pick up the in-memory fixture. Production projects must not. — Reinforced in this scaffold by giving `Abstractions` zero HoneyDrunk dependencies so consumers don't transit unintended pins.
+
+> **Capabilities descriptor-versioning invariant (number assigned by packet 02):** Every registered capability descriptor carries an explicit version; the registry key is `(name, version)`. Unversioned registration is a build failure. — `DefaultCapabilityRegistry.RegisterAsync` validates `descriptor.Version` is non-empty and throws on violation; a unit test covers this.
+
+> **Capabilities authorization invariant (number assigned by packet 02):** Authorization for capability invocation is resolved through `HoneyDrunk.Auth` policy via `ICapabilityGuard`. Capabilities does not maintain an independent permission model. Invocation paths must always pass through the guard before dispatch — no bypass surface exists. — `DefaultCapabilityInvoker` always calls `ICapabilityGuard.CheckAsync` before dispatching; a unit test verifies the guard short-circuits dispatch when it returns Allow=false. The default guard is `AuthBackedCapabilityGuard`, which delegates to `HoneyDrunk.Auth`'s `IAuthorizationPolicy`.
+
+> **Capabilities contract-shape canary invariant (number assigned by packet 02):** The HoneyDrunk.Capabilities Node CI must include a contract-shape canary that fails the build on shape drift to `ICapabilityRegistry`, `CapabilityDescriptor`, `ICapabilityInvoker`, or `ICapabilityGuard` without a corresponding version bump. — `api-compatibility.yml` covers this by scoping to `HoneyDrunk.Capabilities.Abstractions`.
+
+## Referenced ADR Decisions
+
+**ADR-0017 D1 (Tool-registry and dispatch substrate):** HoneyDrunk.Capabilities is the AI sector's shared tool-registry and dispatch substrate, not an orchestrator. This scaffold ships only the substrate — no agent execution, no tool implementations, no policy management.
+
+**ADR-0017 D2 (Package families):** Three package families — `Abstractions` + runtime + `Testing` fixture. All three land in this packet. The `Testing` package is a separate NuGet artifact, not a `Providers.*` slot, because there is no family of providers at the registry layer (no OpenAI-vs-Anthropic axis here).
+
+**ADR-0017 D3 (Exposed contracts):** Four contracts. Records drop `I`; interfaces keep it. The placeholder `ICapability` and `ICapabilityPermission` entries from the prior catalog are **not** authored here — they are superseded by the D3 surface.
+
+**ADR-0017 D5 (Authorization through Auth) and D10 (Auth dependency is first-class):** `AuthBackedCapabilityGuard` is the default `ICapabilityGuard` implementation. It delegates allow/deny decisions to `HoneyDrunk.Auth` via `IAuthorizationPolicy`. Capabilities does not invent its own permission model.
+
+**ADR-0017 D6 (Tool-schema versioning principle, mechanism deferred):** Every descriptor carries an explicit `Version` field. The registry key is `(name, version)`. The scaffold packet picks **plain SemVer strings** as the format — `Version` is a `string`, validated as non-empty by the registry. SemVer parsing is enforced at runtime by analyzer rules (or a future invariant if drift appears), not by the type system. Future packets can tighten parsing without a breaking change to `CapabilityDescriptor` (the field stays `string`).
+
+**ADR-0017 D7 (Telemetry direction):** `CapabilityTelemetry` emits via `ITelemetryActivityFactory` (Kernel). No Pulse package reference. Pulse consumes downstream — out of scope for this packet.
+
+**ADR-0017 D8 (Contract-shape canary):** `api-compatibility.yml` is the canary. Scoped to `HoneyDrunk.Capabilities.Abstractions` since per D9 that is the only public-boundary package.
+
+**ADR-0017 D9 (Downstream coupling):** `Abstractions` is dependency-clean so downstream Nodes can take it without pulling Kernel, Auth, or any other Grid dependency transitively.
+
+**ADR-0017 D2 strict-Abstractions phrasing (already in the ADR text pre-filing):** The strict-Abstractions stance is the active rule. `HoneyDrunk.Capabilities.Abstractions` ships with zero `HoneyDrunk.*` references, including no `HoneyDrunk.Kernel.Abstractions`. Concretely: `CapabilityDescriptor.OwningNodeId` is `string`, `CapabilityInvocationRequest.CallerCorrelationId` is `string`. GridContext propagation lives in the runtime package's `CapabilityTelemetry`, not in any Abstractions type.
+
+## Dependencies
+- `packet:01` — catalog registration must land first so the Architecture catalogs match what this packet ships, and so the integration-points doc exists for the canary checklist.
+- `packet:02` — the four Capabilities invariants (downstream coupling, descriptor versioning, Auth as authorization root, contract-shape canary) must exist in `constitution/invariants.md` at their assigned numbers before this packet's acceptance criteria reference them.
+- `packet:03` — the GitHub repo must exist before this packet can be filed against it. Per the dispatch plan, packet 04 cannot be filed until packet 03 is closed.
+
+## Labels
+`feature`, `tier-2`, `ai`, `scaffolding`, `new-node`, `adr-0017`
+
+## Agent Handoff
+
+**Objective:** Take the empty `HoneyDrunk.Capabilities` repo (created by packet 03) and ship version 0.1.0 with the four D3 contracts, default registry/invoker/Auth-backed guard implementations, in-memory testing fixture, full CI, and the contract-shape canary scoped to Abstractions.
+
+**Target:** HoneyDrunk.Capabilities, branch from `main`. (The repo exists at this point — packet 03 created it with an initial README. Branch from `main` for the first feature commit; do not push directly to `main`.)
+
+**Context:**
+- Goal: Unblock five AI-sector consumer Nodes (Agents, Operator, Memory, Knowledge, Evals) and every domain Node that registers an agent-callable tool (Data, Notify, Vault).
+- Feature: ADR-0017 standup initiative — this is the substrate scaffold, the fourth and largest packet of the initiative.
+- ADRs: ADR-0017 (sole governing ADR for the standup).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packets 01, 02, and 03 of this initiative must complete first.
+
+**Constraints:**
+
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — `HoneyDrunk.Capabilities.Abstractions.csproj` must contain no `HoneyDrunk.*` PackageReference or ProjectReference. The `HoneyDrunk.Standards` reference uses `PrivateAssets="all"` so it does not propagate.
+- **Invariant 3 applied to the `Testing` fixture:** The `Testing` package depends on the parent Node's contracts package, not the runtime. — `HoneyDrunk.Capabilities.Testing.csproj` must reference only `HoneyDrunk.Capabilities.Abstractions`. No reference to `HoneyDrunk.Capabilities` runtime, no reference to `HoneyDrunk.Kernel`, no reference to `HoneyDrunk.Auth`.
+- **`repos/HoneyDrunk.Capabilities/invariants.md:8`:** Every tool invocation passes through a permission check. `ICapabilityGuard` is evaluated before dispatch. No bypass path exists. — `DefaultCapabilityInvoker` calls `ICapabilityGuard.CheckAsync` on every invocation. Unit test covers this.
+- **`repos/HoneyDrunk.Capabilities/invariants.md:11`:** Tool schemas are versioned. Breaking changes to a tool's parameter or return schema require a new version. — `CapabilityDescriptor.Version` is required; `DefaultCapabilityRegistry.RegisterAsync` validates and throws on null/empty.
+- **`repos/HoneyDrunk.Capabilities/invariants.md:14`:** Tool implementations never live in the Capabilities package. Capabilities owns the registry and dispatch. Implementations live in their owning Nodes. — This scaffold ships zero tool implementations. Handler registration is a DI extension that consumers use to wire their Node's tools; it is not the implementation surface.
+- **`repos/HoneyDrunk.Capabilities/invariants.md:17`:** Unregistered tool invocations fail fast. Attempting to invoke a tool that is not registered returns a structured error, not an exception. — `DefaultCapabilityInvoker` returns `CapabilityInvocationResult(Success: false, Error: { Code: CapabilityErrorCode.NotRegistered })` for an unregistered name (or `CapabilityErrorCode.VersionNotFound` if the name is registered but the version is not) for unregistered `(name, version)` pairs. No exception is thrown for the not-registered case (cancellation and execution failure produce different codes).
+- **`repos/HoneyDrunk.Capabilities/invariants.md:20`:** GridContext is propagated through tool invocations. The dispatch pipeline carries CorrelationId and CausationId from agent to tool implementation. — `CapabilityTelemetry` enriches the activity with the current `IGridContext`. The runtime invoker picks up `IGridContext` via `IGridContextAccessor` from Kernel; `CallerCorrelationId` on the request is the *string* mirror so Abstractions can describe the propagation without referencing Kernel types.
+- **Invariant 9 (Vault is the only source of secrets):** No secrets touched in this packet. The Auth dependency is policy resolution by name, not credentials.
+- **Invariant 12:** Semantic versioning with CHANGELOG and README. New projects must have both files from the first commit. — Every one of the three `src/*` projects must ship a `README.md` and `CHANGELOG.md` in the same commit it is added.
+- **Invariant 13:** All public APIs have XML documentation. — Every public type/member in `HoneyDrunk.Capabilities.Abstractions` carries `///` summaries. StyleCop rules from `HoneyDrunk.Standards` enforce this.
+- **Invariant 26:** Packets for .NET code work must include `## NuGet Dependencies`. `HoneyDrunk.Standards` must be on every new .NET project. — Confirmed in the NuGet Dependencies section above.
+- **Invariant 27:** All projects in a solution share one version. — Every `src/*.csproj` ships at `0.1.0`. Test projects do not bump.
+- **Capabilities downstream-coupling invariant (assigned by packet 02):** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Capabilities.Abstractions`. — Reinforced by keeping Abstractions HoneyDrunk-dependency-free.
+- **Capabilities descriptor-versioning invariant (assigned by packet 02):** Every registered descriptor carries an explicit version. — Enforced at register-time in `DefaultCapabilityRegistry`.
+- **Capabilities authorization invariant (assigned by packet 02):** Invocation paths always pass through `ICapabilityGuard`. — `DefaultCapabilityInvoker` calls the guard on every dispatch.
+- **Capabilities contract-shape canary invariant (assigned by packet 02):** CI must include the canary on the four hot-path contracts. — `api-compatibility.yml` covers this by scoping to `HoneyDrunk.Capabilities.Abstractions`.
+- **Canary on the scaffolding PR is expected to report `status: skipped`, not fail.** The shared `HoneyDrunk.Actions/.github/actions/api/check-compatibility/action.yml` emits `::warning::` and exits 0 with `status: skipped` when `git worktree add` against the baseline ref fails — which it always does on a first PR against a near-empty repo (the repo has only the README from packet 03, no Abstractions assembly to baseline against). Do not treat the skip as a misconfiguration. The scaffolding PR's merge establishes the `main` baseline; verification of the canary actually firing happens **post-merge** via a throwaway breaking-change PR that is reverted after observation.
+- **Strict Abstractions stance is deliberate.** `HoneyDrunk.Capabilities.Abstractions` ships with zero `HoneyDrunk.*` references. This is the user's standing scoping resolution applied to ADR-0017 D2 (which already reads `Zero runtime dependencies beyond \`Microsoft.Extensions.*\` abstractions.`) and matches `repos/HoneyDrunk.Capabilities/invariants.md:5`. Concretely: `CapabilityDescriptor.OwningNodeId` is `string`, `CapabilityInvocationRequest.CallerCorrelationId` is `string`. Any GridContext/CorrelationId propagation belongs in the `HoneyDrunk.Capabilities` runtime package (specifically `CapabilityTelemetry`), not in Abstractions. Do not import `HoneyDrunk.Kernel.Abstractions` in any `HoneyDrunk.Capabilities.Abstractions` source file.
+- **Records drop `I`; interfaces keep it.** `CapabilityDescriptor`, `CapabilityParameter`, `CapabilityReturnType`, `CapabilityInvocationRequest`, `CapabilityInvocationResult`, `CapabilityInvocationError`, `CapabilityGuardDecision` are all records. `ICapabilityRegistry`, `ICapabilityInvoker`, `ICapabilityGuard` are interfaces.
+- **D3 is canonical, not the prior catalog placeholder.** Author exactly the four D3 contracts. Do **not** author `ICapability` or `ICapabilityPermission`. If a doc anywhere mentions them, that is drift to be cleaned up by packet 01 or as a follow-up — do not re-introduce the types.
+- **Naming-collision discipline (D4).** Do not use the word "actions" to describe tool invocations in code, comments, or docs (the Ops Node `HoneyDrunk.Actions` owns that English word). Do not use `capabilities:` as a YAML/JSON key for runtime concepts (the superseded ADR-0004 used that as agent-definition frontmatter).
+
+**Key Files:**
+- `HoneyDrunk.Capabilities.slnx`, `Directory.Build.props`
+- `src/HoneyDrunk.Capabilities.Abstractions/ICapabilityRegistry.cs`, `CapabilityDescriptor.cs`, `ICapabilityInvoker.cs`, `ICapabilityGuard.cs` and supporting record types in the same folder
+- `src/HoneyDrunk.Capabilities/ServiceCollectionExtensions.cs`, `Registry/DefaultCapabilityRegistry.cs`, `Dispatch/DefaultCapabilityInvoker.cs`, `Authorization/AuthBackedCapabilityGuard.cs`, `Telemetry/CapabilityTelemetry.cs`
+- `src/HoneyDrunk.Capabilities.Testing/InMemoryCapabilityRegistry.cs`, `InMemoryCapabilityInvoker.cs`, `PermissiveCapabilityGuard.cs`
+- `.github/workflows/{pr-core,release,nightly-deps,nightly-security,api-compatibility}.yml`
+- `README.md`, `CHANGELOG.md` (repo-level), per-package `README.md` and `CHANGELOG.md`
+- `tests/HoneyDrunk.Capabilities.Tests/`, `tests/HoneyDrunk.Capabilities.Testing.Tests/`
+
+**Contracts:**
+- All four D3 contracts authored fresh in this packet inside `HoneyDrunk.Capabilities.Abstractions`.
+- The contract-shape canary establishes its baseline against this packet's commit. Future shape changes to any public type in Abstractions trigger the canary.

--- a/generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/dispatch-plan.md
@@ -1,0 +1,121 @@
+# Dispatch Plan — ADR-0017 HoneyDrunk.Capabilities Standup
+
+**Initiative:** `adr-0017-honeydrunk-capabilities-standup`
+**Sector:** AI
+**Governing ADR:** [ADR-0017 — Stand Up the HoneyDrunk.Capabilities Node](../../../../adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md) (Proposed 2026-04-19; stays Proposed across all four packet PRs. Flips to Accepted only after every packet in this initiative is closed, as a separate post-merge housekeeping step the scope agent runs — see "Status-flip handling" below.)
+**Trigger:** ADR-0017 in the Proposed queue. Five AI-sector Nodes (Agents, Operator, Memory, Knowledge, Evals) plus every domain Node that exposes agent-callable tools (Data, Notify, Vault) are blocked on `HoneyDrunk.Capabilities.Abstractions` existing. This initiative builds the tool-registry and dispatch substrate that unblocks them.
+**Type:** Multi-repo (3 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.Capabilities` + the human chore that creates the latter)
+**Site sync required:** No (scaffold-only; no public-API surface change needs site update yet — when 0.1.0 ships and downstream Nodes start consuming, a site-sync follow-up may be warranted)
+**Rollback plan:** Each packet is a single PR. Rollback is `git revert`. The new `HoneyDrunk.Capabilities` repo's `0.1.0` tag is published only after the human pushes the tag — which is post-merge — so a rollback before tag push is just a revert. After tag push, NuGet packages are immutable but unconsumed at this point in the rollout (downstream Nodes haven't started yet).
+
+## Summary
+
+ADR-0017 is the standup ADR for `HoneyDrunk.Capabilities`. It decides what the Node owns (D1), the package families (D2 — `Abstractions`, runtime, `Testing`), the four exposed contracts (D3 — `ICapabilityRegistry`, `CapabilityDescriptor`, `ICapabilityInvoker`, `ICapabilityGuard`), naming-collision disambiguation (D4), Auth as the authorization root (D5/D10), versioning principle (D6), one-way telemetry to Pulse (D7), the contract-shape canary (D8), and the downstream coupling rule (D9). None of that has been built — the AI repo's catalog entry exists but the GitHub repo does not.
+
+Four packets land the work:
+
+1. **Architecture catalog registration + integration-points** — reconcile `contracts.json` (deprecate `ICapability`/`ICapabilityPermission`, add the four D3 contracts), update `relationships.json` exposes, refresh `grid-health.json`, refresh `nodes.json` and `ai-sector-architecture.md` to match D3 names and the D7 telemetry direction, refresh `repos/HoneyDrunk.Capabilities/overview.md` to drop `ICapabilityDescriptor` (interface) in favor of `CapabilityDescriptor` (record), add a new `repos/HoneyDrunk.Capabilities/integration-points.md`, and update the active-initiatives tracker. Does **not** flip ADR-0017's Status — that is a separate post-merge housekeeping step.
+2. **Constitution invariants** — four new invariants from D9, D6, D5/D10, D8 added to `constitution/invariants.md` at the next four free numbers (currently 43/44/45/46 assuming ADR-0016 lands first and takes 40/41/42; collision check at edit time may shift these).
+3. **Create the HoneyDrunk.Capabilities GitHub repo** — human-only org-admin chore. The GitHub repo does not exist yet. Repo creation is not delegated to agents.
+4. **HoneyDrunk.Capabilities scaffold** — empty repo to first-shippable state. Solution, three packages (`HoneyDrunk.Capabilities.Abstractions`, `HoneyDrunk.Capabilities`, `HoneyDrunk.Capabilities.Testing`), four contracts in `Abstractions`, default registry/invoker/guard implementations in the runtime, in-memory registry/dispatcher fixture in `Testing`, five CI workflow files including the contract-shape canary scoped to `Abstractions` per ADR-0017 D8.
+
+## Wave Diagram
+
+```
+Wave 1: Architecture catalog + constitution updates (sequential)
+   ├─ Architecture: 01-architecture-capabilities-catalog-registration
+   └─ Architecture: 02-architecture-capabilities-invariants
+       Blocked by: 01 (so the invariant text aligns with the contract surface 01 lands)
+
+Wave 2: GitHub repo creation (human-only, parallel-able with Wave 1 in clock time
+        but sequenced after Wave 1 here so the tracking issue lands once the
+        catalogs already point at the eventual repo)
+   └─ Architecture: 03-architecture-create-capabilities-repo
+       Blocked by: 01
+
+Wave 3: Capabilities repo scaffold
+   └─ HoneyDrunk.Capabilities: 04-capabilities-node-scaffold
+       Blocked by: 01, 02, 03
+```
+
+In practice 01 and 02 are both Architecture-repo packets touching different files (catalogs/integration-points vs constitution), so they could be reviewed as a single PR. They are kept as separate packets to honor the "one logical change per packet" rule and to give a clean review surface for each.
+
+Packet 03 is human-only and gates packet 04 because the repo it creates is the target repo of packet 04 — `file-packets.sh` cannot file an issue against a repo that does not exist yet.
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 01 | [Catalog registration + integration-points](./01-architecture-capabilities-catalog-registration.md) | Architecture | 1 | Agent | — |
+| 02 | [Add four new invariants for D9 / D6 / D5+D10 / D8](./02-architecture-capabilities-invariants.md) | Architecture | 1 | Agent | 01 |
+| 03 | [Create `HoneyDrunk.Capabilities` GitHub repo (human-only)](./03-architecture-create-capabilities-repo.md) | Architecture | 2 | Human | 01 |
+| 04 | [Stand up `HoneyDrunk.Capabilities` — solution, three packages, contracts, CI, in-memory testing fixture](./04-capabilities-node-scaffold.md) | HoneyDrunk.Capabilities | 3 | Agent | 01, 02, 03 |
+
+## Phase Mapping
+
+- **Wave 1 (packets 01 + 02) = ADR-0017's "If Accepted" catalog/constitution obligations.**
+  - Packet 01 covers `contracts.json` reconciliation, `grid-health.json` refresh, and the new `integration-points.md`. Packet 01 does **not** flip ADR-0017's Status — that is handled separately post-merge (see "Status-flip handling" below).
+  - Packet 02 covers the invariants ADR-0017 explicitly delegates to the scope agent at acceptance.
+- **Wave 2 (packet 03) = the human-only repo creation chore.** Surfaced as its own packet so it lives on The Hive board with `Actor=Human` and the `human-only` label, instead of being an implicit prerequisite of packet 04.
+- **Wave 3 (packet 04) = the standup itself.** Three packages (not six, unlike AI), four contracts, an in-memory fixture in a separate `Testing` NuGet artifact rather than a `Providers.*` slot per ADR-0017 D2.
+
+## Filing-order rule
+
+Packet 04 hard-codes invariant numbers in its body and acceptance criteria. Filed packets are immutable (invariant 24). Therefore:
+
+**Packet 02 must be filed, its PR merged, and the assigned invariant numbers locked in `constitution/invariants.md` before packet 04 is filed.**
+
+If packet 02's collision check at edit time forces a renumber away from the assumed 43/44/45/46 — for example because ADR-0016 lands first and takes 40/41/42 (consuming the next-three-free that ADR-0026 left at 39), then ADR-0010 Phase 1 lands and takes 29-30, or some other ADR grabs slots in the interim — the packet 04 source file at `generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md` MUST be amended in place before push (it has not been filed yet at that point — invariant 24's pre-filing carve-out applies).
+
+**Packets 02 and 04 cannot be filed in the same push.** Concretely:
+
+1. Push packets 01 and 02 (they may travel together — packet 02's `dependencies: ["packet:01"]` wires the blocking edge automatically).
+2. Push packet 03 in the same wave or shortly after (it depends only on 01).
+3. Wait for packet 02's PR to merge so the assigned invariant numbers actually land in `constitution/invariants.md`.
+4. Wait for packet 03 to close (the repo must exist before packet 04 can be filed against it).
+5. If the numbers shifted away from the assumed 43/44/45/46, edit `04-capabilities-node-scaffold.md` in place to match (pre-filing carve-out under invariant 24).
+6. Push packet 04.
+
+Packet 02's acceptance criteria call this out; packet 04's body assumes the lock has happened.
+
+## What This Initiative Does **NOT** Deliver
+
+The five AI-sector Nodes that consume Capabilities (Agents, Operator, Memory, Knowledge, Evals) are **not** delivered by this initiative. The initiative unblocks them, but each gets its own bring-up under its own standup ADR per the user's "new-Node scaffolding gets its own ADR/packet" rule.
+
+Tool implementations from domain Nodes (Data, Notify, Vault registering their own callable surfaces against `ICapabilityRegistry`) are **not** in scope. Each domain Node will register its tools in a follow-up packet once its agent-callable surface is decided.
+
+The specific tool-schema versioning *mechanism* — name-suffixed strings, strict semver on the package, or a hybrid — is deferred to packet 04 per ADR-0017 D6. The stand-up contract is "versioning is required, descriptors declare it, registry lookup is version-aware" — packet 04 picks the format.
+
+The contract-shape canary in this initiative is wired by reusing `HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml` (the same workflow ADR-0016 D8 leverages for AI). No Actions repo change is required.
+
+## Notes
+
+- **Scoping insight: the contract-shape canary needs no Actions packet.** `HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml` already exists and supports `project-path`-scoped diffing. Per ADR-0017 D9, `HoneyDrunk.Capabilities.Abstractions` is the only public-boundary package — so scoping the canary to that one assembly satisfies D8 without per-type filtering. The wiring is a single `.github/workflows/api-compatibility.yml` file inside HoneyDrunk.Capabilities itself, folded into packet 04's CI bring-up. No Actions repo change required.
+
+- **Why a separate `Testing` package, not a provider slot.** ADR-0017 D2 is explicit: there is no family of providers at the registry layer (no OpenAI-vs-Anthropic axis on the tool-registry side). The in-memory implementation is a testing fixture for downstream Nodes' deterministic unit and integration tests, not a production backend. Shipping it as `HoneyDrunk.Capabilities.Testing` (separate NuGet artifact) makes the intent explicit — production composition references `HoneyDrunk.Capabilities`, test projects reference `HoneyDrunk.Capabilities.Testing`.
+
+- **Naming collision disambiguation surfaces in two repo edits.** ADR-0017 D4 disambiguates two collisions: (a) the superseded ADR-0004's `capabilities:` YAML frontmatter on agent definition files, and (b) HoneyDrunk.Actions (Ops Node for CI/CD). Neither is a code change, but packet 01 should ensure no doc in `repos/HoneyDrunk.Capabilities/` accidentally calls the Node's primitives "actions" or borrows the frontmatter word.
+
+- **Strict Abstractions stance — same precedent as ADR-0016.** Per the user's resolution during ADR-0016 scoping, Abstractions packages ship with zero `HoneyDrunk.*` references. ADR-0017 D2 says `HoneyDrunk.Capabilities.Abstractions` has "Zero runtime dependencies beyond `HoneyDrunk.Kernel` abstractions" — the executing agent for packet 04 must apply the strict stance regardless. Concretely: Capabilities-side types that need a correlation/identity reference use `string`, not `CorrelationId`/`NodeId`. GridContext propagation lives in the `HoneyDrunk.Capabilities` runtime package's invoker pipeline, not in any `Abstractions` type. This matches `repos/HoneyDrunk.Capabilities/invariants.md:5` which already declares the strict stance for Capabilities locally. Packet 01 amends ADR-0017 D2's "beyond `HoneyDrunk.Kernel` abstractions" phrasing to "beyond `Microsoft.Extensions.*` abstractions" in the same edit it lands the catalog work — same pattern packet 01 of ADR-0016 used.
+
+## Status-flip handling
+
+ADR-0017 stays at `Status: Proposed` for the duration of this scoping run and across all four packet PRs. Per the user's standing ADR acceptance workflow (`feedback_adr_workflow.md`): new ADRs start Proposed; the scope agent flips Status → Accepted only after the bundle's PRs have merged, never on a first-draft packet.
+
+None of the four packets in this initiative flip ADR-0017's status. That is a separate housekeeping step the scope agent performs once packets 01 / 02 / 03 / 04 are all closed and the scaffold has merged. The flip is a one-line edit to `adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md` line 3 (`**Status:** Proposed` → `**Status:** Accepted`), plus any matching update to `adrs/README.md` if it carries a per-ADR Status entry, plus a CHANGELOG note. The hive-sync agent's ADR auto-acceptance loop may also reconcile this on its next run if it is delayed.
+
+This is the same pattern ADR-0016's standup initiative followed (`generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/dispatch-plan.md` lines 71-115).
+
+- **No Azure provisioning in scope.** HoneyDrunk.Capabilities is a library Node, not a deployable. There is no Key Vault, no Container App, no resource group to create. App Configuration provisioning is already in place from the ADR-0005/0006 rollout — packet 04 has no App Config consumer in this initiative (Capabilities does not source rate tables or routing policies from App Config; that is AI's concern). The Auth dependency for `ICapabilityGuard`'s default implementation is in-process composition, not a deploy-time wiring.
+
+## Filing
+
+The `file-packets.yml` workflow in `HoneyDrunk.Architecture` triggers automatically on push to `generated/issue-packets/active/**/*.md`. No `gh issue create` commands in this dispatch plan — the pipeline handles filing, project-board addition, field population, and `addBlockedBy` wiring from the `dependencies:` frontmatter on each packet. Verify after push by checking The Hive (org Project #4) for the new items and their blocking edges.
+
+The exception is packet 03 (the human chore), which itself contains a "Next Steps" script the human runs after creating the repo. That script is the path by which packet 04 is filed against the new repo.
+
+## Archival
+
+Per ADR-0008 D10, when every packet in this initiative reaches `Done` on the org Project board and `HoneyDrunk.Capabilities 0.1.0` is published to NuGet, the entire `active/adr-0017-honeydrunk-capabilities-standup/` folder moves to `archive/adr-0017-honeydrunk-capabilities-standup/` in a single commit. Partial archival is forbidden.
+
+The hive-sync agent moves individual closed packet files from `active/` to `completed/` per invariant 37 — that is per-packet lifecycle. Initiative-level archival is the post-completion sweep that follows after the whole folder reaches `Done`.


### PR DESCRIPTION
Introduce multi-packet dispatch plan for HoneyDrunk.Capabilities Node per ADR-0017. Register four canonical contracts in architecture catalogs, update sector docs, and add integration-points file. Append four new Capabilities invariants to the constitution. Document human-only repo creation and full repo scaffold (solution, three packages, CI, contract-shape canary). No application code added; all changes are metadata, documentation, and planning artifacts. Status remains Proposed until all packets close. Unblocks downstream AI-sector and tool-registering Nodes.