### PR TITLE
chore(packets): refine ADR-0016 AI standup packets

### DIFF
--- a/adrs/ADR-0016-stand-up-honeydrunk-ai-node.md
+++ b/adrs/ADR-0016-stand-up-honeydrunk-ai-node.md
@@ -119,13 +119,15 @@ Accepting this ADR — and landing the follow-up scaffold packet that produces a
 - **HoneyDrunk.Knowledge** — same, for retrieval embedding.
 - **HoneyDrunk.Evals** — can target `IModelProvider` and the `InMemory` provider as its deterministic fixture.
 
-### New invariants (proposed for `constitution/invariants.md`)
+### New invariants (assigned in `constitution/invariants.md` at acceptance)
 
-These extend the AI-related invariants already proposed in ADR-0010 (28 on hardcoded model names). Numbering is tentative — scope agent finalizes at acceptance.
+These extend the AI-related invariants already proposed in ADR-0010 (28 on hardcoded model names). Final numbers, assigned by the scope agent — 39 (ADR-0026 multi-tenant) and 40–43 (ADR-0019 Communications) were taken before this initiative scoped, so the next free slots are 44/45/46:
 
-- **Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`.** Composition against `HoneyDrunk.AI` and any provider package is a host-time concern. See ADR-0016 D9.
-- **Token cost rates, routing policies, and capability declarations are sourced from Azure App Configuration via Vault's `IConfigProvider`.** Hardcoded rates or policies in application code are forbidden. See ADR-0016 D5.
-- **The AI Node CI must include a contract-shape canary for `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, and `IModelRouter`.** Shape drift on any of the four is a build failure, not a downstream discovery. See ADR-0016 D8.
+- **Invariant 44 — Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`.** Composition against `HoneyDrunk.AI` and any provider package is a host-time concern. See ADR-0016 D9.
+- **Invariant 45 — Token cost rates, routing policies, and capability declarations are sourced from Azure App Configuration via Vault's `IConfigProvider`.** Hardcoded rates or policies in application code are forbidden. See ADR-0016 D5.
+- **Invariant 46 — The AI Node CI must include a contract-shape canary for `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, and `IModelRouter`.** Shape drift on any of the four is a build failure, not a downstream discovery. See ADR-0016 D8.
+
+Acceptance also drops invariant 28's `(Proposed)` qualifier (ADR-0010 is now Accepted; the AI scaffold makes invariant 28 enforceable). This was originally a paired Architecture edit in ADR-0010 packet 04, which is superseded by the ADR-0016 standup initiative.
 
 ### Contract-shape canary becomes a requirement
 

--- a/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/01-architecture-ai-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/01-architecture-ai-catalog-registration.md
@@ -190,6 +190,38 @@ with:
 
 > `| `HoneyDrunk.AI.Providers.InMemory` | Provider | Deterministic test double for Evals and CI |`
 
+### `repos/HoneyDrunk.AI/boundaries.md` — line 7 (provider list drift)
+
+Current text on line 7 (under `## What AI Owns`):
+
+> `- Provider adapters (OpenAI, Anthropic, Azure OpenAI, local models)`
+
+Replace with:
+
+> `- Provider adapters (OpenAI, Anthropic, Azure OpenAI, InMemory test double)`
+
+The same "Providers.Local → Providers.InMemory" rationale that applies elsewhere applies here. The "local models" framing is retired from D2.
+
+### `repos/HoneyDrunk.AI/invariants.md` — cross-references and packaging clarification
+
+Two surface edits to keep this file aligned with the constitutional invariants packet 02 lands and with ADR-0016 D2/D7.
+
+**(a) Cross-reference the new constitutional invariants (44/45/46).** This file is repo-scoped (lives under `repos/HoneyDrunk.AI/`) and supplements `constitution/invariants.md`. Add a one-line note immediately after the existing list of seven repo-scoped invariants pointing readers at the constitutional invariants that govern AI behavior:
+
+> `_Constitutional invariants 28, 44, 45, 46 (in `constitution/invariants.md`) also apply — hardcoded model names forbidden (28); downstream-only Abstractions coupling (44); App-Config-sourced rates and policies (45); contract-shape canary in CI (46)._`
+
+**(b) Tighten invariant 6 to localize GridContext propagation in the runtime package.** Current invariant 6:
+
+> `6. **GridContext is propagated on every inference call.**`
+> `   CorrelationId and CausationId flow through to provider requests for end-to-end tracing.`
+
+Replace with:
+
+> `6. **GridContext is propagated on every inference call — by the AI runtime package, not by Abstractions.**`
+> `   CorrelationId and CausationId flow through to provider requests for end-to-end tracing. Implementation lives in HoneyDrunk.AI runtime (specifically InferenceTelemetry); HoneyDrunk.AI.Abstractions stays HoneyDrunk-dependency-free per invariant 1.`
+
+This makes the dependency-clean Abstractions stance explicit at the repo-scoped level.
+
 ### `repos/HoneyDrunk.AI/active-work.md` — lines 22–26
 
 The existing list reads:
@@ -214,7 +246,33 @@ Replace the trailing `Local` line so the list reads:
 
 ### Stale `Providers.Local` sweep
 
