### PR TITLE
chore: scope ADR-0020 agents node standup

### DIFF
--- a/generated/issue-packets/active/adr-0020-agents-standup/01-architecture-agents-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0020-agents-standup/01-architecture-agents-catalog-registration.md
@@ -1,0 +1,277 @@
+---
+name: Architecture Catalog Registration
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0020"]
+dependencies: []
+adrs: ["ADR-0020"]
+accepts: ADR-0020
+wave: 1
+initiative: adr-0020-agents-standup
+node: honeydrunk-agents
+---
+
+# Chore: Register HoneyDrunk.Agents's standup decisions in Architecture catalogs
+
+## Summary
+
+Reflect ADR-0020's stand-up decisions in the canonical Architecture catalogs and the AI sector architecture doc. Verify (and tighten descriptions on) the five-interface contract set in `contracts.json`; add the missing `honeydrunk-memory` and `honeydrunk-operator` edges to `relationships.json` `consumes`; add `honeydrunk-actions` to `consumed_by_planned`; refresh `grid-health.json` and `nodes.json`; fix `repos/HoneyDrunk.Agents/boundaries.md` (incorrectly lists `IMemoryScope` as Agents-owned); fix `repos/HoneyDrunk.Agents/integration-points.md` canary description (Agents→AI is `IChatClient` direct, not via `IToolInvoker`); add `repos/HoneyDrunk.Agents/active-work.md` if not present.
+
+ADR-0020 stays at `Status: Proposed` for this packet.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0020 establishes the Agents Node's exposed contracts, package families, and seven new invariants. None of that has reached the catalogs fully. Specific drift items:
+
+1. **`contracts.json` already lists five interfaces** (`IAgent`, `IAgentExecutionContext`, `IAgentLifecycle`, `IToolInvoker`, `IAgentMemory`). Verify alignment with D3; tighten descriptions to reflect D5/D6/D7 compositions.
+2. **`relationships.json` `consumes` is missing `honeydrunk-memory` and `honeydrunk-operator`** per D4 / D6 / D7. Both edges are real at the default-implementation layer.
+3. **`relationships.json` `consumed_by_planned` is missing `honeydrunk-actions`** per the cloud-agent trigger path (ADR-0020 Unblocks).
+4. **`repos/HoneyDrunk.Agents/boundaries.md` lists `IMemoryScope` under Agents-owned contracts.** Per ADR-0020 D6 and ADR-0022 D4, `IMemoryScope` is Memory's, not Agents's. Drift error.
+5. **`repos/HoneyDrunk.Agents/integration-points.md` canary description for Agents→AI says** "verifies `IChatClient` is resolved through `IToolInvoker` mechanism." That's wrong. `IChatClient` is consumed directly from AI; `IToolInvoker` routes tool calls to Capabilities, not inference to AI.
+
+## Proposed Implementation
+
+### `catalogs/contracts.json` — `honeydrunk-agents` block
+
+The current entry already lists the five interfaces from D3. Verify and tighten descriptions:
+
+```json
+{
+  "node": "honeydrunk-agents",
+  "node_name": "HoneyDrunk.Agents",
+  "package": "HoneyDrunk.Agents.Abstractions",
+  "status": "seed",
+  "interfaces": [
+    { "name": "IAgent", "kind": "interface", "description": "Core agent interface — identity, capability declarations, execution entry point. Per ADR-0020 D3 / D4." },
+    { "name": "IAgentExecutionContext", "kind": "interface", "description": "Agents-owned execution context extending Kernel's IOperationContext with AI-specific bindings (memory references, tool bindings, inference binding). Holds execution-scope state only per ADR-0020 D8." },
+    { "name": "IAgentLifecycle", "kind": "interface", "description": "Lifecycle hooks for agents: register → initialize → execute → complete → decommission. ADR-0020 D3 / D11." },
+    { "name": "IToolInvoker", "kind": "interface", "description": "How agents call tools — resolves through Capabilities's ICapabilityRegistry and dispatches through ICapabilityInvoker. Authorization flows through Capabilities's ICapabilityGuard per ADR-0020 D5." },
+    { "name": "IAgentMemory", "kind": "interface", "description": "Memory read/write from the agent's perspective — backed by Memory Node storage via IMemoryScope and IMemoryStore per ADR-0020 D6. No persistence semantics in Agents itself." }
+  ]
+}
+```
+
+No records are added at stand-up per D3. Confirm that the schema has not introduced any `kind: "record"` entries.
+
+### `catalogs/relationships.json` — `honeydrunk-agents` block
+
+**(a) `consumes` array.** Current value listed at line 230 is `["honeydrunk-kernel", "honeydrunk-ai", "honeydrunk-capabilities"]`. Replace with:
+
+```json
+"consumes": ["honeydrunk-kernel", "honeydrunk-ai", "honeydrunk-capabilities", "honeydrunk-operator", "honeydrunk-memory"]
+```
+
+**(b) `consumes_detail`.** Add per-edge entries:
+
+```json
+"consumes_detail": {
+  "honeydrunk-kernel": ["IGridContext", "IOperationContext", "ITelemetryActivityFactory", "HoneyDrunk.Kernel.Abstractions"],
+  "honeydrunk-ai": ["IChatClient", "IEmbeddingGenerator", "ModelCapabilityDeclaration", "HoneyDrunk.AI.Abstractions"],
+  "honeydrunk-capabilities": ["ICapabilityRegistry", "ICapabilityInvoker", "ICapabilityGuard", "HoneyDrunk.Capabilities.Abstractions"],
+  "honeydrunk-operator": ["IApprovalGate", "ICircuitBreaker", "HoneyDrunk.Operator.Abstractions"],
+  "honeydrunk-memory": ["IMemoryStore", "IMemoryScope", "HoneyDrunk.Memory.Abstractions"]
+}
+```
+
+**(c) `consumed_by_planned` array.** Current value lists `["honeydrunk-flow", "honeydrunk-sim", "honeydrunk-lore"]`. Add `honeydrunk-actions` (cloud-agent trigger path per Unblocks) and `honeydrunk-evals`:
+
+```json
+"consumed_by_planned": ["honeydrunk-flow", "honeydrunk-sim", "honeydrunk-lore", "honeydrunk-actions", "honeydrunk-evals"]
+```
+
+**(d) `exposes.packages` array.** Add `HoneyDrunk.Agents.Testing` if not already present:
+
+```json
+"packages": ["HoneyDrunk.Agents.Abstractions", "HoneyDrunk.Agents", "HoneyDrunk.Agents.Testing"]
+```
+
+### `catalogs/grid-health.json` — `honeydrunk-agents` block
+
+Replace the existing stub with:
+
+```json
+{
+  "id": "honeydrunk-agents",
+  "name": "HoneyDrunk.Agents",
+  "sector": "AI",
+  "signal": "Seed",
+  "version": "0.0.0",
+  "canary_status": "none",
+  "last_release": null,
+  "active_blockers": ["Scaffold packet (Agents#NN — packet 03 of adr-0020-agents-standup) not yet executed", "Upstream Abstractions packages (AI, Capabilities, Operator, Memory) may not all be published — packet 03 ships placeholder no-op for any missing upstream"],
+  "notes": "ADR-0020 standup ADR Proposed 2026-04-19 (Status flip is post-merge housekeeping). Catalog surface registered (5 interfaces per D3: IAgent, IAgentExecutionContext, IAgentLifecycle, IToolInvoker, IAgentMemory). No records at stand-up — deferred to scaffold or later ADRs per D3. Awaiting scaffold: HoneyDrunk.Agents.Abstractions, HoneyDrunk.Agents runtime (default IAgent harness, in-process registry, IToolInvoker composing Capabilities, IAgentMemory composing Memory, function-calling adapter per D12), HoneyDrunk.Agents.Testing fixture, Standards wiring, CI with contract-shape canary scoped to four hot-path interfaces (IAgent, IAgentExecutionContext, IToolInvoker, IAgentMemory)."
+}
+```
+
+### `catalogs/nodes.json` — `honeydrunk-agents` block
+
+**(a) `grid_relationship`.** Replace with:
+
+> `"grid_relationship": "Consumes Kernel (context, lifecycle, telemetry), AI (IChatClient, IEmbeddingGenerator, ModelCapabilityDeclaration for inference), Capabilities (ICapabilityRegistry / ICapabilityInvoker / ICapabilityGuard for tool dispatch), Operator (IApprovalGate / ICircuitBreaker for safety-gate composition), Memory (IMemoryStore / IMemoryScope for IAgentMemory composition). Emits lifecycle, execution, tool-invocation, gate-outcome, and memory-access telemetry consumed by Pulse — no runtime dependency on Pulse (ADR-0020 D9). Consumed by Flow (workflow-step agent invocation), Sim (scenario-driven agent runs), Lore (lore-side content generation), HoneyDrunk.Actions (cloud-agent trigger path), HoneyHub (when live), Evals (agent-behavior suites)."`
+
+**(b) `tags`.** Confirm includes `agent-runtime`, `lifecycle`, `tool-invocation`, `function-calling`, `execution-context`.
+
+### `constitution/ai-sector-architecture.md` — Agents section
+
+Update Key Contracts list to match D3 (five interfaces). Update Depends-on:
+
+> `**Depends on:** Kernel (context, lifecycle, telemetry), AI (IChatClient, IEmbeddingGenerator, ModelCapabilityDeclaration), Capabilities (ICapabilityRegistry / ICapabilityInvoker / ICapabilityGuard), Operator (IApprovalGate / ICircuitBreaker), Memory (IMemoryStore / IMemoryScope)`
+>
+> `**Emits to (no runtime dependency):** Pulse (lifecycle / execution / tool-invocation / gate-outcome / memory-access telemetry per call via Kernel's ITelemetryActivityFactory — ADR-0020 D9)`
+
+### `repos/HoneyDrunk.Agents/boundaries.md` — `IMemoryScope` ownership fix
+
+Locate the "What Agents Owns" section. Remove `IMemoryScope` from any list. Add a clarifying note:
+
+> `Agents consumes `IMemoryScope` from `HoneyDrunk.Memory.Abstractions` for its `IAgentMemory` composition (per ADR-0020 D6). Agents does NOT own `IMemoryScope` — that contract is Memory's. Resolved scope flows through `IAgentMemory`; the scope primitive itself is Memory's authorization-window abstraction.`
+
+### `repos/HoneyDrunk.Agents/integration-points.md` — canary description fix + App Config edge
+
+**(a) Canary description fix.** Locate the Agents→AI canary line. Replace any phrasing like "verifies `IChatClient` is resolved through `IToolInvoker` mechanism, inference result is returned" with:
+
+> `Agents.Canary → AI: verifies IChatClient (and IEmbeddingGenerator) are resolved directly from HoneyDrunk.AI.Abstractions and produce inference results. IChatClient is Agents's direct dependency on AI; IToolInvoker is a separate path (Agents → Capabilities for tool dispatch, NOT for inference).`
+
+**(b) Add `Agents → App Config` edge under `## Consumes`.** The function-calling adapter (D12) reads per-`ModelCapabilityDeclaration` translation rules from Azure App Configuration via Vault's `IConfigProvider` — no per-provider adapter code is compiled in. This is a runtime composition concern; the `.Abstractions` package itself takes no dependency on App Config. Add the row:
+
+> `| **Vault** | `IConfigProvider` | The function-calling adapter (D12) reads per-model translation rules from App Configuration via Vault's `IConfigProvider` so per-provider payload shape handling is operator-configurable without a redeploy. No compile-time dependency on App Config from Agents.Abstractions — runtime composition only. |`
+
+### `repos/HoneyDrunk.Agents/active-work.md` — verify or create
+
+If the file exists, add the scaffold packet as the active work item. If not, create it matching the `repos/HoneyDrunk.Knowledge/` template (will exist once that initiative lands; otherwise mirror Capabilities's).
+
+### `initiatives/active-initiatives.md` — new entry
+
+Add under `## In Progress`:
+
+```markdown
+### ADR-0020 HoneyDrunk.Agents Standup
+**Status:** In Progress
+**Scope:** Architecture, HoneyDrunk.Agents
+**Initiative:** `adr-0020-agents-standup`
+**Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)
+**Description:** Stand up `HoneyDrunk.Agents` as the AI sector's agent-runtime substrate per ADR-0020. Catalog reconciliation (add Memory + Operator to consumes, fix boundaries.md IMemoryScope ownership drift, fix integration-points.md Agents→AI canary description), seven new invariants for D2/D5/D6/D5/D6/D12/D13/D10, human-only repo verification + clone confirmation, and the scaffold packet (three packages: Abstractions, runtime, Testing; five contracts; function-calling adapter per D12). Unblocks Flow, Sim, Lore, HoneyDrunk.Actions cloud-agent trigger, HoneyHub when live, Evals.
+
+**Tracking:**
+- [ ] Architecture#NN: Catalog registration + boundary/integration-points fixes (packet 01)
+- [ ] Architecture#NN: Add seven new invariants (packet 02)
+- [ ] Architecture#NN: Verify HoneyDrunk.Agents repo + clone (human-only — packet 02b)
+- [ ] Agents#NN: Scaffold HoneyDrunk.Agents (packet 03)
+
+> **Sync (2026-MM-DD):** Initiative scoped. Packets 01/02/02b ready to file; packet 03 parked on packet 02 + 02b landing + upstream AI/Capabilities/Operator/Memory Abstractions being available.
+```
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to Unreleased: `Architecture: Register ADR-0020 standup decisions in catalogs (contracts.json descriptions tightened for D3 alignment; relationships.json adds Memory + Operator to consumes, adds Actions + Evals to consumed_by_planned, adds Testing package; grid-health.json gets the standup block; nodes.json grid_relationship reflects D4/D9; ai-sector-architecture.md updates Agents Depends-on; repos/HoneyDrunk.Agents/boundaries.md fixes IMemoryScope ownership drift per D6; repos/HoneyDrunk.Agents/integration-points.md fixes Agents→AI canary description; active-initiatives.md gets the new initiative block). ADR-0020 stays Proposed.`
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+- `catalogs/grid-health.json`
+- `catalogs/nodes.json`
+- `constitution/ai-sector-architecture.md`
+- `repos/HoneyDrunk.Agents/boundaries.md`
+- `repos/HoneyDrunk.Agents/integration-points.md`
+- `repos/HoneyDrunk.Agents/active-work.md` (verify/create)
+- `initiatives/active-initiatives.md`
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] No code changes; metadata + docs only.
+- [x] D3 five-interface surface preserved; descriptions tightened only.
+- [x] `IMemoryScope` ownership corrected — Memory owns it, Agents consumes it.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` `honeydrunk-agents` block has exactly the five D3 interfaces with descriptions reflecting D4-D9.
+- [ ] `catalogs/relationships.json` `honeydrunk-agents.consumes` includes `honeydrunk-memory` and `honeydrunk-operator`.
+- [ ] `catalogs/relationships.json` `honeydrunk-agents.consumes_detail` has entries for all five consumed Nodes.
+- [ ] `catalogs/relationships.json` `honeydrunk-agents.consumed_by_planned` includes `honeydrunk-actions` and `honeydrunk-evals`.
+- [ ] `catalogs/relationships.json` `honeydrunk-agents.exposes.packages` includes `HoneyDrunk.Agents.Testing`.
+- [ ] `catalogs/grid-health.json` `honeydrunk-agents` block reflects the standup ADR with scaffold packet as blocker.
+- [ ] `catalogs/nodes.json` `honeydrunk-agents.grid_relationship` reflects D4/D9.
+- [ ] `constitution/ai-sector-architecture.md` Agents section Key Contracts list = five D3 interfaces; Depends-on split into "Depends on" + "Emits to (no runtime dependency)".
+- [ ] `repos/HoneyDrunk.Agents/boundaries.md` does NOT list `IMemoryScope` under Agents-owned contracts; carries clarifying note that Memory owns it.
+- [ ] `repos/HoneyDrunk.Agents/integration-points.md` Agents→AI canary description does NOT say "through IToolInvoker" — describes `IChatClient` as direct dependency.
+- [ ] `repos/HoneyDrunk.Agents/integration-points.md` `## Consumes` table includes a new `Vault | IConfigProvider` row covering the function-calling adapter's per-model translation rules sourced from App Configuration (D12).
+- [ ] `repos/HoneyDrunk.Agents/active-work.md` exists.
+- [ ] `initiatives/active-initiatives.md` includes new "ADR-0020 HoneyDrunk.Agents Standup" block.
+- [ ] `CHANGELOG.md` Unreleased updated.
+- [ ] `adrs/ADR-0020-stand-up-honeydrunk-agents-node.md` is NOT modified — Status stays Proposed.
+
+## Human Prerequisites
+None.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+
+> **Invariant 4:** No circular dependencies. Kernel is always at the root.
+
+> **Invariant 11:** One repo per Node.
+
+## Referenced ADR Decisions
+
+**ADR-0020 D3:** Five interfaces. No records at stand-up.
+
+**ADR-0020 D4:** Boundary decision test against AI / Capabilities / Operator / Memory / Flow.
+
+**ADR-0020 D5:** Tool invocation composes upstream — `IToolInvoker` adapts Capabilities.
+
+**ADR-0020 D6:** Memory access composes upstream — `IAgentMemory` adapts Memory. `IMemoryScope` is Memory-owned.
+
+**ADR-0020 D7:** Safety gate composition with Operator — invoke, not emit.
+
+**ADR-0020 D9:** Telemetry emission — Pulse consumes, Agents does not depend.
+
+**ADR-0020 Unblocks:** Cloud-agent trigger path via HoneyDrunk.Actions — adds `consumed_by_planned` edge.
+
+## Dependencies
+None.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0020`
+
+## Agent Handoff
+
+**Objective:** Bring `HoneyDrunk.Architecture` catalogs into alignment with ADR-0020 D3, D4, D5, D6, D7, D9. Fix the two drift items in `repos/HoneyDrunk.Agents/` (boundaries.md `IMemoryScope` ownership, integration-points.md canary description).
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Context:**
+- Goal: Catalog drift blocks Agents's downstream consumers (Flow, Sim, Lore, Actions cloud-agent path, HoneyHub, Evals).
+- Feature: ADR-0020 standup initiative, Wave 1, Packet 01.
+- ADRs: ADR-0020 (sole standup).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+- **`IMemoryScope` is Memory's, not Agents's.** Fix the drift in `boundaries.md`.
+- **`IChatClient` is Agents → AI, not Agents → IToolInvoker → AI.** Fix the canary description in `integration-points.md`.
+- **D3 says five interfaces and zero records at stand-up.** Verify catalog reflects this; do not add records.
+- **No ADR Status flip in this packet.**
+
+**Key Files:**
+- `catalogs/contracts.json` — verify + tighten descriptions on `honeydrunk-agents`
+- `catalogs/relationships.json` — `consumes` widening + `consumes_detail` + `consumed_by_planned` widening + packages
+- `catalogs/grid-health.json` — replace `honeydrunk-agents` block
+- `catalogs/nodes.json` — `grid_relationship`, `tags`
+- `constitution/ai-sector-architecture.md` — Agents section
+- `repos/HoneyDrunk.Agents/boundaries.md` — `IMemoryScope` ownership fix
+- `repos/HoneyDrunk.Agents/integration-points.md` — canary description fix
+- `repos/HoneyDrunk.Agents/active-work.md` — verify/create
+- `initiatives/active-initiatives.md` — new entry
+- `CHANGELOG.md`
+
+**Contracts:** None authored. Catalog-only.

--- a/generated/issue-packets/active/adr-0020-agents-standup/02-architecture-agents-invariants.md
+++ b/generated/issue-packets/active/adr-0020-agents-standup/02-architecture-agents-invariants.md
@@ -1,0 +1,165 @@
+---
+name: Constitution Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0020", "constitution"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0020"]
+accepts: ADR-0020
+wave: 1
+initiative: adr-0020-agents-standup
+node: honeydrunk-agents
+---
+
+# Chore: Add ADR-0020's seven new invariants to the Grid constitution
+
+## Summary
+
+Add seven new invariants to `constitution/invariants.md` derived from ADR-0020's Consequences section: downstream-coupling (D2/D5/D6), no-direct-model-providers (D5/D9), no-direct-tool-implementations (D5/D9), no-direct-Memory-writes (D6/D8), function-calling-loop-lives-in-Agents-only (D12), Abstractions-no-third-party-AI-runtime (D13), and contract-shape-canary-on-four-hot-paths (D10).
+
+Default-assigned numbers **51, 52, 53, 54, 55, 56, 57** — the next seven free slots after ADR-0016 (44/45/46 already landed in `## AI Invariants`), ADR-0017 (43-46, currently colliding with ADR-0016 — shifts at edit time), ADR-0018 (44-47, also colliding — shifts), ADR-0030 (44 landed in `## Audit Invariants`), and ADR-0031 (45-46 reserved in `## Audit Invariants`). Collision check at edit time decides actual numbers. Parallel downstream initiatives (ADR-0021/0022/0023/0024/0025) currently default to 55-92, so any shift in this packet must also be communicated through `adr-0020-agents-standup/03-agents-node-scaffold.md` updates per invariant 24's pre-filing carve-out.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0020 explicitly delegates final invariant numbering to the scope agent at acceptance time. Seven rules govern Agents:
+
+- **Downstream coupling.** Composition against `HoneyDrunk.Agents` runtime and `HoneyDrunk.Agents.Testing` is a host-time / test-time concern.
+- **No direct model providers.** Inference flows through `IChatClient` from AI; no Node uses provider SDKs directly.
+- **No direct tool implementations.** Tool invocations flow through `IToolInvoker` (which composes Capabilities).
+- **No direct persistent agent-state writes.** Memory access flows through `IAgentMemory` (which composes Memory).
+- **Function-calling loop lives in Agents only.** No other AI-sector Node may introduce an equivalent loop of "model → tool-call → next model call."
+- **Abstractions has no third-party AI-runtime compile-time dependencies.** Microsoft.Extensions.AI, provider SDKs, agent-framework libraries: not in `HoneyDrunk.Agents.Abstractions`.
+- **Contract-shape canary on four hot-path interfaces.** `IAgent`, `IAgentExecutionContext`, `IToolInvoker`, `IAgentMemory`.
+
+## Proposed Implementation
+
+### `constitution/invariants.md` — append seven new entries
+
+Default-assigned numbers 51-57. Use Option A (new `## AI Sector — Agents Invariants` section) if the layout supports it; else Option B (append inside the existing `## AI Invariants` section, after the highest-numbered entry). Mark each with `(Proposed — this invariant takes effect when ADR-0020 is accepted)`.
+
+```markdown
+## AI Sector — Agents Invariants
+
+51. **Downstream Nodes take a runtime dependency only on `HoneyDrunk.Agents.Abstractions`.**
+    Composition against `HoneyDrunk.Agents` and `HoneyDrunk.Agents.Testing` is a host-time (and test-time) concern. Test projects may reference `HoneyDrunk.Agents.Testing` for in-memory fixtures; production projects must not. See ADR-0020 D2, D5, D6 (Proposed — this invariant takes effect when ADR-0020 is accepted).
+
+52. **Agents never call model providers directly.**
+    All inference flows through `IChatClient` from `HoneyDrunk.AI.Abstractions`. Agent code that imports a provider SDK (`OpenAI`, `Anthropic.SDK`, `Azure.AI.OpenAI`, etc.) is a build-time violation. This extends `repos/HoneyDrunk.Agents/invariants.md` item 4 to the Grid level. See ADR-0020 D5, D9 (Proposed — this invariant takes effect when ADR-0020 is accepted).
+
+53. **Agents never call tool implementations directly.**
+    All tool invocations flow through `IToolInvoker`, which composes Capabilities's `ICapabilityRegistry` and `ICapabilityInvoker` and applies `ICapabilityGuard`. This extends `repos/HoneyDrunk.Agents/invariants.md` item 5 to the cross-Node boundary level. See ADR-0020 D5 (Proposed — this invariant takes effect when ADR-0020 is accepted).
+
+54. **Agents never write persistent agent state directly.**
+    All memory access flows through `IAgentMemory`, which composes Memory's `IMemoryStore` and `IMemoryScope`. Execution-scope state stays on `IAgentExecutionContext` and is disposed when the execution ends; anything that must survive the execution is written through `IAgentMemory`. See ADR-0020 D6, D8 (Proposed — this invariant takes effect when ADR-0020 is accepted).
+
+55. **The function-calling loop (model tool-call output → `IToolInvoker` invocations → next inference call) lives in the `HoneyDrunk.Agents` runtime package and nowhere else.**
+    No other AI-sector Node may introduce an equivalent loop. The loop composes inference (AI), tool dispatch (Agents → Capabilities), and execution state (`IAgentExecutionContext`); putting it elsewhere drags two foreign Nodes' concerns into the host. See ADR-0020 D12 (Proposed — this invariant takes effect when ADR-0020 is accepted).
+
+56. **`HoneyDrunk.Agents.Abstractions` takes no third-party AI-runtime compile-time dependencies.**
+    `Microsoft.Extensions.AI`, model-provider SDKs, agent-framework libraries (LangChain, Semantic Kernel, etc.) are forbidden in the Abstractions package. The runtime package may take them where the function-calling adapter or default implementations genuinely benefit, but Abstractions stays clean so downstream consumers do not transit external version pins. See ADR-0020 D13 and `repos/HoneyDrunk.Agents/invariants.md` item 1 (Proposed — this invariant takes effect when ADR-0020 is accepted).
+
+57. **The HoneyDrunk.Agents Node CI must include a contract-shape canary that fails the build on shape drift to `IAgent`, `IAgentExecutionContext`, `IToolInvoker`, or `IAgentMemory` without a corresponding version bump.**
+    These four are the hot-path abstractions every downstream consumer (Flow, Sim, Lore, HoneyHub when live, the Actions cloud-agent trigger path, Evals) compiles against. Accidental shape drift on any of them breaks every Node that runs an agent. The canary makes this a compile-time failure at Agents's own CI. See ADR-0020 D10 (Proposed — this invariant takes effect when ADR-0020 is accepted).
+```
+
+### Collision-check rule
+
+The current state of `constitution/invariants.md` (verified at packet-authoring time, 2026-05-20) is:
+
+- `## AI Invariants` section already occupies **44**, **45**, **46** (ADR-0016, Accepted — these are in the file as of today). 47 is currently free in that section.
+- `## Audit Invariants` section already occupies **44** (ADR-0030 packet 02, Accepted) with **45** and **46** held by a reservation paragraph for the ADR-0031 standup.
+
+Competing in-flight standup initiatives currently pre-claim:
+
+- **ADR-0017 Capabilities** packet 02: defaults 43-46 — collides with ADR-0016 (which now holds 44-46); ADR-0017 must shift at its own edit time per its collision rule.
+- **ADR-0018 Operator** packet 02: defaults 44-47 — collides with ADR-0016; ADR-0018 must shift.
+- **ADR-0030 Audit substrate**: claimed 44 in `## Audit Invariants` (landed).
+- **ADR-0031 Audit Node standup**: claims 45-46 (reserved in `## Audit Invariants`).
+- **ADR-0021 Knowledge** packet 02: defaults 55-59 — collides with this packet's default of 51-57 if both land in the same window.
+- **ADR-0022 Memory** packet 02: defaults 60-66.
+- **ADR-0023 Evals** packet 02: defaults 67-73.
+- **ADR-0024 Flow** packet 02: defaults 74-82.
+- **ADR-0025 Sim** packet 02: defaults 83-92.
+
+Before committing, the executing agent runs `rg -n '^\d+\.\s\*\*' constitution/invariants.md` and:
+
+1. **Finds the highest currently-occupied number across all sections** (currently 46 in `## AI Invariants` and 46 in `## Audit Invariants`'s reservation note). The hard high-water mark is therefore 46.
+2. **Picks the next seven monotonically free integers** that no other already-landed section claims. With current state, the next free range is **51-57** (skipping 47-50 to leave headroom for ADR-0017 / ADR-0018 if they land first and shift into 47-50, since both their PRs will pre-empt this packet's PR's view of the file).
+3. **If ADR-0017 and ADR-0018 have already landed and consumed some of 47-50**, the executing agent picks the next free range above the new high-water mark (e.g. 51-57, 55-61, etc., depending on what's already in the file).
+4. **If ADR-0021 Knowledge has landed first and consumed 55-59**, shift further to 58-64 or whatever next seven free integers are available above the new high-water mark, and update lockstep:
+   - `adrs/ADR-0020-stand-up-honeydrunk-agents-node.md` Consequences "New invariants" section — replace 48-54 / 51-57 with the assigned numbers.
+   - `generated/issue-packets/active/adr-0020-agents-standup/03-agents-node-scaffold.md` — `rg -n '\b5[1-7]\b' …` each match in the default-naming convention, replace with assigned number. Pre-filing carve-out under invariant 24 applies.
+
+Use `rg`, not `grep`.
+
+### `CHANGELOG.md`
+
+Append (substitute actual assigned numbers): `Architecture: Add invariants 51-57 (Agents downstream coupling, no-direct-model-providers, no-direct-tool-impls, no-direct-Memory-writes, function-calling-loop-in-Agents-only, Abstractions-no-third-party-AI-runtime, contract-shape canary) per ADR-0020 D2/D5/D6/D9/D12/D13/D10.`
+
+## Affected Files
+- `constitution/invariants.md`
+- `adrs/ADR-0020-stand-up-honeydrunk-agents-node.md` (only on shift)
+- `generated/issue-packets/active/adr-0020-agents-standup/03-agents-node-scaffold.md` (only on shift)
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] Verbatim restatement of D2/D5/D6/D9/D12/D13/D10 — no new requirements.
+
+## Acceptance Criteria
+- [ ] Seven new invariants present in `constitution/invariants.md` matching ADR-0020.
+- [ ] Numbers verified against the current file state via `rg -n '^\d+\.\s\*\*' constitution/invariants.md`; default 51-57; shifted if upstream sibling initiatives (ADR-0017/0018/0021) have consumed any of those slots.
+- [ ] Each invariant carries `(Proposed — this invariant takes effect when ADR-0020 is accepted)`.
+- [ ] On number shift, ADR-0020 Consequences + packet 03 source updated in lockstep before packet 03 is filed.
+- [ ] `CHANGELOG.md` updated.
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0020 D2/D5/D6:** Three packages; tool invocation composes upstream; memory access composes upstream. Source for invariant 51 (default).
+
+**ADR-0020 D5, D9:** Agents never call model providers or tool implementations directly. Sources for invariants 52, 53 (default).
+
+**ADR-0020 D6, D8:** Memory access via `IAgentMemory`; execution-scope state only on `IAgentExecutionContext`. Source for invariant 54 (default).
+
+**ADR-0020 D12:** Function-calling loop lives in Agents only. Source for invariant 55 (default).
+
+**ADR-0020 D13:** Abstractions takes no third-party AI-runtime compile-time deps. Source for invariant 56 (default).
+
+**ADR-0020 D10:** Contract-shape canary on `IAgent`, `IAgentExecutionContext`, `IToolInvoker`, `IAgentMemory`. Source for invariant 57 (default).
+
+## Dependencies
+- `packet:01`
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0020`, `constitution`
+
+## Agent Handoff
+
+**Objective:** Land seven new ADR-0020-derived invariants at the next available numbers.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packet 01.
+
+**Constraints:**
+
+- Each invariant carries `(Proposed — this invariant takes effect when ADR-0020 is accepted)`.
+- Default 51-57; shift on collision; update ADR-0020 Consequences + packet 03 in lockstep.
+- Pre-filing amendment to packet 03 permitted under invariant 24.
+- Use `rg`, not `grep`.
+
+**Key Files:** `constitution/invariants.md`; conditional ADR-0020 + packet 03; `CHANGELOG.md`.
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0020-agents-standup/02b-architecture-verify-agents-repo.md
+++ b/generated/issue-packets/active/adr-0020-agents-standup/02b-architecture-verify-agents-repo.md
@@ -1,0 +1,120 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "ai", "adr-0020", "human-only", "wave-2"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0020"]
+accepts: ADR-0020
+wave: 2
+initiative: adr-0020-agents-standup
+node: honeydrunk-architecture
+actor: human
+---
+
+# Chore: Verify `HoneyDrunk.Agents` GitHub repo settings + local clone (human-only)
+
+## Summary
+
+Confirm `HoneyDrunkStudios/HoneyDrunk.Agents` matches the Grid's per-repo standard settings (branch protection, default branch, labels, Actions enabled); confirm the local working tree at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Agents/` is on `main` and clean; confirm OIDC federated credential. Both repo and clone already exist (LICENSE + README only). Verification packet.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Actor
+**`Human`.** Org-admin rights required.
+
+## Motivation
+
+Packet 03 defines the solution, three packages, five contracts, function-calling adapter, in-memory testing fixture, and CI pipeline for `HoneyDrunk.Agents` but cannot execute until repo settings are confirmed and local clone is verified.
+
+## Steps
+
+### Step 0 — Reset local clone to `main`
+
+The local clone at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Agents/` is currently on the `chore/wire-standard-workflows` branch (the standard workflows seed that landed via `HoneyDrunk.Actions`). Bring it back to `main` before continuing.
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Agents
+git status                                          # confirm clean
+git checkout chore/wire-standard-workflows         # confirm current branch
+# If the chore PR has merged to main on remote:
+git checkout main 2>/dev/null || git checkout -b main origin/main
+git pull --ff-only origin main
+git branch -d chore/wire-standard-workflows        # delete local chore branch
+```
+
+If `git status` is not clean, stop and resolve before proceeding — the scaffolding work in packet 03 expects a pristine working tree on `main`.
+
+### Step 1 — Verify repo settings (portal)
+
+1. https://github.com/HoneyDrunkStudios/HoneyDrunk.Agents/settings — default branch `main`, Public, Issues + Actions enabled.
+2. https://github.com/HoneyDrunkStudios/HoneyDrunk.Agents/settings/branches — branch protection on `main`: PR required, required check `pr-core / core` only (canary added post-merge), no force pushes, no deletions.
+3. https://github.com/HoneyDrunkStudios/HoneyDrunk.Agents/settings/security_analysis — Dependabot alerts enabled.
+
+### Step 2 — Seed labels (CLI)
+
+```bash
+for label in "feature:0E8A16" "chore:CCCCCC" "tier-1:E99695" "tier-2:FBCA04" "ai:D946EF" "scaffold:BFDADC" "adr-0020:1D76DB" "wave-3:FBCA04" "human-only:B60205" "out-of-band:D4C5F9"; do
+  name="${label%:*}"; color="${label#*:}"
+  gh label create "$name" --repo HoneyDrunkStudios/HoneyDrunk.Agents --color "$color" 2>/dev/null
+done
+```
+
+### Step 3 — Verify local clone
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Agents
+git status                       # clean tree on main (Step 0 guarantees this)
+git branch --show-current        # should be `main`
+ls                                # confirm LICENSE + README + .gitignore + .github/
+```
+
+Working tree on `main`, clean, contains LICENSE + README + .gitignore + the workflows seeded by the `HoneyDrunk.Actions` chore (already merged via Step 0).
+
+### Step 4 — Confirm OIDC federated credential
+
+Cross-link: [`infrastructure/walkthroughs/oidc-federated-credentials.md`](../../../../infrastructure/walkthroughs/oidc-federated-credentials.md).
+
+Confirm `repo:HoneyDrunkStudios/HoneyDrunk.Agents:ref:refs/tags/v*` is in the Grid's NuGet publishing identity's federated credential subject list. Add via Azure portal if missing.
+
+## Acceptance Criteria
+- [ ] Local clone reset from `chore/wire-standard-workflows` to `main`, clean working tree, chore branch deleted (Step 0).
+- [ ] Branch protection on `main` requires `pr-core / core`, no force pushes, no deletions.
+- [ ] Labels seeded.
+- [ ] Local working tree on `main`, clean.
+- [ ] OIDC federated credential confirmed.
+- [ ] Chore issue closed after all five checks.
+
+## Human Prerequisites
+- [ ] Org-admin role on `HoneyDrunkStudios`
+- [ ] Browser logged in
+- [ ] `gh` CLI authenticated
+- [ ] Azure portal access if Step 4 needs work
+
+## Dependencies
+- `packet:01`
+
+## Downstream Unblocks
+- `03-agents-node-scaffold.md` — becomes fileable after this chore is Done and packet 02 has merged.
+
+## Referenced ADR Decisions
+
+**ADR-0020 D1:** HoneyDrunk.Agents is the AI sector's agent-runtime substrate. New Node ⇒ new repo per invariant 11. Repo already created; this packet is verification.
+
+**ADR-0020 D2:** Three package families. Local clone hosts the solution packet 03 authors.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node.
+
+> **Invariant 24:** Issue packets are immutable once filed. Pre-filing amendments to packet 03 permitted if invariant numbers shift in packet 02.
+
+## Labels
+`chore`, `tier-1`, `meta`, `ai`, `adr-0020`, `human-only`, `wave-2`
+
+## Notes
+- ~5-minute task. Mostly verification.
+- Do not commit anything to the local clone. The scaffolding agent in packet 03 authors all source files.
+- No Azure provisioning required.

--- a/generated/issue-packets/active/adr-0020-agents-standup/03-agents-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0020-agents-standup/03-agents-node-scaffold.md
@@ -1,0 +1,486 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Agents
+labels: ["feature", "tier-2", "ai", "scaffold", "adr-0020"]
+dependencies: ["packet:01", "packet:02", "packet:02b", "adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold", "adr-0017-capabilities-standup/04-capabilities-node-scaffold", "adr-0018-operator-standup/03-operator-node-scaffold"]
+adrs: ["ADR-0020", "ADR-0016", "ADR-0017", "ADR-0018", "ADR-0022"]
+accepts: ADR-0020
+wave: 3
+initiative: adr-0020-agents-standup
+node: honeydrunk-agents
+---
+
+# Feature: Stand up the HoneyDrunk.Agents repo — solution, three packages, five contracts, function-calling adapter, CI, in-memory testing fixture
+
+## Summary
+
+Bring the near-empty `HoneyDrunk.Agents` repo from zero to first-shippable state per ADR-0020. Land the solution layout, the three package families (`Abstractions`, runtime, `Testing` fixture), the five D3 interfaces inside `HoneyDrunk.Agents.Abstractions`, default runtime implementations (`DefaultAgent` harness, `DefaultAgentLifecycle` with in-process registry, `DefaultToolInvoker` composing Capabilities, `DefaultAgentMemory` composing Memory), the function-calling adapter per D12, the in-memory testing fixture, the standard CI pipeline, and the contract-shape canary scoped to `HoneyDrunk.Agents.Abstractions` per D10 and the canary invariant (number assigned by packet 02).
+
+This is the unblocker for Flow, Sim, Lore, the HoneyDrunk.Actions cloud-agent trigger path, HoneyHub (when live), and Evals.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Agents`
+
+## Motivation
+
+ADR-0020 establishes what HoneyDrunk.Agents is. The repo is cloned (LICENSE + README only) but otherwise empty. Six downstream consumers are blocked.
+
+This packet is intentionally larger than typical bring-up packets because:
+
+- Five contracts must all land in the first commit for the contract-shape canary baseline.
+- Four default runtime implementations compose four upstream Nodes (AI + Capabilities + Operator + Memory).
+- The function-calling adapter (D12) is a new substrate piece authored here for the first time in the Grid.
+- The in-memory testing fixture is required for downstream Nodes (Flow, Sim, Evals) to write deterministic tests.
+
+## Proposed Implementation
+
+### Repository layout
+
+```
+HoneyDrunk.Agents/
+├── HoneyDrunk.Agents.slnx
+├── Directory.Build.props
+├── CHANGELOG.md
+├── README.md
+├── .editorconfig
+├── .gitignore
+├── .github/
+│   └── workflows/
+│       ├── pr-core.yml
+│       ├── release.yml
+│       ├── nightly-deps.yml
+│       ├── nightly-security.yml
+│       └── api-compatibility.yml
+├── src/
+│   ├── HoneyDrunk.Agents.Abstractions/
+│   │   ├── HoneyDrunk.Agents.Abstractions.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── IAgent.cs
+│   │   ├── IAgentExecutionContext.cs
+│   │   ├── IAgentLifecycle.cs
+│   │   ├── IToolInvoker.cs
+│   │   ├── IAgentMemory.cs
+│   │   └── (request/response records — minimum needed; deeper shape ADRs land later)
+│   ├── HoneyDrunk.Agents/
+│   │   ├── HoneyDrunk.Agents.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── ServiceCollectionExtensions.cs    (AddHoneyDrunkAgents)
+│   │   ├── Execution/DefaultAgent.cs
+│   │   ├── Lifecycle/DefaultAgentLifecycle.cs   (in-process registry)
+│   │   ├── Tools/DefaultToolInvoker.cs           (composes Capabilities)
+│   │   ├── Memory/DefaultAgentMemory.cs          (composes Memory)
+│   │   ├── FunctionCalling/FunctionCallAdapter.cs (D12 — see "Function-calling adapter shape" below)
+│   │   └── Telemetry/AgentTelemetry.cs
+│   └── HoneyDrunk.Agents.Testing/
+│       ├── HoneyDrunk.Agents.Testing.csproj
+│       ├── README.md
+│       ├── CHANGELOG.md
+│       ├── InMemoryAgent.cs
+│       ├── InMemoryAgentLifecycle.cs
+│       ├── InMemoryToolInvoker.cs
+│       ├── InMemoryAgentMemory.cs
+│       ├── DeterministicClock.cs
+│       └── RecordingExecutionLogger.cs
+└── tests/
+    ├── HoneyDrunk.Agents.Abstractions.Tests/
+    ├── HoneyDrunk.Agents.Tests/
+    └── HoneyDrunk.Agents.Testing.Tests/
+```
+
+### Solution
+
+`HoneyDrunk.Agents.slnx` references three `src/*` projects and three `tests/*` projects. `Directory.Build.props` sets `net10.0`, nullable, warnings-as-errors, `Version` 0.1.0 (test projects excluded via `IsTestProject`).
+
+### Contract details — `HoneyDrunk.Agents.Abstractions`
+
+Five interfaces per D3. Minimum supporting records.
+
+```csharp
+// IAgent.cs
+namespace HoneyDrunk.Agents.Abstractions;
+
+public interface IAgent
+{
+    string AgentId { get; }
+    Task<AgentResult> ExecuteAsync(AgentRequest request, IAgentExecutionContext context, CancellationToken cancellationToken = default);
+}
+
+public sealed record AgentRequest(string InputJson, IReadOnlyDictionary<string, string> Metadata, string CallerCorrelationId);
+public sealed record AgentResult(bool Success, string? OutputJson, AgentExecutionError? Error, IReadOnlyList<AgentTraceEntry> Trace);
+public sealed record AgentExecutionError(AgentErrorCode Code, string Message, string? DetailsJson);
+public sealed record AgentTraceEntry(string Kind, string Payload, DateTimeOffset At);
+// Observation: `Kind` is `string` at v0.1.0. A typed `AgentTraceKind` enum (e.g.
+// LifecycleStarted, InferenceCalled, ToolDispatched, MemoryWritten, GateChecked,
+// LifecycleCompleted) would be more discoverable and canary-friendly. No change at
+// stand-up — the trace surface is the most likely to grow, and a flexible string
+// keeps the door open for v0.2 + the contract-shape canary catches the eventual
+// shape commitment. Flag for review when the next consumer (Flow / Sim / Evals)
+// starts asserting on trace shapes.
+
+public enum AgentErrorCode
+{
+    NotInitialized = 0,
+    InferenceFailed = 1,
+    ToolDispatchFailed = 2,
+    ApprovalDenied = 3,
+    BreakerOpen = 4,
+    MemoryAccessDenied = 5,
+    Cancelled = 6,
+    ExecutionFailed = 7,
+}
+```
+
+```csharp
+// IAgentExecutionContext.cs
+namespace HoneyDrunk.Agents.Abstractions;
+
+using HoneyDrunk.Kernel.Abstractions;   // Kernel already exposes the base IAgentExecutionContext
+
+// Per ADR-0020 D3 / D8: Agents extends Kernel's IAgentExecutionContext (see catalogs/relationships.json
+// `honeydrunk-kernel.contracts`) with AI-specific bindings. Interface inheritance — not name shadowing —
+// preserves Kernel ownership of the lifecycle/correlation semantics and lets Agents add only what it owns.
+public interface IAgentExecutionContext : HoneyDrunk.Kernel.Abstractions.IAgentExecutionContext
+{
+    string AgentId { get; }
+    string ExecutionId { get; }
+    IReadOnlyDictionary<string, string> Bindings { get; }   // tool bindings, memory references, inference binding identifier
+    // CorrelationId is inherited from Kernel's interface (not redeclared).
+    // Short-term/execution-scope state lives on this context (ADR-0020 D8).
+    // It is disposed when IAgentLifecycle.CompleteAsync runs.
+}
+```
+
+The interface-inheritance form (not name shadowing) makes the Agents-side concrete: the type Kernel already exposes at `catalogs/relationships.json` line 10 (`honeydrunk-kernel.contracts`) is the base; Agents extends it with `AgentId` / `ExecutionId` / `Bindings`. Downstream consumers that want only the Kernel-level semantics keep using Kernel's interface; consumers that need the AI-specific bindings reach for the Agents one. There is no silent shadowing of Kernel's contract.
+
+```csharp
+// IAgentLifecycle.cs
+public interface IAgentLifecycle
+{
+    Task RegisterAsync(IAgent agent, CancellationToken cancellationToken = default);
+    Task<IAgent?> ResolveAsync(string agentId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<string>> ListAsync(CancellationToken cancellationToken = default);
+    Task<IAgentExecutionContext> InitializeAsync(string agentId, AgentRequest request, CancellationToken cancellationToken = default);
+    Task CompleteAsync(IAgentExecutionContext context, CancellationToken cancellationToken = default);
+    Task DecommissionAsync(string agentId, CancellationToken cancellationToken = default);
+}
+```
+
+```csharp
+// IToolInvoker.cs
+public interface IToolInvoker
+{
+    Task<ToolInvocationResult> InvokeAsync(ToolInvocationRequest request, IAgentExecutionContext context, CancellationToken cancellationToken = default);
+}
+
+public sealed record ToolInvocationRequest(string ToolName, string ToolVersion, string ArgumentsJson);
+public sealed record ToolInvocationResult(bool Success, string? ResultJson, ToolInvocationError? Error);
+public sealed record ToolInvocationError(ToolErrorCode Code, string Message);
+
+public enum ToolErrorCode { NotRegistered = 0, VersionNotFound = 1, Unauthorized = 2, InvalidArguments = 3, ExecutionFailed = 4 }
+```
+
+```csharp
+// IAgentMemory.cs
+public interface IAgentMemory
+{
+    Task WriteAsync(AgentMemoryWriteRequest request, IAgentExecutionContext context, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<AgentMemoryReadResult>> SearchAsync(AgentMemoryQueryRequest query, IAgentExecutionContext context, CancellationToken cancellationToken = default);
+}
+
+public sealed record AgentMemoryWriteRequest(string Content, IReadOnlyDictionary<string, string> Metadata);
+public sealed record AgentMemoryQueryRequest(string QueryText, int MaxResults, IReadOnlyDictionary<string, string> Filters);
+public sealed record AgentMemoryReadResult(string Content, IReadOnlyDictionary<string, string> Metadata, double SimilarityScore);
+```
+
+The `AgentMemory*` prefix disambiguates from Memory Node's `MemoryEntry` / `MemoryQuery` shapes when ADR-0022 ships (Agents owns request/result shapes at its own surface; Memory owns its store-level shapes). Naming records drop the `I` per the Grid-wide convention; interfaces keep `I`.
+
+`HoneyDrunk.Agents.Abstractions` references **only** `Microsoft.Extensions.*` abstractions and `HoneyDrunk.Kernel.Abstractions` (so that Agents's `IAgentExecutionContext` can extend Kernel's base interface — see "Interface inheritance" stanza below). Per invariant 1, `Kernel.Abstractions` is itself an Abstractions package with zero HoneyDrunk runtime dependencies, so the reference does not violate the rule. **Do not** reference any other `HoneyDrunk.*` package from Agents.Abstractions — no AI, no Capabilities, no Operator, no Memory, no Kernel runtime. Per D13, no third-party AI-runtime compile-time dependencies either (no Microsoft.Extensions.AI, no model-provider SDKs, no agent-framework libraries).
+
+**Strict Abstractions stance.** `AgentRequest.CallerCorrelationId` is `string`, not `CorrelationId`. `IAgentExecutionContext.CorrelationId` (inherited from Kernel) follows Kernel's shape — see Kernel.Abstractions for its type contract. The runtime package's `AgentTelemetry` does the GridContext propagation against Kernel — Agents.Abstractions itself carries a reference only to `HoneyDrunk.Kernel.Abstractions` for the base `IAgentExecutionContext`, never to the Kernel runtime package (invariant 1 still holds — `Kernel.Abstractions` is an Abstractions package, not a runtime package).
+
+**First-pass shape; subject to refinement.** Member sets subject to evolution before v0.2.0 baseline lock. Canary catches breaking shape changes.
+
+### Runtime details — `HoneyDrunk.Agents`
+
+`HoneyDrunk.Agents` references:
+- `HoneyDrunk.Agents.Abstractions` (project)
+- `HoneyDrunk.Kernel.Abstractions` (for `ITelemetryActivityFactory`, `IGridContext`, `IGridContextAccessor`, `IOperationContext`, `IAgentExecutionContext`)
+- `HoneyDrunk.AI.Abstractions` (for `IChatClient`, `IEmbeddingGenerator`, `ModelCapabilityDeclaration`)
+- `HoneyDrunk.Capabilities.Abstractions` (for `ICapabilityRegistry`, `ICapabilityInvoker`, `ICapabilityGuard`)
+- `HoneyDrunk.Operator.Abstractions` (for `IApprovalGate`, `ICircuitBreaker` per D7)
+- `HoneyDrunk.Memory.Abstractions` (for `IMemoryStore`, `IMemoryScope` per D6)
+- `Microsoft.Extensions.DependencyInjection.Abstractions`
+- `Microsoft.Extensions.Hosting.Abstractions`
+- `Microsoft.Extensions.Logging.Abstractions`
+
+**Per invariant 2** ("Runtime packages depend on Abstractions, never on other runtime packages at the same layer"), the Agents runtime composes upstream Nodes through their `.Abstractions` packages only — never against the runtime packages (`HoneyDrunk.Kernel`, `HoneyDrunk.AI`, `HoneyDrunk.Capabilities`, `HoneyDrunk.Operator`, `HoneyDrunk.Memory`). Host applications resolve the concrete runtime implementations at composition time.
+
+**Upstream Abstractions availability — hard cross-initiative dependency.** Packet 03's frontmatter declares hard dependencies on the AI, Capabilities, and Operator scaffold packets so `file-packets.yml` blocks filing until all four upstream `.Abstractions` packages exist on NuGet. The Memory `.Abstractions` package is the lone exception: if ADR-0022's scaffold has not yet shipped at edit time, `DefaultAgentMemory` ships as a placeholder no-op with a structured warning and a follow-up packet wires the real composition once Memory lands. AI, Capabilities, and Operator have no such escape — the executing agent should fail the build if any of those three `.Abstractions` packages cannot be resolved.
+
+Four default implementations:
+
+- **`DefaultAgent`** — orchestrates the agent execution: validates request, resolves agent via lifecycle, opens execution context, runs the function-calling loop, returns `AgentResult` with trace.
+- **`DefaultAgentLifecycle`** — in-process registry (`ConcurrentDictionary<string, IAgent>`). `RegisterAsync` validates non-empty `agentId`; `ResolveAsync` returns null for missing entries; `InitializeAsync` creates a fresh `IAgentExecutionContext` with the ambient `IGridContext.CorrelationId` and disposes via `CompleteAsync`. Per D11, the registry is in-process; cross-host distribution is deferred.
+- **`DefaultToolInvoker`** — composes `ICapabilityRegistry` + `ICapabilityInvoker` + `ICapabilityGuard` from Capabilities. Resolve `(toolName, toolVersion)`, check guard, dispatch via `ICapabilityInvoker`, marshal result. Agents never reaches around `ICapabilityInvoker` to dispatch directly.
+- **`DefaultAgentMemory`** — composes `IMemoryStore` + `IMemoryScope` from Memory. Resolves the agent's scope from its execution context's `AgentId`, reads/writes through that scope. Embeddings flow through AI's `IEmbeddingGenerator` (which Memory's runtime composes; Agents does not call `IEmbeddingGenerator` directly from this surface).
+
+Plus one substrate-defining adapter:
+
+- **`FunctionCallAdapter`** — the loop of "model function-call output → `IToolInvoker` calls → next inference call." Per D12, this lives only in `HoneyDrunk.Agents`. The mechanism (Option for this packet: a generic adapter keyed by `ModelCapabilityDeclaration` that translates `IChatClient.CompleteAsync` results' function-call payloads into `ToolInvocationRequest` shapes, dispatches via `IToolInvoker`, builds the result back into the next inference message). Provider-specific shape variations are handled by per-`ModelCapabilityDeclaration` translation rules read from App Config — no per-provider adapter code in this scaffold.
+
+Plus `AgentTelemetry` for D9 emission — wraps every lifecycle, execution, tool-invocation, memory-access call in `ITelemetryActivityFactory` activities and propagates `IGridContext`.
+
+Service registration:
+
+```csharp
+public static IServiceCollection AddHoneyDrunkAgents(this IServiceCollection services, Action<AgentsOptions>? configure = null)
+{
+    services.AddSingleton<IAgentLifecycle, DefaultAgentLifecycle>();
+    services.AddScoped<IAgent, DefaultAgent>();
+    services.AddScoped<IToolInvoker, DefaultToolInvoker>();
+    services.AddScoped<IAgentMemory, DefaultAgentMemory>();
+    services.AddScoped<FunctionCallAdapter>();
+    return services;
+}
+```
+
+### Testing fixture — `HoneyDrunk.Agents.Testing`
+
+In-memory implementations of every Agents-owned interface:
+
+- `InMemoryAgent` — script-driven `ExecuteAsync` that returns canned results without invoking inference, tools, or memory. Used by Flow / Sim / Evals tests where the agent is a black box.
+- `InMemoryAgentLifecycle` — single-threaded dictionary, no telemetry, no Kernel composition.
+- `InMemoryToolInvoker` — script-driven `InvokeAsync` returning canned results without composing Capabilities.
+- `InMemoryAgentMemory` — in-memory dictionary; no composition with Memory.
+- `DeterministicClock` — `IClock` substitute for lifecycle-timing tests.
+- `RecordingExecutionLogger` — captures every execution-trace entry for test assertions.
+
+`HoneyDrunk.Agents.Testing` references **only** `HoneyDrunk.Agents.Abstractions` + `Microsoft.Extensions.*`. No reference to runtime, Kernel, AI, Capabilities, Operator, Memory. Per invariant 3 applied to companion packages.
+
+### CI workflows
+
+Five workflow files, thin callers of `HoneyDrunk.Actions`. `api-compatibility.yml` path-filtered to `src/HoneyDrunk.Agents.Abstractions/**`. The whole-assembly diff covers the four hot-path interfaces from invariant 57 (default — packet 02 assigns final number) (`IAgent`, `IAgentExecutionContext`, `IToolInvoker`, `IAgentMemory`) plus `IAgentLifecycle` and the records.
+
+**`IAgentLifecycle` canary scope — follow-up.** `IAgentLifecycle` is the fifth D3 interface but is not in invariant 57's four hot-path canary set. The whole-assembly diff above will still catch shape drift, but the canary's hard failure mode is scoped to the four hot-path interfaces only. Revisit this once HoneyDrunk.Actions wires the cloud-agent trigger path (per ADR-0020 Unblocks) — that's the first consumer to compile against `IAgentLifecycle` and the natural moment to escalate its shape to hot-path. File the follow-up packet at that wiring time.
+
+### `HoneyDrunk.Standards` wiring
+
+Per invariant 26, every `.csproj` references `HoneyDrunk.Standards` with `PrivateAssets="all"`.
+
+### Documentation
+
+- Repo README — purpose, package matrix, "How to consume" snippet with `AddHoneyDrunkAgents()`, link to ADR-0020. Include a `## For downstream consumers — canary projects` section with the minimal compose-the-runtime snippet.
+- Repo CHANGELOG — `## [0.1.0] - 2026-MM-DD`.
+- Per-package README + CHANGELOG.
+
+## Affected Files
+Entire repo. Notable new files under "Repository layout".
+
+## NuGet Dependencies
+
+### `HoneyDrunk.Agents.Abstractions.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | For the base `IAgentExecutionContext` interface Agents extends (interface inheritance per ADR-0020 D3 / D8) |
+
+(No other PackageReference. Both refs are Abstractions packages so invariant 1 is preserved. Invariant 56 [default, assigned by packet 02] forbids third-party AI-runtime deps — no `Microsoft.Extensions.AI`, no provider SDKs, no agent-framework libraries.)
+
+### `HoneyDrunk.Agents.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | For telemetry, context, `IAgentExecutionContext` base |
+| `HoneyDrunk.AI.Abstractions` | For `IChatClient`, `IEmbeddingGenerator`, `ModelCapabilityDeclaration` |
+| `HoneyDrunk.Capabilities.Abstractions` | For `ICapabilityRegistry`, `ICapabilityInvoker`, `ICapabilityGuard` |
+| `HoneyDrunk.Operator.Abstractions` | For `IApprovalGate`, `ICircuitBreaker` per D7 |
+| `HoneyDrunk.Memory.Abstractions` | For `IMemoryStore`, `IMemoryScope` per D6 — conditional on availability at edit time |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | |
+| `Microsoft.Extensions.Hosting.Abstractions` | |
+| `Microsoft.Extensions.Logging.Abstractions` | |
+
+Per invariant 2, the runtime composes upstream Nodes through `.Abstractions` packages only. The corresponding runtime packages (`HoneyDrunk.Kernel`, `HoneyDrunk.AI`, etc.) are not referenced.
+
+Project reference: `HoneyDrunk.Agents.Abstractions`.
+
+### `HoneyDrunk.Agents.Testing.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | |
+
+Project reference: `HoneyDrunk.Agents.Abstractions`. No reference to runtime, Kernel, AI, Capabilities, Operator, Memory.
+
+### Test projects
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `Microsoft.NET.Test.Sdk`, `xunit`, `xunit.runner.visualstudio`, `Microsoft.Extensions.DependencyInjection`, `NSubstitute` | Standard |
+
+## Boundary Check
+- [x] All work inside `HoneyDrunk.Agents`.
+- [x] `HoneyDrunk.Agents.Abstractions` carries only `HoneyDrunk.Kernel.Abstractions` (for the base `IAgentExecutionContext` interface — both packages are Abstractions, so invariant 1 holds) and `Microsoft.Extensions.*` references. Zero third-party AI-runtime references (invariant 56 — default, assigned by packet 02).
+- [x] `HoneyDrunk.Agents.Testing` references only `HoneyDrunk.Agents.Abstractions` (invariant 3).
+- [x] Agents never imports a model-provider SDK (invariant 52 — default).
+- [x] Agents never reaches around `IToolInvoker` to dispatch tools (invariant 53 — default).
+- [x] Agents never persists agent state outside `IAgentMemory` (invariant 54 — default).
+- [x] Function-calling loop lives only in `HoneyDrunk.Agents` runtime (invariant 55 — default).
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Agents.slnx` builds clean from a fresh clone.
+- [ ] All five D3 interfaces present with XML docs.
+- [ ] `HoneyDrunk.Agents.Abstractions` references only `HoneyDrunk.Kernel.Abstractions` (for the base `IAgentExecutionContext` interface) and `Microsoft.Extensions.*` packages. No reference to AI, Capabilities, Operator, Memory, or any runtime HoneyDrunk package. Zero third-party AI-runtime references (no `Microsoft.Extensions.AI`, no `OpenAI`, no `Anthropic.SDK`, no `Azure.AI.OpenAI`, no LangChain, no Semantic Kernel). `rg` over the .csproj returns zero matches for forbidden references.
+- [ ] `HoneyDrunk.Agents.Testing` references only `HoneyDrunk.Agents.Abstractions` + Microsoft.Extensions.*.
+- [ ] `AddHoneyDrunkAgents()` registers all five contracts; resolves cleanly from DI.
+- [ ] `DefaultAgentLifecycle.RegisterAsync` rejects empty / null `agentId`. Unit test covers.
+- [ ] `DefaultToolInvoker.InvokeAsync` calls `ICapabilityGuard.CheckAsync` before dispatch. Unit test verifies.
+- [ ] `DefaultAgentMemory` resolves scope from `IAgentExecutionContext.AgentId` and writes through Memory's `IMemoryStore`. Unit test verifies.
+- [ ] `FunctionCallAdapter` translates an `IChatClient`-style function-call payload into a `ToolInvocationRequest`, dispatches via `IToolInvoker`, and feeds the result back. Unit test covers the end-to-end loop using `InMemoryToolInvoker`.
+- [ ] `AgentTelemetry` emits per-call activities for lifecycle, execution, tool-invocation, memory-access. Verified by test.
+- [ ] All five `.github/workflows/*.yml` files present and call `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/*@main`.
+- [ ] `api-compatibility.yml` path-filtered to `src/HoneyDrunk.Agents.Abstractions/**`. Scaffolding PR reports `status: skipped` (expected). Verification via throwaway breaking-change PR post-merge.
+- [ ] `pr-core.yml` passes on the scaffolding PR.
+- [ ] Repo + per-package `CHANGELOG.md` + `README.md` present.
+- [ ] All `src/*.csproj` carry Version `0.1.0`; tests excluded.
+- [ ] Manual confirmation that `v0.1.0` tag triggers `release.yml` (verify workflow exists; do not push yet).
+- [ ] **No provider SDK references.** `rg -n 'OpenAI|Anthropic\.SDK|Azure\.AI\.OpenAI|LangChain|SemanticKernel' src/HoneyDrunk.Agents/` returns zero matches (the runtime composes AI's `IChatClient` for inference, never a provider SDK directly).
+- [ ] **No `.github/dependabot.yml`.** Per ADR-0009.
+- [ ] Repo README includes a `## For downstream consumers — canary projects` section.
+
+## Human Prerequisites
+- [ ] Packet 02b complete.
+- [ ] After merge, push tag `v0.1.0` from `main`.
+- [ ] **Upstream Abstractions availability check — AI / Capabilities / Operator are hard prerequisites.** Before this packet's PR is opened, confirm on NuGet: `HoneyDrunk.AI.Abstractions 0.1.0`, `HoneyDrunk.Capabilities.Abstractions 0.1.0`, `HoneyDrunk.Operator.Abstractions 0.1.0`. The filing pipeline's `addBlockedBy` wiring (driven by the cross-initiative `dependencies:` entries in this packet's frontmatter) keeps the Hive board item Blocked until the three upstream scaffold issues close. If any of those three packages is unresolvable at edit time, stop and flag rather than ship a placeholder — the upstream scaffold packet is the right place to land it, not here.
+- [ ] **Memory is the lone placeholder escape.** If `HoneyDrunk.Memory.Abstractions 0.1.0` has not yet shipped, `DefaultAgentMemory` may ship as a placeholder no-op with a structured warning log and a follow-up packet to wire the real composition once Memory lands. This applies only to Memory; AI / Capabilities / Operator have no placeholder escape.
+- [ ] **Branch protection sequencing.** Add `api-compatibility / abstractions-shape` to required checks after the post-merge throwaway-PR verification.
+- [ ] No Azure provisioning required.
+- [ ] After merge + tag, file a SonarCloud onboarding follow-up.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+
+> **Invariant 2:** Runtime packages depend on Abstractions, never on other runtime packages at the same layer. `HoneyDrunk.Transport` depends on `HoneyDrunk.Kernel.Abstractions`, not `HoneyDrunk.Kernel`. Applied here: `HoneyDrunk.Agents` references the `.Abstractions` package of every upstream Node it composes (Kernel, AI, Capabilities, Operator, Memory).
+
+> **Invariant 3:** Companion packages (Testing, Providers) depend on the parent Node's contracts package, not internal implementation details.
+
+> **Invariant 4:** No circular dependencies. Kernel is always at the root.
+
+> **Invariant 11:** One repo per Node.
+
+> **Invariant 12:** Semantic versioning with CHANGELOG and README.
+
+> **Invariant 13:** All public APIs have XML documentation.
+
+> **Invariant 26:** `## NuGet Dependencies` section required; `HoneyDrunk.Standards` on every new .NET project.
+
+> **Invariant 27:** All projects in a solution share one version.
+
+> **Agents downstream-coupling invariant (number assigned by packet 02, default 51):** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Agents.Abstractions`. Composition against `HoneyDrunk.Agents` and `HoneyDrunk.Agents.Testing` is a host-time (and test-time) concern.
+
+> **Agents no-direct-model-providers invariant (default 52):** All inference flows through `IChatClient` from `HoneyDrunk.AI.Abstractions`. No provider SDK imports in any Agents package.
+
+> **Agents no-direct-tool-implementations invariant (default 53):** All tool invocations flow through `IToolInvoker`, which composes Capabilities's `ICapabilityRegistry` + `ICapabilityInvoker` + `ICapabilityGuard`.
+
+> **Agents no-direct-Memory-writes invariant (default 54):** All memory access flows through `IAgentMemory`. Execution-scope state stays on `IAgentExecutionContext`; anything that must survive disposal is written through `IAgentMemory`.
+
+> **Agents function-calling-loop-only-in-Agents invariant (default 55):** The "model tool-call output → `IToolInvoker` calls → next inference call" loop lives in the `HoneyDrunk.Agents` runtime and nowhere else.
+
+> **Agents Abstractions-no-third-party-AI invariant (default 56):** `HoneyDrunk.Agents.Abstractions` takes no third-party AI-runtime compile-time dependencies (no `Microsoft.Extensions.AI`, no provider SDKs, no agent-framework libraries).
+
+> **Agents contract-shape canary invariant (default 57):** The HoneyDrunk.Agents Node CI must include a contract-shape canary that fails the build on shape drift to `IAgent`, `IAgentExecutionContext`, `IToolInvoker`, or `IAgentMemory` without a corresponding version bump.
+
+## Referenced ADR Decisions
+
+**ADR-0020 D1:** HoneyDrunk.Agents is the agent-runtime substrate, not an orchestrator.
+
+**ADR-0020 D2:** Three packages — Abstractions + runtime + Testing.
+
+**ADR-0020 D3:** Five interfaces; no records at stand-up.
+
+**ADR-0020 D4:** Boundary against AI / Capabilities / Operator / Memory / Flow.
+
+**ADR-0020 D5:** Tool invocation composes Capabilities. Agents does not own a registry.
+
+**ADR-0020 D6:** Memory access composes Memory. `IMemoryScope` is Memory's, not Agents's.
+
+**ADR-0020 D7:** Safety-gate composition with Operator — invoke (synchronous), not emit. Agents calls `IApprovalGate` and `ICircuitBreaker` on the hot path. No runtime dependency on Communications.
+
+**ADR-0020 D8:** Agents holds execution-scope state only. `IAgentExecutionContext` disposes when `CompleteAsync` runs.
+
+**ADR-0020 D9:** Pulse consumes Agents telemetry; no runtime dependency on Pulse.
+
+**ADR-0020 D10:** Canary on four hot-path interfaces.
+
+**ADR-0020 D11:** In-process agent registry at stand-up.
+
+**ADR-0020 D12:** Function-calling adapter lives in `HoneyDrunk.Agents` only. Specific mechanism is a scaffold-packet decision; this packet picks a generic adapter keyed by `ModelCapabilityDeclaration` with App-Config-sourced per-model translation rules.
+
+**ADR-0020 D13:** `HoneyDrunk.Agents.Abstractions` takes no third-party AI-runtime compile-time deps. Runtime may.
+
+**ADR-0016 D6 (referenced):** Shape-compatible-with-MEAI is structural, not type-identity. Applies here — `IChatClient` is consumed from `HoneyDrunk.AI.Abstractions`, not from `Microsoft.Extensions.AI`.
+
+## Dependencies
+- `packet:01` — Architecture catalog registration
+- `packet:02` — Constitution invariants for Agents
+- `packet:02b` — Repo + clone verification
+- `adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold` — `HoneyDrunk.AI.Abstractions 0.1.0` must be on NuGet
+- `adr-0017-capabilities-standup/04-capabilities-node-scaffold` — `HoneyDrunk.Capabilities.Abstractions 0.1.0` must be on NuGet
+- `adr-0018-operator-standup/03-operator-node-scaffold` — `HoneyDrunk.Operator.Abstractions 0.1.0` must be on NuGet
+
+Memory's scaffold (`adr-0022-memory-standup/03-memory-node-scaffold`) is intentionally NOT a hard dependency. Memory is the lone substrate Agents may stub with a placeholder no-op (see Human Prerequisites). All three of AI / Capabilities / Operator are required upstream and must ship `.Abstractions 0.1.0` to NuGet before this packet's PR is opened — the filing pipeline's `addBlockedBy` wiring enforces this.
+
+## Labels
+`feature`, `tier-2`, `ai`, `scaffold`, `adr-0020`
+
+## Agent Handoff
+
+**Objective:** Take the `HoneyDrunk.Agents` repo (LICENSE + README) and ship 0.1.0 with five D3 contracts, four default runtime implementations composing AI / Capabilities / Operator / Memory, a function-calling adapter per D12, in-memory testing fixture, full CI, and the contract-shape canary scoped to Abstractions.
+
+**Target:** HoneyDrunk.Agents, branch from `main`.
+
+**Context:**
+- Goal: Unblock Flow / Sim / Lore / Actions cloud-agent path / HoneyHub / Evals.
+- Feature: ADR-0020 standup initiative, packet 03.
+- ADRs: ADR-0020 (sole standup); ADR-0016/0017/0018/0022 (upstream substrates Agents composes).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packets 01, 02, 02b.
+
+**Constraints:**
+
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. `HoneyDrunk.Agents.Abstractions.csproj` contains no `HoneyDrunk.*` PackageReference or ProjectReference.
+- **Invariant 2:** Runtime packages depend on Abstractions, never on other runtime packages at the same layer. `HoneyDrunk.Agents.csproj` references upstream Nodes (Kernel, AI, Capabilities, Operator, Memory) through their `.Abstractions` packages only — never against `HoneyDrunk.Kernel`, `HoneyDrunk.AI`, `HoneyDrunk.Capabilities`, `HoneyDrunk.Operator`, or `HoneyDrunk.Memory` directly.
+- **Invariant 56 (assigned by packet 02, default):** `HoneyDrunk.Agents.Abstractions` takes no third-party AI-runtime compile-time dependencies. No `Microsoft.Extensions.AI`, no model-provider SDKs, no agent-framework libraries.
+- **Invariant 52 (default):** No model-provider SDKs in any Agents package. Inference goes through `IChatClient` from AI.
+- **Invariant 53 (default):** No direct tool implementations or direct `ICapabilityInvoker.InvokeAsync` calls outside `DefaultToolInvoker`. Tool calls go through `IToolInvoker`.
+- **Invariant 54 (default):** No direct `IMemoryStore` writes outside `DefaultAgentMemory`.
+- **Invariant 55 (default):** The function-calling loop lives only in `HoneyDrunk.Agents` runtime. No equivalent loop in any other AI-sector Node.
+- **Invariant 3 applied to Testing:** `HoneyDrunk.Agents.Testing.csproj` references only `HoneyDrunk.Agents.Abstractions`. No runtime, no Kernel, no AI, no Capabilities, no Operator, no Memory.
+- **Strict Abstractions stance.** `AgentRequest.CallerCorrelationId` and `IAgentExecutionContext.CorrelationId` are `string`, not `CorrelationId`. Kernel reference lives in the runtime package's `AgentTelemetry`.
+- **`IMemoryScope` is Memory's, not Agents's.** Do not author `IMemoryScope` in this scaffold; consume it from `HoneyDrunk.Memory.Abstractions` (if available; otherwise no-op placeholder per Human Prereqs).
+- **`IChatClient` is direct from AI, not via `IToolInvoker`.** `IToolInvoker` routes tool calls to Capabilities. The two paths are distinct.
+- **In-process registry per D11.** `DefaultAgentLifecycle` uses `ConcurrentDictionary` keyed by `agentId`. No cross-host persistence at stand-up.
+- **Records drop `I`; interfaces keep it.** `AgentRequest`, `AgentResult`, `AgentExecutionError`, `AgentTraceEntry`, `ToolInvocationRequest`, `ToolInvocationResult`, `ToolInvocationError`, `AgentMemoryWriteRequest`, `AgentMemoryQueryRequest`, `AgentMemoryReadResult` are records. The five D3 interfaces have `I`. The `AgentMemory*` prefix on the memory-side records disambiguates from Memory Node's own shapes (`MemoryEntry`, `MemoryQuery`) — Agents owns request/result records at its surface; Memory owns its store-level records.
+- **Function-calling mechanism for v0.1.0:** generic adapter keyed by `ModelCapabilityDeclaration`. Per-model translation rules read from App Config via `IConfigProvider` (no hardcoded per-provider logic in code). Per-provider adapter classes are deferred to follow-up packets if a specific provider's payload shape proves intractable through the generic mechanism.
+- **Upstream conditional — Memory only.** AI / Capabilities / Operator `.Abstractions 0.1.0` are hard cross-initiative dependencies declared in this packet's frontmatter; the filing pipeline's `addBlockedBy` wiring keeps the Hive board item Blocked until those upstream scaffold issues close. There is no placeholder escape for those three. Memory is the lone exception: if `HoneyDrunk.Memory.Abstractions 0.1.0` has not shipped, `DefaultAgentMemory` ships as a placeholder no-op with a structured warning and a follow-up packet wires the real composition once Memory lands.
+- **Canary on scaffolding PR is expected to skip.** Post-merge verification via throwaway breaking-change PR.
+
+**Key Files:**
+- `HoneyDrunk.Agents.slnx`, `Directory.Build.props`
+- `src/HoneyDrunk.Agents.Abstractions/` — 5 interface files + supporting records
+- `src/HoneyDrunk.Agents/` — `DefaultAgent`, `DefaultAgentLifecycle`, `DefaultToolInvoker`, `DefaultAgentMemory`, `FunctionCallAdapter`, `AgentTelemetry`, `ServiceCollectionExtensions`
+- `src/HoneyDrunk.Agents.Testing/` — in-memory implementations + `DeterministicClock` + `RecordingExecutionLogger`
+- `.github/workflows/{pr-core,release,nightly-deps,nightly-security,api-compatibility}.yml`
+- `README.md`, `CHANGELOG.md` (repo-level + per-package)
+- `tests/HoneyDrunk.Agents.Tests/`, `tests/HoneyDrunk.Agents.Testing.Tests/`
+
+**Contracts:**
+- Five D3 interfaces authored fresh in `HoneyDrunk.Agents.Abstractions`.
+- Supporting records authored alongside.
+- Contract-shape canary baseline established at this packet's commit.

--- a/generated/issue-packets/active/adr-0020-agents-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0020-agents-standup/dispatch-plan.md
@@ -1,0 +1,96 @@
+# Dispatch Plan — ADR-0020 HoneyDrunk.Agents Standup
+
+**Initiative:** `adr-0020-agents-standup`
+**Sector:** AI
+**Governing ADR:** [ADR-0020 — Stand Up the HoneyDrunk.Agents Node](../../../../adrs/ADR-0020-stand-up-honeydrunk-agents-node.md) (Proposed 2026-04-19; flips to Accepted after this initiative's PRs merge per the user's ADR acceptance workflow).
+**Trigger:** ADR-0020 in the Proposed queue. Flow, Sim, Lore, HoneyHub (when live), the HoneyDrunk.Actions cloud-agent trigger path, and Evals are blocked on `HoneyDrunk.Agents.Abstractions` existing. This initiative builds the agent-runtime substrate that unblocks them.
+**Type:** Multi-repo (2 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.Agents`)
+**Site sync required:** No (scaffold-only).
+**Rollback plan:**
+- **Pre-tag:** `git revert` of each PR.
+- **Post-tag, pre-consumer:** NuGet packages immutable; prefer fix-forward as 0.1.1.
+- **Post-consumer:** forward-only.
+
+## Summary
+
+ADR-0020 is the standup ADR for `HoneyDrunk.Agents`. It decides what the Node owns (D1), three package families with a `.Testing` fixture (D2), five exposed interfaces (D3 — `IAgent`, `IAgentExecutionContext`, `IAgentLifecycle`, `IToolInvoker`, `IAgentMemory`; no records at stand-up), the boundary rule against AI/Capabilities/Operator/Memory/Flow (D4), upstream composition rules for tool invocation (D5) and memory (D6), the safety-gate invocation model with Operator (D7), the execution-scope-only state boundary (D8), one-way telemetry to Pulse (D9), the contract-shape canary on four hot-path interfaces (D10), in-process agent registry at stand-up (D11), the function-calling adapter belonging to Agents only (D12), and the `Abstractions` no-third-party-AI-runtime stance (D13).
+
+Agents composes **all three foundation substrates** (AI, Capabilities, Operator) plus Memory at the runtime layer. This makes packet 03 the largest scaffold of the seven initiatives — five contracts, four default runtime implementations (`DefaultAgent` harness, `DefaultAgentLifecycle`, `DefaultToolInvoker` composing Capabilities, `DefaultAgentMemory` composing Memory), the function-calling adapter, the in-memory testing fixture, and the registry.
+
+Four packets land the work:
+
+1. **Architecture catalog registration + integration-points** — confirm five-interface contract set; add `honeydrunk-memory` and `honeydrunk-operator` to `consumes`; add `honeydrunk-actions` to `consumed_by_planned`; fix `repos/HoneyDrunk.Agents/boundaries.md` (`IMemoryScope` is Memory's, not Agents's); fix `repos/HoneyDrunk.Agents/integration-points.md` canary description (Agents→AI is `IChatClient` direct, not "through `IToolInvoker`"); refresh `grid-health.json`, `nodes.json`, the AI sector doc.
+2. **Constitution invariants** — seven new invariants from D2/D5/D6, D5, D6, D12, D13, D10 at the next seven free numbers.
+2b. **Verify `HoneyDrunk.Agents` repo + local clone (human-only)** — the GitHub repo exists, the local clone exists (LICENSE + README); verify branch protection, seed labels, confirm OIDC.
+3. **HoneyDrunk.Agents scaffold** — empty repo to first-shippable. Solution, three packages (`Abstractions`, runtime, `Testing` fixture), five contracts, default `IAgent` harness + `IAgentLifecycle` (in-process registry) + `DefaultToolInvoker` (composes Capabilities) + `DefaultAgentMemory` (composes Memory) + function-calling adapter, in-memory testing fixture, five CI workflow files with contract-shape canary scoped to `HoneyDrunk.Agents.Abstractions`.
+
+## Wave Diagram
+
+```
+Wave 1: Architecture catalog + constitution updates (parallel)
+   ├─ Architecture: 01-architecture-agents-catalog-registration
+   └─ Architecture: 02-architecture-agents-invariants
+       Blocked by: 01
+
+Wave 2: Verify HoneyDrunk.Agents repo + local clone (human)
+   └─ Architecture: 02b-architecture-verify-agents-repo
+       Blocked by: 01
+
+Wave 3: Agents repo scaffold
+   └─ HoneyDrunk.Agents: 03-agents-node-scaffold
+       Blocked by: 01, 02, 02b, ADR-0016#03-ai-node-scaffold,
+                   ADR-0017#04-capabilities-node-scaffold,
+                   ADR-0018#03-operator-node-scaffold
+```
+
+The three cross-initiative blockers are declared in packet 03's `dependencies:` frontmatter so `file-packets.yml` keeps the Hive board item Blocked until each upstream scaffold issue closes. Memory (ADR-0022) is NOT a hard dep — Memory is the lone substrate Agents may stub with a `DefaultAgentMemory` placeholder no-op (see packet 03 Human Prerequisites).
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 01 | [Catalog registration + boundaries.md/integration-points fixes](./01-architecture-agents-catalog-registration.md) | Architecture | 1 | Agent | — |
+| 02 | [Add seven new invariants for D2/D5/D6 / D5 / D6 / D12 / D13 / D10](./02-architecture-agents-invariants.md) | Architecture | 1 | Agent | 01 |
+| 02b | [Verify HoneyDrunk.Agents repo + local clone (human-only)](./02b-architecture-verify-agents-repo.md) | Architecture | 2 | Human | 01 |
+| 03 | [Stand up `HoneyDrunk.Agents` — solution, three packages, contracts, function-calling adapter, CI, in-memory testing fixture](./03-agents-node-scaffold.md) | HoneyDrunk.Agents | 3 | Agent | 01, 02, 02b, ADR-0016 packet 03, ADR-0017 packet 04, ADR-0018 packet 03 |
+
+## Filing-order rule
+
+Packet 03 hard-codes invariant numbers in body and acceptance criteria. **Packet 02 must merge and lock the invariant numbers before packet 03 is filed.** If packet 02's collision check shifts numbers, packet 03 source file is amended pre-filing under invariant 24's carve-out.
+
+## What This Initiative Does **NOT** Deliver
+
+- The downstream consumer Nodes (Flow, Sim, Lore, HoneyHub when live, Actions cloud-agent path) are not delivered here.
+- The **function-calling adapter mechanism** (the specific shape — generic adapter keyed by `ModelCapabilityDeclaration`, per-provider adapters behind `IFunctionCallAdapter`, shape-translation layer) is decided **inside packet 03**, per ADR-0020 D12 ("placement pinned, mechanism deferred to scaffold"). Packet 03's executing agent picks one mechanism and ships it.
+- Record shapes (`AgentId` value type, lifecycle-phase enums promoted to records, invocation-request shapes) are **deferred to scaffold or to a later ADR** per ADR-0020 D3. Packet 03 picks what is needed and ships those; deeper shape decisions wait for the first downstream consumer.
+- Cross-host shared agent registry is deferred per D11; in-process at stand-up.
+- Pulse signal ingress into Agents is deferred (emit-only per D9).
+- The HoneyDrunk.Memory edge depends on `HoneyDrunk.Memory.Abstractions` existing. If Memory's standup initiative has not landed first, packet 03's `DefaultAgentMemory` implementation is a placeholder no-op with a structured warning and a follow-up packet wires the real composition once Memory ships. This placeholder escape is exclusive to Memory — AI / Capabilities / Operator `.Abstractions` are hard cross-initiative dependencies declared in packet 03's frontmatter and enforced via `file-packets.yml` `addBlockedBy` wiring.
+
+## AI-sector standup wave sequencing
+
+ADR-0020 (Agents) requires `HoneyDrunk.AI.Abstractions`, `HoneyDrunk.Capabilities.Abstractions`, `HoneyDrunk.Operator.Abstractions`, and `HoneyDrunk.Memory.Abstractions` to exist before packet 03 can compile. The recommended landing order across the seven AI-sector standup initiatives:
+
+1. ADR-0016 (AI) — packets exist
+2. ADR-0017 (Capabilities) — packets exist
+3. ADR-0018 (Operator) — this initiative's sibling
+4. ADR-0021 (Knowledge) — sibling
+5. ADR-0022 (Memory) — sibling
+6. ADR-0020 (Agents) — **this initiative; requires 1-5 above for packet 03**
+7. ADR-0023 (Evals) — depends on Agents
+8. ADR-0024 (Flow) — depends on Agents, Operator, Communications
+9. ADR-0025 (Sim) — depends on Flow
+
+If Memory or any other upstream Abstractions has not shipped at the time packet 03 of THIS initiative executes, the scaffolding agent ships the corresponding default-implementation as a placeholder no-op + warning and the real composition lands as a follow-up packet. See packet 03 Human Prerequisites.
+
+## Status flip
+
+ADR-0020 stays at `Status: Proposed` for the duration. Scope agent flips after all packets close.
+
+## Filing
+
+`file-packets.yml` auto-files on push. No manual `gh issue create`. Verify on The Hive.
+
+## Archival
+
+Per ADR-0008 D10, when every packet reaches `Done` and `HoneyDrunk.Agents 0.1.0` is published, the entire folder moves to `archive/`.


### PR DESCRIPTION
## Summary

Scopes four packets standing up [HoneyDrunk.Agents](https://github.com/HoneyDrunkStudios/HoneyDrunk.Agents) per [ADR-0020](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0020-stand-up-honeydrunk-agents-node.md). First AI-sector Node to **compose all three AI substrates** (AI + Capabilities + Operator). Claims invariants 51–57.

### Wave 1 — Architecture-repo (parallel)
- **`01-catalog-registration`** — `relationships.json` widens `consumes` to AI/Capabilities/Operator/Memory (all `.Abstractions`); adds App Config edge to `integration-points.md` for function-calling adapter rules.
- **`02-invariants`** — seven new constitution invariants (default 51–57) under `## AI Sector — Agents Invariants`.
- **`02b-verify-agents-repo`** — human-only chore + Step 0 chore-branch reconcile.

### Wave 2 — Agents scaffold
- **`03-agents-node-scaffold`** — three packages, four frozen contracts (`IAgent`, `IAgentExecutionContext` extending Kernel's, `IToolInvoker`, `IAgentMemory`), records use `AgentMemory*` prefix to avoid collision with `HoneyDrunk.Memory`'s `MemoryEntry`/`MemoryStoreQuery`. Function-calling adapter pinned to Agents runtime per D12. Five CI workflows + canary on all four interfaces.

## Cross-initiative dependencies

Packet 03's frontmatter declares hard `dependencies:` on:
- `adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold` (already merged)
- `adr-0017-capabilities-standup/03-capabilities-node-scaffold`
- `adr-0018-operator-standup/03-operator-node-scaffold` (PR #120 just merged; the Operator scaffold issue is now filed but the scaffold PR in HoneyDrunk.Operator hasn't shipped yet)

`file-packets.yml` will wire `addBlockedBy` edges on The Hive. Wave 2 won't unblock until upstream Abstractions ship on NuGet.

## Key design decisions captured

- **NuGet uses `.Abstractions`** throughout (invariant 2).
- **`IAgentExecutionContext` extends Kernel's** via interface inheritance — no silent shadow.
- **State boundary preserved**: Agents holds ephemeral execution state. No `IRepository`, no Data dep. Durable workflow state belongs to Flow; durable learned state belongs to Memory.
- **Record naming**: `AgentMemoryWriteRequest`, `AgentMemoryQueryRequest`, `AgentMemoryReadResult` (prefix avoids collision with Memory's `MemoryEntry`/`MemoryStoreQuery`).

Each packet carries `accepts: ADR-0020` for hive-sync auto-flip.

## Invariant numbering

Default 51–57 assumes ADR-0018 lands first (PR #120 just merged, seeding 47–50). Packet 02's collision-check re-verifies at execution time.

## Test plan

- [ ] After merge, verify four issues file with cross-init dep edges on The Hive
- [ ] Wave 2 issue stays blocked on AI/Capabilities/Operator scaffold issues + own Wave 1
- [ ] When all four close, hive-sync auto-flips ADR-0020 Proposed → Accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)