### PR TITLE
chore: scope ADR-0021 knowledge node standup

### DIFF
--- a/generated/issue-packets/active/adr-0021-knowledge-standup/01-architecture-knowledge-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0021-knowledge-standup/01-architecture-knowledge-catalog-registration.md
@@ -1,0 +1,267 @@
+---
+name: Architecture Catalog Registration
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0021"]
+dependencies: []
+adrs: ["ADR-0021"]
+accepts: ADR-0021
+wave: 1
+initiative: adr-0021-knowledge-standup
+node: honeydrunk-knowledge
+---
+
+# Chore: Register HoneyDrunk.Knowledge's standup decisions in Architecture catalogs
+
+## Summary
+
+Reflect ADR-0021's stand-up decisions in the canonical Architecture catalogs. Promote `IKnowledgeSource` interface → `KnowledgeSource` record per the grid-wide naming rule. Add `honeydrunk-agents` to `consumed_by_planned` (reconciles `catalogs/nodes.json` prose-vs-`relationships.json`-edges drift). Refresh `grid-health.json` and `nodes.json`. Add `integration-points.md` and `active-work.md` under `repos/HoneyDrunk.Knowledge/`.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0021 establishes Knowledge's exposed contracts and the embedding-model coherence rule. Drift items:
+
+1. **`contracts.json`** lists `IKnowledgeSource` as an interface. Per D3 and the grid-wide naming rule, it's a record — rename to `KnowledgeSource` with `kind: "type"`.
+2. **`relationships.json` `exposes.contracts`** uses the same name — rename to `KnowledgeSource`.
+3. **`relationships.json` `consumed_by_planned`** has `honeydrunk-sim` and `honeydrunk-lore` but is missing `honeydrunk-agents` (and prose in `catalogs/nodes.json` says Agents + Lore + HoneyHub).
+4. **`grid-health.json`** is a stub. Refresh.
+5. **`constitution/ai-sector-architecture.md`** and `repos/HoneyDrunk.Knowledge/overview.md` reference `IKnowledgeSource` — replace with `KnowledgeSource`.
+
+## Proposed Implementation
+
+### `catalogs/contracts.json` — `honeydrunk-knowledge` block
+
+Replace with the four D3 surfaces:
+
+```json
+{
+  "node": "honeydrunk-knowledge",
+  "node_name": "HoneyDrunk.Knowledge",
+  "package": "HoneyDrunk.Knowledge.Abstractions",
+  "status": "seed",
+  "interfaces": [
+    { "name": "IKnowledgeStore", "kind": "interface", "description": "Ingest, query, and delete knowledge sources. Storage-facing surface that provider packages implement. ADR-0021 D3." },
+    { "name": "IDocumentIngester", "kind": "interface", "description": "Parse and chunk documents; delegate embedding generation to IEmbeddingGenerator (HoneyDrunk.AI). ADR-0021 D3 / D5." },
+    { "name": "IRetrievalPipeline", "kind": "interface", "description": "Query → ranked results with source attribution and confidence scores. The agent-facing and application-facing RAG entry point. ADR-0021 D3 / D7 / D8." },
+    { "name": "KnowledgeSource", "kind": "type", "description": "Record. Metadata about an ingested source — origin, version, last-updated timestamp, embedding-model identifier (per ADR-0021 D6). Value type; no I prefix per the grid-wide naming rule." }
+  ]
+}
+```
+
+Drop the existing `IKnowledgeSource` interface entry.
+
+### `catalogs/relationships.json` — `honeydrunk-knowledge` block
+
+**(a) `exposes.contracts`.** Replace with:
+
+```json
+"contracts": ["IKnowledgeStore", "IDocumentIngester", "IRetrievalPipeline", "KnowledgeSource"]
+```
+
+(Drop `IKnowledgeSource`, add `KnowledgeSource`.)
+
+**(b) `exposes.packages`.** Confirm includes `HoneyDrunk.Knowledge.Providers.InMemory`:
+
+```json
+"packages": ["HoneyDrunk.Knowledge.Abstractions", "HoneyDrunk.Knowledge", "HoneyDrunk.Knowledge.Providers.InMemory"]
+```
+
+**(c) `consumes_detail` widening (the AI edge).** Confirm AI `consumes_detail` includes `IEmbeddingGenerator` and `HoneyDrunk.AI.Abstractions`. If incomplete, set to:
+
+```json
+"honeydrunk-ai": ["IEmbeddingGenerator", "HoneyDrunk.AI.Abstractions"]
+```
+
+**(d) `consumed_by_planned`.** Currently `["honeydrunk-sim", "honeydrunk-lore"]`. Replace with:
+
+```json
+"consumed_by_planned": ["honeydrunk-sim", "honeydrunk-lore", "honeydrunk-agents", "honeydrunk-evals"]
+```
+
+Add per-edge `consumes_detail`:
+
+- Agents: `["IRetrievalPipeline", "HoneyDrunk.Knowledge.Abstractions"]` (Agents composes Knowledge via `IRetrievalPipeline` for grounded-context retrieval)
+- Evals: `["IRetrievalPipeline", "HoneyDrunk.Knowledge.Abstractions"]` (Evals composes deterministic retrieval fixtures via Abstractions)
+- Sim: `["IKnowledgeStore", "HoneyDrunk.Knowledge.Abstractions"]` — Sim consumes the contract surface only; provider composition (e.g. `Providers.InMemory`) is host-time per the Knowledge downstream-coupling invariant (see packet 02)
+- Lore: `["IRetrievalPipeline", "IKnowledgeStore", "HoneyDrunk.Knowledge.Abstractions"]`
+
+Per the Knowledge downstream-coupling invariant landing in packet 02, downstream Nodes depend on `HoneyDrunk.Knowledge.Abstractions` only. Any specific provider package (`Providers.InMemory`, future `Providers.AzureAISearch`, etc.) is composed at host time and does not appear in `consumes_detail`.
+
+**Prose-only consumer.** `honeydrunk-honeyhub` is NOT added to `consumed_by_planned` (per ADR-0021 framing it is mentioned in prose only — "HoneyHub when live" — and does not create a catalog edge at stand-up). This mirrors how ADR-0020 treated HoneyHub in the Agents stand-up.
+
+### `catalogs/grid-health.json` — `honeydrunk-knowledge` block
+
+Replace existing stub:
+
+```json
+{
+  "id": "honeydrunk-knowledge",
+  "name": "HoneyDrunk.Knowledge",
+  "sector": "AI",
+  "signal": "Seed",
+  "version": "0.0.0",
+  "canary_status": "none",
+  "last_release": null,
+  "active_blockers": ["Scaffold packet (Knowledge#NN — packet 03 of adr-0021-knowledge-standup) not yet executed", "Hard cross-initiative dependency on adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold — packet 03 will not file until the AI scaffold packet's GitHub Issue exists"],
+  "notes": "ADR-0021 standup ADR Proposed 2026-04-19. Catalog surface registered (3 interfaces + 1 record per D3: IKnowledgeStore, IDocumentIngester, IRetrievalPipeline, KnowledgeSource). IKnowledgeSource interface promoted to KnowledgeSource record per the grid-wide naming rule. Awaiting scaffold: HoneyDrunk.Knowledge.Abstractions, HoneyDrunk.Knowledge runtime (default store, ingester, retrieval pipeline composing AI's IEmbeddingGenerator), HoneyDrunk.Knowledge.Providers.InMemory backend, Standards wiring, CI with contract-shape canary scoped to all 4 surfaces. Providers.AzureAISearch and Providers.PostgresVector deferred to follow-up packets."
+}
+```
+
+### `catalogs/nodes.json` — `honeydrunk-knowledge` block
+
+**(a) `grid_relationship`.** Replace with:
+
+> `"grid_relationship": "Consumes Kernel (context, telemetry), Data (IRepository for knowledge-source storage), AI (IEmbeddingGenerator for chunk and query embeddings per ADR-0021 D5). Emits ingestion / retrieval / store-mutation telemetry consumed by Pulse — no runtime dependency on Pulse (ADR-0021 D10). Content NEVER appears in telemetry — metadata only. Consumed by Lore (wiki compilation), Sim (scenario-driven retrieval against deterministic fixtures), Agents (grounded-context retrieval), Evals (retrieval-quality suites), HoneyHub (when live, prose-only at stand-up)."`
+
+**(b) `roadmap_focus`.** Reconcile against D3 — name `KnowledgeSource` not `IKnowledgeSource`.
+
+### `constitution/ai-sector-architecture.md` — Knowledge section
+
+Update Key Contracts list — three interfaces + `KnowledgeSource` (record). Add Depends-on / Emits-to split. Note the embedding-model coherence rule (D6) and the "Knowledge content never appears in telemetry" rule (D10).
+
+### `repos/HoneyDrunk.Knowledge/overview.md`
+
+Replace `IKnowledgeSource` references with `KnowledgeSource`. Add row for `HoneyDrunk.Knowledge.Providers.InMemory` to the Packages table. Add a note about the embedding-model coherence rule and the source attribution guarantee.
+
+### `repos/HoneyDrunk.Knowledge/integration-points.md` — new file
+
+Create matching the `repos/HoneyDrunk.Agents/integration-points.md` template:
+
+```markdown
+# HoneyDrunk.Knowledge — Integration Points
+
+## Consumes
+
+| Node | Contract | Purpose |
+|------|----------|---------|
+| **Kernel** | `IGridContext`, `IOperationContext`, `INodeContext` | Every ingestion and retrieval operation runs inside a Grid context. |
+| **Kernel** | `IStartupHook`, `IShutdownHook` | Knowledge store initialization at startup; graceful drain on shutdown. |
+| **Kernel** | `ITelemetryActivityFactory` | Emits ingestion / retrieval / mutation activities. Pulse consumes. |
+| **AI** | `IEmbeddingGenerator` | Chunk embedding at ingest; query embedding at retrieval. ADR-0016 D3 / ADR-0021 D5. |
+| **Data** | `IRepository`, `IUnitOfWork` | Knowledge-source and chunk persistence (when not in-memory).
+
+## Exposes
+
+| Contract | Consumer | Notes |
+|----------|---------|-------|
+| `IKnowledgeStore` | Lore (wiki storage), Sim (fixture seeding) | Storage-facing surface; provider packages implement.
+| `IDocumentIngester` | Lore, Sim, application Nodes | Parse + chunk + embed.
+| `IRetrievalPipeline` | Agents (grounded-context), Lore, Evals, HoneyHub when live | RAG entry point.
+| `KnowledgeSource` | All consumers | Record. Travels with retrieved chunks for attribution.
+
+## Emits (no runtime dependency)
+
+| Signal | Consumer | Notes |
+|--------|----------|-------|
+| Ingest / retrieve / mutate activities (metadata only) | **Pulse** | Per ADR-0021 D10. Content NEVER appears in telemetry.
+
+## Canary Coverage Required
+
+- `Knowledge.Canary` → Kernel: `IGridContext` flow through ingestion + retrieval.
+- `Knowledge.Canary` → AI: `IEmbeddingGenerator` invocation at ingest and retrieval; mismatched embedding-model errors per D6.
+- `Knowledge.Canary` → Data: persistence round-trips through `IRepository`.
+- `Knowledge.Canary` → contract-shape: CI canary fails on shape drift to `IKnowledgeStore`, `IDocumentIngester`, `IRetrievalPipeline`, `KnowledgeSource` (ADR-0021 D12 / canary invariant — number assigned at acceptance).
+
+## Dependency Order for Bring-Up
+
+Knowledge cannot be scaffolded until:
+1. Kernel (Live)
+2. AI Abstractions (must publish `IEmbeddingGenerator`)
+3. Data (Live)
+
+Knowledge is a hard prerequisite for: Lore, Sim, Evals, Agents (retrieval), HoneyHub when live.
+```
+
+### `repos/HoneyDrunk.Knowledge/active-work.md` — new file (matching the Agents template)
+
+### `initiatives/active-initiatives.md` — new entry
+
+Standard format. Initiative `adr-0021-knowledge-standup`.
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append: `Architecture: Register ADR-0021 standup decisions in catalogs (contracts.json promotes IKnowledgeSource interface → KnowledgeSource record per the grid-wide naming rule; relationships.json updates exposes.contracts, packages, and consumed_by_planned to add honeydrunk-agents and honeydrunk-evals; grid-health.json gets the standup block; nodes.json grid_relationship widens to reflect ADR-0021 D5/D10; ai-sector-architecture.md and repos/HoneyDrunk.Knowledge/overview.md adopt KnowledgeSource record; new integration-points.md and active-work.md filed; active-initiatives.md gets the new initiative block).`
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+- `catalogs/grid-health.json`
+- `catalogs/nodes.json`
+- `constitution/ai-sector-architecture.md`
+- `repos/HoneyDrunk.Knowledge/overview.md`
+- `repos/HoneyDrunk.Knowledge/integration-points.md` (new)
+- `repos/HoneyDrunk.Knowledge/active-work.md` (new)
+- `initiatives/active-initiatives.md`
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] `IKnowledgeSource` → `KnowledgeSource` rename applies the grid-wide naming rule.
+- [x] D3 contract surface preserved (three interfaces + one record).
+- [x] No code changes; metadata + docs only.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` `honeydrunk-knowledge` block lists exactly four surfaces: three interfaces + `KnowledgeSource` (record, `kind: "type"`). No `IKnowledgeSource` interface.
+- [ ] `catalogs/relationships.json` `honeydrunk-knowledge.exposes.contracts` matches the same four surfaces.
+- [ ] `catalogs/relationships.json` `honeydrunk-knowledge.exposes.packages` includes `HoneyDrunk.Knowledge.Providers.InMemory`.
+- [ ] `catalogs/relationships.json` `honeydrunk-knowledge.consumed_by_planned` includes `honeydrunk-agents` and `honeydrunk-evals` alongside existing entries.
+- [ ] `catalogs/grid-health.json` `honeydrunk-knowledge` block reflects standup.
+- [ ] `catalogs/nodes.json` `honeydrunk-knowledge.grid_relationship` reflects D5/D10 phrasing.
+- [ ] `constitution/ai-sector-architecture.md` Knowledge section reads `KnowledgeSource` not `IKnowledgeSource`; Depends-on / Emits-to split present.
+- [ ] `repos/HoneyDrunk.Knowledge/overview.md` reads `KnowledgeSource`; Packages table includes `Providers.InMemory`.
+- [ ] `repos/HoneyDrunk.Knowledge/integration-points.md` and `active-work.md` exist.
+- [ ] `initiatives/active-initiatives.md` includes new entry.
+- [ ] `CHANGELOG.md` Unreleased updated.
+- [ ] `rg -n "IKnowledgeSource" catalogs/ repos/HoneyDrunk.Knowledge/ constitution/` returns zero matches.
+- [ ] `rg -n "honeydrunk-honeyhub" catalogs/relationships.json` returns zero matches inside the `honeydrunk-knowledge` block's `consumed_by_planned` array (HoneyHub stays prose-only per ADR-0021 framing).
+- [ ] ADR-0021 NOT modified — Status stays Proposed.
+
+## Human Prerequisites
+None.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+
+> **Invariant 11:** One repo per Node.
+
+## Referenced ADR Decisions
+
+**ADR-0021 D3:** Four surfaces — three interfaces + `KnowledgeSource` record.
+
+**ADR-0021 D5:** Embedding calls compose AI's `IEmbeddingGenerator`.
+
+**ADR-0021 D6:** `KnowledgeSource` records ingest-time embedding-model identifier; retrieval against mismatched model errors.
+
+**ADR-0021 D7:** Source attribution mandatory.
+
+**ADR-0021 D10:** Knowledge content NEVER in telemetry.
+
+## Dependencies
+None.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0021`
+
+## Agent Handoff
+
+**Objective:** Align catalogs with ADR-0021 D3. Promote `IKnowledgeSource` interface → `KnowledgeSource` record. Add missing consumer edges.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Constraints:**
+- **Records drop `I` prefix; interfaces keep it.** `KnowledgeSource` is a record (no `I`). The three interfaces keep `I`.
+- **`kind: "type"` for the record, `kind: "interface"` for the three interfaces.** No `kind: "record"` anywhere.
+- **No code; catalog + docs only.**
+- **No ADR Status flip.**
+
+**Key Files:** All listed above.
+
+**Contracts:** None authored. Catalog-only.

