### PR TITLE
chore: scope ADR-0028 event-driven architecture follow-ups

### DIFF
--- a/generated/issue-packets/active/adr-0028-event-driven-architecture/01-architecture-transport-integration-points-matrix.md
+++ b/generated/issue-packets/active/adr-0028-event-driven-architecture/01-architecture-transport-integration-points-matrix.md
@@ -1,0 +1,193 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "docs", "core", "adr-0028"]
+dependencies: []
+adrs: ["ADR-0028"]
+accepts: ADR-0028
+wave: 1
+initiative: adr-0028-event-driven-architecture
+node: honeydrunk-architecture
+---
+
+# Chore: Add D2 use-case to backing matrix to Transport integration-points
+
+## Summary
+Add ADR-0028 D2's use-case → backing matrix verbatim to `repos/HoneyDrunk.Transport/integration-points.md` so the Transport repo's context folder is the authoritative developer-facing reference for "which backing serves which use case" across the Grid. Architecture-repo doc edit only; no code or other catalog touches.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0028's "If Accepted — Required Follow-Up Work" checklist line 1 says:
+
+> Add the use-case → backing matrix (D2 below) to `repos/HoneyDrunk.Transport/integration-points.md` so the Transport repo is the authoritative reference for "which backing for which use case"
+
+The Transport repo's `integration-points.md` currently lists only the upstream Kernel dependency and three downstream consumers (Web.Rest, Data, Notify) — it has no surface for the higher-order question "for which Grid use case is Transport the right tool, and which backing does it use?" That question is answered exhaustively in ADR-0028 D2's seven-row matrix, but the ADR lives in the Architecture repo and is not where a Transport-consuming agent looks first.
+
+This packet copies the D2 matrix into the Transport-repo-side context file the Grid uses for cross-Node integration discovery. The ADR remains the source of truth (the matrix is opinionated and any revision is an ADR-amendment event); the Transport context file becomes the developer-facing reference. This is exactly the pattern the ADR §Consequences names: "the matrix lives in this ADR (the source of truth) and is mirrored into `repos/HoneyDrunk.Transport/integration-points.md` (the developer-facing reference)."
+
+## Scope
+
+Single-file edit. No other repo context files touched. No `catalogs/*.json` edits. No constitution edits. No code.
+
+## Proposed Implementation
+
+### Edits to `repos/HoneyDrunk.Transport/integration-points.md`
+
+Append a new top-level section after the existing "Downstream Consumers" table. The section is the D2 matrix verbatim, with a brief framing paragraph and a closing note about source-of-truth.
+
+The current file (as of this packet's edit time) is:
+
+```markdown
+# HoneyDrunk.Transport — Integration Points
+
+## Upstream Dependencies
+
+| Node | Contract | Usage |
+|------|----------|-------|
+| **Kernel** | `HoneyDrunk.Kernel.Abstractions` | `IGridContext`, `CorrelationId`, context mappers |
+
+## Downstream Consumers
+
+| Node | What It Uses | How |
+|------|-------------|-----|
+| **Web.Rest** | `ITransportEnvelope` | Maps envelope to ApiResult |
+| **Data** | `ITransportPublisher` | Outbox dispatcher publishes via Transport |
+| **Notify** | Transport patterns | Follows envelope and middleware patterns |
+```
+
+After the "Downstream Consumers" table, append:
+
+```markdown
+## Use-Case → Backing Matrix
+
+This matrix mirrors ADR-0028 D2 — the Grid-wide use-case → backing matrix. The ADR is the source of truth; this section is the developer-facing reference. New rows are added by follow-up ADRs that name a use case the matrix does not currently cover.
+
+Transport is the abstraction layer for use cases that fit it (#1, #2, #3 below). Use cases #4 (telemetry), #5 (cron), #6 (reactive resource events), and #7 (in-process domain events) do **not** ride Transport — they are listed here so the matrix is exhaustive and so the boundary between Transport and the alternative backings is visible from one place.
+
+| # | Use Case | Primary Backing | Ordering | Durability | Idle Cost | Why this backing |
+|---|---|---|---|---|---|---|
+| 1 | Async commands across Nodes (one sender, one logical recipient — e.g. Flow workflow engine async step boundaries, Communications → Notify post-split **(currently in-process per D4; Service Bus when split)**, long-running Container App hand-offs from Actions; Action-to-Action coordination stays GitHub-native) | **Azure Service Bus queue** via `HoneyDrunk.Transport.AzureServiceBus` | FIFO with sessions when grouped; otherwise best-effort | Durable; dead-letter queue native; duplicate detection native | ~$10/mo Standard tier per namespace (one shared namespace per environment, not per use case) | Sessions, DLQ, duplicate detection, transactions — none of which Storage Queue offers — are all relevant to "send this command exactly once, in order if grouped, with a recovery surface when it fails." |
+| 2 | Pub/sub fanout (one event, many in-Grid consumers — e.g. Pulse `PulseIngested`, future `UserSignedUp`-style domain events with welcome-email + analytics + provisioning consumers) | **Azure Service Bus topic** via `HoneyDrunk.Transport.AzureServiceBus` (same namespace as #1) | Per-subscription FIFO with sessions | Durable per subscription; per-subscription DLQ | Shared namespace cost from #1 — topics are free incremental | Service Bus topics give per-subscriber durability and DLQ. Event Grid (row 6) is the wrong shape here — Event Grid is best for *infrastructure* events (blob written, secret rotated), not for in-Grid domain pub/sub where consumers want guaranteed delivery and replay. |
+| 3 | High-volume commodity work queues (notification dispatch, batch background work — e.g. Notify intake → Notify worker, Notify Cloud `BillingEvent` → Stripe webhook bridge) | **Azure Storage Queue** via `HoneyDrunk.Transport.StorageQueue` | Best-effort, no FIFO | Durable; manual poison-queue pattern (no built-in DLQ) | Cents per month at the Grid's volume (10K ops = $0.0004) | When the workload is "many small messages, ordering doesn't matter, transient failures retry up to N times then go to a poison queue I write myself," Storage Queue is two orders of magnitude cheaper than Service Bus and the feature gap doesn't matter. |
+| 4 | High-volume telemetry / observability signals (Pulse OTLP ingest path) | **Direct OTLP via HTTP/gRPC, then Pulse Collector → backends (Tempo, Loki, Mimir, Sentry, PostHog, Azure Monitor)** | None — best-effort | Best-effort, sink-by-sink failure isolation | Pay-per-ingestion to backends; no broker between Node and Pulse Collector | Telemetry is **not a domain event**. It rides OpenTelemetry, not Transport. The single Transport hop Pulse uses today (`PulseIngested` after a batch lands) is a domain pub/sub event that says "telemetry ingested," not the telemetry itself. |
+| 5 | Scheduled / time-triggered work (cron — nightly-deps, nightly-security, grid-health aggregator, hive-sync, Vault rotation policy schedule, Lore ingestion) | **GitHub Actions `schedule:` cron** for CI-shaped schedules; **Azure Container Apps scheduled jobs** (KEDA cron scaler) for Node-internal schedules where the workload is too heavy for Actions runners | Per-trigger; no message ordering concern | The scheduler retries on the next trigger | Free at the Grid's volume — Actions minutes are free for public repos; Container Apps cron jobs scale to zero between triggers | Cron is not a queue. The scheduler **is** the broker. Adding Service Bus or Event Grid between "the schedule fired" and "the work runs" is rebuilding cron's job. |
+| 6 | Reactive resource events (Azure-emitted system events — blob written, Key Vault secret rotated, Container Registry image pushed — and any future Grid-internal "something changed" event a system topic can publish) | **Azure Event Grid system topics**; custom topics are deferred until a concrete consumer materializes | Best-effort, at-least-once | Durable retry up to 24h, then dead-lettered to Storage | Pay-per-event ($0.60/M events at Basic tier); zero idle cost | Event Grid is the only Azure surface that emits secret-rotated, blob-written, image-pushed events as a managed system topic. The Vault rotation cache-invalidation pathway already implicitly relies on it. |
+| 7 | In-process / same-Node domain events (mediator-style command/handler decoupling within a single Node — e.g. `IMessageIntent` resolution → preference check → cadence check → send delegation, all within Communications) | **In-process MediatR-style or simple `IServiceProvider.GetService<IDomainEventHandler>` fan-out** — not Transport, not a broker | N/A — synchronous in-process | N/A — no durability needed; failure is a thrown exception | Zero | If sender and receiver share a process and a transaction, putting a broker between them adds latency, failure modes, and cost for nothing. |
+
+Use cases #5 (cron) and #7 (in-process) **do not use Transport**. Use case #4 (Pulse telemetry) uses OpenTelemetry, not Transport, except for the single `PulseIngested` domain pub/sub event which rides Transport per row #2. Use cases #1, #2, #3, and #6 are the four genuinely-event-driven backings the Grid commits to; of those, #6 (Event Grid system topics) is reached *outside* the Transport abstraction (Event Grid does not have a Transport provider; the system-topic-to-consumer wiring is portal/Bicep, not `ITransportPublisher`).
+
+### Dead-Letter Strategy
+
+Per ADR-0028 D2 row 8 (dead-letter handling): the strategy is per-backing, not Grid-wide. Service Bus has native DLQ for use cases #1 and #2; Storage Queue uses a manual poison-queue convention for use case #3; Event Grid dead-letters to Storage with a configured destination for use case #6.
+
+### Outbox Bridge
+
+For any use case where a database commit and a Transport publish must be atomic, `HoneyDrunk.Data.Outbox` is the standard bridge. Direct publishes from inside a database transaction are forbidden (no rollback path if the transaction commits and the publish fails or vice versa). The outbox writes the message into the same database transaction; `IOutboxDispatcher` polls and publishes asynchronously with at-least-once delivery semantics.
+
+### Service Bus Namespace
+
+One shared namespace per environment (`sbns-hd-shared-{env}` for `dev`/`stg`/`prod`), Standard tier, ~$10/mo per environment. Per-Node namespaces are rejected for the same reasons per-Node Container Apps Environments are rejected: namespace is not a security boundary (Managed Identity scopes per queue/topic), per-namespace cost is fixed, and a shared namespace simplifies cross-Node observability. Naming: queues are `sbq-{purpose}-{env}` (e.g. `sbq-notify-cloud-billing-stg`); topics are `sbt-{purpose}-{env}` with subscriptions named after the consumer Node.
+
+Provisioning is just-in-time — the namespace is not provisioned until the first cross-Node async pub/sub consumer ships. `PulseIngested` is published today but has no consumers, so the namespace creation defers until the first real consumer lands.
+
+### Source of Truth
+
+If this section ever drifts from ADR-0028 D2, the ADR wins. New rows are added by follow-up ADRs that name a use case the current matrix does not cover.
+```
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the existing in-progress `## [Unreleased]` section under `### Changed`:
+
+- "Transport context: added the use-case → backing matrix from ADR-0028 D2 to `repos/HoneyDrunk.Transport/integration-points.md` so the Transport repo is the authoritative developer-facing reference for which backing serves which Grid use case."
+
+## Affected Files
+- `repos/HoneyDrunk.Transport/integration-points.md` (append the new "Use-Case → Backing Matrix" section after "Downstream Consumers")
+- `CHANGELOG.md` (Unreleased entry)
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo — no .NET projects.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture` — correct repo per routing rules (architecture/ADR/catalog/repo-context files belong in this repo).
+- [x] No code changes anywhere; one markdown doc + CHANGELOG.
+- [x] No `catalogs/*.json` edits. No `constitution/*.md` edits. No `adrs/*.md` edits. No other repo context files (Pulse, Communications, Notify, etc.) edited — those are separate packets in this initiative.
+- [x] The matrix is copied verbatim from the ADR's D2 section. No edits to the matrix content itself — the ADR is the source of truth.
+
+## Acceptance Criteria
+- [ ] `repos/HoneyDrunk.Transport/integration-points.md` carries a new top-level section `## Use-Case → Backing Matrix` after the existing "Downstream Consumers" table.
+- [ ] The matrix in that section has all seven rows verbatim from ADR-0028 D2 (use cases #1 through #7; row #8 from the ADR's dead-letter row is captured in the prose "Dead-Letter Strategy" subsection instead of as a matrix row to keep the use-case axis clean).
+- [ ] The section includes the "Use cases #5 and #7 do not use Transport" disambiguation paragraph and the "Source of Truth" closing paragraph naming ADR-0028 as the source.
+- [ ] The section includes the Outbox-bridge, Service-Bus-namespace, and dead-letter-strategy paragraphs that capture D5, D8, and D9 of the ADR (these are operational notes the matrix alone does not convey).
+- [ ] No other section of `repos/HoneyDrunk.Transport/integration-points.md` is edited. The existing "Upstream Dependencies" and "Downstream Consumers" tables are byte-for-byte unchanged.
+- [ ] No other file in `repos/HoneyDrunk.Transport/` is edited (this packet touches only `integration-points.md`).
+- [ ] `CHANGELOG.md` Unreleased section has the changed-entry described above.
+- [ ] PR description references this packet (per the invariant on PR-to-packet linking, inlined below).
+- [ ] PR description confirms the matrix matches ADR-0028 D2 verbatim — any deviation is grounds to stop and flag rather than ship.
+
+## Human Prerequisites
+None. This packet is fully delegable; the agent edits one doc file and opens a PR.
+
+## Referenced ADR Decisions
+
+**ADR-0028 D1 (Transport remains the abstraction):** `HoneyDrunk.Transport` is the broker-agnostic abstraction for any message that crosses a Node boundary asynchronously. Below the abstraction, two backings are first-class today (Service Bus, Storage Queue) and one (InMemory) for tests. This ADR pins which backing Transport uses for which Grid use case and which use cases bypass Transport entirely.
+
+**ADR-0028 D2 (Use-case → backing matrix):** The load-bearing matrix copied into this packet. Each row is a Grid use case with a primary backing, ordering/durability properties, cost posture, and a one-sentence justification.
+
+**ADR-0028 D5 (Service Bus default broker; one shared namespace per environment):** `sbns-hd-shared-{env}` for `dev`/`stg`/`prod`, Standard tier, queues `sbq-{purpose}-{env}`, topics `sbt-{purpose}-{env}` with consumer-Node-named subscriptions. Provisioning is just-in-time — the namespace is not created until the first cross-Node async pub/sub consumer ships.
+
+**ADR-0028 D8 (Dead-letter strategy is per-backing):** Service Bus native DLQ for #1/#2; Storage Queue manual poison-queue for #3; Event Grid dead-letter-to-Storage for #6.
+
+**ADR-0028 D9 (Outbox is the bridge for committing-then-publishing):** `HoneyDrunk.Data.Outbox` is the only correct pattern for atomic database-commit + Transport-publish. Direct publishes from inside a database transaction are forbidden.
+
+**ADR-0028 §Consequences (mirroring rule):** "the matrix lives in this ADR (the source of truth) and is mirrored into `repos/HoneyDrunk.Transport/integration-points.md` (the developer-facing reference)." This packet is that mirror.
+
+## Dependencies
+None. Wave 1 foundational packet; runs in parallel with packets 02 and 03.
+
+## Labels
+`chore`, `tier-1`, `docs`, `core`, `adr-0028`
+
+## Agent Handoff
+
+**Objective:** Add the ADR-0028 D2 use-case → backing matrix to `repos/HoneyDrunk.Transport/integration-points.md`, plus the operational notes (Service Bus namespace, dead-letter strategy, Outbox bridge, source-of-truth pointer), so the Transport repo context folder is the developer-facing reference for which backing serves which Grid use case.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Mirror the ADR's matrix into the Transport-repo-side context file so cross-Node messaging questions resolve from the Transport repo, not by hunting in the Architecture repo's ADR folder.
+- Feature: ADR-0028 Event-Driven Architecture and Messaging, Wave 1.
+- ADR: ADR-0028 (Proposed at edit time; auto-flipped to Accepted by hive-sync after all four packets in this initiative close).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+
+- **Invariant 12:** Semantic versioning with `CHANGELOG.md` and `README.md`. Breaking changes bump major; new features bump minor; fixes bump patch. Every repo must have a repo-level `CHANGELOG.md`; every shipped change gets an entry. This packet ships a documentation surface change in the Architecture repo — `CHANGELOG.md` entry mandatory.
+
+- **Invariant 23:** Every tracked work item has a GitHub Issue in its target repo. No work tracked exclusively in packet files, chat logs, or external tools. This packet files as an issue against `HoneyDrunk.Architecture` once the manifest picks it up.
+
+- **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. Pre-filing amendments to fill in missing operational context (NuGet deps, key files, constraints) are permitted; post-filing corrections require a new packet.
+
+- **Invariant 32:** Agent-authored PRs must link to their packet in the PR body. The review agent resolves the packet via this link and uses it as the primary scope anchor. Absent the link, the PR receives a degraded review.
+
+- **Verbatim matrix.** The D2 matrix in this packet is the canonical text. The agent does not paraphrase, reorder rows, drop columns, or add new rows — those changes would be drift from the ADR. If the agent reads the live ADR file and finds a difference from the matrix text in this packet (the ADR may have been amended after this packet was authored), the agent follows the **ADR's live text** and notes the divergence in the PR body. The ADR wins.
+
+- **Stay narrow — append-only.** The existing "Upstream Dependencies" and "Downstream Consumers" tables in `integration-points.md` are not edited. No other Transport-context-folder file is touched. No `catalogs/*.json`, no `constitution/*.md`, no `adrs/*.md`, no other repo's context files.
+
+- **No code.** No `.cs`, `.csproj`, `.json` (other than the existing CHANGELOG which is markdown), or YAML touched. This is an Architecture-repo doc edit only.
+
+- **No initiative or roadmap edits.** Per the initiative-level direction, `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, `adrs/README.md`, and `catalogs/*.json` are all out of scope for this initiative.
+
+**Key Files:**
+- `repos/HoneyDrunk.Transport/integration-points.md` — append the new "Use-Case → Backing Matrix" section after "Downstream Consumers"
+- `CHANGELOG.md` — Unreleased section append
+
+**Contracts:** None changed. This is a doc-mirror edit; no interface or type surface is touched.

--- a/generated/issue-packets/active/adr-0028-event-driven-architecture/02-architecture-transport-boundaries-scope-clarification.md
+++ b/generated/issue-packets/active/adr-0028-event-driven-architecture/02-architecture-transport-boundaries-scope-clarification.md
@@ -1,0 +1,226 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "docs", "core", "adr-0028"]
+dependencies: []
+adrs: ["ADR-0028"]
+accepts: ADR-0028
+wave: 1
+initiative: adr-0028-event-driven-architecture
+node: honeydrunk-architecture
+---
+
+# Chore: Clarify Transport scope in boundaries doc — async commands and durable pub/sub only
+
+## Summary
+Update `repos/HoneyDrunk.Transport/boundaries.md` to clarify that Transport is the abstraction layer for **async commands and durable pub/sub only**. Add three explicit out-of-scope items per ADR-0028's "below-the-line" use cases: telemetry signals (Pulse / OTel), CI cron (Actions / GitHub schedules), and reactive resource events (Event Grid system topics). Architecture-repo doc edit only; no code or other catalog touches.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0028's "If Accepted — Required Follow-Up Work" checklist line 2 says:
+
+> Update `repos/HoneyDrunk.Transport/boundaries.md` to clarify that Transport is the abstraction layer for **async commands and durable pub/sub** only — telemetry signals (Pulse), CI cron (Actions), and reactive resource events (Event Grid system topics) are out of Transport's scope
+
+The Transport boundary doc today lists six "What Transport Owns" items and six "What Transport Does NOT Own" items. The "Does NOT Own" list correctly disclaims serialization, business logic, the database outbox store, GridContext, REST/HTTP, and Notify's queue. But it does not yet disclaim three larger surfaces the ADR's matrix walks off the Transport abstraction entirely:
+
+1. **Telemetry signals** — OTel-shaped traces/metrics/logs go through Pulse's OTLP pipeline, not Transport. The conflation "make Pulse a Transport consumer for free observability" is the most-tempting wrong shape in the Grid's messaging surfaces, and the boundary doc should head it off explicitly.
+2. **CI cron / scheduled work** — GitHub Actions `schedule:` cron and Container Apps cron-scaler jobs are the right shape for time-triggered work. Adding a queue layer between the schedule and the workflow is rebuilding what the scheduler already provides.
+3. **Reactive resource events** — Azure-emitted system events (blob written, secret rotated, image pushed) ride Event Grid system topics, not Transport. There is no Event Grid Transport provider and there will not be one for system topics — the system-topic-to-consumer wiring is portal/Bicep.
+
+The positive form ("async commands and durable pub/sub") and the negative form (three explicit out-of-scope items) together pin what Transport is for, so future Nodes and agents reach for the right tool the first time.
+
+## Scope
+
+Single-file edit. No other repo context files touched. No `catalogs/*.json` edits. No constitution edits. No code.
+
+## Proposed Implementation
+
+### Edits to `repos/HoneyDrunk.Transport/boundaries.md`
+
+The current file is:
+
+```markdown
+# HoneyDrunk.Transport — Boundaries
+
+## What Transport Owns
+
+- Message publishing and consumption abstractions
+- Middleware pipeline (GridContext propagation → Telemetry → Logging → Handler)
+- Immutable transport envelope with correlation/causation tracking
+- Transactional outbox abstractions (`IOutboxStore`, `IOutboxDispatcher`)
+- Transport-specific health contributors
+- Provider implementations (Azure Service Bus, Storage Queue, InMemory)
+
+## What Transport Does NOT Own
+
+- **Message serialization format** — Applications choose serializers
+- **Business logic** — Handlers contain business logic, not Transport
+- **Database outbox storage** — `IOutboxStore` implementation belongs in HoneyDrunk.Data.Outbox
+- **Context model** — GridContext definition belongs in Kernel
+- **REST/HTTP** — HTTP-specific concerns belong in Web.Rest
+- **Queue-based notifications** — Queue management for notifications belongs in Notify
+```
+
+Replace it with:
+
+```markdown
+# HoneyDrunk.Transport — Boundaries
+
+## Scope
+
+**Transport is the abstraction layer for async commands and durable pub/sub only.** It is the broker-agnostic surface for messages that cross a Node boundary asynchronously and need delivery, ordering, durability, or per-subscriber fan-out guarantees from the underlying broker.
+
+Below the abstraction: two backings are first-class today — Azure Service Bus (for use cases needing sessions, DLQ, duplicate detection, transactions, or pub/sub topics) and Azure Storage Queue (for high-volume commodity work where ordering doesn't matter and a manual poison-queue pattern is acceptable). InMemory is provided for tests. New backings are added by ADR.
+
+The two messaging shapes Transport serves are:
+
+- **Async commands across Nodes** — one sender, one logical recipient. Backed by a Service Bus queue (sessions when grouped, DLQ on failure) or a Storage Queue (for the cost-sensitive commodity case).
+- **Durable pub/sub fanout** — one event, many in-Grid consumers, each wanting per-subscription durability and replay. Backed by a Service Bus topic.
+
+The full use-case → backing matrix lives in `repos/HoneyDrunk.Transport/integration-points.md` (mirrored from ADR-0028 D2).
+
+## What Transport Owns
+
+- Message publishing and consumption abstractions (`ITransportPublisher`, `ITransportConsumer`, `IMessageHandler<T>`)
+- Middleware pipeline (GridContext propagation → Telemetry → Logging → Handler)
+- Immutable transport envelope with correlation/causation tracking
+- Transactional outbox abstractions (`IOutboxStore`, `IOutboxDispatcher`)
+- Transport-specific health contributors
+- Provider implementations (Azure Service Bus, Storage Queue, InMemory)
+- The seam at which a host swaps backings as a host-time composition change, never as a code rewrite
+
+## What Transport Does NOT Own
+
+- **Message serialization format** — Applications choose serializers.
+- **Business logic** — Handlers contain business logic, not Transport.
+- **Database outbox storage** — `IOutboxStore` implementation belongs in `HoneyDrunk.Data.Outbox`.
+- **Context model** — GridContext definition belongs in Kernel.
+- **REST/HTTP** — HTTP-specific concerns belong in `HoneyDrunk.Web.Rest`.
+- **Queue-based notifications** — Queue management for notifications belongs in `HoneyDrunk.Notify`. Notify intake → Notify worker is an in-Node hop on Notify's own queue abstraction (`HoneyDrunk.Notify.Queue.*`), not a Transport hop. The two queue abstractions coexist by design: Transport for cross-Node, Notify.Queue for in-Node.
+- **Telemetry signals (Pulse / OpenTelemetry)** — traces, logs, metrics, errors, and analytics ride OpenTelemetry over OTLP HTTP/gRPC to the Pulse Collector. They do not ride Transport. Pulse is **not** subscribed to Transport topics; Nodes do **not** emit telemetry through Transport. The single Transport hop Pulse uses today (`PulseIngested`, published after a batch lands) is a domain pub/sub event that says "telemetry was ingested" — it is not the telemetry itself. Do not put metrics on Service Bus topics; do not put domain events through OTLP.
+- **CI cron / scheduled work** — Time-triggered work (nightly-deps, nightly-security, grid-health aggregator, hive-sync, Vault rotation policy schedule, Lore ingestion) runs on GitHub Actions `schedule:` cron for CI-shaped schedules, or on Container Apps cron-scaler jobs for Node-internal schedules that are too heavy for Actions runners. The scheduler is the broker. Adding a Transport queue between the cron trigger and the workflow runner is rebuilding what the scheduler already provides.
+- **Reactive resource events (Azure-emitted system events)** — "this Azure resource changed" events (blob written, Key Vault secret rotated, Container Registry image pushed) ride Event Grid system topics directly to the consumer (Container App webhook, Logic App, or Function). They do not ride Transport, and there is no Event Grid Transport provider for system topics. The Vault rotation cache-invalidation pathway already implicitly relies on this. Event Grid **custom** topics are deferred Grid-wide pending a use case that needs them; Transport does not bridge to custom topics either.
+
+## Decision Test
+
+Before reaching for Transport, ask:
+
+1. Is this a message that crosses a Node boundary asynchronously and needs the broker to guarantee delivery, ordering, or durability? → Transport.
+2. Is this an in-Node hop where producer and consumer share a process? → Not Transport. In-process domain events (mediator-style fan-out) or Notify's in-Node queue (for Notify intake → Notify worker) fit.
+3. Is this a metric, trace, log, error, or analytics signal? → Not Transport. Pulse OTLP pipeline.
+4. Is this a scheduled or time-triggered job? → Not Transport. GitHub Actions cron or Container Apps cron scaler.
+5. Is this a reaction to an Azure-emitted resource event? → Not Transport. Event Grid system topic to the consumer directly.
+
+If the answer to #1 is yes, the next question is: does the use case need sessions, DLQ, duplicate detection, or pub/sub topics? If yes → Service Bus. If no → Storage Queue. The backing is a host-time composition choice; the application code consumes `ITransportPublisher` / `ITransportConsumer` regardless.
+
+## No Raw Broker SDK Calls
+
+Even when the chosen backing is Service Bus or Storage Queue, application code calls `ITransportPublisher` / `ITransportConsumer` — never `Azure.Messaging.ServiceBus.ServiceBusClient.SendAsync` or `Azure.Storage.Queues.QueueClient.SendMessageAsync` directly. The abstraction exists so that backing swaps are host-time composition changes, not code rewrites. Direct SDK use from application code is forbidden; the broker SDKs are wrapped only inside the `HoneyDrunk.Transport.*` provider packages.
+```
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the existing in-progress `## [Unreleased]` section under `### Changed`:
+
+- "Transport boundaries: clarified Transport is the abstraction layer for async commands and durable pub/sub only, with three explicit out-of-scope items per ADR-0028 — telemetry signals (Pulse / OTel), CI cron (Actions / Container Apps scheduled jobs), and reactive resource events (Event Grid system topics). Added a decision-test section and a no-raw-broker-SDK-calls rule."
+
+## Affected Files
+- `repos/HoneyDrunk.Transport/boundaries.md` (rewrite — new "Scope" section, expanded "Does NOT Own" list with three new disclaimers, new "Decision Test" section, new "No Raw Broker SDK Calls" section)
+- `CHANGELOG.md` (Unreleased entry)
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo — no .NET projects.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture` — correct repo per routing rules.
+- [x] No code changes anywhere; one markdown doc + CHANGELOG.
+- [x] No `catalogs/*.json` edits. No `constitution/*.md` edits. No `adrs/*.md` edits. No other repo context files (Pulse, Communications, Notify, etc.) edited.
+- [x] The new "Does NOT Own" items are copies of ADR-0028's decisions in different sections (D3 for telemetry, D2 row 5 for cron, D2 row 6 for Event Grid). The ADR is the source of truth — any deviation is grounds to stop and flag rather than ship.
+- [x] The existing six "Does NOT Own" items are preserved; only three new items are added. The six "Owns" items are preserved with one minor expansion (the third sub-bullet referencing the host-time backing-swap seam).
+
+## Acceptance Criteria
+- [ ] `repos/HoneyDrunk.Transport/boundaries.md` has a new top-level `## Scope` section at the top of the file (after the H1 title) stating Transport is for async commands and durable pub/sub only, naming the two messaging shapes (async commands, durable pub/sub), and pointing at `integration-points.md` for the full matrix.
+- [ ] The "What Transport Owns" section retains all six existing bullets plus one new bullet about the host-time backing-swap seam.
+- [ ] The "What Transport Does NOT Own" section retains all six existing bullets and adds three new bullets: telemetry signals (Pulse / OTel), CI cron (Actions / Container Apps cron), and reactive resource events (Event Grid system topics). Each new bullet matches the text in the Proposed Implementation section above.
+- [ ] The Notify-queue bullet is expanded to name the in-Node-vs-cross-Node split: Transport for cross-Node, `Notify.Queue.*` for in-Node, and the two coexist by design.
+- [ ] A new `## Decision Test` section is added with the five-question checklist matching the Proposed Implementation text.
+- [ ] A new `## No Raw Broker SDK Calls` section is added with the rule that application code calls `ITransportPublisher` / `ITransportConsumer`, never `ServiceBusClient.SendAsync` or `QueueClient.SendMessageAsync` directly.
+- [ ] `CHANGELOG.md` Unreleased section has the changed-entry described above.
+- [ ] No file other than `repos/HoneyDrunk.Transport/boundaries.md` and `CHANGELOG.md` is edited.
+- [ ] PR description references this packet (per the PR-to-packet linking invariant inlined below).
+- [ ] PR description states explicitly: the three new "Does NOT Own" bullets correspond to ADR-0028's D2 rows 4, 5, and 6 (telemetry, cron, Event Grid) and D3 (signals-vs-events). Any drift from those ADR sections is grounds to stop and flag rather than ship.
+
+## Human Prerequisites
+None. This packet is fully delegable; the agent edits one doc file and opens a PR.
+
+## Referenced ADR Decisions
+
+**ADR-0028 D1 (Transport remains the abstraction for cross-Node async messaging):** Transport is not in scope for re-decision. It stays the broker-agnostic abstraction for any message that crosses a Node boundary asynchronously. Below the abstraction, Service Bus and Storage Queue are first-class; InMemory is for tests. The abstraction exists so that backing swaps are host-time composition changes, not code rewrites.
+
+**ADR-0028 D2 (Use-case → backing matrix):** Rows 4 (telemetry), 5 (cron), 6 (reactive resource events), and 7 (in-process domain events) explicitly do **not** ride Transport. Rows 1 (async commands), 2 (pub/sub fanout), and 3 (commodity work queues) do.
+
+**ADR-0028 D3 (Pulse signals are not domain events):** Telemetry signals ride OpenTelemetry over OTLP. Domain events ride Transport. `PulseIngested` is a domain event ("telemetry was ingested for batch X") that happens to be emitted by Pulse — it is not the telemetry. Pulse is not subscribed to Transport topics; Nodes do not emit metrics through Transport.
+
+**ADR-0028 D5 (Service Bus default; one shared namespace per environment):** When use cases #1 and #2 hit production, the backing is Service Bus, with `sbns-hd-shared-{env}` per environment. The reference to "host-time composition" in the new "Owns" bullet is the practical manifestation of D5 — switching from InMemory to Service Bus is a DI change, not a code change.
+
+**ADR-0028 D6 (Event Grid system topics yes; custom topics deferred):** System topics are the only managed channel for Azure-emitted resource events. Custom topics are deferred until a concrete consumer materializes. The new "Reactive resource events" bullet in "Does NOT Own" captures both halves: system topics ride Event Grid (not Transport), and there is no Transport provider for custom topics either.
+
+**ADR-0028 §"New invariants (proposed for `constitution/invariants.md`)":** Two invariants are proposed — "Telemetry signals ride OpenTelemetry; domain events ride Transport" and "Cross-Node async messaging crosses Transport — never raw broker SDK calls." This packet encodes both into the Transport boundary doc (not the constitution — the constitution edit is a separate scope-agent acceptance-time concern out of scope for this initiative). The "No Raw Broker SDK Calls" section in the new boundary doc is the operational form of the second invariant.
+
+## Referenced Invariants
+
+> **Invariant 12:** Semantic versioning with `CHANGELOG.md` and `README.md`. Every shipped change gets an entry in the repo-level changelog. — This packet ships a documentation surface change in the Architecture repo; CHANGELOG entry mandatory.
+
+> **Invariant 23:** Every tracked work item has a GitHub Issue in its target repo. No work tracked exclusively in packet files, chat logs, or external tools.
+
+> **Invariant 32:** Agent-authored PRs must link to their packet in the PR body. The review agent resolves the packet via this link and uses it as the primary scope anchor. Absent the link, the PR receives a degraded review.
+
+## Dependencies
+None. Wave 1 foundational packet; runs in parallel with packets 01 and 03.
+
+## Labels
+`chore`, `tier-1`, `docs`, `core`, `adr-0028`
+
+## Agent Handoff
+
+**Objective:** Update `repos/HoneyDrunk.Transport/boundaries.md` to clarify Transport's scope (async commands and durable pub/sub only), expand the "Does NOT Own" list with three new disclaimers (telemetry, cron, Event Grid system topics), add a decision-test checklist, and add a no-raw-broker-SDK-calls rule.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Pin Transport's scope so future Nodes and agents reach for the right tool the first time. The positive form ("async commands and durable pub/sub") and the negative form (three explicit out-of-scope items) together prevent the conflation patterns the ADR explicitly rejects (Pulse-as-Transport-consumer, queue-between-Actions-and-Nodes, custom-topic-everything).
+- Feature: ADR-0028 Event-Driven Architecture and Messaging, Wave 1.
+- ADR: ADR-0028 (Proposed at edit time; auto-flipped to Accepted by hive-sync after all four packets in this initiative close).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+
+- **Invariant 12:** Semantic versioning with `CHANGELOG.md` and `README.md`. Every shipped change gets an entry in the repo-level changelog. This packet ships a documentation surface change; CHANGELOG entry mandatory.
+
+- **Invariant 23:** Every tracked work item has a GitHub Issue in its target repo. No work tracked exclusively in packet files.
+
+- **Invariant 32:** Agent-authored PRs must link to their packet in the PR body. The review agent resolves the packet via this link and uses it as the primary scope anchor.
+
+- **Verbatim ADR alignment.** The three new "Does NOT Own" bullets and the decision-test and no-raw-SDK-calls sections track ADR-0028 D2/D3/D6 directly. The agent does not paraphrase the rules into something looser or stricter; the text in the Proposed Implementation section above is the canonical wording. If the agent reads the live ADR and finds it has been amended after this packet was authored, the agent follows the ADR's live text and notes the divergence in the PR body.
+
+- **Preserve existing bullets.** The six existing "Owns" bullets and six existing "Does NOT Own" bullets are not removed or reworded. Additions only. The one minor expansion permitted is the Notify-queue bullet (existing wording extended to name the in-Node-vs-cross-Node split per D1's "two queue abstractions coexist by design" note).
+
+- **No code.** No `.cs`, `.csproj`, `.json` (other than the existing CHANGELOG which is markdown), or YAML touched.
+
+- **No other context files.** Pulse boundaries, Communications boundaries, Notify boundaries — all out of scope for this packet; they are separate packets in this initiative (Pulse) or future initiatives (Communications, Notify if needed).
+
+- **No initiative or roadmap or constitution edits.** Per the initiative-level direction, `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, `adrs/README.md`, `catalogs/*.json`, and `constitution/invariants.md` are all out of scope for this initiative. The proposed invariants from the ADR's §New Invariants section are noted in the Transport boundary doc's new "No Raw Broker SDK Calls" section but are not added to the constitution by this packet.
+
+**Key Files:**
+- `repos/HoneyDrunk.Transport/boundaries.md` — full rewrite per the Proposed Implementation section
+- `CHANGELOG.md` — Unreleased section append
+
+**Contracts:** None changed. This is a boundary doc edit; no interface or type surface is touched.

--- a/generated/issue-packets/active/adr-0028-event-driven-architecture/03-architecture-pulse-boundaries-signals-vs-events.md
+++ b/generated/issue-packets/active/adr-0028-event-driven-architecture/03-architecture-pulse-boundaries-signals-vs-events.md
@@ -1,0 +1,201 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "docs", "ops", "adr-0028"]
+dependencies: []
+adrs: ["ADR-0028"]
+accepts: ADR-0028
+wave: 1
+initiative: adr-0028-event-driven-architecture
+node: honeydrunk-architecture
+---
+
+# Chore: Add D3 signals-vs-events disambiguation to Pulse boundaries
+
+## Summary
+Update `repos/HoneyDrunk.Pulse/boundaries.md` to add ADR-0028 D3's "Pulse signals are not domain events" disambiguation as an explicit subsection under "What Pulse Does NOT Own." Architecture-repo doc edit only; no code or other catalog touches.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0028's "If Accepted — Required Follow-Up Work" checklist line 3 says:
+
+> Update `repos/HoneyDrunk.Pulse/boundaries.md` to add the "Pulse signals are not domain events" disambiguation introduced in D3
+
+The Pulse boundary doc today already disclaims Transport under "What Pulse Does NOT Own" ("Message publishing for events belongs in Transport"). That sentence is correct but too short — it does not surface the conflation it is meant to head off. The Grid's most-conflated concept in messaging surfaces is "Pulse is a Transport consumer for free observability" — subscribe Pulse to a Transport topic, route domain events through it, get traces and metrics by side effect. The ADR's D3 explicitly rejects this and pins the rule: telemetry signals ride OpenTelemetry over OTLP; domain events ride Transport; the two channels are intentionally separate and stay separate. Pulse never receives domain events as a consumer.
+
+The negative form is also instructive: do not put metrics on Service Bus topics. Do not put domain events through OTLP. Do not subscribe Pulse to Transport topics to "make it learn what happened." The boundary doc needs to say this in the same place a reader is looking when they ask "what does Pulse not own?" — under "What Pulse Does NOT Own."
+
+This packet adds that disambiguation as a structured subsection so the rule is visible from one glance.
+
+## Scope
+
+Single-file edit. No other repo context files touched. No `catalogs/*.json` edits. No constitution edits. No code.
+
+## Proposed Implementation
+
+### Edits to `repos/HoneyDrunk.Pulse/boundaries.md`
+
+The current file is:
+
+```markdown
+# HoneyDrunk.Pulse - Boundaries
+
+## What Pulse Owns
+- Sink interfaces (`ITraceSink`, `ILogSink`, `IMetricsSink`, `IAnalyticsSink`, `IErrorSink`)
+- OpenTelemetry preconfigured pipelines with Grid context enrichment
+- Multi-backend fan-out with per-sink failure isolation
+- Pulse.Collector (OTLP HTTP + gRPC receiver) using Kernel canonical Pulse identity fallback
+- Shared event contracts (`PulseIngested`, etc.)
+
+## What Pulse Does NOT Own
+- **Context model** - GridContext definition and canonical Node IDs belong in Kernel
+- **Transport** - Message publishing for events belongs in Transport
+- **Secret management** - Sink credentials come from Vault
+```
+
+Replace it with:
+
+```markdown
+# HoneyDrunk.Pulse - Boundaries
+
+## What Pulse Owns
+- Sink interfaces (`ITraceSink`, `ILogSink`, `IMetricsSink`, `IAnalyticsSink`, `IErrorSink`)
+- OpenTelemetry preconfigured pipelines with Grid context enrichment
+- Multi-backend fan-out with per-sink failure isolation
+- Pulse.Collector (OTLP HTTP + gRPC receiver) using Kernel canonical Pulse identity fallback
+- Shared event contracts (`PulseIngested`, etc.) — emitted by Pulse via Transport when a batch lands; not a substitute for telemetry
+
+## What Pulse Does NOT Own
+- **Context model** - GridContext definition and canonical Node IDs belong in Kernel
+- **Transport** - Message publishing for events belongs in Transport
+- **Secret management** - Sink credentials come from Vault
+
+## Pulse Signals Are Not Domain Events
+
+The single most-conflated concept in the Grid's messaging surfaces is "Pulse is a Transport consumer for free observability" — subscribe Pulse to a Transport topic, route domain events through it, get traces and metrics by side effect. This is the wrong shape, and the Grid's messaging architecture intentionally rejects it.
+
+**Telemetry signals ride OpenTelemetry over OTLP.** Nodes emit traces, metrics, logs, errors, and analytics signals to the Pulse Collector via OTLP HTTP or gRPC. The Pulse Collector fans out to backends (Tempo, Loki, Mimir, Sentry, PostHog, Azure Monitor) with per-sink failure isolation. No Transport hop, no Service Bus topic, no Event Grid involvement. This is the existing pipeline and the only correct shape for telemetry.
+
+**Domain events ride Transport.** `PulseIngested` is a domain event ("telemetry was ingested for batch X") that happens to be emitted by Pulse — it is *not* the telemetry itself. It rides Transport as a pub/sub event so downstream Grid Nodes can react to ingestion completion. Other domain events emitted by Pulse, if any are added later, ride the same Transport channel by the same rule.
+
+**Pulse never receives domain events as a consumer.** Pulse observes; it does not subscribe. If a Node wants Pulse to see something, it emits a span / metric / log via the OpenTelemetry pipeline, not a Transport message. Subscribing Pulse to a Transport topic to "make it learn what happened" would couple observability to event schemas, put telemetry processing in the path of domain delivery, and blur the architectural seam between OTel-shaped signals and Transport-shaped events. None of those costs are paid by the existing design, and they will not be paid by this one.
+
+The negative form, said directly:
+
+- Do **not** put metrics on Service Bus topics.
+- Do **not** put traces or logs on Service Bus queues.
+- Do **not** put domain events through OTLP.
+- Do **not** subscribe Pulse to Transport topics to "instrument what happened."
+- Do **not** treat `PulseIngested` as a telemetry channel — it is a domain pub/sub event about ingestion completion, not the telemetry it announces.
+
+Pulse instruments domain events from inside the Nodes that emit them, via the OpenTelemetry pipeline. The two channels — OTel for signals, Transport for events — are intentionally separate and stay separate.
+
+## Decision Test
+
+If the concern is **trace, metric, log, error, or analytics signal**, it belongs on the OpenTelemetry pipeline. Emit via OTLP HTTP/gRPC to the Pulse Collector. Pulse owns.
+
+If the concern is **a durable, attributable record of "this business thing happened, with these consumers needing to react"**, it is a domain event. It rides Transport, not Pulse. The downstream consumers subscribe to the Transport topic; Pulse observes whatever traces and metrics those consumers emit while processing the event.
+
+If both channels seem to apply ("I want a metric AND a domain event"), emit both — a metric via OTLP and a domain event via Transport. They do not collapse into one channel.
+```
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the existing in-progress `## [Unreleased]` section under `### Changed`:
+
+- "Pulse boundaries: added the 'Pulse signals are not domain events' disambiguation per ADR-0028 D3. Telemetry rides OpenTelemetry to the Pulse Collector; domain events ride Transport; Pulse never receives domain events as a consumer. Negative-form rules and a decision test included."
+
+## Affected Files
+- `repos/HoneyDrunk.Pulse/boundaries.md` (rewrite — adds `## Pulse Signals Are Not Domain Events` and `## Decision Test` sections; one minor expansion of the existing `PulseIngested` bullet under "What Pulse Owns")
+- `CHANGELOG.md` (Unreleased entry)
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo — no .NET projects.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture` — correct repo per routing rules.
+- [x] No code changes anywhere; one markdown doc + CHANGELOG.
+- [x] No `catalogs/*.json` edits. No `constitution/*.md` edits. No `adrs/*.md` edits. No other repo context files (Transport, Communications, Notify, etc.) edited.
+- [x] The new disambiguation text mirrors ADR-0028 D3 directly. The ADR is the source of truth — any deviation is grounds to stop and flag rather than ship.
+- [x] The existing three "Does NOT Own" bullets (Context model, Transport, Secret management) are preserved. The existing five "Owns" bullets are preserved with one minor expansion (the `PulseIngested` bullet extended to name it as "emitted by Pulse via Transport when a batch lands; not a substitute for telemetry").
+
+## Acceptance Criteria
+- [ ] `repos/HoneyDrunk.Pulse/boundaries.md` retains the existing "What Pulse Owns" section with all five existing bullets; the `PulseIngested` bullet is extended to clarify it is a Transport-emitted batch-completion event, not telemetry.
+- [ ] The existing three "What Pulse Does NOT Own" bullets are preserved verbatim.
+- [ ] A new `## Pulse Signals Are Not Domain Events` section is added after "What Pulse Does NOT Own" with the text from the Proposed Implementation section: an introductory framing paragraph, three principle paragraphs (telemetry rides OTel; domain events ride Transport; Pulse never receives domain events as a consumer), a negative-form bulleted list of five "Do not" rules, and a closing sentence about the two channels staying separate.
+- [ ] A new `## Decision Test` section is added after the signals-vs-events section with the three-bullet test from the Proposed Implementation (signal → OTel; domain event → Transport; both → emit both, do not collapse).
+- [ ] `CHANGELOG.md` Unreleased section has the changed-entry described above.
+- [ ] No file other than `repos/HoneyDrunk.Pulse/boundaries.md` and `CHANGELOG.md` is edited.
+- [ ] PR description references this packet (per the PR-to-packet linking invariant inlined below).
+- [ ] PR description states explicitly: the new sections track ADR-0028 D3 — any drift from D3 is grounds to stop and flag rather than ship.
+
+## Human Prerequisites
+None. This packet is fully delegable; the agent edits one doc file and opens a PR.
+
+## Referenced ADR Decisions
+
+**ADR-0028 D3 (Pulse signals are not domain events):** Telemetry signals ride OpenTelemetry over the OTLP wire format. Nodes emit traces/metrics/logs to the Pulse Collector via HTTP or gRPC. The Pulse Collector fans out to backends (Tempo, Loki, Mimir, Sentry, PostHog, Azure Monitor). No Transport hop, no Service Bus topic, no Event Grid involvement. Domain events ride Transport. `PulseIngested` is a domain event ("telemetry was ingested for batch X") that happens to be emitted by Pulse — it is *not* the telemetry. Pulse never receives domain events as a consumer; Pulse observes, it does not subscribe.
+
+**ADR-0028 D2 row 4 (telemetry use case):** Primary backing is direct OTLP via HTTP/gRPC, then Pulse Collector → backends. No broker between Node and Pulse Collector. The matrix's "Why this backing" cell: "Telemetry is **not a domain event**. It rides OpenTelemetry, not Transport."
+
+**ADR-0028 §Alternatives — "Treat Pulse as a Transport consumer and route domain events through it for 'free observability'":** Rejected. "This is the conflation D3 names explicitly. Pulse is observability infrastructure; domain events are business state. Subscribing Pulse to Transport topics would (a) couple observability to event schema, (b) put telemetry processing in the path of domain delivery, (c) blur the architectural seam between OTel-shaped signals and Transport-shaped events." The new "Pulse Signals Are Not Domain Events" section in the boundary doc is the operational form of this rejection.
+
+**ADR-0028 §"New invariants (proposed for `constitution/invariants.md`)":** The first proposed invariant is "Telemetry signals ride OpenTelemetry; domain events ride Transport. Pulse is not subscribed to Transport topics. Nodes do not emit metrics or traces over Transport. The two channels stay separate." This packet encodes the rule into the Pulse boundary doc (not the constitution — the constitution edit is a separate scope-agent acceptance-time concern out of scope for this initiative).
+
+## Referenced Invariants
+
+> **Invariant 12:** Semantic versioning with `CHANGELOG.md` and `README.md`. Every shipped change gets an entry in the repo-level changelog. — This packet ships a documentation surface change in the Architecture repo; CHANGELOG entry mandatory.
+
+> **Invariant 23:** Every tracked work item has a GitHub Issue in its target repo. No work tracked exclusively in packet files, chat logs, or external tools.
+
+> **Invariant 32:** Agent-authored PRs must link to their packet in the PR body. The review agent resolves the packet via this link and uses it as the primary scope anchor. Absent the link, the PR receives a degraded review.
+
+## Dependencies
+None. Wave 1 foundational packet; runs in parallel with packets 01 and 02.
+
+## Labels
+`chore`, `tier-1`, `docs`, `ops`, `adr-0028`
+
+## Agent Handoff
+
+**Objective:** Update `repos/HoneyDrunk.Pulse/boundaries.md` to add ADR-0028 D3's "Pulse signals are not domain events" disambiguation as an explicit `## Pulse Signals Are Not Domain Events` section, plus a `## Decision Test` section. The existing "Owns" and "Does NOT Own" content is preserved with one minor `PulseIngested` clarification.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Close the most-conflated concept in the Grid's messaging surfaces ("Pulse is a Transport consumer for free observability") by stating the rule directly in the Pulse boundary doc and giving readers a quick decision test.
+- Feature: ADR-0028 Event-Driven Architecture and Messaging, Wave 1.
+- ADR: ADR-0028 (Proposed at edit time; auto-flipped to Accepted by hive-sync after all four packets in this initiative close).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+
+- **Invariant 12:** Semantic versioning with `CHANGELOG.md` and `README.md`. Every shipped change gets an entry in the repo-level changelog. This packet ships a documentation surface change; CHANGELOG entry mandatory.
+
+- **Invariant 23:** Every tracked work item has a GitHub Issue in its target repo. No work tracked exclusively in packet files.
+
+- **Invariant 32:** Agent-authored PRs must link to their packet in the PR body. The review agent resolves the packet via this link and uses it as the primary scope anchor.
+
+- **Verbatim ADR alignment.** The new disambiguation text tracks ADR-0028 D3 directly. The agent does not paraphrase the rule into something looser or stricter; the text in the Proposed Implementation section above is the canonical wording. If the agent reads the live ADR and finds it has been amended after this packet was authored, the agent follows the ADR's live text and notes the divergence in the PR body.
+
+- **Preserve existing bullets.** The five existing "Owns" bullets and three existing "Does NOT Own" bullets are not removed or reworded. The one expansion permitted is the `PulseIngested` bullet, extended to name it as a Transport-emitted batch-completion event so the new section's reference to it lands cleanly.
+
+- **No code.** No `.cs`, `.csproj`, `.json` (other than the existing CHANGELOG which is markdown), or YAML touched.
+
+- **No other context files.** Transport boundaries, Communications boundaries, Notify boundaries — all out of scope for this packet; they are separate packets in this initiative (Transport, packet 02) or out of scope.
+
+- **No initiative or roadmap or constitution edits.** Per the initiative-level direction, `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, `adrs/README.md`, `catalogs/*.json`, and `constitution/invariants.md` are all out of scope for this initiative.
+
+**Key Files:**
+- `repos/HoneyDrunk.Pulse/boundaries.md` — full rewrite per the Proposed Implementation section
+- `CHANGELOG.md` — Unreleased section append
+
+**Contracts:** None changed. This is a boundary doc edit; no interface or type surface is touched.

--- a/generated/issue-packets/active/adr-0028-event-driven-architecture/04-communications-notify-sender-boundary.md
+++ b/generated/issue-packets/active/adr-0028-event-driven-architecture/04-communications-notify-sender-boundary.md
@@ -1,0 +1,253 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Communications
+labels: ["chore", "tier-2", "docs", "ops", "adr-0028"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0028", "ADR-0019"]
+accepts: ADR-0028
+wave: 2
+initiative: adr-0028-event-driven-architecture
+node: honeydrunk-communications
+---
+
+# Chore: Document the Communications → Notify in-process boundary and Service Bus migration path
+
+## Summary
+Add a `## Notify Delivery Boundary` section to `README.md` in `HoneyDrunk.Communications` that documents the concrete `INotificationSender` → `INotificationQueue` boundary settled by ADR-0028 D4: Communications calls Notify in-process via `INotificationSender`, Notify's intake enqueues onto its internal `INotificationQueue`, and Notify's worker consumes the queue. The section also documents the v2 migration path: when scale demands independently-scaled Container Apps for Communications and Notify, the seam moves to Service Bus via the existing `ITransportPublisher` / `ITransportConsumer` abstraction — a host-time composition change, not a code rewrite. Communications repo doc edit only; no behavior change.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Communications`
+
+## Motivation
+
+ADR-0028's "If Accepted — Required Follow-Up Work" checklist line 4 says:
+
+> Add a follow-up packet against Communications to specify the concrete `INotificationSender` → `INotifyQueueWriter` boundary and confirm that Communications dispatches to Notify in-process (not via Transport) — D4 settles the principle; the implementation packet wires it
+
+The implementation has shipped — Communications v0.2.0 takes a first-class runtime dependency on `HoneyDrunk.Notify.Abstractions` per ADR-0019 D5, and its `CommunicationOrchestrator` constructor injects `INotificationSender` from that package and calls it synchronously after the preference/cadence/decision-log checks. The boundary doc, however, does not yet name the boundary at the granularity the ADR's D4 settles. Specifically:
+
+- The current `README.md` says "delegating delivery mechanics to HoneyDrunk.Notify" — true, but doesn't pin the call shape (in-process vs broker).
+- The current `boundaries.md` says "Delegating approved delivery to Notify through `INotificationSender` from `HoneyDrunk.Notify.Abstractions`" — true, but doesn't disclose Notify's own internal queue (`INotificationQueue` in `HoneyDrunk.Notify.Queue.Abstractions`) as the first async hop, and doesn't name the v2 Service Bus migration path.
+
+D4 settles the principle: at v1 (single Container App per Node, low/bursty traffic), Communications → Notify is in-process. The seam to Service Bus opens when Notify Cloud's tier ceiling pressures it — at that point, Communications and Notify get separate Container Apps and the call crosses a Service Bus queue via the existing `ITransportPublisher` abstraction. The abstractions are in place; the change is a host-time composition.
+
+The user's prompt names the contract as "`INotifyQueueWriter`" — at the time of scope, the live Notify contract is `INotificationQueue` in `HoneyDrunk.Notify.Queue.Abstractions`. The verb-form "queue writer" maps to the `EnqueueAsync` method on that interface. This packet uses the live contract name (`INotificationQueue`) and surfaces the mapping in the doc.
+
+This packet codifies the boundary in the Communications repo's `README.md` so future readers (and future agents) see the call shape, the in-Node hop, and the migration path in one section. It is documentation-only — no code change, no contract change.
+
+## Scope
+
+Single-file edit in the Communications repo: `README.md`. No other files touched. No code changes. No CHANGELOG-version-bump (this is a docs edit; per the no-Unreleased rule, the entry goes under a new patch version section).
+
+## Proposed Implementation
+
+### Edits to `README.md`
+
+The current `README.md` is short — Status, Packages, Canonical Node Entry. Add a new top-level section after "Packages" (before "Canonical Node Entry"):
+
+```markdown
+## Notify Delivery Boundary
+
+Communications delegates approved sends to Notify by calling `INotificationSender` from `HoneyDrunk.Notify.Abstractions`. The boundary is **in-process** at v1: `INotificationSender` is registered in the same DI container as `ICommunicationOrchestrator`, and the call is a synchronous method invocation, not a broker hop.
+
+### Call shape at v1
+
+```
+caller → ICommunicationOrchestrator.SendAsync(intent)
+       → recipient resolution
+       → IPreferenceStore + ICadencePolicy check
+       → ICommunicationDecisionLog append
+       → INotificationSender.SendAsync(envelope)   ← in-process call into HoneyDrunk.Notify
+            → Notify intake validates the envelope
+            → Notify intake enqueues onto INotificationQueue (HoneyDrunk.Notify.Queue.Abstractions)
+            → Notify worker dequeues and dispatches via provider adapter (SMTP, Resend, Twilio, ...)
+```
+
+The first async hop in the path is Notify's **own internal** queue — `INotificationQueue` in `HoneyDrunk.Notify.Queue.Abstractions`. That queue is a Notify-internal concern (Notify intake writes, Notify worker reads, both inside the Notify Container App) and is intentionally **not** routed through `HoneyDrunk.Transport`. The Transport boundary doc explicitly disclaims this surface: "Queue management for notifications belongs in Notify."
+
+### Why in-process at v1
+
+- Communications and Notify ship as one Container App in the v1 Notify Cloud deployment. A single deployable composes Communications + Notify; no Node boundary is crossed.
+- The single most-trafficked seam the Grid is about to ship is Communications → Notify. Putting a broker between them at v1 adds latency, failure modes, and ~$10/mo of Service Bus namespace cost for no boundary-crossing benefit.
+- The abstractions are already in place. When the seam needs to move to a broker, the call site is unchanged — only the DI registration swaps.
+
+### v2 migration path (Service Bus)
+
+When Notify Cloud's tier ceiling pressures the deployment — different replica counts for Communications and Notify, different scaling triggers, different release cadences — the path is:
+
+1. Split Communications and Notify into separate Container Apps within the shared Container Apps Environment.
+2. Provision a Service Bus queue (`sbq-communications-notify-{env}`) in the existing shared namespace (`sbns-hd-shared-{env}`).
+3. Register `ITransportPublisher` against `HoneyDrunk.Transport.AzureServiceBus` in Communications' composition.
+4. Replace the in-process `INotificationSender` registration with a Transport-backed implementation that publishes the envelope onto the queue.
+5. Register a Transport consumer in Notify's composition that reads the queue and invokes the existing internal `INotificationSender`.
+
+No application code in either Node changes. The orchestrator still calls `INotificationSender.SendAsync(envelope)`; the registered implementation changes from "synchronous in-process call" to "publish onto a Service Bus queue and return." The consumer side resolves to the existing Notify implementation that enqueues onto `INotificationQueue`. The abstractions seam is the migration boundary — `INotificationSender` is the seam, and the `HoneyDrunk.Transport.*` packages are already part of the Grid.
+
+### What this section is not
+
+- It is not a contract change. `INotificationSender` and `INotificationQueue` are not modified by this section.
+- It is not a behavior change. The current v0.2.0 runtime already calls `INotificationSender` in-process; this section documents that choice.
+- It is not a deployment trigger. The v2 migration is gated on tier-ceiling pressure, not on this packet. No Service Bus provisioning happens here.
+
+### References
+
+- ADR-0028 D4 — Communications → Notify is in-process at v1; Service Bus when scale demands it.
+- ADR-0028 D5 — Service Bus shared namespace (`sbns-hd-shared-{env}`), Standard tier, queues named `sbq-{purpose}-{env}`.
+- ADR-0019 D5 — Communications takes a first-class runtime dependency on `HoneyDrunk.Notify.Abstractions`. The dependency direction is settled; this section documents what rides over it.
+- ADR-0015 — Container Apps hosting platform (per-Node Container Apps within a shared environment).
+```
+
+### `CHANGELOG.md` (Communications repo)
+
+Per the Grid's no-Unreleased convention (use a dated versioned section + SemVer bump before committing), add a new patch version section above the most-recent existing version entry. The CHANGELOG today has v0.2.0 as the most-recent entry; this packet adds v0.2.1 as a docs-only patch bump.
+
+The `Directory.Build.props` (or equivalent version source) bumps from `0.2.0` to `0.2.1` for both packages in the solution (per the all-projects-in-a-solution-share-one-version rule). Both `HoneyDrunk.Communications.Abstractions` and `HoneyDrunk.Communications` move together even though only the runtime package has a doc change; this is consistent with the alignment-bump rule (per-package CHANGELOGs are updated only for packages with actual changes — but here the README is at the repo root, not per-package, so only the repo-level CHANGELOG gets an entry).
+
+New CHANGELOG entry. The existing repo CHANGELOG carries a rolling `## Unreleased` section with two pre-existing `### Internal` entries (a coverage backfill to 83.4% + Grid PR coverage gate baseline; a PR-validation split for read-only contents permissions). Per the no-Unreleased-commits rule, those entries must be **folded into the new dated `## 0.2.1 - 2026-05-20` section** alongside the new `### Changed` entry, and the `## Unreleased` header itself must be removed. The repo's existing convention uses bracket-free version headers (e.g., `## 0.2.0 - 2026-05-18`); the new section matches.
+
+Final consolidated CHANGELOG state after this packet's edits (the new section replaces both `## Unreleased` and sits above `## 0.2.0 - 2026-05-18`):
+
+```markdown
+## 0.2.1 - 2026-05-20
+
+### Changed
+- README: documented the Communications → Notify in-process delivery boundary per ADR-0028 D4. Includes the v1 call shape (`INotificationSender` synchronous call → Notify intake → `INotificationQueue` → Notify worker), the rationale for in-process at v1, and the v2 Service Bus migration path (host-time DI composition change via the existing `ITransportPublisher` abstraction; no code change). Documentation-only — no behavior change, no contract change.
+
+### Internal
+- Backfilled Communications test coverage to 83.4% and seeded the Grid PR coverage gate baseline at 83.3% to avoid rounded-threshold drift.
+- Split PR validation from the default-branch coverage baseline ratchet so pull requests keep read-only contents permissions.
+```
+
+If filing slips past 2026-05-20, the agent uses the **actual filing date** in the section header (e.g., `## 0.2.1 - 2026-05-22`) — the date is the date the version is cut, not the date this packet was authored.
+
+Per-package CHANGELOGs (`src/HoneyDrunk.Communications/CHANGELOG.md` and `src/HoneyDrunk.Communications.Abstractions/CHANGELOG.md`) are **not** updated for this docs-only repo-root edit — the alignment-bump rule (invariant 27) is explicit that per-package CHANGELOGs add noise entries only when the package itself has functional changes. The README is not part of either package.
+
+### Version bump
+
+The version source (`Directory.Build.props` or equivalent) bumps from `0.2.0` to `0.2.1`. Both projects in the solution move together (invariant 27). The bump is a patch — no public surface changes, no breaking changes, no new feature; documentation clarification only.
+
+Per the no-manual-tag-push rule, the agent does **not** push a git tag for the v0.2.1 release. Tag pushes are user-driven.
+
+## Affected Files
+- `README.md` (append the `## Notify Delivery Boundary` section before `## Canonical Node Entry`)
+- `CHANGELOG.md` (new `## 0.2.1 - 2026-05-20` section, bracket-free per repo convention; fold the existing `## Unreleased` Internal entries into this new dated section and delete the `## Unreleased` header)
+- `Directory.Build.props` (version `0.2.0` → `0.2.1`) — if the version is sourced elsewhere (e.g., per-`csproj`), bump each project file in the solution (excluding test projects) consistently
+
+## NuGet Dependencies
+None. This packet does not add or remove `PackageReference` entries on any project. No code change.
+
+## Boundary Check
+- [x] Target is the Communications repo (`HoneyDrunk.Communications`) — correct per the user's prompt and per the ADR's "follow-up packet against Communications" line.
+- [x] No code changes — `README.md`, `CHANGELOG.md`, and the version source file only.
+- [x] No contract changes. `INotificationSender` (in `HoneyDrunk.Notify.Abstractions`), `INotificationQueue` (in `HoneyDrunk.Notify.Queue.Abstractions`), `ITransportPublisher` (in `HoneyDrunk.Transport`) — all referenced by name in the documentation, none modified.
+- [x] No invariant violations. The version bump respects invariants 12 and 27 (semver, all-projects-move-together). The per-package CHANGELOG rule is respected (no alignment-bump noise on per-package CHANGELOGs). No new public API surface, so no README updates beyond this packet's own section.
+- [x] Communications boundary preserved. The new section confirms what is already true (Communications calls `INotificationSender` in-process); it does not introduce new responsibilities or remove existing ones.
+
+## Acceptance Criteria
+- [ ] `README.md` has a new `## Notify Delivery Boundary` section placed after `## Packages` and before `## Canonical Node Entry`.
+- [ ] The section includes the call-shape fenced block (caller → `ICommunicationOrchestrator.SendAsync` → preference + cadence + decision log → `INotificationSender.SendAsync` → Notify intake → `INotificationQueue` → Notify worker).
+- [ ] The section names `INotificationQueue` in `HoneyDrunk.Notify.Queue.Abstractions` explicitly as Notify's internal queue (the first async hop in the path), and explicitly states that this queue is **not** routed through `HoneyDrunk.Transport`.
+- [ ] The section includes the "Why in-process at v1" subsection with at least the three bullets from the Proposed Implementation (single-Container-App composition; most-trafficked seam doesn't need a broker at v1; abstractions already in place for the v2 swap).
+- [ ] The section includes the "v2 migration path (Service Bus)" subsection with the five-step sequence (split Container Apps; provision Service Bus queue; register `ITransportPublisher`; swap `INotificationSender` registration; register Transport consumer in Notify). The five steps must explicitly state that **no application code in either Node changes** — the swap is host-time DI composition only.
+- [ ] The section includes the "References" subsection naming ADR-0028 D4, ADR-0028 D5, ADR-0019 D5, and ADR-0015.
+- [ ] `CHANGELOG.md` has a new `## 0.2.1 - 2026-05-20` section (bracket-free header, matching the repo's existing convention — `## 0.2.0 - 2026-05-18` is the immediate predecessor) under `### Changed` with the docs-only entry described in the Proposed Implementation.
+- [ ] **If the packet is filed/landed after 2026-05-20, the agent uses the actual landing date in the section header** (e.g., `## 0.2.1 - 2026-05-22`). The date is the date the version is cut, not the date this packet was authored. Do not ship a `## 0.2.1 - 2026-05-20` section if the PR merges on a later date.
+- [ ] Fold the existing `## Unreleased` content into `## 0.2.1 - 2026-05-20` under appropriate `### Internal` subsections alongside the new `### Changed` entry; do **not** leave an `## Unreleased` section in the file. The two existing `### Internal` entries (coverage backfill to 83.4% + Grid PR coverage gate baseline; PR-validation split for read-only contents permissions) belong inside the new dated section, not above it.
+- [ ] The version source for both `HoneyDrunk.Communications` and `HoneyDrunk.Communications.Abstractions` is bumped to `0.2.1`. Both projects in the solution move together (invariant 27); test projects are excluded from the bump.
+- [ ] Per-package CHANGELOGs (`src/HoneyDrunk.Communications/CHANGELOG.md` and `src/HoneyDrunk.Communications.Abstractions/CHANGELOG.md`) are **not** edited — no alignment-bump noise (invariant 27).
+- [ ] The agent does not push a git tag for v0.2.1; tag pushes are user-driven.
+- [ ] No code file in `src/**` or `tests/**` is modified. No `.cs`, no `.csproj` other than the version-source bump if it lives in per-`csproj` (and even then only the `<Version>` element).
+- [ ] PR description references this packet (per the PR-to-packet linking invariant inlined below).
+- [ ] PR description states explicitly: this is a documentation packet that codifies the existing v1 in-process call shape and the v2 Service Bus migration path. No behavior change. No contract change. No deployment trigger.
+
+## Human Prerequisites
+None. This packet is fully delegable; the agent edits two doc files and the version source, then opens a PR.
+
+## Referenced ADR Decisions
+
+**ADR-0028 D4 (Communications → Notify is in-process at v1, Service Bus when scale demands it):**
+
+> At v1 (single Container App per Node, low/bursty traffic), the call is in-process. Communications resolves intent, checks preferences and cadence, then synchronously invokes Notify's `INotificationSender`. Notify's *own internal* queue (Notify intake → Notify worker, use case #3) is the first async hop. This matches the existing design and the behavior Notify already ships.
+>
+> The seam to Service Bus opens when Notify Cloud's tier ceiling pressures it... If Notify Cloud sustains a load where Communications and Notify benefit from being independently scaled — different replica counts, different Container Apps — the path is to introduce a Service Bus queue between them via the existing `ITransportPublisher` / `ITransportConsumer` abstraction. **Communications already composes Transport in its planned dependencies** (Communications → Transport is implied by orchestration over a queue); the abstractions are in place. The change is a host-time composition, not a code rewrite.
+
+The documentation section produced by this packet is the operational form of D4.
+
+**ADR-0028 D5 (Service Bus shared namespace per environment):** `sbns-hd-shared-{env}` for `dev`/`stg`/`prod`, Standard tier, queues `sbq-{purpose}-{env}`. The v2 migration path documented in this packet uses `sbq-communications-notify-{env}` as the queue name pattern, matching this rule.
+
+**ADR-0019 D5 (Communications takes a first-class runtime dependency on `HoneyDrunk.Notify.Abstractions`):** Communications composes `HoneyDrunk.Notify.Abstractions` directly; downstream Nodes consume only `HoneyDrunk.Communications.Abstractions`. This packet does not change that direction — it documents what rides over the dependency.
+
+**ADR-0015 (Container Apps hosting platform):** Containerized deployable Nodes run on Azure Container Apps within a shared Container Apps Environment per environment. The v2 migration path documented in this packet lives inside that environment — no cross-environment routing, no per-Node environments.
+
+## Referenced Invariants
+
+> **Invariant 12:** Semantic versioning with `CHANGELOG.md` and `README.md`. Every shipped change gets an entry in the repo-level changelog. — This packet bumps the version from `0.2.0` to `0.2.1` (patch, docs-only) and adds a repo-level CHANGELOG entry.
+
+> **Invariant 23:** Every tracked work item has a GitHub Issue in its target repo. No work tracked exclusively in packet files, chat logs, or external tools.
+
+> **Invariant 27:** All projects in a solution share one version and move together. When a version bump is warranted, every `.csproj` in the solution (excluding test projects) is updated to the same new version in a single commit. Partial bumps are forbidden. **The first packet to land on a solution in an initiative bumps the version; subsequent packets on the same solution append to the CHANGELOG only. The repo-level `CHANGELOG.md` must always get an entry for the new version. Per-package changelogs are updated only for packages with actual changes — do not add alignment-bump noise entries.** — This packet is the only Communications-repo packet in this initiative, so it both bumps the version and appends the entry. Per-package CHANGELOGs stay untouched.
+
+> **Invariant 32:** Agent-authored PRs must link to their packet in the PR body. The review agent resolves the packet via this link and uses it as the primary scope anchor. Absent the link, the PR receives a degraded review.
+
+> **Invariant 40:** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Communications.Abstractions`. Composition against `HoneyDrunk.Communications` is a host-time concern. — Not violated; this packet does not change Communications' public dependency surface.
+
+> **Invariant 41:** Preference enforcement, cadence rules, and suppression logic for outbound messages live in HoneyDrunk.Communications, not in HoneyDrunk.Notify. Notify owns delivery mechanics; Communications owns decision logic. — Not violated; the new section reaffirms this split (preference + cadence + decision-log checks happen in Communications before `INotificationSender.SendAsync` is called).
+
+## Dependencies
+
+Blocked by packets 01 and 02 of this initiative. The new section's "References" subsection points at ADR-0028 D4 (settled by the ADR itself), but the developer-facing reference for "which backing serves which use case" lives in the Transport repo's `integration-points.md` (packet 01) and the "no telemetry on Transport" rule lives in Transport's `boundaries.md` (packet 02). Both must merge before this packet's Communications-side doc lands so the cross-references are not dangling.
+
+Packet 03 (Pulse boundaries) is independent — Pulse is not on Communications' call path and is not referenced by this packet's new section. No dependency on packet 03.
+
+## Labels
+`chore`, `tier-2`, `docs`, `ops`, `adr-0028`
+
+## Agent Handoff
+
+**Objective:** Add a `## Notify Delivery Boundary` section to `HoneyDrunk.Communications/README.md` documenting the v1 in-process `INotificationSender` → `INotificationQueue` call shape and the v2 Service Bus migration path (host-time DI composition change via the existing `ITransportPublisher` abstraction). Bump the solution version from `0.2.0` to `0.2.1` and append the corresponding repo-level CHANGELOG entry. No code changes; no per-package CHANGELOG edits; no git-tag push.
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Communications`, branch from `main`.
+
+**Context:**
+- Goal: Codify the Communications → Notify boundary at the call-shape level so future readers see the in-process choice, the Notify-internal queue (`INotificationQueue`) as the first async hop, and the host-time migration path to Service Bus in one place.
+- Feature: ADR-0028 Event-Driven Architecture and Messaging, Wave 2.
+- ADRs: ADR-0028 (Proposed at edit time; auto-flipped to Accepted by hive-sync after all four packets in this initiative close). ADR-0019 (Accepted — settled the dependency direction; this packet documents what rides over it). ADR-0015 (Container Apps hosting platform — referenced in the migration-path subsection).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** packet:01 (Transport `integration-points.md` matrix), packet:02 (Transport `boundaries.md` scope clarification).
+
+**Constraints:**
+
+- **Invariant 12:** Semantic versioning with `CHANGELOG.md` and `README.md`. Breaking changes bump major; new features bump minor; fixes bump patch. Every shipped change gets an entry in the repo-level changelog. This packet is a docs-only patch bump (`0.2.0` → `0.2.1`).
+
+- **Invariant 23:** Every tracked work item has a GitHub Issue in its target repo.
+
+- **Invariant 27:** All projects in a solution share one version and move together. When a version bump is warranted, every `.csproj` in the solution (excluding test projects) is updated to the same new version in a single commit. Partial bumps are forbidden. Per-package CHANGELOGs are updated only for packages with actual changes — do not add alignment-bump noise entries. The repo-level `CHANGELOG.md` always gets an entry for the new version.
+
+- **Invariant 32:** Agent-authored PRs must link to their packet in the PR body.
+
+- **No code, no contracts.** Do NOT modify any `.cs` file. Do NOT modify `INotificationSender`, `INotificationQueue`, `ITransportPublisher`, or any other contract referenced in the new section. Do NOT change `INotificationSender`'s name to `INotifyQueueWriter` — the user's prompt used that name informally; the live contract is `INotificationSender` (in `HoneyDrunk.Notify.Abstractions`) and `INotificationQueue` (in `HoneyDrunk.Notify.Queue.Abstractions`). Reference the live names; do not rename.
+
+- **No deployment trigger.** The v2 migration-path subsection is a forward-looking description, not an action. Do NOT provision any Service Bus namespace, queue, or Container App. Do NOT modify `Directory.Build.props` deployment targets. The migration is gated on tier-ceiling pressure, not on this packet.
+
+- **No per-package CHANGELOG edits.** The README is at the repo root, not inside a package. Only the repo-level `CHANGELOG.md` is updated. `src/HoneyDrunk.Communications/CHANGELOG.md` and `src/HoneyDrunk.Communications.Abstractions/CHANGELOG.md` stay untouched (the alignment-bump-without-functional-changes case).
+
+- **No git-tag push.** The version bump prepares the release; the user pushes the tag when ready. Do not run `git tag` or `git push --tags`.
+
+- **No edits outside Communications repo.** Do not touch `HoneyDrunk.Transport`, `HoneyDrunk.Notify`, `HoneyDrunk.Architecture`, or any other repo. This is a Communications-repo packet only.
+
+- **No changes to `boundaries.md` in the Communications repo's Architecture-side context folder.** The user direction is explicit: this initiative does not touch shared index files or other-repo context files. The Communications repo's own `README.md` is the only doc target for this packet. (The Communications context folder lives in `HoneyDrunk.Architecture/repos/HoneyDrunk.Communications/` — separate repo, separate concern.)
+
+**Key Files:**
+- `README.md` — append the `## Notify Delivery Boundary` section before `## Canonical Node Entry`
+- `CHANGELOG.md` — new `## 0.2.1 - 2026-05-20` section (bracket-free, matching the repo's existing `## 0.2.0 - 2026-05-18` convention); fold the existing `## Unreleased` Internal entries into the new dated section and remove the `## Unreleased` header
+- `Directory.Build.props` (or per-`csproj` if the version is sourced there) — bump `0.2.0` → `0.2.1` for both runtime projects, exclude test projects
+
+**Contracts:**
+- `INotificationSender` (existing, in `HoneyDrunk.Notify.Abstractions`) — referenced by name; not modified.
+- `INotificationQueue` (existing, in `HoneyDrunk.Notify.Queue.Abstractions`) — referenced by name; not modified.
+- `ITransportPublisher` / `ITransportConsumer` (existing, in `HoneyDrunk.Transport`) — referenced by name in the migration-path subsection; not modified.
+- `ICommunicationOrchestrator` (existing, in `HoneyDrunk.Communications.Abstractions`) — referenced by name in the call-shape block; not modified.

--- a/generated/issue-packets/active/adr-0028-event-driven-architecture/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0028-event-driven-architecture/dispatch-plan.md
@@ -1,0 +1,71 @@
+# Dispatch Plan: ADR-0028 Event-Driven Architecture and Messaging
+
+**Date:** 2026-05-20
+**Trigger:** ADR-0028 (Event-Driven Architecture and Messaging — Use-Case-First Backing Selection) Proposed — pins the use-case → backing matrix, disambiguates Pulse signals from domain events, confirms Communications → Notify is in-process at v1, and commits the Grid to Service Bus + Storage Queue + Event Grid system topics + cron + in-process domain events as the six event-driven backings.
+**Type:** Multi-packet, cross-repo. Three packets land in `HoneyDrunk.Architecture` (Transport integration-points, Transport boundaries, Pulse boundaries); one lands in `HoneyDrunk.Communications` (in-process dispatch boundary confirmation).
+**Sector:** Core (Transport) · Ops (Communications, Notify, Pulse)
+**Site sync required:** No.
+**Rollback plan:** All four packets are documentation-only — no code semantics change. Rollback is `git revert` per PR if a packet's edit turns out to be wrong shape. The ADR itself stays Proposed until packets 01–03 merge; if a showstopper surfaces during packet review, the ADR is still Proposed and there is no code-state to unwind. Packet 04 is the Communications-side documentation of an already-shipped in-process design (ADR-0019 D5 settled the dependency direction); reverting that packet would only undo a doc clarification, not behavior.
+
+## Summary
+
+ADR-0028's "If Accepted" checklist enumerates four concrete cross-repo edits that must land before Status flips to Accepted. Each is a discrete documentation packet against the relevant repo's boundary or integration-points file. The deferred `catalogs/contracts.json` update for `IEventPublisher` (custom-topic shape) is **not** scoped in this initiative — D6 defers it explicitly until a future custom-topic use case materializes.
+
+- **P1** (`01-architecture-transport-integration-points-matrix`) — Adds the D2 use-case → backing matrix to `repos/HoneyDrunk.Transport/integration-points.md`. The Transport repo becomes the authoritative developer-facing reference for "which backing for which use case." Architecture-repo edit; ADR-0028's primary acceptance gate.
+- **P2** (`02-architecture-transport-boundaries-scope-clarification`) — Updates `repos/HoneyDrunk.Transport/boundaries.md` to clarify Transport is the abstraction layer for **async commands and durable pub/sub only** — telemetry signals (Pulse), CI cron (Actions), and reactive resource events (Event Grid system topics) are explicitly out of Transport's scope. Encodes the negative-form of D2 (use cases #4, #5, #6 are not Transport) into the boundary doc.
+- **P3** (`03-architecture-pulse-boundaries-signals-vs-events`) — Updates `repos/HoneyDrunk.Pulse/boundaries.md` with D3's "Pulse signals are not domain events" disambiguation. Closes the most-conflated concept in the Grid's messaging surfaces.
+- **P4** (`04-communications-notify-sender-boundary`) — Updates Communications repo documentation to confirm D4's settled principle: `ICommunicationOrchestrator` → `INotificationSender` is in-process at v1, with the Service Bus migration path documented as a future seam (via the existing `ITransportPublisher` abstraction). The implementation already ships per ADR-0019 D5; this packet documents the boundary so future readers don't reinvent it.
+
+All four packets carry `accepts: ADR-0028` in frontmatter so hive-sync auto-flips ADR-0028 Status → Accepted once all four issues close.
+
+**Excluded from this initiative (per the ADR and user direction):**
+- `catalogs/contracts.json` update for `IEventPublisher` (custom-topic shape) — deferred per D6 until a future custom-topic use case lands; flagged here, not scoped.
+- New invariants (telemetry-vs-events; no-raw-broker-SDK-calls) — the ADR proposes them but their landing in `constitution/invariants.md` is a separate scope-agent acceptance-time edit, not packet-driven.
+- Any code change in Transport, Pulse, Notify, or Communications. This ADR is a boundary/decision codification; no shipped behavior changes.
+
+## Execution Model
+
+Two waves. Filing is un-gated — all four packets file in one pass; the `dependencies:` frontmatter wires the blocking chain at filing time.
+
+### Wave 1 — Architecture-repo doc edits (run first, all parallel)
+
+The three Architecture-repo doc edits are independent at the packet level — none blocks the others. They can land in any order or in parallel. They edit different files (Transport's `integration-points.md`, Transport's `boundaries.md`, Pulse's `boundaries.md`).
+
+- [ ] `HoneyDrunk.Architecture`: Add D2 use-case → backing matrix to `repos/HoneyDrunk.Transport/integration-points.md` — [`01-architecture-transport-integration-points-matrix.md`](01-architecture-transport-integration-points-matrix.md)
+- [ ] `HoneyDrunk.Architecture`: Clarify Transport scope in `repos/HoneyDrunk.Transport/boundaries.md` — [`02-architecture-transport-boundaries-scope-clarification.md`](02-architecture-transport-boundaries-scope-clarification.md)
+- [ ] `HoneyDrunk.Architecture`: Add D3 signals-vs-events disambiguation to `repos/HoneyDrunk.Pulse/boundaries.md` — [`03-architecture-pulse-boundaries-signals-vs-events.md`](03-architecture-pulse-boundaries-signals-vs-events.md)
+
+**Wave 1 exit criteria:**
+- `repos/HoneyDrunk.Transport/integration-points.md` carries the use-case → backing matrix from D2.
+- `repos/HoneyDrunk.Transport/boundaries.md` carries the "async commands and durable pub/sub only" scope clarification with explicit out-of-scope items (telemetry signals, CI cron, reactive resource events).
+- `repos/HoneyDrunk.Pulse/boundaries.md` carries the explicit "Pulse signals are not domain events" sentence with the negative-form rules from D3.
+
+### Wave 2 — Communications-side documentation (run after Wave 1)
+
+The Communications-side boundary documentation depends on the Transport-side scope being authoritative first — Communications references "the Transport abstraction" as the migration path, so Transport's own boundary doc needs to be settled before Communications can point at it. Single packet.
+
+- [ ] `HoneyDrunk.Communications`: Confirm in-process `INotificationSender` boundary and document Service Bus migration path — [`04-communications-notify-sender-boundary.md`](04-communications-notify-sender-boundary.md)
+
+**Wave 2 exit criteria:**
+- Communications repo's `README.md` (or equivalent boundary section) explicitly states that `ICommunicationOrchestrator` → `INotificationSender` is in-process at v1.
+- The migration path to Service Bus (via the existing `ITransportPublisher` abstraction, host-time composition) is documented as the v2 seam.
+- The Notify intake → Notify worker queue is documented as the first async hop, separate from any Transport-mediated path.
+
+## ADR Acceptance Gate
+
+Every packet in this initiative carries `accepts: ADR-0028` in frontmatter. The hive-sync agent auto-flips ADR-0028 Status → Accepted when all four filed issues close. No manual ADR-flip edit is part of any packet's acceptance criteria — the auto-flip is the mechanism.
+
+The user's direction also specifies: do **not** touch `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, `adrs/README.md`, `catalogs/*.json`, or any other shared index file. The ADR file header itself is auto-flipped by hive-sync; everything else is out-of-scope for this initiative.
+
+## Archival
+
+Per ADR-0008 D10, when every packet in this initiative reaches `Done` on the org Project board, the entire `active/adr-0028-event-driven-architecture/` folder is moved to `completed/adr-0028-event-driven-architecture/` in a single commit. Partial archival is forbidden.
+
+## Notes
+
+- **No code packets.** Every shipped behavior referenced by this ADR already exists (Transport's providers, Pulse's OTel pipeline, Communications' in-process `INotificationSender` call, Notify's internal queue, Data's Outbox, Vault rotation's Event Grid plumbing). This ADR is a boundary-and-decision codification — the work is documenting the existing choices so future readers (and agents) don't reinvent them. The four packets here all edit doc files; none touch `.cs`, `.csproj`, or any code surface.
+- **Deferred items explicitly flagged.** Custom Event Grid topics (D6), per-flow schema versioning, the static analyzer for "no raw broker SDK calls," and Notify Cloud's external webhook story are all named in the ADR as deferred. None are scoped here; the ADR itself is the tracking surface for those future ADRs.
+- **The two proposed invariants (telemetry-vs-events; no-raw-broker-SDK-calls) are not landed by these packets.** They are listed in the ADR's "New invariants (proposed for `constitution/invariants.md`)" section. Their addition to the constitution is a scope-agent acceptance-time edit, not a packet's job — and per the user's direction this initiative does not touch `constitution/invariants.md`. If the user wants the invariants landed, that is a separate one-packet pass after ADR-0028 flips Accepted.
+- **Catalog state.** No `catalogs/*.json` edits in this initiative. `catalogs/contracts.json`'s existing four Transport contracts (`ITransportPublisher`, `ITransportConsumer`, `IMessageHandler`, `ITransportEnvelope`) are already correct; the `IEventPublisher` entry for D6's deferred custom-topic shape is **not** added here. `catalogs/relationships.json` already captures Pulse → Transport (`PulseIngested`) and Communications → Notify edges; no new edges are introduced.
+- **CHANGELOG conventions across the two affected repos differ on purpose.** Architecture CHANGELOG uses rolling `## Unreleased` — that is the repo convention for catalog/docs nodes (Architecture is not a deployable). Packets 01/02/03 correctly append to `## Unreleased` per this convention. Packet 04's Communications repo is a deployable and follows the no-Unreleased rule: the new section is dated (`## 0.2.1 - 2026-05-20`, bracket-free to match the existing `## 0.2.0 - 2026-05-18` header), and the existing `## Unreleased` entries in the Communications CHANGELOG must be folded into the new dated section before the PR ships.
+- **Self-containment.** Each packet inlines the D-section text it depends on (D2 matrix, D3 disambiguation, D4 in-process decision) so the executing agent never needs to open the ADR file. Invariant 23 and 32 are inlined where relevant; ADR-0019 D5 is inlined in P4 because Communications already settled the dependency direction there.


### PR DESCRIPTION
## Summary

Scopes four packets implementing [ADR-0028](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0028-event-driven-architecture-and-messaging.md)'s required follow-up work (Consequences section). All edits are Architecture-repo docs (Wave 1) plus one Communications-repo README + version bump (Wave 2).

### Wave 1 — parallel doc edits (Architecture)
- **`01-transport-integration-points-matrix`** — adds the D2 use-case → backing matrix verbatim from ADR D2 (7 rows, both qualifiers preserved).
- **`02-transport-boundaries-scope-clarification`** — three new "Does NOT Own" disclaimers in Transport boundaries.md (telemetry/cron/Event Grid system topics).
- **`03-pulse-boundaries-signals-vs-events`** — D3 "Pulse signals are not domain events" disambiguation.

### Wave 2 — Communications repo
- **`04-communications-notify-sender-boundary`** — README documents the concrete `INotificationSender` → `INotificationQueue` boundary + the in-process Communications → Notify hop with the Service Bus migration path. Bumps Communications solution `0.2.0` → `0.2.1` (docs-only patch per invariants 12 + 27, alignment-bump rule). Folds existing `## Unreleased` CHANGELOG entries into the new dated `## 0.2.1 - 2026-05-20` section per the no-Unreleased-commits rule. Depends on packets 01 + 02.

## Out of scope (explicit deferrals)
- The two **proposed constitutional invariants** (telemetry-vs-events; no-raw-broker-SDK-calls) — NOT landed as constitution edits. They live as operational rules in the Transport boundary doc.
- **`catalogs/contracts.json` `IEventPublisher`** — deferred per ADR-0028 D6 (Event Grid custom topics not committed at v1).
- No catalog edits, no constitutional invariants.

## Hive-sync wiring

All four packets carry `accepts: ADR-0028` so hive-sync auto-flips the ADR to Accepted when all four issues close.

## Filing

When this merges, `file-packets.yml` auto-files four issues — three against `HoneyDrunkStudios/HoneyDrunk.Architecture` (Wave 1 doc edits) and one against `HoneyDrunkStudios/HoneyDrunk.Communications` (Wave 2 README + version bump).

## Test plan

- [ ] After merge, verify four issues file automatically
- [ ] Confirm Wave 2 packet's `dependencies:` are wired as `addBlockedBy` edges on The Hive
- [ ] After Wave 1 PRs land in Architecture, Wave 2 unblocks
- [ ] When all four close, hive-sync auto-flips ADR-0028 Proposed → Accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)