### PR TITLE
Scope Kernel adoption alignment and reconcile Pulse node ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Scoped the Kernel Adoption Alignment initiative with per-repo packets for Kernel, Transport, Vault, Auth, Web.Rest, Data, Vault.Rotation, Notify, Pulse, Communications, and Architecture catalog reconciliation.
+- Reconciled Pulse's canonical Node ID from legacy `pulse` to `honeydrunk-pulse` across architecture catalogs and naming conventions.
 - Accept ADR-0030 (Grid-Wide Audit Substrate). Register `honeydrunk-audit` Node across nodes.json/relationships.json/contracts.json/grid-health.json/modules.json with four new edges (Audit→Kernel, Audit→Data, Auth→Audit planned, Operator→Audit planned). Add Core-sector Audit row. Mark Operator's `IAuditLog` as relocated to `honeydrunk-audit`. (ADR-0018's pre-existing 2026-05-16 amendment recording the `IAuditLog`/`AuditEntry` relocation and Operator's reclassification to consumer-not-owner was verified unchanged — not modified by this PR.) Create `repos/HoneyDrunk.Audit/` context folder. ADR-0030 flipped Proposed → Accepted; ADR-0031 standup remains Proposed (separate initiative).
 - Renamed the legacy initiative sync agent to `hive-sync` and moved the runtime contract from GitHub Actions/Anthropic to OpenClaw scheduled/manual execution.
 - Added Hive Sync packet lifecycle handling for `active/` → `completed/` moves and `filed-packets.json` path reconciliation.

--- a/catalogs/compatibility.json
+++ b/catalogs/compatibility.json
@@ -53,7 +53,7 @@
       "notes": "Transport dependency for outbox store implementations."
     },
     {
-      "node": "pulse",
+      "node": "honeydrunk-pulse",
       "currentVersion": "0.1.0",
       "compatibleWith": {
         "honeydrunk-kernel": ">=0.4.0"

--- a/catalogs/contracts.json
+++ b/catalogs/contracts.json
@@ -120,7 +120,7 @@
       ]
     },
     {
-      "node": "pulse",
+      "node": "honeydrunk-pulse",
       "node_name": "HoneyDrunk.Pulse",
       "package": "HoneyDrunk.Pulse.Contracts",
       "status": "seed",

--- a/catalogs/grid-health.json
+++ b/catalogs/grid-health.json
@@ -116,7 +116,7 @@
       "notes": "v0.1.0 packages released. Contracts and welcome-flow runtime are stood up: intents, recipient resolution, preference store, cadence policy, decision log, and Notify delegation. Durable stores/testing package remain deferred. CORRECTION 2026-05-16: canary_status was reported 'passing' in error — no contract-shape canary is actually wired (Communications uses shared pr-core.yml, which has no api-compatibility job). See Communications#12."
     },
     {
-      "id": "pulse",
+      "id": "honeydrunk-pulse",
       "name": "HoneyDrunk.Pulse",
       "sector": "Ops",
       "signal": "Seed",
@@ -277,6 +277,6 @@
     "canary_passing": 8,
     "canary_none": 15,
     "canary_failing": 0,
-    "blocked_nodes": ["honeydrunk-vault-rotation", "honeydrunk-notify", "honeydrunk-communications", "pulse", "honeydrunk-lore", "honeydrunk-actions", "honeydrunk-agents", "honeydrunk-ai", "honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-evals", "honeydrunk-capabilities", "honeydrunk-flow", "honeydrunk-operator", "honeydrunk-sim", "honeydrunk-audit"]
+    "blocked_nodes": ["honeydrunk-vault-rotation", "honeydrunk-notify", "honeydrunk-communications", "honeydrunk-pulse", "honeydrunk-lore", "honeydrunk-actions", "honeydrunk-agents", "honeydrunk-ai", "honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-evals", "honeydrunk-capabilities", "honeydrunk-flow", "honeydrunk-operator", "honeydrunk-sim", "honeydrunk-audit"]
   }
 }

