### PR TITLE
chore: scope ADR-0022 memory node standup

### DIFF
--- a/generated/issue-packets/active/adr-0022-memory-standup/01-architecture-memory-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0022-memory-standup/01-architecture-memory-catalog-registration.md
@@ -1,0 +1,270 @@
+---
+name: Architecture Catalog Registration
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0022"]
+dependencies: []
+adrs: ["ADR-0022", "ADR-0020"]
+accepts: ADR-0022
+wave: 1
+initiative: adr-0022-memory-standup
+node: honeydrunk-memory
+---
+
+# Chore: Register HoneyDrunk.Memory's standup decisions in Architecture catalogs + fix short-term-memory ownership drift
+
+## Summary
+
+Reflect ADR-0022 in catalogs. Confirm three-interface contract set in `contracts.json` (no records at stand-up). Widen Memory→AI `consumes_detail` to include `IChatClient` alongside `IEmbeddingGenerator` per D5. Add `honeydrunk-agents` to `consumed_by_planned` (coordinated with ADR-0020 Agents→Memory edge). Refresh `grid-health.json` and `nodes.json`. **Fix the short-term-memory ownership drift** in `repos/HoneyDrunk.Memory/overview.md`, `repos/HoneyDrunk.Memory/boundaries.md`, and the Memory section of `constitution/ai-sector-architecture.md` — those previously describe Memory as owning short-term memory, but Position A from ADR-0022 D4/D7 (aligned with ADR-0020 D8) places short-term memory on `IAgentExecutionContext` (Agents-owned). Memory owns long-term only. Add `integration-points.md` and `active-work.md`.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0022 establishes Memory's contract surface (D3) and Position A for the short-term/long-term boundary. Drift items:
+
+1. **`contracts.json`** already lists three interfaces. Verify alignment; tighten descriptions per D5/D6.
+2. **`relationships.json` Memory→AI `consumes_detail`** currently lists `IEmbeddingGenerator` alone; needs widening to include `IChatClient` (summarization path per D5).
+3. **`relationships.json` `consumed_by_planned`** missing `honeydrunk-agents`.
+4. **`repos/HoneyDrunk.Memory/overview.md`** lists short-term memory as Memory-owned. Per ADR-0022 D4/D7 (Position A) and ADR-0020 D8, that's wrong — short-term lives on `IAgentExecutionContext`.
+5. **`repos/HoneyDrunk.Memory/boundaries.md`** same drift.
+6. **`constitution/ai-sector-architecture.md`** Memory section same drift.
+
+## Proposed Implementation
+
+### `catalogs/contracts.json` — `honeydrunk-memory` block
+
+Verify and tighten:
+
+```json
+{
+  "node": "honeydrunk-memory",
+  "node_name": "HoneyDrunk.Memory",
+  "package": "HoneyDrunk.Memory.Abstractions",
+  "status": "seed",
+  "interfaces": [
+    { "name": "IMemoryStore", "kind": "interface", "description": "Write, read, search, delete, and supersede memory entries. The storage-facing surface that provider packages implement. Supersession is a D10-driven mechanism (re-embedding under a new model is supersession), introduced at scaffold per ADR-0022 D10. ADR-0022 D3 / D8 / D10." },
+    { "name": "IMemoryScope", "kind": "interface", "description": "Scoped memory access — an agent only sees its authorized memories through a resolved scope. Gates cross-scope access via the Auth policy path per ADR-0022 D6. Escalate() routes through Auth's IAuthorizationPolicy." },
+    { "name": "IMemorySummarizer", "kind": "interface", "description": "Compress memory entries beyond a configured threshold. Delegates embedding generation to IEmbeddingGenerator and summarization inference to IChatClient (both from HoneyDrunk.AI per ADR-0022 D5). Public so consumers can swap the summarization strategy." }
+  ]
+}
+```
+
+No records at stand-up per D3. The `MemoryEntry` record (carrying the per-entry embedding-model identifier per D10) is deferred to the scaffold packet.
+
+### `catalogs/relationships.json` — `honeydrunk-memory` block
+
+**(a) `consumes_detail.honeydrunk-ai`.** Replace with:
+
+```json
+"honeydrunk-ai": ["IEmbeddingGenerator", "IChatClient", "HoneyDrunk.AI.Abstractions"]
+```
+
+(IChatClient added — Memory's summarizer uses chat completion per D5.)
+
+**(b) `consumes`.** Confirm includes `honeydrunk-auth` (for scope escalation per D6). If missing, add. Also add per-edge `consumes_detail`:
+
+```json
+"honeydrunk-auth": ["IAuthorizationPolicy", "IAuthenticatedIdentityAccessor", "HoneyDrunk.Auth.Abstractions"]
+```
+
+**(c) `consumed_by_planned`.** Add `honeydrunk-agents` per ADR-0020 D6:
+
+```json
+"consumed_by_planned": ["honeydrunk-agents", "honeydrunk-flow", "honeydrunk-sim", "honeydrunk-evals", "honeydrunk-lore"]
+```
+
+`consumed_by_planned` is a list of node names. **No `consumes_detail` block is added for the planned consumers under ADR-0023/0024/0025**, because those ADRs are still Proposed — their D-shaped detail will land in their own standup packets, not this catalog edit. The list stays at:
+
+```json
+"consumed_by_planned": ["honeydrunk-agents", "honeydrunk-flow", "honeydrunk-sim", "honeydrunk-evals", "honeydrunk-lore"]
+```
+
+Agents is the only `consumed_by_planned` consumer with a coordinated edge live today (ADR-0020 is Accepted; the open ADR-0020 Agents→Memory follow-up edge lands the Agents-side `consumes_detail` entry). Flow / Sim / Evals add their own `consumes_detail` blocks when their respective standup ADRs accept.
+
+**(d) `exposes.packages`.** Confirm:
+
+```json
+"packages": ["HoneyDrunk.Memory.Abstractions", "HoneyDrunk.Memory", "HoneyDrunk.Memory.Providers.InMemory"]
+```
+
+### `catalogs/grid-health.json` — `honeydrunk-memory` block
+
+Replace stub with standup-aware version naming the scaffold packet as blocker, the three D3 interfaces, the three packages, and the deferred `Providers.SqlServer` / `Providers.CosmosDB`.
+
+### `catalogs/nodes.json` — `honeydrunk-memory` block
+
+**(a) `grid_relationship`.** Replace with:
+
+> `"grid_relationship": "Consumes Kernel (context, telemetry, TenantId / ProjectId strong types per ADR-0026 D1/D2), AI (IEmbeddingGenerator for similarity, IChatClient for summarization per ADR-0022 D5), Auth (IAuthorizationPolicy for IMemoryScope.Escalate() per ADR-0022 D6), Data (IRepository for non-in-memory persistence). Emits write / read / summarize / supersede telemetry consumed by Pulse — no runtime dependency on Pulse. Content NEVER appears in telemetry. Consumed by Agents (IAgentMemory composition), Flow (indirectly through Agents — no direct edge planned), Sim (fixture composition), Evals (fixture composition), Lore (persistent curation context). Short-term memory is owned by Agents's IAgentExecutionContext, NOT Memory (Position A from ADR-0022 D4/D7)."`
+
+### `constitution/ai-sector-architecture.md` — Memory section
+
+**(a) Key Contracts list** — three interfaces.
+
+**(b) Depends-on:**
+
+> `**Depends on:** Kernel (context, telemetry), AI (IEmbeddingGenerator + IChatClient per D5), Auth (IAuthorizationPolicy for scope escalation per D6), Data (IRepository for non-in-memory persistence)`
+>
+> `**Emits to (no runtime dependency):** Pulse (write / read / summarize / supersede metadata-only telemetry per D9 — content NEVER carried)`
+
+**(c) Short-term-memory ownership note.** Add or update text to explicitly state:
+
+> `**Short-term memory ownership:** Short-term, execution-scoped memory (in-progress conversation turns, current tool-call sequence, ephemeral context) lives on Agents's IAgentExecutionContext per ADR-0020 D8 and ADR-0022 D4/D7 (Position A). Memory owns long-term agent-generated content that must survive the end of an execution. Conversation transcripts that must persist across executions are written as MemoryEntry records through IMemoryStore.`
+
+### `repos/HoneyDrunk.Memory/overview.md`
+
+Remove any text describing Memory as owning short-term memory. Replace with the long-term-only statement above. Add a row for `HoneyDrunk.Memory.Providers.InMemory` to the Packages table.
+
+### `repos/HoneyDrunk.Memory/boundaries.md`
+
+Same short-term-memory ownership fix. Add a "What Memory does not own" subsection clarifying short-term lives on `IAgentExecutionContext`.
+
+### `repos/HoneyDrunk.Memory/integration-points.md` — new file
+
+Matching the template:
+
+```markdown
+# HoneyDrunk.Memory — Integration Points
+
+## Consumes
+
+| Node | Contract | Purpose |
+|------|----------|---------|
+| **Kernel** | `IGridContext`, `IOperationContext`, telemetry | Context flow.
+| **Kernel** | `TenantId`, `ProjectId` (strong types from `Kernel.Abstractions.Identity`) | Scope coordinates on `IMemoryScope` and `MemoryEntry` per ADR-0026 D1/D2. `Abstractions`-level consumption — Memory.Abstractions takes a NuGet ref on Kernel.Abstractions per invariant 1's allow-list.
+| **AI** | `IEmbeddingGenerator` | Embedding for similarity-search at write and at read.
+| **AI** | `IChatClient` | Summarization inference per D5.
+| **Auth** | `IAuthorizationPolicy`, `IAuthenticatedIdentityAccessor` | Scope escalation per D6.
+| **Data** | `IRepository`, `IUnitOfWork` | Non-in-memory persistence.
+
+## Exposes
+
+| Contract | Consumer | Notes |
+|----------|---------|-------|
+| `IMemoryStore` | Agents, Sim, Evals, Lore | Storage-facing surface; providers implement.
+| `IMemoryScope` | Agents | Authorization-window primitive. Escalate() routes through Auth.
+| `IMemorySummarizer` | Agents (when configured) | Public so consumers swap summarization strategy.
+
+## Emits (no runtime dependency)
+
+| Signal | Consumer | Notes |
+|--------|----------|-------|
+| Write / read / summarize / supersede activities (metadata only) | **Pulse** | Per ADR-0022 D9. Content NEVER carried.
+
+## Canary Coverage Required
+
+- `Memory.Canary` → Kernel: `IGridContext` flow.
+- `Memory.Canary` → AI: `IEmbeddingGenerator` + `IChatClient` invocation; embedding-model coherence per D10.
+- `Memory.Canary` → Auth: scope-escalation rejection / approval through `IAuthorizationPolicy`.
+- `Memory.Canary` → Data: persistence round-trip.
+- `Memory.Canary` → contract-shape: canary on `IMemoryStore`, `IMemoryScope`, `IMemorySummarizer`.
+
+## Dependency Order for Bring-Up
+
+1. Kernel (Live)
+2. AI Abstractions (must publish `IEmbeddingGenerator`, `IChatClient`)
+3. Auth (Live)
+4. Data (Live)
+
+Memory is a hard prerequisite for: Agents (`IAgentMemory` composition), Sim / Evals (fixture composition), Lore (curation persistence).
+```
+
+### `repos/HoneyDrunk.Memory/active-work.md` — new file
+
+### `initiatives/active-initiatives.md` — new entry
+
+Standard format. Note the short-term-memory ownership fix and the coordinated edge with ADR-0020.
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append: `Architecture: Register ADR-0022 standup decisions in catalogs (verify three-interface contract surface; widen Memory→AI consumes_detail to include IChatClient per D5; add Auth edge per D6; add honeydrunk-agents to consumed_by_planned; refresh grid-health.json and nodes.json; fix short-term-memory ownership drift in repos/HoneyDrunk.Memory/overview.md + boundaries.md + ai-sector-architecture.md per Position A from D4/D7 and ADR-0020 D8; new integration-points.md and active-work.md; active-initiatives.md gets the new initiative block). ADR-0022 stays Proposed.`
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+- `catalogs/grid-health.json`
+- `catalogs/nodes.json`
+- `constitution/ai-sector-architecture.md`
+- `repos/HoneyDrunk.Memory/overview.md`
+- `repos/HoneyDrunk.Memory/boundaries.md`
+- `repos/HoneyDrunk.Memory/integration-points.md` (new)
+- `repos/HoneyDrunk.Memory/active-work.md` (new)
+- `initiatives/active-initiatives.md`
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] D3 three-interface surface preserved.
+- [x] Position A (short-term in Agents, long-term in Memory) applied across all three docs.
+- [x] `IMemoryScope` is Memory-owned (per D3).
+- [x] AI edge widened to include IChatClient + IEmbeddingGenerator per D5.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` `honeydrunk-memory` block lists exactly the three D3 interfaces with descriptions tightened per D5/D6. `IMemoryStore` description names supersession as the D10-driven fifth operation. No records.
+- [ ] `catalogs/relationships.json` `honeydrunk-memory.consumes_detail.honeydrunk-ai` includes both `IEmbeddingGenerator` and `IChatClient`.
+- [ ] `catalogs/relationships.json` `honeydrunk-memory.consumes` includes `honeydrunk-auth`.
+- [ ] `catalogs/relationships.json` `honeydrunk-memory.consumed_by_planned` includes `honeydrunk-agents`.
+- [ ] `catalogs/relationships.json` `honeydrunk-memory.exposes.packages` includes `HoneyDrunk.Memory.Providers.InMemory`.
+- [ ] `catalogs/grid-health.json` `honeydrunk-memory` reflects standup.
+- [ ] `catalogs/nodes.json` `honeydrunk-memory.grid_relationship` includes the Position A note and the IChatClient widening.
+- [ ] `constitution/ai-sector-architecture.md` Memory section reads Position A (short-term in Agents); Depends-on / Emits-to split present.
+- [ ] `repos/HoneyDrunk.Memory/overview.md` does NOT claim Memory owns short-term memory. Carries the Position A statement.
+- [ ] `repos/HoneyDrunk.Memory/boundaries.md` does NOT claim Memory owns short-term memory. Carries the "What Memory does not own" subsection.
+- [ ] `repos/HoneyDrunk.Memory/integration-points.md` and `active-work.md` exist.
+- [ ] `initiatives/active-initiatives.md` includes new entry.
+- [ ] `CHANGELOG.md` Unreleased updated.
+- [ ] `adrs/ADR-0022-stand-up-honeydrunk-memory-node.md` NOT modified — Status stays Proposed.
+
+## Human Prerequisites
+None.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+
+> **Invariant 11:** One repo per Node.
+
+## Referenced ADR Decisions
+
+**ADR-0022 D3:** Three interfaces; no records at stand-up.
+
+**ADR-0022 D4 / D7 (Position A):** Short-term memory on `IAgentExecutionContext`; Memory owns long-term only.
+
+**ADR-0022 D5:** Embedding + summarization compose AI's `IEmbeddingGenerator` and `IChatClient`.
+
+**ADR-0022 D6:** Scope escalation gated by Auth.
+
+**ADR-0022 D9:** Content NEVER in telemetry.
+
+**ADR-0020 D8 (referenced):** Execution-scope state lives on `IAgentExecutionContext`.
+
+**ADR-0026 D1 / D2 (Accepted):** `TenantId` is a non-nullable ULID `readonly record struct` in `HoneyDrunk.Kernel.Abstractions.Identity`. Memory.Abstractions consumes the strong type for `IMemoryScope.TenantId` and `MemoryEntry.TenantId`. `ProjectId` follows the same pattern. `AgentId` stays `string` at scaffold pending Kernel-side strong type.
+
+## Dependencies
+None.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0022`
+
+## Agent Handoff
+
+**Objective:** Align catalogs with ADR-0022 D3-D9. Fix short-term-memory ownership drift across overview.md / boundaries.md / ai-sector-architecture.md.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Constraints:**
+- **Position A is canonical.** Short-term memory lives on `IAgentExecutionContext` (Agents per ADR-0020 D8). Memory owns long-term only. Apply across all three docs.
+- **AI edge widening is mandatory.** Both `IEmbeddingGenerator` (similarity) and `IChatClient` (summarization) per D5.
+- **Auth edge is real.** `IAuthorizationPolicy` for scope escalation per D6.
+- **No ADR Status flip.**
+- **Coordinate with ADR-0020 Agents→Memory edge.** Both sides of the edge land in one reconciliation pass.
+
+**Key Files:** All listed above.
+
+**Contracts:** None authored.

