### PR TITLE
chore: scope ADR-0018 operator node standup

### DIFF
--- a/generated/issue-packets/active/adr-0018-operator-standup/01-architecture-operator-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0018-operator-standup/01-architecture-operator-catalog-registration.md
@@ -1,0 +1,400 @@
+---
+name: Architecture Catalog Registration
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0018"]
+dependencies: []
+adrs: ["ADR-0018", "ADR-0030", "ADR-0031"]
+accepts: ADR-0018
+wave: 1
+initiative: adr-0018-operator-standup
+node: honeydrunk-operator
+---
+
+# Chore: Register HoneyDrunk.Operator's standup decisions in Architecture catalogs
+
+## Summary
+
+Reflect ADR-0018's stand-up decisions in the canonical Architecture catalogs and the AI sector architecture doc. Reconcile `contracts.json` to drop the placeholder `ICostController`, add `ICostGuard` and the missing `IDecisionPolicy` + `ISafetyFilter` interfaces, and add three Operator-owned governance records (`CostEvent`, `ApprovalRequest`, `ApprovalDecision`) — leaving the eight Operator-owned contracts (five interfaces + three records) net of the `IAuditLog`/`AuditEntry` relocation. Update `catalogs/relationships.json` `consumes`, `exposes.contracts`, `exposes.packages`, and `consumed_by_planned` for `honeydrunk-operator`. Refresh `catalogs/grid-health.json` and `catalogs/nodes.json`. Add `repos/HoneyDrunk.Operator/integration-points.md` and `active-work.md`.
+
+**Critical amendment:** per the 2026-05-16 ADR-0030/0031 amendment to ADR-0018, `IAuditLog` and `AuditEntry` are **relocated** out of `HoneyDrunk.Operator.Abstractions` into the new `HoneyDrunk.Audit.Abstractions`. Operator becomes a consumer of those two contracts, not their owner. The catalog edits in this packet reflect the relocation by marking the two contracts as relocated to `honeydrunk-audit` (or removing them from the `honeydrunk-operator` block, depending on the catalog schema's relocation convention at edit time).
+
+ADR-0018 stays at `Status: Proposed` for this packet — the Status flip is a separate post-merge housekeeping step the scope agent handles after the entire initiative completes.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0018 establishes the Operator Node's exposed contracts, package families, downstream-coupling rule, and four invariants the scope agent finalizes at acceptance. None of that has reached the catalogs yet. Until it does, every downstream consumer (Agents, Flow, AI, Capabilities, Evals) reads stale or inconsistent metadata when scoping their own work.
+
+Specific drift items to resolve in this packet:
+
+1. **`contracts.json` lists the old four-interface set** (`IApprovalGate`, `ICircuitBreaker`, `ICostController`, `IAuditLog`). ADR-0018 D3 supersedes that set with six interfaces (renaming `ICostController` → `ICostGuard`, adding `IDecisionPolicy` and `ISafetyFilter`) plus four records (`CostEvent`, `AuditEntry`, `ApprovalRequest`, `ApprovalDecision`). The 2026-05-16 ADR-0030/0031 amendment then relocates `IAuditLog` and `AuditEntry` to `honeydrunk-audit`, leaving **eight Operator-owned** contracts (five interfaces + three records).
+2. **`relationships.json` `honeydrunk-operator.exposes.contracts`** (line 300) currently reads `["IApprovalGate", "ICircuitBreaker", "ICostGuard", "IAuditLog", "IDecisionPolicy", "ISafetyFilter"]`. It already has `ICostGuard` (the rename half landed early) and already has `IDecisionPolicy` + `ISafetyFilter`, but it still lists `IAuditLog` and is missing the three records (`CostEvent`, `ApprovalRequest`, `ApprovalDecision`). Drop `IAuditLog` (relocated per amendment) and add the three records.
+3. **`relationships.json` `honeydrunk-operator.consumed_by_planned`** (line 297) currently reads `["honeydrunk-audit"]` — incomplete. Under ADR-0018 D11 and the Unblocks section, the consumer list is Agents, Flow, AI, Capabilities, Evals, Sim. (`honeydrunk-audit` is not a downstream consumer of Operator; remove it from the list. Audit is an upstream dependency of Operator under the amendment, not a downstream consumer.)
+4. **`relationships.json` `honeydrunk-operator.exposes.packages`** (line 301) lists only `["HoneyDrunk.Operator.Abstractions", "HoneyDrunk.Operator"]`. Add `HoneyDrunk.Operator.Testing` per ADR-0018 D2.
+5. **`relationships.json` `honeydrunk-operator.consumes`** (line 295) is `["honeydrunk-kernel", "honeydrunk-auth", "honeydrunk-data"]` — missing `honeydrunk-audit` (added per the amendment, since Operator now consumes `IAuditLog` from Audit). Add it.
+6. **Amendment from ADR-0030/0031:** `IAuditLog` and `AuditEntry` relocate to `honeydrunk-audit`. Operator consumes them rather than owning them. This affects `contracts.json` (drop entries), `relationships.json` `exposes.contracts` (drop `IAuditLog`) and `relationships.json` `consumes` (add `honeydrunk-audit`).
+7. **`grid-health.json`** has `honeydrunk-operator` only as a stub. It should reflect the standup ADR with the scaffold packet as the active blocker.
+8. **Prose drift for `ICostController`** appears in `repos/HoneyDrunk.Operator/overview.md`, `repos/HoneyDrunk.Operator/boundaries.md`, and `constitution/ai-sector-architecture.md` (note: `relationships.json` itself already uses `ICostGuard`). All `ICostController` references in prose must change to `ICostGuard`.
+
+## Proposed Implementation
+
+### `catalogs/contracts.json` — `honeydrunk-operator` block
+
+Replace the current four-interface seed with the **eight Operator-owned contracts** per D3 as amended — five interfaces (`IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, `IDecisionPolicy`, `ISafetyFilter`) and three records (`CostEvent`, `ApprovalRequest`, `ApprovalDecision`). The original D3 set was six interfaces + four records (ten total); the 2026-05-16 ADR-0030 D5 amendment relocates `IAuditLog` and `AuditEntry` to `honeydrunk-audit`, leaving the eight here. Records drop the `I` prefix and use `kind: "type"`; interfaces keep the prefix and use `kind: "interface"`.
+
+```json
+{
+  "node": "honeydrunk-operator",
+  "node_name": "HoneyDrunk.Operator",
+  "package": "HoneyDrunk.Operator.Abstractions",
+  "status": "seed",
+  "interfaces": [
+    { "name": "IApprovalGate", "kind": "interface", "description": "Raise an approval request, check status, consume a decision. Blocks the calling workflow until resolved or timed out. ADR-0018 D3." },
+    { "name": "ICircuitBreaker", "kind": "interface", "description": "Trip, reset, and query the state of a named breaker. Halts agent, workflow, or inference execution when safety thresholds are breached. ADR-0018 D3." },
+    { "name": "ICostGuard", "kind": "interface", "description": "Check and record spend against per-agent, per-tenant, and per-window budgets. Enforces hard limits; no soft warnings. ADR-0018 D3. Renamed from the previous placeholder ICostController." },
+    { "name": "IDecisionPolicy", "kind": "interface", "description": "Evaluate a declarative rule set to produce allow / deny / require-approval against a given action context. ADR-0018 D3." },
+    { "name": "ISafetyFilter", "kind": "interface", "description": "Validate an outbound content or action payload; rejections block the output, no log-and-continue path. ADR-0018 D3." },
+    { "name": "CostEvent", "kind": "type", "description": "Record. Records a spend event — agent, tenant, window, amount, unit, source. Written by ICostGuard, read by the audit log. ADR-0018 D3." },
+    { "name": "ApprovalRequest", "kind": "type", "description": "Record. Machine-readable approval ask — subject, context, requested scope, expiry. ADR-0018 D3." },
+    { "name": "ApprovalDecision", "kind": "type", "description": "Record. Approval outcome — decision, approver identity, timestamp, reason. ADR-0018 D3." }
+  ]
+}
+```
+
+Changes vs current state:
+
+- **Drop** `ICostController` placeholder.
+- **Rename concept** → `ICostGuard` lands as a new entry per D3.
+- **Add** `IDecisionPolicy` and `ISafetyFilter`.
+- **Add** `CostEvent`, `ApprovalRequest`, `ApprovalDecision` records.
+- **Remove** the existing `IAuditLog` entry from `honeydrunk-operator` per the 2026-05-16 ADR-0030/0031 amendment. `IAuditLog` and `AuditEntry` will be added under `honeydrunk-audit` by the HoneyDrunk.Audit Node standup initiative (out of scope here).
+
+If the catalog schema supports a "relocated to" annotation, add a one-line note on the `honeydrunk-operator` block explaining the audit contracts relocated to `honeydrunk-audit`. Otherwise, the PR body explicitly notes the relocation.
+
+### `catalogs/relationships.json` — `honeydrunk-operator` block
+
+Five edits to the block at lines 293-308.
+
+**(a) `consumes` array** (line 295). Add `honeydrunk-audit` per the 2026-05-16 ADR-0030/0031 amendment — Operator now consumes `IAuditLog` from Audit:
+
+```json
+"consumes": ["honeydrunk-kernel", "honeydrunk-auth", "honeydrunk-data", "honeydrunk-audit"]
+```
+
+**(b) `exposes.contracts` array** (line 300). Replace with the eight Operator-owned contracts (drop `IAuditLog`, add three records):
+
+```json
+"contracts": ["IApprovalGate", "ICircuitBreaker", "ICostGuard", "IDecisionPolicy", "ISafetyFilter", "CostEvent", "ApprovalRequest", "ApprovalDecision"]
+```
+
+**(c) `exposes.packages` array** (line 301). Add `HoneyDrunk.Operator.Testing` per ADR-0018 D2:
+
+```json
+"packages": ["HoneyDrunk.Operator.Abstractions", "HoneyDrunk.Operator", "HoneyDrunk.Operator.Testing"]
+```
+
+**(d) `consumed_by_planned` array** (line 297). Replace the current incomplete `["honeydrunk-audit"]` entry with the six AI-sector downstream consumers:
+
+```json
+"consumed_by_planned": ["honeydrunk-agents", "honeydrunk-flow", "honeydrunk-ai", "honeydrunk-capabilities", "honeydrunk-evals", "honeydrunk-sim"]
+```
+
+**Note on `honeydrunk-sim` addition.** ADR-0018's original Unblocks section enumerated five consumer Nodes (Agents, Flow, AI, Capabilities, Evals). `honeydrunk-sim` is added here per **ADR-0025 D9** (Sim's standup ADR) which lists Operator's `ICostGuard`, `ISafetyFilter`, and `IApprovalGate` as compile-time prerequisites for the observation-only prediction composition Sim uses. This is a justified expansion of ADR-0018's "Required Follow-Up Work" set, not a scope override — Sim was either underspecified at ADR-0018 authoring time or added between ADR-0018 and ADR-0025. The catalog needs to reflect the full consumer set; ADR-0018 itself stays Proposed unchanged in this packet.
+
+**Note on removing `honeydrunk-audit` from `consumed_by_planned`.** The current entry treats Audit as a downstream consumer of Operator — that is no longer correct under the amendment. Audit is an **upstream** dependency of Operator (Operator consumes `IAuditLog`). Move `honeydrunk-audit` from `consumed_by_planned` into `consumes` (see edit (a) above).
+
+**(e) `consumes_detail`** (lines 303-307). Add an upstream `honeydrunk-audit` entry, and add downstream `consumes_detail` reverse-edge entries for each `consumed_by_planned` consumer:
+
+- Add to existing block: `"honeydrunk-audit": ["IAuditLog", "AuditEntry", "HoneyDrunk.Audit.Abstractions"]` per the 2026-05-16 amendment.
+- Per-downstream-edge `consumes_detail` (these are reverse-edges; whether they live in a sibling block in `relationships.json` schema is a judgment call for the executing agent — if the schema only carries upstream `consumes_detail`, capture the downstream detail in the consumer Node blocks instead):
+  - Agents: `["IApprovalGate", "ICircuitBreaker", "HoneyDrunk.Operator.Abstractions"]` (ADR-0020 D7)
+  - Flow: `["IApprovalGate", "ICircuitBreaker", "ICostGuard", "HoneyDrunk.Operator.Abstractions"]` (ADR-0024 D7)
+  - AI: `["ICostGuard", "ISafetyFilter", "ICircuitBreaker", "HoneyDrunk.Operator.Abstractions"]` (ADR-0018 Unblocks)
+  - Capabilities: `["IDecisionPolicy", "HoneyDrunk.Operator.Abstractions"]` (ADR-0018 Unblocks — chained above `ICapabilityGuard`)
+  - Evals: `["ISafetyFilter", "ICostGuard", "HoneyDrunk.Operator.Abstractions"]` (ADR-0023 D7)
+  - Sim: `["ICostGuard", "ISafetyFilter", "IApprovalGate", "HoneyDrunk.Operator.Abstractions"]` (ADR-0025 D9 — justified expansion of ADR-0018's original Unblocks set)
+
+### `catalogs/grid-health.json` — `honeydrunk-operator` block
+
+Replace the existing stub with one that reflects ADR-0018 acceptance:
+
+```json
+{
+  "id": "honeydrunk-operator",
+  "name": "HoneyDrunk.Operator",
+  "sector": "AI",
+  "signal": "Seed",
+  "version": "0.0.0",
+  "canary_status": "none",
+  "last_release": null,
+  "active_blockers": ["Scaffold packet (Operator#NN — packet 03 of adr-0018-operator-standup) not yet executed"],
+  "notes": "ADR-0018 standup ADR Proposed 2026-04-19 (Status flip is post-merge housekeeping). Catalog surface registered (8 Operator-owned contracts per D3 minus IAuditLog/AuditEntry which relocate to honeydrunk-audit per 2026-05-16 ADR-0030/0031 amendment). Awaiting scaffold: HoneyDrunk.Operator.Abstractions, HoneyDrunk.Operator runtime, HoneyDrunk.Operator.Testing fixture, Standards wiring, CI with contract-shape canary scoped to four hot-path interfaces (IApprovalGate, ICircuitBreaker, ICostGuard, ISafetyFilter)."
+}
+```
+
+### `catalogs/nodes.json` — `honeydrunk-operator` block
+
+Locate the `honeydrunk-operator` block and:
+
+**(a) `grid_relationship` field.** Replace with text reflecting D11 + D12:
+
+> `"grid_relationship": "Consumes Kernel (context, identity, lifecycle, telemetry), Auth (authorization policy for IDecisionPolicy / IApprovalGate's default), Data (IRepository / IUnitOfWork for the spend ledger), and Audit (IAuditLog consumed per ADR-0030/0031 amendment). Emits gate, breaker, cost, and audit-decision telemetry consumed by Pulse — no runtime dependency on Pulse. Emits approval-needed events consumed by Communications via event-out — no runtime dependency on Communications. Consumed by Agents, Flow, AI, Capabilities, Evals, Sim."`
+
+**(b) `tags`.** Ensure tags reflect the contract surface: include `approval`, `circuit-breaker`, `cost-guard`, `decision-policy`, `safety-filter`. Drop any `cost-controller` tag if present.
+
+**(c) `value_props`.** Replace any reference to `ICostController` with `ICostGuard`. Add a value-prop string for `IDecisionPolicy` and `ISafetyFilter` if not already present.
+
+### `constitution/ai-sector-architecture.md` — Operator section
+
+Locate the Operator section. Apply these edits:
+
+**(a) Key Contracts list.** Replace the current contract list with:
+
+```
+- `IApprovalGate` — Raise an approval request; consume a decision
+- `ICircuitBreaker` — Trip, reset, query state
+- `ICostGuard` — Per-agent/tenant/window budget enforcement
+- `IDecisionPolicy` — Declarative rule evaluation → allow/deny/require-approval
+- `ISafetyFilter` — Validate outbound content or action payloads
+- `CostEvent` — Record. Spend-event metadata
+- `ApprovalRequest` / `ApprovalDecision` — Records. Approval ask + outcome
+- `IAuditLog` / `AuditEntry` — relocated to `HoneyDrunk.Audit` per ADR-0030/0031 amendment; Operator consumes
+```
+
+**(b) Depends-on phrasing.** Split into:
+
+> `**Depends on:** Kernel (context, lifecycle, telemetry), Auth (IAuthorizationPolicy for IDecisionPolicy and IApprovalGate's default), Data (IRepository, IUnitOfWork for the spend ledger), Audit (IAuditLog consumed per ADR-0030/0031 amendment)`
+>
+> `**Emits to (no runtime dependency):** Pulse (gate / breaker / cost / decision telemetry per call via Kernel's ITelemetryActivityFactory); Communications (approval-needed events via event-out per ADR-0018 D8)`
+
+### `repos/HoneyDrunk.Operator/overview.md`
+
+Replace `ICostController` with `ICostGuard` in the Key Interfaces list. Add `IDecisionPolicy` and `ISafetyFilter` if not already present. The current overview already lists six interfaces matching D3 except for the `ICostController` → `ICostGuard` rename.
+
+Add a Packages-table row for `HoneyDrunk.Operator.Testing`:
+
+```
+| `HoneyDrunk.Operator.Testing` | Testing fixture | Opt-in NuGet package — in-memory implementations of every exposed interface for deterministic unit and integration tests. Never composed into production hosts. |
+```
+
+Add a note immediately below the Key Interfaces list:
+
+> `**Note:** `IAuditLog` and `AuditEntry` are relocated to `HoneyDrunk.Audit.Abstractions` per the 2026-05-16 ADR-0030/0031 amendment. Operator consumes those two contracts; it does not own them. The other eight contracts above stay Operator-owned.`
+
+### `repos/HoneyDrunk.Operator/boundaries.md`
+
+Replace any `ICostController` reference with `ICostGuard`. Add a "What Operator does not own" subsection clarifying that audit ownership transferred to HoneyDrunk.Audit per the ADR-0030/0031 amendment.
+
+### `repos/HoneyDrunk.Operator/integration-points.md` — new file
+
+Create this file matching the template used by `repos/HoneyDrunk.Agents/integration-points.md`:
+
+```markdown
+# HoneyDrunk.Operator — Integration Points
+
+How Operator connects to the rest of the Grid. Every item here represents a cross-Node boundary that requires a canary test.
+
+## Consumes
+
+| Node | Contract | Purpose |
+|------|----------|---------|
+| **Kernel** | `IGridContext`, `IOperationContext`, `INodeContext` | Every gate, breaker, cost, and decision operation runs inside a Grid context. CorrelationId flows through every decision. |
+| **Kernel** | `IStartupHook`, `IShutdownHook` | Breaker / gate state initialization at startup; graceful drain on shutdown. |
+| **Kernel** | `ITelemetryActivityFactory` | Emits per-call activities for gate outcomes, breaker state changes, cost events, decision evaluations, safety-filter decisions. Pulse consumes these — see Emits below. |
+| **Auth** | `IAuthorizationPolicy`, `AuthorizationDecision` | The default `IDecisionPolicy` and the `IApprovalGate` permissions-check delegate to Auth. Operator does not maintain an independent permission model (ADR-0018 D5). |
+| **Data** | `IRepository`, `IUnitOfWork` | Spend ledger persistence for `ICostGuard`; breaker state persistence (when non-volatile); approval request/decision persistence (when the runtime decides to outlive an in-memory store). ADR-0018 D12. |
+| **Audit** | `IAuditLog`, `AuditEntry` | Per the ADR-0030/0031 amendment, the audit-log surface is owned by the HoneyDrunk.Audit Node. Operator emits AuditEntry records through IAuditLog for every gate / breaker / cost / approval / safety-filter decision.
+
+## Exposes
+
+| Contract | Consumer | Notes |
+|----------|---------|-------|
+| `IApprovalGate` | Agents, Flow, AI | Synchronous on the hot path; raises ApprovalRequest events emitted via event-out for Communications to deliver. |
+| `ICircuitBreaker` | Agents, Flow, AI, Capabilities | Trip-and-halt semantics; consumers consult before dispatching expensive or safety-critical work. |
+| `ICostGuard` | Agents, Flow, AI, Evals, Sim | Per-agent / per-tenant / per-window budget enforcement. Hard limits, no soft warnings. |
+| `IDecisionPolicy` | Capabilities (chained above `ICapabilityGuard`), Agents, Flow | Declarative rule evaluation → allow / deny / require-approval. |
+| `ISafetyFilter` | AI, Evals, Sim | Output-side content validation; rejections block the output, no log-and-continue. |
+| `CostEvent`, `ApprovalRequest`, `ApprovalDecision` | All consumers | Records carrying cost / approval metadata; travel through ICostGuard / IApprovalGate / IAuditLog. |
+
+## Emits (no runtime dependency)
+
+| Signal | Consumer | Notes |
+|--------|----------|-------|
+| Gate / breaker / cost / decision / safety-filter activities | **Pulse** | Emitted via Kernel's ITelemetryActivityFactory. One-way by contract. |
+| `ApprovalRequest`-needed events | **Communications** | Event-out per ADR-0018 D8. Operator does not call ICommunicationOrchestrator directly. Transport mechanism deferred to scaffold. |
+| `AuditEntry` writes | **Audit** | Per the ADR-0030/0031 amendment, the audit surface is owned by HoneyDrunk.Audit. Operator emits, Audit owns the durable log.
+
+## Canary Coverage Required
+
+Before any Operator code can be considered production-ready:
+
+- `Operator.Canary` → Kernel: verifies `IGridContext` flows through every gate / breaker / cost / decision operation, CorrelationId is propagated.
+- `Operator.Canary` → Auth: verifies `IDecisionPolicy` default returns allow / deny / require-approval according to Auth policy.
+- `Operator.Canary` → Data: verifies cost ledger writes round-trip through `IRepository` and `IUnitOfWork`.
+- `Operator.Canary` → Audit: verifies that every gate / breaker / cost / approval / safety-filter decision produces an `AuditEntry` written via `IAuditLog` (consumed from Audit per ADR-0030/0031).
+- `Operator.Canary` → contract-shape: contract-shape canary in CI fails the build if `IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, or `ISafetyFilter` change shape without a version bump (ADR-0018 D10 / Operator canary invariant — number assigned at acceptance).
+
+## Dependency Order for Bring-Up
+
+Operator cannot be scaffolded until these Nodes have published their Abstractions packages:
+
+1. Kernel (already Live — `HoneyDrunk.Kernel.Abstractions` stable)
+2. Auth (already Live — `HoneyDrunk.Auth.Abstractions` stable)
+3. Data (already Live — Repository / UnitOfWork stable)
+4. Audit (must publish `HoneyDrunk.Audit.Abstractions` for `IAuditLog`/`AuditEntry` consumption per ADR-0030/0031 amendment — if not yet published at Operator's scaffold time, Operator's runtime can ship without writing audit and add the Audit dependency in a follow-up packet)
+
+Operator is itself a hard prerequisite for:
+
+1. Agents (`HoneyDrunk.Agents.Abstractions` — Seed, blocked on Operator for `IApprovalGate`, `ICircuitBreaker` consumption per ADR-0020 D7)
+2. Flow (`HoneyDrunk.Flow.Abstractions` — Seed, blocked on Operator for synchronous in-loop composition per ADR-0024 D7)
+3. AI (currently Seed — needs `ICostGuard`, `ISafetyFilter`, `ICircuitBreaker` for the inference-bounding path)
+4. Capabilities (currently Seed — chains `IDecisionPolicy` above `ICapabilityGuard`)
+5. Evals (`HoneyDrunk.Evals.Abstractions` — Seed, blocked on Operator for observation-only composition per ADR-0023 D7)
+6. Sim (`HoneyDrunk.Sim.Abstractions` — Seed, blocked on Operator for observation-only prediction composition per ADR-0025 D9)
+```
+
+### `repos/HoneyDrunk.Operator/active-work.md` — new file
+
+Create this file matching the template used by `repos/HoneyDrunk.Agents/active-work.md`. Include the scaffold packet as the active work item.
+
+### `initiatives/active-initiatives.md` — new entry
+
+Add a new entry under `## In Progress`:
+
+```markdown
+### ADR-0018 HoneyDrunk.Operator Standup
+**Status:** In Progress
+**Scope:** Architecture, HoneyDrunk.Operator
+**Initiative:** `adr-0018-operator-standup`
+**Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)
+**Description:** Stand up `HoneyDrunk.Operator` as the AI sector's human-policy-enforcement substrate per ADR-0018. Catalog reconciliation (rename ICostController → ICostGuard; add IDecisionPolicy, ISafetyFilter, three Operator-owned records — CostEvent, ApprovalRequest, ApprovalDecision; reflect 2026-05-16 ADR-0030 D5 amendment relocating IAuditLog / AuditEntry to honeydrunk-audit), four new invariants for D11 / D6 / D8 / D10 (default numbers 47/48/49/50), human-only repo verification + clone confirmation, and the scaffold packet (three packages: Abstractions, runtime, Testing fixture). Unblocks Agents, Flow, AI, Capabilities, Evals, Sim.
+
+**Tracking:**
+- [ ] Architecture#NN: Catalog registration + integration-points (packet 01)
+- [ ] Architecture#NN: Add four new invariants for D11 / D6 / D8 / D10 (packet 02)
+- [ ] Architecture#NN: Verify HoneyDrunk.Operator repo + clone (human-only — packet 02b)
+- [ ] Operator#NN: Scaffold HoneyDrunk.Operator (packet 03)
+
+> **Sync (2026-MM-DD):** Initiative scoped today. Packets 01/02/02b ready to file in Wave 1/2; packet 03 (Operator scaffold) parked on packets 02 + 02b landing.
+```
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the Unreleased section:
+
+`Architecture: Register ADR-0018 standup decisions in catalogs (contracts.json drops ICostController and adds the eight Operator-owned D3 contracts; relationships.json reconciles consumes, exposes.contracts/packages, consumed_by_planned, and consumes_detail; grid-health.json gets the standup block; nodes.json grid_relationship reflects D11/D12; ai-sector-architecture.md and Operator overview/boundaries adopt ICostGuard rename; new repos/HoneyDrunk.Operator/integration-points.md and active-work.md filed; active-initiatives.md gets the new initiative block). Reflects the 2026-05-16 ADR-0030 D5 amendment relocating IAuditLog / AuditEntry to honeydrunk-audit. ADR-0018 stays Proposed in this packet — the Status flip is a separate post-merge housekeeping step.`
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+- `catalogs/grid-health.json`
+- `catalogs/nodes.json`
+- `constitution/ai-sector-architecture.md`
+- `repos/HoneyDrunk.Operator/overview.md`
+- `repos/HoneyDrunk.Operator/boundaries.md`
+- `repos/HoneyDrunk.Operator/integration-points.md` (new)
+- `repos/HoneyDrunk.Operator/active-work.md` (new)
+- `initiatives/active-initiatives.md`
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] No code changes; metadata + docs only.
+- [x] D3 contract surface (eight Operator-owned contracts) authored verbatim per ADR-0018.
+- [x] `IAuditLog` / `AuditEntry` relocation respects the 2026-05-16 ADR-0030/0031 amendment.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` `honeydrunk-operator` block lists exactly the eight Operator-owned D3 contracts: `IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, `IDecisionPolicy`, `ISafetyFilter`, `CostEvent`, `ApprovalRequest`, `ApprovalDecision`. No `ICostController`. No `IAuditLog` / `AuditEntry` (relocated).
+- [ ] Records use `kind: "type"` (not `kind: "record"` and not `kind: "interface"`).
+- [ ] `catalogs/relationships.json` `honeydrunk-operator` `exposes.contracts` array matches the same eight-contract surface.
+- [ ] `catalogs/relationships.json` `honeydrunk-operator` `exposes.packages` includes `HoneyDrunk.Operator.Testing` as third entry.
+- [ ] `catalogs/relationships.json` `honeydrunk-operator` `consumed_by_planned` lists `honeydrunk-agents`, `honeydrunk-flow`, `honeydrunk-ai`, `honeydrunk-capabilities`, `honeydrunk-evals`, `honeydrunk-sim`, each with `consumes_detail` per the table above.
+- [ ] `catalogs/grid-health.json` `honeydrunk-operator` block reflects the standup ADR with the scaffold packet noted as the active blocker; `notes` field names the eight D3 contracts and the ADR-0030/0031 amendment.
+- [ ] `catalogs/nodes.json` `honeydrunk-operator.grid_relationship` field reflects D11/D12; one-way emission to Pulse and Communications per D7/D8.
+- [ ] `catalogs/nodes.json` `honeydrunk-operator.tags` includes `cost-guard`, `decision-policy`, `safety-filter`; no `cost-controller` token.
+- [ ] `constitution/ai-sector-architecture.md` Operator section Key Contracts list updated with the eight D3 contracts + amendment note; Depends-on phrasing split into "Depends on" and "Emits to (no runtime dependency)" lines.
+- [ ] `repos/HoneyDrunk.Operator/overview.md` Key Interfaces list reads `ICostGuard` not `ICostController`; Packages table includes `HoneyDrunk.Operator.Testing` row; amendment note added.
+- [ ] `repos/HoneyDrunk.Operator/boundaries.md` no `ICostController` references; "What Operator does not own" subsection clarifies audit relocation per ADR-0030/0031.
+- [ ] `repos/HoneyDrunk.Operator/integration-points.md` exists and matches the structure of `repos/HoneyDrunk.Agents/integration-points.md`.
+- [ ] `repos/HoneyDrunk.Operator/active-work.md` exists.
+- [ ] `grep -nr "ICostController" catalogs/ repos/HoneyDrunk.Operator/ constitution/` returns zero matches.
+- [ ] `adrs/ADR-0018-stand-up-honeydrunk-operator-node.md` is **not** modified by this packet. ADR-0018 stays at `Status: Proposed`.
+- [ ] `initiatives/active-initiatives.md` includes a new "ADR-0018 HoneyDrunk.Operator Standup" block under `## In Progress`.
+- [ ] `CHANGELOG.md` Unreleased section updated.
+
+## Human Prerequisites
+None. The 2026-05-16 ADR-0030/0031 amendment text is already present in ADR-0018 (Amendment section). This packet reflects it in the catalogs.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — Reinforces why `HoneyDrunk.Operator.Abstractions` is the only thing downstream Nodes compile against, and why the package field on the `honeydrunk-operator` `contracts.json` entry stays at that name.
+
+> **Invariant 4:** No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+
+> **Invariant 11:** One repo per Node (or tightly coupled Node family). Each repo has its own solution, CI pipeline, and versioning.
+
+## Referenced ADR Decisions
+
+**ADR-0018 D3 (Exposed contracts), as amended by ADR-0030 D5:** Originally six interfaces + four records (ten total); after the 2026-05-16 ADR-0030 D5 relocation of `IAuditLog`/`AuditEntry` to `honeydrunk-audit`, the Operator-owned set is **eight** — five interfaces (`IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, `IDecisionPolicy`, `ISafetyFilter`) + three records (`CostEvent`, `ApprovalRequest`, `ApprovalDecision`). `ICostController` superseded by `ICostGuard`. Records drop `I` prefix; interfaces keep it.
+
+**ADR-0018 D5 (Authorization through Auth):** Operator runs on top of Auth's decision. The default `IDecisionPolicy` and `IApprovalGate` delegate to Auth's policy.
+
+**ADR-0018 D7 (Telemetry direction):** Operator emits via Kernel's `ITelemetryActivityFactory`; Pulse consumes. No runtime dependency on Pulse.
+
+**ADR-0018 D8 (Approval event-out):** Operator emits `ApprovalRequest`-needed events that Communications consumes. No runtime dependency on Communications.
+
+**ADR-0018 D11 (Downstream coupling):** Downstream Nodes compile only against `HoneyDrunk.Operator.Abstractions`.
+
+**ADR-0018 D12 (Kernel, Auth, Data first-class):** Operator takes first-class runtime dependencies on Kernel, Auth, and Data.
+
+**ADR-0018 Amendment (2026-05-16, driven by ADR-0030 D5 with ADR-0031 standup):** `IAuditLog` and `AuditEntry` are relocated to `HoneyDrunk.Audit.Abstractions` per ADR-0030 D5 ("Contract reconciliation — `IAuditLog`/`AuditEntry` are promoted; Operator becomes a consumer"). ADR-0031 is the corresponding Audit Node standup that ships those contracts. Operator becomes a consumer of those two contracts per the recorder-must-not-be-the-actor structural rule. The other eight Operator contracts remain Operator-owned and are unaffected.
+
+## Dependencies
+None. Packet 01 is the foundation of the initiative.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0018`
+
+## Agent Handoff
+
+**Objective:** Bring `HoneyDrunk.Architecture` catalogs into alignment with ADR-0018 D3, D7, D8, D11, D12 — and reflect the 2026-05-16 ADR-0030/0031 amendment relocating `IAuditLog`/`AuditEntry`.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Context:**
+- Goal: Catalog drift blocks downstream Operator consumers (Agents, Flow, AI, Capabilities, Evals, Sim) from scoping their own work. This packet removes the drift.
+- Feature: ADR-0018 standup initiative, Wave 1, Packet 01.
+- ADRs: ADR-0018 (sole standup); ADR-0030 + ADR-0031 (amendment relocating audit).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- **D3 (as amended by ADR-0030 D5) is canonical.** Drop `ICostController` (placeholder superseded). Add `ICostGuard`, `IDecisionPolicy`, `ISafetyFilter`. Add three Operator-owned records (`CostEvent`, `ApprovalRequest`, `ApprovalDecision`). Do not add `AuditEntry` to the `honeydrunk-operator` block — it relocates to `honeydrunk-audit` under the amendment.
+- **Records drop `I` prefix; interfaces keep it.** `CostEvent`, `ApprovalRequest`, `ApprovalDecision` are records. The five other surfaces are interfaces.
+- **Audit relocation is mandatory.** Per the 2026-05-16 ADR-0030/0031 amendment, `IAuditLog` and `AuditEntry` are no longer Operator-owned. Drop them from `honeydrunk-operator` blocks. The `honeydrunk-audit` Node will register them under its own standup initiative.
+- **Pulse is one-way; Communications is event-out, not a runtime edge.** Edit `grid_relationship` and `ai-sector-architecture.md` accordingly. Do not add Pulse or Communications to `consumes` on `honeydrunk-operator`.
+- **No ADR Status flip in this packet.** ADR-0018 stays Proposed.
+
+**Key Files:**
+- `catalogs/contracts.json` — replace `honeydrunk-operator` block's interfaces array
+- `catalogs/relationships.json` — `honeydrunk-operator.exposes.contracts/packages` + `consumed_by_planned` + `consumes_detail`
+- `catalogs/grid-health.json` — replace the `honeydrunk-operator` block
+- `catalogs/nodes.json` — edit `grid_relationship`, `tags`, `value_props`
+- `constitution/ai-sector-architecture.md` — Operator section
+- `repos/HoneyDrunk.Operator/overview.md`, `boundaries.md` — rename + amendment note
+- `repos/HoneyDrunk.Operator/integration-points.md` and `active-work.md` — new files
+- `initiatives/active-initiatives.md` — new entry
+- `CHANGELOG.md`
+
+**Contracts:** This packet does not author `.cs` files. Catalog-only.

--- a/generated/issue-packets/active/adr-0018-operator-standup/02-architecture-operator-invariants.md
+++ b/generated/issue-packets/active/adr-0018-operator-standup/02-architecture-operator-invariants.md
@@ -1,0 +1,157 @@
+---
+name: Constitution Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0018", "constitution"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0018"]
+accepts: ADR-0018
+wave: 1
+initiative: adr-0018-operator-standup
+node: honeydrunk-operator
+---
+
+# Chore: Add ADR-0018's four new invariants to the Grid constitution
+
+## Summary
+
+Add four new invariants to `constitution/invariants.md` derived from ADR-0018's Consequences section: D11 (downstream coupling rule), D6 (App Configuration sourcing for cost rates / policies / thresholds), D8 (approval-event event-out, no Communications runtime edge), and D10 (contract-shape canary on four hot-path interfaces). Assign them numbers **47, 48, 49, 50** — the next four free slots above the current high-water mark of 46 (ADR-0016 already landed 44/45/46 in `## AI Invariants`; ADR-0019 occupies 40-43; collision check at edit time confirms actual numbers).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0018 explicitly delegates final invariant numbering to the scope agent at acceptance time. The four invariants the ADR proposes (in its "New invariants" section under Consequences) need to land in `constitution/invariants.md` so the canary infrastructure, downstream Node packets, and the review agent all have numbered, citable rules to reference.
+
+These four rules govern the Operator Node's first-shipping behavior:
+
+- **D11 — downstream coupling.** Every downstream consumer of Operator (Agents, Flow, AI, Capabilities, Evals, Sim) will compile against `HoneyDrunk.Operator.Abstractions` only. Without an invariant, drift toward runtime references or `Testing` references in production composition is silent until canaries catch it.
+- **D6 — App Configuration sourcing.** Cost-rate tables, breaker thresholds, decision policies, and safety-filter configuration in code defeat the entire reason `IDecisionPolicy` and `ICostGuard` exist. An invariant makes a hardcoded threshold a build-time gating concern.
+- **D8 — Communications is event-out, not a runtime edge.** A direct Operator → Communications runtime call would collapse the ADR-0013 / ADR-0019 boundary that gave Communications the single authority for outbound message orchestration. An invariant locks the rule.
+- **D10 — contract-shape canary.** Even with the canary wired in CI (handled by packet 03), the obligation to *keep* the canary running on the four hot-path interfaces must outlive any single CI workflow file. An invariant ensures any future CI rewrite preserves the gate.
+
+## Proposed Implementation
+
+### `constitution/invariants.md` — append four new entries
+
+Assigned numbers **47, 48, 49, 50** — the current high-water mark in `constitution/invariants.md` is **46** (ADR-0016 landed 44/45/46 in `## AI Invariants`; ADR-0019 occupies 40-43 in `## Communications Invariants`). Verify at edit time with `rg -n '^[0-9]+\.' constitution/invariants.md | tail -n 20`.
+
+**Insertion layout (Option A — chosen).** Introduce a new section `## AI Sector — Operator Invariants` placed **immediately after the `## Communications Invariants` section** (which ends at the invariant-43 entry on line 164 at the time of this packet). Append it before any later sector sections that may land between packet authoring and packet execution. This mirrors the pattern Communications established with its own dedicated section and keeps Operator's four invariants discoverable as a block. The previously-considered "append to existing `## AI Invariants`" option is rejected — it would interleave Operator rules with the cross-sector AI rules (28, 44, 45, 46) and obscure ownership.
+
+Mark each new entry with `(Proposed — this invariant takes effect when ADR-0018 is accepted)` since ADR-0018 stays at `Status: Proposed` throughout this initiative.
+
+The four entries:
+
+```markdown
+## AI Sector — Operator Invariants
+
+47. **Downstream Nodes take a runtime dependency only on `HoneyDrunk.Operator.Abstractions`.**
+    Composition against `HoneyDrunk.Operator` and `HoneyDrunk.Operator.Testing` is a host-time (and test-time) concern. Test projects may reference `HoneyDrunk.Operator.Testing` to pick up the in-memory fixture; production projects must not. This is the same abstraction/runtime split applied for AI, Capabilities, Vault, and Transport, restated here because it is the specific rule that allows Agents, Flow, AI, Capabilities, Evals, and Sim to proceed on `Abstractions` alone without waiting for runtime or pulling the testing fixture into production composition. See ADR-0018 D11 (Proposed — this invariant takes effect when ADR-0018 is accepted).
+
+48. **Cost-rate tables, circuit-breaker thresholds, decision-policy rule sets, and safety-filter configuration are sourced from Azure App Configuration via Vault's `IConfigProvider`.**
+    Hardcoded rates, thresholds, or policies in application code are forbidden. Rate-and-threshold refresh is operator-driven — change the config value, restart or hot-reload, no deploy required. This applies in particular to the per-window budget tables consumed by `ICostGuard` and the threshold values consumed by `ICircuitBreaker`. See ADR-0018 D6 and ADR-0005 (Proposed — this invariant takes effect when ADR-0018 is accepted).
+
+49. **Approval notifications are emitted as events; `HoneyDrunk.Operator` does not take a runtime dependency on `HoneyDrunk.Communications`.**
+    When `IApprovalGate` raises an `ApprovalRequest` that needs human attention, Operator emits an approval-needed event via the configured transport. Communications subscribes and owns the downstream workflow (resolve recipient, check preferences, check cadence, deliver via Notify) per ADR-0013 / ADR-0019. Operator does not call `ICommunicationOrchestrator` directly. This keeps Operator's safety-critical path free of an orchestration-layer dependency and keeps Communications as the single authority for whether and how a message reaches a human. See ADR-0018 D8 (Proposed — this invariant takes effect when ADR-0018 is accepted).
+
+50. **The HoneyDrunk.Operator Node CI must include a contract-shape canary that fails the build on shape drift to `IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, or `ISafetyFilter` without a corresponding version bump.**
+    These four are the hot-path abstractions every downstream consumer (Agents, Flow, AI, Capabilities, Evals, Sim) compiles against. Accidental shape drift on any of them breaks every AI-sector Node that gates, breaks, budgets, or filters. The canary makes this a compile-time failure at Operator's own CI, not a discovery at consumer sites. The implementation may be the existing `job-api-compatibility.yml` reusable workflow scoped to `HoneyDrunk.Operator.Abstractions`; the obligation is to keep the gate, not to use any specific implementation. See ADR-0018 D10 (Proposed — this invariant takes effect when ADR-0018 is accepted).
+```
+
+### Collision-check rule
+
+Before committing, scan `constitution/invariants.md` and confirm the highest existing number. The default of **47-50** assumes the file's high-water mark is **46** at edit time. If something has landed in between (e.g. another AI-sector standup initiative claims 47+ first), shift the four entries to the next four free numbers and update **all three of the following in lockstep**:
+
+1. **ADR-0018 Consequences "New invariants" section** (`adrs/ADR-0018-stand-up-honeydrunk-operator-node.md` lines 166-173) — state the assigned numbers.
+2. **This packet 02 file** — update the section heading numbers, the four entry numbers, the Summary line, the Motivation bullets, the CHANGELOG entry text, and the Referenced ADR Decisions cross-references.
+3. **Packet 03 source file** at `generated/issue-packets/active/adr-0018-operator-standup/03-operator-node-scaffold.md` — every line that names an Operator invariant number must be updated. Packet 03 currently embeds the default numbers 47/48/49/50; shifts cascade from there. **Exhaustive cross-reference list** (verify each before push; line numbers approximate, use `rg` to confirm exact positions):
+   - Line ~298: `"named in invariant 50"` and `"per D11 invariant 47, Abstractions is the only thing"`
+   - Line ~427: `> **Operator downstream-coupling invariant (number assigned by packet 02, default 47):**`
+   - Line ~429: `> **Operator App-Config-sourcing invariant (number assigned by packet 02, default 48):**`
+   - Line ~431: `> **Operator approval-event-out invariant (number assigned by packet 02, default 49):**`
+   - Line ~433: `> **Operator contract-shape canary invariant (number assigned by packet 02, default 50):**`
+
+   Run `rg -n '\b(47|48|49|50|51|52|53|54)\b' generated/issue-packets/active/adr-0018-operator-standup/03-operator-node-scaffold.md` (extend the bracket to the next four numbers above the current default block to catch any shifted references). Visually classify each match as either an Operator-invariant reference (must be updated) or an unrelated number (line numbers, port numbers, etc — leave alone). Pre-filing carve-out under invariant 24 applies because packet 03 has not been filed yet.
+
+Use ripgrep (`rg`), not `grep`, to avoid Windows Git Bash CR/LF boundary issues.
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the Unreleased section: `Architecture: Add invariants 47 (Operator downstream coupling), 48 (App Config-sourced Operator rate tables, breaker thresholds, decision policies, safety-filter config), 49 (Operator approval-event event-out — no Communications runtime edge), and 50 (Operator contract-shape canary) per ADR-0018 D11, D6, D8, D10. New section `## AI Sector — Operator Invariants` introduced. (Numbers shift to next-available if collision check finds 47-50 taken.)`
+
+## Affected Files
+- `constitution/invariants.md`
+- `adrs/ADR-0018-stand-up-honeydrunk-operator-node.md` (only if numbers shift)
+- `generated/issue-packets/active/adr-0018-operator-standup/03-operator-node-scaffold.md` (only if numbers shift — pre-filing amendment under invariant 24)
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] No new design decisions — invariant text restates D11/D6/D8/D10 with constitutional voice.
+- [x] No existing invariants modified, only appended.
+- [x] Pre-filing amendment to packet 03 permitted under invariant 24's carve-out.
+
+## Acceptance Criteria
+- [ ] Four new invariants present in `constitution/invariants.md` with text matching ADR-0018 D11, D6, D8, D10.
+- [ ] Assigned numbers verified against file's current highest number. Default assumption **47-50** (current high-water mark is 46).
+- [ ] Each invariant carries the qualifier `(Proposed — this invariant takes effect when ADR-0018 is accepted)`. ADR-0018 stays Proposed for this initiative.
+- [ ] New section heading `## AI Sector — Operator Invariants` introduced (Option A) — entries are NOT appended to the existing `## AI Invariants` section.
+- [ ] Section placed immediately after `## Communications Invariants` (the current last numbered section ending at invariant 43).
+- [ ] Existing entries unmodified.
+- [ ] If numbers shift, ADR-0018's Consequences section + this packet + packet 03 source file are updated in lockstep before packet 03 is filed (see the exhaustive cross-reference list in Proposed Implementation).
+- [ ] `CHANGELOG.md` Unreleased section updated with assigned numbers.
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0018 D6 (App Configuration sourcing):** Cost-rate tables, budget windows, breaker thresholds, decision-policy rule sets, and safety-filter configuration live in Azure App Configuration via Vault's `IConfigProvider`. Source for invariant 48.
+
+**ADR-0018 D8 (Approval event-out, no runtime edge to Communications):** Operator emits approval-needed events; Communications subscribes. No runtime dependency on Communications. Source for invariant 49.
+
+**ADR-0018 D10 (Contract-shape canary on four hot-path interfaces):** `IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, `ISafetyFilter` are canary-frozen. Source for invariant 50.
+
+**ADR-0018 D11 (Downstream coupling rule):** Downstream Nodes compile only against `HoneyDrunk.Operator.Abstractions`. Source for invariant 47.
+
+## Dependencies
+- `packet:01` — packet 01 lands the catalog surface that invariant 47's canary will guard. Filing 02 before 01 would dangle a forward reference.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0018`, `constitution`
+
+## Agent Handoff
+
+**Objective:** Land four new ADR-0018-derived invariants in the Grid constitution at numbers 47-50 (or the next four available if collision check finds them taken), in a new section `## AI Sector — Operator Invariants`.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Context:**
+- Goal: ADR-0018's "New invariants" section is a placeholder. This packet is the finalization.
+- Feature: ADR-0018 standup initiative, Wave 1, Packet 02.
+- ADRs: ADR-0018.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packet 01.
+
+**Constraints:**
+
+- **Each new invariant carries `(Proposed — this invariant takes effect when ADR-0018 is accepted)`.** Mirror the qualifier pattern from invariants 28, 31/32/33.
+- **Insertion layout is Option A (new section).** Introduce `## AI Sector — Operator Invariants` immediately after `## Communications Invariants`. Do not append to the existing `## AI Invariants` section.
+- **Number collision check is a hard gate.** Default **47-50** (current high-water mark is 46). Verify against the file's highest number at edit time. If shifted, update ADR-0018 Consequences section + this packet + packet 03 source file in lockstep per the exhaustive cross-reference list in Proposed Implementation.
+- **Verbatim alignment with ADR-0018.** Restate D11/D6/D8/D10 with constitutional voice; do not introduce new requirements.
+- **Pre-filing amendment to packet 03 is the mechanism** for handling number shifts. Invariant 24's carve-out applies.
+
+**Key Files:**
+- `constitution/invariants.md`
+- `adrs/ADR-0018-stand-up-honeydrunk-operator-node.md` (only on shift)
+- `generated/issue-packets/active/adr-0018-operator-standup/03-operator-node-scaffold.md` (only on shift)
+- `CHANGELOG.md`
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0018-operator-standup/02b-architecture-verify-operator-repo.md
+++ b/generated/issue-packets/active/adr-0018-operator-standup/02b-architecture-verify-operator-repo.md
@@ -1,0 +1,143 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "ai", "adr-0018", "human-only", "wave-2"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0018"]
+accepts: ADR-0018
+wave: 2
+initiative: adr-0018-operator-standup
+node: honeydrunk-architecture
+actor: human
+---
+
+# Chore: Verify `HoneyDrunk.Operator` GitHub repo settings + local clone (human-only)
+
+## Summary
+
+Confirm `HoneyDrunkStudios/HoneyDrunk.Operator` matches the Grid's per-repo standard settings (branch protection, default branch, labels, Actions enabled), confirm the local working tree at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Operator/` is up to date with `main`, and confirm the OIDC federated credential for NuGet publishing is in place. Both the GitHub repo and the local clone already exist (the repo carries `.gitignore`, `LICENSE`, `README.md` plus drafting folders `docs/`, `contracts/`, `policies/`, `prompts/`, `staging/`). This is a verification packet, not a creation packet.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture` (tracking issue lives here; actual portal/CLI work is on GitHub and locally)
+
+## Actor
+**`Human`.** Org-admin rights required to set branch protection and seed labels; local-clone verification is a human action.
+
+## Motivation
+
+Packet 03 (the scaffold) defines the solution, three packages, eight contracts, default runtime, in-memory testing fixture, and CI pipeline for `HoneyDrunk.Operator` but cannot be executed by the scaffolding agent until:
+
+1. The local working tree at `c:/.../HoneyDrunkStudios/HoneyDrunk.Operator` is on `main` and clean.
+2. Branch protection rules are applied (PR required, `pr-core` required, no force-pushes, no deletions).
+3. Labels needed for issue filing exist on the repo.
+4. The OIDC federated credential for the NuGet publishing identity is in place.
+
+The existing drafting folders (`docs/`, `contracts/`, `policies/`, `prompts/`, `staging/`) are **source material for the scaffolding agent**, not a finished scaffold. They contain design notes that the agent should consult while authoring `.cs` files but should not commit verbatim. Packet 03 handles this distinction in its own Constraints section.
+
+## Steps
+
+### Step 1 — Verify repo settings (portal)
+
+1. Open https://github.com/HoneyDrunkStudios/HoneyDrunk.Operator/settings — confirm:
+   - **Default branch:** `main`
+   - **Visibility:** Public (HoneyDrunk Grid default)
+   - **Features:** Issues enabled, Actions enabled
+2. Open https://github.com/HoneyDrunkStudios/HoneyDrunk.Operator/settings/branches — confirm or create branch protection rule on `main`:
+   - **Require a pull request before merging:** on
+   - **Require status checks to pass before merging:** on
+   - **Required status checks:** `pr-core / core` only for now (the canary check is added post-merge after the throwaway-PR verification — see packet 03 Human Prerequisites)
+   - **Allow force pushes:** off
+   - **Allow deletions:** off
+3. Open https://github.com/HoneyDrunkStudios/HoneyDrunk.Operator/settings/security_analysis — confirm Dependabot alerts are enabled (org default).
+
+### Step 2 — Seed labels (CLI)
+
+```bash
+for label in "feature:0E8A16" "chore:CCCCCC" "tier-1:E99695" "tier-2:FBCA04" "ai:D946EF" "scaffold:BFDADC" "adr-0018:1D76DB" "wave-3:FBCA04" "human-only:B60205" "out-of-band:D4C5F9"; do
+  name="${label%:*}"; color="${label#*:}"
+  gh label create "$name" --repo HoneyDrunkStudios/HoneyDrunk.Operator --color "$color" 2>/dev/null
+done
+```
+
+Already-exists errors are fine — idempotent.
+
+### Step 3 — Verify local clone
+
+**Pre-check.** The local working tree at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Operator/` is currently on `chore/wire-standard-workflows` at the time this packet was authored. Do **not** issue a bare `git checkout main` — the branch may not exist locally yet. Follow this sequence:
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Operator
+
+# Step 0 — confirm state
+git status                                         # confirm clean working tree
+git branch --show-current                          # confirm chore/wire-standard-workflows (or current branch)
+git fetch origin
+
+# Branch A — chore PR has already merged to origin/main:
+#   create the local main branch (if it doesn't exist) from origin/main, then drop the chore branch.
+git checkout main 2>/dev/null || git checkout -b main origin/main
+git pull --ff-only origin main
+git branch -d chore/wire-standard-workflows 2>/dev/null || true    # safe-delete only if fully merged
+
+# Branch B — chore PR has NOT merged yet:
+#   STOP. Do not run the lines above. Merge `chore/wire-standard-workflows` to `main` on GitHub first
+#   (review + approve + squash-merge), then return here and execute Branch A.
+
+ls
+```
+
+Confirm the working tree is on `main`, clean, and contains at minimum `.gitignore`, `LICENSE`, `README.md` plus the drafting folders (`docs/`, `contracts/`, `policies/`, `prompts/`, `staging/`).
+
+**If `git branch -d chore/wire-standard-workflows` errors** with "not fully merged" the human should NOT use `-D` (force) without first confirming the chore work landed on `main`. The branch deletion is a cleanup nicety, not a blocker for the rest of this packet.
+
+### Step 4 — Confirm OIDC federated credential
+
+Cross-link: [`infrastructure/walkthroughs/oidc-federated-credentials.md`](../../../../infrastructure/walkthroughs/oidc-federated-credentials.md).
+
+Confirm the Grid's NuGet publishing identity has `repo:HoneyDrunkStudios/HoneyDrunk.Operator:ref:refs/tags/v*` in its federated credential subject list. If not, add it via Microsoft Entra → App registrations → the NuGet publishing identity → Certificates & secrets → Federated credentials.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunkStudios/HoneyDrunk.Operator` has branch protection on `main` requiring `pr-core / core`, no force-pushes, no deletions
+- [ ] Labels `feature`, `chore`, `tier-1`, `tier-2`, `ai`, `scaffold`, `adr-0018`, `wave-3`, `human-only`, `out-of-band` exist on the repo
+- [ ] Local working tree at `c:/.../HoneyDrunkStudios/HoneyDrunk.Operator/` is on `main`, clean, contains `.gitignore`, `LICENSE`, `README.md` + drafting folders
+- [ ] OIDC federated credential exists for `repo:HoneyDrunkStudios/HoneyDrunk.Operator:ref:refs/tags/v*`
+- [ ] This chore issue is closed after all four checks above are verified
+- [ ] After this chore is Done **and** packet 02 has merged, packet 03 is fileable
+
+## Human Prerequisites
+- [ ] Org-admin role on `HoneyDrunkStudios`
+- [ ] Browser with GitHub session as org owner
+- [ ] `gh` CLI installed locally and authenticated
+- [ ] Azure portal access for OIDC verification (only if Step 4 finds a missing credential)
+
+## Dependencies
+- `packet:01` — catalog registration must merge first.
+
+## Downstream Unblocks
+- `03-operator-node-scaffold.md` — becomes fileable the moment this chore is Done **and** packet 02 has merged.
+
+## Referenced ADR Decisions
+
+**ADR-0018 D1 (Substrate Node):** HoneyDrunk.Operator is the AI sector's human-policy enforcement substrate. New Node ⇒ new repo per invariant 11 — the repo is already created on GitHub and cloned locally; this packet is the verification half of the standup.
+
+**ADR-0018 D2 (Package families):** Three package families. The local clone hosts the solution that packet 03 authors.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node. Each repo has its own solution, CI pipeline, and versioning.
+
+> **Invariant 24:** Issue packets are immutable once filed. Pre-filing amendments to packet 03 are permitted under invariant 24 if invariant numbers shift in packet 02.
+
+## Labels
+`chore`, `tier-1`, `meta`, `ai`, `adr-0018`, `human-only`, `wave-2`
+
+## Notes for the human executing this chore
+
+- This is a ~5-minute task — most of the work is verification, not creation, because the repo and local clone both already exist.
+- After all four steps complete, close this chore issue and unblock packet 03.
+- If branch protection is already correctly applied, Step 1 is verify-only.
+- If the OIDC federated credential is already in place, Step 4 is verify-only.
+- Do **not** commit anything to the local clone in this chore — the scaffolding agent in packet 03 authors all source files. The drafting folders (`docs/`, `contracts/`, `policies/`, `prompts/`, `staging/`) are read-only source material for the agent.
+- No Azure provisioning required. HoneyDrunk.Operator is a library Node with no Azure footprint.

--- a/generated/issue-packets/active/adr-0018-operator-standup/03-operator-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0018-operator-standup/03-operator-node-scaffold.md
@@ -1,0 +1,521 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Operator
+labels: ["feature", "tier-2", "ai", "scaffold", "adr-0018"]
+dependencies: ["packet:01", "packet:02", "packet:02b"]
+adrs: ["ADR-0018", "ADR-0030", "ADR-0031", "ADR-0005"]
+accepts: ADR-0018
+wave: 3
+initiative: adr-0018-operator-standup
+node: honeydrunk-operator
+---
+
+# Feature: Stand up the HoneyDrunk.Operator repo — solution, three packages, contracts, CI, in-memory testing fixture
+
+## Summary
+
+Bring the near-empty `HoneyDrunk.Operator` repo from zero to first-shippable state per ADR-0018. Land the solution layout, the three package families (`Abstractions`, runtime, `Testing` fixture), the eight Operator-owned D3 contracts inside `HoneyDrunk.Operator.Abstractions`, default runtime implementations (`DefaultApprovalGate`, `DefaultCircuitBreaker`, `DefaultCostGuard`, `AuthBackedDecisionPolicy`, `DefaultSafetyFilter`, `OperatorTelemetry`), the in-memory testing fixture, the standard CI pipeline (PR core + release + nightly + secrets), and the contract-shape canary scoped to `HoneyDrunk.Operator.Abstractions` per ADR-0018 D10 and the Operator canary invariant (number assigned by packet 02).
+
+**Critical amendment:** per the 2026-05-16 ADR-0030/0031 amendment to ADR-0018, `IAuditLog` and `AuditEntry` are **NOT** authored in this packet. Those two contracts live in `HoneyDrunk.Audit.Abstractions` (separate Node standup ADR). Operator is a **consumer** of `IAuditLog` — at this packet's commit, the consumer wiring depends on whether `HoneyDrunk.Audit.Abstractions` has shipped. If it has, this scaffold takes a runtime dependency on it for audit emission. If it has not, the scaffold ships with a placeholder no-op `IAuditLog` consumer interface that fails-soft (logs a structured warning) and the Audit edge is wired in a follow-up packet once `HoneyDrunk.Audit.Abstractions 0.1.0` is available.
+
+This is the unblocker for the six AI-sector Nodes that consume Operator (Agents, Flow, AI, Capabilities, Evals, Sim). After this packet merges and a `0.1.0` tag lands, those Nodes can compile against `HoneyDrunk.Operator.Abstractions`.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Operator`
+
+## Motivation
+
+ADR-0018 establishes *what* HoneyDrunk.Operator is and what contracts it exposes. The repo is created on GitHub and cloned locally (packet 02b verifies), and carries drafting folders (`docs/`, `contracts/`, `policies/`, `prompts/`, `staging/`) with design notes — but no `.slnx`, no projects, no CI, no contracts. Six AI-sector Nodes plus every domain Node that needs policy enforcement on agent paths are blocked on this single repo coming online.
+
+This packet is intentionally larger than typical bring-up packets because:
+
+- The Node has three packages.
+- The eight Operator-owned D3 contracts must all land in the first commit so the contract-shape canary has a baseline.
+- The `Testing` fixture is required for downstream Nodes to compose Operator without standing up real Auth policy resolution.
+- Per the user's standing convention, a new Node's scaffold work bundles into one packet rather than fragmenting.
+
+## Proposed Implementation
+
+### Repository layout
+
+```
+HoneyDrunk.Operator/
+├── HoneyDrunk.Operator.slnx
+├── Directory.Build.props
+├── CHANGELOG.md
+├── README.md
+├── .editorconfig                    (from HoneyDrunk.Standards)
+├── .gitignore
+├── .github/
+│   └── workflows/
+│       ├── pr-core.yml
+│       ├── release.yml
+│       ├── nightly-deps.yml
+│       ├── nightly-security.yml
+│       └── api-compatibility.yml    (D10 canary)
+├── docs/         (existing drafting folder — kept as source material, not edited)
+├── contracts/    (existing drafting folder — kept as source material, not edited)
+├── policies/     (existing drafting folder — kept as source material, not edited)
+├── prompts/      (existing drafting folder — kept as source material, not edited)
+├── staging/      (existing drafting folder — kept as source material, not edited)
+├── src/
+│   ├── HoneyDrunk.Operator.Abstractions/
+│   │   ├── HoneyDrunk.Operator.Abstractions.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── IApprovalGate.cs
+│   │   ├── ICircuitBreaker.cs
+│   │   ├── ICostGuard.cs
+│   │   ├── IDecisionPolicy.cs
+│   │   ├── ISafetyFilter.cs
+│   │   ├── ApprovalRequest.cs
+│   │   ├── ApprovalDecision.cs
+│   │   ├── CostEvent.cs
+│   │   └── (supporting record/enum types)
+│   ├── HoneyDrunk.Operator/
+│   │   ├── HoneyDrunk.Operator.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── ServiceCollectionExtensions.cs    (AddHoneyDrunkOperator)
+│   │   ├── Approval/DefaultApprovalGate.cs
+│   │   ├── Breaker/DefaultCircuitBreaker.cs
+│   │   ├── Cost/DefaultCostGuard.cs
+│   │   ├── Policy/AuthBackedDecisionPolicy.cs
+│   │   ├── Safety/DefaultSafetyFilter.cs
+│   │   ├── Telemetry/OperatorTelemetry.cs
+│   │   └── Events/ApprovalEventEmitter.cs    (event-out per D8 — emits via ITransportPublisher or configured transport)
+│   └── HoneyDrunk.Operator.Testing/
+│       ├── HoneyDrunk.Operator.Testing.csproj
+│       ├── README.md
+│       ├── CHANGELOG.md
+│       ├── InMemoryApprovalGate.cs
+│       ├── InMemoryCircuitBreaker.cs
+│       ├── InMemoryCostGuard.cs
+│       ├── PermissiveDecisionPolicy.cs
+│       ├── PermissiveSafetyFilter.cs
+│       └── RecordingApprovalEventEmitter.cs
+└── tests/
+    ├── HoneyDrunk.Operator.Abstractions.Tests/
+    ├── HoneyDrunk.Operator.Tests/
+    └── HoneyDrunk.Operator.Testing.Tests/
+```
+
+### Solution
+
+`HoneyDrunk.Operator.slnx` references the three `src/*` projects and three `tests/*` projects. Solution-level `Directory.Build.props` sets target framework `net10.0`, nullable enable, implicit usings, warnings as errors, `Version` 0.1.0 (test projects excluded via `IsTestProject` condition), authors, repository URL, symbols/snupkg.
+
+### Contract details — `HoneyDrunk.Operator.Abstractions`
+
+All eight Operator-owned D3 contracts. Records drop `I` prefix; interfaces keep it.
+
+```csharp
+// IApprovalGate.cs
+namespace HoneyDrunk.Operator.Abstractions;
+
+public interface IApprovalGate
+{
+    Task<ApprovalDecision> RequestAsync(ApprovalRequest request, CancellationToken cancellationToken = default);
+    Task<ApprovalDecision?> CheckStatusAsync(string approvalId, CancellationToken cancellationToken = default);
+}
+```
+
+```csharp
+// ICircuitBreaker.cs
+public interface ICircuitBreaker
+{
+    Task<bool> IsAllowedAsync(string breakerName, CancellationToken cancellationToken = default);
+    Task TripAsync(string breakerName, string reason, CancellationToken cancellationToken = default);
+    Task ResetAsync(string breakerName, CancellationToken cancellationToken = default);
+    Task<BreakerState> GetStateAsync(string breakerName, CancellationToken cancellationToken = default);
+}
+
+public enum BreakerState
+{
+    Closed = 0,
+    Open = 1,
+    HalfOpen = 2,
+}
+```
+
+```csharp
+// ICostGuard.cs
+public interface ICostGuard
+{
+    Task<CostCheckResult> CheckBudgetAsync(string scope, string window, decimal amount, CancellationToken cancellationToken = default);
+    Task RecordAsync(CostEvent costEvent, CancellationToken cancellationToken = default);
+    Task<CostStatus> GetStatusAsync(string scope, string window, CancellationToken cancellationToken = default);
+}
+
+public sealed record CostCheckResult(bool Allowed, decimal Remaining, decimal Limit, string? DenyReason);
+public sealed record CostStatus(decimal Spent, decimal Limit, decimal Remaining, string Window);
+```
+
+```csharp
+// IDecisionPolicy.cs
+public interface IDecisionPolicy
+{
+    Task<PolicyDecision> EvaluateAsync(ActionContext context, CancellationToken cancellationToken = default);
+}
+
+public sealed record ActionContext(string ActorId, string Action, string Resource, IReadOnlyDictionary<string, string> Attributes);
+public sealed record PolicyDecision(PolicyOutcome Outcome, string? Reason, string[] EvaluatedRules);
+
+public enum PolicyOutcome { Allow = 0, Deny = 1, RequireApproval = 2 }
+```
+
+```csharp
+// ISafetyFilter.cs
+public interface ISafetyFilter
+{
+    Task<SafetyFilterResult> CheckAsync(SafetyFilterRequest request, CancellationToken cancellationToken = default);
+}
+
+public sealed record SafetyFilterRequest(string Content, string ContentKind, IReadOnlyDictionary<string, string> Context);
+public sealed record SafetyFilterResult(bool Allowed, string? BlockReason, string[] FiredRules);
+```
+
+```csharp
+// ApprovalRequest.cs (record — no I prefix)
+public sealed record ApprovalRequest(
+    string ApprovalId,
+    string Subject,
+    string Action,
+    IReadOnlyDictionary<string, string> Context,
+    string RequestedScope,
+    DateTimeOffset Expiry,
+    string RequesterCorrelationId);
+```
+
+```csharp
+// ApprovalDecision.cs
+public sealed record ApprovalDecision(
+    string ApprovalId,
+    ApprovalOutcome Outcome,
+    string ApproverIdentity,
+    DateTimeOffset DecidedAt,
+    string? Reason);
+
+public enum ApprovalOutcome { Pending = 0, Approved = 1, Denied = 2, Expired = 3 }
+```
+
+```csharp
+// CostEvent.cs
+public sealed record CostEvent(
+    string EventId,
+    string AgentId,
+    string TenantId,
+    string Window,
+    decimal Amount,
+    string Unit,
+    string Source,
+    DateTimeOffset OccurredAt,
+    string OperationCorrelationId);
+```
+
+`HoneyDrunk.Operator.Abstractions` references **only** `Microsoft.Extensions.*` abstractions per invariant 1 (specifically `Microsoft.Extensions.Logging.Abstractions`). **Do not** reference any other `HoneyDrunk.*` package from Abstractions — no `HoneyDrunk.Kernel.Abstractions`, no `HoneyDrunk.Auth.Abstractions`, no `HoneyDrunk.Data.Abstractions`. Identity/correlation fields are `string`, not strongly-typed Kernel types.
+
+**`IAuditLog` and `AuditEntry` are NOT authored in this Abstractions package** per the 2026-05-16 ADR-0030/0031 amendment. Those contracts live in `HoneyDrunk.Audit.Abstractions`. The Operator runtime package consumes them; the Abstractions surface does not declare them.
+
+**v0.1.0 shape baseline.** The member sets of `ICostGuard`, `IDecisionPolicy`, `ISafetyFilter` and their supporting records ship as v0.1.0 contracts. The contract-shape canary established here makes any change to them a deliberate version-bump event under invariant 50. A separate follow-up packet (filed after the six downstream consumer Nodes start composing against `HoneyDrunk.Operator.Abstractions`) revisits the shapes once real consumer usage surfaces missing or surplus members — that packet, not this one, is the place for shape refinement.
+
+### Runtime details — `HoneyDrunk.Operator`
+
+`HoneyDrunk.Operator` references:
+- `HoneyDrunk.Operator.Abstractions` (project)
+- `HoneyDrunk.Kernel.Abstractions` (for `ITelemetryActivityFactory`, `IGridContext`, `IOperationContext` contracts)
+- `HoneyDrunk.Auth.Abstractions` (for `IAuthorizationPolicy` contract consumed by `AuthBackedDecisionPolicy` per D5)
+- `HoneyDrunk.Data.Abstractions` (for `IRepository`, `IUnitOfWork` contracts for cost-ledger and approval-store persistence per D12)
+- `HoneyDrunk.Vault.Abstractions` (for `IConfigProvider` contract to read cost rates, breaker thresholds, policies from App Config per D6)
+- **Optionally** `HoneyDrunk.Audit.Abstractions` (for `IAuditLog`, `AuditEntry`) — depends on whether `HoneyDrunk.Audit.Abstractions 0.1.0` has shipped at this packet's commit time. **Simplification per S2:** if not yet shipped, do NOT introduce a placeholder no-op `IAuditLog` interface inside Operator. Instead, mark every prospective audit-emission site with a `TODO(audit): wire IAuditLog.AppendAsync once HoneyDrunk.Audit.Abstractions ships — see follow-up packet 04` comment and ship the scaffold without the audit edge. A follow-up packet adds the package reference and the actual `IAuditLog.AppendAsync` calls in one PR. The executing agent verifies at edit time by checking NuGet.org or `catalogs/contracts.json` for `honeydrunk-audit`'s status.
+- `Microsoft.Extensions.DependencyInjection.Abstractions`
+- `Microsoft.Extensions.Hosting.Abstractions`
+- `Microsoft.Extensions.Logging.Abstractions`
+
+Six default implementations:
+
+- **`DefaultApprovalGate`** — issues an `ApprovalRequest` with a generated `ApprovalId`, persists via `IRepository`, emits an approval-needed event via `ApprovalEventEmitter` (event-out per D8), returns immediately with a `Pending` decision. Consumers poll `CheckStatusAsync` or subscribe to a completion event.
+- **`DefaultCircuitBreaker`** — in-process state machine (Closed → Open → HalfOpen → Closed). Thresholds (failure count, half-open trial count, reset window) read from App Config via `IConfigProvider` at startup; refreshes on config change.
+- **`DefaultCostGuard`** — in-process accumulator backed by `IRepository` for durability. Reads cost-rate tables from App Config via `IConfigProvider`. Throws (or returns DenyReason) when budget exceeded per D6.
+- **`AuthBackedDecisionPolicy`** — depends on `HoneyDrunk.Auth`'s `IAuthorizationPolicy`. Evaluates `descriptor`-style rules sourced from App Config via `IConfigProvider`. Returns `Allow`/`Deny`/`RequireApproval`.
+- **`DefaultSafetyFilter`** — pluggable rule chain. The default rule set is loaded from App Config; consumers can register custom `ISafetyRule` implementations via DI.
+- **`OperatorTelemetry`** — wraps every gate / breaker / cost / decision / safety-filter call in `ITelemetryActivityFactory`-created activities. Emits per-call attributes per D7. GridContext / CorrelationId propagation lives here in the runtime package, not in Abstractions.
+
+Plus one event-out component:
+
+- **`ApprovalEventEmitter`** — emits `ApprovalRequest`-needed events via the configured transport (deferred to host configuration per D8; the scaffold supplies an `ITransportPublisher`-backed default and a no-op fallback). The wire shape is a follow-up packet's concern.
+
+**Audit emission (conditional, S2 simplification).** If `HoneyDrunk.Audit.Abstractions` is available at packet-execution time, every gate / breaker / cost / approval / safety-filter decision in the runtime calls `IAuditLog.AppendAsync(AuditEntry)` per the ADR-0030/0031 amendment. If `HoneyDrunk.Audit.Abstractions` is **not** available, do **not** introduce a placeholder internal interface in Operator (no risk of a name collision with the real `IAuditLog` that lands in HoneyDrunk.Audit later). Instead, mark each prospective audit-emission site with:
+
+```csharp
+// TODO(audit): emit AuditEntry via IAuditLog.AppendAsync once
+//   HoneyDrunk.Audit.Abstractions 0.1.0 ships. Tracked in follow-up
+//   packet 04-operator-wire-audit-emission.md.
+```
+
+and leave the call site otherwise untouched (no log statement, no warning, no no-op). The follow-up packet adds the package reference, removes the TODO comments, and wires the actual `IAuditLog.AppendAsync` calls in one PR. This keeps the scaffold's internal surface free of throwaway types.
+
+Service registration:
+
+```csharp
+public static IServiceCollection AddHoneyDrunkOperator(this IServiceCollection services, Action<OperatorOptions>? configure = null)
+{
+    services.AddSingleton<IApprovalGate, DefaultApprovalGate>();
+    services.AddSingleton<ICircuitBreaker, DefaultCircuitBreaker>();
+    services.AddSingleton<ICostGuard, DefaultCostGuard>();
+    services.AddSingleton<IDecisionPolicy, AuthBackedDecisionPolicy>();
+    services.AddSingleton<ISafetyFilter, DefaultSafetyFilter>();
+    services.AddSingleton<ApprovalEventEmitter>();
+    return services;
+}
+```
+
+### Testing fixture — `HoneyDrunk.Operator.Testing`
+
+In-memory implementations of every Operator-owned interface:
+
+- `InMemoryApprovalGate` — script-driven decisions; default returns `Approved` immediately for deterministic tests.
+- `InMemoryCircuitBreaker` — always-closed default; configurable to simulate trips.
+- `InMemoryCostGuard` — in-memory accumulator with caller-supplied budget.
+- `PermissiveDecisionPolicy` — always returns `Allow`. Intended for unit tests where policy is not under test.
+- `PermissiveSafetyFilter` — always returns `Allowed: true`.
+- `RecordingApprovalEventEmitter` — captures emitted events for test assertions.
+
+`HoneyDrunk.Operator.Testing` references **only** `HoneyDrunk.Operator.Abstractions` (project reference) and the test-relevant `Microsoft.Extensions.*` packages. **No reference to** `HoneyDrunk.Operator` runtime, `HoneyDrunk.Kernel`, `HoneyDrunk.Auth`, `HoneyDrunk.Data`, or `HoneyDrunk.Vault`. Per invariant 3 applied to companion packages.
+
+### CI workflows
+
+All five workflow files are thin callers of `HoneyDrunk.Actions` reusable workflows. The `api-compatibility.yml` workflow is path-filtered to `src/HoneyDrunk.Operator.Abstractions/**` so it only runs when Abstractions changes.
+
+```yaml
+# .github/workflows/api-compatibility.yml — ADR-0018 D10 canary
+name: API Compatibility (Abstractions)
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/HoneyDrunk.Operator.Abstractions/**'
+jobs:
+  abstractions-shape:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml@main
+    with:
+      project-path: src/HoneyDrunk.Operator.Abstractions/HoneyDrunk.Operator.Abstractions.csproj
+```
+
+The whole-assembly diff is sufficient to cover the four hot-path interfaces named in invariant 50 (`IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, `ISafetyFilter`) plus the records and the `IDecisionPolicy` interface — per D11 invariant 47, Abstractions is the only thing downstream Nodes compile against.
+
+### `HoneyDrunk.Standards` wiring
+
+Each `.csproj` references `HoneyDrunk.Standards` with `PrivateAssets="all"` per invariant 26.
+
+### Documentation
+
+- **Repo `README.md`** — purpose statement, package matrix, "How to consume" snippet with `AddHoneyDrunkOperator()` + `AddOperatorPolicy<T>()` + an event-subscriber-side example, link to ADR-0018. Include a note about the ADR-0030/0031 amendment and the relocated audit contracts.
+- **Repo `CHANGELOG.md`** — `## [0.1.0] - 2026-MM-DD` entry covering the scaffold.
+- **Per-package `README.md` + `CHANGELOG.md`** — required by invariant 12.
+
+### Drafting folders disposition
+
+The existing folders at the repo root (`docs/`, `contracts/`, `policies/`, `prompts/`, `staging/`) are **source material** for the scaffolding agent. The agent should:
+
+1. Read them to understand the intended Operator design.
+2. NOT commit them verbatim into `src/` projects.
+3. NOT delete them in this packet (a follow-up cleanup packet decides whether they remain in the repo as reference docs or move under `docs/`).
+
+The scaffold agent's commit should leave the drafting folders untouched.
+
+## Affected Files
+Entire repo (except drafting folders). Notable new files listed under "Repository layout" above.
+
+## NuGet Dependencies
+
+Every new `.csproj` lists `HoneyDrunk.Standards` (`PrivateAssets="all"`) per invariant 26.
+
+### `HoneyDrunk.Operator.Abstractions.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+
+(No other PackageReference. Invariant 1.)
+
+### `HoneyDrunk.Operator.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | For `ITelemetryActivityFactory`, `IGridContext`, `IOperationContext` contracts. Use `.Abstractions` (not runtime) per invariant 2 — runtime packages depend on upstream Abstractions, not upstream runtime. |
+| `HoneyDrunk.Auth.Abstractions` | For `IAuthorizationPolicy` consumed by `AuthBackedDecisionPolicy` per D5. `.Abstractions` only — the runtime Auth package would pull a JWT-validation stack Operator doesn't need. |
+| `HoneyDrunk.Data.Abstractions` | For `IRepository`, `IUnitOfWork` contracts per D12. `.Abstractions` only — Operator composes against the contract surface; the concrete provider is wired by the host. |
+| `HoneyDrunk.Vault.Abstractions` | For `IConfigProvider` per D6. `.Abstractions` only — the host wires a provider implementation; Operator just consumes the contract. |
+| `HoneyDrunk.Audit.Abstractions` | Conditional — only if `HoneyDrunk.Audit.Abstractions 0.1.0` has shipped at this packet's execution time. See S2 simplification: if not yet shipped, ship the runtime **without** the package reference and mark every prospective audit call site with a `TODO(audit): wire IAuditLog.AppendAsync once HoneyDrunk.Audit.Abstractions 0.1.0 ships — follow-up packet 04` comment. The follow-up packet adds the reference and emission in one PR. No placeholder no-op interface, no internal name collision risk. |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | DI helpers |
+| `Microsoft.Extensions.Hosting.Abstractions` | Startup hooks |
+| `Microsoft.Extensions.Logging.Abstractions` | Logger contracts |
+
+Project reference: `HoneyDrunk.Operator.Abstractions`.
+
+**Note on `.Abstractions` vs runtime dependencies.** Operator's runtime package consumes only contract surfaces from upstream Nodes. There is no scenario at v0.1.0 that requires reaching into Kernel/Auth/Data/Vault concrete implementations — telemetry activity creation, authorization-policy evaluation, repository/unit-of-work, and config-provider reads are all expressed through interfaces in the corresponding `.Abstractions` packages. This keeps Operator composable: a host wiring Operator picks its own Kernel/Auth/Data/Vault runtime providers without inheriting Operator's pin.
+
+### `HoneyDrunk.Operator.Testing.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | DI helpers |
+
+Project reference: `HoneyDrunk.Operator.Abstractions`. **No reference to** `HoneyDrunk.Operator` runtime or any other Grid Node.
+
+### Test projects
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `Microsoft.NET.Test.Sdk` | Standard |
+| `xunit` | Standard |
+| `xunit.runner.visualstudio` | Standard |
+| `Microsoft.Extensions.DependencyInjection` | For DI in runtime tests |
+| `NSubstitute` | For mocking Auth / Kernel / Data dependencies |
+
+## Boundary Check
+- [x] All work inside `HoneyDrunk.Operator`.
+- [x] `HoneyDrunk.Operator.Abstractions` carries zero `HoneyDrunk.*` references — invariant 1.
+- [x] `HoneyDrunk.Operator.Testing` references only `HoneyDrunk.Operator.Abstractions` — invariant 3 applied.
+- [x] `IAuditLog` / `AuditEntry` NOT authored in Abstractions per the 2026-05-16 ADR-0030/0031 amendment.
+- [x] No tool implementations live in any Operator package — Operator owns policy primitives only.
+- [x] Records drop `I` prefix; interfaces keep it.
+- [x] No secrets in code. Auth dependency is policy-resolution by name.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Operator.slnx` builds clean from a fresh clone via `dotnet build` with no warnings.
+- [ ] All eight Operator-owned D3 contracts present in `HoneyDrunk.Operator.Abstractions` with XML documentation per invariant 13.
+- [ ] `IAuditLog` and `AuditEntry` are **NOT** authored in `HoneyDrunk.Operator.Abstractions` (relocated to HoneyDrunk.Audit per ADR-0030/0031 amendment). `rg -n 'interface IAuditLog|record AuditEntry' src/HoneyDrunk.Operator.Abstractions/` returns zero matches.
+- [ ] **No internal `IAuditLog` placeholder anywhere in the repo** — per S6, the scaffold ships without a no-op placeholder type to avoid future name collision with the real `IAuditLog` interface that lands in `HoneyDrunk.Audit.Abstractions`. `rg -n 'IAuditLog' src/ tests/` returns matches **only** if `HoneyDrunk.Audit.Abstractions` was pulled in as a package at execution time (in which case the matches are usages of the genuine contract, not an internal placeholder). If Audit wasn't yet shipped, the only `IAuditLog` references should be `TODO(audit)` comments — see Audit emission (conditional, S2 simplification).
+- [ ] `HoneyDrunk.Operator.Abstractions` has zero `HoneyDrunk.*` PackageReference or ProjectReference entries (invariant 1).
+- [ ] `HoneyDrunk.Operator.Testing` has zero references to `HoneyDrunk.Operator` runtime, `HoneyDrunk.Kernel`, `HoneyDrunk.Auth`, `HoneyDrunk.Data`, `HoneyDrunk.Vault`. Only `HoneyDrunk.Operator.Abstractions` and Microsoft.Extensions.*.
+- [ ] `HoneyDrunk.Operator` runtime exposes `AddHoneyDrunkOperator()`; all five contracts resolve from DI.
+- [ ] `DefaultCostGuard`, `DefaultCircuitBreaker`, `AuthBackedDecisionPolicy`, `DefaultSafetyFilter` all read configuration from App Config via `IConfigProvider`. No hardcoded thresholds, rates, or policies. Unit test verifies one of each.
+- [ ] `DefaultApprovalGate` emits an approval-needed event via `ApprovalEventEmitter` and persists the request via `IRepository`. Unit test verifies emission.
+- [ ] `OperatorTelemetry` emits per-call activities for every gate / breaker / cost / decision / safety-filter call. Verified by test.
+- [ ] `HoneyDrunk.Operator.Testing` ships in-memory implementations of every Operator-owned interface. Each verified by unit test.
+- [ ] All five `.github/workflows/*.yml` files present and reference `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/*@main`.
+- [ ] `api-compatibility.yml` path-filtered to `src/HoneyDrunk.Operator.Abstractions/**`. On the scaffolding PR the workflow reports `status: skipped` against the absent `main` baseline (expected first-build behavior). Post-merge verification via a throwaway breaking-change PR — see procedure under Human Prerequisites.
+- [ ] `pr-core.yml` passes on the scaffolding PR.
+- [ ] Repo-level `CHANGELOG.md` has `## [0.1.0]` entry; per-package `CHANGELOG.md` each have `## [0.1.0]` entries.
+- [ ] Repo-level `README.md` and per-package `README.md` present per invariant 12. Repo README notes the ADR-0030/0031 amendment.
+- [ ] Test suite minimum coverage: `DefaultCircuitBreaker` Closed→Open→HalfOpen→Closed state machine; `DefaultCostGuard` accumulation + budget-exceeded denial; `AuthBackedDecisionPolicy` Allow/Deny/RequireApproval against mocked `IAuthorizationPolicy`; `DefaultApprovalGate` emission + status check; `OperatorTelemetry` activity emission; in-memory testing-fixture smoke tests.
+- [ ] All projects in the solution share `Version` 0.1.0 (test projects excluded via `IsTestProject`).
+- [ ] Manual confirmation that pushing tag `v0.1.0` triggers `release.yml` (verify workflow exists; do not push yet).
+- [ ] Drafting folders (`docs/`, `contracts/`, `policies/`, `prompts/`, `staging/`) remain untouched.
+- [ ] **`ICostController` does not appear anywhere** in the scaffold. `rg -n 'ICostController' src/ tests/` returns zero matches.
+
+## Human Prerequisites
+- [ ] Packet 02b complete — repo settings verified, branch protection in place, labels seeded, local working tree on `main`, OIDC federated credential confirmed.
+- [ ] After this packet's PR merges, push tag `v0.1.0` from `main` to trigger the first NuGet publish. Tags are human-pushed per invariant 27.
+- [ ] **Throwaway breaking-change PR procedure.** After the scaffolding PR merges (which sets the canary's baseline), open a throwaway PR off `main` that intentionally breaks one of the four hot-path interfaces — e.g. add a parameter to `IApprovalGate.RequestAsync` or rename a property on `CostEvent`. Open the PR, confirm the `api-compatibility / abstractions-shape` check **fails** with a shape-drift report, then close the PR without merging. This proves the canary is wired correctly against the v0.1.0 baseline. The throwaway PR is never merged. Track this as a one-off verification step, not a recurring concern.
+- [ ] **Branch protection sequencing.** After the throwaway PR above confirms the canary fires, add `api-compatibility / abstractions-shape` to required checks in the repo's branch protection rule on `main`.
+- [ ] **Audit Node dependency decision (executing agent, S2 simplification).** At packet execution time, check whether `HoneyDrunk.Audit.Abstractions 0.1.0` is available (via NuGet.org or `catalogs/contracts.json` `honeydrunk-audit.status`). If yes, take the package reference and wire audit emission. If no, ship **without** any audit edge — no internal placeholder interface, no no-op fallback, no warning logs. Mark each prospective emission site with a `TODO(audit): wire IAuditLog.AppendAsync once HoneyDrunk.Audit.Abstractions ships — follow-up packet 04` comment. File the follow-up packet (`04-operator-wire-audit-emission.md`) immediately after this packet's PR merges, regardless of which branch was taken — if the package was already available the follow-up is a no-op verification; if not, it carries the real wiring work.
+- [ ] After merge + `v0.1.0` ships, file a SonarCloud onboarding follow-up modeled on the equivalent Kernel onboarding packet.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+
+> **Invariant 2:** Runtime packages depend on Abstractions, never on other runtime packages at the same layer.
+
+> **Invariant 3:** Companion packages (Testing, Providers) depend on the parent Node's contracts package, not internal implementation details.
+
+> **Invariant 4:** No circular dependencies. The dependency graph is a DAG. Kernel is always at the root.
+
+> **Invariant 9:** Vault is the only source of secrets. No Node reads secrets directly from env vars, config files, or provider SDKs.
+
+> **Invariant 11:** One repo per Node. Each repo has its own solution, CI pipeline, and versioning.
+
+> **Invariant 12:** Semantic versioning with CHANGELOG and README. New projects must have both files from the first commit.
+
+> **Invariant 13:** All public APIs have XML documentation. Enforced by HoneyDrunk.Standards analyzers.
+
+> **Invariant 26:** Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section. `HoneyDrunk.Standards` must be on every new .NET project.
+
+> **Invariant 27:** All projects in a solution share one version and move together.
+
+> **Operator downstream-coupling invariant (number assigned by packet 02, default 47):** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Operator.Abstractions`. Production projects must not reference `HoneyDrunk.Operator.Testing`.
+
+> **Operator App-Config-sourcing invariant (number assigned by packet 02, default 48):** Cost-rate tables, breaker thresholds, decision policies, and safety-filter configuration are sourced from Azure App Configuration via Vault's `IConfigProvider`. No hardcoded values.
+
+> **Operator approval-event-out invariant (number assigned by packet 02, default 49):** Operator does not take a runtime dependency on Communications. Approval-needed events are emitted via the configured transport.
+
+> **Operator contract-shape canary invariant (number assigned by packet 02, default 50):** CI must include a contract-shape canary on `IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, `ISafetyFilter`.
+
+## Referenced ADR Decisions
+
+**ADR-0018 D1 (Substrate Node):** Operator owns human-policy primitives. It does not reason; it constrains.
+
+**ADR-0018 D2 (Package families):** Three packages — Abstractions + runtime + Testing.
+
+**ADR-0018 D3 (Ten exposed contracts as originally written; this packet authors the eight Operator-owned after the amendment):** Original D3 — six interfaces + four records (ten total). After the 2026-05-16 ADR-0030 D5 relocation of `IAuditLog`/`AuditEntry` to `HoneyDrunk.Audit.Abstractions`, the Operator-owned set is **eight** — five interfaces (`IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, `IDecisionPolicy`, `ISafetyFilter`) + three records (`CostEvent`, `ApprovalRequest`, `ApprovalDecision`).
+
+**ADR-0018 D5 (Authorization through Auth):** `AuthBackedDecisionPolicy` and `DefaultApprovalGate` delegate to Auth's `IAuthorizationPolicy`.
+
+**ADR-0018 D6 (App Configuration sourcing):** Cost rates, breaker thresholds, decision-policy rule sets, safety-filter config all sourced from App Config via `IConfigProvider`.
+
+**ADR-0018 D7 (Telemetry direction):** `OperatorTelemetry` emits via Kernel's `ITelemetryActivityFactory`; no Pulse runtime edge.
+
+**ADR-0018 D8 (Approval event-out):** `ApprovalEventEmitter` is the event-out surface. Communications is the consumer; Operator does not call `ICommunicationOrchestrator`.
+
+**ADR-0018 D10 (Contract-shape canary):** `api-compatibility.yml` scoped to `HoneyDrunk.Operator.Abstractions`.
+
+**ADR-0018 D11 (Downstream coupling):** Abstractions is HoneyDrunk-dependency-free so consumers don't inherit transitive Kernel/Auth/Data pins.
+
+**ADR-0018 D12 (First-class deps on Kernel, Auth, Data):** Runtime package takes those edges; Abstractions does not.
+
+**ADR-0018 Amendment (2026-05-16, driven by ADR-0030 D5 with ADR-0031 standup):** `IAuditLog` and `AuditEntry` are NOT in this Abstractions package. They live in `HoneyDrunk.Audit.Abstractions` per ADR-0030 D5 ("Contract reconciliation — `IAuditLog`/`AuditEntry` are promoted; Operator becomes a consumer"). ADR-0031 is the corresponding HoneyDrunk.Audit Node standup that ships those contracts. Operator's runtime consumes them when Audit Node ships.
+
+**ADR-0005 (already accepted, App Config split):** HoneyDrunk.Operator is a library Node. App Config is a Grid-shared resource — the runtime reads from it via `IConfigProvider` when composed into a deployable host.
+
+## Dependencies
+- `packet:01` — catalog registration must land first.
+- `packet:02` — four invariants must exist before this packet's acceptance criteria reference them.
+- `packet:02b` — repo settings verified, local clone confirmed.
+
+## Labels
+`feature`, `tier-2`, `ai`, `scaffold`, `adr-0018`
+
+## Agent Handoff
+
+**Objective:** Take the `HoneyDrunk.Operator` repo (carries drafting folders + LICENSE + README) and ship version 0.1.0 with the eight Operator-owned D3 contracts, default runtime, in-memory testing fixture, full CI, and the contract-shape canary scoped to Abstractions. Respect the ADR-0030/0031 amendment relocating audit.
+
+**Target:** HoneyDrunk.Operator, branch from `main`.
+
+**Context:**
+- Goal: Unblock six AI-sector consumer Nodes (Agents, Flow, AI, Capabilities, Evals, Sim).
+- Feature: ADR-0018 standup initiative — this is the substrate scaffold, packet 03.
+- ADRs: ADR-0018 (sole standup); ADR-0030, ADR-0031 (amendment relocating audit); ADR-0005 (App Config split).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packets 01, 02, 02b.
+
+**Constraints:**
+
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. `HoneyDrunk.Operator.Abstractions.csproj` contains no `HoneyDrunk.*` PackageReference or ProjectReference.
+- **Invariant 3 applied to Testing:** `HoneyDrunk.Operator.Testing.csproj` references only `HoneyDrunk.Operator.Abstractions`. No reference to runtime, Kernel, Auth, Data, Vault.
+- **Audit relocation is mandatory.** Do NOT author `IAuditLog` or `AuditEntry` in `HoneyDrunk.Operator.Abstractions`. They live in `HoneyDrunk.Audit.Abstractions` per the 2026-05-16 ADR-0030/0031 amendment.
+- **`ICostController` is dead.** Author `ICostGuard`. If you find any reference to `ICostController` in the drafting folders, do not propagate it.
+- **Records drop `I`; interfaces keep it.** `ApprovalRequest`, `ApprovalDecision`, `CostEvent`, `CostCheckResult`, `CostStatus`, `ActionContext`, `PolicyDecision`, `SafetyFilterRequest`, `SafetyFilterResult` are records. `IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, `IDecisionPolicy`, `ISafetyFilter` are interfaces.
+- **Strict Abstractions stance.** No HoneyDrunk-side types in Abstractions records. `ApprovalRequest.RequesterCorrelationId`, `CostEvent.OperationCorrelationId` are `string`, not `CorrelationId`.
+- **Event-out for approval per D8.** `ApprovalEventEmitter` is the event-out surface. Do NOT take a runtime reference to `HoneyDrunk.Communications` from anywhere in this scaffold.
+- **App Config sourcing per D6.** All thresholds, rates, policies, rule sets read from `IConfigProvider`. No hardcoded values. Unit tests verify config-driven behavior.
+- **Drafting folders are read-only source material.** Don't commit them into `src/`. Don't delete them. Leave them as-is.
+- **Canary on scaffolding PR is expected to skip.** Verification of canary firing happens post-merge via a throwaway breaking-change PR.
+- **Audit Node dependency conditional (S2 simplification).** Check at edit time whether `HoneyDrunk.Audit.Abstractions 0.1.0` is shipped. If yes, take the package reference and emit `IAuditLog.AppendAsync` at every gate / breaker / cost / approval / safety-filter site. If no, ship the scaffold **without** an audit edge — no placeholder interface, no no-op fallback, no warning logs. Mark each prospective emission site with a `TODO(audit): wire IAuditLog.AppendAsync once HoneyDrunk.Audit.Abstractions ships — follow-up packet 04` comment. A follow-up packet adds the reference and the emission in one PR.
+
+**Key Files:**
+- `HoneyDrunk.Operator.slnx`, `Directory.Build.props`
+- `src/HoneyDrunk.Operator.Abstractions/` — eight contract files + supporting record/enum files
+- `src/HoneyDrunk.Operator/` — six default implementations + `ApprovalEventEmitter` + `ServiceCollectionExtensions`
+- `src/HoneyDrunk.Operator.Testing/` — in-memory implementations + `RecordingApprovalEventEmitter`
+- `.github/workflows/{pr-core,release,nightly-deps,nightly-security,api-compatibility}.yml`
+- `README.md`, `CHANGELOG.md` (repo-level + per-package)
+- `tests/HoneyDrunk.Operator.Tests/`, `tests/HoneyDrunk.Operator.Testing.Tests/`
+
+**Contracts:**
+- Eight Operator-owned D3 contracts authored fresh in `HoneyDrunk.Operator.Abstractions`.
+- `IAuditLog`/`AuditEntry` NOT authored here.

--- a/generated/issue-packets/active/adr-0018-operator-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0018-operator-standup/dispatch-plan.md
@@ -1,0 +1,97 @@
+# Dispatch Plan — ADR-0018 HoneyDrunk.Operator Standup
+
+**Initiative:** `adr-0018-operator-standup`
+**Sector:** AI
+**Governing ADR:** [ADR-0018 — Stand Up the HoneyDrunk.Operator Node](../../../../adrs/ADR-0018-stand-up-honeydrunk-operator-node.md) (Proposed 2026-04-19; flips to Accepted after this initiative's PRs merge per the user's ADR acceptance workflow — scope agent flips Status, never on first draft. ADR-0018 carries an additive 2026-05-16 amendment from ADR-0030/0031 relocating `IAuditLog` / `AuditEntry` out of Operator into the new `HoneyDrunk.Audit` Node — this initiative respects that amendment.)
+**Trigger:** ADR-0018 in the Proposed queue. Five AI-sector consumers (Agents, Flow, AI, Capabilities, Evals) plus every domain Node that needs policy enforcement on agent-invoked paths are blocked on `HoneyDrunk.Operator.Abstractions` existing. This initiative builds the human-policy-enforcement substrate that unblocks them.
+**Type:** Multi-repo (2 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.Operator`)
+**Site sync required:** No (scaffold-only).
+**Rollback plan:**
+- **Pre-tag rollback** (before `v0.1.0` is pushed): `git revert` of each PR. Packets 01/02/02b are independent reverts; packet 03 reverts the entire scaffold as a single PR.
+- **Post-tag rollback** (after `v0.1.0` is pushed but before downstream Nodes consume): NuGet packages are immutable. Either `dotnet nuget delete` if the packages were just pushed pre-discovery, or fix-forward as `0.1.1`. Practical hard rollback after a tag is messy — prefer fix-forward.
+- **After downstream consumers start:** rollback is no longer a clean option; treat any defect as forward-only.
+
+## Summary
+
+ADR-0018 is the standup ADR for `HoneyDrunk.Operator`. It decides what the Node owns (D1), three package families with a `.Testing` fixture (D2), **eight Operator-owned contracts (five interfaces + three records)** plus two more (`IAuditLog`, `AuditEntry`) relocated to HoneyDrunk.Audit per the 2026-05-16 amendment (D3 as amended), the lowercase "operator" disambiguation (D4), Auth layering (D5), App Configuration sourcing (D6), one-way telemetry to Pulse (D7), the event-out approval pattern for Communications (D8), append-only-by-interface audit log — now owned by Audit per the amendment (D9), the contract-shape canary on four hot-path interfaces (D10), the downstream coupling rule (D11), and first-class runtime dependencies on Kernel + Auth + Data (D12).
+
+**Critical amendment to respect:** the 2026-05-16 ADR-0030/0031 amendment relocates `IAuditLog` and `AuditEntry` out of `HoneyDrunk.Operator.Abstractions` into the new `HoneyDrunk.Audit.Abstractions`. Operator is now a **consumer** of those two contracts, not their owner. The other eight Operator contracts (`IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, `IDecisionPolicy`, `ISafetyFilter`, `CostEvent`, `ApprovalRequest`, `ApprovalDecision`) are unaffected and stay Operator-owned. Every packet in this initiative reflects this amendment.
+
+Four packets land the work:
+
+1. **Architecture catalog registration + integration-points** — `contracts.json` (rename `ICostController` → `ICostGuard`; add `IDecisionPolicy`, `ISafetyFilter`; add three Operator-owned records `CostEvent`, `ApprovalRequest`, `ApprovalDecision`; mark `IAuditLog`/`AuditEntry` as relocated to `honeydrunk-audit`); update `relationships.json` `consumes`/`exposes.contracts`/`exposes.packages`/`consumed_by_planned`; refresh `grid-health.json`; tighten prose drift for `ICostController` → `ICostGuard`; add `integration-points.md` and `active-work.md`.
+2. **Constitution invariants** — four new invariants from D11, D6, D8, D10 at the next four free numbers (47/48/49/50 assumed; collision check at edit time — current high-water mark in `constitution/invariants.md` is 46). Landed in a new `## AI Sector — Operator Invariants` section (Option A in packet 02).
+2b. **Verify `HoneyDrunk.Operator` repo + verify local clone (human-only)** — the GitHub repo exists, the local working tree at `c:/.../HoneyDrunk.Operator/` exists and is a proper git clone (has scaffolding-source materials in `docs/`, `contracts/`, `policies/`, `prompts/`, `staging/`). Confirm branch protection, seed labels, verify OIDC federated credential.
+3. **HoneyDrunk.Operator scaffold** — empty repo to first-shippable state. Solution, three packages (`Abstractions`, runtime, `Testing` fixture), eight Operator-owned contracts (`IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, `IDecisionPolicy`, `ISafetyFilter`, `CostEvent`, `ApprovalRequest`, `ApprovalDecision`) inside `HoneyDrunk.Operator.Abstractions`, default runtime implementations, in-memory testing fixture, five CI workflow files including the contract-shape canary on the four hot-path interfaces per D10.
+
+## Wave Diagram
+
+```
+Wave 1: Architecture catalog + constitution updates (parallel)
+   ├─ Architecture: 01-architecture-operator-catalog-registration
+   └─ Architecture: 02-architecture-operator-invariants
+       Blocked by: 01
+
+Wave 2: Verify HoneyDrunk.Operator repo and local clone (human)
+   └─ Architecture: 02b-architecture-verify-operator-repo
+       Blocked by: 01
+
+Wave 3: Operator repo scaffold
+   └─ HoneyDrunk.Operator: 03-operator-node-scaffold
+       Blocked by: 01, 02, 02b
+```
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 01 | [Catalog registration + integration-points](./01-architecture-operator-catalog-registration.md) | Architecture | 1 | Agent | — |
+| 02 | [Add four new invariants for D11 / D6 / D8 / D10](./02-architecture-operator-invariants.md) | Architecture | 1 | Agent | 01 |
+| 02b | [Verify HoneyDrunk.Operator repo + clone (human-only)](./02b-architecture-verify-operator-repo.md) | Architecture | 2 | Human | 01 |
+| 03 | [Stand up `HoneyDrunk.Operator` — solution, three packages, contracts, CI, in-memory testing fixture](./03-operator-node-scaffold.md) | HoneyDrunk.Operator | 3 | Agent | 01, 02, 02b |
+
+## Filing-order rule
+
+Packet 03 hard-codes invariant numbers (default 47/48/49/50 — current high-water mark in `constitution/invariants.md` is 46) in its body and acceptance criteria. Filed packets are immutable (invariant 24). Therefore:
+
+**Packet 02 cannot be filed until packet 01 has been filed.** Packet 02's `dependencies: ["packet:01"]` makes this explicit at the data layer, and per invariant 24 packet 02 becomes immutable the moment it lands as a GitHub Issue — so the dependency resolves to a `packet:01` issue number that must already exist. The filing pipeline (`file-packets.yml`) processes packets in two-digit-prefix order on each push, so as long as packets 01 and 02 land in the same push the wiring is automatic.
+
+**Packet 02 must be filed, its PR merged, and the assigned invariant numbers locked in `constitution/invariants.md` before packet 03 is filed.** Packet 02b can run in parallel with packet 02. If packet 02's collision check shifts numbers away from 47/48/49/50, the packet 02 source file AND the packet 03 source file MUST be amended in place before push (pre-filing carve-out under invariant 24). Packet 02's Proposed Implementation section carries an exhaustive cross-reference list of every numbered line in packet 03 to keep this rewrite mechanical.
+
+**Race between AI-sector standup initiatives.** ADR-0018, 0020, 0021, 0022, 0023, 0024, 0025 all want the next free invariant numbers. Whichever lands first claims them; the others shift in lockstep. The dispatch plan assumes a serial landing order across the seven AI-sector standup initiatives — see "AI-sector standup wave sequencing" below.
+
+## What This Initiative Does **NOT** Deliver
+
+- The five downstream consumer Nodes (Agents, Flow, AI, Capabilities, Evals) are not delivered here. Operator's stand-up unblocks them; each gets its own standup ADR + initiative.
+- `IAuditLog` and `AuditEntry` are explicitly **out of scope** in this initiative per the 2026-05-16 ADR-0030/0031 amendment. They land under the HoneyDrunk.Audit Node standup initiative, not here.
+- The approval-notification **transport mechanism** (D8) is deferred to a follow-up packet. The stand-up commitment is the event-out pattern, not the wire shape.
+- Pulse signal ingress into Operator is deferred (emit-only at stand-up per D7).
+- The first production decision-policy implementations (e.g. an OPA-style rule evaluator) ship as follow-up packets.
+
+## AI-sector standup wave sequencing
+
+The seven AI-sector standup initiatives (ADR-0016 through ADR-0025) all want next-free invariant numbers and all build on each other's `Abstractions` packages. Recommended serial landing order:
+
+1. ADR-0016 (AI) — landed; claimed invariants 44/45/46 in `## AI Invariants`
+2. ADR-0017 (Capabilities) — packets exist; claims the next set
+3. ADR-0018 (Operator) — this initiative; default claim 47/48/49/50 in a new `## AI Sector — Operator Invariants` section
+4. ADR-0020 (Agents) — depends on AI, Capabilities, Operator, Memory, Knowledge `Abstractions` existing
+5. ADR-0021 (Knowledge) — depends on AI `Abstractions`
+6. ADR-0022 (Memory) — depends on AI, Auth `Abstractions`
+7. ADR-0023 (Evals) — depends on AI, Agents, Capabilities, Operator, Knowledge, Memory `Abstractions`
+8. ADR-0024 (Flow) — depends on Agents, Operator, Communications `Abstractions`
+9. ADR-0025 (Sim) — depends on AI, Flow, Memory, Operator `Abstractions`
+
+Practical ordering: stand up AI + Capabilities + Operator first (the three substrates), then Memory + Knowledge in parallel, then Agents (composes the substrates + Memory + Knowledge), then Evals + Flow + Sim (each composes Agents).
+
+## Status flip
+
+ADR-0018 stays at `Status: Proposed` for the duration of this initiative's PRs. The scope agent flips Status → Accepted after all four packets close, per the user's standing ADR acceptance workflow — not from inside any packet.
+
+## Filing
+
+The `file-packets.yml` workflow auto-files on push to `generated/issue-packets/active/**/*.md`. No manual `gh issue create` commands. Verify by checking The Hive (org Project #4) for the new items and their blocking edges.
+
+## Archival
+
+Per ADR-0008 D10, when every packet reaches `Done` and `HoneyDrunk.Operator 0.1.0` is published to NuGet, the entire `active/adr-0018-operator-standup/` folder moves to `archive/adr-0018-operator-standup/` in a single commit.


### PR DESCRIPTION
## Summary

Scopes four packets standing up [HoneyDrunk.Operator](https://github.com/HoneyDrunkStudios/HoneyDrunk.Operator) per [ADR-0018](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0018-stand-up-honeydrunk-operator-node.md). This is the **first AI-sector Node standup** to land its invariants — seeds the 47–50 band and sets the pattern for the rest of the wave (Agents, Knowledge, Memory, Evals, Flow, Sim).

### Wave 1 — Architecture-repo (parallel)
- **`01-catalog-registration`** — `contracts.json` rename `ICostController` → `ICostGuard`, add `IDecisionPolicy`/`ISafetyFilter`, add three records (`CostEvent`, `ApprovalRequest`, `ApprovalDecision`); `relationships.json` consumes/exposes/`consumed_by_planned` widening; mark `IAuditLog`/`AuditEntry` as **RELOCATED to honeydrunk-audit** per ADR-0030 D5; grid-health refresh; integration-points.md + active-work.md.
- **`02-invariants`** — four new constitution invariants (default 47–50, collision-check at edit time) in a new `## AI Sector — Operator Invariants` section.
- **`02b-verify-operator-repo`** — human-only chore, includes Step 0 for `chore/wire-standard-workflows` branch reconcile.

### Wave 2 — Operator scaffold
- **`03-operator-node-scaffold`** — three packages (Abstractions, runtime, Testing fixture), eight Operator-owned contracts, default runtime impls, in-memory fixture, five CI workflows, contract-shape canary on four hot-path interfaces per D10.

## ADR-0030 amendment respected

The 2026-05-16 ADR-0030 D5 amendment relocated `IAuditLog`/`AuditEntry` out of Operator into the new `HoneyDrunk.Audit` Node. This initiative does NOT author those contracts in Operator.Abstractions. Every Audit call site in the runtime gets a `TODO(audit-relocation)` comment referencing the follow-up wire packet to be filed after `HoneyDrunk.Audit.Abstractions` ships (ADR-0031 standup).

## Conventions

- **NuGet uses `.Abstractions` packages** throughout (invariant 2).
- **Records drop `I`** (`CostEvent`, `ApprovalRequest`, `ApprovalDecision`); **interfaces keep `I`** (`IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, `IDecisionPolicy`, `ISafetyFilter`).
- Each packet carries `accepts: ADR-0018` for hive-sync auto-flip.

## Filing

When this merges, `file-packets.yml` auto-files four issues: three against Architecture (Wave 1) and one against HoneyDrunk.Operator (Wave 2). `dependencies:` frontmatter wires `addBlockedBy` edges on The Hive (02 blocked by 01; 02b blocked by 01; 03 blocked by 01 + 02 + 02b).

## Invariant numbering

Default 47–50 (current `constitution/invariants.md` high-water is 46 after ADR-0016 landed 44/45/46). Packet 02's collision-check protocol re-verifies at execution time; if a sibling AI-sector standup lands first, packet 02 + packet 03 re-key under the invariant-24 pre-filing carve-out.

## Test plan

- [ ] After merge, verify four issues file automatically with correct The Hive fields
- [ ] Confirm packet 02's collision-check picks 47–50 (or shifts if needed)
- [ ] Wave 2 packet 03 stays blocked on The Hive until packets 01, 02, 02b close
- [ ] When all four close, hive-sync auto-flips ADR-0018 Proposed → Accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)