--- a/catalogs/modules.json
+++ b/catalogs/modules.json
@@ -137,7 +137,7 @@
   },
   {
     "id": "pulse-contracts",
-    "nodeId": "pulse",
+    "nodeId": "honeydrunk-pulse",
     "name": "HoneyDrunk.Pulse.Contracts",
     "type": "abstractions",
     "version": "0.1.0",
@@ -145,7 +145,7 @@
   },
   {
     "id": "telemetry-abstractions",
-    "nodeId": "pulse",
+    "nodeId": "honeydrunk-pulse",
     "name": "HoneyDrunk.Telemetry.Abstractions",
     "type": "abstractions",
     "version": "0.1.0",
@@ -153,7 +153,7 @@
   },
   {
     "id": "telemetry-otel",
-    "nodeId": "pulse",
+    "nodeId": "honeydrunk-pulse",
     "name": "HoneyDrunk.Telemetry.OpenTelemetry",
     "type": "runtime",
     "version": "0.1.0",

--- a/catalogs/nodes.json
+++ b/catalogs/nodes.json
@@ -354,10 +354,10 @@
     "cooldown_days": 14
   },
   {
-    "id": "pulse",
+    "id": "honeydrunk-pulse",
     "type": "node",
-    "name": "Pulse",
-    "public_name": "Pulse",
+    "name": "HoneyDrunk.Pulse",
+    "public_name": "HoneyDrunk.Pulse",
     "short": "Observability suite (logs/traces/metrics)",
     "description": "Unified observability. Logs, traces, and metrics in one interface. See the heartbeat of The Hive.",
     "sector": "Ops",

--- a/catalogs/relationships.json
+++ b/catalogs/relationships.json
@@ -3,7 +3,7 @@
     {
       "id": "honeydrunk-kernel",
       "consumes": [],
-      "consumed_by": ["honeydrunk-transport", "honeydrunk-vault", "honeydrunk-auth", "honeydrunk-web-rest", "honeydrunk-data", "honeydrunk-notify", "pulse"],
+      "consumed_by": ["honeydrunk-transport", "honeydrunk-vault", "honeydrunk-auth", "honeydrunk-web-rest", "honeydrunk-data", "honeydrunk-notify", "honeydrunk-pulse"],
       "consumed_by_planned": ["honeydrunk-ai", "honeydrunk-capabilities", "honeydrunk-agents", "honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-flow", "honeydrunk-operator", "honeydrunk-vault-rotation", "honeydrunk-audit"],
       "blocked_by": [],
       "exposes": {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "id": "pulse",
+      "id": "honeydrunk-pulse",
       "consumes": ["honeydrunk-kernel"],
       "consumed_by": [],
       "consumed_by_planned": [],

--- a/catalogs/services.json
+++ b/catalogs/services.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "pulse-collector",
-    "nodeId": "pulse",
+    "nodeId": "honeydrunk-pulse",
     "name": "Pulse.Collector",
     "type": "service",
     "description": "Deployable OTLP receiver that ingests traces, logs, and metrics and fans out to configured sinks",

--- a/constitution/naming-conventions.md
+++ b/constitution/naming-conventions.md
@@ -2,7 +2,7 @@
 
 Canonical naming rules for all artifacts in the HoneyDrunk Grid.
 
-**Last Updated:** 2026-03-22
+**Last Updated:** 2026-05-17
 
 ---
 
@@ -12,9 +12,9 @@ Used in `catalogs/nodes.json`, `relationships.json`, `services.json`, and the we
 
 - **Format:** `honeydrunk-{name}` (kebab-case)
 - **Examples:** `honeydrunk-kernel`, `honeydrunk-transport`, `honeydrunk-web-rest`
-- **Exception:** `pulse` — historical, no prefix
+- **No exceptions:** all Node IDs use the `honeydrunk-` prefix.
 
-When creating a new Node, always use the `honeydrunk-` prefix. The `pulse` exception is grandfathered and should not be repeated.
+When creating a new Node, always use the `honeydrunk-` prefix. Pulse now follows the same prefix rule as every other Node.
 
 ---
 
@@ -125,7 +125,4 @@ Used in `catalogs/services.json` to identify deployable processes.
 
 ## Known Exceptions
 
-| Item | Convention | Actual | Reason |
-|------|-----------|--------|--------|
-| Pulse node ID | `honeydrunk-pulse` | `pulse` | Historical — predates convention. Grandfathered. |
-| Pulse repo name | `HoneyDrunk.Pulse` | `HoneyDrunk.Pulse` | Repo name follows convention; only the catalog ID is short. |
+None currently. Pulse previously used the short catalog ID `pulse`, but the canonical Node ID is now `honeydrunk-pulse`.

--- a/generated/issue-packets/active/kernel-adoption-alignment/01-kernel-context-bootstrap-and-well-known-node-ids.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/01-kernel-context-bootstrap-and-well-known-node-ids.md
@@ -1,0 +1,101 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Kernel
+labels: ["feature", "tier-2", "core", "kernel", "wave-1", "kernel-adoption"]
+dependencies: []
+adrs: []
+accepts: []
+wave: 1
+initiative: kernel-adoption-alignment
+node: honeydrunk-kernel
+---
+
+# Align Kernel context bootstrap and well-known Node IDs
+
+## Summary
+Add the Kernel-side primitives needed for downstream Nodes to consume canonical Node identity and initialize Grid context without depending on concrete runtime internals.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Kernel`
+
+## Context
+The adoption audit found two Kernel-owned blockers: downstream Nodes need canonical `WellKnownNodes` values (`honeydrunk-*`) and Transport currently depends on full `HoneyDrunk.Kernel` because context initialization requires concrete `GridContext.Initialize()`. Kernel must provide the canonical source of truth so downstream repos do not duplicate identity strings or concrete initialization behavior.
+
+## Scope
+- Update `WellKnownNodes` to canonical `honeydrunk-*` values and include current Grid Nodes across Core/Ops/Meta/AI.
+- Add an Abstractions-visible context bootstrap/factory seam sufficient for Transport and other downstream libraries to create/initialize valid Grid contexts without referencing the full Kernel runtime package.
+- Preserve existing host composition APIs (`AddHoneyDrunkNode`, lifecycle, health/readiness) for app hosts.
+- Update package versions/changelogs consistently across all non-test Kernel projects.
+
+## Proposed Implementation
+1. Pin canonical `WellKnownNodes` values in tests, including `honeydrunk-pulse`, `honeydrunk-notify`, `honeydrunk-vault-rotation`, `honeydrunk-audit`, and AI-sector IDs.
+2. Introduce the minimal Abstractions seam for context initialization/factory behavior. Keep it cohesive; do not expose concrete runtime implementation details.
+3. Update runtime implementation to satisfy the new seam.
+4. Update README/package docs if public installation or API guidance changes.
+5. Bump all non-test Kernel projects together and update repo-level + affected per-package changelogs.
+6. Replace deprecated test packages if still present and verify no deprecated package output remains.
+
+## Affected Files
+- `HoneyDrunk.Kernel.Abstractions/**`
+- `HoneyDrunk.Kernel/**`
+- `HoneyDrunk.Kernel.Tests/**`
+- `CHANGELOG.md` and per-package changelogs
+
+## NuGet Dependencies
+No new runtime packages expected. Test package cleanup may update `xunit.v3`, `Microsoft.NET.Test.Sdk`, `coverlet.collector`, and `FluentAssertions` as test-only dependencies.
+
+## Boundary Check
+- [x] Work is scoped to `HoneyDrunk.Kernel` and stays inside that Node's ownership boundary.
+- [x] Kernel-owned primitives remain in Kernel; downstream repos consume them rather than reimplementing context or identity rules.
+- [x] No secrets are introduced into source, logs, traces, or test fixtures.
+
+## Acceptance Criteria
+- [ ] `WellKnownNodes` returns canonical `honeydrunk-*` IDs for all current Grid Nodes.
+- [ ] Downstream libraries can create/initialize a valid Grid context through Abstractions-visible API without referencing concrete `HoneyDrunk.Kernel` types.
+- [ ] New/updated tests cover canonical Node IDs, uniqueness, validity, and the context bootstrap seam.
+- [ ] All non-test Kernel projects share the same new version.
+- [ ] Repo-level `CHANGELOG.md` and affected per-package changelogs document the behavior/API changes.
+- [ ] `dotnet restore`, `dotnet build`, `dotnet test`, and `dotnet list package --deprecated` pass for the solution.
+
+## Human Prerequisites
+None.
+
+Actor=Agent.
+
+## Dependencies
+None.
+
+## Labels
+`feature`, `tier-2`, `core`, `kernel`, `wave-1`, `kernel-adoption`
+
+## Agent Handoff
+
+**Objective:** Add the Kernel-side primitives needed for downstream Nodes to consume canonical Node identity and initialize Grid context without depending on concrete runtime internals.
+**Target:** HoneyDrunk.Kernel, branch from `main`
+
+**Context:**
+- Initiative: `kernel-adoption-alignment`.
+- Audit trigger: Kernel adoption audit found uneven use of Grid context, version drift, and avoidable runtime dependencies.
+- ADRs: None specific; governed by Grid invariants inlined below.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+- **Context invariant:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null tenant value. CorrelationId is never null or empty, and tenant context defaults to `TenantId.Internal` for internal Grid work.
+- **Dependency invariant:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages except permitted `Microsoft.Extensions.*` abstractions. Runtime packages consume upstream Abstractions whenever possible; avoid full runtime dependencies unless a host composition package explicitly needs runtime behavior.
+- **Packaging invariant:** Semantic versioning with repo-level `CHANGELOG.md`; per-package changelogs only for packages with actual functional changes. All non-test projects in a solution move versions together when a package version bump is warranted.
+- **Testing invariant:** Tests never depend on external services. Use in-memory/fake collaborators. No test code in runtime packages; tests live in dedicated `.Tests` or `.Canary` projects.
+
+
+**Key Files:**
+- `HoneyDrunk.Kernel.Abstractions/**`
+- `HoneyDrunk.Kernel/**`
+- `HoneyDrunk.Kernel.Tests/**`
+- `CHANGELOG.md` and per-package changelogs
+
+**Contracts:**
+Kernel may add Abstractions-visible context bootstrap/factory contracts. Treat this as a minor or major version decision based on API compatibility; document any breaking behavior explicitly.

--- a/generated/issue-packets/active/kernel-adoption-alignment/02-transport-drop-kernel-runtime-dependency.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/02-transport-drop-kernel-runtime-dependency.md
@@ -1,0 +1,100 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Transport
+labels: ["chore", "tier-2", "core", "transport", "wave-2", "kernel-adoption"]
+dependencies: ["packet:01"]
+adrs: []
+accepts: []
+wave: 2
+initiative: kernel-adoption-alignment
+node: honeydrunk-transport
+---
+
+# Drop Transport dependency on Kernel runtime
+
+## Summary
+Update Transport to consume Kernel Abstractions for context creation/propagation instead of depending on full `HoneyDrunk.Kernel` runtime internals.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Transport`
+
+## Context
+Architecture compatibility already records Transport's runtime Kernel dependency as an invariant violation. The audit confirmed `GridContextFactory` casts to concrete Kernel `GridContext` to call `Initialize()`. Once Kernel exposes the needed Abstractions seam, Transport should move back to the intended dependency shape.
+
+## Scope
+- Replace direct `HoneyDrunk.Kernel` package references with the new `HoneyDrunk.Kernel.Abstractions` version where possible.
+- Refactor context factory/propagation middleware to use the Kernel Abstractions seam from packet 01.
+- Keep provider packages consuming only exported contracts.
+- Update canaries/tests around message context propagation.
+
+## Proposed Implementation
+1. Update package references to the Kernel version produced by packet 01.
+2. Refactor `Context/GridContextFactory.cs` and any middleware/helpers that require concrete `GridContext`.
+3. Verify envelopes/messages still propagate correlation, causation, tenant, node, studio, and environment correctly.
+4. Remove obsolete comments that describe the known invariant violation once fixed.
+
+## Affected Files
+- `HoneyDrunk.Transport/HoneyDrunk.Transport.csproj`
+- `HoneyDrunk.Transport/Context/GridContextFactory.cs`
+- `HoneyDrunk.Transport*/**/*Context*`
+- `HoneyDrunk.Transport.Tests/**`
+- `CHANGELOG.md` and per-package changelogs
+
+## NuGet Dependencies
+Update `HoneyDrunk.Kernel.Abstractions` to the package version from packet 01. Remove full `HoneyDrunk.Kernel` where no longer required.
+
+## Boundary Check
+- [x] Work is scoped to `HoneyDrunk.Transport` and stays inside that Node's ownership boundary.
+- [x] Kernel-owned primitives remain in Kernel; downstream repos consume them rather than reimplementing context or identity rules.
+- [x] No secrets are introduced into source, logs, traces, or test fixtures.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Transport` no longer references full `HoneyDrunk.Kernel` unless a host-only composition project explicitly needs runtime hosting behavior.
+- [ ] Context propagation tests/canaries pass and cover tenant/correlation preservation.
+- [ ] No provider package consumes internal Transport or Kernel runtime implementation details.
+- [ ] Repo-level and affected per-package changelogs updated; all non-test package versions aligned if bumped.
+- [ ] `dotnet restore`, `dotnet build`, and `dotnet test` pass.
+
+## Human Prerequisites
+None.
+
+Actor=Agent.
+
+## Dependencies
+This packet is blocked by: packet:01. Dependencies are mirrored in frontmatter for filing automation.
+
+## Labels
+`chore`, `tier-2`, `core`, `transport`, `wave-2`, `kernel-adoption`
+
+## Agent Handoff
+
+**Objective:** Update Transport to consume Kernel Abstractions for context creation/propagation instead of depending on full `HoneyDrunk.Kernel` runtime internals.
+**Target:** HoneyDrunk.Transport, branch from `main`
+
+**Context:**
+- Initiative: `kernel-adoption-alignment`.
+- Audit trigger: Kernel adoption audit found uneven use of Grid context, version drift, and avoidable runtime dependencies.
+- ADRs: None specific; governed by Grid invariants inlined below.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** packet:01
+
+**Constraints:**
+- **Context invariant:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null tenant value. CorrelationId is never null or empty, and tenant context defaults to `TenantId.Internal` for internal Grid work.
+- **Dependency invariant:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages except permitted `Microsoft.Extensions.*` abstractions. Runtime packages consume upstream Abstractions whenever possible; avoid full runtime dependencies unless a host composition package explicitly needs runtime behavior.
+- **Packaging invariant:** Semantic versioning with repo-level `CHANGELOG.md`; per-package changelogs only for packages with actual functional changes. All non-test projects in a solution move versions together when a package version bump is warranted.
+- **Testing invariant:** Tests never depend on external services. Use in-memory/fake collaborators. No test code in runtime packages; tests live in dedicated `.Tests` or `.Canary` projects.
+
+
+**Key Files:**
+- `HoneyDrunk.Transport/HoneyDrunk.Transport.csproj`
+- `HoneyDrunk.Transport/Context/GridContextFactory.cs`
+- `HoneyDrunk.Transport*/**/*Context*`
+- `HoneyDrunk.Transport.Tests/**`
+- `CHANGELOG.md` and per-package changelogs
+
+**Contracts:**
+No Transport public contract change intended; dependency surface should shrink.

--- a/generated/issue-packets/active/kernel-adoption-alignment/03-vault-align-kernel-version.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/03-vault-align-kernel-version.md
@@ -1,0 +1,96 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Vault
+labels: ["chore", "tier-2", "core", "vault", "wave-3", "kernel-adoption"]
+dependencies: ["packet:01"]
+adrs: []
+accepts: []
+wave: 3
+initiative: kernel-adoption-alignment
+node: honeydrunk-vault
+---
+
+# Align Vault to current Kernel packages
+
+## Summary
+Update Vault Kernel package references and canaries to the current Kernel version while preserving Vault as the secret boundary.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Vault`
+
+## Context
+Vault adoption is mostly healthy: it uses Kernel lifecycle/health/readiness and remains the Grid secret boundary. The remaining issue is version drift after Kernel alignment.
+
+## Scope
+- Update Kernel package references to the version produced by packet 01.
+- Verify lifecycle, health/readiness, App Configuration, Key Vault bootstrap, and Event Grid invalidation still work.
+- Do not move secret retrieval out of Vault or introduce direct secret reads in consumers.
+
+## Proposed Implementation
+1. Update `HoneyDrunk.Kernel` / `HoneyDrunk.Kernel.Abstractions` references as applicable.
+2. Run and update canaries/tests that cover lifecycle, secret store, App Configuration, and event-driven invalidation.
+3. Update changelogs/version metadata per solution rules.
+
+## Affected Files
+- `HoneyDrunk.Vault*/**/*.csproj`
+- Vault registration/lifecycle/health files
+- Vault tests/canaries
+- `CHANGELOG.md` and per-package changelogs
+
+## NuGet Dependencies
+Update Kernel package references to the package version from packet 01. No new packages expected.
+
+## Boundary Check
+- [x] Work is scoped to `HoneyDrunk.Vault` and stays inside that Node's ownership boundary.
+- [x] Kernel-owned primitives remain in Kernel; downstream repos consume them rather than reimplementing context or identity rules.
+- [x] No secrets are introduced into source, logs, traces, or test fixtures.
+
+## Acceptance Criteria
+- [ ] Vault builds/tests against the current Kernel package version.
+- [ ] Existing Vault lifecycle/health/readiness behavior remains intact.
+- [ ] No new direct secret logging or config-file secret reads are introduced.
+- [ ] Repo-level and affected per-package changelogs updated; all non-test package versions aligned if bumped.
+- [ ] `dotnet restore`, `dotnet build`, and `dotnet test` pass.
+
+## Human Prerequisites
+None.
+
+Actor=Agent.
+
+## Dependencies
+This packet is blocked by: packet:01. Dependencies are mirrored in frontmatter for filing automation.
+
+## Labels
+`chore`, `tier-2`, `core`, `vault`, `wave-3`, `kernel-adoption`
+
+## Agent Handoff
+
+**Objective:** Update Vault Kernel package references and canaries to the current Kernel version while preserving Vault as the secret boundary.
+**Target:** HoneyDrunk.Vault, branch from `main`
+
+**Context:**
+- Initiative: `kernel-adoption-alignment`.
+- Audit trigger: Kernel adoption audit found uneven use of Grid context, version drift, and avoidable runtime dependencies.
+- ADRs: None specific; governed by Grid invariants inlined below.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** packet:01
+
+**Constraints:**
+- **Context invariant:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null tenant value. CorrelationId is never null or empty, and tenant context defaults to `TenantId.Internal` for internal Grid work.
+- **Dependency invariant:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages except permitted `Microsoft.Extensions.*` abstractions. Runtime packages consume upstream Abstractions whenever possible; avoid full runtime dependencies unless a host composition package explicitly needs runtime behavior.
+- **Packaging invariant:** Semantic versioning with repo-level `CHANGELOG.md`; per-package changelogs only for packages with actual functional changes. All non-test projects in a solution move versions together when a package version bump is warranted.
+- **Testing invariant:** Tests never depend on external services. Use in-memory/fake collaborators. No test code in runtime packages; tests live in dedicated `.Tests` or `.Canary` projects.
+
+
+**Key Files:**
+- `HoneyDrunk.Vault*/**/*.csproj`
+- Vault registration/lifecycle/health files
+- Vault tests/canaries
+- `CHANGELOG.md` and per-package changelogs
+
+**Contracts:**
+No Vault public contract change intended.

--- a/generated/issue-packets/active/kernel-adoption-alignment/04-auth-align-kernel-version.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/04-auth-align-kernel-version.md
@@ -1,0 +1,98 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Auth
+labels: ["chore", "tier-2", "core", "auth", "wave-3", "kernel-adoption"]
+dependencies: ["packet:01", "packet:03"]
+adrs: []
+accepts: []
+wave: 3
+initiative: kernel-adoption-alignment
+node: honeydrunk-auth
+---
+
+# Align Auth to current Kernel packages
+
+## Summary
+Update Auth Kernel package references and verify Auth continues to consume Vault-backed secrets and Kernel context correctly.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Auth`
+
+## Context
+Auth adoption is functionally healthy but version-lagged. It should align after Kernel and Vault references are current so token validation, policy evaluation, startup validation, and Vault signing-key retrieval stay coherent.
+
+## Scope
+- Update Kernel references to the current version.
+- Verify Auth still requires `AddHoneyDrunkNode()`/Kernel services and retrieves signing keys through Vault, not config/env secrets.
+- Preserve Auth boundary: validate tokens, do not issue them.
+
+## Proposed Implementation
+1. Update package references to current Kernel/Vault versions as needed.
+2. Run token validation, policy, startup validation, and Vault signing-key tests.
+3. Update changelogs/version metadata per solution rules.
+
+## Affected Files
+- `HoneyDrunk.Auth*/**/*.csproj`
+- Auth startup/DI validation files
+- Vault signing-key retrieval code
+- Auth tests/canaries
+- `CHANGELOG.md` and per-package changelogs
+
+## NuGet Dependencies
+Update Kernel package references to the package version from packet 01; update Vault package reference only if required by packet 03.
+
+## Boundary Check
+- [x] Work is scoped to `HoneyDrunk.Auth` and stays inside that Node's ownership boundary.
+- [x] Kernel-owned primitives remain in Kernel; downstream repos consume them rather than reimplementing context or identity rules.
+- [x] No secrets are introduced into source, logs, traces, or test fixtures.
+
+## Acceptance Criteria
+- [ ] Auth builds/tests against current Kernel packages.
+- [ ] JWT signing keys still resolve through Vault (`ISecretStore`), not direct env/config secret reads.
+- [ ] Auth validates tokens only; no identity-provider/token-issuer behavior is added.
+- [ ] Repo-level and affected per-package changelogs updated; all non-test package versions aligned if bumped.
+- [ ] `dotnet restore`, `dotnet build`, and `dotnet test` pass.
+
+## Human Prerequisites
+None.
+
+Actor=Agent.
+
+## Dependencies
+This packet is blocked by: packet:01, packet:03. Dependencies are mirrored in frontmatter for filing automation.
+
+## Labels
+`chore`, `tier-2`, `core`, `auth`, `wave-3`, `kernel-adoption`
+
+## Agent Handoff
+
+**Objective:** Update Auth Kernel package references and verify Auth continues to consume Vault-backed secrets and Kernel context correctly.
+**Target:** HoneyDrunk.Auth, branch from `main`
+
+**Context:**
+- Initiative: `kernel-adoption-alignment`.
+- Audit trigger: Kernel adoption audit found uneven use of Grid context, version drift, and avoidable runtime dependencies.
+- ADRs: None specific; governed by Grid invariants inlined below.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** packet:01, packet:03
+
+**Constraints:**
+- **Context invariant:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null tenant value. CorrelationId is never null or empty, and tenant context defaults to `TenantId.Internal` for internal Grid work.
+- **Dependency invariant:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages except permitted `Microsoft.Extensions.*` abstractions. Runtime packages consume upstream Abstractions whenever possible; avoid full runtime dependencies unless a host composition package explicitly needs runtime behavior.
+- **Packaging invariant:** Semantic versioning with repo-level `CHANGELOG.md`; per-package changelogs only for packages with actual functional changes. All non-test projects in a solution move versions together when a package version bump is warranted.
+- **Testing invariant:** Tests never depend on external services. Use in-memory/fake collaborators. No test code in runtime packages; tests live in dedicated `.Tests` or `.Canary` projects.
+
+
+**Key Files:**
+- `HoneyDrunk.Auth*/**/*.csproj`
+- Auth startup/DI validation files
+- Vault signing-key retrieval code
+- Auth tests/canaries
+- `CHANGELOG.md` and per-package changelogs
+
+**Contracts:**
+No Auth public contract change intended.

--- a/generated/issue-packets/active/kernel-adoption-alignment/05-web-rest-require-kernel-request-context.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/05-web-rest-require-kernel-request-context.md
@@ -1,0 +1,97 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Web.Rest
+labels: ["bug", "tier-2", "core", "web-rest", "wave-3", "kernel-adoption"]
+dependencies: ["packet:01"]
+adrs: []
+accepts: []
+wave: 3
+initiative: kernel-adoption-alignment
+node: honeydrunk-web-rest
+---
+
+# Require Kernel context in Web.Rest request pipeline
+
+## Summary
+Ensure Web.Rest HTTP middleware consumes or establishes live Kernel request context instead of silently falling back to ad-hoc correlation values.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Web.Rest`
+
+## Context
+The audit found `CorrelationMiddleware` can process a request with no current Operation/Grid context, falling back to headers or generated GUIDs. That masks host misconfiguration and permits HTTP scoped operations without full Grid context/tenant.
+
+## Scope
+- Update Web.Rest ASP.NET Core middleware/registration so request handling requires or establishes Kernel context.
+- Keep Web.Rest boundary focused on HTTP response shaping, exception mapping, correlation headers, and REST conventions; do not move Kernel hosting ownership into Web.Rest beyond explicit middleware integration.
+- Add tests for missing/misordered Kernel context registration.
+
+## Proposed Implementation
+1. Inspect current `CorrelationMiddleware` and service registration.
+2. Decide the smallest safe behavior: fail fast on missing Kernel context, or establish context via the Kernel-provided request middleware/factory before Web.Rest correlation processing.
+3. Add tests for correctly wired host, missing Kernel context, and correlation mismatch behavior.
+4. Update docs/README if host setup order changes.
+
+## Affected Files
+- `HoneyDrunk.Web.Rest.AspNetCore/Middleware/CorrelationMiddleware.cs`
+- `HoneyDrunk.Web.Rest.AspNetCore/Extensions/ServiceCollectionExtensions.cs`
+- Web.Rest tests/canaries
+- README/changelogs
+
+## NuGet Dependencies
+Update Kernel package references to the package version from packet 01. No new packages expected.
+
+## Boundary Check
+- [x] Work is scoped to `HoneyDrunk.Web.Rest` and stays inside that Node's ownership boundary.
+- [x] Kernel-owned primitives remain in Kernel; downstream repos consume them rather than reimplementing context or identity rules.
+- [x] No secrets are introduced into source, logs, traces, or test fixtures.
+
+## Acceptance Criteria
+- [ ] Every Web.Rest HTTP request path either has a populated Kernel `IGridContext`/`IOperationContext` or fails with an actionable configuration error.
+- [ ] No request is processed with only an ad-hoc header/generated correlation ID and no tenant context.
+- [ ] Middleware ordering/registration guidance is documented if changed.
+- [ ] Repo-level and affected per-package changelogs updated; all non-test package versions aligned if bumped.
+- [ ] `dotnet restore`, `dotnet build`, and `dotnet test` pass.
+
+## Human Prerequisites
+None.
+
+Actor=Agent.
+
+## Dependencies
+This packet is blocked by: packet:01. Dependencies are mirrored in frontmatter for filing automation.
+
+## Labels
+`bug`, `tier-2`, `core`, `web-rest`, `wave-3`, `kernel-adoption`
+
+## Agent Handoff
+
+**Objective:** Ensure Web.Rest HTTP middleware consumes or establishes live Kernel request context instead of silently falling back to ad-hoc correlation values.
+**Target:** HoneyDrunk.Web.Rest, branch from `main`
+
+**Context:**
+- Initiative: `kernel-adoption-alignment`.
+- Audit trigger: Kernel adoption audit found uneven use of Grid context, version drift, and avoidable runtime dependencies.
+- ADRs: None specific; governed by Grid invariants inlined below.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** packet:01
+
+**Constraints:**
+- **Context invariant:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null tenant value. CorrelationId is never null or empty, and tenant context defaults to `TenantId.Internal` for internal Grid work.
+- **Dependency invariant:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages except permitted `Microsoft.Extensions.*` abstractions. Runtime packages consume upstream Abstractions whenever possible; avoid full runtime dependencies unless a host composition package explicitly needs runtime behavior.
+- **Packaging invariant:** Semantic versioning with repo-level `CHANGELOG.md`; per-package changelogs only for packages with actual functional changes. All non-test projects in a solution move versions together when a package version bump is warranted.
+- **Testing invariant:** Tests never depend on external services. Use in-memory/fake collaborators. No test code in runtime packages; tests live in dedicated `.Tests` or `.Canary` projects.
+
+
+**Key Files:**
+- `HoneyDrunk.Web.Rest.AspNetCore/Middleware/CorrelationMiddleware.cs`
+- `HoneyDrunk.Web.Rest.AspNetCore/Extensions/ServiceCollectionExtensions.cs`
+- Web.Rest tests/canaries
+- README/changelogs
+
+**Contracts:**
+No REST response contract change intended unless fail-fast errors are public; document any externally visible behavior.

--- a/generated/issue-packets/active/kernel-adoption-alignment/06-data-require-context-for-outbox-enrichment.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/06-data-require-context-for-outbox-enrichment.md
@@ -1,0 +1,99 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Data
+labels: ["bug", "tier-2", "core", "data", "wave-3", "kernel-adoption"]
+dependencies: ["packet:01", "packet:02"]
+adrs: []
+accepts: []
+wave: 3
+initiative: kernel-adoption-alignment
+node: honeydrunk-data
+---
+
+# Require context for Data outbox enrichment
+
+## Summary
+Make Data outbox context enrichment fail fast when configured but no current Kernel operation context exists.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Data`
+
+## Context
+The audit found `EfOutboxWriter` silently emits outbox messages without correlation/tenant when `IOperationContextAccessor.Current` is null. That drops Grid context across async/message boundaries and makes downstream diagnostics unreliable.
+
+## Scope
+- Update outbox write path to require current operation/grid context when `AutoPopulateFromContext` is enabled.
+- Preserve explicit override paths for tests or deliberate system messages only if they still produce valid correlation/tenant context.
+- Update package references after Kernel/Transport alignment.
+
+## Proposed Implementation
+1. Inspect `EfOutboxWriter` context enrichment branch.
+2. Add fail-fast validation when autopopulation is enabled and operation/grid context is missing or incomplete.
+3. Add tests for populated context, missing context fail-fast, explicit metadata override, and tenant propagation.
+4. Verify Transport outbox integration still passes after packet 02.
+
+## Affected Files
+- `HoneyDrunk.Data.Outbox/Persistence/EfOutboxWriter.cs`
+- `HoneyDrunk.Data/Registration/ServiceCollectionExtensions.cs`
+- Data outbox tests/canaries
+- `.csproj` package references
+- `CHANGELOG.md` and per-package changelogs
+
+## NuGet Dependencies
+Update Kernel package references to the package version from packet 01 and Transport references to the version from packet 02 where applicable.
+
+## Boundary Check
+- [x] Work is scoped to `HoneyDrunk.Data` and stays inside that Node's ownership boundary.
+- [x] Kernel-owned primitives remain in Kernel; downstream repos consume them rather than reimplementing context or identity rules.
+- [x] No secrets are introduced into source, logs, traces, or test fixtures.
+
+## Acceptance Criteria
+- [ ] Outbox messages produced with autopopulation enabled always include correlation and tenant context.
+- [ ] Missing operation/grid context fails fast with a clear exception instead of silently publishing partial metadata.
+- [ ] Tests cover success/failure paths and tenant propagation.
+- [ ] Repo-level and affected per-package changelogs updated; all non-test package versions aligned if bumped.
+- [ ] `dotnet restore`, `dotnet build`, and `dotnet test` pass.
+
+## Human Prerequisites
+None.
+
+Actor=Agent.
+
+## Dependencies
+This packet is blocked by: packet:01, packet:02. Dependencies are mirrored in frontmatter for filing automation.
+
+## Labels
+`bug`, `tier-2`, `core`, `data`, `wave-3`, `kernel-adoption`
+
+## Agent Handoff
+
+**Objective:** Make Data outbox context enrichment fail fast when configured but no current Kernel operation context exists.
+**Target:** HoneyDrunk.Data, branch from `main`
+
+**Context:**
+- Initiative: `kernel-adoption-alignment`.
+- Audit trigger: Kernel adoption audit found uneven use of Grid context, version drift, and avoidable runtime dependencies.
+- ADRs: None specific; governed by Grid invariants inlined below.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** packet:01, packet:02
+
+**Constraints:**
+- **Context invariant:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null tenant value. CorrelationId is never null or empty, and tenant context defaults to `TenantId.Internal` for internal Grid work.
+- **Dependency invariant:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages except permitted `Microsoft.Extensions.*` abstractions. Runtime packages consume upstream Abstractions whenever possible; avoid full runtime dependencies unless a host composition package explicitly needs runtime behavior.
+- **Packaging invariant:** Semantic versioning with repo-level `CHANGELOG.md`; per-package changelogs only for packages with actual functional changes. All non-test projects in a solution move versions together when a package version bump is warranted.
+- **Testing invariant:** Tests never depend on external services. Use in-memory/fake collaborators. No test code in runtime packages; tests live in dedicated `.Tests` or `.Canary` projects.
+
+
+**Key Files:**
+- `HoneyDrunk.Data.Outbox/Persistence/EfOutboxWriter.cs`
+- `HoneyDrunk.Data/Registration/ServiceCollectionExtensions.cs`
+- Data outbox tests/canaries
+- `.csproj` package references
+- `CHANGELOG.md` and per-package changelogs
+
+**Contracts:**
+Behavioral contract change: missing context with autopopulation enabled becomes an error. Document in changelog/README if public.

--- a/generated/issue-packets/active/kernel-adoption-alignment/07-vault-rotation-establish-timer-operation-context.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/07-vault-rotation-establish-timer-operation-context.md
@@ -1,0 +1,100 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Vault.Rotation
+labels: ["bug", "tier-2", "core", "vault-rotation", "wave-3", "kernel-adoption"]
+dependencies: ["packet:01", "packet:03"]
+adrs: []
+accepts: []
+wave: 3
+initiative: kernel-adoption-alignment
+node: honeydrunk-vault-rotation
+---
+
+# Establish Kernel context for rotation timer jobs
+
+## Summary
+Ensure every Vault.Rotation timer execution creates a populated Kernel Grid/Operation context with correlation and tenant values.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Vault.Rotation`
+
+## Context
+The audit found the timer-triggered rotation function runs without injecting or initializing live `IGridContext`/`IOperationContext`; `RotationContext.CorrelationId` is nullable. Background jobs are scoped operations and must carry Grid context.
+
+## Scope
+- Add per-run context creation/initialization for timer-triggered rotation execution.
+- Use canonical `WellKnownNodes.Core.VaultRotation` for Node identity when Kernel version supports it, while preserving deploy-time `HONEYDRUNK_NODE_ID` override if the host supports override.
+- Ensure `RotationContext` has non-empty correlation and internal tenant/default context values.
+
+## Proposed Implementation
+1. Update Function startup/DI to register current Kernel context services.
+2. At timer entry, create or scope a new operation context with correlation ID, `TenantId.Internal`, node ID, studio ID, and environment.
+3. Flow that context into rotation orchestration and logging.
+4. Add unit/integration tests for timer entry context creation and `RotationContext` correlation non-null behavior.
+
+## Affected Files
+- `HoneyDrunk.Vault.Rotation/Program.cs`
+- `HoneyDrunk.Vault.Rotation/RotateThirdPartySecretsFunction.cs`
+- `HoneyDrunk.Vault.Rotation.Abstractions/RotationContext.cs`
+- Vault.Rotation tests
+- `.csproj` package references and changelogs
+
+## NuGet Dependencies
+Update Kernel and Vault package references to versions from packets 01 and 03. No new external packages expected.
+
+## Boundary Check
+- [x] Work is scoped to `HoneyDrunk.Vault.Rotation` and stays inside that Node's ownership boundary.
+- [x] Kernel-owned primitives remain in Kernel; downstream repos consume them rather than reimplementing context or identity rules.
+- [x] No secrets are introduced into source, logs, traces, or test fixtures.
+
+## Acceptance Criteria
+- [ ] Each timer execution has populated `IGridContext` and `IOperationContext` before rotation work begins.
+- [ ] `RotationContext.CorrelationId` is non-null/non-empty for live rotations.
+- [ ] Tenant context defaults to internal sentinel for system rotation work.
+- [ ] Node identity uses Kernel well-known Vault.Rotation fallback while preserving env override semantics.
+- [ ] Repo-level and affected per-package changelogs updated; all non-test package versions aligned if bumped.
+- [ ] `dotnet restore`, `dotnet build`, and `dotnet test` pass.
+
+## Human Prerequisites
+None.
+
+Actor=Agent.
+
+## Dependencies
+This packet is blocked by: packet:01, packet:03. Dependencies are mirrored in frontmatter for filing automation.
+
+## Labels
+`bug`, `tier-2`, `core`, `vault-rotation`, `wave-3`, `kernel-adoption`
+
+## Agent Handoff
+
+**Objective:** Ensure every Vault.Rotation timer execution creates a populated Kernel Grid/Operation context with correlation and tenant values.
+**Target:** HoneyDrunk.Vault.Rotation, branch from `main`
+
+**Context:**
+- Initiative: `kernel-adoption-alignment`.
+- Audit trigger: Kernel adoption audit found uneven use of Grid context, version drift, and avoidable runtime dependencies.
+- ADRs: None specific; governed by Grid invariants inlined below.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** packet:01, packet:03
+
+**Constraints:**
+- **Context invariant:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null tenant value. CorrelationId is never null or empty, and tenant context defaults to `TenantId.Internal` for internal Grid work.
+- **Dependency invariant:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages except permitted `Microsoft.Extensions.*` abstractions. Runtime packages consume upstream Abstractions whenever possible; avoid full runtime dependencies unless a host composition package explicitly needs runtime behavior.
+- **Packaging invariant:** Semantic versioning with repo-level `CHANGELOG.md`; per-package changelogs only for packages with actual functional changes. All non-test projects in a solution move versions together when a package version bump is warranted.
+- **Testing invariant:** Tests never depend on external services. Use in-memory/fake collaborators. No test code in runtime packages; tests live in dedicated `.Tests` or `.Canary` projects.
+
+
+**Key Files:**
+- `HoneyDrunk.Vault.Rotation/Program.cs`
+- `HoneyDrunk.Vault.Rotation/RotateThirdPartySecretsFunction.cs`
+- `HoneyDrunk.Vault.Rotation.Abstractions/RotationContext.cs`
+- Vault.Rotation tests
+- `.csproj` package references and changelogs
+
+**Contracts:**
+Potential Abstractions behavior tightening: `RotationContext.CorrelationId` should become required/non-null if source-compatible. If breaking, bump version and document migration.

--- a/generated/issue-packets/active/kernel-adoption-alignment/08-notify-align-identity-and-queue-secret-boundary.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/08-notify-align-identity-and-queue-secret-boundary.md
@@ -1,0 +1,103 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["bug", "tier-2", "ops", "notify", "wave-3", "kernel-adoption", "adr-0005", "adr-0006"]
+dependencies: ["packet:01", "packet:03"]
+adrs: ["ADR-0005", "ADR-0006"]
+accepts: []
+wave: 3
+initiative: kernel-adoption-alignment
+node: honeydrunk-notify
+---
+
+# Align Notify Kernel identity and queue secret boundary
+
+## Summary
+Update Notify to use Kernel canonical Notify identity and remove direct queue connection secret/config reads from runtime bootstrap paths.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Notify`
+
+## Context
+The audit found Notify hardcodes `HONEYDRUNK_NODE_ID = "honeydrunk-notify"` in Worker/Functions and reads `NotifyQueueConnection` directly for Azure Storage Queue wiring. Notify should use Kernel well-known identity fallback while preserving env override, and queue credentials should follow the Grid Vault/App Configuration bootstrap model.
+
+## Scope
+- Replace hardcoded Notify Node ID fallback with `WellKnownNodes.Ops.Notify` once Kernel version supports it.
+- Preserve deploy-time `HONEYDRUNK_NODE_ID` override; do not overwrite an existing env/config value.
+- Move queue credential resolution away from direct config secret reads toward Vault/managed identity/App Configuration bootstrap semantics.
+- Review Azure Functions `QueueTrigger(Connection=...)` constraints; if Functions runtime requires an app setting name, document the boundary and ensure the value is populated via deployment/bootstrap rather than committed config.
+
+## Proposed Implementation
+1. Update Worker and Functions startup identity fallback to Kernel well-known Notify ID.
+2. Replace direct `builder.Configuration["NotifyQueueConnection"]` use where possible with `ISecretStore` or managed identity-capable queue client wiring.
+3. For Functions trigger binding, document/implement the deployment-safe pattern for the connection setting without exposing secret values in source/logs.
+4. Add tests for env override, default Node ID, and queue option resolution behavior.
+
+## Affected Files
+- `HoneyDrunk.Notify.Worker/Program.cs`
+- `HoneyDrunk.Notify.Functions/Program.cs`
+- `HoneyDrunk.Notify.Functions/NotifyDispatcherFunction.cs`
+- `HoneyDrunk.Notify.Queue.AzureStorage/**`
+- Notify tests/canaries
+- `.csproj` package references and changelogs
+
+## NuGet Dependencies
+Update Kernel package references to the version from packet 01 and Vault package references to the version from packet 03 where needed. No new queue SDK expected unless moving to identity-based Azure Queue client construction requires it.
+
+## Boundary Check
+- [x] Work is scoped to `HoneyDrunk.Notify` and stays inside that Node's ownership boundary.
+- [x] Kernel-owned primitives remain in Kernel; downstream repos consume them rather than reimplementing context or identity rules.
+- [x] No secrets are introduced into source, logs, traces, or test fixtures.
+
+## Acceptance Criteria
+- [ ] Notify Worker and Functions default to `WellKnownNodes.Ops.Notify.Value` and do not overwrite an existing `HONEYDRUNK_NODE_ID` override.
+- [ ] Queue connection secret is not read directly as an application secret in runtime code except for an unavoidable Functions binding setting documented as deployment-provided.
+- [ ] No secret values are logged/traced; only secret names/identifiers appear in diagnostics.
+- [ ] Tests cover default identity, env override, and queue credential resolution/failure behavior.
+- [ ] Repo-level and affected per-package changelogs updated; all non-test package versions aligned if bumped.
+- [ ] `dotnet restore`, `dotnet build`, and `dotnet test` pass.
+
+## Human Prerequisites
+- [ ] If the final Functions binding still requires an app setting, ensure deploy/runtime configuration provides `NotifyQueueConnection` or the replacement setting from Vault/App Configuration without committing secret values.
+
+Actor=Agent.
+
+## Dependencies
+This packet is blocked by: packet:01, packet:03. Dependencies are mirrored in frontmatter for filing automation.
+
+## Labels
+`bug`, `tier-2`, `ops`, `notify`, `wave-3`, `kernel-adoption`, `adr-0005`, `adr-0006`
+
+## Agent Handoff
+
+**Objective:** Update Notify to use Kernel canonical Notify identity and remove direct queue connection secret/config reads from runtime bootstrap paths.
+**Target:** HoneyDrunk.Notify, branch from `main`
+
+**Context:**
+- Initiative: `kernel-adoption-alignment`.
+- Audit trigger: Kernel adoption audit found uneven use of Grid context, version drift, and avoidable runtime dependencies.
+- ADRs: ADR-0005, ADR-0006
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** packet:01, packet:03
+
+**Constraints:**
+- **Context invariant:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null tenant value. CorrelationId is never null or empty, and tenant context defaults to `TenantId.Internal` for internal Grid work.
+- **Dependency invariant:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages except permitted `Microsoft.Extensions.*` abstractions. Runtime packages consume upstream Abstractions whenever possible; avoid full runtime dependencies unless a host composition package explicitly needs runtime behavior.
+- **Packaging invariant:** Semantic versioning with repo-level `CHANGELOG.md`; per-package changelogs only for packages with actual functional changes. All non-test projects in a solution move versions together when a package version bump is warranted.
+- **Testing invariant:** Tests never depend on external services. Use in-memory/fake collaborators. No test code in runtime packages; tests live in dedicated `.Tests` or `.Canary` projects.
+
+
+**Key Files:**
+- `HoneyDrunk.Notify.Worker/Program.cs`
+- `HoneyDrunk.Notify.Functions/Program.cs`
+- `HoneyDrunk.Notify.Functions/NotifyDispatcherFunction.cs`
+- `HoneyDrunk.Notify.Queue.AzureStorage/**`
+- Notify tests/canaries
+- `.csproj` package references and changelogs
+
+**Contracts:**
+No Notify public notification contract change intended. Runtime bootstrap behavior changes; document in release notes.

--- a/generated/issue-packets/active/kernel-adoption-alignment/09-pulse-align-kernel-identity-and-version.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/09-pulse-align-kernel-identity-and-version.md
@@ -1,0 +1,99 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Pulse
+labels: ["bug", "tier-2", "ops", "pulse", "wave-3", "kernel-adoption"]
+dependencies: ["packet:01", "packet:02"]
+adrs: []
+accepts: []
+wave: 3
+initiative: kernel-adoption-alignment
+node: honeydrunk-pulse
+---
+
+# Align Pulse to Kernel canonical identity
+
+## Summary
+Update Pulse Collector to use Kernel well-known Pulse identity as the fallback while preserving deploy-time `HONEYDRUNK_NODE_ID` override.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Pulse`
+
+## Context
+Pulse had identity drift: deployment/App Configuration uses `honeydrunk-pulse`, while Collector previously used short `pulse` fallbacks. Kernel now owns canonical `WellKnownNodes.Ops.Pulse`; Pulse should consume that rather than hardcoding strings.
+
+## Scope
+- Update `Pulse.Collector` Kernel reference to the version from packet 01.
+- Use `WellKnownNodes.Ops.Pulse.Value` as fallback/default Node ID.
+- Preserve `HONEYDRUNK_NODE_ID` override.
+- Align Transport package references if needed after packet 02.
+
+## Proposed Implementation
+1. Replace short/hardcoded Pulse Node ID fallback in Collector startup.
+2. Ensure `options.NodeId` uses configured override first, Kernel well-known fallback second.
+3. Add/keep smoke test verifying default Node ID is `honeydrunk-pulse`.
+4. Run Collector and transport publishing tests.
+
+## Affected Files
+- `Pulse.Collector/Program.cs`
+- `Pulse.Collector/HoneyDrunk.Pulse.Collector.csproj`
+- `Pulse.Tests/Collector/CollectorSmokeTests.cs`
+- Pulse changelogs
+
+## NuGet Dependencies
+Update `HoneyDrunk.Kernel` to the version from packet 01. Update Transport packages to the version from packet 02 if required to avoid Kernel context ABI mismatch.
+
+## Boundary Check
+- [x] Work is scoped to `HoneyDrunk.Pulse` and stays inside that Node's ownership boundary.
+- [x] Kernel-owned primitives remain in Kernel; downstream repos consume them rather than reimplementing context or identity rules.
+- [x] No secrets are introduced into source, logs, traces, or test fixtures.
+
+## Acceptance Criteria
+- [ ] No runtime `"pulse"` Node ID fallback remains in Collector startup.
+- [ ] Default Collector `INodeContext.NodeId` is `honeydrunk-pulse`.
+- [ ] `HONEYDRUNK_NODE_ID` override still wins.
+- [ ] Transport publishing tests still pass with aligned Kernel/Transport versions.
+- [ ] Repo-level and affected per-package changelogs updated; all non-test package versions aligned if bumped.
+- [ ] `dotnet restore`, `dotnet build`, and `dotnet test` pass.
+
+## Human Prerequisites
+None.
+
+Actor=Agent.
+
+## Dependencies
+This packet is blocked by: packet:01, packet:02. Dependencies are mirrored in frontmatter for filing automation.
+
+## Labels
+`bug`, `tier-2`, `ops`, `pulse`, `wave-3`, `kernel-adoption`
+
+## Agent Handoff
+
+**Objective:** Update Pulse Collector to use Kernel well-known Pulse identity as the fallback while preserving deploy-time `HONEYDRUNK_NODE_ID` override.
+**Target:** HoneyDrunk.Pulse, branch from `main`
+
+**Context:**
+- Initiative: `kernel-adoption-alignment`.
+- Audit trigger: Kernel adoption audit found uneven use of Grid context, version drift, and avoidable runtime dependencies.
+- ADRs: None specific; governed by Grid invariants inlined below.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** packet:01, packet:02
+
+**Constraints:**
+- **Context invariant:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null tenant value. CorrelationId is never null or empty, and tenant context defaults to `TenantId.Internal` for internal Grid work.
+- **Dependency invariant:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages except permitted `Microsoft.Extensions.*` abstractions. Runtime packages consume upstream Abstractions whenever possible; avoid full runtime dependencies unless a host composition package explicitly needs runtime behavior.
+- **Packaging invariant:** Semantic versioning with repo-level `CHANGELOG.md`; per-package changelogs only for packages with actual functional changes. All non-test projects in a solution move versions together when a package version bump is warranted.
+- **Testing invariant:** Tests never depend on external services. Use in-memory/fake collaborators. No test code in runtime packages; tests live in dedicated `.Tests` or `.Canary` projects.
+
+
+**Key Files:**
+- `Pulse.Collector/Program.cs`
+- `Pulse.Collector/HoneyDrunk.Pulse.Collector.csproj`
+- `Pulse.Tests/Collector/CollectorSmokeTests.cs`
+- Pulse changelogs
+
+**Contracts:**
+No Pulse public contract change intended; runtime identity fallback changes.

--- a/generated/issue-packets/active/kernel-adoption-alignment/10-communications-drop-kernel-runtime-dependency.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/10-communications-drop-kernel-runtime-dependency.md
@@ -1,0 +1,99 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Communications
+labels: ["chore", "tier-2", "ops", "communications", "wave-3", "kernel-adoption"]
+dependencies: ["packet:01"]
+adrs: []
+accepts: []
+wave: 3
+initiative: kernel-adoption-alignment
+node: honeydrunk-communications
+---
+
+# Drop Communications runtime Kernel dependency
+
+## Summary
+Remove the unnecessary `HoneyDrunk.Kernel` runtime dependency from Communications when Abstractions-only references are sufficient.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Communications`
+
+## Context
+The audit found Communications conceptually propagates Grid context well through decisions and Notify envelopes, but its runtime package references both `HoneyDrunk.Kernel` and `HoneyDrunk.Kernel.Abstractions`. Source usage appears to need only Kernel abstractions (`IGridContextAccessor`, `IOperationContextAccessor`, lifecycle/health, telemetry factory).
+
+## Scope
+- Remove full `HoneyDrunk.Kernel` package reference if no concrete runtime types are used.
+- Keep `HoneyDrunk.Kernel.Abstractions` and validate host-time prerequisites remain enforced by `AddCommunications()`.
+- Preserve Communications boundary: decision logic lives in Communications; delivery remains Notify.
+
+## Proposed Implementation
+1. Remove `HoneyDrunk.Kernel` reference from runtime project.
+2. Update `HoneyDrunk.Kernel.Abstractions` to the version from packet 01.
+3. Build to identify any accidental concrete runtime usage; replace with abstractions or host prerequisites.
+4. Keep/extend tests around `IGridContextAccessor` propagation into decision logs and `NotificationEnvelope`.
+
+## Affected Files
+- `src/HoneyDrunk.Communications/HoneyDrunk.Communications.csproj`
+- `src/HoneyDrunk.Communications/CommunicationsServiceCollectionExtensions.cs`
+- `src/HoneyDrunk.Communications/Internal/CommunicationOrchestrator.cs`
+- Communications tests
+- changelogs
+
+## NuGet Dependencies
+Remove full `HoneyDrunk.Kernel`; update `HoneyDrunk.Kernel.Abstractions` to the package version from packet 01. No new packages expected.
+
+## Boundary Check
+- [x] Work is scoped to `HoneyDrunk.Communications` and stays inside that Node's ownership boundary.
+- [x] Kernel-owned primitives remain in Kernel; downstream repos consume them rather than reimplementing context or identity rules.
+- [x] No secrets are introduced into source, logs, traces, or test fixtures.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Communications` runtime package has no full `HoneyDrunk.Kernel` dependency unless a concrete use is justified in the PR.
+- [ ] `AddCommunications()` still validates required Kernel abstractions and Notify sender registration.
+- [ ] Decision logs and Notify envelopes still carry correlation, node/environment, and tenant context.
+- [ ] Repo-level and affected per-package changelogs updated; all non-test package versions aligned if bumped.
+- [ ] `dotnet restore`, `dotnet build`, and `dotnet test` pass.
+
+## Human Prerequisites
+None.
+
+Actor=Agent.
+
+## Dependencies
+This packet is blocked by: packet:01. Dependencies are mirrored in frontmatter for filing automation.
+
+## Labels
+`chore`, `tier-2`, `ops`, `communications`, `wave-3`, `kernel-adoption`
+
+## Agent Handoff
+
+**Objective:** Remove the unnecessary `HoneyDrunk.Kernel` runtime dependency from Communications when Abstractions-only references are sufficient.
+**Target:** HoneyDrunk.Communications, branch from `main`
+
+**Context:**
+- Initiative: `kernel-adoption-alignment`.
+- Audit trigger: Kernel adoption audit found uneven use of Grid context, version drift, and avoidable runtime dependencies.
+- ADRs: None specific; governed by Grid invariants inlined below.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** packet:01
+
+**Constraints:**
+- **Context invariant:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null tenant value. CorrelationId is never null or empty, and tenant context defaults to `TenantId.Internal` for internal Grid work.
+- **Dependency invariant:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages except permitted `Microsoft.Extensions.*` abstractions. Runtime packages consume upstream Abstractions whenever possible; avoid full runtime dependencies unless a host composition package explicitly needs runtime behavior.
+- **Packaging invariant:** Semantic versioning with repo-level `CHANGELOG.md`; per-package changelogs only for packages with actual functional changes. All non-test projects in a solution move versions together when a package version bump is warranted.
+- **Testing invariant:** Tests never depend on external services. Use in-memory/fake collaborators. No test code in runtime packages; tests live in dedicated `.Tests` or `.Canary` projects.
+
+
+**Key Files:**
+- `src/HoneyDrunk.Communications/HoneyDrunk.Communications.csproj`
+- `src/HoneyDrunk.Communications/CommunicationsServiceCollectionExtensions.cs`
+- `src/HoneyDrunk.Communications/Internal/CommunicationOrchestrator.cs`
+- Communications tests
+- changelogs
+
+**Contracts:**
+No Communications public contract change intended; dependency surface should shrink.

--- a/generated/issue-packets/active/kernel-adoption-alignment/11-architecture-reconcile-kernel-adoption-catalogs.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/11-architecture-reconcile-kernel-adoption-catalogs.md
@@ -1,0 +1,104 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "meta", "architecture", "wave-4", "kernel-adoption"]
+dependencies: ["packet:01", "packet:02", "packet:03", "packet:04", "packet:05", "packet:06", "packet:07", "packet:08", "packet:09", "packet:10"]
+adrs: []
+accepts: []
+wave: 4
+initiative: kernel-adoption-alignment
+node: honeydrunk-architecture
+---
+
+# Reconcile Kernel adoption catalogs and compatibility
+
+## Summary
+Update Architecture catalogs, compatibility matrix, and initiative trackers after Kernel adoption alignment lands across repos.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Context
+Architecture currently records stale Kernel compatibility (`0.4.0`) while local Kernel alignment is moving toward newer canonical identity/context behavior. After implementation PRs land, Architecture must become the source of truth again.
+
+## Scope
+- Update `catalogs/compatibility.json` current versions and compatibility notes for Kernel and downstream repos.
+- Update `catalogs/relationships.json` notes if dependencies shrink (e.g., Transport/Communications dropping full runtime Kernel dependency).
+- Update `catalogs/nodes.json`, repo context files, initiative trackers, roadmap/releases as needed.
+- Move/mark packets according to the normal Hive Sync lifecycle only after issues are filed/closed; do not pre-mark completion.
+
+## Proposed Implementation
+1. Read merged PRs/issues from packets 01-10.
+2. Update compatibility matrix and relationship notes to match actual package references and versions.
+3. Update Architecture changelog and relevant initiative/roadmap/release notes.
+4. Validate all catalog JSON files.
+
+## Affected Files
+- `catalogs/compatibility.json`
+- `catalogs/relationships.json`
+- `catalogs/nodes.json` if version/signal changes are needed
+- `initiatives/active-initiatives.md`
+- `initiatives/roadmap.md`
+- `initiatives/releases.md`
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+No NuGet dependencies. Architecture repo metadata/docs only.
+
+## Boundary Check
+- [x] Work is scoped to `HoneyDrunk.Architecture` and stays inside that Node's ownership boundary.
+- [x] Kernel-owned primitives remain in Kernel; downstream repos consume them rather than reimplementing context or identity rules.
+- [x] No secrets are introduced into source, logs, traces, or test fixtures.
+
+## Acceptance Criteria
+- [ ] `catalogs/compatibility.json` reflects actual merged package versions and no longer claims Kernel current is stale.
+- [ ] Relationship notes correctly identify Abstractions-only vs runtime dependencies after alignment.
+- [ ] Architecture changelog and initiative/roadmap/release trackers are updated.
+- [ ] All `catalogs/*.json` parse successfully.
+- [ ] No packet is moved to completed before the corresponding filed issue is actually closed.
+
+## Human Prerequisites
+None.
+
+Actor=Agent.
+
+## Dependencies
+This packet is blocked by: packet:01, packet:02, packet:03, packet:04, packet:05, packet:06, packet:07, packet:08, packet:09, packet:10. Dependencies are mirrored in frontmatter for filing automation.
+
+## Labels
+`chore`, `tier-2`, `meta`, `architecture`, `wave-4`, `kernel-adoption`
+
+## Agent Handoff
+
+**Objective:** Update Architecture catalogs, compatibility matrix, and initiative trackers after Kernel adoption alignment lands across repos.
+**Target:** HoneyDrunk.Architecture, branch from `main`
+
+**Context:**
+- Initiative: `kernel-adoption-alignment`.
+- Audit trigger: Kernel adoption audit found uneven use of Grid context, version drift, and avoidable runtime dependencies.
+- ADRs: None specific; governed by Grid invariants inlined below.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** packet:01, packet:02, packet:03, packet:04, packet:05, packet:06, packet:07, packet:08, packet:09, packet:10
+
+**Constraints:**
+- **Context invariant:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null tenant value. CorrelationId is never null or empty, and tenant context defaults to `TenantId.Internal` for internal Grid work.
+- **Dependency invariant:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages except permitted `Microsoft.Extensions.*` abstractions. Runtime packages consume upstream Abstractions whenever possible; avoid full runtime dependencies unless a host composition package explicitly needs runtime behavior.
+- **Packaging invariant:** Semantic versioning with repo-level `CHANGELOG.md`; per-package changelogs only for packages with actual functional changes. All non-test projects in a solution move versions together when a package version bump is warranted.
+- **Testing invariant:** Tests never depend on external services. Use in-memory/fake collaborators. No test code in runtime packages; tests live in dedicated `.Tests` or `.Canary` projects.
+
+
+**Key Files:**
+- `catalogs/compatibility.json`
+- `catalogs/relationships.json`
+- `catalogs/nodes.json` if version/signal changes are needed
+- `initiatives/active-initiatives.md`
+- `initiatives/roadmap.md`
+- `initiatives/releases.md`
+- `CHANGELOG.md`
+
+**Contracts:**
+No code contracts. Architecture metadata must mirror merged repo reality.

--- a/generated/issue-packets/active/kernel-adoption-alignment/dispatch-plan.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/dispatch-plan.md
@@ -1,0 +1,75 @@
+# Dispatch Plan — Kernel Adoption Alignment
+
+## Summary
+Coordinate per-repo fixes from the Kernel adoption audit so every active .NET Node consumes Kernel identity/context correctly, avoids unnecessary runtime dependencies, and updates Architecture compatibility metadata after implementation reality changes.
+
+## Trigger
+2026-05-17 Kernel adoption audit found drift: missing Grid/Operation context at some entry points, direct queue secret/config reads in Notify, runtime Kernel dependency where Abstractions should suffice, and stale compatibility/version metadata.
+
+## Classification
+- Request type: `cross-repo-change` / `dependency-upgrade`
+- Tier: 2
+- Initiative: `kernel-adoption-alignment`
+- Actor: Agent for all packets; Notify has one deploy-time human prerequisite for runtime setting confirmation if the Functions binding still requires it.
+
+## Wave Diagram
+
+### Wave 1 — Kernel foundation
+- [ ] `01-kernel-context-bootstrap-and-well-known-node-ids.md` — establish canonical identity/context seams.
+
+### Wave 2 — Upstream Core dependency cleanup
+- [ ] `02-transport-drop-kernel-runtime-dependency.md`
+  - Blocked by: packet 01.
+
+### Wave 3 — Per-repo consumers, parallel after prerequisites
+- [ ] `03-vault-align-kernel-version.md` — blocked by packet 01.
+- [ ] `04-auth-align-kernel-version.md` — blocked by packets 01, 03.
+- [ ] `05-web-rest-require-kernel-request-context.md` — blocked by packet 01.
+- [ ] `06-data-require-context-for-outbox-enrichment.md` — blocked by packets 01, 02.
+- [ ] `07-vault-rotation-establish-timer-operation-context.md` — blocked by packets 01, 03.
+- [ ] `08-notify-align-identity-and-queue-secret-boundary.md` — blocked by packets 01, 03.
+- [ ] `09-pulse-align-kernel-identity-and-version.md` — blocked by packets 01, 02.
+- [ ] `10-communications-drop-kernel-runtime-dependency.md` — blocked by packet 01.
+
+### Wave 4 — Architecture truth reconciliation
+- [ ] `11-architecture-reconcile-kernel-adoption-catalogs.md` — blocked by packets 01-10.
+
+## Packet Links
+- [01 — HoneyDrunk.Kernel: Kernel context bootstrap + well-known Node IDs](01-kernel-context-bootstrap-and-well-known-node-ids.md)
+- [02 — HoneyDrunk.Transport: Drop full Kernel runtime dependency](02-transport-drop-kernel-runtime-dependency.md)
+- [03 — HoneyDrunk.Vault: Align Kernel package version](03-vault-align-kernel-version.md)
+- [04 — HoneyDrunk.Auth: Align Kernel package version](04-auth-align-kernel-version.md)
+- [05 — HoneyDrunk.Web.Rest: Require Kernel context in HTTP pipeline](05-web-rest-require-kernel-request-context.md)
+- [06 — HoneyDrunk.Data: Require context for outbox enrichment](06-data-require-context-for-outbox-enrichment.md)
+- [07 — HoneyDrunk.Vault.Rotation: Establish timer operation context](07-vault-rotation-establish-timer-operation-context.md)
+- [08 — HoneyDrunk.Notify: Align identity and queue secret boundary](08-notify-align-identity-and-queue-secret-boundary.md)
+- [09 — HoneyDrunk.Pulse: Align canonical Pulse identity](09-pulse-align-kernel-identity-and-version.md)
+- [10 — HoneyDrunk.Communications: Drop unnecessary Kernel runtime dependency](10-communications-drop-kernel-runtime-dependency.md)
+- [11 — HoneyDrunk.Architecture: Reconcile catalogs/compatibility](11-architecture-reconcile-kernel-adoption-catalogs.md)
+
+## Site Sync Flag
+No immediate Studios website packet is required unless Architecture reconciliation changes public Node versions/signals surfaced on the website. If packet 11 updates public-facing catalog data consumed by Studios, run `site-sync` afterward.
+
+## Rollback Plan
+- Kernel packet 01 is the dependency root. If it fails, do not start packets 02-10.
+- Downstream packets should be separate PRs. Revert a failing downstream PR independently without reverting Kernel unless the shared seam is proven defective.
+- Architecture packet 11 should land last and reflect only merged repo reality; if downstream work is partially complete, record partial compatibility instead of claiming full alignment.
+
+## Filing Commands
+
+```bash
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Kernel --title "Kernel context bootstrap + well-known Node IDs" --body-file "generated/issue-packets/active/kernel-adoption-alignment/01-kernel-context-bootstrap-and-well-known-node-ids.md" --label "kernel-adoption,tier-2"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Transport --title "Drop full Kernel runtime dependency" --body-file "generated/issue-packets/active/kernel-adoption-alignment/02-transport-drop-kernel-runtime-dependency.md" --label "kernel-adoption,tier-2"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Vault --title "Align Kernel package version" --body-file "generated/issue-packets/active/kernel-adoption-alignment/03-vault-align-kernel-version.md" --label "kernel-adoption,tier-2"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Auth --title "Align Kernel package version" --body-file "generated/issue-packets/active/kernel-adoption-alignment/04-auth-align-kernel-version.md" --label "kernel-adoption,tier-2"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Web.Rest --title "Require Kernel context in HTTP pipeline" --body-file "generated/issue-packets/active/kernel-adoption-alignment/05-web-rest-require-kernel-request-context.md" --label "kernel-adoption,tier-2"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Data --title "Require context for outbox enrichment" --body-file "generated/issue-packets/active/kernel-adoption-alignment/06-data-require-context-for-outbox-enrichment.md" --label "kernel-adoption,tier-2"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Vault.Rotation --title "Establish timer operation context" --body-file "generated/issue-packets/active/kernel-adoption-alignment/07-vault-rotation-establish-timer-operation-context.md" --label "kernel-adoption,tier-2"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Notify --title "Align identity and queue secret boundary" --body-file "generated/issue-packets/active/kernel-adoption-alignment/08-notify-align-identity-and-queue-secret-boundary.md" --label "kernel-adoption,tier-2"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Pulse --title "Align canonical Pulse identity" --body-file "generated/issue-packets/active/kernel-adoption-alignment/09-pulse-align-kernel-identity-and-version.md" --label "kernel-adoption,tier-2"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Communications --title "Drop unnecessary Kernel runtime dependency" --body-file "generated/issue-packets/active/kernel-adoption-alignment/10-communications-drop-kernel-runtime-dependency.md" --label "kernel-adoption,tier-2"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Reconcile catalogs/compatibility" --body-file "generated/issue-packets/active/kernel-adoption-alignment/11-architecture-reconcile-kernel-adoption-catalogs.md" --label "kernel-adoption,tier-2"
+```
+
+## Blocking Relationships
+The `dependencies:` frontmatter in each packet is canonical. After filing, wire GitHub blocked-by relationships for every dependency entry using `addBlockedBy`.

--- a/generated/issue-packets/active/kernel-adoption-alignment/handoff-wave3-downstream-alignment.md
+++ b/generated/issue-packets/active/kernel-adoption-alignment/handoff-wave3-downstream-alignment.md
@@ -1,0 +1,19 @@
+# Handoff — Kernel Adoption Alignment
+
+## Purpose
+Use this when moving from Kernel foundation work into downstream repo execution.
+
+## Upstream Expectations
+Packet 01 must publish/merge a Kernel package version that provides:
+- Canonical `WellKnownNodes` values for current Grid Nodes (`honeydrunk-*`).
+- An Abstractions-visible context bootstrap/factory seam so libraries like Transport do not need concrete `GridContext.Initialize()`.
+- Passing Kernel build/tests and updated changelogs/version metadata.
+
+## Downstream Execution Rule
+Each downstream repo branches from updated `main`, updates only its own package references/code/tests/changelogs, and validates with repo-local restore/build/test. Do not merge any repo until Oleg explicitly verifies.
+
+## Critical Invariants
+- Every HTTP request, message handler, and background job must have populated Grid context: correlation, node, studio, environment, and tenant (`TenantId.Internal` for internal/system work).
+- Secret values never appear in logs/traces/exceptions. Vault is the only source of secrets; deploy-time bootstrap settings are identifiers/endpoints, not committed secrets.
+- Abstractions packages stay dependency-light; avoid full runtime package references when Abstractions contracts are sufficient.
+- All non-test projects in a solution move version together when a bump is warranted.

--- a/initiatives/active-initiatives.md
+++ b/initiatives/active-initiatives.md
@@ -4,6 +4,28 @@ Tracked initiatives currently in progress or planned. Completed and cancelled in
 
 ## In Progress
 
+### Kernel Adoption Alignment
+**Status:** Scoped
+**Scope:** Kernel, Transport, Vault, Auth, Web.Rest, Data, Vault.Rotation, Notify, Pulse, Communications, Architecture
+**Initiative:** `kernel-adoption-alignment`
+**Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)
+**Description:** Follow-up from the 2026-05-17 Kernel adoption audit. Align active .NET Nodes on canonical Kernel identity/context usage, remove avoidable runtime Kernel dependencies, enforce Grid/Operation context at HTTP/message/background entry points, clean up Notify queue-secret bootstrap drift, and reconcile Architecture compatibility metadata after repo PRs merge.
+
+**Tracking:**
+- [ ] Kernel#NN: Align Kernel context bootstrap and well-known Node IDs (packet 01)
+- [ ] Transport#NN: Drop Transport dependency on Kernel runtime (packet 02)
+- [ ] Vault#NN: Align Vault to current Kernel packages (packet 03)
+- [ ] Auth#NN: Align Auth to current Kernel packages (packet 04)
+- [ ] Web.Rest#NN: Require Kernel context in Web.Rest request pipeline (packet 05)
+- [ ] Data#NN: Require context for Data outbox enrichment (packet 06)
+- [ ] Vault.Rotation#NN: Establish Kernel context for rotation timer jobs (packet 07)
+- [ ] Notify#NN: Align Notify Kernel identity and queue secret boundary (packet 08)
+- [ ] Pulse#NN: Align Pulse to Kernel canonical identity (packet 09)
+- [ ] Communications#NN: Drop Communications runtime Kernel dependency (packet 10)
+- [ ] Architecture#NN: Reconcile Kernel adoption catalogs and compatibility (packet 11)
+
+> **Sync (2026-05-17):** Packets scoped under `generated/issue-packets/active/kernel-adoption-alignment/`. Filing pending.
+
 ### ADR-0010 Observation Layer & AI Routing — Phase 1
 **Status:** In Progress
 **Scope:** Architecture, Observe (new), AI


### PR DESCRIPTION
## Summary

- Reconcile Pulse's canonical Architecture Node ID from legacy `pulse` to `honeydrunk-pulse`
- Remove the Pulse exception from naming conventions
- Add the `kernel-adoption-alignment` initiative with per-repo packets, dispatch plan, and downstream handoff
- Track the new initiative in `initiatives/active-initiatives.md`

## Validation

- Packet structure check passed for all 11 Kernel adoption packets
- `dependencies:` frontmatter uses `packet:NN` schema
- Every packet includes Human Prerequisites, NuGet Dependencies, and Agent Handoff
- `catalogs/*.json` parse successfully
- `git diff --check` passed

## Notes

This PR is Architecture-only. It does not file GitHub issues yet; it creates the packet set and dispatch plan for the Kernel adoption alignment work.
