### PR TITLE
chore(packets): supersede ADR-0010 04 routing-contracts packet

### DIFF
--- a/generated/issue-packets/active/adr-0010-observe-ai-routing-phase-1/04-ai-add-routing-contracts.superseded.md
+++ b/generated/issue-packets/active/adr-0010-observe-ai-routing-phase-1/04-ai-add-routing-contracts.superseded.md
@@ -9,12 +9,16 @@ adrs: ["ADR-0010", "ADR-0005"]
 wave: 2
 initiative: adr-0010-observe-ai-routing-phase-1
 node: honeydrunk-ai
-status: deferred-pending-ai-standup
+status: superseded-by-adr-0016
 ---
 
 # Feature: Add `IModelRouter`, `IRoutingPolicy`, `ModelCapabilityDeclaration` to `HoneyDrunk.AI.Abstractions`
 
-> **STATUS — deferred (2026-04-18):** This packet is parked. The HoneyDrunk.AI GitHub repo exists but is empty. Scaffolding choices for a foundational Node — solution layout, Microsoft.Extensions.AI alignment, package family split, inference-vs-routing contract boundaries, Pulse/Vault integration, first provider — are architectural decisions that deserve their own ADR. Bundling that scaffold into a routing-contracts packet would embed those decisions silently. **Do not file this packet until a HoneyDrunk.AI standup ADR (provisional `ADR-0014-honeydrunk-ai-standup`) is accepted and its scaffolding initiative has shipped `HoneyDrunk.AI.Abstractions` as a minimum-viable Abstractions package.** Once that foundation exists, the packet body below becomes fileable as a strict contracts-addition PR.
+> **STATUS — superseded (2026-05-05):** This packet is **superseded by the ADR-0016 standup initiative** at `generated/issue-packets/active/adr-0016-honeydrunk-ai-standup/`. The three contracts originally scoped here (`IModelRouter`, `IRoutingPolicy`, `ModelCapabilityDeclaration`) are authored as part of the seven-contract D3 surface in **packet 03** of that initiative. The cross-repo invariant-28 qualifier-removal originally scoped here is rolled into **packet 02** of that initiative.
+>
+> The `.superseded.md` suffix prevents `file-packets.yml` from picking this packet up. Kept on disk for historical traceability rather than deleted outright.
+>
+> **Original deferral note (2026-04-18, pre-supersession, retained for context):** This packet was parked. The HoneyDrunk.AI GitHub repo exists but is empty. Scaffolding choices for a foundational Node — solution layout, Microsoft.Extensions.AI alignment, package family split, inference-vs-routing contract boundaries, Pulse/Vault integration, first provider — are architectural decisions that deserve their own ADR. Bundling that scaffold into a routing-contracts packet would embed those decisions silently. The deferral was correct; ADR-0016 is the standup ADR that resolves it, and its scaffolding initiative absorbs this packet's scope.
 
 ## Summary
 Add the three AI routing contracts defined in ADR-0010 Phase 1 to `HoneyDrunk.AI.Abstractions`. These contracts make application-code-level model hardcoding architecturally impossible (invariant 28) by providing a single entry point (`IModelRouter`) for model selection, a pluggable policy shape (`IRoutingPolicy`), and a machine-readable capability declaration (`ModelCapabilityDeclaration`) that policies reason over.


### PR DESCRIPTION
## Summary
- Renames `04-ai-add-routing-contracts.md` → `04-ai-add-routing-contracts.superseded.md`
- The `.superseded.md` suffix prevents `file-packets.yml` from picking it up
- Kept on disk for historical traceability rather than deleted outright

## Why
The three contracts originally scoped in this packet — `IModelRouter`, `IRoutingPolicy`, `ModelCapabilityDeclaration` — and the invariant-28 qualifier removal are now absorbed into the **ADR-0016** AI standup initiative:
- Contracts authored as part of the seven-contract D3 surface in **packet 03** of the ADR-0016 initiative
- Cross-repo invariant-28 qualifier-removal rolled into **packet 02** of the ADR-0016 initiative

The original deferral note (2026-04-18) is retained inside the file for context.

## Test plan
- [ ] Verify `file-packets.yml` no longer matches the superseded packet
- [ ] Confirm no other dispatch plan references the original 04 packet path

🤖 Generated with [Claude Code](https://claude.com/claude-code)