-Before opening the PR, grep `catalogs/` and `repos/HoneyDrunk.AI/` for any remaining `Providers.Local` or `local/ONNX` strings the explicit fix list above missed. None should remain after this packet. The grep is a hard check, not a best-effort.
+Before opening the PR, grep `catalogs/` and `repos/HoneyDrunk.AI/` for any remaining `Providers.Local` or `local/ONNX` or `local models` strings the explicit fix list above missed. None should remain after this packet. The grep is a hard check, not a best-effort.
+
+### `relationships.json` honeydrunk-ai dependency direction — verify, don't edit
+
+`catalogs/relationships.json` line 185 currently reads `"consumes": ["honeydrunk-kernel", "honeydrunk-vault"]` for `honeydrunk-ai`. Per ADR-0016 D7, this is correct as-is — `honeydrunk-pulse` must NOT appear in the `consumes` array. As an acceptance check (verify-don't-edit):
+
+- Open `catalogs/relationships.json`, find the `honeydrunk-ai` block (around line 184).
+- Confirm `consumes` is exactly `["honeydrunk-kernel", "honeydrunk-vault"]` — no `honeydrunk-pulse`.
+- If `honeydrunk-pulse` is present, remove it. Otherwise no edit is needed; this is a confirmation only.
+
+The integration-points doc at `repos/HoneyDrunk.AI/integration-points.md` already states the Pulse row as "no runtime dependency" — also verify-don't-edit; if drift is present, fix it in the same PR.
+
+### `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` — `If Accepted` checklist correction (line 12)
+
+The checklist on line 12 of the ADR currently reads:
+
+> `- [ ] Add entries to \`catalogs/contracts.json\` for the seven exposed contracts: \`IChatClient\`, \`IEmbeddingGenerator\`, \`IInferenceResult\`, \`IModelProvider\`, \`IModelRouter\`, \`IRoutingPolicy\`, \`ModelCapabilityDeclaration\``
+
+Replace `IInferenceResult` with `ICostLedger` so the checklist matches the canonical D3 surface this packet lands:
+
+> `- [ ] Add entries to \`catalogs/contracts.json\` for the seven exposed contracts: \`IChatClient\`, \`IEmbeddingGenerator\`, \`IModelProvider\`, \`IModelRouter\`, \`IRoutingPolicy\`, \`ModelCapabilityDeclaration\`, \`ICostLedger\``
+
+Same correction may also be needed on line 15 of the ADR (the canary obligation lists `IChatClient`, `IEmbeddingGenerator`, `IInferenceResult`, `IModelProvider`). Per D8, the four hot-path contracts are `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, `IModelRouter` — replace `IInferenceResult` with `IModelRouter` on line 15:
+
+> `- [ ] Wire the contract-shape canary into Actions (freezes \`IChatClient\`, \`IEmbeddingGenerator\`, \`IModelProvider\`, \`IModelRouter\` shapes)`
+
+Document both line corrections in the PR body alongside the D2 line 42 amendment.
 
 ### `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` — D2 line 42 amendment
 
@@ -235,13 +293,16 @@ Append to the Unreleased section a line: `Architecture: Register ADR-0016 standu
 
 ## Affected Files
 - `catalogs/contracts.json`
-- `catalogs/relationships.json`
+- `catalogs/relationships.json` (verify `consumes` does not include `honeydrunk-pulse`; edit `exposes.contracts` and `exposes.packages`)
 - `catalogs/grid-health.json`
 - `catalogs/nodes.json`
 - `constitution/ai-sector-architecture.md`
 - `repos/HoneyDrunk.AI/overview.md`
 - `repos/HoneyDrunk.AI/active-work.md`
-- `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` (D2 line 42 amendment only)
+- `repos/HoneyDrunk.AI/boundaries.md` (line 7 — drop "local models" → "InMemory test double")
+- `repos/HoneyDrunk.AI/invariants.md` (cross-reference invariants 28/44/45/46; tighten invariant 6)
+- `repos/HoneyDrunk.AI/integration-points.md` (verify-don't-edit; ensure Pulse row says "no runtime dependency")
+- `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` (D2 line 42 amendment + line 12 / line 15 checklist contract-name fixes)
 - `CHANGELOG.md`
 
 ## NuGet Dependencies
@@ -265,14 +326,20 @@ None. Architecture is a knowledge repo — no .NET projects.
 - [ ] `constitution/ai-sector-architecture.md` line ~114 split into "Depends on" (no Pulse) and "Emits to (no runtime dependency): Pulse" lines.
 - [ ] `repos/HoneyDrunk.AI/overview.md` line 21 reads the new `Providers.InMemory` row instead of `Providers.Local`.
 - [ ] `repos/HoneyDrunk.AI/active-work.md` lines 22–26 list `InMemory` (deterministic test double for Evals and CI) as the fourth provider slot — no `Local` (ONNX — deferred) bullet.
-- [ ] `grep -nr "Providers.Local\|local/ONNX" catalogs/ repos/HoneyDrunk.AI/` returns no matches after edits.
+- [ ] `repos/HoneyDrunk.AI/boundaries.md` line 7 reads `Provider adapters (OpenAI, Anthropic, Azure OpenAI, InMemory test double)` — no `local models`.
+- [ ] `repos/HoneyDrunk.AI/invariants.md` carries a one-line cross-reference to constitutional invariants 28/44/45/46 and invariant 6 reads as the runtime-localized GridContext propagation rule.
+- [ ] `grep -nr "Providers.Local\|local/ONNX\|local models" catalogs/ repos/HoneyDrunk.AI/` returns no matches after edits.
+- [ ] `catalogs/relationships.json` `honeydrunk-ai.consumes` is `["honeydrunk-kernel", "honeydrunk-vault"]` exactly — no `honeydrunk-pulse`. (Verify; edit only if drift is present.)
+- [ ] `repos/HoneyDrunk.AI/integration-points.md` Pulse row reads "no runtime dependency". (Verify; edit only if drift is present.)
 - [ ] `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` D2 line 42 amended from `Zero runtime dependencies beyond \`HoneyDrunk.Kernel\` abstractions.` to `Zero runtime dependencies beyond \`Microsoft.Extensions.*\` abstractions.`
-- [ ] `CHANGELOG.md` Unreleased section updated with all five drift reconciliations called out.
-- [ ] PR body explicitly notes the three "ADR drift reconciled" items: (1) D3-canonical resolution of the `IInferenceResult` vs `ICostLedger` checklist mismatch, (2) `Providers.Local` → `Providers.InMemory` rename completing D2's first-wave provider list, (3) D2 line 42 amendment from `HoneyDrunk.Kernel`-allowed to `Microsoft.Extensions.*`-only Abstractions stance.
+- [ ] `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` line 12 `If Accepted` checklist item updated: `IInferenceResult` → `ICostLedger` so the seven contracts match D3.
+- [ ] `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` line 15 `If Accepted` canary item updated: `IInferenceResult` → `IModelRouter` so the four frozen contracts match D8.
+- [ ] `CHANGELOG.md` Unreleased section updated with all drift reconciliations called out.
+- [ ] PR body explicitly notes the four "ADR drift reconciled" items: (1) D3-canonical resolution of the `IInferenceResult` vs `ICostLedger` checklist mismatch (line 12 + line 15), (2) `Providers.Local` → `Providers.InMemory` rename completing D2's first-wave provider list, (3) D2 line 42 amendment from `HoneyDrunk.Kernel`-allowed to `Microsoft.Extensions.*`-only Abstractions stance, (4) `repos/HoneyDrunk.AI/{boundaries.md, invariants.md}` aligned to D2 (provider-list) and D7 (runtime-vs-Abstractions GridContext propagation).
 
 ## Human Prerequisites
-- [ ] Reconcile the `IInferenceResult` mention in ADR-0016's "If Accepted" checklist (line 12 of `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md`). The cleanest path is to update the checklist to match D3 (`ICostLedger` instead of `IInferenceResult`) when flipping ADR-0016 to Accepted. Either resolve in this packet's PR or hold as a separate one-line edit.
 - [ ] Confirm the D2 line 42 amendment in this packet (Kernel-abstractions → `Microsoft.Extensions.*` only) is the intended stance before merge — this is the user's explicit scoping resolution but it is also the kind of decision that benefits from a final eye before it lands in the canonical ADR.
+- [ ] Confirm the line 12 / line 15 `IInferenceResult` corrections in the ADR's `If Accepted` checklist match the user's understanding of D3 (the seven exposed contracts) and D8 (the four frozen-shape contracts) — both edits are mechanical drift fixes, but ADR Consequences edits warrant a quick eye.
 
 ## Referenced Invariants
 
@@ -321,13 +388,16 @@ None. This packet is the foundation of the initiative — it can land before the
 
 **Key Files:**
 - `catalogs/contracts.json` — replace the `honeydrunk-ai` block's interfaces array; drop `local` from `IModelProvider` description
-- `catalogs/relationships.json` — swap `IInferenceResult` for `ICostLedger` in `exposes.contracts`; swap `Providers.Local` for `Providers.InMemory` in `exposes.packages` (line 191)
+- `catalogs/relationships.json` — verify `consumes` does not include `honeydrunk-pulse`; swap `IInferenceResult` for `ICostLedger` in `exposes.contracts`; swap `Providers.Local` for `Providers.InMemory` in `exposes.packages` (line 191)
 - `catalogs/grid-health.json` — replace the `honeydrunk-ai` block
 - `catalogs/nodes.json` — edit line 603 (`grid_relationship` field), line 596 (`value_props` adapters string), line 586 (`tags` — add `inmemory`, drop any `local`/`onnx` tokens)
 - `constitution/ai-sector-architecture.md` — edit Provider Slot Pattern block (line 111 row replacement) and dependency phrasing line ~114
 - `repos/HoneyDrunk.AI/overview.md` — edit line 21 provider table row
 - `repos/HoneyDrunk.AI/active-work.md` — edit lines 22–26 provider list bullets
-- `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` — amend D2 line 42 (`HoneyDrunk.Kernel` abstractions → `Microsoft.Extensions.*` abstractions)
+- `repos/HoneyDrunk.AI/boundaries.md` — edit line 7 (drop "local models" → "InMemory test double")
+- `repos/HoneyDrunk.AI/invariants.md` — add cross-reference to constitutional invariants 28/44/45/46; tighten invariant 6 to localize GridContext propagation in runtime
+- `repos/HoneyDrunk.AI/integration-points.md` — verify Pulse row reads "no runtime dependency"
+- `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` — amend D2 line 42 (`HoneyDrunk.Kernel` abstractions → `Microsoft.Extensions.*` abstractions); fix line 12 `If Accepted` contracts list (`IInferenceResult` → `ICostLedger`); fix line 15 `If Accepted` canary contracts list (`IInferenceResult` → `IModelRouter`)
 - `CHANGELOG.md` — Unreleased entry
 
 **Contracts:**

--- a/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/02-architecture-ai-invariants.md
+++ b/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/02-architecture-ai-invariants.md
@@ -14,7 +14,9 @@ node: honeydrunk-ai
 # Chore: Add ADR-0016's three new invariants to the Grid constitution
 
 ## Summary
-Add three new invariants to `constitution/invariants.md` derived from ADR-0016 D9 (downstream coupling rule), D5 (App Configuration sourcing), and D8 (contract-shape canary). Assign them numbers 39, 40, and 41 (the next three free slots after invariant 38 — the most recent addition from ADR-0014's Hive Sync rollout).
+Add three new invariants to `constitution/invariants.md` derived from ADR-0016 D9 (downstream coupling rule), D5 (App Configuration sourcing), and D8 (contract-shape canary). Assign them numbers **44, 45, 46** — the next three free slots after invariant 43 (ADR-0019 Communications canary). Numbers 39 (ADR-0026 multi-tenant) and 40–43 (ADR-0019 Communications) are already taken as of 2026-05-05.
+
+Also drop the `(Proposed — this invariant takes effect when ADR-0010 is accepted)` qualifier from invariant 28. ADR-0010 is Accepted; the AI scaffold (packet 03 of this initiative) is what makes invariant 28 enforceable in code, so the qualifier is stale text.
 
 ## Target Repo
 `HoneyDrunkStudios/HoneyDrunk.Architecture`
@@ -30,13 +32,16 @@ These three rules govern the AI Node's first-shipping behavior:
 
 ## Proposed Implementation
 
-### `constitution/invariants.md` — append three new entries to the existing AI Invariants section
+### `constitution/invariants.md` — append three new entries to the existing AI Invariants section, drop invariant 28's qualifier
 
-The existing AI Invariants section (starting at line 105) already contains invariant 28 with a `(Proposed — this invariant takes effect when ADR-0010 is accepted)` qualifier and a placeholder reserving invariants 29–30 for the Observation Layer (ADR-0010). Per the active-initiatives.md sync (2026-05-03), ADR-0010 Phase 1 work is in progress; invariants 29–30 are still reserved.
+The existing AI Invariants section (starting at line 108) already contains invariant 28 with a `(Proposed — this invariant takes effect when ADR-0010 is accepted)` qualifier and a placeholder reserving invariants 29–30 for the Observation Layer (ADR-0010).
 
-Add three new invariants at the **next free numbers** — currently **39, 40, 41**. Verify the highest assigned number in `constitution/invariants.md` at edit time and shift if any newly accepted ADRs have grabbed 39/40/41 between when this packet was written and when it lands.
+Two changes to this section:
 
-The three entries are appended directly to the existing `## AI Invariants` section, immediately after the `_Invariants 29–30 are reserved..._` line. **Do not introduce a new section header.** Non-monotonic numbering within a section (28, then 39/40/41 after the 29–30 reservation) is fine — other sections in this file already do the same kind of sparse sequencing.
+1. **Remove invariant 28's `(Proposed — this invariant takes effect when ADR-0010 is accepted)` qualifier.** ADR-0010 is Accepted; the AI scaffold (packet 03 of this initiative) is what makes invariant 28 actually enforceable in code (the runtime `IModelRouter` lands there). The parked ADR-0010 packet 04 originally carried this qualifier-removal as a paired Architecture edit; that packet is superseded by this initiative (see dispatch-plan §Supersedes).
+2. **Add three new invariants at numbers 44, 45, 46.** These are the next free slots after invariant 43 (ADR-0019 Communications canary). Numbers 39 (ADR-0026 multi-tenant) and 40–43 (ADR-0019 Communications) are already taken — verify at edit time and shift only if a newer ADR has grabbed 44/45/46 between authoring and landing.
+
+The three new entries are appended directly to the existing `## AI Invariants` section, immediately after the `_Invariants 29–30 are reserved..._` line. **Do not introduce a new section header.** Non-monotonic numbering within a section (28, then 44/45/46 after the 29–30 reservation) is fine — other sections in this file already do the same kind of sparse sequencing.
 
 The current end of the AI Invariants section reads:
 
@@ -51,23 +56,23 @@ _Invariants 29–30 are reserved for the Observation Layer (ADR-0010). They will
 ## Code Review Invariants
 ```
 
-Append the three new entries between the `_Invariants 29–30 are reserved..._` line and the `## Code Review Invariants` header so the section reads:
+Replace the invariant 28 block to drop the `(Proposed)` qualifier and append the three new entries between the `_Invariants 29–30 are reserved..._` line and the `## Code Review Invariants` header so the section reads:
 
 ```markdown
 ## AI Invariants
 
 28. **Application code must never hardcode a model name or provider.**
-    All model selection goes through `IModelRouter` in HoneyDrunk.AI. Routing policies are stored in App Configuration (ADR-0005) and are operator-configurable without a redeploy. See ADR-0010 (Proposed — this invariant takes effect when ADR-0010 is accepted).
+    All model selection goes through `IModelRouter` in HoneyDrunk.AI. Routing policies are stored in App Configuration (ADR-0005) and are operator-configurable without a redeploy. See ADR-0010.
 
 _Invariants 29–30 are reserved for the Observation Layer (ADR-0010). They will be added here when ADR-0010 is accepted._
 
-39. **Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`.**
+44. **Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`.**
     Composition against `HoneyDrunk.AI` and any `HoneyDrunk.AI.Providers.*` package is a host-time concern resolved at application startup from App Configuration. This is the same abstraction/runtime split applied for Vault and Transport, restated here because it is the specific rule that allows blocked AI-sector Nodes (Capabilities, Operator, Agents, Memory, Knowledge, Evals) to proceed on `Abstractions` alone without waiting for provider packages. See ADR-0016 D9.
 
-40. **Token cost rates, routing policies, and capability declarations are sourced from Azure App Configuration via Vault's `IConfigProvider`.**
+45. **Token cost rates, routing policies, and capability declarations are sourced from Azure App Configuration via Vault's `IConfigProvider`.**
     Hardcoded rates, policies, or capability declarations in application code are forbidden. Rate-table refresh is operator-driven — change the config value, restart or hot-reload, no deploy required. This applies in particular to the cost-rate table consumed by `ICostLedger`: token prices per model are operator-configurable, never compiled constants. See ADR-0016 D5 and ADR-0005.
 
-41. **The HoneyDrunk.AI Node CI must include a contract-shape canary that fails the build on shape drift to `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, or `IModelRouter` without a corresponding version bump.**
+46. **The HoneyDrunk.AI Node CI must include a contract-shape canary that fails the build on shape drift to `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, or `IModelRouter` without a corresponding version bump.**
     These four are the hot-path abstractions every downstream consumer compiles against. Accidental shape drift on any of them breaks every AI-sector Node simultaneously. The canary makes this a compile-time failure at AI's own CI, not a discovery at consumer sites. The implementation may be the existing `job-api-compatibility.yml` reusable workflow scoped to `HoneyDrunk.AI.Abstractions`; the obligation is to keep the gate, not to use any specific implementation. See ADR-0016 D8.
 
 ## Code Review Invariants
@@ -75,24 +80,24 @@ _Invariants 29–30 are reserved for the Observation Layer (ADR-0010). They will
 
 Notes for the executing agent:
 
-- The three new entries land **inside** the existing `## AI Invariants` section. Do **not** create a `## AI Invariants (continued)` or any other new heading — the section header at line 105 covers all of 28, 39, 40, 41.
-- Do not modify the existing 28's `(Proposed — this invariant takes effect when ADR-0010 is accepted)` qualifier — that is ADR-0010's concern, not this packet's.
-- Do not modify the `_Invariants 29–30 are reserved..._` placeholder line — it stays where it is, between 28 and the new 39.
+- The three new entries land **inside** the existing `## AI Invariants` section. Do **not** create a `## AI Invariants (continued)` or any other new heading — the section header at line 108 covers all of 28, 44, 45, 46.
+- **Drop invariant 28's `(Proposed — this invariant takes effect when ADR-0010 is accepted)` qualifier.** ADR-0010 is Accepted (status confirmed in `adrs/ADR-0010-*.md` and `initiatives/active-initiatives.md`); the AI scaffold packet 03 of this initiative is what makes invariant 28 enforceable in code. The ADR-0010 packet 04 originally carried this qualifier-removal as a paired Architecture edit; that packet is superseded by this initiative.
+- Do not modify the `_Invariants 29–30 are reserved..._` placeholder line — it stays where it is, between 28 and the new 44.
 - Mark the three new invariants with the same convention used elsewhere — they should **not** carry a `(Proposed)` qualifier because ADR-0016 is being flipped to Accepted concurrently with this initiative landing (the scope agent flips Status → Accepted after this initiative's PR merges, per the user's ADR acceptance workflow).
 
 ### Verify no number collision
 
-Before committing, scan `constitution/invariants.md` and confirm the highest existing number. If invariants 32–38 are present (Code Review + Container Apps + Hive Sync waves), 39 is the next free number. If any newer ADR has grabbed 39/40/41 in the interim, shift this packet's three entries to the next three free numbers and update the cross-references in:
+Before committing, scan `constitution/invariants.md` and confirm the highest existing number. As of 2026-05-05 the highest is **43** (ADR-0019 Communications canary). 44/45/46 are the next three free slots. Numbers 39 (ADR-0026 multi-tenant) and 40–43 (ADR-0019 Communications) are already taken — do not collide. If any newer ADR has grabbed 44/45/46 in the interim, shift this packet's three entries to the next three free numbers and update the cross-references in:
 
 - `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` (the "New invariants (proposed for `constitution/invariants.md`)" section under Consequences) — replace the bullet text with the assigned numbers.
-- The packet 03 source file at `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md` — update any "see invariant 39/40/41" or "Invariant 39/40/41" references to match the assigned numbers. Packet 03 has not been filed yet at the time packet 02 lands (per the dispatch plan filing order), so amending its source file in place is permitted under invariant 24's pre-filing carve-out.
+- The packet 03 source file at `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md` — update any "see invariant 44/45/46" or "Invariant 44/45/46" references to match the assigned numbers. Packet 03 has not been filed yet at the time packet 02 lands (per the dispatch plan filing order), so amending its source file in place is permitted under invariant 24's pre-filing carve-out.
 
 ### `CHANGELOG.md` (Architecture repo)
-Append to the Unreleased section: `Architecture: Add invariants 39 (AI downstream coupling), 40 (App Config-sourced AI rate tables and policies), and 41 (AI contract-shape canary) per ADR-0016 D9, D5, D8.`
+Append to the Unreleased section: `Architecture: Add invariants 44 (AI downstream coupling), 45 (App Config-sourced AI rate tables and policies), and 46 (AI contract-shape canary) per ADR-0016 D9, D5, D8. Drop invariant 28's "(Proposed)" qualifier — ADR-0010 is Accepted and the AI scaffold makes the invariant enforceable.`
 
 ## Affected Files
 - `constitution/invariants.md`
-- `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` (only if the assigned numbers differ from 39/40/41)
+- `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md` (only if the assigned numbers differ from 44/45/46)
 - `CHANGELOG.md`
 
 ## NuGet Dependencies
@@ -105,23 +110,26 @@ None. Architecture is a knowledge repo.
 
 ## Acceptance Criteria
 - [ ] Three new invariants present in `constitution/invariants.md` with text matching ADR-0016 D9, D5, D8.
-- [ ] The three new invariants are **appended directly to the existing `## AI Invariants` section** (which begins at line 105), immediately after the `_Invariants 29–30 are reserved..._` line. No new section header is introduced — `## AI Invariants (continued)` or similar is forbidden.
-- [ ] Assigned numbers verified against the current highest number in the file (39, 40, 41 unless taken — the file's highest existing number as of 2026-05-03 is 38).
+- [ ] The three new invariants are **appended directly to the existing `## AI Invariants` section** (which begins at line 108), immediately after the `_Invariants 29–30 are reserved..._` line. No new section header is introduced — `## AI Invariants (continued)` or similar is forbidden.
+- [ ] Assigned numbers verified against the current highest number in the file (44, 45, 46 unless taken — the file's highest existing number as of 2026-05-05 is 43).
 - [ ] Each invariant's body cites its source ADR decision (D5 / D8 / D9) and any related ADRs (ADR-0005 for D5).
-- [ ] If invariant numbers shift away from 39/40/41 due to collision, packet 03's source file at `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md` is updated before that packet is filed. The dispatch plan's filing-order rule guarantees packet 03 has not been filed yet at the time packet 02 lands.
-- [ ] If numbers shifted from 39/40/41, the corresponding bullets in ADR-0016's Consequences section ("New invariants (proposed for `constitution/invariants.md`)") are updated to match, and packet 03's source file is updated to match.
-- [ ] `CHANGELOG.md` Unreleased section updated with the three invariant numbers actually assigned.
+- [ ] **Invariant 28's `(Proposed — this invariant takes effect when ADR-0010 is accepted)` qualifier is removed.** The body now reads as fully active and references `See ADR-0010.` (no parenthetical). This was the cross-repo edit originally scoped to ADR-0010 packet 04, which is superseded by this initiative.
+- [ ] If invariant numbers shift away from 44/45/46 due to collision, packet 03's source file at `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md` is updated before that packet is filed. The dispatch plan's filing-order rule guarantees packet 03 has not been filed yet at the time packet 02 lands.
+- [ ] If numbers shifted from 44/45/46, the corresponding bullets in ADR-0016's Consequences section ("New invariants (proposed for `constitution/invariants.md`)") are updated to match, and packet 03's source file is updated to match.
+- [ ] `CHANGELOG.md` Unreleased section updated with the three invariant numbers actually assigned, plus the invariant 28 qualifier removal.
 
 ## Human Prerequisites
 None.
 
 ## Referenced ADR Decisions
 
-**ADR-0016 D5 (Routing policy source — App Configuration via Vault):** Routing policies, cost-rate tables, and capability declarations all live in Azure App Configuration and are read through `IConfigProvider` from the Vault Node per ADR-0005. No policies or rate tables are hardcoded in application code. — This is the source for invariant 40.
+**ADR-0016 D5 (Routing policy source — App Configuration via Vault):** Routing policies, cost-rate tables, and capability declarations all live in Azure App Configuration and are read through `IConfigProvider` from the Vault Node per ADR-0005. No policies or rate tables are hardcoded in application code. — This is the source for invariant 45.
 
-**ADR-0016 D8 (Contract-shape canary):** A fifth canary is added to the AI Node's CI: a contract-shape canary that fails the build if any of `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, or `IModelRouter` change shape without a corresponding version bump. — This is the source for invariant 41.
+**ADR-0016 D8 (Contract-shape canary):** A fifth canary is added to the AI Node's CI: a contract-shape canary that fails the build if any of `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, or `IModelRouter` change shape without a corresponding version bump. — This is the source for invariant 46.
 
-**ADR-0016 D9 (Downstream coupling rule):** Downstream AI-sector Nodes (Capabilities, Operator, Agents, Memory, Knowledge, Evals) compile only against `HoneyDrunk.AI.Abstractions`. They do not take a runtime dependency on `HoneyDrunk.AI` or any `HoneyDrunk.AI.Providers.*` package. — This is the source for invariant 39.
+**ADR-0016 D9 (Downstream coupling rule):** Downstream AI-sector Nodes (Capabilities, Operator, Agents, Memory, Knowledge, Evals) compile only against `HoneyDrunk.AI.Abstractions`. They do not take a runtime dependency on `HoneyDrunk.AI` or any `HoneyDrunk.AI.Providers.*` package. — This is the source for invariant 44.
+
+**ADR-0010 (already accepted):** Invariant 28's `(Proposed)` qualifier referenced ADR-0010's pending acceptance. ADR-0010 is now Accepted; the qualifier-removal originally scoped to ADR-0010 packet 04 is rolled into this packet (see dispatch-plan §Supersedes).
 
 ## Dependencies
 - `packet:01` — packet 01 lands the catalog surface that invariant 41's canary will guard. Filing 02 before 01 would leave a forward-reference dangling.
@@ -147,7 +155,8 @@ None.
 **Constraints:**
 
 - **No `(Proposed)` qualifier on the new invariants.** ADR-0016 is flipping to Accepted concurrently with this initiative landing; the new invariants take effect immediately. The user's ADR acceptance workflow handles the Status flip after merge — this packet's text should read as fully active.
-- **Number collision check is a hard gate.** If 39/40/41 are taken, shift to the next free numbers and update both ADR-0016's Consequences section and packet 03 (the scaffold packet) cross-references. Do not file partial edits.
+- **Number collision check is a hard gate.** Numbers 39 (ADR-0026 multi-tenant) and 40–43 (ADR-0019 Communications) are taken. 44/45/46 are the next free slots. If any newer ADR has grabbed those numbers since this packet was authored, shift to the next free numbers and update both ADR-0016's Consequences section and packet 03 (the scaffold packet) cross-references. Do not file partial edits.
+- **Drop invariant 28's `(Proposed)` qualifier in the same edit.** The qualifier-removal was originally scoped to ADR-0010 packet 04 (now superseded by this initiative — see dispatch-plan §Supersedes). ADR-0010 is Accepted and the AI scaffold makes invariant 28 enforceable; the qualifier is stale.
 - **Verbatim alignment with ADR-0016.** The invariant bodies should restate D5/D8/D9 with constitutional voice, not introduce new requirements. Anything novel belongs in a follow-up ADR.
 
 **Key Files:**

--- a/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/02b-architecture-verify-ai-repo.md
+++ b/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/02b-architecture-verify-ai-repo.md
@@ -1,0 +1,125 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "ai", "adr-0016", "human-only", "wave-2"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0016"]
+wave: 2
+initiative: adr-0016-honeydrunk-ai-standup
+node: honeydrunk-architecture
+actor: human
+---
+
+# Chore: Verify `HoneyDrunk.AI` GitHub repo settings + clone locally (human-only)
+
+## Summary
+Confirm `HoneyDrunkStudios/HoneyDrunk.AI` matches the Grid's per-repo standard settings (branch protection, default branch, labels, Actions enabled), and clone the repo locally so packet 03's scaffolding agent has a working tree to author into. The repo itself was created during ADR-0016 drafting and currently contains only `.gitignore`, `LICENSE`, `README.md` — no scaffold yet. This is an org-admin / human action that cannot be delegated to an agent — it gates packet 03.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture` (this is where the tracking issue lives; the actual work happens on GitHub at the org level + locally on the user's machine)
+
+## Actor
+**`Human`.** Org-admin rights on `HoneyDrunkStudios` are required to apply branch protection and seed labels; cloning the repo locally is also a human action. Frontmatter sets `actor: human` and labels include `human-only`; the filing pipeline mirrors `Actor=Human` onto The Hive.
+
+## Motivation
+`03-ai-node-scaffold.md` defines the solution, six packages, seven contracts, default runtime, four provider slots (InMemory functional, three stubs), and CI pipeline for `HoneyDrunk.AI` but cannot be executed by the scaffolding agent until:
+
+1. The local working tree at `c:/.../HoneyDrunkStudios/HoneyDrunk.AI` exists. As of 2026-05-05 it does not — the GitHub repo exists but the user has not cloned it locally. The scaffolding agent will fail on `git clone` or directory-not-found if this prereq is unmet.
+2. Branch protection rules are applied so the scaffolding PR can't be force-pushed to `main` and `pr-core` is required.
+3. Labels needed for issue filing exist on the repo (`feature`, `tier-2`, `ai`, `scaffold`, `adr-0016`).
+
+Surfacing this as an explicit Wave-2 work item keeps it visible on The Hive board as a human-only blocker instead of an implicit prerequisite. Same shape as `adr-0017-capabilities-standup/03-architecture-create-capabilities-repo.md` — except that one was create-and-configure, and this one is verify-and-clone-and-configure.
+
+## Steps
+
+### Step 1 — Verify repo settings (portal)
+
+1. Open https://github.com/HoneyDrunkStudios/HoneyDrunk.AI/settings — confirm:
+   - **Default branch:** `main` (if not, change to `main`)
+   - **Visibility:** Public (matches HoneyDrunk Grid default)
+   - **Features:** Issues enabled, Actions enabled, Discussions optional
+2. Open https://github.com/HoneyDrunkStudios/HoneyDrunk.AI/settings/branches — confirm or create branch protection rule on `main`:
+   - **Require a pull request before merging:** on
+   - **Require status checks to pass before merging:** on
+   - **Required status checks:** `pr-core / core` only for now (the `api-compatibility / abstractions-shape` check will be added to required-checks in a follow-up branch-protection update *after* the throwaway breaking-change PR confirms the canary fires post-merge — see packet 03 Human Prerequisites for the rationale)
+   - **Allow force pushes:** off
+   - **Allow deletions:** off
+   - **Require signed commits:** off (matches other Grid repos)
+   - Mirror the settings on `HoneyDrunk.Auth` if any field is unclear
+3. Open https://github.com/HoneyDrunkStudios/HoneyDrunk.AI/settings/security_analysis — confirm Dependabot alerts are enabled (org default — should already be on); CodeQL default-setup stays off per the org "HoneyDrunk Grid — public default" config.
+
+### Step 2 — Seed labels (CLI)
+
+Run the following from any local directory with `gh` CLI authenticated as the org owner. Color choices follow the existing convention used by other Grid repos.
+
+```bash
+for label in "feature:0E8A16" "chore:CCCCCC" "tier-1:E99695" "tier-2:FBCA04" "ai:D946EF" "scaffold:BFDADC" "adr-0016:1D76DB" "wave-3:FBCA04" "human-only:B60205" "out-of-band:D4C5F9"; do
+  name="${label%:*}"; color="${label#*:}"
+  gh label create "$name" --repo HoneyDrunkStudios/HoneyDrunk.AI --color "$color" 2>/dev/null
+done
+```
+
+If `gh label create` errors with "already exists" for any label, that is fine — it's idempotent for our purposes.
+
+### Step 3 — Clone the repo locally
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/
+git clone https://github.com/HoneyDrunkStudios/HoneyDrunk.AI.git
+cd HoneyDrunk.AI
+git status
+```
+
+The clone should land at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.AI/`. After cloning, confirm the working tree contains `.gitignore`, `LICENSE`, `README.md` and nothing else. The scaffolding agent (packet 03) will create everything else.
+
+### Step 4 — Confirm OIDC federated credential
+
+Cross-link: [`infrastructure/oidc-federated-credentials.md`](../../../infrastructure/oidc-federated-credentials.md).
+
+Confirm the Grid's NuGet publishing identity has `repo:HoneyDrunkStudios/HoneyDrunk.AI:ref:refs/tags/v*` in its federated credential subject list. If not, add it via the Azure portal (Microsoft Entra → App registrations → the NuGet publishing identity → Certificates & secrets → Federated credentials). Without this, `release.yml` will fail to obtain a token at first tag-push.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunkStudios/HoneyDrunk.AI` has branch protection on `main` requiring `pr-core / core`, no force-pushes, no deletions
+- [ ] Labels `feature`, `chore`, `tier-1`, `tier-2`, `ai`, `scaffold`, `adr-0016`, `wave-3`, `human-only`, `out-of-band` exist on the repo
+- [ ] Local working tree at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.AI/` exists and contains `.gitignore`, `LICENSE`, `README.md`
+- [ ] OIDC federated credential exists for `repo:HoneyDrunkStudios/HoneyDrunk.AI:ref:refs/tags/v*` against the Grid's NuGet publishing identity
+- [ ] This chore issue is closed after all four checks above are verified
+- [ ] After this chore is Done **and** packet 02 has merged, packet 03 (`03-ai-node-scaffold.md`) is fileable
+
+## Human Prerequisites
+- [ ] Org-admin role on `HoneyDrunkStudios` (required to set branch protection and seed labels)
+- [ ] Browser with GitHub session logged in as the org owner
+- [ ] `gh` CLI installed locally and authenticated as the org owner
+- [ ] Azure portal access for the OIDC federated credential check (only needed if Step 4 turns up missing — the credential is usually pre-configured for new Grid repos)
+
+## Dependencies
+- `packet:01` — catalog registration must merge first so the `repos/HoneyDrunk.AI/` files in the Architecture repo are aligned with what the local clone will eventually carry. Sequenced after Wave 1 by dispatch plan; the actual portal/CLI actions could run in parallel with Wave 1, but the tracking issue is filed in Wave 2.
+
+## Downstream Unblocks
+- `03-ai-node-scaffold.md` — becomes fileable and executable the moment this chore is Done **and** packet 02 has merged
+
+## Referenced ADR Decisions
+
+**ADR-0016 (Stand Up the HoneyDrunk.AI Node):**
+- **§Decision / D1:** HoneyDrunk.AI is the AI sector's inference substrate. New Node ⇒ new repo per invariant 11 — the repo is already created on GitHub; this packet is the verification + clone half of the standup that lives outside the scaffolding agent's reach.
+- **§Decision / D2:** Six package families. The local clone hosts the solution that packet 03 authors.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node. Each repo has its own solution, CI pipeline, and versioning.
+
+> **Invariant 24:** Issue packets are immutable once filed. This chore packet is itself filed in Wave 2; pre-filing amendments to packet 03 (the scaffold) are permitted under invariant 24 if invariant numbers shift in packet 02.
+
+## Labels
+`chore`, `tier-1`, `meta`, `ai`, `adr-0016`, `human-only`, `wave-2`
+
+## Notes for the human executing this chore
+
+- This is a 5-minute task split across portal + CLI + a single `git clone`. Most of the work is verification, not creation.
+- After all four steps complete, close this chore issue and unblock packet 03.
+- If branch protection is already correctly applied (org default kicks in for new repos), Step 1 is verify-only.
+- If the OIDC federated credential is already in place (Grid default), Step 4 is verify-only.
+- Do not provision any Azure resources. HoneyDrunk.AI is a library Node with no Azure footprint.
+- Do not commit anything to the local clone in this chore — the scaffolding agent in packet 03 authors all source files.

--- a/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md
@@ -4,9 +4,9 @@ type: repo-feature
 tier: 2
 target_repo: HoneyDrunkStudios/HoneyDrunk.AI
 labels: ["feature", "tier-2", "ai", "scaffold", "adr-0016"]
-dependencies: ["packet:01", "packet:02"]
-adrs: ["ADR-0016", "ADR-0010", "ADR-0005"]
-wave: 2
+dependencies: ["packet:01", "packet:02", "packet:02b"]
+adrs: ["ADR-0016", "ADR-0010", "ADR-0009", "ADR-0005"]
+wave: 3
 initiative: adr-0016-honeydrunk-ai-standup
 node: honeydrunk-ai
 ---
@@ -14,15 +14,17 @@ node: honeydrunk-ai
 # Feature: Stand up the HoneyDrunk.AI repo — solution, packages, contracts, CI, InMemory provider
 
 ## Summary
-Bring the empty `HoneyDrunk.AI` repo from zero to first-shippable state per ADR-0016. Land the solution layout, the six package families (Abstractions + runtime + four provider slots), the seven D3 contracts inside `HoneyDrunk.AI.Abstractions`, default routing/cost/policy implementations in the `HoneyDrunk.AI` runtime, the deterministic InMemory provider, the standard CI pipeline (PR core + release + nightly), and the contract-shape canary scoped to `HoneyDrunk.AI.Abstractions` per ADR-0016 D8 / invariant 41.
+Bring the empty `HoneyDrunk.AI` repo from zero to first-shippable state per ADR-0016. Land the solution layout, the six package families (Abstractions + runtime + four provider slots), the seven D3 contracts inside `HoneyDrunk.AI.Abstractions`, default routing/cost/policy implementations in the `HoneyDrunk.AI` runtime, the deterministic InMemory provider, the standard CI pipeline (PR core + release + nightly), and the contract-shape canary scoped to `HoneyDrunk.AI.Abstractions` per ADR-0016 D8 / invariant 46.
 
 This is the unblocker for the six AI-sector Nodes currently waiting on AI (Capabilities, Operator, Agents, Memory, Knowledge, Evals). After this packet merges and a `0.1.0` tag lands, those Nodes can compile against `HoneyDrunk.AI.Abstractions` and start their own work in parallel.
+
+This packet **also supersedes** the parked ADR-0010 packet at `generated/issue-packets/active/adr-0010-observe-ai-routing-phase-1/04-ai-add-routing-contracts.md` — that packet's three contracts (`IModelRouter`, `IRoutingPolicy`, `ModelCapabilityDeclaration`) are authored here as part of the seven-contract D3 surface. The ADR-0010 packet 04 file is renamed `*.superseded.md` and never filed (see dispatch-plan §Supersedes).
 
 ## Target Repo
 `HoneyDrunkStudios/HoneyDrunk.AI`
 
 ## Motivation
-ADR-0016 establishes *what* HoneyDrunk.AI is and what contracts it exposes. The repo carries a working tree on disk but is empty — no `.slnx`, no projects, no CI, no contracts. Six AI-sector Nodes are blocked on this single repo coming online. Standing it up is the highest-leverage unblock available right now.
+ADR-0016 establishes *what* HoneyDrunk.AI is and what contracts it exposes. The `HoneyDrunkStudios/HoneyDrunk.AI` GitHub repo exists (created during ADR-0016 drafting; carries `.gitignore`, `LICENSE`, `README.md`) but is otherwise empty — no `.slnx`, no projects, no CI, no contracts. The local working tree at `c:/.../HoneyDrunkStudios/HoneyDrunk.AI` does not exist yet — packet 02b cloned it. Six AI-sector Nodes are blocked on this single repo coming online. Standing it up is the highest-leverage unblock available right now.
 
 This packet is intentionally larger than typical bring-up packets because:
 
@@ -316,7 +318,7 @@ jobs:
       project-path: src/HoneyDrunk.AI.Abstractions/HoneyDrunk.AI.Abstractions.csproj
 ```
 
-The path filter ensures the canary only runs when Abstractions changes — keeps PR feedback fast for runtime/provider-only changes. The whole-assembly diff produced by `job-api-compatibility.yml` is sufficient to enforce D8: per D9 invariant 39, Abstractions is the only thing downstream Nodes compile against, so any shape drift in any public type in Abstractions counts.
+The path filter ensures the canary only runs when Abstractions changes — keeps PR feedback fast for runtime/provider-only changes. The whole-assembly diff produced by `job-api-compatibility.yml` is sufficient to enforce D8: per D9 invariant 44, Abstractions is the only thing downstream Nodes compile against, so any shape drift in any public type in Abstractions counts.
 
 ```yaml
 # .github/workflows/release.yml
@@ -351,7 +353,7 @@ This pulls in the StyleCop ruleset, `.editorconfig`, and analyzer suite that eve
 
 ### Documentation
 
-- **Repo `README.md`** — purpose statement, package matrix, "How to consume from a downstream Node" snippet showing `AddHoneyDrunkAI()` + `AddModelProvider<InMemoryModelProvider>()`, link to ADR-0016.
+- **Repo `README.md`** — purpose statement, package matrix, link to ADR-0016, plus a dedicated `## For downstream consumers — canary projects` section showing the minimal `services.AddHoneyDrunkAI().AddModelProvider<InMemoryModelProvider>()` wiring (with a sample `ScriptedResponses` dictionary). This snippet is copy-pasteable into a downstream Node's `.Canary` project and is what the six downstream standup ADRs will model on. Also include a "How to consume from a downstream production host" snippet that registers a real provider plus `IConfigProvider`.
 - **Repo `CHANGELOG.md`** — `## [0.1.0] - 2026-MM-DD` entry covering the entire scaffold landing.
 - **Per-package `README.md`** — purpose, public API surface summary, install command. Required by invariant 12 for new packages.
 - **Per-package `CHANGELOG.md`** — `## [0.1.0]` entry for each package introduced in this packet.
@@ -443,12 +445,19 @@ Project references as appropriate to each `.Tests` project.
 - [ ] Test suite runs and passes — minimum coverage: `DefaultModelRouter` happy-path test with two providers + a cost-first policy, `DefaultCostLedger` accumulation test, `InMemoryChatClient` scripted-response test + default-echo test, `InMemoryEmbeddingGenerator` determinism test.
 - [ ] All projects in the solution carry the same `Version` (0.1.0), excluding test projects (invariant 27).
 - [ ] Manual confirmation that pushing tag `v0.1.0` triggers `release.yml` and produces NuGet packages for the six `src/*` projects (do not actually push the tag — verify the workflow exists and a tag-push trigger is configured).
+- [ ] **No `Microsoft.Extensions.AI` reference anywhere.** `grep -rn "Microsoft.Extensions.AI" src/HoneyDrunk.AI.Abstractions/ src/HoneyDrunk.AI/` returns zero matches. (D6 commits to shape compatibility, not type-identity coupling.)
+- [ ] **No `.github/dependabot.yml` file exists.** Per ADR-0009, dependency-scanning lives in the nightly workflows; no Dependabot config file is committed.
+- [ ] **`ICostLedger` is tenant-agnostic.** `InferenceCost` and `CostSummary` records do not contain `TenantId` or `string Tenant` fields. `ICostLedger.GetSummaryAsync` takes `string scope` (not a typed tenant identifier). Per ADR-0026, per-tenant billing flows through `IBillingEventEmitter` at consumer-Node integration, not from inside AI.
+- [ ] **Repo `README.md` includes a `## For downstream consumers — canary projects` section** showing the minimal `services.AddHoneyDrunkAI().AddModelProvider<InMemoryModelProvider>()` snippet against a `ScriptedResponses` dictionary, copy-pasteable into a downstream Node's `.Canary` project. This is load-bearing for the six downstream standups to model their canary projects on.
 
 ## Human Prerequisites
+- [ ] Packet 02b complete — `HoneyDrunk.AI` repo confirmed on GitHub with org-default branch protection and labels seeded, and the local working tree cloned at `c:/.../HoneyDrunkStudios/HoneyDrunk.AI`.
 - [ ] Confirm OIDC federated credential exists for the `HoneyDrunk.AI` repo's release workflow against the Grid's NuGet publishing identity. Cross-link: [`infrastructure/oidc-federated-credentials.md`](../../../../infrastructure/oidc-federated-credentials.md). The Grid has a standard NuGet publishing identity used by every Node — confirm `repo:HoneyDrunkStudios/HoneyDrunk.AI:ref:refs/tags/v*` is in its federated credential list.
 - [ ] After this packet's PR merges, push tag `v0.1.0` from `main` to trigger the first NuGet publish. Tags are human-pushed per invariant 27.
-- [ ] Repo settings: branch protection on `main` requires `pr-core / core` and `api-compatibility / abstractions-shape` checks, no force-pushes, signed commits not required (matches other Grid repos).
+- [ ] **Branch protection sequencing.** Set branch protection on `main` requiring only `pr-core / core` for the initial scaffolding PR (the `api-compatibility / abstractions-shape` check reports `status: skipped` on the first PR — see acceptance criteria). After the throwaway breaking-change PR confirms the canary fires post-merge, add `api-compatibility / abstractions-shape` to required checks in a follow-up branch-protection update. No force-pushes, signed commits not required (matches other Grid repos).
 - [ ] No Azure resource provisioning required for this packet — HoneyDrunk.AI is a library Node, not a deployable. (When a future packet stands up the cost-rate App Config keys, that packet will carry the App Config provisioning Human Prereq, not this one.)
+- [ ] After this packet's PR merges and `v0.1.0` ships, file a small follow-up to add `HoneyDrunk.AI` to the grid-health aggregator's watched-repos list in `HoneyDrunk.Actions` — only if the aggregator does not auto-discover from `catalogs/nodes.json`. Verify which behavior is in place at the time this prereq is being checked. (If auto-discovery is wired, packet 01's `grid-health.json` edit is sufficient and this prereq is satisfied automatically.)
+- [ ] After this packet's PR merges, file a SonarCloud onboarding follow-up packet for `HoneyDrunk.AI` modeled on `generated/issue-packets/active/adr-0011-code-review-pipeline/06-kernel-sonarcloud-onboarding.md` (or whichever ADR-0011 onboarding packet is the closest match in shape).
 
 ## Referenced Invariants
 
@@ -480,11 +489,11 @@ Project references as appropriate to each `.Tests` project.
 
 > **Invariant 28:** Application code must never hardcode a model name or provider. All model selection goes through `IModelRouter` in HoneyDrunk.AI. Routing policies are stored in App Configuration (ADR-0005) and are operator-configurable without a redeploy. — `DefaultModelRouter` and `DefaultCostLedger` both read from App Config via `IConfigProvider`. No `if (modelId == "gpt-4") ...` branches anywhere.
 
-> **Invariant 39 (this initiative, packet 02):** Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`. Composition against `HoneyDrunk.AI` and any `HoneyDrunk.AI.Providers.*` package is a host-time concern resolved at application startup from App Configuration. — Reinforced in this scaffold by giving `Abstractions` zero HoneyDrunk dependencies so consumers don't transit unintended pins.
+> **Invariant 44 (this initiative, packet 02):** Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`. Composition against `HoneyDrunk.AI` and any `HoneyDrunk.AI.Providers.*` package is a host-time concern resolved at application startup from App Configuration. — Reinforced in this scaffold by giving `Abstractions` zero HoneyDrunk dependencies so consumers don't transit unintended pins.
 
-> **Invariant 40 (this initiative, packet 02):** Token cost rates, routing policies, and capability declarations are sourced from Azure App Configuration via Vault's `IConfigProvider`. Hardcoded rates, policies, or capability declarations in application code are forbidden. — `DefaultCostLedger` reads token prices from `IConfigProvider`; `PolicyLoader` reads `policy:active` and policy-specific config keys.
+> **Invariant 45 (this initiative, packet 02):** Token cost rates, routing policies, and capability declarations are sourced from Azure App Configuration via Vault's `IConfigProvider`. Hardcoded rates, policies, or capability declarations in application code are forbidden. — `DefaultCostLedger` reads token prices from `IConfigProvider`; `PolicyLoader` reads `policy:active` and policy-specific config keys.
 
-> **Invariant 41 (this initiative, packet 02):** The HoneyDrunk.AI Node CI must include a contract-shape canary that fails the build on shape drift to `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, or `IModelRouter` without a corresponding version bump. — `api-compatibility.yml` calls `HoneyDrunk.Actions/job-api-compatibility.yml` scoped to `HoneyDrunk.AI.Abstractions`. The whole-assembly diff covers all four hot-path contracts plus `IRoutingPolicy`, `ModelCapabilityDeclaration`, `ICostLedger`.
+> **Invariant 46 (this initiative, packet 02):** The HoneyDrunk.AI Node CI must include a contract-shape canary that fails the build on shape drift to `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, or `IModelRouter` without a corresponding version bump. — `api-compatibility.yml` calls `HoneyDrunk.Actions/job-api-compatibility.yml` scoped to `HoneyDrunk.AI.Abstractions`. The whole-assembly diff covers all four hot-path contracts plus `IRoutingPolicy`, `ModelCapabilityDeclaration`, `ICostLedger`.
 
 ## Referenced ADR Decisions
 
@@ -510,7 +519,8 @@ Project references as appropriate to each `.Tests` project.
 
 ## Dependencies
 - `packet:01` — catalog registration must land first so the Architecture catalogs match what this packet ships. Filing order matters for the `addBlockedBy` graph on The Hive.
-- `packet:02` — invariants 39, 40, 41 must exist in `constitution/invariants.md` before this packet's acceptance criteria reference them by number.
+- `packet:02` — invariants 44, 45, 46 must exist in `constitution/invariants.md` before this packet's acceptance criteria reference them by number. Packet 02 also drops invariant 28's `(Proposed)` qualifier.
+- `packet:02b` — the `HoneyDrunk.AI` GitHub repo must have its standard org settings (branch protection, labels, default branch) applied and its local working tree cloned at `c:/.../HoneyDrunkStudios/HoneyDrunk.AI` before the scaffolding agent can author files. The repo itself already exists on GitHub; packet 02b is the human-only verification + clone chore.
 
 ## Labels
 `feature`, `tier-2`, `ai`, `scaffold`, `adr-0016`
@@ -540,14 +550,16 @@ Project references as appropriate to each `.Tests` project.
 - **Invariant 26:** Packets for .NET code work must include `## NuGet Dependencies`. `HoneyDrunk.Standards` must be on every new .NET project. — Confirmed in the NuGet Dependencies section above.
 - **Invariant 27:** All projects in a solution share one version. — Every `src/*.csproj` ships at `0.1.0`. Test projects do not bump.
 - **Invariant 28:** No hardcoded model name or provider. — `DefaultModelRouter`, `DefaultCostLedger`, and `PolicyLoader` all read from App Config. The InMemory provider's two synthetic models are declared via `ModelCapabilityDeclaration` data, not branched on by string in any consumer.
-- **Invariant 39:** Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`. — Reinforced by keeping Abstractions HoneyDrunk-dependency-free.
-- **Invariant 40:** Token cost rates, routing policies, and capability declarations sourced from App Configuration via `IConfigProvider`. — `DefaultCostLedger` and `PolicyLoader` both read from `IConfigProvider`. No `decimal RatePerKToken = 0.03m` literals anywhere.
-- **Invariant 41:** AI Node CI must include the contract-shape canary on the four hot-path contracts. — `api-compatibility.yml` covers this by scoping to `HoneyDrunk.AI.Abstractions`.
+- **Invariant 44:** Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`. — Reinforced by keeping Abstractions HoneyDrunk-dependency-free.
+- **Invariant 45:** Token cost rates, routing policies, and capability declarations sourced from App Configuration via `IConfigProvider`. — `DefaultCostLedger` and `PolicyLoader` both read from `IConfigProvider`. No `decimal RatePerKToken = 0.03m` literals anywhere.
+- **Invariant 46:** AI Node CI must include the contract-shape canary on the four hot-path contracts. — `api-compatibility.yml` covers this by scoping to `HoneyDrunk.AI.Abstractions`.
 - **Canary on the scaffolding PR is expected to report `status: skipped`, not fail.** The shared `HoneyDrunk.Actions/.github/actions/api/check-compatibility/action.yml` emits `::warning::` and exits 0 with `status: skipped` when `git worktree add` against the baseline ref fails — which it always does on a first PR against an empty repo. Do not treat the skip as a misconfiguration and do not chase it. The scaffolding PR's merge establishes the `main` baseline; verification of the canary actually firing happens **post-merge** via a throwaway breaking-change PR that is reverted after observation.
 - **Strict Abstractions stance is deliberate.** `HoneyDrunk.AI.Abstractions` ships with zero `HoneyDrunk.*` references. This is the user's explicit scoping resolution — see ADR-0016 D2 line 42 (amended by packet 01 to `Microsoft.Extensions.*` only) and `repos/HoneyDrunk.AI/invariants.md:5`. Any GridContext/CorrelationId propagation belongs in the `HoneyDrunk.AI` runtime package (specifically `InferenceTelemetry`), not in Abstractions. `InferenceCost.OperationCorrelationId` is a `string`; `ICostLedger.GetSummaryAsync(string scope, ...)` takes a `string`. Do not import `HoneyDrunk.Kernel.Abstractions` in any `HoneyDrunk.AI.Abstractions` source file.
 - **D3 is canonical, not the "If Accepted" checklist.** Author exactly the seven D3 contracts. Do **not** author `IInferenceResult`. If you find a reference to `IInferenceResult` anywhere in scope (e.g. an old example in the AI sector architecture doc), that is drift to be cleaned up by packet 01 or as a follow-up — do not invent the type just because the ADR's checklist mentions it.
 - **Records drop `I`; interfaces keep it.** `ModelCapabilityDeclaration` is a record (no `I`). The other six contracts are interfaces (with `I`). Supporting record types in the same files (`RoutedModel`, `ModelCandidate`, `RoutingDecision`, `InferenceCost`, `CostSummary`, `ChatMessage`, `ChatCompletion`, `Embedding`, `EmbeddingOptions`, `ChatOptions`) all drop the `I`.
 - **Shape compatibility with `Microsoft.Extensions.AI` is structural, not type-identity.** Match the parameter shapes and member sets where they are stable. Do **not** reference any `Microsoft.Extensions.AI.*` package. The MEAI interop adapter is deferred to Q3 2026 per D6.
+- **Per ADR-0009, no `.github/dependabot.yml` is created.** Dependency-scanning is delegated to `nightly-deps.yml` and `nightly-security.yml` calling `HoneyDrunk.Actions` reusable workflows. GitHub Dependabot security alerts remain enabled at repo settings (org default — packet 02b confirms). No grouped or per-package `dependabot.yml` configuration file is committed to this repo.
+- **`ICostLedger` is internal cost accounting only — do NOT add `TenantId` or `string Tenant` fields to `InferenceCost` / `CostSummary` in this packet.** Per ADR-0026 (Accepted 2026-05-02), tenant-scoped billing events emit through `IBillingEventEmitter` at the consumer-Node integration layer, not from inside AI. `ICostLedger.GetSummaryAsync(string scope, ...)` keeps `string` for scope. Per-tenant AI cost rollups are a follow-up under whichever Node first commercializes inference (see PDR-0002 / ADR-0026 D10), not in scope here.
 
 **Key Files:**
 - `HoneyDrunk.AI.slnx`, `Directory.Build.props`

--- a/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/dispatch-plan.md
@@ -6,16 +6,21 @@
 **Trigger:** ADR-0016 accepted into the Proposed queue. Six AI-sector Nodes (Capabilities, Operator, Agents, Memory, Knowledge, Evals) are blocked on `HoneyDrunk.AI.Abstractions` existing. This initiative builds the substrate that unblocks them.
 **Type:** Multi-repo (2 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.AI`)
 **Site sync required:** No (scaffold-only; no public-API surface change needs site update yet — when 0.1.0 ships and downstream Nodes start consuming, a site-sync follow-up may be warranted)
-**Rollback plan:** Each packet is a single PR. Rollback is `git revert`. The new `HoneyDrunk.AI` repo's `0.1.0` tag is published only after the human pushes the tag — which is post-merge — so a rollback before tag push is just a revert. After tag push, NuGet packages are immutable but unconsumed at this point in the rollout (downstream Nodes haven't started yet).
+**Rollback plan:**
+- **Pre-tag rollback** (before `v0.1.0` is pushed): `git revert` of each PR. Packets 01/02/02b are independent reverts; packet 03 reverts the entire scaffold as a single PR.
+- **Post-tag rollback** (after `v0.1.0` is pushed but before downstream Nodes consume): NuGet packages are immutable. Either `dotnet nuget delete` if the packages were just pushed and pre-discovery, or fix-forward as `0.1.1`. Practical hard rollback after a tag is messy — prefer fix-forward.
+- **After downstream consumers start (post-this-initiative):** rollback is no longer a clean option; treat any defect as forward-only.
+- **`file-packets.yml` lifecycle gotcha:** after this initiative's packets have moved through The Hive, hive-sync may move source packet files from `active/` to `completed/` per invariant 37. A `git revert` only undoes code changes, not packet-file moves. If a revert is needed after lifecycle moves, restore the packet files manually as part of the revert PR.
 
 ## Summary
 
 ADR-0016 is the standup ADR for `HoneyDrunk.AI`. It decides what the Node owns (D1), the package families (D2), the seven exposed contracts (D3), routing scope (D4), App Configuration sourcing for routing/cost (D5), Microsoft.Extensions.AI shape compatibility without type-identity coupling (D6), one-way telemetry to Pulse (D7), the contract-shape canary (D8), and the downstream coupling rule (D9). None of that has been built — the AI repo is empty.
 
-Three packets land the work:
+Four packets land the work:
 
-1. **Architecture catalog registration** — `contracts.json`, `relationships.json`, `grid-health.json`, `nodes.json`, `ai-sector-architecture.md`. Resolves the D3-vs-"If Accepted" checklist discrepancy by treating D3 as canonical (drops `IInferenceResult`, adds `ICostLedger`).
-2. **Constitution invariants** — three new invariants from D5, D8, D9 added to `constitution/invariants.md` at numbers 39/40/41.
+1. **Architecture catalog registration** — `contracts.json`, `relationships.json`, `grid-health.json`, `nodes.json`, `ai-sector-architecture.md`, `repos/HoneyDrunk.AI/{boundaries,invariants}.md`. Resolves the D3-vs-"If Accepted" checklist discrepancy by treating D3 as canonical (drops `IInferenceResult`, adds `ICostLedger`).
+2. **Constitution invariants** — three new invariants from D5, D8, D9 added to `constitution/invariants.md` at numbers 44/45/46. Also drops invariant 28's `(Proposed)` qualifier (originally scoped to ADR-0010 packet 04 — superseded; see §Supersedes).
+2b. **Verify `HoneyDrunk.AI` repo + clone locally (human-only)** — the GitHub repo exists from ADR-0016 drafting (only `.gitignore`, `LICENSE`, `README.md` committed), but the local working tree at `c:/.../HoneyDrunkStudios/HoneyDrunk.AI` does not. This packet is a chore: confirm branch protection matches Grid org default, seed labels, clone the repo locally, and gate filing of packet 03.
 3. **HoneyDrunk.AI scaffold** — empty repo to first-shippable state. Solution, six packages, seven contracts, default runtime, four provider slots (InMemory functional, three stubs), five CI workflow files including the contract-shape canary scoped to Abstractions.
 
 ## Wave Diagram
@@ -26,27 +31,33 @@ Wave 1: Architecture catalog + constitution updates (parallel)
    └─ Architecture: 02-architecture-ai-invariants
        Blocked by: 01 (so 02's invariant text aligns with the catalog surface 01 lands)
 
-Wave 2: AI repo scaffold
+Wave 2: Verify HoneyDrunk.AI repo and clone locally (human)
+   └─ Architecture: 02b-architecture-verify-ai-repo
+       Blocked by: 01 (catalog must register the AI Node first)
+
+Wave 3: AI repo scaffold
    └─ HoneyDrunk.AI: 03-ai-node-scaffold
-       Blocked by: 01, 02
+       Blocked by: 01, 02, 02b
 ```
 
-In practice 01 and 02 are both Architecture-repo packets touching different files (catalogs vs constitution), so they could be authored as a single PR. They are kept as separate packets to honor the "one logical change per packet" rule and to give the user a clean review surface for each (catalog drift is one mental model; invariant numbering is another).
+In practice 01 and 02 are both Architecture-repo packets touching different files (catalogs vs constitution), so they could be authored as a single PR. They are kept as separate packets to honor the "one logical change per packet" rule and to give the user a clean review surface for each (catalog drift is one mental model; invariant numbering is another). Packet 02b is a separate human-only chore so the work stays visible on The Hive board as its own item.
 
 ## Packet List
 
-| # | Packet | Repo | Wave | Depends On |
-|---|--------|------|------|------------|
-| 01 | [Catalog registration (`contracts.json`, `relationships.json`, `grid-health.json`, `nodes.json`, `ai-sector-architecture.md`)](./01-architecture-ai-catalog-registration.md) | Architecture | 1 | — |
-| 02 | [Add invariants 39/40/41 (downstream coupling, App Config sourcing, contract-shape canary)](./02-architecture-ai-invariants.md) | Architecture | 1 | 01 |
-| 03 | [Stand up `HoneyDrunk.AI` — solution, six packages, contracts, CI, InMemory provider](./03-ai-node-scaffold.md) | HoneyDrunk.AI | 2 | 01, 02 |
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 01 | [Catalog registration (`contracts.json`, `relationships.json`, `grid-health.json`, `nodes.json`, `ai-sector-architecture.md`, repo invariants/boundaries)](./01-architecture-ai-catalog-registration.md) | Architecture | 1 | Agent | — |
+| 02 | [Add invariants 44/45/46 + drop invariant 28 `(Proposed)` qualifier](./02-architecture-ai-invariants.md) | Architecture | 1 | Agent | 01 |
+| 02b | [Verify HoneyDrunk.AI repo + clone locally (human-only)](./02b-architecture-verify-ai-repo.md) | Architecture (tracking issue) | 2 | Human | 01 |
+| 03 | [Stand up `HoneyDrunk.AI` — solution, six packages, contracts, CI, InMemory provider](./03-ai-node-scaffold.md) | HoneyDrunk.AI | 3 | Agent | 01, 02, 02b |
 
 ## Phase Mapping
 
 - **Wave 1 (packets 01 + 02) = ADR-0016's "If Accepted" catalog/constitution obligations.**
-  - Packet 01 covers all four catalog/doc edits in the "If Accepted" checklist except invariants and the scaffold (catalogs/contracts.json + grid-health.json + nodes.json phrasing + ai-sector-architecture.md phrasing) and resolves the D3-vs-checklist discrepancy.
-  - Packet 02 covers the invariants ADR-0016 explicitly delegates to the scope agent at acceptance.
-- **Wave 2 (packet 03) = the standup itself.** Larger than typical bring-up packets because the AI Node carries six packages and seven contracts, all of which must land together to give the contract-shape canary a coherent baseline.
+  - Packet 01 covers all four catalog/doc edits in the "If Accepted" checklist except invariants and the scaffold (catalogs/contracts.json + grid-health.json + nodes.json phrasing + ai-sector-architecture.md phrasing) and resolves the D3-vs-checklist discrepancy. Also lands `repos/HoneyDrunk.AI/{boundaries.md, invariants.md}` cleanups for `local models` drift and constitutional cross-references.
+  - Packet 02 covers the invariants ADR-0016 explicitly delegates to the scope agent at acceptance, plus the invariant 28 qualifier removal originally scoped to the now-superseded ADR-0010 packet 04.
+- **Wave 2 (packet 02b) = repo verification + local clone (human-only chore).** The GitHub repo exists, but the local clone doesn't and branch protection / labels need to be confirmed before scaffolding. Same shape as `adr-0017-capabilities-standup/03-architecture-create-capabilities-repo.md`, except this one is verify-and-clone rather than create.
+- **Wave 3 (packet 03) = the standup itself.** Larger than typical bring-up packets because the AI Node carries six packages and seven contracts, all of which must land together to give the contract-shape canary a coherent baseline.
 
 ## Discrepancies Flagged for the User
 
@@ -68,20 +79,36 @@ Also: `relationships.json` line 190 currently lists `IInferenceResult` in the `h
 
 Packet 01 amends ADR-0016 D2 line 42 in the same edit it lands the catalog drift fixes — replacing `Zero runtime dependencies beyond \`HoneyDrunk.Kernel\` abstractions.` with `Zero runtime dependencies beyond \`Microsoft.Extensions.*\` abstractions.` Packet 03 keeps `Abstractions` HoneyDrunk-free in code and explicitly cites this stance in its Constraints section so the executing agent does not introduce a Kernel.Abstractions reference. Practical fallout: `InferenceCost.OperationCorrelationId` stays `string`; `ICostLedger.GetSummaryAsync(string scope, ...)` keeps `string` params; GridContext/CorrelationId propagation lives in the AI runtime package's `InferenceTelemetry`, not in any Abstractions type.
 
+## Supersedes
+
+This initiative supersedes the parked routing-contracts packet at `generated/issue-packets/active/adr-0010-observe-ai-routing-phase-1/04-ai-add-routing-contracts.md`. That packet's three contracts (`IModelRouter`, `IRoutingPolicy`, `ModelCapabilityDeclaration`) are authored here as part of the seven-contract D3 surface in packet 03. The cross-repo edit it carried — removing invariant 28's `(Proposed — this invariant takes effect when ADR-0010 is accepted)` qualifier — is rolled into packet 02 of this initiative.
+
+**Action:** As part of packet 01's PR (or in a small Architecture cleanup commit), rename `generated/issue-packets/active/adr-0010-observe-ai-routing-phase-1/04-ai-add-routing-contracts.md` to `04-ai-add-routing-contracts.superseded.md`. The `.superseded.md` suffix prevents `file-packets.yml` from picking it up. The file is kept for historical traceability rather than deleted outright. The ADR-0010 initiative's dispatch plan (if it references packet 04) should also be updated to reflect the supersession.
+
 ## Filing-order rule
 
-Packet 03 hard-codes invariant numbers 39/40/41 in its body and acceptance criteria. Filed packets are immutable (invariant 24). Therefore:
+Packet 03 hard-codes invariant numbers 44/45/46 in its body and acceptance criteria. Filed packets are immutable (invariant 24). Therefore:
 
-**Packet 02 must be filed, its PR merged, and the assigned invariant numbers locked in `constitution/invariants.md` before packet 03 is filed.**
+**Packet 02 must be filed, its PR merged, and the assigned invariant numbers locked in `constitution/invariants.md` before packet 03 is filed.** Packet 02b can run in parallel with packet 02 — it doesn't depend on the invariant numbers — but its issue must be Done before packet 03 is filed (the local working tree must exist for the scaffolding agent).
 
-If packet 02's collision check at edit time forces a renumber away from 39/40/41, the packet 03 source file at `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md` MUST be amended in place before push (it has not been filed yet at that point — invariant 24's pre-filing carve-out applies). **Packets 02 and 03 cannot be filed in the same push.** Concretely:
+If packet 02's collision check at edit time forces a renumber away from 44/45/46, the packet 03 source file at `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md` MUST be amended in place before push (it has not been filed yet at that point — invariant 24's pre-filing carve-out applies). **Packets 02 and 03 cannot be filed in the same push.** Concretely:
 
-1. Push packets 01 and 02 (they may travel together — packet 02's `dependencies: ["packet:01"]` wires the blocking edge automatically).
-2. Wait for packet 02's PR to merge so the assigned invariant numbers actually land in `constitution/invariants.md`.
-3. If the numbers shifted away from 39/40/41, edit `03-ai-node-scaffold.md` in place to match (pre-filing carve-out under invariant 24).
+1. Push packets 01, 02, and 02b (they may travel together — packet 02's `dependencies: ["packet:01"]` and packet 02b's `dependencies: ["packet:01"]` wire the blocking edges automatically; packet 02b is also `actor: human` so it routes onto The Hive as a human-only item).
+2. Wait for packet 02's PR to merge so the assigned invariant numbers actually land in `constitution/invariants.md`. Wait for packet 02b's chore issue to be Done so the local working tree exists.
+3. If the numbers shifted away from 44/45/46, edit `03-ai-node-scaffold.md` in place to match (pre-filing carve-out under invariant 24).
 4. Push packet 03.
 
 Packet 02's acceptance criteria call this out; packet 03's body assumes the lock has happened.
+
+## Sequencing vs ADR-0017 (Capabilities standup)
+
+ADR-0017's standup initiative also intends to claim the next three free invariant numbers. There is a **race condition between the two initiatives' packet 02s** — whichever lands first takes 44/45/46; the other shifts.
+
+**Recommended order:** ADR-0016 lands first because (a) it unblocks six Nodes including Capabilities itself, and (b) ADR-0017's scaffold compiles against `HoneyDrunk.AI.Abstractions` which doesn't exist until ADR-0016 ships. If ADR-0017 lands first by accident, ADR-0016's packet 02 shifts its three invariants to 47/48/49 and packet 03's source file is amended accordingly under invariant 24's pre-filing carve-out.
+
+## Asymmetry vs ADR-0017's `*.Testing` package — deliberate
+
+ADR-0017 D2 uses a separate `HoneyDrunk.Capabilities.Testing` NuGet artifact for downstream test fixtures. ADR-0016 D2 uses `HoneyDrunk.AI.Providers.InMemory` instead — same role (deterministic test double), different shape (a "provider slot" not a `*.Testing` package). The asymmetry is deliberate: the InMemory provider is a real provider implementation that can ship in production hosts (e.g., Evals as a deterministic eval fixture in production-grade eval runs), while a `*.Testing` artifact would be tagged production-forbidden. Downstream Node standup ADRs in the AI sector should pick the pattern that matches their fixture's intended runtime stance — not blindly copy whichever they read first.
 
 ## What This Initiative Does **NOT** Deliver
 
@@ -100,6 +127,14 @@ The three OpenAI/Anthropic/AzureOpenAI provider implementations are **stubs** in
 
 The `HoneyDrunk.AI.Interop.MEAI` adapter package is deferred to Q3 2026 per ADR-0016 D6 and is not in scope for this initiative.
 
+**SonarCloud onboarding for `HoneyDrunk.AI`** follows the pattern from `generated/issue-packets/active/adr-0011-code-review-pipeline/06-kernel-sonarcloud-onboarding.md` — a separate follow-up packet, not in scope here. Packet 03's Human Prerequisites flag this as a post-merge follow-up.
+
+**`IRoutingPolicy` first implementation** (e.g., a cost-first concrete policy) is **not in scope** for this initiative. Packet 03 ships the contracts and a `DefaultModelRouter` that resolves a registered policy from DI; the cost-first implementation lands as a follow-up so the contract surface can settle before any policy locks against it. `repos/HoneyDrunk.AI/active-work.md` mentions a cost-first first implementation — that's directional, not a packet-3 deliverable.
+
+**Per-tenant AI cost rollups** (composing `ICostLedger` with ADR-0026's `IBillingEventEmitter`) are deferred to whichever Node first commercializes inference, per ADR-0026 D10 and PDR-0002 (Notify-as-a-Service). `ICostLedger` ships tenant-agnostic in this initiative.
+
+**Grid-health aggregator** wiring for the new repo: if `HoneyDrunk.Actions/.github/workflows/grid-health-aggregator.yml` auto-discovers from `catalogs/nodes.json`, packet 01's edit is sufficient. If not, packet 03's Human Prerequisites flag a small follow-up to add `HoneyDrunk.AI` to the watched-repos list. Confirm which behavior is in place at execution time.
+
 ## Archival
 
 Per ADR-0008 D10, when every packet in this initiative reaches `Done` on the org Project board and `HoneyDrunk.AI 0.1.0` is published to NuGet, the entire `active/adr-0016-honeydrunk-ai-standup/` folder moves to `archive/adr-0016-honeydrunk-ai-standup/` in a single commit. Partial archival is forbidden.
@@ -111,6 +146,8 @@ The hive-sync agent moves individual closed packet files from `active/` to `comp
 - **Scoping insight: the contract-shape canary needs no Actions packet.** Initially scoped this initiative as four packets (with a separate Actions packet to wire the canary). Investigation showed `HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml` already exists and supports `project-path`-scoped diffing. Per ADR-0016 D9, `HoneyDrunk.AI.Abstractions` is the only public-boundary package — so scoping the canary to that one assembly satisfies D8 without per-type filtering. The wiring is a single `.github/workflows/api-compatibility.yml` file inside HoneyDrunk.AI itself, folded into packet 03's CI bring-up. No Actions repo change required.
 
 - **Why two Architecture packets in Wave 1, not one.** Catalog drift correction (packet 01) and invariant numbering (packet 02) are conceptually separate review concerns. A single mega-PR mixing them would obscure the D3-canonical resolution of the `IInferenceResult`/`ICostLedger` discrepancy. Packets 01 and 02 may be filed in the same push (their `dependencies:` frontmatter wires the `packet:01 → packet:02` blocking edge automatically); the **hard split is between 02 and 03** — see the Filing-order rule above. Packet 03 must not be filed until packet 02 has landed in `constitution/invariants.md` and the assigned numbers are confirmed, so any required amendments to packet 03's source file can happen pre-filing.
+
+- **Why packet 02b is its own item.** The `HoneyDrunk.AI` GitHub repo already exists (created during ADR-0016 drafting), but the local working tree at `c:/.../HoneyDrunkStudios/HoneyDrunk.AI` doesn't, and branch protection / labels need to be checked. Surfacing this as a Hive-board item with `Actor=Human` keeps it visible as a blocker on packet 03 instead of becoming a hidden prereq buried in the scaffold packet's body. Same shape as `adr-0017-capabilities-standup/03-architecture-create-capabilities-repo.md` — except verify-and-clone, not create.
 
 - **Status flip happens after merge, not now.** ADR-0016 stays Proposed for this scoping run. The user's standing workflow says the scope agent flips Status → Accepted after the follow-up PR merges. None of the three packets in this initiative flip ADR-0016's status — that is a separate housekeeping step the scope agent handles when the initiative completes.
 


### PR DESCRIPTION
## Summary
- Iterates on ADR-0016 (HoneyDrunk AI Node standup) and its dispatch plan
- Refines packets 01 (catalog registration), 02 (invariants), 03 (node scaffold)
- Adds packet **02b — verify AI repo** as a follow-on to packet 02
- Updates `dispatch-plan.md` to reflect the refined packet set

## Files
- `adrs/ADR-0016-stand-up-honeydrunk-ai-node.md`
- `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/01-architecture-ai-catalog-registration.md`
- `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/02-architecture-ai-invariants.md`
- `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/02b-architecture-verify-ai-repo.md` (new)
- `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold.md`
- `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/dispatch-plan.md`

## Test plan
- [ ] Re-read packets 01/02/02b/03 + dispatch-plan for consistency before filing
- [ ] Confirm ADR-0016 wording matches the refined packet set
- [ ] Verify `02b` slot in dispatch-plan ordering is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)