### PR TITLE
fix(packets): shorten ADR-0017 initiative slug to fit 50-char label cap

### DIFF
--- a/generated/issue-packets/active/adr-0017-capabilities-standup/01-architecture-capabilities-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0017-capabilities-standup/01-architecture-capabilities-catalog-registration.md
@@ -7,7 +7,7 @@ labels: ["chore", "tier-2", "architecture", "ai", "adr-0017"]
 dependencies: []
 adrs: ["ADR-0017"]
 wave: 1
-initiative: adr-0017-honeydrunk-capabilities-standup
+initiative: adr-0017-capabilities-standup
 node: honeydrunk-capabilities
 ---
 
@@ -152,7 +152,7 @@ Replace with:
   "version": "0.0.0",
   "canary_status": "none",
   "last_release": null,
-  "active_blockers": ["GitHub repo not yet created (Architecture#NN — packet 03 of adr-0017-honeydrunk-capabilities-standup)", "Scaffold packet (Capabilities#NN — packet 04 of adr-0017-honeydrunk-capabilities-standup) not yet executed"],
+  "active_blockers": ["GitHub repo not yet created (Architecture#NN — packet 03 of adr-0017-capabilities-standup)", "Scaffold packet (Capabilities#NN — packet 04 of adr-0017-capabilities-standup) not yet executed"],
   "notes": "ADR-0017 standup ADR Proposed 2026-04-19 (Status flip to Accepted is a separate post-merge housekeeping step after the initiative completes). Catalog surface registered (4 contracts per D3: ICapabilityRegistry, CapabilityDescriptor, ICapabilityInvoker, ICapabilityGuard). Integration-points doc filed at repos/HoneyDrunk.Capabilities/integration-points.md. Awaiting GitHub repo creation (human-only) and scaffold execution: HoneyDrunk.Capabilities.Abstractions (4 contracts, zero HoneyDrunk dependencies), HoneyDrunk.Capabilities runtime (default registry, invoker, Auth-backed guard), HoneyDrunk.Capabilities.Testing (in-memory registry/dispatcher fixture), Standards wiring, CI with contract-shape canary scoped to Abstractions (D8)."
 }
 ```
@@ -332,7 +332,7 @@ Add a new entry under `## In Progress`, immediately after the "ADR-0010 Observat
 ### ADR-0017 HoneyDrunk.Capabilities Standup
 **Status:** In Progress
 **Scope:** Architecture, HoneyDrunk.Capabilities (new repo)
-**Initiative:** `adr-0017-honeydrunk-capabilities-standup`
+**Initiative:** `adr-0017-capabilities-standup`
 **Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)
 **Description:** Stand up `HoneyDrunk.Capabilities` as the AI sector's tool-registry and dispatch substrate per ADR-0017. Catalog reconciliation (drop placeholder `ICapability`/`ICapabilityPermission`, add four D3 contracts), four new invariants for D9 / D6 / D5+D10 / D8, human-only repo creation, and the scaffold packet (three packages: `Abstractions`, runtime, `Testing` fixture). Unblocks Agents, Operator, Memory, Knowledge, Evals, and any domain Node that registers a callable tool.
 

--- a/generated/issue-packets/active/adr-0017-capabilities-standup/02-architecture-capabilities-invariants.md
+++ b/generated/issue-packets/active/adr-0017-capabilities-standup/02-architecture-capabilities-invariants.md
@@ -7,7 +7,7 @@ labels: ["chore", "tier-2", "architecture", "ai", "adr-0017", "constitution"]
 dependencies: ["packet:01"]
 adrs: ["ADR-0017"]
 wave: 1
-initiative: adr-0017-honeydrunk-capabilities-standup
+initiative: adr-0017-capabilities-standup
 node: honeydrunk-capabilities
 ---
 