--- a/generated/issue-packets/active/adr-0022-memory-standup/02-architecture-memory-invariants.md
+++ b/generated/issue-packets/active/adr-0022-memory-standup/02-architecture-memory-invariants.md
@@ -1,0 +1,113 @@
+---
+name: Constitution Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0022", "constitution"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0022"]
+accepts: ADR-0022
+wave: 1
+initiative: adr-0022-memory-standup
+node: honeydrunk-memory
+---
+
+# Chore: Add ADR-0022's seven new invariants to the Grid constitution
+
+## Summary
+
+Add seven new invariants from ADR-0022: downstream-coupling (D2), no-Agent-state-outside-IMemoryStore (D7 + ADR-0020 D8), content-only-through-IMemoryStore (D8), embedding-model coherence at similarity retrieval (D10), content-never-in-telemetry (D9), scope-escalation gated by Auth + bulk-reads through Operator (D6), contract-shape canary on three surfaces (D12).
+
+Default numbers **60, 61, 62, 63, 64, 65, 66** (assumes ADR-0018 + ADR-0020 + ADR-0021 have landed claiming 44-59; collision check decides).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Proposed Implementation
+
+### `constitution/invariants.md` — append seven new entries
+
+```markdown
+## AI Sector — Memory Invariants
+
+60. **Downstream Nodes take a runtime dependency only on `HoneyDrunk.Memory.Abstractions`.**
+    Composition against `HoneyDrunk.Memory` and any `HoneyDrunk.Memory.Providers.*` package is a host-time concern. See ADR-0022 D2 (Proposed — this invariant takes effect when ADR-0022 is accepted).
+
+61. **Agents never persist agent-generated state outside `IMemoryStore` and `IMemoryScope`.**
+    Execution-scope state stays on `IAgentExecutionContext` per ADR-0020 D8 and is disposed when the execution ends. Anything that must survive the execution is written through Memory's surface. This includes cross-execution conversation transcripts — each turn is a `MemoryEntry`. See ADR-0022 D7 (Proposed — this invariant takes effect when ADR-0022 is accepted).
+
+62. **Memory content never leaves the Node except through `IMemoryStore`.**
+    Provider packages may not expose raw database handles, direct query surfaces, or any escape hatch that bypasses `IMemoryScope`. Every production path for reading or writing a memory goes through `IMemoryStore`, and `IMemoryStore` is the single surface where the scope check is applied. See ADR-0022 D8 (Proposed — this invariant takes effect when ADR-0022 is accepted).
+
+63. **Every `MemoryEntry` records the embedding-model identifier used at write time, and similarity retrieval against a mismatched model errors or returns empty.**
+    Memory never produces a cross-model similarity score. Re-embedding an entry under a new model is treated as supersession — the old entry is superseded and a new entry with the new identifier is written. See ADR-0022 D10 (Proposed — this invariant takes effect when ADR-0022 is accepted).
+
+64. **Memory content never appears in telemetry.**
+    Only metadata — scope coordinates, entry identity, entry size, query latency, result count, model identifier — may cross the telemetry boundary. Memory payload contents, query text, and retrieved entry contents are NEVER carried in Pulse signals. The separation is structural, not advisory. See ADR-0022 D9 (Proposed — this invariant takes effect when ADR-0022 is accepted).
+
+65. **`IMemoryScope.Escalate()` is gated by Auth; bulk operational reads are gated by Operator's `IApprovalGate`.**
+    Two distinct authorization paths for cross-scope access: scope escalation from within an agent path runs through `HoneyDrunk.Auth`'s `IAuthorizationPolicy` (synchronous, agent-runtime concern); bulk operational reads from outside an agent path raise an `ApprovalRequest` through `HoneyDrunk.Operator`'s `IApprovalGate` (asynchronous, human-policy concern). No escape path crosses scope without one of the two authorization paths. See ADR-0022 D6 (Proposed — this invariant takes effect when ADR-0022 is accepted).
+
+66. **The HoneyDrunk.Memory Node CI must include a contract-shape canary that fails the build on shape drift to `IMemoryStore`, `IMemoryScope`, or `IMemorySummarizer` without a corresponding version bump.**
+    These three are the hot path for every consumer that reads or writes agent memory. Memory's boundary is narrow — all three surfaces in the canary from stand-up. When the `MemoryEntry` record lands at scaffold, its shape is added to the canary the same way `KnowledgeSource` is in ADR-0021 D12. See ADR-0022 D12 (Proposed — this invariant takes effect when ADR-0022 is accepted).
+```
+
+### Collision check
+
+Default 60-66. Shift on collision; update ADR-0022 Consequences + packet 03 source in lockstep. `rg` only.
+
+### Lockstep update list (packet 03 cross-references on number shift)
+
+If the seven invariants land at numbers other than 60-66, every cross-reference inside packet 03 must shift in the same commit. The complete cross-reference list in packet 03 is named below so nothing is missed during the lockstep edit. Each item is keyed by the **named invariant** (which never shifts) so the editor can find every callsite regardless of which number eventually lands:
+
+| Named invariant | Default | Callsites in packet 03 |
+|---|---|---|
+| Memory downstream-coupling | 60 | Referenced Invariants block (`(default 60)` token) |
+| Memory no-Agent-state-outside-`IMemoryStore` | 61 | Referenced Invariants block (`(default 61)` token) |
+| Memory content-only-through-`IMemoryStore` | 62 | Boundary Check line ("number assigned by packet 02, default 62"); Referenced Invariants block (`(default 62)` token) |
+| Memory embedding-coherence | 63 | Boundary Check line ("default 63"); Referenced Invariants block (`(default 63)` token) |
+| Memory content-never-in-telemetry | 64 | Boundary Check line ("default 64"); Referenced Invariants block (`(default 64)` token) |
+| Memory scope-escalation-gated | 65 | Referenced Invariants block (`(default 65)` token) |
+| Memory contract-shape canary | 66 | Referenced Invariants block (`(default 66)` token) |
+
+On shift, run `rg "default 6[0-6]"` and `rg "(invariant 6[0-6]|invariants? 6[0-6])"` against `generated/issue-packets/active/adr-0022-memory-standup/03-memory-node-scaffold.md` and ADR-0022 to confirm every callsite is rewritten. The named-token style (e.g., "Memory embedding-coherence invariant — number assigned by packet 02, default 63") keeps the text grammatical at both pre-shift and post-shift readings.
+
+### `CHANGELOG.md`
+
+Append: `Architecture: Add invariants 60-66 (Memory downstream coupling, no-direct-Agent-state-writes, content-only-through-IMemoryStore, embedding-coherence at similarity retrieval, content-never-in-telemetry, scope-escalation gated by Auth + bulk-reads gated by Operator, Memory contract-shape canary) per ADR-0022 D2/D7/D8/D10/D9/D6/D12.`
+
+## Affected Files
+- `constitution/invariants.md`
+- `adrs/ADR-0022-stand-up-honeydrunk-memory-node.md` (only on shift)
+- `generated/issue-packets/active/adr-0022-memory-standup/03-memory-node-scaffold.md` (only on shift)
+- `CHANGELOG.md`
+
+## Acceptance Criteria
+- [ ] Seven invariants present, matching ADR-0022.
+- [ ] Numbers verified; default 60-66.
+- [ ] `(Proposed — this invariant takes effect when ADR-0022 is accepted)` qualifier on each.
+- [ ] On shift, ADR-0022 Consequences + packet 03 updated in lockstep.
+- [ ] `CHANGELOG.md` updated.
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0022 D2, D6, D7, D8, D9, D10, D12.** Sources for invariants 60-66.
+
+## Dependencies
+- `packet:01`
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0022`, `constitution`
+
+## Agent Handoff
+
+**Objective:** Seven new invariants. Default 60-66. Shift on collision; lockstep updates.
+
+**Constraints:** `(Proposed)` qualifier each. `rg` for collision checks.
+
+**Key Files:** `constitution/invariants.md`; conditional ADR-0022 + packet 03; `CHANGELOG.md`.
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0022-memory-standup/02b-architecture-verify-memory-repo.md
+++ b/generated/issue-packets/active/adr-0022-memory-standup/02b-architecture-verify-memory-repo.md
@@ -1,0 +1,99 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "ai", "adr-0022", "human-only", "wave-2"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0022"]
+accepts: ADR-0022
+wave: 2
+initiative: adr-0022-memory-standup
+node: honeydrunk-architecture
+actor: human
+---
+
+# Chore: Verify `HoneyDrunk.Memory` GitHub repo settings + local clone (human-only)
+
+## Summary
+
+Confirm `HoneyDrunkStudios/HoneyDrunk.Memory` matches Grid standard settings; confirm local clone is on `main` clean; confirm OIDC. Repo and clone exist (LICENSE + README).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Actor
+**`Human`.**
+
+## Steps
+
+### Step 1 — Repo settings (portal)
+- /settings — default branch `main`, Public, Issues + Actions on.
+- /settings/branches — branch protection: PR required, `pr-core / core` required, no force pushes, no deletions.
+- /settings/security_analysis — Dependabot alerts on.
+
+### Step 2 — Seed labels
+
+```bash
+for label in "feature:0E8A16" "chore:CCCCCC" "tier-1:E99695" "tier-2:FBCA04" "ai:D946EF" "scaffold:BFDADC" "adr-0022:1D76DB" "wave-3:FBCA04" "human-only:B60205" "out-of-band:D4C5F9"; do
+  name="${label%:*}"; color="${label#*:}"
+  gh label create "$name" --repo HoneyDrunkStudios/HoneyDrunk.Memory --color "$color" 2>/dev/null
+done
+```
+
+### Step 3 — Verify local clone
+
+The HoneyDrunk.Memory clone is currently sitting on a `chore/wire-standard-workflows` branch from an earlier standard-workflow wave. Step 0 below brings it back to a clean `main` before the scaffold packet executes against it. If the chore PR for `chore/wire-standard-workflows` has not merged yet, leave the branch alone and re-run Step 3 after that PR lands.
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Memory
+
+# Step 0 — get the clone onto a clean main
+git status                                          # confirm clean (no uncommitted edits)
+git checkout chore/wire-standard-workflows         # confirm current branch
+# If the chore PR has merged to main on remote:
+git checkout main 2>/dev/null || git checkout -b main origin/main
+git pull --ff-only origin main
+git branch -d chore/wire-standard-workflows        # delete local chore branch
+
+# Step 3 — verify
+git status; git fetch origin; git checkout main; git pull --ff-only origin main; ls
+```
+
+### Step 4 — OIDC federated credential
+
+Cross-link: [`infrastructure/walkthroughs/oidc-federated-credentials.md`](../../../../infrastructure/walkthroughs/oidc-federated-credentials.md). Confirm `repo:HoneyDrunkStudios/HoneyDrunk.Memory:ref:refs/tags/v*` in the NuGet publishing identity's federated credential list.
+
+## Acceptance Criteria
+- [ ] Branch protection configured.
+- [ ] Labels seeded.
+- [ ] Local clone on `main`, clean.
+- [ ] OIDC credential verified.
+- [ ] Chore issue closed.
+
+## Human Prerequisites
+- [ ] Org-admin role; browser; gh CLI; Azure portal access for Step 4 if needed.
+
+## Dependencies
+- `packet:01`
+
+## Downstream Unblocks
+- `03-memory-node-scaffold.md` — fileable after this chore Done + packet 02 merged.
+
+## Referenced ADR Decisions
+
+**ADR-0022 D1 / D2:** Substrate Node, three packages.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node.
+
+> **Invariant 24:** Pre-filing amendments to packet 03 permitted if invariant numbers shift in packet 02.
+
+## Labels
+`chore`, `tier-1`, `meta`, `ai`, `adr-0022`, `human-only`, `wave-2`
+
+## Notes
+- ~5-minute verification task.
+- No commits to the local clone.
+- No Azure provisioning.