--- a/generated/issue-packets/active/adr-0021-knowledge-standup/02-architecture-knowledge-invariants.md
+++ b/generated/issue-packets/active/adr-0021-knowledge-standup/02-architecture-knowledge-invariants.md
@@ -1,0 +1,123 @@
+---
+name: Constitution Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0021", "constitution"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0021"]
+accepts: ADR-0021
+wave: 1
+initiative: adr-0021-knowledge-standup
+node: honeydrunk-knowledge
+---
+
+# Chore: Add ADR-0021's six new invariants to the Grid constitution
+
+## Summary
+
+Add six new invariants derived from ADR-0021: downstream-coupling (D2), source-attribution-mandatory (D7), embedding-model-coherence (D6), confidence-scores-mandatory (D8), content-never-in-telemetry (D10), contract-shape-canary on all four surfaces (D12).
+
+D8 (mandatory confidence scores) is elevated from Node-local to Grid-level for consistency with D7's treatment — both are interface-contract guarantees on `IRetrievalPipeline` results, and consumers (Lore, Sim, Agents, Evals) need to know the score contract is stable across providers and across the substrate's lifetime. Without elevation, providers could in principle ship without scores or with caller-opaque score semantics, defeating consumer-side thresholding. Treating D8 the same way D7 is treated (interface-contract guarantee → Grid invariant) keeps the contract surface coherent.
+
+Default assigned numbers **57, 58, 59, 60, 61, 62** (next-actually-free band above current invariants.md high-water mark of 46 and above the bands already claimed by ADR-0020 Agents standup at 48-54 and ADR-0027 Notify Cloud standup at 51-56). Collision-check at edit time is still authoritative — see the section below.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+Six rules govern Knowledge's first-shipping behavior:
+
+- **Downstream coupling.** Composition against runtime / providers is host-time.
+- **Source attribution mandatory.** Every retrieved chunk carries the `KnowledgeSource` identity, position, version. No anonymous retrieval.
+- **Embedding-model coherence (level b).** Every `KnowledgeSource` records ingest-time model; retrieval against mismatched model errors or returns empty. Knowledge never produces cross-model similarity scores.
+- **Confidence scores mandatory.** Every `IRetrievalPipeline` result carries a per-chunk relevance/confidence score. Knowledge does not threshold; consumers do.
+- **Content never in telemetry.** Only metadata crosses the Pulse boundary.
+- **Canary on all four surfaces.** Knowledge has a narrow boundary; all four are hot-path.
+
+## Proposed Implementation
+
+### `constitution/invariants.md` — append six new entries
+
+Default 57-62. Use Option A (new `## AI Sector — Knowledge Invariants` section) or Option B (append to `## AI Invariants`). Mark each `(Proposed — this invariant takes effect when ADR-0021 is accepted)`.
+
+```markdown
+## AI Sector — Knowledge Invariants
+
+57. **Downstream Nodes take a runtime dependency only on `HoneyDrunk.Knowledge.Abstractions`.**
+    Composition against `HoneyDrunk.Knowledge` and any `HoneyDrunk.Knowledge.Providers.*` package is a host-time concern. See ADR-0021 D2 (Proposed — this invariant takes effect when ADR-0021 is accepted).
+
+58. **Every retrieved chunk carries source attribution — the `KnowledgeSource` identity, the chunk's position within the source, and the source version.**
+    The `IRetrievalPipeline` interface contract guarantees this; provider packages that cannot preserve attribution cannot implement `IKnowledgeStore`. No mode, flag, or provider returns an unattributed chunk. See ADR-0021 D7 (Proposed — this invariant takes effect when ADR-0021 is accepted).
+
+59. **Every `KnowledgeSource` records the embedding-model identifier used at ingest time, and a retrieval against a mismatched model errors or returns empty.**
+    Knowledge never produces a cross-model similarity score. Re-ingesting a source under a new embedding model is treated as a new version. See ADR-0021 D6 (Proposed — this invariant takes effect when ADR-0021 is accepted).
+
+60. **Every `IRetrievalPipeline` result carries a per-chunk relevance/confidence score; Knowledge applies no cutoff threshold.**
+    Thresholding is a consumer concern (Lore, Sim, Agents, Evals each pick their own cutoff). Provider packages that cannot expose a stable score for every returned chunk cannot implement `IKnowledgeStore` or back `IRetrievalPipeline`. The score contract is part of the interface so consumer-side thresholding is portable across providers. See ADR-0021 D8 (Proposed — this invariant takes effect when ADR-0021 is accepted).
+
+61. **Knowledge content never appears in telemetry.**
+    Only metadata — source id, chunk count, query latency, result count, model identifier — may cross the telemetry boundary. Document text, chunk contents, query text, and retrieved chunk contents are NEVER carried in Pulse signals. The separation is structural, not advisory: the telemetry activity factory never receives content payloads from Knowledge code paths. See ADR-0021 D10 (Proposed — this invariant takes effect when ADR-0021 is accepted).
+
+62. **The HoneyDrunk.Knowledge Node CI must include a contract-shape canary that fails the build on shape drift to `IKnowledgeStore`, `IDocumentIngester`, `IRetrievalPipeline`, or `KnowledgeSource` without a corresponding version bump.**
+    These four are the hot path for every downstream consumer. Knowledge's boundary is narrow — all four surfaces are in the canary from stand-up because there is no lower-traffic tier to carve out. See ADR-0021 D12 (Proposed — this invariant takes effect when ADR-0021 is accepted).
+```
+
+### Collision check
+
+The current high-water mark in `constitution/invariants.md` is **46** (`## AI Invariants` ends there). However, two in-flight standup initiatives have already claimed bands above 46:
+
+- **ADR-0020 (Agents standup) — claims 48-54.** Packet 02 of `adr-0020-agents-standup` lands seven invariants. Confirmed in that packet's body and ADR-0020 Consequences.
+- **ADR-0027 (Notify Cloud standup) — claims 51-56.** Packet 02 of `adr-0027-notify-cloud-standup` lands six invariants. The 51-56 band overlaps with Agents 48-54 — Notify Cloud's packet 02 explicitly notes the race and resolves via runtime collision-check at filing time.
+
+To stay clear of both bands regardless of which lands first, **Knowledge's default band is 57-62** (six invariants). If at edit time either of the above has landed at different numbers, recompute against the actual high-water mark by running:
+
+```bash
+rg -nP '^\d+\.\s\*\*' constitution/invariants.md | tail -10
+```
+
+Then claim the next six free numbers. If the band shifts, update ADR-0021 Consequences + packet 03 source file in lockstep (pre-filing amendment carve-out per invariant 24).
+
+### `CHANGELOG.md`
+
+Append: `Architecture: Add invariants 57 (Knowledge downstream coupling), 58 (mandatory source attribution), 59 (embedding-model coherence at retrieval boundary), 60 (mandatory confidence scores on retrieval results), 61 (Knowledge content NEVER in telemetry), 62 (Knowledge contract-shape canary on all four surfaces) per ADR-0021 D2/D7/D6/D8/D10/D12.` (If the collision-check at edit time shifted the band, substitute the actual six numbers.)
+
+## Affected Files
+- `constitution/invariants.md`
+- `adrs/ADR-0021-stand-up-honeydrunk-knowledge-node.md` (only on shift)
+- `generated/issue-packets/active/adr-0021-knowledge-standup/03-knowledge-node-scaffold.md` (only on shift)
+- `CHANGELOG.md`
+
+## Acceptance Criteria
+- [ ] Six invariants present, matching ADR-0021 D2/D7/D6/D8/D10/D12.
+- [ ] D8 (mandatory confidence scores) is elevated to a Grid-level invariant alongside D7.
+- [ ] Numbers verified via `rg -nP '^\d+\.\s\*\*' constitution/invariants.md | tail -10` and do not collide with bands claimed by other in-flight initiatives (ADR-0020 Agents 48-54, ADR-0027 Notify Cloud 51-56).
+- [ ] `(Proposed — this invariant takes effect when ADR-0021 is accepted)` qualifier on each.
+- [ ] On shift, ADR-0021 Consequences + packet 03 source file updated in lockstep (pre-filing amendment per invariant 24).
+- [ ] `CHANGELOG.md` Unreleased updated.
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0021 D2, D7, D6, D8, D10, D12.** Sources for invariants 57-62 respectively (default — collision-check at edit time is authoritative).
+
+## Dependencies
+- `packet:01`
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0021`, `constitution`
+
+## Agent Handoff
+
+**Objective:** Land six new ADR-0021-derived invariants (D2, D7, D6, D8, D10, D12). D8 is elevated to a Grid-level invariant alongside D7 for consistency in interface-contract guarantees on `IRetrievalPipeline` results.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Constraints:** Default 57-62; collision-check at edit time against ADR-0020 (Agents, 48-54) and ADR-0027 (Notify Cloud, 51-56). If the band shifts, update ADR-0021 Consequences + packet 03 source file in lockstep before filing (pre-filing amendment per invariant 24). `(Proposed — this invariant takes effect when ADR-0021 is accepted)` qualifier on each.
+
+**Key Files:** `constitution/invariants.md`; conditional ADR-0021 + packet 03; `CHANGELOG.md`.
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0021-knowledge-standup/02b-architecture-verify-knowledge-repo.md
+++ b/generated/issue-packets/active/adr-0021-knowledge-standup/02b-architecture-verify-knowledge-repo.md
@@ -1,0 +1,112 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "ai", "adr-0021", "human-only", "wave-2"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0021"]
+accepts: ADR-0021
+wave: 2
+initiative: adr-0021-knowledge-standup
+node: honeydrunk-architecture
+actor: human
+---
+
+# Chore: Verify `HoneyDrunk.Knowledge` GitHub repo settings + local clone (human-only)
+
+## Summary
+
+Confirm `HoneyDrunkStudios/HoneyDrunk.Knowledge` matches the Grid's per-repo standard settings; confirm the local clone at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Knowledge/` is on `main` and clean; confirm OIDC federated credential. Repo and clone already exist (LICENSE + README).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Actor
+**`Human`.**
+
+## Steps
+
+### Step 0 — Reconcile local clone branch state
+
+The local clone at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Knowledge/` may currently be checked out on `chore/wire-standard-workflows` (the per-repo Standards-wiring chore branch). Before any other verification work, confirm the clone is clean and align it back to `main` so packet 03's scaffolding agent starts from a known baseline.
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Knowledge
+git status                                          # confirm clean
+git checkout chore/wire-standard-workflows         # confirm current branch
+# If the chore PR has merged to main on remote:
+git checkout main 2>/dev/null || git checkout -b main origin/main
+git pull --ff-only origin main
+git branch -d chore/wire-standard-workflows        # delete local chore branch
+```
+
+If `git status` reports uncommitted changes on the chore branch, stop and resolve those first — do not force-delete the branch. If the chore PR has not yet merged, defer the `git branch -d` step and leave the local chore branch in place; the scaffolding agent in packet 03 branches from `main` independently and is not blocked by the chore branch's presence.
+
+### Step 1 — Verify repo settings (portal)
+- https://github.com/HoneyDrunkStudios/HoneyDrunk.Knowledge/settings — default branch `main`, Public, Issues + Actions enabled.
+- /settings/branches — branch protection: PR required, `pr-core / core` required, no force pushes, no deletions.
+- /settings/security_analysis — Dependabot alerts enabled.
+
+### Step 2 — Seed labels
+
+```bash
+for label in "feature:0E8A16" "chore:CCCCCC" "tier-1:E99695" "tier-2:FBCA04" "ai:D946EF" "scaffold:BFDADC" "adr-0021:1D76DB" "wave-3:FBCA04" "human-only:B60205" "out-of-band:D4C5F9"; do
+  name="${label%:*}"; color="${label#*:}"
+  gh label create "$name" --repo HoneyDrunkStudios/HoneyDrunk.Knowledge --color "$color" 2>/dev/null
+done
+```
+
+### Step 3 — Verify local clone (final sanity check)
+
+Step 0 already aligned the clone to `main`. This step is a final post-portal sanity check:
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Knowledge
+git status                                          # clean, on main
+git fetch origin
+git pull --ff-only origin main                     # absorb any portal-driven default-branch updates
+ls                                                  # confirm LICENSE + README present
+```
+
+### Step 4 — Confirm OIDC federated credential
+
+Cross-link: [`infrastructure/walkthroughs/oidc-federated-credentials.md`](../../../../infrastructure/walkthroughs/oidc-federated-credentials.md).
+
+Confirm `repo:HoneyDrunkStudios/HoneyDrunk.Knowledge:ref:refs/tags/v*` in the Grid's NuGet publishing identity's federated credential list.
+
+## Acceptance Criteria
+- [ ] Branch protection on `main` configured.
+- [ ] Labels seeded.
+- [ ] Local clone is on `main`, clean, and the `chore/wire-standard-workflows` local branch has either been deleted (if the chore PR merged) or explicitly left in place with a note (if it has not yet merged).
+- [ ] OIDC credential verified.
+- [ ] Chore issue closed.
+
+## Human Prerequisites
+- [ ] Org-admin role
+- [ ] Browser + gh CLI authenticated
+- [ ] Azure portal access if Step 4 needs work
+
+## Dependencies
+- `packet:01`
+
+## Downstream Unblocks
+- `03-knowledge-node-scaffold.md` — fileable after this chore Done and packet 02 merged.
+
+## Referenced ADR Decisions
+
+**ADR-0021 D1 / D2:** Substrate Node, three packages. Repo already exists; this is verification.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node.
+
+> **Invariant 24:** Pre-filing amendments to packet 03 permitted if invariant numbers shift in packet 02.
+
+## Labels
+`chore`, `tier-1`, `meta`, `ai`, `adr-0021`, `human-only`, `wave-2`
+
+## Notes
+- ~5-minute task. Verification only.
+- Do not commit anything to the local clone. Scaffolding agent in packet 03 authors all source files.
+- No Azure provisioning required.

--- a/generated/issue-packets/active/adr-0021-knowledge-standup/03-knowledge-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0021-knowledge-standup/03-knowledge-node-scaffold.md
@@ -1,0 +1,353 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Knowledge
+labels: ["feature", "tier-2", "ai", "scaffold", "adr-0021"]
+dependencies: ["packet:01", "packet:02", "packet:02b", "adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold"]
+adrs: ["ADR-0021", "ADR-0016"]
+accepts: ADR-0021
+wave: 3
+initiative: adr-0021-knowledge-standup
+node: honeydrunk-knowledge
+---
+
+# Feature: Stand up the HoneyDrunk.Knowledge repo — solution, three packages, contracts, CI, InMemory provider
+
+## Summary
+
+Bring the near-empty `HoneyDrunk.Knowledge` repo from zero to first-shippable per ADR-0021. Land the solution, the three package families (`Abstractions`, runtime, `Providers.InMemory`), the four D3 surfaces in `HoneyDrunk.Knowledge.Abstractions` (three interfaces + `KnowledgeSource` record), default runtime implementations composing AI's `IEmbeddingGenerator` per D5, the in-memory provider backend, the standard CI pipeline, and the contract-shape canary scoped to `HoneyDrunk.Knowledge.Abstractions` per D12 and the canary invariant (number assigned by packet 02).
+
+Unblocks Lore, Sim, Agents (retrieval composition), HoneyHub (when live), Evals.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Knowledge`
+
+## Motivation
+
+ADR-0021 establishes what HoneyDrunk.Knowledge is. The repo is cloned (LICENSE + README only). Five downstream consumers blocked.
+
+This scaffold ships the contract surface plus an in-memory backend; production backends (`Providers.AzureAISearch`, `Providers.PostgresVector`) follow as separate packets.
+
+## Proposed Implementation
+
+### Repository layout
+
+```
+HoneyDrunk.Knowledge/
+├── HoneyDrunk.Knowledge.slnx
+├── Directory.Build.props
+├── CHANGELOG.md
+├── README.md
+├── .editorconfig
+├── .gitignore
+├── .github/workflows/
+│   ├── pr-core.yml
+│   ├── release.yml
+│   ├── nightly-deps.yml
+│   ├── nightly-security.yml
+│   └── api-compatibility.yml
+├── src/
+│   ├── HoneyDrunk.Knowledge.Abstractions/
+│   │   ├── HoneyDrunk.Knowledge.Abstractions.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── IKnowledgeStore.cs
+│   │   ├── IDocumentIngester.cs
+│   │   ├── IRetrievalPipeline.cs
+│   │   ├── KnowledgeSource.cs
+│   │   └── (retrieval request/response records — minimum needed)
+│   ├── HoneyDrunk.Knowledge/
+│   │   ├── HoneyDrunk.Knowledge.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── ServiceCollectionExtensions.cs
+│   │   ├── Storage/DefaultKnowledgeStore.cs
+│   │   ├── Ingestion/DefaultDocumentIngester.cs    (composes IEmbeddingGenerator)
+│   │   ├── Retrieval/DefaultRetrievalPipeline.cs   (composes IEmbeddingGenerator; enforces D6)
+│   │   └── Telemetry/KnowledgeTelemetry.cs
+│   └── HoneyDrunk.Knowledge.Providers.InMemory/
+│       ├── HoneyDrunk.Knowledge.Providers.InMemory.csproj
+│       ├── README.md
+│       ├── CHANGELOG.md
+│       ├── InMemoryKnowledgeStore.cs
+│       └── (in-memory index/storage internals)
+└── tests/
+    ├── HoneyDrunk.Knowledge.Abstractions.Tests/
+    ├── HoneyDrunk.Knowledge.Tests/
+    └── HoneyDrunk.Knowledge.Providers.InMemory.Tests/
+```
+
+### Solution
+
+`Directory.Build.props` sets `net10.0`, nullable, warnings-as-errors, `Version` 0.1.0 (test projects excluded via `IsTestProject`).
+
+### Contract details — `HoneyDrunk.Knowledge.Abstractions`
+
+```csharp
+// IKnowledgeStore.cs
+namespace HoneyDrunk.Knowledge.Abstractions;
+
+public interface IKnowledgeStore
+{
+    Task IngestAsync(KnowledgeSource source, IReadOnlyList<KnowledgeChunk> chunks, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<RetrievedChunk>> QueryAsync(KnowledgeQuery query, CancellationToken cancellationToken = default);
+    Task DeleteAsync(string sourceId, CancellationToken cancellationToken = default);
+    Task<KnowledgeSource?> GetSourceAsync(string sourceId, CancellationToken cancellationToken = default);
+}
+
+public sealed record KnowledgeChunk(string Content, int Position, float[] Embedding, IReadOnlyDictionary<string, string> Metadata);
+
+public sealed record KnowledgeQuery(string QueryText, float[]? QueryEmbedding, int MaxResults, IReadOnlyDictionary<string, string> Filters, string EmbeddingModelIdentifier);
+
+public sealed record RetrievedChunk(string Content, int Position, double SimilarityScore, KnowledgeSource Source, IReadOnlyDictionary<string, string> Metadata);
+```
+
+```csharp
+// IDocumentIngester.cs
+public interface IDocumentIngester
+{
+    Task<KnowledgeSource> IngestAsync(IngestionRequest request, CancellationToken cancellationToken = default);
+}
+
+public sealed record IngestionRequest(string SourceUri, string ContentType, string OriginContent, IReadOnlyDictionary<string, string> Metadata, IngestionOptions? Options);
+public sealed record IngestionOptions(int ChunkSize, int ChunkOverlap, string? EmbeddingModelIdentifier);
+```
+
+```csharp
+// IRetrievalPipeline.cs
+public interface IRetrievalPipeline
+{
+    Task<IReadOnlyList<RetrievedChunk>> QueryAsync(string queryText, RetrievalOptions? options = null, CancellationToken cancellationToken = default);
+}
+
+public sealed record RetrievalOptions(int MaxResults, IReadOnlyDictionary<string, string> Filters, string? EmbeddingModelIdentifier);
+```
+
+```csharp
+// KnowledgeSource.cs (record — no I prefix)
+public sealed record KnowledgeSource(
+    string SourceId,
+    string Origin,
+    string Version,
+    DateTimeOffset LastUpdated,
+    string EmbeddingModelIdentifier,         // D6 — required for retrieval coherence
+    string ContentType,
+    IReadOnlyDictionary<string, string> Metadata);
+```
+
+Per invariant 1, `HoneyDrunk.Knowledge.Abstractions` carries `Microsoft.Extensions.*` abstractions only, **with one explicit exception**: it takes a compile-time reference to `HoneyDrunk.Kernel.Abstractions` (context types) and `HoneyDrunk.AI.Abstractions` (for `IEmbeddingGenerator`, which appears in `IDocumentIngester` and/or `IRetrievalPipeline` member signatures per ADR-0021 D5). The transitive `HoneyDrunk.AI.Abstractions` edge to every downstream consumer is the explicit decision recorded in ADR-0021 D5: "Downstream Nodes inherit a transitive compile-time dependency on `HoneyDrunk.AI.Abstractions` because `IEmbeddingGenerator` appears in the Abstractions surface — this is accepted and matches the way ADR-0020 D5/D6 treated Agents's `Abstractions`-level edges." **No other HoneyDrunk reference is allowed in Abstractions** — no `HoneyDrunk.Kernel` (runtime), no `HoneyDrunk.AI` (runtime), no `HoneyDrunk.Data`, no Vault, no anything else.
+
+**Strict Abstractions stance — `EmbeddingModelIdentifier` shape.** `KnowledgeSource.EmbeddingModelIdentifier` is `string`. Knowledge does not import `ModelCapabilityDeclaration` from `HoneyDrunk.AI.Abstractions` into the record's member shape — the `string` identifier carries the model identity at the record level, and the `IEmbeddingGenerator` reference at the interface level is the only AI-record shape Knowledge inherits. This keeps Knowledge's record surface stable across AI's record-shape revisions.
+
+### Runtime details — `HoneyDrunk.Knowledge`
+
+`HoneyDrunk.Knowledge` references:
+- `HoneyDrunk.Knowledge.Abstractions` (project)
+- `HoneyDrunk.Kernel.Abstractions` (for telemetry-factory and context abstractions)
+- `HoneyDrunk.AI.Abstractions` (for `IEmbeddingGenerator` per ADR-0021 D5 — concrete generator wired by host into DI)
+- `HoneyDrunk.Data.Abstractions` (for `IRepository` / `IUnitOfWork` — concrete data runtime wired by host)
+- `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Hosting.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`
+
+Three default implementations:
+
+- **`DefaultDocumentIngester` — RAG (chunk-and-embed) paradigm; extensibility seam reserved.** Parses content into fixed-size overlapping chunks, generates per-chunk embeddings via `IEmbeddingGenerator`, persists chunks + embeddings + `KnowledgeSource` via `IKnowledgeStore`. Records the embedding-model identifier on `KnowledgeSource`. **This default targets the RAG paradigm only.** Alternative ingestion paradigms — most notably structured-wiki ingestion where the unit of retrieval is a semantically meaningful entry with hand-curated edges rather than an embedding-positioned chunk — are explicitly out of scope for the default ingester and are supported via the provider-extension seam: consumers ship their own `IDocumentIngester` implementation alongside a matching `IKnowledgeStore` shape, and host composition wires the alternative pair in place of the default. The `IDocumentIngester` interface itself is paradigm-agnostic; only the default implementation is RAG-locked. Document this in the runtime package README and on the `IDocumentIngester` XML doc.
+- **`DefaultRetrievalPipeline`** — embeds the query via `IEmbeddingGenerator`, delegates to `IKnowledgeStore.QueryAsync`. Enforces D6: if `KnowledgeQuery.EmbeddingModelIdentifier` does not match the source's recorded model, returns empty / errors rather than producing cross-model similarity scores. Enforces D8 (mandatory confidence scores) by requiring every `RetrievedChunk` returned by the underlying store to carry a non-null `SimilarityScore`. Alternative retrieval paradigms (e.g. structured-wiki graph traversal, hybrid sparse + dense retrieval) are supported via host-substituted `IRetrievalPipeline` implementations.
+- **`DefaultKnowledgeStore`** — façade over the configured provider package; default DI registration wires `InMemoryKnowledgeStore` for dev / test, with production hosts swapping in a real provider.
+- **`KnowledgeTelemetry`** — per-ingest, per-retrieval, per-mutation activities emitted via `ITelemetryActivityFactory`. **Content NEVER carried in telemetry** per D10. Only metadata.
+
+### Providers.InMemory details
+
+`InMemoryKnowledgeStore` — in-process dictionary keyed by `sourceId` and chunk position. Naive linear-scan similarity for queries (cosine similarity over stored embeddings). Suitable for tests, dev, fixtures — never production. Source attribution round-trips through every chunk per D7.
+
+### CI workflows
+
+Five workflow files. `api-compatibility.yml` path-filtered to `src/HoneyDrunk.Knowledge.Abstractions/**`.
+
+### `HoneyDrunk.Standards`
+
+Per invariant 26.
+
+### Documentation
+
+Repo README — purpose, package matrix, "How to consume" snippet with `AddHoneyDrunkKnowledge()` + `AddInMemoryKnowledgeStore()`, link to ADR-0021. Note the embedding-model coherence rule (D6) and the source-attribution guarantee (D7). Per-package README + CHANGELOG.
+
+## Affected Files
+Entire repo. See "Repository layout".
+
+## NuGet Dependencies
+
+### `HoneyDrunk.Knowledge.Abstractions.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | Context types (`IGridContext`, `IOperationContext`) referenced in interface signatures. |
+| `HoneyDrunk.AI.Abstractions` | **Required** per ADR-0021 D5 — `IEmbeddingGenerator` appears in `IDocumentIngester` / `IRetrievalPipeline` member signatures. The transitive compile-time edge to every downstream consumer is the explicit ADR-0021 D5 decision. |
+
+(No `HoneyDrunk.AI`, no `HoneyDrunk.Data` runtime references in Abstractions — only `.Abstractions` peers, per invariant 1.)
+
+### `HoneyDrunk.Knowledge.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | Telemetry factory abstractions, context types |
+| `HoneyDrunk.AI.Abstractions` | `IEmbeddingGenerator` per ADR-0021 D5 — runtime resolves the concrete generator from DI; the runtime package does not take a hard dependency on `HoneyDrunk.AI` because the embedding generator implementation is host-composed (host references `HoneyDrunk.AI` and wires the generator into DI). |
+| `HoneyDrunk.Data.Abstractions` | `IRepository`, `IUnitOfWork` for non-in-memory persistence — runtime package references the contract surface, never the data runtime. |
+| `Microsoft.Extensions.DependencyInjection.Abstractions`, `.Hosting.Abstractions`, `.Logging.Abstractions` | |
+
+Project reference: `HoneyDrunk.Knowledge.Abstractions`.
+
+**Rationale for `.Abstractions`-only references in the runtime package:** Invariant 2 prohibits runtime packages from depending on other Nodes' runtime packages. Knowledge's runtime needs the `IEmbeddingGenerator` interface (to call) and the `IRepository` interface (to persist), but the concrete implementations are wired by the consuming host — so the runtime package compiles against the `.Abstractions` peers and lets DI resolve the concretes. Hosts pull in `HoneyDrunk.AI` and `HoneyDrunk.Data` themselves.
+
+### `HoneyDrunk.Knowledge.Providers.InMemory.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+
+Project reference: `HoneyDrunk.Knowledge.Abstractions`.
+
+### Test projects: standard.
+
+## Boundary Check
+- [x] All work inside `HoneyDrunk.Knowledge`.
+- [x] `HoneyDrunk.Knowledge.Abstractions` references only `HoneyDrunk.Kernel.Abstractions` + `HoneyDrunk.AI.Abstractions` HoneyDrunk peers (plus `Microsoft.Extensions.*`); no runtime-package references per invariant 1 / ADR-0021 D5.
+- [x] `HoneyDrunk.Knowledge` runtime package references only `.Abstractions` peers (no other runtime packages) per invariant 2.
+- [x] `Providers.InMemory` references only `HoneyDrunk.Knowledge.Abstractions` (invariant 3).
+- [x] Content never appears in telemetry (D10 / invariant 61 — default; collision-check at edit time authoritative).
+- [x] `KnowledgeSource` carries `EmbeddingModelIdentifier`; retrieval enforces coherence (D6 / invariant 59 — default).
+- [x] Every `RetrievedChunk` carries `SimilarityScore`; Knowledge does not threshold (D8 / invariant 60 — default).
+- [x] Records drop `I` prefix; interfaces keep `I` per the grid-wide naming rule.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Knowledge.slnx` builds clean.
+- [ ] Three D3 interfaces + `KnowledgeSource` record present with XML docs.
+- [ ] `HoneyDrunk.Knowledge.Abstractions` references `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.AI.Abstractions` (and only those two HoneyDrunk peers, plus `Microsoft.Extensions.*`). No `HoneyDrunk.Kernel`, no `HoneyDrunk.AI`, no `HoneyDrunk.Data`, no `HoneyDrunk.Data.Abstractions` in Abstractions.
+- [ ] `HoneyDrunk.Knowledge` runtime package references only `.Abstractions` peers — specifically `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.AI.Abstractions`, `HoneyDrunk.Data.Abstractions`, plus the project reference to `HoneyDrunk.Knowledge.Abstractions`. No `HoneyDrunk.Kernel`, no `HoneyDrunk.AI`, no `HoneyDrunk.Data` runtime references (per invariant 2).
+- [ ] `HoneyDrunk.Knowledge.Providers.InMemory` references only `HoneyDrunk.Knowledge.Abstractions`.
+- [ ] `AddHoneyDrunkKnowledge()` resolves all three interfaces.
+- [ ] `DefaultDocumentIngester` records `EmbeddingModelIdentifier` on `KnowledgeSource` and rejects ingestion without a model identifier. Unit test verifies.
+- [ ] `DefaultDocumentIngester` is RAG-paradigm only (chunk + embed); the runtime package README and the `IDocumentIngester` XML doc document the extensibility seam for alternative paradigms (e.g. structured-wiki ingestion) via host-substituted `IDocumentIngester` implementations.
+- [ ] `DefaultRetrievalPipeline` enforces embedding-model coherence (returns empty / errors on mismatch). Unit test verifies the mismatch path.
+- [ ] `DefaultRetrievalPipeline` requires every `RetrievedChunk` from the store to carry a non-null `SimilarityScore`; results without a score fail loudly rather than silently returning. Unit test verifies (D8 / invariant 60 — default).
+- [ ] Source attribution round-trips through `IKnowledgeStore.QueryAsync` (every `RetrievedChunk` carries a valid `KnowledgeSource`). Unit test verifies.
+- [ ] `KnowledgeTelemetry` emits per-ingest / per-retrieval / per-mutation activities. **Content does NOT appear in activity tags or attributes.** Unit test verifies by asserting that activity payloads contain only metadata.
+- [ ] `InMemoryKnowledgeStore` works deterministically; round-trips ingestion + retrieval + delete. Unit test verifies.
+- [ ] All five `.github/workflows/*.yml` present.
+- [ ] `api-compatibility.yml` path-filtered to Abstractions; scaffolding PR reports `status: skipped` (expected).
+- [ ] `pr-core.yml` passes.
+- [ ] Repo + per-package `CHANGELOG.md` + `README.md` present.
+- [ ] All `src/*.csproj` Version 0.1.0; tests excluded.
+- [ ] Manual confirmation `v0.1.0` tag triggers `release.yml` (verify; do not push yet).
+- [ ] **No `Providers.AzureAISearch` or `Providers.PostgresVector` in this packet** — they ship under separate follow-up packets.
+- [ ] **No content in telemetry.** `rg -n "activity\.SetTag.*content|activity\.AddAttribute.*content" src/` returns zero matches that would expose chunk or query payloads.
+- [ ] **`KnowledgeSource` is a `sealed record` (interface naming check).** `rg -nP '\binterface\s+KnowledgeSource\b' src/` returns zero matches; `rg -nP '\bsealed\s+record\s+KnowledgeSource\b' src/HoneyDrunk.Knowledge.Abstractions/` returns exactly one match.
+
+## Human Prerequisites
+- [ ] Packet 02b complete.
+- [ ] **Confirm `HoneyDrunk.AI.Abstractions 0.1.0` has shipped to NuGet** before this packet's scaffolding agent starts work. The cross-initiative dependency `adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold` in this packet's frontmatter is wired by `file-packets.yml`, but the agent still needs the package available on a feed to compile against — confirm at `https://www.nuget.org/packages/HoneyDrunk.AI.Abstractions` or the internal feed before approving the wave-3 dispatch.
+- [ ] After merge, push tag `v0.1.0`.
+- [ ] **Branch protection sequencing.** Add `api-compatibility / abstractions-shape` to required checks post-merge.
+- [ ] No Azure provisioning required.
+- [ ] After merge + tag, file SonarCloud onboarding follow-up.
+- [ ] File `Providers.AzureAISearch` and `Providers.PostgresVector` follow-up packets when a real production consumer drives the shape.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages — only `Microsoft.Extensions.*` abstractions are permitted, with explicit exceptions only where another `.Abstractions` peer is required by interface signature. Knowledge's `Abstractions` carries `HoneyDrunk.Kernel.Abstractions` (context types) and `HoneyDrunk.AI.Abstractions` (for `IEmbeddingGenerator`, appearing in `IDocumentIngester` / `IRetrievalPipeline` member signatures) per ADR-0021 D5 — this is the explicit, accepted exception.
+
+> **Invariant 2:** Runtime packages depend on Abstractions, never on other runtime packages at the same layer. `HoneyDrunk.Knowledge` references only `.Abstractions` peers — `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.AI.Abstractions`, `HoneyDrunk.Data.Abstractions` — and lets hosts wire the concrete implementations into DI.
+
+> **Invariant 3:** Provider packages depend on the parent Node's contracts package, not internal implementation details. `HoneyDrunk.Knowledge.Providers.InMemory` references only `HoneyDrunk.Knowledge.Abstractions`.
+
+> **Invariant 11:** One repo per Node.
+
+> **Invariant 12:** Semantic versioning with CHANGELOG and README — repo-level and per-package.
+
+> **Invariant 13:** All public APIs have XML documentation.
+
+> **Invariant 26:** Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section.
+
+> **Invariant 27:** All projects in a solution share one version and move together.
+
+> **Knowledge downstream-coupling invariant (number assigned by packet 02; default 57):** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Knowledge.Abstractions`. Composition against `HoneyDrunk.Knowledge` and any `HoneyDrunk.Knowledge.Providers.*` package is a host-time concern.
+
+> **Knowledge source-attribution invariant (default 58):** Every retrieved chunk carries the `KnowledgeSource` identity, the chunk's position within the source, and the source version. No mode, flag, or provider returns an unattributed chunk.
+
+> **Knowledge embedding-coherence invariant (default 59):** Every `KnowledgeSource` records the embedding-model identifier used at ingest time; retrieval against a mismatched model errors or returns empty. Knowledge never produces a cross-model similarity score.
+
+> **Knowledge confidence-score invariant (default 60):** Every `IRetrievalPipeline` result carries a per-chunk relevance/confidence score; Knowledge applies no cutoff threshold. Provider packages that cannot expose a stable score for every returned chunk cannot back `IRetrievalPipeline`.
+
+> **Knowledge content-never-in-telemetry invariant (default 61):** Only metadata — source id, chunk count, query latency, result count, model identifier — may cross the telemetry boundary. Document text, chunk contents, query text, and retrieved chunk contents are NEVER carried in Pulse signals.
+
+> **Knowledge contract-shape canary invariant (default 62):** CI canary on `IKnowledgeStore`, `IDocumentIngester`, `IRetrievalPipeline`, and `KnowledgeSource`.
+
+## Referenced ADR Decisions
+
+**ADR-0021 D1:** External-knowledge ingestion + retrieval substrate.
+
+**ADR-0021 D2:** Three packages — Abstractions + runtime + Providers.InMemory.
+
+**ADR-0021 D3:** Four surfaces; `IKnowledgeSource` promoted to `KnowledgeSource` record.
+
+**ADR-0021 D5:** Embedding calls compose `IEmbeddingGenerator` from AI.
+
+**ADR-0021 D6:** Embedding-model coherence enforced at retrieval; mismatched model errors.
+
+**ADR-0021 D7:** Source attribution mandatory.
+
+**ADR-0021 D8:** Confidence scores mandatory.
+
+**ADR-0021 D10:** Content NEVER in telemetry.
+
+**ADR-0021 D11:** Content-safety is Operator's `ISafetyFilter` on output side — Knowledge does not own ingest-time scanning.
+
+**ADR-0021 D12:** Canary on all four surfaces.
+
+**ADR-0016 D3 (referenced):** `IEmbeddingGenerator` is a HoneyDrunk.AI.Abstractions interface.
+
+## Dependencies
+- `packet:01` — catalog registration must land first so the contract surface is registered before scaffold lands the actual types.
+- `packet:02` — invariants must land first so packet 03 can reference them by their final assigned numbers (defaults 57-62; collision-check at edit time authoritative).
+- `packet:02b` — repo + local clone verification must complete first; the scaffolding agent assumes a clean checkout on `main`.
+- `adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold` — **hard cross-initiative dependency.** Knowledge's Abstractions package compiles against `HoneyDrunk.AI.Abstractions` per ADR-0021 D5 (the `IEmbeddingGenerator` reference). The AI Abstractions package must have shipped at least one published version (0.1.0) before this packet can build. If AI's scaffold packet has not filed yet, `file-packets.yml` will block this packet's filing until the AI scaffold packet's GitHub Issue exists.
+
+## Labels
+`feature`, `tier-2`, `ai`, `scaffold`, `adr-0021`
+
+## Agent Handoff
+
+**Objective:** Take the `HoneyDrunk.Knowledge` repo (LICENSE + README) and ship 0.1.0 with the four D3 surfaces, default runtime composing AI's `IEmbeddingGenerator`, `Providers.InMemory` backend, full CI, and the contract-shape canary scoped to Abstractions.
+
+**Target:** HoneyDrunk.Knowledge, branch from `main`.
+
+**Context:**
+- Goal: Unblock Lore, Sim, Agents (retrieval), HoneyHub, Evals.
+- Feature: ADR-0021 standup, packet 03.
+- ADRs: ADR-0021 (standup); ADR-0016 (AI source of `IEmbeddingGenerator`).
+
+**Constraints:**
+
+- **Invariant 1 (Abstractions package dependencies).** `HoneyDrunk.Knowledge.Abstractions` references `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.AI.Abstractions` and `Microsoft.Extensions.*` peers — and nothing else from HoneyDrunk. The `HoneyDrunk.AI.Abstractions` edge is the explicit ADR-0021 D5 decision (because `IEmbeddingGenerator` appears in `IDocumentIngester` / `IRetrievalPipeline` member signatures). Do NOT add `HoneyDrunk.Kernel`, `HoneyDrunk.AI`, `HoneyDrunk.Data`, or `HoneyDrunk.Data.Abstractions` to Abstractions.
+- **Invariant 2 (runtime → only Abstractions).** `HoneyDrunk.Knowledge` runtime references only `.Abstractions` peers — `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.AI.Abstractions`, `HoneyDrunk.Data.Abstractions`. Hosts wire the concrete runtime implementations (`HoneyDrunk.AI`, `HoneyDrunk.Data`, etc.) into DI; the Knowledge runtime package does not take hard runtime-package dependencies.
+- **Invariant 3 (provider package dependencies).** `HoneyDrunk.Knowledge.Providers.InMemory` references only `HoneyDrunk.Knowledge.Abstractions`. No reference to the runtime package, Kernel, AI, Data, or any other HoneyDrunk peer.
+- **Invariant 58 (default — source attribution):** Every `RetrievedChunk` carries a valid `KnowledgeSource` identity, chunk position, and source version. No anonymous-retrieval mode anywhere.
+- **Invariant 59 (default — embedding-model coherence):** `KnowledgeSource.EmbeddingModelIdentifier` is required (non-empty `string`). `DefaultRetrievalPipeline` enforces coherence — a query embedded with a model that does not match the source's recorded model returns empty / errors rather than producing a cross-model similarity score.
+- **Invariant 60 (default — mandatory confidence scores):** Every `RetrievedChunk` carries a non-null `SimilarityScore`. Knowledge does NOT apply a cutoff threshold; thresholding is a consumer concern. The retrieval pipeline rejects store results with missing scores.
+- **Invariant 61 (default — content never in telemetry):** No document text, chunk content, query text, or retrieved chunk text appears in any activity tag, attribute, baggage entry, log message, or exception payload. Only metadata (source id, chunk count, query latency, result count, model identifier) crosses the telemetry boundary.
+- **Strict Abstractions stance — `EmbeddingModelIdentifier` shape.** `KnowledgeSource.EmbeddingModelIdentifier` is `string`, not `ModelCapabilityDeclaration`. The `string` identifier keeps the record decoupled from AI's record-shape revisions while the `IEmbeddingGenerator` reference at the interface level carries the type identity needed at compile time.
+- **RAG-paradigm default ingester with extensibility seam.** `DefaultDocumentIngester` is chunk-and-embed only (RAG paradigm). Alternative ingestion paradigms (most notably structured-wiki ingestion) are supported via host-substituted `IDocumentIngester` + matching `IKnowledgeStore` implementations; the runtime package README and the `IDocumentIngester` XML doc must document this seam.
+- **Records drop `I`; interfaces keep it.** `KnowledgeSource`, `KnowledgeChunk`, `KnowledgeQuery`, `RetrievedChunk`, `IngestionRequest`, `IngestionOptions`, `RetrievalOptions` are records (no `I` prefix). `IKnowledgeStore`, `IDocumentIngester`, `IRetrievalPipeline` are interfaces (keep `I` prefix).
+- **Canary on scaffolding PR is expected to skip.** Verification post-merge via throwaway breaking-change PR.
+- **No `Providers.AzureAISearch` or `Providers.PostgresVector` in this packet.** Provider slot exists; production backends ship in follow-up packets.
+- **Invariant numbers above are defaults.** Packet 02 lands the actual numbers via collision-check at edit time (default band 57-62). If the band shifts during 02's filing, packet 03 source is amended in lockstep before filing (pre-filing carve-out per invariant 24).
+
+**Key Files:**
+- `HoneyDrunk.Knowledge.slnx`, `Directory.Build.props`
+- `src/HoneyDrunk.Knowledge.Abstractions/` — 3 interfaces + `KnowledgeSource` record + supporting records
+- `src/HoneyDrunk.Knowledge/` — `DefaultDocumentIngester`, `DefaultRetrievalPipeline`, `DefaultKnowledgeStore`, `KnowledgeTelemetry`, `ServiceCollectionExtensions`
+- `src/HoneyDrunk.Knowledge.Providers.InMemory/` — `InMemoryKnowledgeStore`
+- `.github/workflows/*.yml`
+- `README.md`, `CHANGELOG.md` (repo + per-package)
+- `tests/`
+
+**Contracts:** Four D3 surfaces authored fresh.

--- a/generated/issue-packets/active/adr-0021-knowledge-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0021-knowledge-standup/dispatch-plan.md
@@ -1,0 +1,77 @@
+# Dispatch Plan — ADR-0021 HoneyDrunk.Knowledge Standup
+
+**Initiative:** `adr-0021-knowledge-standup`
+**Sector:** AI
+**Governing ADR:** [ADR-0021 — Stand Up the HoneyDrunk.Knowledge Node](../../../../adrs/ADR-0021-stand-up-honeydrunk-knowledge-node.md) (Proposed 2026-04-19; flips to Accepted after this initiative's PRs merge).
+**Trigger:** ADR-0021 in the Proposed queue. Sim, Lore, Agents (for grounded-context retrieval), HoneyHub when live, and Evals are blocked on `HoneyDrunk.Knowledge.Abstractions` existing.
+**Type:** Multi-repo (2 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.Knowledge`)
+**Site sync required:** No.
+**Rollback plan:** Pre-tag `git revert`; post-tag prefer fix-forward as 0.1.1.
+
+## Summary
+
+ADR-0021 is the standup ADR for `HoneyDrunk.Knowledge`. It decides what the Node owns (D1), three package families (`Abstractions`, runtime, `Providers.InMemory` — no separate `Testing`) (D2), four exposed contracts — three interfaces and one record (D3 — `IKnowledgeStore`, `IDocumentIngester`, `IRetrievalPipeline`, `KnowledgeSource`), boundary against AI/Memory/Lore/Sim/Agents (D4), embedding calls compose AI's `IEmbeddingGenerator` from `HoneyDrunk.AI.Abstractions` (D5 — the explicit accepted Abstractions-to-Abstractions edge), embedding-model coherence rule (D6 — `KnowledgeSource` records ingest-time model identifier; retrieval errors on mismatch), mandatory source attribution (D7 — elevated to Grid invariant), mandatory confidence scores (D8 — elevated to Grid invariant alongside D7 for consistency), state-boundary (D9 — Knowledge holds ingestion + retrieval state only), telemetry direction with content-never-in-telemetry rule (D10), content-safety deferred to Operator's `ISafetyFilter` on output side (D11), contract-shape canary on all four surfaces (D12).
+
+Promotes `IKnowledgeSource` interface → `KnowledgeSource` record per the grid-wide naming rule.
+
+Four packets land the work:
+
+1. **Architecture catalog registration + integration-points** — promote `IKnowledgeSource` to `KnowledgeSource` record across `contracts.json` and `relationships.json`; reconcile prose-vs-edges drift (nodes.json mentions Agents + HoneyHub; relationships.json only lists Sim + Lore — add `honeydrunk-agents` to `consumed_by_planned`); refresh `grid-health.json`; align repo overview and AI sector doc to the four D3 surfaces; add `integration-points.md` and `active-work.md`.
+2. **Constitution invariants** — six new invariants from D2, D7, D6, D8, D10, D12 at the next six free numbers (default band 57-62, above the bands claimed by ADR-0020 Agents standup at 48-54 and ADR-0027 Notify Cloud standup at 51-56; collision-check at edit time is authoritative). D8 (mandatory confidence scores) is elevated from Node-local to Grid-level for consistency with D7's treatment.
+2b. **Verify `HoneyDrunk.Knowledge` repo + local clone (human-only)** — repo and clone exist; verify branch protection, labels, OIDC.
+3. **HoneyDrunk.Knowledge scaffold** — empty repo to first-shippable. Solution, three packages (`Abstractions`, runtime, `Providers.InMemory`), four contracts in Abstractions, default `IKnowledgeStore` / `IDocumentIngester` / `IRetrievalPipeline` implementations in runtime that compose AI's `IEmbeddingGenerator`, in-memory backend in Providers.InMemory, five CI workflow files with the canary scoped to `HoneyDrunk.Knowledge.Abstractions`.
+
+## Wave Diagram
+
+```
+Wave 1: Architecture catalog + constitution updates (parallel)
+   ├─ Architecture: 01-architecture-knowledge-catalog-registration
+   └─ Architecture: 02-architecture-knowledge-invariants
+       Blocked by: 01
+
+Wave 2: Verify repo + clone (human)
+   └─ Architecture: 02b-architecture-verify-knowledge-repo
+       Blocked by: 01
+
+Wave 3: Knowledge repo scaffold
+   └─ HoneyDrunk.Knowledge: 03-knowledge-node-scaffold
+       Blocked by: 01, 02, 02b, adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold
+```
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 01 | [Catalog registration + IKnowledgeSource→KnowledgeSource promotion + integration-points](./01-architecture-knowledge-catalog-registration.md) | Architecture | 1 | Agent | — |
+| 02 | [Add six new invariants for D2 / D7 / D6 / D8 / D10 / D12](./02-architecture-knowledge-invariants.md) | Architecture | 1 | Agent | 01 |
+| 02b | [Verify HoneyDrunk.Knowledge repo + clone (human-only)](./02b-architecture-verify-knowledge-repo.md) | Architecture | 2 | Human | 01 |
+| 03 | [Stand up `HoneyDrunk.Knowledge` — solution, three packages, contracts, CI, InMemory provider](./03-knowledge-node-scaffold.md) | HoneyDrunk.Knowledge | 3 | Agent | 01, 02, 02b, `adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold` |
+
+## Filing-order rule
+
+Packet 03 hard-codes invariant numbers (defaults 57-62) and carries a hard cross-initiative dependency on `adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold` (because Knowledge's Abstractions compiles against `HoneyDrunk.AI.Abstractions` per ADR-0021 D5). Packet 02 must merge first; if its collision-check shifts the band, packet 03 source file is amended in lockstep before filing (pre-filing carve-out per invariant 24). `file-packets.yml` will not file packet 03 until the AI scaffold packet's GitHub Issue exists.
+
+## What This Initiative Does **NOT** Deliver
+
+- Sim, Lore, Agents (retrieval composition), HoneyHub, Evals are not delivered.
+- `Providers.AzureAISearch` and `Providers.PostgresVector` packages are **not first-wave**. They follow as separate packets once `Providers.InMemory` has exercised the slot shape and a real consumer drives the production-backend choice.
+- Ingest-time content-safety scanning is deferred per D11 (Operator's `ISafetyFilter` on output side covers the immediate need).
+- Level (c) router-level embedding-model pinning is deferred to ADR-0010's `IModelRouter` per D6.
+- Pulse signal ingress into Knowledge is deferred (emit-only per D10).
+- No separate `HoneyDrunk.Knowledge.Testing` package — `Providers.InMemory` plays that role per D2.
+
+## AI-sector standup wave sequencing
+
+Knowledge requires `HoneyDrunk.AI.Abstractions` for `IEmbeddingGenerator` consumption. Recommended landing order: AI → Capabilities → Operator → **Knowledge** + Memory (parallel) → Agents (depends on Knowledge, Memory) → Evals + Flow + Sim.
+
+## Status flip
+
+ADR-0021 stays Proposed for the duration; scope agent flips after all packets close.
+
+## Filing
+
+`file-packets.yml` auto-files on push.
+
+## Archival
+
+Per ADR-0008 D10, post-completion archive to `archive/adr-0021-knowledge-standup/`.


### PR DESCRIPTION
## Summary

Scopes four packets standing up [HoneyDrunk.Knowledge](https://github.com/HoneyDrunkStudios/HoneyDrunk.Knowledge) per [ADR-0021](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0021-stand-up-honeydrunk-knowledge-node.md) — the AI sector's external ingestion and retrieval substrate. Claims invariants **57–62** (shifted from 55–59 to avoid ADR-0027's 51–56 overlap).

### Wave 1 — Architecture-repo (parallel)
- **`01-catalog-registration`** — `relationships.json` consumes adds Kernel + `AI.Abstractions` (for `IEmbeddingGenerator` per D5); `consumed_by_planned` lists Agents/Evals semantically (no D-number citations of Proposed sibling ADRs); explicit prose-only carve-out for HoneyHub (not in `consumed_by_planned`).
- **`02-invariants`** — six new constitution invariants (default 57–62) under `## AI Sector — Knowledge Invariants`. **D8 confidence-scores elevated to Grid invariant** (consistency with D7 attribution treatment).
- **`02b-verify-knowledge-repo`** — human-only chore + chore-branch reconcile.

### Wave 2 — Knowledge scaffold
- **`03-knowledge-node-scaffold`** — three packages, four frozen contracts (`IKnowledgeStore`, `IDocumentIngester`, `IRetrievalPipeline`, `KnowledgeSource`). `HoneyDrunk.AI.Abstractions` IS referenced in Knowledge.Abstractions per ADR-0021 D5 (transitive `IEmbeddingGenerator` dep). `DefaultDocumentIngester` documented as **RAG-paradigm with extensibility seam** for structured-wiki ingestion via provider axis. **Embedding-model coherence pin** enforced — every `KnowledgeSource` records ingest-time model identifier; mismatched similarity search errors or returns empty.

## Cross-initiative dependency

Packet 03 frontmatter declares hard `dependencies:` on `adr-0016-honeydrunk-ai-standup/03-ai-node-scaffold`. `file-packets.yml` wires the `addBlockedBy` edge on The Hive — Wave 2 won't unblock until AI Abstractions ships on NuGet.

## Conventions

- **NuGet uses `.Abstractions`** throughout (invariant 2).
- **Records drop `I`** (`KnowledgeSource`); **interfaces keep `I`** (three).
- Sim's `consumes_detail` correctly uses Abstractions only (provider composition is host-time, per the new Grid invariant `Knowledge downstream-coupling`).
- Each packet carries `accepts: ADR-0021`.

## Test plan

- [ ] After merge, four issues file with cross-init dep edges on The Hive
- [ ] Wave 2 stays blocked on AI scaffold issue + own Wave 1
- [ ] When all four close, hive-sync auto-flips ADR-0021 Proposed → Accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)