@@ -46,7 +46,7 @@ Working assumption: ADR-0016 packet 02 lands first (it is also Wave 1 and depend
 If the assigned numbers shift away from 43-46:
 
 - The corresponding bullets in ADR-0017's Consequences section ("New invariants (proposed for `constitution/invariants.md`)") at lines 128-131 are updated to state the assigned numbers.
-- The packet 04 source file at `generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md` is amended in place before push. Per the dispatch plan's filing-order rule, packet 04 is not filed until this packet has merged, so the pre-filing carve-out under invariant 24 applies.
+- The packet 04 source file at `generated/issue-packets/active/adr-0017-capabilities-standup/04-capabilities-node-scaffold.md` is amended in place before push. Per the dispatch plan's filing-order rule, packet 04 is not filed until this packet has merged, so the pre-filing carve-out under invariant 24 applies.
 - `repos/HoneyDrunk.Capabilities/integration-points.md` (created in packet 01) references the canary invariant by phrase ("number assigned at acceptance") rather than by number, so no edit is required there. If for some reason a number has been baked into that file already, update it.
 
 ### Where the four entries land in `constitution/invariants.md`
@@ -104,7 +104,7 @@ Packet 04 (the scaffold) hard-codes the assumed invariant numbers 43-46 in rough
 After determining the actually-assigned numbers, run:
 
 ```bash
-rg -n '\b4[3-6]\b' generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md
+rg -n '\b4[3-6]\b' generated/issue-packets/active/adr-0017-capabilities-standup/04-capabilities-node-scaffold.md
 ```
 
 Use ripgrep (`rg`), not `grep` — Windows Git Bash's `grep` boundary semantics differ subtly from ripgrep's. For each match, replace the old number with the assigned one. The matches are concentrated in the Constraints and Referenced Invariants sections; verify by re-running the rg query and confirming zero hits at the old numbers and the expected count at the new numbers. Where a reference is purely narrative ("the Capabilities downstream-coupling invariant"), the number does not need to be there at all — those phrase-keyed references are preferred per the packet's existing pattern. The numbers stay in places where they are genuinely needed (e.g. parenthetical "default 43" annotations, the actual `constitution/invariants.md` insertion).
@@ -118,7 +118,7 @@ If renumbered, update the changelog line to state the actually-assigned numbers.
 ## Affected Files
 - `constitution/invariants.md`
 - `adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md` (only if the assigned numbers differ from 43/44/45/46 — update the Consequences "New invariants" bullets)
-- `generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md` (only if the assigned numbers differ from 43/44/45/46 — pre-filing amendment per invariant 24's carve-out)
+- `generated/issue-packets/active/adr-0017-capabilities-standup/04-capabilities-node-scaffold.md` (only if the assigned numbers differ from 43/44/45/46 — pre-filing amendment per invariant 24's carve-out)
 - `CHANGELOG.md`
 
 ## NuGet Dependencies
@@ -137,7 +137,7 @@ None. Architecture is a knowledge repo.
 - [ ] **Each new invariant entry carries the qualifier `(Proposed — this invariant takes effect when ADR-0017 is accepted)`** at the end of its body. ADR-0017 stays at `Status: Proposed` for this entire initiative — the Status flip is a separate post-merge housekeeping step. This pattern matches existing entries 28 (ADR-0010), 31, 32, 33 (ADR-0011) which all carry the same qualifier shape.
 - [ ] Existing entries (28, 29-30 reservation, 31-39) are unmodified.
 - [ ] If invariant numbers shifted away from 43-46, the corresponding bullets in ADR-0017's Consequences section ("New invariants (proposed for `constitution/invariants.md`)") at lines 128-131 are updated to match.
-- [ ] If invariant numbers shifted away from 43-46, the packet 04 source file at `generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md` is amended before that packet is filed. After determining the assigned numbers, run `rg -n '\b4[3-6]\b' generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md` and update each match to the actually-assigned number. Use ripgrep (`rg`), not `grep`, for predictable boundary semantics on Windows Git Bash. After replacement, re-run the rg query and confirm zero hits at the old numbers. The dispatch plan's filing-order rule guarantees packet 04 has not been filed yet at the time this packet's PR merges.
+- [ ] If invariant numbers shifted away from 43-46, the packet 04 source file at `generated/issue-packets/active/adr-0017-capabilities-standup/04-capabilities-node-scaffold.md` is amended before that packet is filed. After determining the assigned numbers, run `rg -n '\b4[3-6]\b' generated/issue-packets/active/adr-0017-capabilities-standup/04-capabilities-node-scaffold.md` and update each match to the actually-assigned number. Use ripgrep (`rg`), not `grep`, for predictable boundary semantics on Windows Git Bash. After replacement, re-run the rg query and confirm zero hits at the old numbers. The dispatch plan's filing-order rule guarantees packet 04 has not been filed yet at the time this packet's PR merges.
 - [ ] `CHANGELOG.md` Unreleased section updated with the four invariant numbers actually assigned.
 
 ## Human Prerequisites
@@ -187,7 +187,7 @@ None.
 **Key Files:**
 - `constitution/invariants.md` — append four entries (Option A: under a new `## AI Sector — Capabilities Invariants` section; Option B: inside `## AI Invariants`)
 - `adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md` — only edited if numbers shifted from 43/44/45/46 (lines 128-131 in the Consequences section)
-- `generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md` — only edited if numbers shifted from 43/44/45/46
+- `generated/issue-packets/active/adr-0017-capabilities-standup/04-capabilities-node-scaffold.md` — only edited if numbers shifted from 43/44/45/46
 - `CHANGELOG.md`
 
 **Contracts:** None.

--- a/generated/issue-packets/active/adr-0017-capabilities-standup/03-architecture-create-capabilities-repo.md
+++ b/generated/issue-packets/active/adr-0017-capabilities-standup/03-architecture-create-capabilities-repo.md
@@ -7,7 +7,7 @@ labels: ["chore", "tier-1", "meta", "new-node", "adr-0017", "human-only", "wave-
 dependencies: ["packet:01"]
 adrs: ["ADR-0017"]
 wave: 2
-initiative: adr-0017-honeydrunk-capabilities-standup
+initiative: adr-0017-capabilities-standup
 node: honeydrunk-architecture
 actor: human
 ---
@@ -59,7 +59,7 @@ These commands seed labels on the new repo, file `04-capabilities-node-scaffold.
 **Important order-of-operations:** Per the dispatch plan's filing-order rule, packet 04 cannot be filed until packet 02's PR has merged (so the assigned invariant numbers are locked in `constitution/invariants.md`) and any required pre-filing amendments to `04-capabilities-node-scaffold.md` have been applied. If packet 02 has not yet merged at the time this chore is being closed, file packet 04 **after** packet 02 lands — not now.
 
 ```bash
-PACKETS="generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup"
+PACKETS="generated/issue-packets/active/adr-0017-capabilities-standup"
 
 # 1. Seed the new repo with the labels the filing command needs.
 #    Color choices follow the existing convention used by other Grid repos:
@@ -80,7 +80,7 @@ echo "Filed: $ISSUE_URL"
 # 3. Add to The Hive — field IDs per infrastructure/github-projects-field-ids.md
 gh project item-add 4 --owner HoneyDrunkStudios --url "$ISSUE_URL"
 
-# 4. Set board fields (Wave 3 / Initiative adr-0017-honeydrunk-capabilities-standup / Node honeydrunk-capabilities / Tier 2 / Actor Agent)
+# 4. Set board fields (Wave 3 / Initiative adr-0017-capabilities-standup / Node honeydrunk-capabilities / Tier 2 / Actor Agent)
 # See infrastructure/github-projects-field-ids.md for current option IDs; apply via `gh project item-edit`.
 # (If that file does not exist yet, copy field option IDs from another already-filed packet's project-item state, e.g. an ADR-0016 or ADR-0026 issue.)
 ```

--- a/generated/issue-packets/active/adr-0017-capabilities-standup/04-capabilities-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0017-capabilities-standup/04-capabilities-node-scaffold.md
@@ -7,7 +7,7 @@ labels: ["feature", "tier-2", "ai", "scaffolding", "new-node", "adr-0017"]
 dependencies: ["packet:01", "packet:02", "packet:03"]
 adrs: ["ADR-0017"]
 wave: 3
-initiative: adr-0017-honeydrunk-capabilities-standup
+initiative: adr-0017-capabilities-standup
 node: honeydrunk-capabilities
 ---
 

--- a/generated/issue-packets/active/adr-0017-capabilities-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0017-capabilities-standup/dispatch-plan.md
@@ -1,6 +1,6 @@
 # Dispatch Plan — ADR-0017 HoneyDrunk.Capabilities Standup
 
-**Initiative:** `adr-0017-honeydrunk-capabilities-standup`
+**Initiative:** `adr-0017-capabilities-standup`
 **Sector:** AI
 **Governing ADR:** [ADR-0017 — Stand Up the HoneyDrunk.Capabilities Node](../../../../adrs/ADR-0017-stand-up-honeydrunk-capabilities-node.md) (Proposed 2026-04-19; stays Proposed across all four packet PRs. Flips to Accepted only after every packet in this initiative is closed, as a separate post-merge housekeeping step the scope agent runs — see "Status-flip handling" below.)
 **Trigger:** ADR-0017 in the Proposed queue. Five AI-sector Nodes (Agents, Operator, Memory, Knowledge, Evals) plus every domain Node that exposes agent-callable tools (Data, Notify, Vault) are blocked on `HoneyDrunk.Capabilities.Abstractions` existing. This initiative builds the tool-registry and dispatch substrate that unblocks them.
@@ -65,7 +65,7 @@ Packet 04 hard-codes invariant numbers in its body and acceptance criteria. File
 
 **Packet 02 must be filed, its PR merged, and the assigned invariant numbers locked in `constitution/invariants.md` before packet 04 is filed.**
 
-If packet 02's collision check at edit time forces a renumber away from the assumed 43/44/45/46 — for example because ADR-0016 lands first and takes 40/41/42 (consuming the next-three-free that ADR-0026 left at 39), then ADR-0010 Phase 1 lands and takes 29-30, or some other ADR grabs slots in the interim — the packet 04 source file at `generated/issue-packets/active/adr-0017-honeydrunk-capabilities-standup/04-capabilities-node-scaffold.md` MUST be amended in place before push (it has not been filed yet at that point — invariant 24's pre-filing carve-out applies).
+If packet 02's collision check at edit time forces a renumber away from the assumed 43/44/45/46 — for example because ADR-0016 lands first and takes 40/41/42 (consuming the next-three-free that ADR-0026 left at 39), then ADR-0010 Phase 1 lands and takes 29-30, or some other ADR grabs slots in the interim — the packet 04 source file at `generated/issue-packets/active/adr-0017-capabilities-standup/04-capabilities-node-scaffold.md` MUST be amended in place before push (it has not been filed yet at that point — invariant 24's pre-filing carve-out applies).
 
 **Packets 02 and 04 cannot be filed in the same push.** Concretely:
 
@@ -116,6 +116,6 @@ The exception is packet 03 (the human chore), which itself contains a "Next Step
 
 ## Archival
 
-Per ADR-0008 D10, when every packet in this initiative reaches `Done` on the org Project board and `HoneyDrunk.Capabilities 0.1.0` is published to NuGet, the entire `active/adr-0017-honeydrunk-capabilities-standup/` folder moves to `archive/adr-0017-honeydrunk-capabilities-standup/` in a single commit. Partial archival is forbidden.
+Per ADR-0008 D10, when every packet in this initiative reaches `Done` on the org Project board and `HoneyDrunk.Capabilities 0.1.0` is published to NuGet, the entire `active/adr-0017-capabilities-standup/` folder moves to `archive/adr-0017-capabilities-standup/` in a single commit. Partial archival is forbidden.
 
 The hive-sync agent moves individual closed packet files from `active/` to `completed/` per invariant 37 — that is per-packet lifecycle. Initiative-level archival is the post-completion sweep that follows after the whole folder reaches `Done`.


### PR DESCRIPTION
## Summary
- The file-packets workflow run on the merge of #85 failed at the first ADR-0017 packet because the auto-generated label `initiative-adr-0017-honeydrunk-capabilities-standup` is 51 characters — one over GitHub's 50-character cap. (See [run 25402591375](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/actions/runs/25402591375).)
- Drops the redundant `honeydrunk-` from the initiative slug. `adr-0017-capabilities-standup` (29 chars) → `initiative-adr-0017-capabilities-standup` label (40 chars) — comfortably under the cap and consistent with sibling initiatives (ADR-0010/0011/0012/0013/0015/0016/0026 all fit).
- Renames the packet directory and updates the `initiative:` frontmatter field plus body-text mentions across all 5 files. No issues were filed yet for this initiative (manifest empty for ADR-0017), so the rename is purely textual — no manifest reconciliation, no board re-wiring.

## Why drop `honeydrunk-` instead of e.g. truncating in the script
- "capabilities-standup" is unambiguous on its own — no other Node would use that pair.
- A script-side truncation/hashing fallback would be opaque (the label wouldn't visibly correspond to the directory) and would silently mask future violations. Keeping the constraint explicit (slug length) is more debuggable.
- The 50-char cap is a known [GitHub label limit](https://docs.github.com/en/rest/issues/labels), and a separate tightening — adding a length pre-check to the file-packets script — could be filed as a small follow-up so a future packet hits a friendly error before the API call. (Out of scope here.)

## Test plan
- [ ] Once merged to `main`, the File Issue Packets workflow runs and successfully files all 4 ADR-0017 packets (the previously failing `01-architecture-capabilities-catalog-registration.md` and the three behind it).
- [ ] The auto-created `initiative-adr-0017-capabilities-standup` label appears on each filed issue.
- [ ] The Hive project board mirror picks up the new issues and assigns Wave/Initiative/Node fields per the dispatch plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)