--- a/generated/issue-packets/active/adr-0022-memory-standup/03-memory-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0022-memory-standup/03-memory-node-scaffold.md
@@ -1,0 +1,360 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Memory
+labels: ["feature", "tier-2", "ai", "scaffold", "adr-0022"]
+dependencies: ["packet:01", "packet:02", "packet:02b"]
+adrs: ["ADR-0022", "ADR-0016", "ADR-0020"]
+accepts: ADR-0022
+wave: 3
+initiative: adr-0022-memory-standup
+node: honeydrunk-memory
+---
+
+# Feature: Stand up the HoneyDrunk.Memory repo — solution, three packages, contracts, CI, InMemory provider
+
+## Summary
+
+Bring `HoneyDrunk.Memory` from zero to first-shippable per ADR-0022. Land the solution, three packages (`Abstractions`, runtime, `Providers.InMemory`), three D3 interfaces in Abstractions, the `MemoryEntry` record (per-entry metadata including embedding-model identifier per D10), default runtime composing AI's `IEmbeddingGenerator` + `IChatClient` (per D5) and Auth's `IAuthorizationPolicy` (per D6), in-memory provider, standard CI, contract-shape canary scoped to Abstractions per D12 (number assigned by packet 02).
+
+Unblocks Agents (`IAgentMemory` composition per ADR-0020 D6), Flow (indirectly via Agents), Sim (fixture composition), Evals (fixture composition), Lore (curation persistence), HoneyHub when live.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Memory`
+
+## Motivation
+
+ADR-0022 establishes Memory's contract surface. Repo is cloned (LICENSE + README only).
+
+## Proposed Implementation
+
+### Repository layout
+
+```
+HoneyDrunk.Memory/
+├── HoneyDrunk.Memory.slnx
+├── Directory.Build.props
+├── CHANGELOG.md
+├── README.md
+├── .editorconfig
+├── .gitignore
+├── .github/workflows/{pr-core,release,nightly-deps,nightly-security,api-compatibility}.yml
+├── src/
+│   ├── HoneyDrunk.Memory.Abstractions/
+│   │   ├── HoneyDrunk.Memory.Abstractions.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── IMemoryStore.cs
+│   │   ├── IMemoryScope.cs
+│   │   ├── IMemorySummarizer.cs
+│   │   ├── MemoryEntry.cs
+│   │   └── (query/scope request/response records)
+│   ├── HoneyDrunk.Memory/
+│   │   ├── HoneyDrunk.Memory.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── ServiceCollectionExtensions.cs
+│   │   ├── Storage/DefaultMemoryStore.cs
+│   │   ├── Scope/DefaultMemoryScope.cs           (composes Auth for Escalate())
+│   │   ├── Summarization/DefaultMemorySummarizer.cs  (composes IEmbeddingGenerator + IChatClient)
+│   │   └── Telemetry/MemoryTelemetry.cs
+│   └── HoneyDrunk.Memory.Providers.InMemory/
+│       ├── HoneyDrunk.Memory.Providers.InMemory.csproj
+│       ├── README.md
+│       ├── CHANGELOG.md
+│       └── InMemoryMemoryStore.cs
+└── tests/
+    ├── HoneyDrunk.Memory.Abstractions.Tests/
+    ├── HoneyDrunk.Memory.Tests/
+    └── HoneyDrunk.Memory.Providers.InMemory.Tests/
+```
+
+### Contract details — `HoneyDrunk.Memory.Abstractions`
+
+```csharp
+// IMemoryStore.cs
+namespace HoneyDrunk.Memory.Abstractions;
+
+using HoneyDrunk.Kernel.Abstractions.Identity;  // TenantId, ProjectId
+
+public interface IMemoryStore
+{
+    Task WriteAsync(MemoryEntry entry, IMemoryScope scope, CancellationToken cancellationToken = default);
+    Task<MemoryEntry?> ReadAsync(string entryId, IMemoryScope scope, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<MemoryEntry>> SearchAsync(MemoryStoreQuery query, IMemoryScope scope, CancellationToken cancellationToken = default);
+    Task DeleteAsync(string entryId, IMemoryScope scope, CancellationToken cancellationToken = default);
+    Task SupersedeAsync(string entryId, MemoryEntry replacement, IMemoryScope scope, CancellationToken cancellationToken = default);
+}
+
+public sealed record MemoryStoreQuery(string? QueryText, float[]? QueryEmbedding, IReadOnlyDictionary<string, string> Filters, int MaxResults, string EmbeddingModelIdentifier);
+```
+
+> **Naming note — record name disambiguation from Agents.** Memory's query record is `MemoryStoreQuery`, not `MemoryQuery`. `HoneyDrunk.Agents.Abstractions` exposes `IAgentMemory` with its own `MemoryWriteRequest` / `MemoryQueryRequest` / `MemoryReadResult` record family (those are the agent-facing intent shapes that lower onto Memory's `MemoryEntry` / `MemoryStoreQuery`). Per Agents' own refine, the Agents-side records will be renamed to `AgentMemoryWriteRequest` / `AgentMemoryQueryRequest` / `AgentMemoryReadResult`. Memory's lower-layer storage shape is named `MemoryStoreQuery` (note the `Store` qualifier) so the boundary is visibly distinct on both sides — Agents' `AgentMemoryQueryRequest` lowers into Memory's `MemoryStoreQuery`. The persisted shape (`MemoryEntry`) keeps its plain name because the read result on the Agents side lifts back from `MemoryEntry`, not the other way around.
+
+```csharp
+// IMemoryScope.cs
+using HoneyDrunk.Kernel.Abstractions.Identity;  // TenantId, ProjectId
+
+public interface IMemoryScope
+{
+    TenantId TenantId { get; }
+    ProjectId ProjectId { get; }
+    string AgentId { get; }   // string until Kernel ships strong AgentId — follow-up packet rotates this once available
+    bool IsEscalated { get; }
+    Task<IMemoryScope> EscalateAsync(ScopeEscalationRequest request, CancellationToken cancellationToken = default);
+}
+
+public sealed record ScopeEscalationRequest(string Reason, string[] RequestedAccess, IReadOnlyDictionary<string, string> Context);
+```
+
+```csharp
+// IMemorySummarizer.cs
+public interface IMemorySummarizer
+{
+    Task<MemoryEntry> SummarizeAsync(IReadOnlyList<MemoryEntry> entries, SummarizationOptions options, CancellationToken cancellationToken = default);
+}
+
+public sealed record SummarizationOptions(int TargetTokenBudget, string EmbeddingModelIdentifier);
+```
+
+```csharp
+// MemoryEntry.cs (record — no I prefix)
+using HoneyDrunk.Kernel.Abstractions.Identity;  // TenantId, ProjectId
+
+public sealed record MemoryEntry(
+    string EntryId,
+    TenantId TenantId,                  // strong type from Kernel.Abstractions per ADR-0026 D1/D2 (Accepted)
+    ProjectId ProjectId,                // strong type from Kernel.Abstractions
+    string AgentId,                     // string until Kernel ships strong AgentId — follow-up packet rotates this once available
+    string Content,
+    float[]? Embedding,
+    string EmbeddingModelIdentifier,   // D10 — required for coherence
+    DateTimeOffset WrittenAt,
+    string? SummaryOfEntryId,           // non-null if this entry summarizes another
+    IReadOnlyDictionary<string, string> Metadata);
+```
+
+Per invariant 1, `HoneyDrunk.Kernel.Abstractions` is on the allowed list for Abstractions packages alongside `Microsoft.Extensions.*`. **No other HoneyDrunk references in Abstractions** — no AI, no Auth, no Data. `TenantId`/`ProjectId` are strong types from Kernel; `AgentId` stays `string` until Kernel ships the matching strong type.
+
+**Abstractions stance — Kernel-Abstractions is the allowed dependency.** Memory.Abstractions consumes `HoneyDrunk.Kernel.Abstractions` for strong-typed identifiers per invariant 1 (Kernel.Abstractions is the allowed Grid-level abstraction) and per ADR-0026 D1/D2 — Memory is the Grid's authorization boundary for agent-generated content, and stringly-typing tenancy here would re-introduce exactly the footgun ADR-0026 eliminated. `MemoryEntry.EmbeddingModelIdentifier` stays `string`, not `ModelCapabilityDeclaration` (no transitive AI.Abstractions reference at stand-up).
+
+### Boundary with Agents' `IAgentMemory` records
+
+`HoneyDrunk.Agents.Abstractions.IAgentMemory` exposes the agent-facing intent layer:
+
+| Agents (intent layer) | Memory (storage layer) | Direction |
+|---|---|---|
+| `AgentMemoryWriteRequest` | `MemoryEntry` | lowers into |
+| `AgentMemoryQueryRequest` | `MemoryStoreQuery` | lowers into |
+| `AgentMemoryReadResult` | `MemoryEntry` | lifts from |
+
+The pair lowering is one-way: Agents owns the agent-side intent records (now name-prefixed with `Agent` per Agents' own refine), Memory owns the storage records. A consumer composing against `IAgentMemory` (the default `IAgentMemory` per ADR-0020 D6) never sees `MemoryEntry` directly — they hand `AgentMemoryWriteRequest` to the agent, the default `IAgentMemory` implementation lowers it into `MemoryEntry` and writes through `IMemoryStore.WriteAsync(MemoryEntry, IMemoryScope, ...)`. The naming (`MemoryStoreQuery` not `MemoryQuery`, `AgentMemoryQueryRequest` not `MemoryQueryRequest`) is what keeps the boundary visible at every callsite.
+
+### Runtime details — `HoneyDrunk.Memory`
+
+`HoneyDrunk.Memory` references:
+- `HoneyDrunk.Memory.Abstractions` (project)
+- `HoneyDrunk.Kernel.Abstractions` (telemetry, context, `TenantId` / `ProjectId` strong types)
+- `HoneyDrunk.AI.Abstractions` (`IEmbeddingGenerator` + `IChatClient` per D5)
+- `HoneyDrunk.Auth.Abstractions` (`IAuthorizationPolicy` + `IAuthenticatedIdentityAccessor` for `Escalate` per D6)
+- `HoneyDrunk.Data.Abstractions` (`IRepository` + `IUnitOfWork` for non-in-memory persistence — conditional, defer if Data refactor pending)
+- Microsoft.Extensions.* (DI, Hosting, Logging)
+
+Default implementations:
+
+- **`DefaultMemoryStore`** — façade; default DI wires `InMemoryMemoryStore` for dev/test.
+- **`DefaultMemoryScope`** — composes Auth. `EscalateAsync` consults `IAuthorizationPolicy` against the current identity; denied escalation throws; approved returns a widened scope with `IsEscalated: true`.
+- **`DefaultMemorySummarizer`** — calls `IChatClient.CompleteAsync` on the configured summarization prompt, re-embeds the summary via `IEmbeddingGenerator`, writes a new `MemoryEntry` with `SummaryOfEntryId` populated, supersedes originals via `IMemoryStore.SupersedeAsync`.
+- **`MemoryTelemetry`** — per-write / per-read / per-summarize / per-supersede activities. **Content NEVER carried** per D9. Only scope coordinates, entry identity, sizes, durations, model identifiers.
+
+> **D3 surface clarification — supersession is the fifth method.** ADR-0022 D3 names four operations (write, read, search, delete) in the body table. D10 introduces supersession as the model-rotation mechanic ("re-embedding an entry under a new model is treated as supersession — the old entry is superseded and a new entry with the new embedding-model identifier is written"). At scaffold, supersession is exposed as a fifth method on `IMemoryStore` — `SupersedeAsync(entryId, replacement, scope, ct)` — and a `SummaryOfEntryId` field on `MemoryEntry` (non-null when the entry summarizes another) so summarizer-driven supersession is observable at the record level. Both are public surface, both are covered by the D12 contract-shape canary, and both reflect a D10-mandated mechanism rather than an undocumented expansion. The catalog `contracts.json` description for `IMemoryStore` updates to "write, read, search, delete, **and supersede** memory entries" (packet 01 carries that catalog edit if it lands first; otherwise the scaffold PR includes a one-line follow-up note for packet 01 to amend).
+
+### Providers.InMemory details
+
+`InMemoryMemoryStore` — in-process dictionary keyed by `(TenantId, ProjectId, AgentId, EntryId)` where `TenantId` and `ProjectId` are the strong-typed record-structs from `HoneyDrunk.Kernel.Abstractions.Identity`. Enforces scope check on every read. Linear-scan similarity over stored embeddings. Suitable for tests, dev, fixtures.
+
+### CI workflows
+
+Five files; `api-compatibility.yml` path-filtered to `src/HoneyDrunk.Memory.Abstractions/**`.
+
+### `HoneyDrunk.Standards`
+
+Per invariant 26.
+
+### Documentation
+
+Repo README — purpose, package matrix, "How to consume" snippet, link to ADR-0022. Note the embedding-model coherence rule (D10), the content-never-in-telemetry rule (D9), the Position A short-term/long-term boundary (D4/D7).
+
+## Affected Files
+Entire repo. See layout.
+
+## NuGet Dependencies
+
+### `HoneyDrunk.Memory.Abstractions.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | `TenantId`, `ProjectId` strong types per ADR-0026 D1/D2 — invariant 1 allows Kernel.Abstractions |
+
+(No other PackageReference. Invariant 1 allows `Microsoft.Extensions.*` abstractions plus `HoneyDrunk.Kernel.Abstractions`.)
+
+### `HoneyDrunk.Memory.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | Telemetry, context, strong-typed identifiers |
+| `HoneyDrunk.AI.Abstractions` | `IEmbeddingGenerator` + `IChatClient` per D5 |
+| `HoneyDrunk.Auth.Abstractions` | `IAuthorizationPolicy` + `IAuthenticatedIdentityAccessor` per D6 |
+| `HoneyDrunk.Data.Abstractions` | `IRepository` + `IUnitOfWork` for non-in-memory persistence |
+| `Microsoft.Extensions.DependencyInjection.Abstractions`, `.Hosting.Abstractions`, `.Logging.Abstractions` | |
+
+Project reference: `HoneyDrunk.Memory.Abstractions`.
+
+### `HoneyDrunk.Memory.Providers.InMemory.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+
+Project reference: `HoneyDrunk.Memory.Abstractions`. **No reference to runtime / Kernel / AI / Auth / Data.**
+
+### Test projects: standard.
+
+## Boundary Check
+- [x] `HoneyDrunk.Memory.Abstractions` references only the Grid's Abstractions-allow-list — `HoneyDrunk.Kernel.Abstractions` + `Microsoft.Extensions.*` (invariant 1).
+- [x] `Providers.InMemory` references only `HoneyDrunk.Memory.Abstractions` (invariant 3).
+- [x] Position A applied — Memory holds long-term only; execution-scope state stays on `IAgentExecutionContext` (Agents).
+- [x] `IMemoryScope` enforces scope at every `IMemoryStore` call (Memory content-only-through-`IMemoryStore` invariant — number assigned by packet 02, default 62).
+- [x] `MemoryEntry.EmbeddingModelIdentifier` is required (Memory embedding-coherence invariant — number assigned by packet 02, default 63).
+- [x] Content NEVER in telemetry (Memory content-never-in-telemetry invariant — number assigned by packet 02, default 64).
+- [x] Records drop `I`; interfaces keep it.
+- [x] `TenantId` / `ProjectId` are the strong types from `HoneyDrunk.Kernel.Abstractions.Identity` per ADR-0026 D1/D2 (Accepted). `AgentId` stays `string` pending a Kernel-side `AgentId` ULID record-struct.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Memory.slnx` builds clean.
+- [ ] Three D3 interfaces + `MemoryEntry` record + `MemoryStoreQuery` query record present with XML docs.
+- [ ] `IMemoryStore` exposes `WriteAsync` / `ReadAsync` / `SearchAsync` / `DeleteAsync` / `SupersedeAsync` (D3 four + D10 supersession).
+- [ ] `IMemoryScope.TenantId` is `HoneyDrunk.Kernel.Abstractions.Identity.TenantId` (strong type), not `string`. Same for `ProjectId`. `AgentId` stays `string`.
+- [ ] `MemoryEntry.TenantId` / `ProjectId` use the Kernel strong types; `AgentId` is `string`.
+- [ ] `HoneyDrunk.Memory.Abstractions.csproj` PackageReference set is exactly `{ HoneyDrunk.Standards (PrivateAssets=all), HoneyDrunk.Kernel.Abstractions }`. No other `HoneyDrunk.*` references.
+- [ ] `Providers.InMemory` references only `HoneyDrunk.Memory.Abstractions`.
+- [ ] `AddHoneyDrunkMemory()` resolves all three interfaces.
+- [ ] `IMemoryStore.WriteAsync` rejects `MemoryEntry` with null/empty `EmbeddingModelIdentifier` (or short-circuits write — implementation choice, but D10 requires it be non-empty). Unit test verifies.
+- [ ] `DefaultMemoryStore.SearchAsync` errors / returns empty when `MemoryStoreQuery.EmbeddingModelIdentifier` mismatches the stored entries' models (D10). Unit test verifies the mismatch path.
+- [ ] `DefaultMemoryScope.EscalateAsync` calls `IAuthorizationPolicy` (mocked); denied escalation throws; approved returns widened scope. Unit test verifies both.
+- [ ] `DefaultMemorySummarizer` calls `IChatClient.CompleteAsync` and `IEmbeddingGenerator.GenerateAsync`. Writes a new `MemoryEntry` with `SummaryOfEntryId` populated. Unit test verifies.
+- [ ] `MemoryTelemetry` emits per-write/read/summarize/supersede activities. **Activity tags / attributes contain only metadata.** Unit test asserts that content text does not appear in any activity payload.
+- [ ] `InMemoryMemoryStore` enforces scope on every read/write. Cross-scope read attempts return empty (or throw, depending on impl choice). Unit test verifies.
+- [ ] All five `.github/workflows/*.yml` present.
+- [ ] `api-compatibility.yml` path-filtered to Abstractions; scaffolding PR reports `status: skipped`.
+- [ ] `pr-core.yml` passes.
+- [ ] Repo + per-package `CHANGELOG.md` + `README.md` present.
+- [ ] All `src/*.csproj` Version 0.1.0; tests excluded.
+- [ ] Manual confirmation `v0.1.0` tag triggers `release.yml`.
+- [ ] **No `Providers.SqlServer` or `Providers.CosmosDB` in this packet.**
+- [ ] **No bulk-delete API in this packet.** Per ADR-0022 D11, the API surface is deferred. Per-entry and per-scope delete (`IMemoryStore.DeleteAsync`) is the only delete surface at stand-up.
+- [ ] **No content in telemetry.** Verified by test fixture.
+
+## Human Prerequisites
+- [ ] Packet 02b complete.
+- [ ] After merge, push tag `v0.1.0`.
+- [ ] **Upstream Abstractions check.** AI Abstractions (`IEmbeddingGenerator`, `IChatClient`) + Auth Abstractions (`IAuthorizationPolicy`) must be available. If AI Abstractions is missing, ship `DefaultMemorySummarizer` and `DefaultMemoryStore` similarity path as placeholder no-ops + warnings. If Auth Abstractions is missing, ship `DefaultMemoryScope.EscalateAsync` as throw-not-implemented + warning. Follow-up packets wire real composition.
+- [ ] **Branch protection sequencing.** Add `api-compatibility / abstractions-shape` to required checks post-merge.
+- [ ] No Azure provisioning required.
+- [ ] After merge + tag, file SonarCloud onboarding follow-up.
+- [ ] File `Providers.SqlServer` and `Providers.CosmosDB` follow-ups when production consumers drive the shape.
+- [ ] File bulk-delete API follow-up once Operator's `IDecisionPolicy` shape concrete + a real erasure request drives shape.
+- [ ] File bulk-read API follow-up alongside bulk-delete once Operator's `IApprovalGate` matures (ADR-0022 D6 names the gate, D11 defers the surface — pair the bulk-read and bulk-delete surfaces in one follow-up ADR so both human-policy-gated paths land together).
+- [ ] File a follow-up packet to rotate `IMemoryScope.AgentId` and `MemoryEntry.AgentId` from `string` to the Kernel `AgentId` strong type once `HoneyDrunk.Kernel.Abstractions.Identity.AgentId` ships (parallel to ADR-0026's `TenantId` promotion). Includes contract-shape canary update at the same time.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+
+> **Invariant 3:** Providers reference parent Node's contracts, not internal implementation details.
+
+> **Invariant 11:** One repo per Node.
+
+> **Invariant 12, 13, 26, 27.** Standard.
+
+> **Memory downstream-coupling invariant (number assigned by packet 02, default 60):** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Memory.Abstractions`.
+
+> **Memory no-Agent-state-outside-IMemoryStore invariant (default 61):** Agents never persist state outside Memory's surface.
+
+> **Memory content-only-through-IMemoryStore invariant (default 62):** No provider escape hatches.
+
+> **Memory embedding-coherence invariant (default 63):** `MemoryEntry` records ingest-time embedding model; mismatched retrieval errors.
+
+> **Memory content-never-in-telemetry invariant (default 64):** Only metadata crosses telemetry boundary.
+
+> **Memory scope-escalation-gated invariant (default 65):** Escalate gated by Auth; bulk reads by Operator.
+
+> **Memory contract-shape canary invariant (default 66):** CI canary on three Abstractions surfaces.
+
+## Referenced ADR Decisions
+
+**ADR-0022 D1:** Agent-memory substrate.
+
+**ADR-0022 D2:** Three packages — Abstractions + runtime + Providers.InMemory.
+
+**ADR-0022 D3:** Three interfaces at stand-up; `MemoryEntry` record introduced at scaffold (this packet).
+
+**ADR-0022 D4 / D7 (Position A):** Short-term on `IAgentExecutionContext` (Agents); Memory owns long-term only.
+
+**ADR-0022 D5:** Embedding (`IEmbeddingGenerator`) + summarization (`IChatClient`) compose AI.
+
+**ADR-0022 D6:** Scope escalation gated by Auth; bulk reads gated by Operator's `IApprovalGate`.
+
+**ADR-0022 D8:** Memory content never leaves except through `IMemoryStore`.
+
+**ADR-0022 D9:** Content NEVER in telemetry.
+
+**ADR-0022 D10:** Embedding-model coherence at similarity retrieval.
+
+**ADR-0022 D11:** Right-to-erasure principle pinned; bulk-delete API deferred.
+
+**ADR-0022 D12:** Canary on three surfaces.
+
+**ADR-0016 D3 (referenced):** `IEmbeddingGenerator`, `IChatClient` from `HoneyDrunk.AI.Abstractions`.
+
+**ADR-0020 D8 (referenced):** Execution-scope state on `IAgentExecutionContext`. Memory does not duplicate.
+
+## Dependencies
+- `packet:01`, `packet:02`, `packet:02b`
+
+## Labels
+`feature`, `tier-2`, `ai`, `scaffold`, `adr-0022`
+
+## Agent Handoff
+
+**Objective:** Ship `HoneyDrunk.Memory 0.1.0` with three D3 interfaces, `MemoryEntry` record, default runtime composing AI + Auth, `Providers.InMemory`, CI, canary.
+
+**Target:** HoneyDrunk.Memory, branch from `main`.
+
+**Constraints:**
+- **Invariant 1:** Abstractions zero `HoneyDrunk.*` references.
+- **Invariant 3 applied to Providers.InMemory:** References only Abstractions.
+- **Position A:** Memory owns long-term only. No execution-scope-state surface in Memory.
+- **`MemoryEntry.EmbeddingModelIdentifier` required.** Non-empty string. Write rejects if absent.
+- **Embedding-model coherence at search.** Mismatched model returns empty / errors.
+- **Content NEVER in telemetry.** Activity tags / attributes contain only metadata. No `entry.content`, no `query.text`, no `result.content` in any tag/attribute.
+- **No bulk-delete API.** Per-entry and per-scope `DeleteAsync` only.
+- **No bulk-read API.** Deferred alongside bulk-delete until Operator's `IApprovalGate` matures.
+- **Abstractions stance — Kernel.Abstractions allowed.** `TenantId` / `ProjectId` from `HoneyDrunk.Kernel.Abstractions.Identity` per ADR-0026 D1/D2. `AgentId` stays `string` until Kernel ships the strong type. `EmbeddingModelIdentifier` stays `string` (no transitive AI.Abstractions reference at stand-up).
+- **Records drop `I`; interfaces keep it.**
+- **Memory's query record is `MemoryStoreQuery`, not `MemoryQuery`.** This is the lower-layer storage shape; Agents' `IAgentMemory` exposes `AgentMemoryQueryRequest` which lowers into `MemoryStoreQuery`. Persisted shape stays `MemoryEntry`.
+- **Canary skip on scaffolding PR expected.**
+- **Upstream conditional.** If AI/Auth Abstractions missing, placeholder no-ops + warnings.
+
+**Telemetry-content-leak test pattern.** The "content NEVER in telemetry" assertion must use a **unique-token sentinel** strategy, not a key-name allow-list. Test arrangement: write a `MemoryEntry` whose `Content` contains a unique token (e.g., `"SENTINEL-DO-NOT-LEAK-{guid}"`); issue a `SearchAsync` whose `QueryText` contains a second sentinel (`"QUERY-SENTINEL-{guid}"`); capture every emitted `Activity` (and every tag/baggage value, recursively) for write / read / search / summarize / supersede; assert that **no captured tag value, no baggage value, no event payload contains either sentinel token**. A key-name allow-list (e.g., "tags named `entry.content` or `query.text` must be absent") is insufficient — it catches naming convention violations but not someone embedding content inside `entry.metadata` or `result.summary`. The sentinel approach catches any code path that puts content into telemetry regardless of where in the activity structure it lands.
+
+**Key Files:**
+- `HoneyDrunk.Memory.slnx`, `Directory.Build.props`
+- `src/HoneyDrunk.Memory.Abstractions/` — 3 interfaces + `MemoryEntry` record + supporting records (`MemoryStoreQuery`, `ScopeEscalationRequest`, `SummarizationOptions`)
+- `src/HoneyDrunk.Memory/` — `DefaultMemoryStore`, `DefaultMemoryScope`, `DefaultMemorySummarizer`, `MemoryTelemetry`, `ServiceCollectionExtensions`
+- `src/HoneyDrunk.Memory.Providers.InMemory/` — `InMemoryMemoryStore`
+- `.github/workflows/*.yml`
+- `README.md`, `CHANGELOG.md` (repo + per-package)
+- `tests/`
+
+**Contracts:** Three D3 interfaces + `MemoryEntry` record + `MemoryStoreQuery` query record authored fresh. `IMemoryStore` exposes five methods (write / read / search / delete / supersede); `IMemoryScope` carries strong-typed `TenantId` + `ProjectId` from `HoneyDrunk.Kernel.Abstractions.Identity` plus a `string AgentId` placeholder pending Kernel's strong type.

--- a/generated/issue-packets/active/adr-0022-memory-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0022-memory-standup/dispatch-plan.md
@@ -1,0 +1,76 @@
+# Dispatch Plan — ADR-0022 HoneyDrunk.Memory Standup
+
+**Initiative:** `adr-0022-memory-standup`
+**Sector:** AI
+**Governing ADR:** [ADR-0022 — Stand Up the HoneyDrunk.Memory Node](../../../../adrs/ADR-0022-stand-up-honeydrunk-memory-node.md) (Proposed 2026-04-19; flips to Accepted after merge).
+**Trigger:** ADR-0022 in the Proposed queue. Agents (default `IAgentMemory` via ADR-0020 D6), Flow, Sim, Lore, HoneyHub when live, Evals all need agent-memory primitives.
+**Type:** Multi-repo (2 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.Memory`)
+**Site sync required:** No.
+**Rollback plan:** Pre-tag revert; post-tag fix-forward.
+
+## Summary
+
+ADR-0022 is the standup ADR for `HoneyDrunk.Memory`. Owns agent-memory primitives — `IMemoryStore`, `IMemoryScope`, `IMemorySummarizer`. Three packages (`Abstractions`, runtime, `Providers.InMemory`). Composes AI's `IEmbeddingGenerator` (similarity) and `IChatClient` (summarization) per D5. Auth-gated scope escalation per D6. Operator-`IApprovalGate`-mediated bulk operational reads per D6. Content NEVER in telemetry per D9. Embedding-model coherence rule per D10 (level b — `MemoryEntry` records ingest-time model identifier). Right-to-erasure principle pinned, bulk-delete API surface deferred to scaffold per D11. Canary on all three surfaces per D12.
+
+Two prose-correction items: `repos/HoneyDrunk.Memory/overview.md` and `repos/HoneyDrunk.Memory/boundaries.md` previously describe Memory as owning short-term memory; ADR-0022 D4/D7 (Position A) and ADR-0020 D8 fix that — short-term lives on `IAgentExecutionContext`, Memory owns long-term only.
+
+Four packets land the work:
+
+1. **Architecture catalog registration + integration-points + short-term-memory ownership fix** — verify three-interface contract surface in `contracts.json`; widen Memory→AI `consumes_detail` to include `IChatClient` per D5; add `honeydrunk-agents` to `consumed_by_planned`; refresh `grid-health.json` and `nodes.json`; fix the short-term-memory ownership drift in `repos/HoneyDrunk.Memory/overview.md`, `boundaries.md`, `constitution/ai-sector-architecture.md` (Position A); add `integration-points.md` and `active-work.md`.
+2. **Constitution invariants** — seven new invariants from D2, D7+ADR-0020 D8, D8, D10, D9, D6, D12.
+2b. **Verify `HoneyDrunk.Memory` repo + local clone (human-only)**.
+3. **HoneyDrunk.Memory scaffold** — empty repo to first-shippable. Solution, three packages (`Abstractions`, runtime, `Providers.InMemory`), three interfaces in Abstractions, default runtime implementations composing AI + Auth, Providers.InMemory backend, five CI workflow files with canary scoped to Abstractions.
+
+## Wave Diagram
+
+```
+Wave 1: Architecture catalog + constitution updates (parallel)
+   ├─ Architecture: 01-architecture-memory-catalog-registration
+   └─ Architecture: 02-architecture-memory-invariants
+       Blocked by: 01
+
+Wave 2: Verify repo + clone (human)
+   └─ Architecture: 02b-architecture-verify-memory-repo
+       Blocked by: 01
+
+Wave 3: Memory repo scaffold
+   └─ HoneyDrunk.Memory: 03-memory-node-scaffold
+       Blocked by: 01, 02, 02b
+```
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 01 | [Catalog registration + short-term-memory ownership fix + integration-points](./01-architecture-memory-catalog-registration.md) | Architecture | 1 | Agent | — |
+| 02 | [Add seven new invariants for D2 / D7+D8 / D8 / D10 / D9 / D6 / D12](./02-architecture-memory-invariants.md) | Architecture | 1 | Agent | 01 |
+| 02b | [Verify HoneyDrunk.Memory repo + clone (human-only)](./02b-architecture-verify-memory-repo.md) | Architecture | 2 | Human | 01 |
+| 03 | [Stand up `HoneyDrunk.Memory` — solution, three packages, contracts, CI, InMemory provider](./03-memory-node-scaffold.md) | HoneyDrunk.Memory | 3 | Agent | 01, 02, 02b |
+
+## What This Initiative Does **NOT** Deliver
+
+- Downstream consumer Nodes not delivered.
+- `Providers.SqlServer` and `Providers.CosmosDB` deferred to follow-up packets.
+- The bulk-delete API surface (right-to-erasure) is principle-pinned but **API-shape deferred** per D11.
+- The bulk-read API surface (operator-mediated reads gated by Operator's `IApprovalGate` per D6) is principle-pinned but **API-shape deferred** alongside bulk-delete — both human-policy-gated paths land together in the follow-up ADR.
+- Level (c) router-level embedding-model pinning deferred to ADR-0010.
+- Pulse signal ingress into Memory deferred (emit-only per D9).
+- Cross-host shared scope-resolution registry deferred.
+- No separate `HoneyDrunk.Memory.Testing` package — `Providers.InMemory` plays that role per D2.
+- No strong-typed `AgentId` — Memory uses `string AgentId` at scaffold; follow-up packet rotates to a Kernel-side `AgentId` strong type once it ships (parallel to ADR-0026's `TenantId` / `ProjectId` shape).
+
+## AI-sector standup wave sequencing
+
+Memory requires `HoneyDrunk.AI.Abstractions` (for `IEmbeddingGenerator` + `IChatClient`) and `HoneyDrunk.Auth.Abstractions` (for `IAuthorizationPolicy` in scope escalation per D6). Recommended order: AI → Capabilities → Operator → **Memory** + Knowledge (parallel) → Agents (depends on Memory) → Evals + Flow + Sim.
+
+## Status flip
+
+ADR-0022 stays Proposed for duration.
+
+## Filing
+
+`file-packets.yml` auto-files.
+
+## Archival
+
+Per ADR-0008 D10, archive to `archive/adr-0022-memory-standup/` post-completion.


### PR DESCRIPTION
## Summary

Scopes four packets standing up [HoneyDrunk.Memory](https://github.com/HoneyDrunkStudios/HoneyDrunk.Memory) per [ADR-0022](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0022-stand-up-honeydrunk-memory-node.md). Memory is the Grid's authorization boundary for agent-generated content — this initiative lands it on the right side of [ADR-0026](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0026-grid-multi-tenant-primitives.md)'s strong-typed tenancy decision. Claims invariants **60–66**.

### Wave 1 — Architecture-repo (parallel)
- **`01-catalog-registration`** — `relationships.json` consumes Kernel/AI/Auth/Data (all `.Abstractions`); D-number citations of Proposed sibling ADRs (0023/0024/0025) stripped; `grid_relationship` prose anchored to ADR-0026 D1/D2 for strong-typed tenant primitives.
- **`02-invariants`** — seven new constitution invariants (default 60–66) under `## AI Sector — Memory Invariants`. Includes content-only-through-`IMemoryStore`, retention/PII enforcement seat, three-level scope.
- **`02b-verify-memory-repo`** — human-only chore + chore-branch reconcile.

### Wave 2 — Memory scaffold
- **`03-memory-node-scaffold`** — three packages, three frozen interfaces (`IMemoryStore`, `IMemoryScope`, `IMemorySummarizer`), two records (`MemoryEntry`, `MemoryStoreQuery` — renamed from `MemoryQuery` to avoid Agents' `AgentMemoryQueryRequest` collision).

## Strong-typed tenancy

`MemoryEntry.TenantId` and `MemoryEntry.ProjectId` use Kernel.Abstractions **strong types** (`TenantId`, `ProjectId`) per ADR-0026. `AgentId` stays `string` at v0.1.0 with a follow-up to rotate once Kernel ships the strong type. `Memory.Abstractions` takes `HoneyDrunk.Kernel.Abstractions` as a dep so the strong types are in scope.

## Notable surface decisions

- **`IMemoryStore.SupersedeAsync`** added explicitly as the fifth method per D10 (no longer a silent surface expansion — packet 01 updates `contracts.json` description).
- **Bulk-read API** deferred per D6 with explicit follow-up flag in dispatch-plan negative-scope list.
- **Position A state boundary** applied: Memory holds durable learned state; Agents holds ephemeral execution state.

## Conventions

- **NuGet uses `.Abstractions`** throughout (invariant 2).
- **Records drop `I`** (`MemoryEntry`, `MemoryStoreQuery`); **interfaces keep `I`**.
- Telemetry-content leak test pattern documented (unique-token sentinel strategy, not key-name allow-list).
- Each packet carries `accepts: ADR-0022`.

## Test plan

- [ ] After merge, four issues file with dependency edges on The Hive
- [ ] Verify Wave 2's `MemoryEntry` strong-typed fields land per ADR-0026
- [ ] When all four close, hive-sync auto-flips ADR-0022 Proposed → Accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)