### PR TITLE
chore: scope ADR-0033 environment-gated deploy-trigger model

### DIFF
--- a/generated/issue-packets/active/adr-0033-deploy-trigger-model/01-notify-functions-deploy-trigger-model.md
+++ b/generated/issue-packets/active/adr-0033-deploy-trigger-model/01-notify-functions-deploy-trigger-model.md
@@ -1,0 +1,253 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["ci", "tier-2", "ops", "adr-0033"]
+dependencies: []
+adrs: ["ADR-0033", "ADR-0012", "ADR-0015"]
+accepts: ["ADR-0033"]
+wave: 1
+initiative: adr-0033-deploy-trigger-model
+node: honeydrunk-notify
+---
+
+# Amend `release-functions.yml` for environment-gated deploy triggers
+
+## Summary
+Add a path-filtered push-to-`main` trigger that resolves to `dev`, make the trigger-to-environment mapping explicit in the `resolve` job, and add a `concurrency` block keyed on the resolved environment. Replace the existing "dev-only / tag-only — intentional, not a gap" header framing with the dual-trigger model decided in ADR-0033.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Notify`
+
+## Target Workflow
+**File:** `.github/workflows/release-functions.yml`
+**Family:** release (consumer caller of `HoneyDrunk.Actions/.github/workflows/job-deploy-function.yml@main`)
+
+## Motivation
+The Notify.Functions release line currently fires only on `functions-v*` tag pushes plus `workflow_dispatch`. For a disposable `dev` environment under a continuous solo-dev + AI-agent merge cadence, requiring a tag per dev deploy is friction with no payoff — `dev` is never a promotion source, so its version-of-record is irrelevant there. Tag-gating must remain in place for `staging`/`prod` (when those are provisioned) because the CHANGELOG + SemVer tag is the version-of-record and the rollback target. ADR-0033 resolves this by adding a second trigger (push-to-`main`, path-filtered → `dev`) alongside the existing tag trigger and making the mapping explicit.
+
+The reusable deploy workflow in `HoneyDrunk.Actions` is unchanged — it already accepts an `environment` input and has no opinion about what triggered the caller. Trigger policy belongs in the consumer `on:` block and cannot be centralized through `workflow_call` (this is the structural reason ADR-0012's invariant on reusable workflows is not violated).
+
+## Proposed Change
+
+### 1. `on:` block — add path-filtered push trigger
+Add a `push: branches: [main]` trigger with a `paths:` filter scoped to **only `Notify.Functions`'s source**. The tag trigger remains unfiltered (a deliberately pushed tag is always deploy-intent). `workflow_dispatch` is retained as the manual escape hatch for both paths.
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths:
+      # Functions deployable source (the .csproj at .Functions/HoneyDrunk.Notify.Functions.csproj
+      # is already covered by this glob — no standalone .csproj entry needed).
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Functions/**'
+      # Shared libraries the Functions binary links against (per
+      # HoneyDrunk.Notify.Functions.csproj ProjectReference graph): runtime
+      # core, abstractions, hosting glue, the three provider packages, and
+      # the HostBootstrap shared identity source. A change to any of these
+      # produces a runtime behavior change in the deployed Functions binary
+      # and must redeploy on main. D3 makes this an active correctness
+      # concern, not a fire-and-forget setting.
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Abstractions/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Hosting.AspNetCore/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Providers.Email.Smtp/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Providers.Email.Resend/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Providers.Sms.Twilio/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.HostBootstrap/**'
+      # Solution file and the workflow itself.
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.slnx'
+      - '.github/workflows/release-functions.yml'
+    tags:
+      - 'functions-v*'
+  workflow_dispatch:
+```
+
+The Worker source (`HoneyDrunk.Notify/HoneyDrunk.Notify.Worker/**`) and Worker-only shared paths (`HoneyDrunk.Notify.Queue.*/**`) must **not** be in this filter (D4 — Functions-only commits must not redeploy the Worker; the Worker workflow has the symmetric filter for itself). The shared libraries listed above (`HoneyDrunk.Notify`, `HoneyDrunk.Notify.Abstractions`, `HoneyDrunk.Notify.Hosting.AspNetCore`, the three Provider packages, `HoneyDrunk.Notify.HostBootstrap`) are legitimately referenced by **both** the Functions and Worker `.csproj` files — appearing in both workflows' filters is correct and intentional. D4 disjointness is preserved by the deployable-source-tree paths (`HoneyDrunk.Notify.Functions/**` vs. `HoneyDrunk.Notify.Worker/**`), not by the shared-library paths.
+
+Forward-looking note: `Directory.Build.props` and `Directory.Packages.props` do not currently exist in the HoneyDrunk.Notify repo. If they are added later (centralized package versioning, shared MSBuild properties), the implementing agent must add them to this filter at that time — they would affect the build of every project in the solution.
+
+### 2. `resolve` job — explicit trigger-to-environment mapping
+The `resolve` job is the single place trigger intent is mapped to a target environment. Today it hard-codes `environment: dev`. Replace that with an explicit conditional resolution emitting a `target_environment` output that all downstream jobs consume.
+
+```yaml
+  resolve:
+    name: Resolve target environment and config
+    runs-on: ubuntu-latest
+    # ADR-0033 D2: trigger intent is mapped here, once, explicitly.
+    # - refs/tags/functions-v*  -> promotion environment (staging / prod when
+    #   provisioned; for now, no tag-driven promotion is wired beyond dev — a
+    #   tag still resolves to `dev` until the environment value is decided per
+    #   ADR-0033 D6 at staging/prod stand-up).
+    # - refs/heads/main         -> dev (continuous deploy of the disposable env).
+    # - workflow_dispatch       -> dev (manual escape hatch on the same path).
+    environment: dev
+    outputs:
+      target_environment: dev
+      functions-app: func-hd-notify-${{ vars.HD_ENV }}
+      resource-group: rg-hd-notify-${{ vars.HD_ENV }}
+      keyvault-name: kv-hd-notify-${{ vars.HD_ENV }}
+      azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
+      azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+    steps:
+      - name: Echo resolved targets
+        run: |
+          echo "Trigger      : ${{ github.event_name }} / ${{ github.ref }}"
+          echo "Environment  : dev"
+          echo "Function App : func-hd-notify-${{ vars.HD_ENV }}"
+          echo "Resource Grp : rg-hd-notify-${{ vars.HD_ENV }}"
+          echo "Key Vault    : kv-hd-notify-${{ vars.HD_ENV }}"
+```
+
+The `target_environment: dev` output is the explicit-mapping anchor: today both paths resolve to `dev`, but the value lives in the `outputs:` block — not implicitly via `vars.HD_ENV` — so the staging/prod conditional (D6) is added in one place when those environments are provisioned. The downstream `deploy` job consumes `needs.resolve.outputs.target_environment` instead of the literal string `dev`.
+
+### 3. `concurrency` block — keyed on resolved environment
+Add a top-level `concurrency` block that keys on the resolved environment so dev churn never cancels a staging/prod promotion (D5). Dev (branch-push path) sets `cancel-in-progress: true` to supersede in-flight dev deploys; tag path sets `cancel-in-progress: false` so deliberate versioned promotions queue rather than being silently cancelled.
+
+```yaml
+concurrency:
+  # Dev branch pushes share a single key and supersede each other (latest main wins).
+  # Tag promotions get their own per-ref key and queue (never cancel-in-progress).
+  # Single-line expression form is the well-known-safe shape — GitHub Actions
+  # expression parsing across newlines inside ${{ }} has bitten projects in
+  # the past. Keep this on one line.
+  group: release-functions-${{ startsWith(github.ref, 'refs/tags/') && format('tag-{0}', github.ref_name) || 'dev' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+```
+
+### 4. `deploy` job — consume resolved environment
+Change the `deploy` job to pass `environment: ${{ needs.resolve.outputs.target_environment }}` to the reusable workflow rather than the literal `dev`. No other inputs change. The reusable workflow's behavior is unchanged.
+
+The existing `build` job's structure and `needs:` chain is unchanged — it fires under both triggers (branch push and tag push) and its restore/build/test/publish/upload-artifact sequence stays as-is. The trigger-model change is purely in the `on:` block, the `resolve` job's outputs, the top-level `concurrency` block, and the `deploy` job's `environment` input.
+
+**No `image-tag` adjustment in this packet.** Functions deploy publishes a `.zip` artifact (via `actions/upload-artifact`) consumed by `job-deploy-function.yml`, not a tagged container image. Packets 02 and 03 add a SHA-derived branch-path image tag for their respective Container App deployables — that machinery does not apply here.
+
+### 5. Header comment block — replace dev-only/tag-only framing
+Replace the existing header lines (currently "A `functions-v*` tag therefore deploys to dev and nothing else — intentional, not a gap.") with the dual-trigger framing per ADR-0033:
+
+```yaml
+# Dual-trigger release for Notify.Functions:
+#
+#  - push to main, path-filtered to Notify.Functions sources  -> dev
+#  - functions-v* tag, unfiltered                              -> staging / prod
+#                                                                 (when provisioned)
+#  - workflow_dispatch                                          -> manual escape hatch
+#
+# Trigger intent is mapped to environment in the `resolve` job (single source).
+# The reusable deploy workflow in HoneyDrunk.Actions takes an `environment`
+# input and has no opinion about what triggered the caller — trigger policy is
+# consumer-owned by construction (ADR-0012 invariant on reusable workflows
+# is unchanged: the `on:` block cannot be centralized through workflow_call).
+#
+# Path filter (D3/D4): scoped to Notify.Functions' own source only. A
+# Worker-only commit must not redeploy Functions (the Worker workflow has the
+# symmetric filter for itself).
+#
+# Concurrency (D5): keyed on the resolved environment. Dev branch pushes
+# supersede in-flight dev deploys (latest main wins). Tag promotions queue
+# (cancel-in-progress: false) so a deliberate versioned promotion is never
+# silently cancelled by a later one.
+#
+# The version-of-record rule (CHANGELOG + SemVer tag) is unchanged: a
+# push-to-main dev deploy has no version stamp by design and is explicitly
+# not a promotion source.
+```
+
+The previous `# Environment scope: dev only, by design.` paragraph is removed wholesale — it is superseded.
+
+## Consumer Impact
+No consumer impact. This is a consumer release workflow; nothing else consumes it. `HoneyDrunk.Actions/.github/workflows/job-deploy-function.yml@main` is the upstream and is unchanged.
+
+## Breaking Change?
+- [x] No — backward compatible at the trigger level. The existing `functions-v*` tag trigger still deploys to dev as it does today. The new `main` branch-push trigger is additive.
+- [ ] Yes — consumers need to update their caller workflows
+
+## Affected Files
+- `.github/workflows/release-functions.yml` — header comment, `on:` block, `resolve` job (outputs + comment), top-level `concurrency` block, `deploy` job input.
+- `CHANGELOG.md` — repo-level entry for "ADR-0033: environment-gated deploy triggers for Notify.Functions."
+
+No application code changes. No new packages.
+
+## NuGet Dependencies
+None. This is a workflow-only change; no `.csproj` files are touched.
+
+## Boundary Check
+- [x] Workflow-only change. No Transport contract change, no `HoneyDrunk.Actions` change (the reusable workflow is consumed as-is).
+- [x] Trigger policy is irreducibly per-consumer-repo (a `workflow_call` reusable workflow cannot own the caller's `on:` block) — the ADR-0012 invariant on reusable workflows is preserved exactly as written.
+- [x] Path filter is scoped to **only `Notify.Functions`** — a Worker-only commit must not redeploy Functions, per D4. This is enforced here in the Functions filter; the symmetric enforcement lives in the Worker workflow (packet 02).
+
+## Acceptance Criteria
+- [ ] `on:` block includes both the path-filtered `push: branches: [main]` trigger and the existing `push: tags: ['functions-v*']` trigger, plus `workflow_dispatch`.
+- [ ] The `main` path filter includes `HoneyDrunk.Notify/HoneyDrunk.Notify.Functions/**`, the solution `.slnx`, the workflow file itself, and the shared library projects the Functions binary links against per `HoneyDrunk.Notify.Functions.csproj`'s `ProjectReference` graph: `HoneyDrunk.Notify/**`, `HoneyDrunk.Notify.Abstractions/**`, `HoneyDrunk.Notify.Hosting.AspNetCore/**`, `HoneyDrunk.Notify.Providers.Email.Smtp/**`, `HoneyDrunk.Notify.Providers.Email.Resend/**`, `HoneyDrunk.Notify.Providers.Sms.Twilio/**`, `HoneyDrunk.Notify.HostBootstrap/**`. The filter **does not** include any path under `HoneyDrunk.Notify/HoneyDrunk.Notify.Worker/` or under any `HoneyDrunk.Notify.Queue.*` package (Worker-only).
+- [ ] No standalone `HoneyDrunk.Notify.Functions.csproj` entry in the filter — the file is at `HoneyDrunk.Notify/HoneyDrunk.Notify.Functions/HoneyDrunk.Notify.Functions.csproj` and is already covered by the project-directory glob.
+- [ ] `Directory.Build.props` / `Directory.Packages.props` are **not** listed in the filter (they do not currently exist in HoneyDrunk.Notify). If they are added later, this filter must be updated at the same time.
+- [ ] `resolve` job emits a `target_environment` output (literal `dev` today; explicit-mapping anchor for future staging/prod conditional per D6).
+- [ ] The `deploy` job consumes `needs.resolve.outputs.target_environment` rather than the literal string `dev`.
+- [ ] Top-level `concurrency` block exists, group key includes the resolved environment (or `tag-<ref_name>` for the tag path), and `cancel-in-progress` is `true` on the dev branch-push path / `false` on the tag path.
+- [ ] Header comment block describes the dual-trigger model and explicitly removes the prior "dev-only / tag-only — intentional, not a gap" framing.
+- [ ] Test 1 (branch-push path, in-filter): a no-op commit to `HoneyDrunk.Notify/HoneyDrunk.Notify.Functions/README.md` on `main` (or equivalent in-filter file) triggers `release-functions.yml`, resolves to `dev`, and runs through to a successful deploy.
+- [ ] Test 2 (branch-push path, out-of-filter / Worker-only): a no-op commit to `HoneyDrunk.Notify/HoneyDrunk.Notify.Worker/README.md` on `main` does **not** trigger `release-functions.yml`. Verified by inspecting the Actions run list for the commit SHA.
+- [ ] Test 3 (tag path): pushing a `functions-v*` tag still triggers `release-functions.yml`, resolves to `dev`, deploys, and the `concurrency` group uses the `tag-<ref_name>` key with `cancel-in-progress: false`.
+- [ ] Test 4 (dev supersession): two rapid in-filter pushes to `main` produce two workflow runs in the same `dev` concurrency group; the older run is cancelled by GitHub Actions ("Canceled" in the Actions UI). The latest `main` wins.
+- [ ] Test 5 (tests-only commit, out-of-filter): a no-op commit under `HoneyDrunk.Notify/HoneyDrunk.Notify.Tests/**` or `HoneyDrunk.Notify/HoneyDrunk.Notify.IntegrationTests/**` on `main` does **not** trigger `release-functions.yml`. Test projects are explicitly outside the filter — they affect the gate (PR `pr.yml`) but not the deploy.
+- [ ] `CHANGELOG.md` updated under the appropriate dated version section (no commits under `Unreleased` — move to a dated SemVer section before merge, per the no-Unreleased-commits convention). This is a CI/workflow change — no `.csproj` version bump.
+- [ ] No ADR number appears in the workflow header comment, code comments, or `CHANGELOG.md` prose. The runtime packet-data reference `adr-0033` is acceptable only as packet-data identifier in this packet's frontmatter.
+
+## Human Prerequisites
+None. The `dev` GitHub Environment, OIDC federated credentials, and Azure resources for `func-hd-notify-dev` are already in place from the ADR-0015 rollout. ADR-0033 D7 explicitly mandates that the `dev` environment remain unprotected (no required-reviewer rule), so no environment-protection change is needed; verify in the GitHub Environment settings that `dev` has no required reviewers before merging.
+
+**Branch protection note.** Release workflow runs are **not** required checks on the `main` branch-protection rule. The PR-side checks (`pr.yml`) remain the merge gate; a release that fails *after* merge is a deploy concern (revert PR or hot-fix), not a branch-protection concern. Do not add the new dual-trigger release workflow to required checks on `main` — doing so would block merges while waiting for a post-merge deploy.
+
+## Referenced ADR Decisions
+
+**ADR-0033 D1 — Trigger model per environment.** Each consumer release workflow gains a second trigger alongside its existing tag trigger: push to `main` path-filtered → `dev`; SemVer-shaped tag unfiltered → staging/prod (when provisioned); `workflow_dispatch` retained as the manual escape hatch for both paths.
+
+**ADR-0033 D2 — Trigger-to-environment resolution is explicit.** The `resolve` job is the single place trigger intent is mapped to a target environment. A tag ref resolves the promotion environment; a `main` branch push resolves `dev`. The mapping is an explicit conditional/output in `resolve`, not inferred implicitly from `vars.HD_ENV` and not scattered across jobs.
+
+**ADR-0033 D3 — Path filtering is part of the decision, not optional.** The `push: branches: [main]` trigger carries a `paths:` filter scoped to **that deployable's own source** — its project directory and `.csproj`, plus solution-level inputs that affect its build. The tag trigger is **not** path-filtered: a deliberately pushed tag is always deploy-intent.
+
+**ADR-0033 D4 — Multi-deployable repos: per-deployable independence.** In HoneyDrunk.Notify (two deployables: `Notify.Functions` on `functions-v*` / `Notify.Functions/`, and `Notify.Worker` on `worker-v*` / `Notify.Worker/`), each release workflow's push-to-`main` path filter is scoped to **only its own** deployable's source. A Functions-only commit must not redeploy the Worker, and vice versa.
+
+**ADR-0033 D5 — Concurrency.** Each release workflow declares a `concurrency` group whose key includes the **resolved environment**, so dev churn can never cancel a staging/prod promotion. Dev (branch-push path): `cancel-in-progress: true`. Tag (promotion path): `cancel-in-progress: false`.
+
+**ADR-0033 D7 — `dev` remains an unprotected GitHub Environment by design.** A required-reviewer protection rule on the `dev` GitHub Environment would block push-to-`main` deploys on approval, defeating the purpose of D1. Environment protection rules are the mechanism for `staging`/`prod` only.
+
+**ADR-0033 D8 — Relationship to ADR-0012 and ADR-0015.** This decision clarifies ADR-0012 without changing any of its invariants: trigger policy is consumer-workflow-owned (the `on:` block, inherently per-repo); deploy mechanics remain control-plane-owned. No `catalogs/relationships.json` edge changes — this is CI trigger policy, not a Node contract or dependency-graph change. No `HoneyDrunk.Actions` PR is part of this initiative.
+
+## Dependencies
+None. This packet does not depend on packets 02 or 03 — the three workflow amendments are independent and can land in any order.
+
+## Labels
+`ci`, `tier-2`, `ops`, `adr-0033`
+
+## Agent Handoff
+
+**Objective:** Amend `release-functions.yml` in HoneyDrunk.Notify to support environment-gated deploy triggers per ADR-0033 — path-filtered push-to-`main` → `dev` alongside the existing tag-driven promotion path, with explicit `resolve` mapping and environment-keyed concurrency.
+
+**Target:** HoneyDrunk.Notify, branch from `main`.
+
+**Context:**
+- Goal: Remove tag-cutting ceremony from continuous dev deploys while preserving SemVer-tagged promotion for staging/prod (when provisioned).
+- Feature: ADR-0033 initiative (`adr-0033-deploy-trigger-model`).
+- ADRs: ADR-0033 (this decision), ADR-0012 (CI/CD control plane — unchanged), ADR-0015 (hosting — unchanged).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+- **ADR-0012 invariant — deploy logic in HoneyDrunk.Actions only.** `release-functions.yml` must continue to consume `HoneyDrunk.Actions/.github/workflows/job-deploy-function.yml@main` for deploy mechanics. No deploy logic (Azure login, artifact handling, traffic shift, health probe) may be inlined into this workflow. Trigger policy (the `on:` block, the `resolve` mapping, the `concurrency` block) is consumer-owned by construction and is the only surface this packet edits.
+- **Invariant 8 (secrets in telemetry):** Secret values never appear in logs, traces, exceptions, or telemetry. Only secret names/identifiers may be traced. `VaultTelemetry` enforces this. The workflow's `Echo resolved targets` step must continue to echo only resource names and refs — never secret values.
+- **Invariant 9 (Vault as the only source of secrets):** Vault is the only source of secrets. No Node reads secrets directly from environment variables, config files, or provider SDKs. All access goes through `ISecretStore`. The trigger-model change does not relax this; provider credentials still resolve through the existing Vault bootstrap on the Function App.
+- **Path-filter correctness (D4):** A Worker-only commit must not redeploy Functions. The `paths:` list under `push: branches: [main]` must not include any `HoneyDrunk.Notify.Worker/**` entry. Reviewer checks both this packet's filter and packet 02's (Worker) filter for symmetric correctness.
+- **Concurrency key composition (D5):** The `concurrency.group` expression must produce a different key for the tag path than for any dev branch-push path. A naive `group: release-functions-${{ github.ref }}` is wrong because rapid main pushes would still queue each other if `github.ref` differs per commit (it does not — `refs/heads/main` is stable — but the failure mode to avoid is folding tag and branch into the same key). The expression shown under D5 above is the canonical form.
+- **No version-of-record drift.** Push-to-`main` dev deploys have no version stamp by design. The deploy artifact for the dev path is identified by commit SHA only. Do not introduce a tag-on-push or `version` input to compensate — that would resurrect tag-cutting friction and defeat D1.
+- **Header comment is not optional.** The replacement header text must be in place; the prior "dev-only / tag-only — intentional, not a gap" sentence must be deleted. The ADR explicitly supersedes that framing (D8 / Follow-up Work). No ADR number in the comment per Grid doc convention.
+
+**Key Files:**
+- `.github/workflows/release-functions.yml` — the only file authored.
+- `CHANGELOG.md` — repo-level entry under a dated SemVer section (not under `Unreleased`).
+
+**Contracts:** None changed. This is CI trigger policy, not a Node contract or dependency-graph change. No `catalogs/relationships.json` edge changes.

--- a/generated/issue-packets/active/adr-0033-deploy-trigger-model/02-notify-worker-deploy-trigger-model.md
+++ b/generated/issue-packets/active/adr-0033-deploy-trigger-model/02-notify-worker-deploy-trigger-model.md
@@ -1,0 +1,272 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["ci", "tier-2", "ops", "adr-0033"]
+dependencies: []
+adrs: ["ADR-0033", "ADR-0012", "ADR-0015"]
+accepts: ["ADR-0033"]
+wave: 1
+initiative: adr-0033-deploy-trigger-model
+node: honeydrunk-notify
+---
+
+# Amend `release-worker.yml` for environment-gated deploy triggers
+
+## Summary
+Add a path-filtered push-to-`main` trigger that resolves to `dev`, make the trigger-to-environment mapping explicit in the `resolve` job, and add a `concurrency` block keyed on the resolved environment. Replace the existing "dev-only / tag-only — intentional, not a gap" header framing with the dual-trigger model decided in ADR-0033. Path-scope strictly to `Notify.Worker` sources so the Worker workflow does not redeploy on Functions-only commits (D4).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Notify`
+
+## Target Workflow
+**File:** `.github/workflows/release-worker.yml`
+**Family:** release (consumer caller of `HoneyDrunk.Actions/.github/workflows/job-deploy-container-app.yml@main`)
+
+## Motivation
+Same motivation as packet 01 (Notify.Functions): remove tag-cutting ceremony from continuous dev deploys to a disposable environment while preserving SemVer-tagged promotion for staging/prod. The Worker line is a Container App (revision-based deploys per ADR-0015) — orthogonal to the trigger-model decision, which is about the consumer `on:` block and the `resolve` mapping.
+
+This is the **D4 correctness twin** of packet 01: in a repo with two deployables (`Notify.Functions` and `Notify.Worker`), each release workflow's path filter must be scoped to **only its own** deployable's source. The Functions filter (packet 01) and the Worker filter (this packet) together enforce that a Functions-only commit does not redeploy the Worker and vice versa.
+
+## Proposed Change
+
+### 1. `on:` block — add path-filtered push trigger
+Add a `push: branches: [main]` trigger with a `paths:` filter scoped to **only `Notify.Worker`'s source**. The tag trigger remains unfiltered. `workflow_dispatch` is retained.
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths:
+      # Worker deployable source. The Worker Dockerfile lives under
+      # HoneyDrunk.Notify.Worker/ — covered by this glob. The .csproj at
+      # .Worker/HoneyDrunk.Notify.Worker.csproj is also covered.
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Worker/**'
+      # Shared libraries the Worker binary links against (per
+      # HoneyDrunk.Notify.Worker.csproj ProjectReference graph): hosting
+      # glue, the three provider packages, the three queue packages, and
+      # the HostBootstrap shared identity source. A change to any of these
+      # produces a runtime behavior change in the deployed Worker binary
+      # and must redeploy on main. D3 makes this an active correctness
+      # concern, not a fire-and-forget setting.
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Hosting.AspNetCore/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Providers.Email.Smtp/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Providers.Email.Resend/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Providers.Sms.Twilio/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Queue.Abstractions/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Queue.InMemory/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.Queue.AzureStorage/**'
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.HostBootstrap/**'
+      # Solution file and the workflow itself.
+      - 'HoneyDrunk.Notify/HoneyDrunk.Notify.slnx'
+      - '.github/workflows/release-worker.yml'
+    tags:
+      - 'worker-v*'
+  workflow_dispatch:
+```
+
+The Functions source (`HoneyDrunk.Notify/HoneyDrunk.Notify.Functions/**`) and Functions-only shared paths (`HoneyDrunk.Notify/**`, `HoneyDrunk.Notify.Abstractions/**`) must **not** be in this filter (D4 — Worker-only commits must not redeploy Functions; the Functions workflow has the symmetric filter for itself). The shared libraries listed above (`HoneyDrunk.Notify.Hosting.AspNetCore`, the three Provider packages, `HoneyDrunk.Notify.HostBootstrap`) are legitimately referenced by **both** the Functions and Worker `.csproj` files — appearing in both workflows' filters is correct and intentional. The three `HoneyDrunk.Notify.Queue.*` packages are Worker-only (not referenced by Functions). D4 disjointness is preserved by the deployable-source-tree paths (`HoneyDrunk.Notify.Worker/**` vs. `HoneyDrunk.Notify.Functions/**`), not by the shared-library paths.
+
+Forward-looking note: `Directory.Build.props` and `Directory.Packages.props` do not currently exist in HoneyDrunk.Notify. If they are added later, the implementing agent must add them to this filter at that time.
+
+### 2. `resolve` job — explicit trigger-to-environment mapping
+Replace the hard-coded `environment: dev` resolution with an explicit `target_environment` output. Today both paths resolve to `dev`; the output exists so the staging/prod conditional (D6) is added in one place when those environments are provisioned.
+
+```yaml
+  resolve:
+    name: Resolve target environment and config
+    runs-on: ubuntu-latest
+    # ADR-0033 D2: trigger intent is mapped here, once, explicitly.
+    # - refs/tags/worker-v*    -> promotion environment (staging / prod when
+    #   provisioned; for now resolves to `dev` per ADR-0033 D6).
+    # - refs/heads/main        -> dev (continuous deploy of the disposable env).
+    # - workflow_dispatch      -> dev (manual escape hatch on the same path).
+    environment: dev
+    outputs:
+      target_environment: dev
+      acr-registry: acrhdshared${{ vars.HD_ENV }}.azurecr.io
+      container-app: ca-hd-notify-worker-${{ vars.HD_ENV }}
+      resource-group: rg-hd-notify-${{ vars.HD_ENV }}
+      keyvault-name: kv-hd-notify-${{ vars.HD_ENV }}
+      azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
+      azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+    steps:
+      - name: Echo resolved targets
+        run: |
+          echo "Trigger       : ${{ github.event_name }} / ${{ github.ref }}"
+          echo "Environment   : dev"
+          echo "Container App : ca-hd-notify-worker-${{ vars.HD_ENV }}"
+          echo "Resource Grp  : rg-hd-notify-${{ vars.HD_ENV }}"
+          echo "ACR           : acrhdshared${{ vars.HD_ENV }}.azurecr.io"
+          echo "Key Vault     : kv-hd-notify-${{ vars.HD_ENV }}"
+```
+
+The downstream `deploy` job consumes `needs.resolve.outputs.target_environment` instead of the literal `dev`.
+
+### 3. `concurrency` block — keyed on resolved environment
+Same form as packet 01 — separate per-environment key for the dev branch-push path; per-tag key for the tag path; `cancel-in-progress` differs by path.
+
+```yaml
+concurrency:
+  # Dev branch pushes share a single key and supersede each other (latest main wins).
+  # Tag promotions get their own per-ref key and queue (never cancel-in-progress).
+  # Single-line expression form is the well-known-safe shape — keep on one line.
+  group: release-worker-${{ startsWith(github.ref, 'refs/tags/') && format('tag-{0}', github.ref_name) || 'dev' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+```
+
+The group name prefix is `release-worker-` (not `release-functions-`) so the two Notify release workflows do not contend on the same concurrency keys. Each line's concurrency is independent.
+
+### 4. `deploy` job — consume resolved environment + handle branch-push image tag
+Change the `deploy` job to pass `environment: ${{ needs.resolve.outputs.target_environment }}` rather than the literal `dev`. The image-tag input today is `${{ github.ref_name }}`, which is the tag name on the tag path and the branch name (`main`) on the push path. The Container App can be deployed with `main` as an image tag for dev, but a tag-equal-to-branch-name across many commits produces ACR overwrites — undesirable. Replace the `image-tag` input with an expression that picks the SemVer tag on the tag path and a SHA-derived tag on the branch path:
+
+```yaml
+      # Tag path: use the SemVer tag verbatim (e.g. worker-v0.1.0).
+      # Branch path: use a SHA-derived tag (dev-<sha>, full 40-char SHA from
+      # github.sha) — image-per-commit rather than a moving `main` tag, so
+      # ACR has the artifact-per-deploy trail that revision-based rollback
+      # (ADR-0015) expects. Full SHA is intentional: simpler than a short-sha
+      # output step, and ACR has no tag-length friction at 40 chars.
+      # Single-line expression form is the well-known-safe shape.
+      image-tag: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || format('dev-{0}', github.sha) }}
+```
+
+This is a deploy-mechanics tweak that lives in the consumer caller because the reusable workflow simply takes an `image-tag` input and does not own the tagging policy. It does not violate ADR-0012 — the build/push/revision mechanics inside `job-deploy-container-app.yml` are unchanged; only the input value computed by the caller changes.
+
+### 5. Header comment block — replace dev-only/tag-only framing
+Replace the current header (specifically the paragraph ending "A `worker-v*` tag therefore deploys to dev and nothing else — intentional, not a gap.") with the dual-trigger framing, mirroring packet 01's header text but specialized to Worker / `worker-v*` / Container Apps / `ca-hd-notify-worker-{env}`. The "Replaces the previous App Service slot-swap deploy.yml" sentence already in the file is historical context and stays.
+
+```yaml
+# Dual-trigger release for Notify.Worker:
+#
+#  - push to main, path-filtered to Notify.Worker sources  -> dev
+#  - worker-v* tag, unfiltered                              -> staging / prod
+#                                                              (when provisioned)
+#  - workflow_dispatch                                       -> manual escape hatch
+#
+# Trigger intent is mapped to environment in the `resolve` job (single source).
+# The reusable deploy workflow in HoneyDrunk.Actions takes an `environment`
+# input and has no opinion about what triggered the caller — trigger policy is
+# consumer-owned by construction.
+#
+# Path filter (D3/D4): scoped to Notify.Worker's own source only. A
+# Functions-only commit must not redeploy Worker (the Functions workflow has
+# the symmetric filter for itself). HoneyDrunk.Notify has two deployables;
+# this filter is the D4 correctness boundary for the Worker side.
+#
+# Concurrency (D5): keyed on the resolved environment. Dev branch pushes
+# supersede in-flight dev deploys (latest main wins). Tag promotions queue
+# (cancel-in-progress: false) so a deliberate versioned promotion is never
+# silently cancelled by a later one.
+#
+# Image tag composition: SemVer tag verbatim on the tag path; dev-<sha> on
+# the branch path (full 40-char github.sha — not a short-sha). Image-per-commit
+# on dev preserves the rollback trail in ACR; moving the `main` tag would not.
+#
+# The version-of-record rule (CHANGELOG + SemVer tag) is unchanged: a
+# push-to-main dev deploy has no version stamp by design and is explicitly
+# not a promotion source.
+```
+
+The current paragraph framing dev-only/tag-only as "intentional, not a gap" is removed wholesale — superseded.
+
+## Consumer Impact
+No consumer impact. This is a consumer release workflow; nothing else consumes it. The upstream `HoneyDrunk.Actions/.github/workflows/job-deploy-container-app.yml@main` is unchanged.
+
+## Breaking Change?
+- [x] No — backward compatible at the trigger level. The `worker-v*` tag trigger still deploys to dev as it does today. The new `main` branch-push trigger is additive. The image-tag change is internal to the workflow and does not break consumer behavior.
+- [ ] Yes — consumers need to update their caller workflows
+
+## Affected Files
+- `.github/workflows/release-worker.yml` — header comment, `on:` block, `resolve` job (outputs + comment), top-level `concurrency` block, `deploy` job inputs (`environment`, `image-tag`).
+- `CHANGELOG.md` — repo-level entry under a dated SemVer section. CHANGELOG version sequencing for HoneyDrunk.Notify across packets 01 and 02 is owned by the dispatch plan (see `dispatch-plan.md` § CHANGELOG sequencing). Do not invent sequencing rules in-packet.
+
+No application code changes. No new packages.
+
+## NuGet Dependencies
+None. Workflow-only change.
+
+## Boundary Check
+- [x] Workflow-only change. No Transport contract change, no `HoneyDrunk.Actions` change.
+- [x] Trigger policy is irreducibly per-consumer-repo. ADR-0012 invariant on reusable workflows preserved.
+- [x] Path filter is scoped to **only `Notify.Worker`** — a Functions-only commit must not redeploy Worker, per D4. Symmetric enforcement to packet 01.
+- [x] Image-tag derivation lives in the caller (deploy-mechanics input value, not deploy-mechanics logic) — the reusable workflow's build/push/revision/probe/traffic-shift sequence is unchanged.
+
+## Acceptance Criteria
+- [ ] `on:` block includes both the path-filtered `push: branches: [main]` trigger and the existing `push: tags: ['worker-v*']` trigger, plus `workflow_dispatch`.
+- [ ] The `main` path filter includes `HoneyDrunk.Notify/HoneyDrunk.Notify.Worker/**`, the solution `.slnx`, the workflow file itself, and the shared library projects the Worker binary links against per `HoneyDrunk.Notify.Worker.csproj`'s `ProjectReference` graph: `HoneyDrunk.Notify.Hosting.AspNetCore/**`, `HoneyDrunk.Notify.Providers.Email.Smtp/**`, `HoneyDrunk.Notify.Providers.Email.Resend/**`, `HoneyDrunk.Notify.Providers.Sms.Twilio/**`, `HoneyDrunk.Notify.Queue.Abstractions/**`, `HoneyDrunk.Notify.Queue.InMemory/**`, `HoneyDrunk.Notify.Queue.AzureStorage/**`, `HoneyDrunk.Notify.HostBootstrap/**`. The filter **does not** include any path under `HoneyDrunk.Notify/HoneyDrunk.Notify.Functions/` and **does not** include `HoneyDrunk.Notify/HoneyDrunk.Notify/**` or `HoneyDrunk.Notify/HoneyDrunk.Notify.Abstractions/**` (referenced by Functions only).
+- [ ] `Directory.Build.props` / `Directory.Packages.props` are **not** listed in the filter (they do not currently exist in HoneyDrunk.Notify). If they are added later, this filter must be updated at the same time.
+- [ ] `resolve` job emits a `target_environment` output (literal `dev` today; explicit-mapping anchor for D6).
+- [ ] The `deploy` job consumes `needs.resolve.outputs.target_environment` rather than the literal string `dev`.
+- [ ] The `image-tag` input is computed: SemVer tag on the tag path; `dev-<sha>` on the branch path (full 40-char `github.sha`). Verified by inspecting two real deploys (one tag, one main push) — ACR shows two distinct image tags.
+- [ ] Top-level `concurrency` block exists with prefix `release-worker-`, group key includes the resolved environment (or `tag-<ref_name>` for the tag path), and `cancel-in-progress` is `true` on the dev branch-push path / `false` on the tag path.
+- [ ] Header comment block describes the dual-trigger model and removes the prior "dev-only / tag-only — intentional, not a gap" framing.
+- [ ] Test 1 (branch-push path, in-filter): a no-op commit to `HoneyDrunk.Notify/HoneyDrunk.Notify.Worker/README.md` on `main` triggers `release-worker.yml`, resolves to `dev`, builds an image tagged `dev-<sha>` (full 40-char SHA), and rolls a new revision on `ca-hd-notify-worker-dev`.
+- [ ] Test 2 (branch-push path, out-of-filter / Functions-only): a no-op commit to `HoneyDrunk.Notify/HoneyDrunk.Notify.Functions/README.md` on `main` does **not** trigger `release-worker.yml`. Verified in the Actions run list for the commit SHA.
+- [ ] Test 3 (tag path): pushing a `worker-v*` tag still triggers `release-worker.yml`, resolves to `dev`, deploys with the SemVer tag as the image tag, and the `concurrency` group uses the `tag-<ref_name>` key with `cancel-in-progress: false`.
+- [ ] Test 4 (dev supersession): two rapid in-filter pushes to `main` produce two workflow runs in the same `dev` concurrency group; the older run is cancelled.
+- [ ] Test 5 (tests-only commit, out-of-filter): a no-op commit under `HoneyDrunk.Notify/HoneyDrunk.Notify.Tests/**` or `HoneyDrunk.Notify/HoneyDrunk.Notify.IntegrationTests/**` on `main` does **not** trigger `release-worker.yml`. Test projects are outside the filter — they affect the PR gate, not the deploy.
+- [ ] `CHANGELOG.md` updated per the dispatch plan's CHANGELOG sequencing instructions (`dispatch-plan.md` § CHANGELOG sequencing). No commits under `Unreleased`.
+- [ ] No ADR number in workflow header comment, code comments, or `CHANGELOG.md` prose. The packet-data identifier `adr-0033` is acceptable only as packet frontmatter.
+
+## Human Prerequisites
+None. The `dev` GitHub Environment, OIDC federated credentials, `acrhdshared{env}`, `cae-hd-{env}`, and `ca-hd-notify-worker-dev` are already in place from the ADR-0015 rollout. Per ADR-0033 D7, `dev` must remain an unprotected GitHub Environment (no required-reviewer rule) — verify in the GitHub Environment settings before merging.
+
+**Branch protection note.** Release workflow runs are **not** required checks on the `main` branch-protection rule. The PR-side checks (`pr.yml`) remain the merge gate; a release that fails *after* merge is a deploy concern, not a branch-protection concern. Do not add `release-worker.yml` to required checks on `main`.
+
+## Referenced ADR Decisions
+
+**ADR-0033 D1 — Trigger model per environment.** Push-to-`main` path-filtered → `dev`; SemVer-shaped tag (`worker-v*`) unfiltered → staging/prod (when provisioned); `workflow_dispatch` retained.
+
+**ADR-0033 D2 — Trigger-to-environment resolution is explicit.** Single mapping point in `resolve`; `target_environment` output.
+
+**ADR-0033 D3 — Path filtering is part of the decision, not optional.** The branch-push trigger carries a `paths:` filter scoped to the Worker's own source plus solution-level build inputs. The tag trigger is unfiltered.
+
+**ADR-0033 D4 — Multi-deployable repos: per-deployable independence.** HoneyDrunk.Notify is the exemplar two-deployable repo. The Worker path filter must not include any `Notify.Functions/**` entry; packet 01's Functions filter must not include any `Notify.Worker/**` entry. Reviewer cross-checks both filters for symmetry.
+
+**ADR-0033 D5 — Concurrency.** Dev path `cancel-in-progress: true`; tag path `cancel-in-progress: false`. Key includes the resolved environment.
+
+**ADR-0033 D7 — `dev` remains an unprotected GitHub Environment by design.** No required-reviewer rule on `dev`.
+
+**ADR-0033 D8 — Relationship to ADR-0012 and ADR-0015.** ADR-0012's invariant on reusable workflows is preserved (deploy mechanics are unchanged in `HoneyDrunk.Actions`). ADR-0015's `Multiple`-revision Container Apps hosting is unchanged. No `catalogs/relationships.json` edge changes.
+
+**ADR-0015 (referenced):** Container Apps revision mode is `Multiple` with explicit traffic splitting on deploy. The branch-push path produces a new revision per commit (image tagged `dev-<sha>`), which is correct for revision-based rollback. Operational consequence per ADR-0033: continuous dev deploys produce Container App inactive revisions at merge cadence. ADR-0015 sets no revision-retention policy; revision GC is named as a follow-up consideration, explicitly out of scope here.
+
+## Dependencies
+None. Independent of packets 01 and 03.
+
+## Labels
+`ci`, `tier-2`, `ops`, `adr-0033`
+
+## Agent Handoff
+
+**Objective:** Amend `release-worker.yml` in HoneyDrunk.Notify to support environment-gated deploy triggers per ADR-0033 — path-filtered push-to-`main` → `dev`, explicit `resolve` mapping, environment-keyed concurrency, SHA-derived image tag on the branch path. Path-scope strictly to `Notify.Worker` sources so Functions-only commits do not redeploy the Worker.
+
+**Target:** HoneyDrunk.Notify, branch from `main`. CHANGELOG sequencing across packets 01 and 02 is owned by the dispatch plan — follow its instructions.
+
+**Context:**
+- Goal: Continuous dev deploys without tag-cutting friction, preserved promotion path for staging/prod.
+- Feature: ADR-0033 initiative (`adr-0033-deploy-trigger-model`).
+- ADRs: ADR-0033 (this decision), ADR-0012 (CI/CD control plane — unchanged), ADR-0015 (Container Apps hosting — unchanged).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None hard. Soft CHANGELOG sequencing with packet 01 is owned by the dispatch plan.
+
+**Constraints:**
+- **ADR-0012 invariant — deploy logic in HoneyDrunk.Actions only.** The reusable `job-deploy-container-app.yml@main` is consumed verbatim. The only deploy-mechanics-adjacent change in this packet is the `image-tag` input expression in the caller — this is computing an input value, not implementing deploy logic. Do not inline Azure login, image push, revision creation, traffic shift, or health probe steps.
+- **Invariant 8 (secrets in telemetry):** Secret values never appear in logs, traces, exceptions, or telemetry. Only secret names/identifiers may be traced. `VaultTelemetry` enforces this. The `Echo resolved targets` step echoes only resource names and refs.
+- **Invariant 9 (Vault as the only source of secrets):** Vault is the only source of secrets. The trigger-model change does not relax this; the Container App resolves the six Key Vault secrets via Managed Identity at runtime as today.
+- **Path-filter correctness (D4):** A Functions-only commit must not redeploy the Worker. The `paths:` list under `push: branches: [main]` must not include any `HoneyDrunk.Notify.Functions/**` entry. Reviewer cross-checks against packet 01's Functions filter for symmetric correctness.
+- **Concurrency group prefix is `release-worker-`** (not `release-functions-`) so the two Notify lines have independent concurrency. Tag-path key is `tag-<ref_name>`; branch-path key is `dev`. The expression in the proposed change is the canonical form.
+- **Image-tag policy on the branch path is `dev-<sha>`, not `main`.** A moving `main` tag in ACR would overwrite the prior image and remove the revision-rollback trail. SHA-derived tags preserve image-per-commit. The tag path keeps the SemVer tag verbatim (`worker-v0.1.0`, etc.) as the image tag — unchanged from today.
+- **Header comment is not optional.** The prior "dev-only / tag-only — intentional, not a gap" sentence must be deleted. The "Replaces the previous App Service slot-swap deploy.yml" historical paragraph stays. No ADR number in the comment per Grid doc convention.
+- **Revision accumulation is accepted, not solved here.** ADR-0033's Operational Consequences explicitly name dev revision accumulation as a known follow-up under ADR-0015, low priority. Do not add a revision-GC step to this workflow.
+
+**Key Files:**
+- `.github/workflows/release-worker.yml` — the only file authored.
+- `CHANGELOG.md` — per dispatch-plan CHANGELOG sequencing instructions.
+
+**Contracts:** None changed. No `catalogs/relationships.json` edge changes.

--- a/generated/issue-packets/active/adr-0033-deploy-trigger-model/03-pulse-collector-deploy-trigger-model.md
+++ b/generated/issue-packets/active/adr-0033-deploy-trigger-model/03-pulse-collector-deploy-trigger-model.md
@@ -1,0 +1,273 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Pulse
+labels: ["ci", "tier-2", "ops", "adr-0033"]
+dependencies: []
+adrs: ["ADR-0033", "ADR-0012", "ADR-0015"]
+accepts: ["ADR-0033"]
+wave: 1
+initiative: adr-0033-deploy-trigger-model
+node: honeydrunk-pulse
+---
+
+# Amend `release-collector.yml` for environment-gated deploy triggers
+
+## Summary
+Add a path-filtered push-to-`main` trigger that resolves to `dev`, make the trigger-to-environment mapping explicit in the `resolve` job, and add a `concurrency` block keyed on the resolved environment. Replace the existing dev-only/tag-only header framing with the dual-trigger model decided in ADR-0033. HoneyDrunk.Pulse is a single-deployable repo, so D4 (per-deployable independence) is trivially satisfied — the path filter is scoped to `Pulse.Collector`'s source plus solution-level inputs, with no sibling-deployable exclusion concern.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Pulse`
+
+## Target Workflow
+**File:** `.github/workflows/release-collector.yml`
+**Family:** release (consumer caller of `HoneyDrunk.Actions/.github/workflows/job-deploy-container-app.yml@main`)
+
+## Motivation
+Same motivation as packets 01 and 02 in this initiative: remove tag-cutting ceremony from continuous dev deploys to a disposable environment while preserving SemVer-tagged promotion for staging/prod. Pulse.Collector is a gRPC Container App; the trigger-model change is orthogonal to the hosting decision and applies uniformly across the three deployable lines.
+
+D4 is trivially satisfied for this workflow because HoneyDrunk.Pulse has only one deployable today. The path filter still gets scoped tightly to Pulse.Collector's source under D3 (path filtering is part of the decision, not optional) — so if a second Pulse deployable is added later, the existing filter is already correct.
+
+## Proposed Change
+
+### 1. `on:` block — add path-filtered push trigger
+Add a `push: branches: [main]` trigger with a `paths:` filter scoped to Pulse.Collector's source plus solution-level inputs that affect its build. The tag trigger remains unfiltered. `workflow_dispatch` is retained.
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths:
+      # Collector deployable source. Dockerfile and proto files live under
+      # Pulse.Collector/ — covered by this glob.
+      - 'HoneyDrunk.Pulse/Pulse.Collector/**'
+      # Pulse libraries the Collector binary links against (per
+      # HoneyDrunk.Pulse.Collector.csproj ProjectReference graph): contracts,
+      # telemetry abstractions, telemetry OpenTelemetry pipeline, and all
+      # telemetry sink packages (AzureMonitor, Loki, Mimir, PostHog, Sentry,
+      # Tempo — covered by the .Sink.* glob, which also catches Sink.Shared).
+      # A change to any of these produces a runtime behavior change in the
+      # deployed Collector binary and must redeploy on main.
+      - 'HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/**'
+      - 'HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/**'
+      - 'HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/**'
+      - 'HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.*/**'
+      # Solution file and the workflow itself.
+      - 'HoneyDrunk.Pulse/HoneyDrunk.Pulse.slnx'
+      - '.github/workflows/release-collector.yml'
+    tags:
+      - 'collector-v*'
+  workflow_dispatch:
+```
+
+Forward-looking note: `Directory.Build.props` and `Directory.Packages.props` do not currently exist in HoneyDrunk.Pulse. If they are added later (centralized package versioning, shared MSBuild properties), the implementing agent must add them to this filter at the same time — they would affect the build of every project in the solution.
+
+The library set above was reconciled against `HoneyDrunk.Pulse.Collector.csproj`'s `ProjectReference` graph at scope time. The Sink glob `HoneyDrunk.Telemetry.Sink.*/**` covers `Sink.AzureMonitor`, `Sink.Loki`, `Sink.Mimir`, `Sink.PostHog`, `Sink.Sentry`, `Sink.Tempo`, and `Sink.Shared` — all sink packages present in the repo. A path filter that is too narrow makes dev silently stop auto-deploying on a meaningful change (a fail-safe no-op per ADR-0033 Operational Consequences, but invisible to grid-health today); a filter that is too wide costs only an extra dev revision per unrelated commit. The Sink-glob is a deliberate lean-slightly-wide call to preserve future sink additions automatically.
+
+### 2. `resolve` job — explicit trigger-to-environment mapping
+Replace the hard-coded `environment: dev` resolution with an explicit `target_environment` output. Pulse uses underscore-named outputs in its `resolve` block (a deliberate choice noted in the existing file comment to avoid hyphenated-context-key ambiguity in dot-notation) — keep that convention.
+
+```yaml
+  resolve:
+    name: Resolve target environment and config
+    runs-on: ubuntu-latest
+    # ADR-0033 D2: trigger intent is mapped here, once, explicitly.
+    # - refs/tags/collector-v*  -> promotion environment (staging / prod when
+    #   provisioned; for now resolves to `dev` per ADR-0033 D6).
+    # - refs/heads/main         -> dev (continuous deploy of the disposable env).
+    # - workflow_dispatch       -> dev (manual escape hatch on the same path).
+    environment: dev
+    # Output names use underscores (not hyphens). Dot-notation access
+    # (needs.resolve.outputs.acr_registry) is unambiguous this way — avoids
+    # any reader/linter doubt about hyphenated context keys. Convention
+    # established before this packet; preserved.
+    outputs:
+      target_environment: dev
+      acr_registry: acrhdshared${{ vars.HD_ENV }}.azurecr.io
+      container_app: ca-hd-pulse-${{ vars.HD_ENV }}
+      resource_group: rg-hd-pulse-${{ vars.HD_ENV }}
+      keyvault_name: kv-hd-pulse-${{ vars.HD_ENV }}
+      azure_client_id: ${{ vars.AZURE_CLIENT_ID }}
+      azure_tenant_id: ${{ vars.AZURE_TENANT_ID }}
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+    steps:
+      - name: Echo resolved targets
+        run: |
+          echo "Trigger       : ${{ github.event_name }} / ${{ github.ref }}"
+          echo "Environment   : dev"
+          echo "Container App : ca-hd-pulse-${{ vars.HD_ENV }}"
+          echo "Resource Grp  : rg-hd-pulse-${{ vars.HD_ENV }}"
+          echo "ACR           : acrhdshared${{ vars.HD_ENV }}.azurecr.io"
+          echo "Key Vault     : kv-hd-pulse-${{ vars.HD_ENV }}"
+```
+
+The downstream `deploy` job consumes `needs.resolve.outputs.target_environment` instead of the literal `dev`.
+
+### 3. `concurrency` block — keyed on resolved environment
+Same form as packets 01 and 02. Prefix is `release-collector-`.
+
+```yaml
+concurrency:
+  # Dev branch pushes share a single key and supersede each other (latest main wins).
+  # Tag promotions get their own per-ref key and queue (never cancel-in-progress).
+  # Single-line expression form is the well-known-safe shape — keep on one line.
+  group: release-collector-${{ startsWith(github.ref, 'refs/tags/') && format('tag-{0}', github.ref_name) || 'dev' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+```
+
+### 4. `deploy` job — consume resolved environment + SHA-derived image tag on branch path
+Mirror the packet 02 change to `image-tag`: SemVer tag verbatim on the tag path; `dev-<sha>` on the branch path. Image-per-commit on dev preserves the ACR rollback trail (ADR-0015 Container Apps `Multiple` revision mode depends on it).
+
+```yaml
+      # Tag path: use the SemVer tag verbatim (e.g. collector-v0.1.0).
+      # Branch path: use a SHA-derived tag (dev-<sha>, full 40-char SHA from
+      # github.sha) — image-per-commit rather than a moving `main` tag, so
+      # ACR has the artifact-per-deploy trail that revision-based rollback
+      # (ADR-0015) expects. Full SHA is intentional: simpler than a short-sha
+      # output step, and ACR has no tag-length friction at 40 chars.
+      # Single-line expression form is the well-known-safe shape.
+      image-tag: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || format('dev-{0}', github.sha) }}
+```
+
+The `environment` input becomes `${{ needs.resolve.outputs.target_environment }}`. Reusable-workflow input names stay hyphenated (`environment`, `image-tag`, etc.) — the underscore/hyphen split is consumer outputs vs. reusable-workflow inputs and stays as the file's existing comment explains.
+
+### 5. Header comment block — replace dev-only/tag-only framing
+The current header text frames the dev-only/tag-only scope implicitly via "Push a tag like `collector-v0.1.0` to … deploy". Replace it with the dual-trigger framing. The "Replaces the previous App Service slot-swap deploy.yml" sentence is historical context and stays.
+
+```yaml
+# Dual-trigger release for Pulse.Collector:
+#
+#  - push to main, path-filtered to Pulse.Collector sources  -> dev
+#  - collector-v* tag, unfiltered                             -> staging / prod
+#                                                                (when provisioned)
+#  - workflow_dispatch                                         -> manual escape hatch
+#
+# Trigger intent is mapped to environment in the `resolve` job (single source).
+# The reusable deploy workflow in HoneyDrunk.Actions takes an `environment`
+# input and has no opinion about what triggered the caller — trigger policy is
+# consumer-owned by construction.
+#
+# Path filter (D3): scoped to Pulse.Collector's own source plus the Pulse
+# libraries it links against, plus solution-level build inputs. HoneyDrunk.Pulse
+# has a single deployable today, so D4 (per-deployable independence) is
+# trivially satisfied; if a second Pulse deployable is added later, this
+# filter is already correctly scoped.
+#
+# Concurrency (D5): keyed on the resolved environment. Dev branch pushes
+# supersede in-flight dev deploys (latest main wins). Tag promotions queue
+# (cancel-in-progress: false) so a deliberate versioned promotion is never
+# silently cancelled by a later one.
+#
+# Image tag composition: SemVer tag verbatim on the tag path; dev-<sha> on
+# the branch path (full 40-char github.sha — not a short-sha). Image-per-commit
+# on dev preserves the rollback trail in ACR for revision-based rollback.
+#
+# The version-of-record rule (CHANGELOG + SemVer tag) is unchanged: a
+# push-to-main dev deploy has no version stamp by design and is explicitly
+# not a promotion source.
+```
+
+The current paragraph that does not exist verbatim ("dev-only / tag-only — intentional, not a gap" framing is implicit in this file rather than spelled out as in the Notify files) is superseded by the dual-trigger framing. Any sentence implying tag-only scope is removed.
+
+## Consumer Impact
+None. Consumer release workflow; not consumed by anything else.
+
+## Breaking Change?
+- [x] No — backward compatible at the trigger level. The `collector-v*` tag trigger still deploys to dev as today. The new `main` branch-push trigger is additive. Image-tag change is internal.
+- [ ] Yes — consumers need to update their caller workflows
+
+## Affected Files
+- `.github/workflows/release-collector.yml` — header comment, `on:` block, `resolve` job (outputs + comment), top-level `concurrency` block, `deploy` job inputs.
+- `CHANGELOG.md` — repo-level entry under a dated SemVer section.
+
+No application code changes. No new packages.
+
+## NuGet Dependencies
+None. Workflow-only change.
+
+## Boundary Check
+- [x] Workflow-only change. No `HoneyDrunk.Actions` change.
+- [x] Trigger policy is irreducibly per-consumer-repo. ADR-0012 invariant on reusable workflows preserved.
+- [x] D4 trivially satisfied (single deployable). D3 filter is still tight per the path-filtering-is-part-of-the-decision rule.
+- [x] Image-tag derivation is a caller-side input value, not deploy mechanics.
+
+## Acceptance Criteria
+- [ ] `on:` block includes both the path-filtered `push: branches: [main]` trigger and the existing `push: tags: ['collector-v*']` trigger, plus `workflow_dispatch`.
+- [ ] The `main` path filter includes `HoneyDrunk.Pulse/Pulse.Collector/**`, the solution `.slnx`, the workflow file itself, and the Pulse library projects that the Collector binary links against per `HoneyDrunk.Pulse.Collector.csproj`'s `ProjectReference` graph: `HoneyDrunk.Pulse.Contracts/**`, `HoneyDrunk.Telemetry.Abstractions/**`, `HoneyDrunk.Telemetry.OpenTelemetry/**`, and the `HoneyDrunk.Telemetry.Sink.*/**` glob (covering AzureMonitor, Loki, Mimir, PostHog, Sentry, Tempo, and Sink.Shared).
+- [ ] `Directory.Build.props` / `Directory.Packages.props` are **not** listed in the filter (they do not currently exist in HoneyDrunk.Pulse). If they are added later, this filter must be updated at the same time.
+- [ ] `resolve` job emits a `target_environment` output (literal `dev` today; explicit-mapping anchor for D6). Underscore-naming convention preserved.
+- [ ] The `deploy` job consumes `needs.resolve.outputs.target_environment` rather than the literal string `dev`.
+- [ ] The `image-tag` input is computed: SemVer tag on the tag path; `dev-<sha>` on the branch path (full 40-char `github.sha`). Verified by inspecting two real deploys — ACR shows two distinct image tags.
+- [ ] Top-level `concurrency` block exists with prefix `release-collector-`, group key includes the resolved environment (or `tag-<ref_name>` for the tag path), and `cancel-in-progress` is `true` on the dev branch-push path / `false` on the tag path.
+- [ ] Header comment block describes the dual-trigger model and removes any framing implying tag-only scope. The "Replaces the previous App Service slot-swap deploy.yml" historical paragraph stays.
+- [ ] Test 1 (branch-push path, in-filter): a no-op commit to `HoneyDrunk.Pulse/Pulse.Collector/README.md` on `main` triggers `release-collector.yml`, resolves to `dev`, builds an image tagged `dev-<sha>` (full 40-char SHA), and rolls a new revision on `ca-hd-pulse-dev`.
+- [ ] Test 2 (branch-push path, out-of-filter): a no-op commit to a Pulse repo file outside the filter set (e.g. a doc-only edit under `HoneyDrunk.Pulse/docs/` if such a path exists, or any file in the repo root that is not in the filter) does **not** trigger `release-collector.yml`. Verified in the Actions run list for the commit SHA.
+- [ ] Test 3 (tag path): pushing a `collector-v*` tag still triggers `release-collector.yml`, resolves to `dev`, deploys with the SemVer tag as the image tag, and the `concurrency` group uses the `tag-<ref_name>` key with `cancel-in-progress: false`.
+- [ ] Test 4 (dev supersession): two rapid in-filter pushes to `main` produce two workflow runs in the same `dev` concurrency group; the older run is cancelled.
+- [ ] Test 5 (tests-only commit, out-of-filter): a no-op commit under `HoneyDrunk.Pulse/Pulse.Tests/**` on `main` does **not** trigger `release-collector.yml`. Test projects are outside the filter — they affect the PR gate, not the deploy.
+- [ ] `CHANGELOG.md` updated under a dated SemVer section. No commits under `Unreleased`.
+- [ ] No ADR number in workflow header comment, code comments, or `CHANGELOG.md` prose. Packet-data identifier `adr-0033` acceptable only in frontmatter.
+
+## Human Prerequisites
+None. The `dev` GitHub Environment, OIDC federated credentials, `acrhdshared{env}`, `cae-hd-{env}`, and `ca-hd-pulse-dev` are already in place from the ADR-0015 rollout. Per ADR-0033 D7, `dev` must remain an unprotected GitHub Environment — verify in the GitHub Environment settings before merging.
+
+**Branch protection note.** Release workflow runs are **not** required checks on the `main` branch-protection rule. The PR-side checks (`pr.yml`) remain the merge gate; a release that fails *after* merge is a deploy concern, not a branch-protection concern. Do not add `release-collector.yml` to required checks on `main`.
+
+## Referenced ADR Decisions
+
+**ADR-0033 D1 — Trigger model per environment.** Push-to-`main` path-filtered → `dev`; SemVer-shaped tag (`collector-v*`) unfiltered → staging/prod (when provisioned); `workflow_dispatch` retained.
+
+**ADR-0033 D2 — Trigger-to-environment resolution is explicit.** Single mapping point in `resolve`; `target_environment` output.
+
+**ADR-0033 D3 — Path filtering is part of the decision, not optional.** The branch-push trigger carries a `paths:` filter scoped to Pulse.Collector's own source plus the libraries it links against plus solution-level build inputs. The tag trigger is unfiltered.
+
+**ADR-0033 D4 — Multi-deployable repos: per-deployable independence.** Trivially satisfied — HoneyDrunk.Pulse has a single deployable. Filter is still tight per D3.
+
+**ADR-0033 D5 — Concurrency.** Dev path `cancel-in-progress: true`; tag path `cancel-in-progress: false`. Key includes the resolved environment.
+
+**ADR-0033 D6 — Stated promotion model for staging/prod (deferred but decided).** When `staging`/`prod` are provisioned, a `collector-v*` tag cut from a `main` commit that has already been dev-deployed and observed will rebuild from the tagged source through the same reusable deploy workflow. Identical-artifact promotion is explicitly deferred. This packet does not implement staging/prod resolution; it leaves the explicit-mapping anchor (`target_environment` output) in place for that future change.
+
+**ADR-0033 D7 — `dev` remains an unprotected GitHub Environment by design.**
+
+**ADR-0033 D8 — Relationship to ADR-0012 and ADR-0015.** ADR-0012 invariant on reusable workflows preserved (deploy mechanics unchanged). ADR-0015's `Multiple`-revision Container Apps hosting unchanged. No `catalogs/relationships.json` edge changes.
+
+**ADR-0015 (referenced):** Container Apps revision mode is `Multiple` with explicit traffic splitting on deploy. The branch-push path produces a new revision per commit, which is the correct shape for revision-based rollback. ADR-0033 Operational Consequences names dev revision accumulation as a known follow-up under ADR-0015, low priority — not solved here.
+
+## Dependencies
+None. Independent of packets 01 and 02 (different repo, no shared state).
+
+## Labels
+`ci`, `tier-2`, `ops`, `adr-0033`
+
+## Agent Handoff
+
+**Objective:** Amend `release-collector.yml` in HoneyDrunk.Pulse to support environment-gated deploy triggers per ADR-0033 — path-filtered push-to-`main` → `dev`, explicit `resolve` mapping, environment-keyed concurrency, SHA-derived image tag on the branch path.
+
+**Target:** HoneyDrunk.Pulse, branch from `main`.
+
+**Context:**
+- Goal: Continuous dev deploys without tag-cutting friction, preserved promotion path for staging/prod.
+- Feature: ADR-0033 initiative (`adr-0033-deploy-trigger-model`).
+- ADRs: ADR-0033 (this decision), ADR-0012 (CI/CD control plane — unchanged), ADR-0015 (Container Apps hosting — unchanged).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+- **ADR-0012 invariant — deploy logic in HoneyDrunk.Actions only.** The reusable `job-deploy-container-app.yml@main` is consumed verbatim. The only deploy-mechanics-adjacent change is the `image-tag` input expression in the caller — computing an input value is not implementing deploy logic.
+- **Invariant 8 (secrets in telemetry):** Secret values never appear in logs, traces, exceptions, or telemetry. Only secret names/identifiers may be traced. `VaultTelemetry` enforces this. The `Echo resolved targets` step echoes only resource names and refs.
+- **Invariant 9 (Vault as the only source of secrets):** Vault is the only source of secrets. The trigger-model change does not relax this; Pulse.Collector resolves its Key Vault secrets via Managed Identity at runtime as today.
+- **Path filter scope correctness (D3):** The filter must include Pulse.Collector's source and the library projects Pulse.Collector links against. The library set in the proposed filter was reconciled against `HoneyDrunk.Pulse.Collector.csproj`'s `ProjectReference` entries at scope time. Re-verify at implementation time before committing — a too-narrow filter causes silent dev no-deploys on meaningful library changes (fail-safe but invisible per ADR-0033 Operational Consequences). When in doubt, lean slightly wide on the library set; the cost is an extra dev revision per unrelated commit, which is bounded.
+- **Underscore-naming convention in `resolve` outputs is preserved.** The existing file uses `acr_registry`, `container_app`, etc. — deliberate per the in-file comment. The new `target_environment` output follows the same convention. Reusable-workflow input names on the `deploy` job remain hyphenated; the underscore/hyphen split is consumer-outputs vs. reusable-workflow-inputs and stays.
+- **Concurrency group prefix is `release-collector-`.** Independent of Notify's release lines.
+- **Image-tag policy on the branch path is `dev-<sha>`, not `main`.** Moving the `main` tag in ACR would erase the per-commit rollback trail.
+- **Header comment is not optional.** Any sentence implying tag-only/dev-only scope is removed. The "Replaces the previous App Service slot-swap deploy.yml" historical paragraph stays. No ADR number in the comment per Grid doc convention.
+- **Revision accumulation accepted, not solved here.** ADR-0033 Operational Consequences names this as a known follow-up under ADR-0015, low priority. No revision-GC step.
+
+**Key Files:**
+- `.github/workflows/release-collector.yml` — the only file authored.
+- `CHANGELOG.md` — repo-level entry under a dated SemVer section.
+
+**Contracts:** None changed. No `catalogs/relationships.json` edge changes.

--- a/generated/issue-packets/active/adr-0033-deploy-trigger-model/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0033-deploy-trigger-model/dispatch-plan.md
@@ -1,0 +1,154 @@
+# Dispatch Plan: ADR-0033 Environment-Gated Deploy-Trigger Model
+
+**Date:** 2026-05-20
+**Trigger:** ADR-0033 (Environment-Gated Deploy-Trigger Model for Deployable Nodes) Proposed 2026-05-18 — scoped 2026-05-20.
+**Type:** Multi-repo (per-deployable consumer-workflow amendments across two repos; no control-plane PR).
+**Sector:** Ops.
+**Site sync required:** No. ADR-0033 governs consumer release-workflow trigger policy and changes nothing user-facing.
+
+**Rollback plan:**
+- Each packet edits a single workflow file in a single repo. Revert per packet via `git revert` — the workflow returns to tag-only triggering, the `resolve` job goes back to its hard-coded `environment: dev`, the `concurrency` block disappears, and the header comment goes back to the dev-only/tag-only framing. No data loss, no consumer breakage (consumer release workflows are not themselves consumed by anything).
+- No Azure resources, no secrets, no GitHub Environment changes provisioned by this initiative. Nothing to deprovision.
+- A partially-reverted state (e.g. packet 01 reverted, 02 still in) is operationally fine — the three workflows are independent. A revert on the Notify Worker (packet 02) without a matching revert on Notify Functions (packet 01) means the Functions line keeps its dual-trigger model and the Worker line goes back to tag-only — no shared state to corrupt.
+
+## Summary
+
+ADR-0033 resolves the explicitly-deferred staging/prod gating question left by ADR-0015 and the dev-only/tag-only follow-up already named in the three release workflows' headers. The decision is a **hybrid, environment-gated trigger model** implemented entirely in consumer release workflows — no `HoneyDrunk.Actions` change, no new invariants, no `catalogs/relationships.json` edge change.
+
+Each consumer release workflow gains:
+- a path-filtered `push: branches: [main]` trigger (continuous dev deploy);
+- an explicit trigger-to-environment mapping in the `resolve` job (`target_environment` output as the single anchor for future staging/prod conditional);
+- a `concurrency` block keyed on the resolved environment (dev `cancel-in-progress: true`, tag path `cancel-in-progress: false`);
+- a header comment that replaces the current "dev-only / tag-only — intentional, not a gap" framing with the dual-trigger model.
+
+The existing SemVer tag triggers (`functions-v*`, `worker-v*`, `collector-v*`) are preserved unchanged — they remain the promotion trigger for staging/prod (when provisioned). The version-of-record rule (CHANGELOG + SemVer tag) is untouched; push-to-`main` dev deploys are explicitly **not** a promotion source.
+
+**Three packets across two repos, one wave:**
+
+- 1 Notify packet for `release-functions.yml` (Functions deployable)
+- 1 Notify packet for `release-worker.yml` (Worker deployable)
+- 1 Pulse packet for `release-collector.yml` (Collector deployable)
+
+The three workflow amendments are independent — same logical change, three different files in two repos. They can land in any order. Each packet carries `accepts: ["ADR-0033"]` so the `hive-sync` auto-flip will move ADR-0033 from Proposed to Accepted once all three implementing issues close (capped by `MAX_FLIPS_PER_RUN=3`, fine here — only one ADR is implicated).
+
+## Important constraints (from ADR-0033 itself and the scope brief)
+
+- **HoneyDrunk.Actions gets NO change packet.** ADR-0033 D8 / Affected Nodes pins this explicitly. The reusable deploy workflows in `HoneyDrunk.Actions` (`job-deploy-function.yml`, `job-deploy-container-app.yml`) already take an `environment` input and have no opinion about what triggered the caller. Trigger policy is consumer-owned by construction (a `workflow_call` reusable workflow cannot own the caller's `on:` block). The ADR-0012 invariant on reusable workflows is preserved exactly as written — this initiative does not touch it.
+- **Two LOW-PRIORITY follow-ups are NOT scoped here, by direction.**
+  - Extending the ADR-0012 grid-health aggregator to track release workflows is named in ADR-0033 Follow-up Work but explicitly low priority / not committed. Not in this initiative.
+  - A Container App inactive-revision retention/GC policy as a possible ADR-0015 amendment is named as low priority. Not in this initiative.
+  Both are deliberately deferred. Re-scope them later if dev revision accumulation or release-workflow-silent-no-op surface as concrete problems.
+- **`accepts: ["ADR-0033"]` on every packet.** ADR-0033 stays Proposed at scope time; per the established ADR acceptance workflow and the `hive-sync` auto-flip rule, the ADR flips to Accepted when **every** packet carrying `accepts: ADR-0033` closes on GitHub. Three packets — all three must close. No acceptance packet is included in this initiative (and ADR-0033 itself is not edited by any packet here).
+- **No shared-index-file edits.** Per the scope brief, this initiative does not touch `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, `adrs/README.md`, `catalogs/*.json`, or any other shared index file. Those are `hive-sync` outputs — the agent will surface ADR-0033 in `proposed-adrs.md` automatically until the three packets close, then flip it.
+- **Header comment doc convention.** No ADR number in any workflow header comment, code comment, README prose, or CHANGELOG entry text. The runtime packet-data identifier `adr-0033` is acceptable only as packet frontmatter.
+- **CHANGELOG, not Unreleased.** Per the no-Unreleased-commits convention, each packet's CHANGELOG entry lands under a dated SemVer section, not under `Unreleased`. Per-repo sequencing details are spelled out in § CHANGELOG sequencing below — the in-packet bodies defer to this section rather than carrying their own sequencing rules (which would push against packet immutability when execution order shifts).
+- **No `.csproj` version bump.** All three packets are CI/workflow-only — no source-tree change, no runtime artifact change. Invariant 27 (one solution version, all projects move together) does not apply to workflow-only changes.
+
+## Cross-packet sanity checks (D4 enforcement)
+
+Two of the three packets live in HoneyDrunk.Notify, which has two deployables. D4 (per-deployable independence) is enforced **across** packets 01 and 02 — neither one alone can satisfy it.
+
+| Packet | Workflow | Filter must include | Filter must NOT include |
+|---|---|---|---|
+| 01 | `release-functions.yml` | `HoneyDrunk.Notify.Functions/**` + solution-level inputs | any `HoneyDrunk.Notify.Worker/**` path |
+| 02 | `release-worker.yml` | `HoneyDrunk.Notify.Worker/**` + solution-level inputs | any `HoneyDrunk.Notify.Functions/**` path |
+| 03 | `release-collector.yml` | `Pulse.Collector/**` + Pulse libraries it links against + solution-level inputs | (single-deployable repo — D4 trivially satisfied) |
+
+Reviewer instruction: when reviewing packet 01's PR, also look at the current state of `release-worker.yml`'s filter on `main`. When reviewing packet 02's PR, also look at the current state of `release-functions.yml`'s filter on `main`. The two filters must be disjoint on the deployable-source paths. This is the D4 correctness boundary and the only inter-packet review concern in this initiative.
+
+## Wave Diagram
+
+### Wave 1 — Three independent workflow amendments (no internal blockers, fully parallel)
+
+All three packets are independent. They can be filed in one pass and executed in parallel on Codex Cloud (or wherever PRs are authored). There is no Wave 2.
+
+- [ ] `HoneyDrunk.Notify`: amend `release-functions.yml` for environment-gated deploy triggers — [`01-notify-functions-deploy-trigger-model.md`](01-notify-functions-deploy-trigger-model.md)
+  - Blocked by: nothing.
+- [ ] `HoneyDrunk.Notify`: amend `release-worker.yml` for environment-gated deploy triggers — [`02-notify-worker-deploy-trigger-model.md`](02-notify-worker-deploy-trigger-model.md)
+  - Blocked by: nothing.
+- [ ] `HoneyDrunk.Pulse`: amend `release-collector.yml` for environment-gated deploy triggers — [`03-pulse-collector-deploy-trigger-model.md`](03-pulse-collector-deploy-trigger-model.md)
+  - Blocked by: nothing.
+
+**Wave 1 exit criteria (= initiative exit criteria):**
+- All three workflows have a `push: branches: [main]` trigger with a tight `paths:` filter scoped to the deployable's own source (and, for Pulse.Collector, the libraries it links against).
+- D4 disjoint-filter check holds on the two Notify workflows: a Functions-only commit on `main` triggers `release-functions.yml` only; a Worker-only commit on `main` triggers `release-worker.yml` only. Verified end-to-end on real merges (or no-op test commits).
+- All three `resolve` jobs emit a `target_environment` output. All three `deploy` jobs consume that output instead of the literal `dev`.
+- All three workflows have a top-level `concurrency` block with the documented expression form (dev key vs. per-tag key; `cancel-in-progress` differs by path).
+- Both Container App workflows (packets 02 and 03) use `dev-<sha>` as the image tag on the branch-push path and the SemVer tag verbatim on the tag path.
+- All three workflow header comments describe the dual-trigger model; the prior dev-only/tag-only framing is removed.
+- The `dev` GitHub Environment in HoneyDrunk.Notify and HoneyDrunk.Pulse remains unprotected (no required-reviewer rule) per ADR-0033 D7 — verified before merge.
+- Both `CHANGELOG.md` files (Notify and Pulse) have entries under dated SemVer sections, not `Unreleased`.
+- All three GitHub Issues close on the target repos. `hive-sync` auto-flips ADR-0033 from Proposed to Accepted on its next run.
+
+## Filing
+
+Filing is automated. Pushing these packets to `main` under `generated/issue-packets/active/adr-0033-deploy-trigger-model/` triggers `file-packets.yml` in HoneyDrunk.Architecture, which:
+1. Creates the GitHub issue in `target_repo` for each packet.
+2. Adds it to The Hive (Project #4).
+3. Sets `Status`, `Wave`, `Node`, `Tier`, `Actor` (default Agent), `Initiative`, and `ADR` fields from frontmatter.
+4. Resolves each `dependencies:` entry (none in this initiative — all three packets are independent) and calls `addBlockedBy` for any blocking edges.
+
+No manual `gh issue create` / `addBlockedBy` is emitted here by design — the scope agent's job ends at writing the packets. The user pushes the packet directory to `main` to trigger filing.
+
+## Recommended dispatch order
+
+There is no required order. Three suggestions, in increasing levels of caution:
+
+1. **Fastest:** File all three at once, open three PRs in parallel, merge as each is reviewed.
+2. **Sequential by repo:** Land packet 03 (Pulse — single deployable, simplest D4 story) first to validate the trigger model end-to-end on real infra; then land packets 01 and 02 together (same repo, same CHANGELOG entry, D4 disjoint-filter check shared between them).
+3. **Most cautious:** Land packet 03 first (single deployable, lowest D4 risk); observe two real-world branch-push deploys for a day or two on Pulse; then land packets 01 and 02. Adds a day of confidence at the cost of a day of latency on Notify.
+
+The user picks the order at PR time. None of these choices change the packets.
+
+## Archival
+
+Per ADR-0008 D10, when every packet in this initiative reaches `Done` on The Hive and the Wave 1 exit criteria are met, the entire `active/adr-0033-deploy-trigger-model/` folder is moved to `completed/adr-0033-deploy-trigger-model/` in a single commit (per the `hive-sync` invariant on lifecycle moves and the no-partial-archival rule). The `hive-sync` agent handles the move and updates `filed-packets.json` path keys.
+
+## CHANGELOG sequencing
+
+Per-repo CHANGELOG version sequencing for this initiative — the in-packet bodies defer to this section.
+
+### HoneyDrunk.Notify (packets 01 + 02)
+
+The implementing agent for either packet inspects `HoneyDrunk.Notify/CHANGELOG.md` and picks the next patch version above the current latest (e.g. if latest is `0.5.0`, next is `0.5.1`).
+
+- **If packets 01 and 02 ship together (single PR or same-day separate PRs):** both packets append entries under the same dated `0.5.1` (or next-patch) section. One version entry, two bullet items.
+- **If packet 01 ships first and packet 02 follows:** packet 01 creates the dated `0.5.1` section. Packet 02 appends to that same `0.5.1` section if the agent is working same-day; otherwise it bumps to `0.5.2` and creates its own dated section.
+- **If packet 02 ships first and packet 01 follows:** symmetric — packet 02 creates the entry, packet 01 appends or bumps.
+- **No `.csproj` version bump** for either packet. Workflow-only changes; Invariant 27 (one solution version, all projects move together) does not apply.
+
+The agent for whichever packet lands first owns the version-entry creation. The agent for the second packet inspects the existing CHANGELOG state at implementation time and follows the rule above. Packet bodies must not encode "I am first" or "I am second" assumptions — the dispatch plan owns that sequencing.
+
+### HoneyDrunk.Pulse (packet 03)
+
+Independent repo. The implementing agent inspects `HoneyDrunk.Pulse/CHANGELOG.md` and picks the next patch version above the current latest. Single packet, single dated version entry, no cross-packet sequencing.
+
+## Considered and explicitly out-of-scope path-filter entries
+
+For audit traceability, the following paths were considered for the `paths:` filters and explicitly ruled out:
+
+- `obj/`, `bin/` — build artifacts, never committed (covered by `.gitignore`).
+- `.gitignore` itself — affects only ignore behavior, never the deployed binary.
+- `pr-body.md`, `coverage-raw`, `coverage-report` — PR-pipeline artifacts, not committed to `main` as source.
+- `nightly-deps.yml` and any other unrelated workflow file — only the per-deployable release workflow path is in each filter (one workflow file per filter; cross-listing other workflows would create false-positive deploys).
+- `HoneyDrunk.Notify.Tools/**`, `HoneyDrunk.Notify.ProviderSupport/**` — utility projects not referenced by either deployable's `.csproj`. If they become runtime dependencies later, add them at that time.
+- `HoneyDrunk.Notify.IntegrationTests/**`, `HoneyDrunk.Notify.Tests/**`, `Pulse.Tests/**` — test projects. Test-only commits must not trigger release workflows (Test 5 in each packet's acceptance criteria asserts this).
+- `HoneyDrunk.Pulse.Sample.Api/**`, `HoneyDrunk.Pulse.Sample.Worker/**` — sample projects, not part of the Collector's `ProjectReference` graph.
+
+None of these intersect with the deployable's runtime binary. Adding any of them to the filter would either silently bloat redeploys or violate D4.
+
+## Branch protection note
+
+Release workflow runs are **not** required checks on the `main` branch-protection rule in either HoneyDrunk.Notify or HoneyDrunk.Pulse. The PR-side checks (`pr.yml`) remain the merge gate; a failing release **after** merge is a deploy concern (revert PR or hot-fix), not a branch-protection concern. Do not add the dual-trigger release workflows to required checks on `main` — doing so would block merges while waiting for a post-merge deploy. This is a deliberate design choice consistent with the ADR-0033 dual-trigger model: dev deploys must follow merges, not gate them.
+
+## Notes
+
+- **ADR-0033 stays Proposed at scope time.** Auto-flip happens via `hive-sync` once all three packet issues close. No manual flip is in this initiative.
+- **Actor=Agent for all three packets.** No packet requires a human in the critical path. The only `dev` GitHub Environment protection-rule check (D7) is a five-second look at the Environment settings to confirm no required reviewer was added since ADR-0015 stood up the environment — folded into the Human Prerequisites of each packet as "None" with a verification note, not as a required portal step.
+- **Two LOW-PRIORITY follow-ups deliberately not scoped:** grid-health aggregator extension for release workflows; Container App inactive-revision retention/GC policy. Both named in ADR-0033 Follow-up Work, both explicitly low priority / not committed. Re-scope as standalone packets if and when concrete need surfaces.
+- **The dispatch plan is the one exception to packet immutability** (per ADR-0008 D7). Updates at wave boundaries are the historical record. Packet bodies are immutable post-filing.
+
+## Revision history
+
+- **2026-05-20 initial scope** — three packets, single wave, fully parallel. One per consumer release workflow (`release-functions.yml`, `release-worker.yml` in HoneyDrunk.Notify; `release-collector.yml` in HoneyDrunk.Pulse). No `HoneyDrunk.Actions` change. No shared-index-file edits. ADR-0033 left Proposed; auto-flip on packet closure via `hive-sync`. Grid-health aggregator extension and Container App revision-GC policy named in ADR-0033 Follow-up Work but not scoped here per direction.
+- **2026-05-20 refine pass** — applied refine-report fixes against the actual source repos before filing. Path-filter corrections: dropped non-existent `Directory.Build.props` / `Directory.Packages.props` from all three packets (forward-looking note added in each); dropped standalone `HoneyDrunk.Notify.Functions.csproj` from packet 01 (covered by project-directory glob); added shared-library paths to packets 01 and 02 per `HoneyDrunk.Notify.Functions.csproj` and `HoneyDrunk.Notify.Worker.csproj` `ProjectReference` graphs to close the silent-no-deploy gap (packet 03's Pulse library set was already correct). Prose corrections: fixed `Pulse.Collector.csproj` → `HoneyDrunk.Pulse.Collector.csproj` in packet 03. Expression form: collapsed multi-line `${{ }}` in `concurrency.group` and `image-tag` to single-line in all three packets; switched `dev-<short-sha>` → `dev-<sha>` (full 40-char `github.sha`) in packets 02 and 03 comments and prose, no expression change. Acceptance criteria: added Test 5 (tests-only commit does not trigger release) to all three packets. Packet 01: added build-job clarification and image-tag omission rationale. CHANGELOG sequencing moved out of packet 02 prose into this dispatch plan's new § CHANGELOG sequencing. Added § Considered and explicitly out-of-scope path-filter entries and § Branch protection note here; mirrored branch-protection guidance into each packet's Human Prerequisites.


### PR DESCRIPTION
## Summary

Scopes three packets implementing [ADR-0033](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0033-environment-gated-deploy-trigger-model.md)'s hybrid trigger model for the Grid's deployable Nodes. Each packet amends one release workflow:

- **`01-notify-functions`** — `release-functions.yml`: path-filtered push-to-`main` → `dev`, `resolve` step, environment-keyed `concurrency` group, header comment update. No image-tag (Functions deploys `.zip` artifacts).
- **`02-notify-worker`** — `release-worker.yml`: same trigger model + `dev-<sha>` image-tag on the branch path (preserves ACR per-commit rollback per ADR-0015 `Multiple`-revision mode).
- **`03-pulse-collector`** — `release-collector.yml`: same as Worker.

## D4 per-deployable independence

Notify Functions and Worker have disjoint deployable-source paths so each fires independently. Shared-library paths (Abstractions, Hosting.AspNetCore, Providers, HostBootstrap, Queue.*) are listed in both filters per ADR-0033's Operational Consequences guidance ("lean slightly wide on the library set").

## Out of scope (per ADR-0033 D8)

- **No HoneyDrunk.Actions packet** — control plane untouched.
- No grid-health aggregator extension (low-priority/not-committed in ADR).
- No Container App revision GC policy.
- No new constitutional invariants.
- No catalog edits.

## Hive-sync wiring

All three packets carry `accepts: ADR-0033` so hive-sync auto-flips the ADR to Accepted when all three issues close.

## Filing

When this merges, `file-packets.yml` will auto-file three issues against `HoneyDrunkStudios/HoneyDrunk.Notify` (×2) and `HoneyDrunkStudios/HoneyDrunk.Pulse` (×1), wired to The Hive board with the right Wave/Tier/Initiative fields.

## Test plan

- [ ] After merge, verify three issues are filed automatically by `file-packets.yml`
- [ ] Confirm issues land on The Hive with `Initiative = adr-0033-deploy-trigger-model`
- [ ] Spot-check one packet's frontmatter `accepts: ADR-0033` is read by hive-sync's next pass
- [ ] When the three workflow PRs land in Notify + Pulse, hive-sync auto-flips ADR-0033 Proposed → Accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)