### PR TITLE
chore: scope ADR-0023 evals node standup

### DIFF
--- a/generated/issue-packets/active/adr-0023-evals-standup/01-architecture-evals-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0023-evals-standup/01-architecture-evals-catalog-registration.md
@@ -1,0 +1,223 @@
+---
+name: Architecture Catalog Registration
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0023"]
+dependencies: []
+adrs: ["ADR-0023"]
+accepts: ADR-0023
+wave: 1
+initiative: adr-0023-evals-standup
+node: honeydrunk-evals
+---
+
+# Chore: Register HoneyDrunk.Evals's standup decisions in Architecture catalogs + reconcile three-way drift
+
+## Summary
+
+Reflect ADR-0023 in catalogs. **Reconcile a three-way drift** between `catalogs/contracts.json` (`IEvalRunner`, `IEvalScorer`, `IEvalSuite`), `catalogs/relationships.json` `exposes.contracts` (`IEvaluator`, `IEvalDataset`, `IEvalScorer`, `IEvalReport`), and `repos/HoneyDrunk.Evals/overview.md` (same four). Land the D3 definitive set: `IEvaluator`, `IEvalScorer`, `IEvalSuite`, `IEvalTarget`, `EvalCase`, `EvalReport` (four interfaces + two records).
+
+Widen `consumes` to add seven missing edges (Kernel, Agents, Capabilities, Operator, Knowledge, Memory). Widen AI `consumes_detail`. Update `roadmap_focus` prose in `nodes.json`. Refresh `grid-health.json`. Align `constitution/ai-sector-architecture.md` Evals section. Add `integration-points.md` and `active-work.md` under `repos/HoneyDrunk.Evals/`.
+
+ADR-0023 stays Proposed.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0023 establishes Evals's contract surface (D3) and reconciles a three-way drift across cataloged sources. Specific drift items:
+
+1. **`contracts.json` lists three interfaces** (`IEvalRunner`, `IEvalScorer`, `IEvalSuite`) — none of which match D3.
+2. **`relationships.json` `exposes.contracts` lists four interfaces** (`IEvaluator`, `IEvalDataset`, `IEvalScorer`, `IEvalReport`) — closer but `IEvalDataset` is wrong (should be `IEvalSuite`); `IEvalReport` should be a record (`EvalReport`); `IEvalTarget` is missing.
+3. **`relationships.json` `consumes` lists only `honeydrunk-ai`** with limited `consumes_detail` — seven other edges missing per D4.
+4. **`nodes.json roadmap_focus`** names `IEvaluator`, `IEvalDataset`, `IEvalScorer` — needs updating to D3 definitive set.
+5. **`repos/HoneyDrunk.Evals/overview.md`** lists `IEvaluator`, `IEvalDataset`, `IEvalScorer`, `IEvalReport` — needs same updates.
+
+## Proposed Implementation
+
+### `catalogs/contracts.json` — `honeydrunk-evals` block
+
+Replace existing three-interface seed with the six D3 surfaces:
+
+```json
+{
+  "node": "honeydrunk-evals",
+  "node_name": "HoneyDrunk.Evals",
+  "package": "HoneyDrunk.Evals.Abstractions",
+  "status": "seed",
+  "interfaces": [
+    { "name": "IEvaluator", "kind": "interface", "description": "Run a suite of cases against a target, collect scored results, produce an EvalReport. The top-level orchestration surface. ADR-0023 D3." },
+    { "name": "IEvalScorer", "kind": "interface", "description": "Scoring function over a case output. Automated (regex, schema validation, rubric) or model-as-judge (using IChatClient). Marked deterministic vs non-deterministic per the Node-local invariant. ADR-0023 D3 / D5." },
+    { "name": "IEvalSuite", "kind": "interface", "description": "Named, versioned collection of EvalCases with a rubric specification. Replaces the previous IEvalDataset name. ADR-0023 D3." },
+    { "name": "IEvalTarget", "kind": "interface", "description": "The thing being evaluated — a chat model, an agent, a retrieval pipeline, a memory-backed workflow. Abstracts over what the case is run against without binding Evals to any consumer's runtime surface. New in ADR-0023 D3 / D6 — router-bypass boundary." },
+    { "name": "EvalCase", "kind": "type", "description": "Record. A single evaluation case — input, expected output or rubric criteria, per-case metadata (case identity, suite version, tags). ADR-0023 D3." },
+    { "name": "EvalReport", "kind": "type", "description": "Record. Structured evaluation results — per-case scores, per-case inputs and outputs (subject to D10 sensitivity rules), rubric breakdown, run metadata (target identity, ModelCapabilityDeclaration identity, suite version, timestamp). Durable per D13. Previously IEvalReport interface — promoted to record per the grid-wide naming rule. ADR-0023 D3 / D12." }
+  ]
+}
+```
+
+Drop `IEvalRunner`, `IEvalDataset`, `IEvalReport` placeholder entries.
+
+### `catalogs/relationships.json` — `honeydrunk-evals` block
+
+**(a) `consumes` widening.** Currently `["honeydrunk-ai"]`. Replace with:
+
+```json
+"consumes": ["honeydrunk-kernel", "honeydrunk-ai", "honeydrunk-agents", "honeydrunk-capabilities", "honeydrunk-operator", "honeydrunk-knowledge", "honeydrunk-memory"]
+```
+
+**(b) `consumes_detail`.** Add per-edge entries:
+
+```json
+"consumes_detail": {
+  "honeydrunk-kernel": ["IGridContext", "IOperationContext", "ITelemetryActivityFactory", "HoneyDrunk.Kernel.Abstractions"],
+  "honeydrunk-ai": ["IChatClient", "IEmbeddingGenerator", "IModelProvider", "ModelCapabilityDeclaration", "HoneyDrunk.AI.Abstractions"],
+  "honeydrunk-agents": ["IAgent", "HoneyDrunk.Agents.Abstractions"],
+  "honeydrunk-capabilities": ["ICapabilityInvoker", "HoneyDrunk.Capabilities.Abstractions"],
+  "honeydrunk-operator": ["ISafetyFilter", "ICostGuard", "IAuditLog", "HoneyDrunk.Operator.Abstractions"],
+  "honeydrunk-knowledge": ["HoneyDrunk.Knowledge.Abstractions", "HoneyDrunk.Knowledge.Providers.InMemory"],
+  "honeydrunk-memory": ["HoneyDrunk.Memory.Abstractions", "HoneyDrunk.Memory.Providers.InMemory"]
+}
+```
+
+**(c) `exposes.contracts`.** Replace with:
+
+```json
+"contracts": ["IEvaluator", "IEvalScorer", "IEvalSuite", "IEvalTarget", "EvalCase", "EvalReport"]
+```
+
+**(d) `exposes.packages`.** Replace with:
+
+```json
+"packages": ["HoneyDrunk.Evals.Abstractions", "HoneyDrunk.Evals", "HoneyDrunk.Evals.Providers.InMemory"]
+```
+
+### `catalogs/grid-health.json` — `honeydrunk-evals` block
+
+Replace with standup-aware block naming D3 contracts and scaffold packet as blocker.
+
+### `catalogs/nodes.json` — `honeydrunk-evals` block
+
+**(a) `roadmap_focus`.** Replace prose naming `IEvaluator`, `IEvalDataset`, `IEvalScorer` with the D3 six surfaces.
+
+**(b) `grid_relationship`.** Update to reflect D4 — names every Node Evals composes (AI, Agents, Capabilities, Operator, Knowledge, Memory) and emit-to-Pulse-with-content-carve-out per D10.
+
+**(c) `honeydrunk-ai` block — note model-pinning resolution.** Add a one-line entry to the AI Node's `nodes.json` block (e.g. into `notes` or `roadmap_focus`) recording that the ADR-0016 D3 model-pinning concern is now resolved by ADR-0023 D6: **the sanctioned router-bypass primitive is `IEvalTarget` in HoneyDrunk.Evals.Abstractions** — no other Node introduces an alternate inference path that pins a `ModelCapabilityDeclaration` outside the routing layer.
+
+### `constitution/ai-sector-architecture.md` — Evals section
+
+Update Key Contracts list to the D3 six surfaces. Note the eval-signal carve-out (D10) and the router-bypass via `IEvalTarget` (D6). Depends-on / Emits-to split:
+
+> `**Depends on:** Kernel, AI (IChatClient, IEmbeddingGenerator, IModelProvider, ModelCapabilityDeclaration), Agents (IAgent — for AgentTarget when scaffolded), Capabilities (ICapabilityInvoker — for agent-target tool dispatch flowing through), Operator (ISafetyFilter, ICostGuard, IAuditLog — observation-only per ADR-0023 D7), Knowledge (Providers.InMemory for retrieval fixtures), Memory (Providers.InMemory for memory fixtures).`
+>
+> `**Emits to (no runtime dependency):** Pulse (eval-signal telemetry with content carve-out per ADR-0023 D10 — content carried unless suite declares sensitive).`
+
+### `repos/HoneyDrunk.Evals/overview.md`
+
+Rewrite Key Contracts section to the D3 six surfaces. Add Packages table including `HoneyDrunk.Evals.Providers.InMemory`. Note the `EvalReport` durability (D13), the router-bypass primitive (D6), and the eval-signal carve-out (D10).
+
+### `repos/HoneyDrunk.Evals/integration-points.md` — new file
+
+Standard template; reflect D4 and D7.
+
+### `repos/HoneyDrunk.Evals/active-work.md` — new file
+
+### `initiatives/active-initiatives.md` — new entry
+
+Standard format. Note the three-way drift reconciliation.
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append: `Architecture: Register ADR-0023 standup decisions in catalogs — RECONCILES three-way drift across contracts.json (renamed IEvalRunner→IEvaluator, IEvalDataset→IEvalSuite; promoted IEvalReport→EvalReport record; added IEvalTarget interface and EvalCase record); relationships.json widens consumes to add Kernel/Agents/Capabilities/Operator/Knowledge/Memory edges with consumes_detail, sets exposes.contracts to D3 six-surface set, adds Providers.InMemory to exposes.packages; nodes.json roadmap_focus updated to D3; grid-health.json gets standup block; ai-sector-architecture.md Evals section reflects D3 + D6 router-bypass + D10 carve-out; repos/HoneyDrunk.Evals/overview.md updated; new integration-points.md and active-work.md; active-initiatives.md gets new entry. ADR-0023 stays Proposed.`
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+- `catalogs/grid-health.json`
+- `catalogs/nodes.json` (Evals block + AI block one-liner per S4)
+- `constitution/ai-sector-architecture.md`
+- `repos/HoneyDrunk.Evals/overview.md`
+- `repos/HoneyDrunk.Evals/boundaries.md` (sweep for stale `IEvalDataset` / `IEvalRunner` / interface-form `IEvalReport`)
+- `repos/HoneyDrunk.Evals/invariants.md` (same sweep)
+- `repos/HoneyDrunk.Evals/integration-points.md` (new)
+- `repos/HoneyDrunk.Evals/active-work.md` (new)
+- `initiatives/active-initiatives.md`
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] D3 six-surface set is canonical — interfaces keep `I`, records drop it (`EvalCase`, `EvalReport`).
+- [x] Three-way drift reconciled in a single PR.
+- [x] No code changes; metadata + docs only.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` `honeydrunk-evals` block lists exactly the D3 six surfaces — four interfaces (`IEvaluator`, `IEvalScorer`, `IEvalSuite`, `IEvalTarget`) + two records (`EvalCase`, `EvalReport`). No `IEvalRunner`, no `IEvalDataset`, no `IEvalReport` (the interface).
+- [ ] Records use `kind: "type"`.
+- [ ] `catalogs/relationships.json` `honeydrunk-evals.consumes` includes Kernel, Agents, Capabilities, Operator, Knowledge, Memory alongside AI.
+- [ ] `catalogs/relationships.json` `honeydrunk-evals.consumes_detail` has entries per edge.
+- [ ] `catalogs/relationships.json` `honeydrunk-evals.exposes.contracts` matches D3 six surfaces.
+- [ ] `catalogs/relationships.json` `honeydrunk-evals.exposes.packages` includes `HoneyDrunk.Evals.Providers.InMemory`.
+- [ ] `catalogs/grid-health.json` `honeydrunk-evals` reflects standup.
+- [ ] `catalogs/nodes.json` `honeydrunk-evals.roadmap_focus` reflects D3.
+- [ ] `catalogs/nodes.json` `honeydrunk-evals.grid_relationship` reflects D4 + D10.
+- [ ] `constitution/ai-sector-architecture.md` Evals section lists the D3 six surfaces; Depends-on / Emits-to split present; D6 router-bypass and D10 carve-out noted.
+- [ ] `repos/HoneyDrunk.Evals/overview.md` updated to D3 six surfaces; Packages table includes `Providers.InMemory`.
+- [ ] `repos/HoneyDrunk.Evals/integration-points.md` and `active-work.md` exist.
+- [ ] `initiatives/active-initiatives.md` includes new entry.
+- [ ] `CHANGELOG.md` Unreleased updated.
+- [ ] `rg -n "IEvalRunner|IEvalDataset" catalogs/ repos/HoneyDrunk.Evals/ constitution/` returns zero matches.
+- [ ] `rg -n "\bIEvalReport\b" catalogs/ repos/HoneyDrunk.Evals/ constitution/` returns zero matches (the interface name is gone; the record `EvalReport` remains).
+- [ ] `rg -n "IEvalDataset|IEvalRunner|interface IEvalReport" repos/HoneyDrunk.Evals/` returns zero matches — catches stale references in `repos/HoneyDrunk.Evals/boundaries.md`, `invariants.md`, and any other repo-doc file under that subtree.
+- [ ] ADR-0016 D3 model-pinning concern is documented as resolved by ADR-0023 D6 (one-line addition to `nodes.json` AI block noting that `IEvalTarget` is the sanctioned router-bypass primitive).
+- [ ] `adrs/ADR-0023-stand-up-honeydrunk-evals-node.md` NOT modified — Status stays Proposed.
+
+## Human Prerequisites
+None.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted.
+
+> **Invariant 11:** One repo per Node.
+
+## Referenced ADR Decisions
+
+**ADR-0023 D3:** Six surfaces — four interfaces + two records (`EvalCase`, `EvalReport`).
+
+**ADR-0023 D4:** Boundary decision test against every adjacent Node.
+
+**ADR-0023 D5:** AI composition for chat-backed target + model-as-judge scorer.
+
+**ADR-0023 D6:** Router bypass via `IEvalTarget`.
+
+**ADR-0023 D7:** Operator composition as observation-only scoring signals.
+
+**ADR-0023 D10:** Eval-signal content carve-out (deliberate — content permitted unless suite declares sensitive).
+
+**ADR-0023 D12 / D13:** `EvalReport` provenance + durability.
+
+## Dependencies
+None.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0023`
+
+## Agent Handoff
+
+**Objective:** Reconcile three-way drift in catalogs. Land the D3 six-surface set across all four cataloged sources.
+
+**Constraints:**
+- **D3 is canonical.** Drop `IEvalRunner`, `IEvalDataset`, `IEvalReport` (interface). Add `IEvaluator`, `IEvalSuite`, `IEvalTarget`, `EvalCase`, `EvalReport` (record).
+- **Records use `kind: "type"` in `contracts.json`, not `kind: "record"`.**
+- **`consumes` widening.** Seven edges total (Kernel, AI, Agents, Capabilities, Operator, Knowledge, Memory). Each with `consumes_detail`.
+- **No code; catalog + docs only.**
+- **No ADR Status flip.**
+
+**Key Files:** All listed above.
+
+**Contracts:** None authored. Catalog-only.

--- a/generated/issue-packets/active/adr-0023-evals-standup/02-architecture-evals-invariants.md
+++ b/generated/issue-packets/active/adr-0023-evals-standup/02-architecture-evals-invariants.md
@@ -1,0 +1,131 @@
+---
+name: Constitution Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0023", "constitution"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0023"]
+accepts: ADR-0023
+wave: 1
+initiative: adr-0023-evals-standup
+node: honeydrunk-evals
+---
+
+# Chore: Add ADR-0023's seven new invariants to the Grid constitution
+
+## Summary
+
+Add seven new invariants derived from ADR-0023: downstream-coupling (D8), read-only-observer (D11), `EvalReport` full-provenance (D12), `EvalReport` durable-not-ephemeral (D13), eval-signal content carve-out (D10), router-bypass via `IEvalTarget` only (D6), contract-shape canary on four hot-path surfaces (D14).
+
+Default numbers **67, 68, 69, 70, 71, 72, 73** (assumes ADR-0018 + ADR-0020 + ADR-0021 + ADR-0022 have landed first; collision check decides).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Proposed Implementation
+
+### `constitution/invariants.md` — append seven new entries
+
+```markdown
+## AI Sector — Evals Invariants
+
+67. **Downstream Nodes take a runtime dependency only on `HoneyDrunk.Evals.Abstractions`.**
+    Composition against `HoneyDrunk.Evals` and any `HoneyDrunk.Evals.Providers.*` package is a host-time concern. See ADR-0023 D8 (Proposed — this invariant takes effect when ADR-0023 is accepted).
+
+68. **Evals is a read-only observer of targets.**
+    No `IEvalTarget` implementation may mutate the target under test from the harness side; the target's own behavior is what the evaluation scores. The harness's behavior is not what is being evaluated. This extends `repos/HoneyDrunk.Evals/invariants.md` item 5 to the Grid level. See ADR-0023 D11 (Proposed — this invariant takes effect when ADR-0023 is accepted).
+
+69. **Every `EvalReport` records the full run provenance — suite identity and version, target identity, `ModelCapabilityDeclaration` identity (when a model was pinned), timestamps, scorer set.**
+    `EvalReport` without provenance is not a valid report. A quality signal months later that points to "model X caused regression on suite Y" depends on `EvalReport` having recorded the model-capability identity. See ADR-0023 D12 (Proposed — this invariant takes effect when ADR-0023 is accepted).
+
+70. **`EvalReport` is durable, not ephemeral telemetry.**
+    A Pulse signal records *that* a run happened (suite, top-line scores, regression flags); the `EvalReport` is the full artifact (per-case scores, inputs, outputs, rubric breakdown, run provenance) that a regression investigation reads months later when a signal fires. The two are complements, not substitutes. The specific storage substrate is deferred to scaffold per D13; the durability principle is not. See ADR-0023 D13 (Proposed — this invariant takes effect when ADR-0023 is accepted).
+
+71. **Eval-signal telemetry may carry prompts and outputs unless the suite declares itself sensitive.**
+    This is a deliberate carve-out from Knowledge's and Memory's content-never-in-telemetry rule, structurally necessary for regression diagnosis — a quality signal that case X dropped from 0.95 to 0.62 is useless for triage without the text of case X. Sensitive suites strip content from emitted signals (metadata only). The `IEvalSuite` sensitivity flag is the contract this carve-out rests on. See ADR-0023 D10 (Proposed — this invariant takes effect when ADR-0023 is accepted).
+
+72. **Router bypass is permitted only through `IEvalTarget`.**
+    No other Node introduces an alternate inference path that pins a `ModelCapabilityDeclaration` outside the routing layer. Evals's carve-out is narrow and auditable via `EvalReport` provenance per D12 — every bypass is recorded on the corresponding report's `ModelCapabilityDeclaration` identity. Sim has a parallel-but-distinct surface (`ISimulationTarget`) per ADR-0025 D8; the two do not share types. See ADR-0023 D6 (Proposed — this invariant takes effect when ADR-0023 is accepted).
+
+73. **The HoneyDrunk.Evals Node CI must include a contract-shape canary that fails the build on shape drift to `IEvaluator`, `IEvalScorer`, `IEvalTarget`, `EvalReport`, or `IEvalSuite` without a corresponding version bump.**
+    These five are the hot path for every real consumer (Agents ships agent-behavior suites, Knowledge ships retrieval suites, Memory ships memory-workflow suites, Flow / Sim / Lore / HoneyHub when live). Accidental shape drift on any of them breaks every Node that ships suites or consumes reports. `IEvalSuite` is in scope specifically because `IsSensitive` is first-pass as a boolean and expected to evolve to a graded enum (`SensitivityClassification`); the canary catches that change and forces a version bump. See ADR-0023 D14 (Proposed — this invariant takes effect when ADR-0023 is accepted).
+```
+
+### Collision check
+
+Default 67-73. Shift on collision; update ADR-0023 Consequences + packet 04 source in lockstep. `rg` only.
+
+**Cross-reference points in packet 04.** When invariant numbers shift, every line in `04-evals-node-scaffold.md` that names an invariant number must be updated in lockstep. The complete list of cross-reference sites — each must be re-pointed if the default 67-73 collides:
+
+**Packet 04 — Boundary Check section (numbered list of checkbox lines):**
+
+- `IEvalTarget` is the router-bypass boundary — **invariant 72** (router-bypass via `IEvalTarget`).
+- `ChatTarget` composing `IModelProvider` is the sanctioned bypass — **invariant 72** (cross-reference, same number).
+- Operator primitives composed observation-only — **invariant 68** (read-only observer).
+- `EvalReport` provenance fields populated including typed `PinnedModelCapability` — **invariant 69** (`EvalReport` records full provenance).
+- `EvalReport` is durable at stand-up via `Providers.InMemory` — **invariant 70** (`EvalReport` durable, not ephemeral).
+- Content-carve-out flag honored — **invariant 71** (eval-signal content carve-out).
+- Multi-tenant identity uses Kernel's `TenantId` strong type — does NOT bind to invariants 67-73; references ADR-0026. Stable across collision shifts.
+- (Plus generic invariants 1, 3 — these are stable and do not shift with this packet.)
+
+**Packet 04 — Acceptance Criteria section:**
+
+- The `EvalsTelemetry` content-carve-out criterion cites **invariant 71** ("deliberate carve-out per D10 / invariant 71").
+
+**Packet 04 — Referenced Invariants section (heading list):**
+
+- Downstream-coupling — **invariant 67** ("Evals downstream-coupling invariant").
+- Read-only observer — **invariant 68** ("Evals read-only-observer invariant").
+- Provenance — **invariant 69** ("Evals provenance invariant").
+- Durable-not-ephemeral — **invariant 70** ("Evals durable-not-ephemeral invariant").
+- Content carve-out — **invariant 71** ("Evals content-carve-out invariant").
+- Router-bypass — **invariant 72** ("Evals router-bypass invariant").
+- Contract-shape canary — **invariant 73** ("Evals contract-shape canary invariant").
+
+**Packet 04 — Agent Handoff Constraints section:**
+
+- "**Invariant 71 (default):** Honor `IEvalSuite.IsSensitive` flag…" — re-point if 71 shifts.
+- "**Invariant 72 (default):** `IEvalTarget` is the only router-bypass primitive…" — re-point if 72 shifts.
+
+On collision, every line above (six in Boundary Check, one in Acceptance Criteria, seven in Referenced Invariants, two in Constraints) must be re-pointed in the same PR.
+
+### `CHANGELOG.md`
+
+Append: `Architecture: Add invariants 67-73 (Evals downstream coupling, read-only observer, EvalReport provenance, EvalReport durable-not-ephemeral, eval-signal content carve-out, router-bypass via IEvalTarget only, Evals contract-shape canary on four hot-path surfaces) per ADR-0023 D8/D11/D12/D13/D10/D6/D14.`
+
+## Affected Files
+- `constitution/invariants.md`
+- `adrs/ADR-0023-stand-up-honeydrunk-evals-node.md` (only on shift)
+- `generated/issue-packets/active/adr-0023-evals-standup/04-evals-node-scaffold.md` (only on shift)
+- `CHANGELOG.md`
+
+## Acceptance Criteria
+- [ ] Seven invariants present matching ADR-0023.
+- [ ] Numbers verified; default 67-73.
+- [ ] `(Proposed — this invariant takes effect when ADR-0023 is accepted)` qualifier on each.
+- [ ] On shift, ADR-0023 + packet 04 updated lockstep.
+- [ ] `CHANGELOG.md` updated.
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0023 D6, D8, D10, D11, D12, D13, D14.** Sources for invariants 67-73.
+
+## Dependencies
+- `packet:01`
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0023`, `constitution`
+
+## Agent Handoff
+
+**Objective:** Seven new invariants. Default 67-73. Shift on collision; lockstep updates.
+
+**Constraints:** `(Proposed)` qualifier each. `rg` only.
+
+**Key Files:** `constitution/invariants.md`; conditional ADR-0023 + packet 04; `CHANGELOG.md`.
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0023-evals-standup/03-architecture-create-evals-repo.md
+++ b/generated/issue-packets/active/adr-0023-evals-standup/03-architecture-create-evals-repo.md
@@ -1,0 +1,113 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "ai", "adr-0023", "human-only", "wave-2", "new-node"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0023"]
+accepts: ADR-0023
+wave: 2
+initiative: adr-0023-evals-standup
+node: honeydrunk-architecture
+actor: human
+---
+
+# Chore: Create `HoneyDrunk.Evals` GitHub repo + clone locally (human-only)
+
+## Summary
+
+Create the `HoneyDrunkStudios/HoneyDrunk.Evals` repo on GitHub with the Grid's standard per-repo settings, and clone it locally so packet 04 has a working tree. Same pattern as `adr-0017-capabilities-standup/03-architecture-create-capabilities-repo.md` — the GitHub repo does NOT yet exist for Evals.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Actor
+**`Human`.** Org-admin rights required to create a new repo.
+
+## Motivation
+
+Packet 04 defines the solution, three packages, six surfaces, default runtime, in-memory provider, CI for `HoneyDrunk.Evals` but cannot be filed against a repo that does not exist. Surfaces this as Wave-2 human-only work.
+
+## Steps
+
+### Step 1 — Create repo (portal)
+
+1. https://github.com/organizations/HoneyDrunkStudios/repositories/new
+2. **Repository name:** `HoneyDrunk.Evals`
+3. **Description:** `Evaluation and quality substrate for the AI sector — runs suites of cases against targets (chat, agent, retrieval, memory-backed workflows), scores outputs against rubrics, produces structured durable EvalReports with full run provenance. Pinned router-bypass through IEvalTarget for regression-grade model comparison.`
+4. **Visibility:** Public.
+5. **Initialize with:**
+   - [x] Add a README file
+   - [x] `.gitignore` → `VisualStudio` template
+   - [x] License — match `HoneyDrunk.Auth/LICENSE` shape
+6. Click **Create repository**
+7. Apply org defaults:
+   - Branch protection on `main` (mirror `HoneyDrunk.Auth`): PR required, `pr-core / core` required (canary added post-merge), no force pushes, no deletions
+   - Default branch `main`
+   - Actions enabled
+
+### Step 2 — Seed labels
+
+```bash
+for label in "feature:0E8A16" "chore:CCCCCC" "tier-1:E99695" "tier-2:FBCA04" "ai:D946EF" "scaffold:BFDADC" "adr-0023:1D76DB" "wave-3:FBCA04" "human-only:B60205" "out-of-band:D4C5F9" "new-node:C5DEF5"; do
+  name="${label%:*}"; color="${label#*:}"
+  gh label create "$name" --repo HoneyDrunkStudios/HoneyDrunk.Evals --color "$color" 2>/dev/null
+done
+```
+
+### Step 3 — Clone locally
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/
+git clone https://github.com/HoneyDrunkStudios/HoneyDrunk.Evals.git
+cd HoneyDrunk.Evals
+git status
+ls
+```
+
+Confirm `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Evals/` exists with `.gitignore`, `LICENSE`, `README.md`.
+
+### Step 4 — OIDC federated credential
+
+Cross-link: [`infrastructure/walkthroughs/oidc-federated-credentials.md`](../../../../infrastructure/walkthroughs/oidc-federated-credentials.md).
+
+Confirm `repo:HoneyDrunkStudios/HoneyDrunk.Evals:ref:refs/tags/v*` in the NuGet publishing identity's federated credential list. Add via Azure portal if missing.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunkStudios/HoneyDrunk.Evals` exists, is Public, default branch `main`.
+- [ ] Branch protection on `main` requires `pr-core / core`, no force pushes, no deletions.
+- [ ] Labels seeded.
+- [ ] Local working tree at `c:/.../HoneyDrunkStudios/HoneyDrunk.Evals/` exists with `.gitignore`, `LICENSE`, `README.md`.
+- [ ] OIDC federated credential verified.
+- [ ] Chore issue closed.
+
+## Human Prerequisites
+- [ ] Org-admin role on `HoneyDrunkStudios`
+- [ ] Browser logged in as org owner
+- [ ] `gh` CLI authenticated as org owner
+- [ ] Azure portal access if Step 4 needs work
+
+## Dependencies
+- `packet:01`
+
+## Downstream Unblocks
+- `04-evals-node-scaffold.md` — fileable after this chore is Done AND packet 02 has merged.
+
+## Referenced ADR Decisions
+
+**ADR-0023 D1 / D2:** Evals is the evaluation and quality substrate. New Node ⇒ new repo per invariant 11.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node.
+
+> **Invariant 24:** Pre-filing amendments to packet 04 permitted if invariant numbers shift in packet 02.
+
+## Labels
+`chore`, `tier-1`, `meta`, `ai`, `adr-0023`, `human-only`, `wave-2`, `new-node`
+
+## Notes
+- ~5-minute portal task + a single `git clone`.
+- Do not commit anything to the local clone — scaffolding agent in packet 04 authors all source files.
+- No Azure provisioning required. HoneyDrunk.Evals is a library Node.

--- a/generated/issue-packets/active/adr-0023-evals-standup/04-evals-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0023-evals-standup/04-evals-node-scaffold.md
@@ -1,0 +1,406 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Evals
+labels: ["feature", "tier-2", "ai", "scaffold", "adr-0023", "new-node"]
+dependencies: ["packet:01", "packet:02", "packet:03"]
+adrs: ["ADR-0023", "ADR-0016", "ADR-0018"]
+accepts: ADR-0023
+wave: 3
+initiative: adr-0023-evals-standup
+node: honeydrunk-evals
+---
+
+# Feature: Stand up the HoneyDrunk.Evals repo — solution, three packages, six surfaces, CI, InMemory provider
+
+## Summary
+
+Bring the newly-created `HoneyDrunk.Evals` repo from zero to first-shippable per ADR-0023. Land the solution, three packages (`Abstractions`, runtime, `Providers.InMemory`), six D3 surfaces in `HoneyDrunk.Evals.Abstractions` (four interfaces + two records), default runtime implementations including a `ChatTarget` shape with the router-bypass primitive per D6, a default `IEvalScorer` set (rubric scorers + model-as-judge scorer composing `IChatClient`), Operator-composition observation-only scoring per D7, `Providers.InMemory` backend for `EvalReport` persistence + suite fixtures, the standard CI pipeline, and the contract-shape canary scoped to Abstractions per D14 (number assigned by packet 02).
+
+Unblocks Agents (agent-behavior suites), Knowledge (retrieval-quality suites), Memory (memory-workflow suites), Flow (workflow-level suites), Sim, Lore, HoneyHub when live.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Evals`
+
+## Motivation
+
+ADR-0023 establishes Evals's contract surface. Repo created in packet 03 (LICENSE + README only). Seven downstream consumers blocked.
+
+## Proposed Implementation
+
+### Repository layout
+
+```
+HoneyDrunk.Evals/
+├── HoneyDrunk.Evals.slnx
+├── Directory.Build.props
+├── CHANGELOG.md
+├── README.md
+├── .editorconfig
+├── .gitignore
+├── .github/workflows/{pr-core,release,nightly-deps,nightly-security,api-compatibility}.yml
+├── src/
+│   ├── HoneyDrunk.Evals.Abstractions/
+│   │   ├── HoneyDrunk.Evals.Abstractions.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── IEvaluator.cs
+│   │   ├── IEvalScorer.cs
+│   │   ├── IEvalSuite.cs
+│   │   ├── IEvalTarget.cs
+│   │   ├── EvalCase.cs
+│   │   └── EvalReport.cs
+│   ├── HoneyDrunk.Evals/
+│   │   ├── HoneyDrunk.Evals.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── ServiceCollectionExtensions.cs
+│   │   ├── Orchestration/DefaultEvaluator.cs
+│   │   ├── Targets/ChatTarget.cs              (D6 router-bypass primitive)
+│   │   ├── Scoring/AutomatedRubricScorer.cs
+│   │   ├── Scoring/ModelAsJudgeScorer.cs       (composes IChatClient)
+│   │   ├── ObserverScoring/SafetyFilterObserver.cs    (D7 observation-only)
+│   │   ├── ObserverScoring/CostGuardObserver.cs       (D7 observation-only)
+│   │   ├── ObserverScoring/AuditLogObserver.cs        (D7 observation-only)
+│   │   └── Telemetry/EvalsTelemetry.cs                 (D10 content carve-out)
+│   └── HoneyDrunk.Evals.Providers.InMemory/
+│       ├── HoneyDrunk.Evals.Providers.InMemory.csproj
+│       ├── README.md
+│       ├── CHANGELOG.md
+│       ├── InMemoryReportStore.cs                       (EvalReport persistence)
+│       └── InMemorySuiteRepository.cs                   (suite fixture persistence)
+└── tests/
+    ├── HoneyDrunk.Evals.Abstractions.Tests/
+    ├── HoneyDrunk.Evals.Tests/
+    └── HoneyDrunk.Evals.Providers.InMemory.Tests/
+```
+
+### Contract details — `HoneyDrunk.Evals.Abstractions`
+
+```csharp
+// IEvaluator.cs
+namespace HoneyDrunk.Evals.Abstractions;
+
+public interface IEvaluator
+{
+    Task<EvalReport> RunAsync(IEvalSuite suite, IEvalTarget target, IReadOnlyList<IEvalScorer> scorers, CancellationToken cancellationToken = default);
+}
+```
+
+```csharp
+// IEvalScorer.cs
+public interface IEvalScorer
+{
+    string ScorerName { get; }
+    bool IsDeterministic { get; }
+    Task<EvalScore> ScoreAsync(EvalCase testCase, string targetOutput, CancellationToken cancellationToken = default);
+}
+
+public sealed record EvalScore(string ScorerName, double Score, string? Detail, IReadOnlyDictionary<string, string> Tags);
+```
+
+```csharp
+// IEvalSuite.cs
+public interface IEvalSuite
+{
+    string SuiteId { get; }
+    string SuiteVersion { get; }
+
+    /// <summary>
+    /// D10 carve-out flag. <c>true</c> means eval-signal telemetry strips content (metadata only);
+    /// <c>false</c> means content (case inputs, target outputs) MAY ride on telemetry payloads.
+    /// </summary>
+    /// <remarks>
+    /// Follow-up: this boolean is intentionally first-pass (S1). It is expected to evolve to an enum
+    /// (e.g. <c>SensitivityClassification</c> with values None / PII / Regulated / Internal-Only) once a
+    /// downstream consumer drives a concrete need for graded sensitivity. The contract-shape canary
+    /// scoped to <c>IEvalSuite</c> per D14 will catch the shape drift on that evolution and require a
+    /// version bump.
+    /// </remarks>
+    bool IsSensitive { get; }
+    Task<IReadOnlyList<EvalCase>> GetCasesAsync(CancellationToken cancellationToken = default);
+    Task<RubricSpec> GetRubricAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed record RubricSpec(IReadOnlyList<string> RequiredScorers, IReadOnlyDictionary<string, double> ScorerWeights);
+```
+
+```csharp
+// IEvalTarget.cs (D6 router-bypass)
+using HoneyDrunk.AI.Abstractions;        // ModelCapabilityDeclaration — per ADR-0023 D2 / D5
+
+public interface IEvalTarget
+{
+    string TargetId { get; }
+    ModelCapabilityDeclaration? PinnedModelCapability { get; }    // D6 — non-null when target pins a model. Typed reference into AI's contract.
+    Task<string> InvokeAsync(EvalCase testCase, CancellationToken cancellationToken = default);
+}
+```
+
+```csharp
+// EvalCase.cs (record)
+using HoneyDrunk.Kernel.Abstractions;      // TenantId strong type — per ADR-0026 multi-tenant alignment
+
+public sealed record EvalCase
+{
+    public required string CaseId { get; init; }
+    public required string SuiteVersion { get; init; }
+    public required string InputJson { get; init; }
+    public string? ExpectedOutputJson { get; init; }
+    public string? RubricCriteriaJson { get; init; }
+    public required IReadOnlyDictionary<string, string> Tags { get; init; }
+
+    // I3 — strong-typed multi-tenant identity per ADR-0026. Defaults to TenantId.Internal so a single-tenant suite
+    // does not need to plumb it. Carried onto the case so per-tenant regression analysis (e.g. "did model X regress
+    // on tenant Y's suite but not tenant Z's") is expressible without rebinding cases between tenants.
+    public TenantId TenantId { get; init; } = TenantId.Internal;
+}
+```
+
+```csharp
+// EvalReport.cs (record — D12 / D13)
+using HoneyDrunk.AI.Abstractions;          // ModelCapabilityDeclaration — per ADR-0023 D2 / D5
+using HoneyDrunk.Kernel.Abstractions;      // TenantId strong type — per ADR-0026 multi-tenant alignment
+
+public sealed record EvalReport
+{
+    public required string ReportId { get; init; }
+    public required string SuiteId { get; init; }
+    public required string SuiteVersion { get; init; }
+    public required string TargetId { get; init; }
+
+    // D6 — when the target pinned a model, capture the typed declaration on the report. Null when no pin was applied.
+    public ModelCapabilityDeclaration? PinnedModelCapability { get; init; }
+
+    // I3 — strong-typed multi-tenant identity per ADR-0026. Defaults to TenantId.Internal so single-tenant callers do not need to plumb it.
+    public TenantId TenantId { get; init; } = TenantId.Internal;
+
+    public required DateTimeOffset StartedAt { get; init; }
+    public required DateTimeOffset CompletedAt { get; init; }
+    public required IReadOnlyList<string> ScorerSet { get; init; }
+    public required IReadOnlyList<EvalCaseResult> CaseResults { get; init; }
+    public required EvalReportSummary Summary { get; init; }
+}
+
+public sealed record EvalCaseResult(string CaseId, string TargetOutput, IReadOnlyList<EvalScore> Scores, ObservedOperatorPrediction? OperatorObservations);
+
+public sealed record EvalReportSummary(double AggregateScore, int CaseCount, int PassedCount, int FailedCount);
+
+/// <summary>
+/// Observation-only Operator signals captured during a case run (D7).
+/// Each property is nullable to distinguish two distinct states:
+///   - <c>null</c> means the corresponding observer was not wired into the host's composition (e.g. Operator unavailable, observer not registered, or this target did not flow through that signal path).
+///   - non-null means the observer ran and recorded the value (including <c>false</c> / <c>0</c> as a meaningful observation).
+/// </summary>
+/// <param name="SafetyFilterFired">
+/// <c>true</c> when <see cref="ISafetyFilter"/> would have fired on the target output; <c>false</c> when it ran and did not fire; <c>null</c> when the safety-filter observer was not wired.
+/// </param>
+public sealed record ObservedOperatorPrediction(bool? SafetyFilterFired, decimal? CostMarker, bool? ApprovalWouldBeRequired);
+```
+
+`HoneyDrunk.Evals.Abstractions` references `Microsoft.Extensions.*` abstractions plus two Abstractions packages that ADR-0023 D2 explicitly permits: `HoneyDrunk.Kernel.Abstractions` (for the `TenantId` strong type per I3 / ADR-0026) and `HoneyDrunk.AI.Abstractions` (for `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, and `ModelCapabilityDeclaration` — see D2 line 59 and D5). The transitive compile-time edge into `HoneyDrunk.AI.Abstractions` is accepted and matches the pattern ADR-0020 D5 / ADR-0021 D5 / ADR-0022 D5 established for prior AI-sector stand-ups. Invariant 1 (no runtime dependencies on non-Abstractions HoneyDrunk packages) is satisfied — only the upstream `Abstractions` siblings are referenced, never `HoneyDrunk.Kernel`, `HoneyDrunk.AI`, or any runtime package.
+
+**Typed identity stance.** `IEvalTarget.PinnedModelCapability` is typed (`ModelCapabilityDeclaration?`) per D6. `EvalReport.PinnedModelCapability` is typed (`ModelCapabilityDeclaration?`) per D12 + D6. Multi-tenant fields on `EvalReport` and `EvalCase` use the strong `TenantId` from Kernel.Abstractions per ADR-0026 — string-typing those would cost the cross-Node strong-typing pattern.
+
+**First-pass shape.** Member sets subject to evolution before v0.2.0 baseline lock. Canary catches breaking changes.
+
+### Runtime details — `HoneyDrunk.Evals`
+
+`HoneyDrunk.Evals` references:
+- `HoneyDrunk.Evals.Abstractions` (project)
+- `HoneyDrunk.Kernel` (telemetry, context)
+- `HoneyDrunk.AI` (`IChatClient` for `ChatTarget` + model-as-judge scorer; `IModelProvider` + `ModelCapabilityDeclaration` for `ChatTarget` pinning per D6)
+- `HoneyDrunk.Operator` (`ISafetyFilter`, `ICostGuard`, `IAuditLog` per D7 — conditional on the ADR-0030/0031 audit relocation)
+- `Microsoft.Extensions.*` (DI, Hosting, Logging)
+
+Default implementations:
+
+- **`DefaultEvaluator`** — orchestrates: gets cases from suite, invokes target per case, runs scorer set, builds `EvalReport` with full provenance (D12). Persists via `Providers.InMemory` at stand-up.
+- **`ChatTarget`** — wraps `IChatClient`. Pins a `ModelCapabilityDeclaration` (or null for router-managed). Per D6, when pinned, the target resolves `IModelProvider` (from `HoneyDrunk.AI.Abstractions`, sourced through the host's DI container the same way AI's runtime package resolves providers) for the specific declaration and bypasses the router. The boundary check is intact: `IModelProvider` is an AI-Abstractions surface, `HoneyDrunk.Evals` runtime references `HoneyDrunk.AI` per the table below, and `HoneyDrunk.Evals.Abstractions` references `HoneyDrunk.AI.Abstractions` (where `ModelCapabilityDeclaration` lives) per D2. Pinning is recorded on every `EvalReport`.
+- **`AutomatedRubricScorer`** — regex, schema validation, exact-match scoring against `EvalCase.ExpectedOutputJson` / `RubricCriteriaJson`. Marked `IsDeterministic: true`.
+- **`ModelAsJudgeScorer`** — composes `IChatClient` to evaluate output against rubric. Marked `IsDeterministic: false`.
+- **`SafetyFilterObserver` / `CostGuardObserver` / `AuditLogObserver`** — per D7, composes Operator primitives as observation-only inputs. Records what the filter would do, what the cost would be, whether approval would be required — without invoking Operator's enforcement path.
+- **`EvalsTelemetry`** — emits per-suite-run / per-case-result / per-regression activities. **Content carve-out per D10:** if `suite.IsSensitive` is `false`, activity payloads MAY include the case input, target output, expected output. If `suite.IsSensitive` is `true`, payloads contain metadata only.
+
+### Providers.InMemory details
+
+- `InMemoryReportStore` — in-memory dictionary of `EvalReport` keyed by `ReportId`. Persists for the lifetime of the process. **`EvalReport` durability principle** (D13) — production hosts swap in a real store; in-memory satisfies the contract.
+- `InMemorySuiteRepository` — in-memory dictionary of `IEvalSuite` for tests / fixtures.
+
+### CI workflows
+
+Five files; `api-compatibility.yml` path-filtered to `src/HoneyDrunk.Evals.Abstractions/**`.
+
+### `HoneyDrunk.Standards`
+
+Per invariant 26.
+
+### Documentation
+
+Repo README — purpose, package matrix, "How to consume" snippet with `AddHoneyDrunkEvals()` + `AddChatTarget()` example, link to ADR-0023. Note the eval-signal content carve-out (D10) and the router-bypass primitive (D6). Per-package README + CHANGELOG.
+
+## Affected Files
+Entire repo. See layout.
+
+## NuGet Dependencies
+
+### `HoneyDrunk.Evals.Abstractions.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | `TenantId` strong type per ADR-0026 / I3. |
+| `HoneyDrunk.AI.Abstractions` | `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, `ModelCapabilityDeclaration` — per ADR-0023 D2 (line 59) and D5. Transitive compile-time edge accepted, matches ADR-0020 / 0021 / 0022 D5 pattern. |
+| `Microsoft.Extensions.*` abstractions | Standard. |
+
+(No runtime HoneyDrunk packages. Invariant 1 satisfied — only upstream `Abstractions` siblings referenced.)
+
+### `HoneyDrunk.Evals.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel` | Telemetry, context |
+| `HoneyDrunk.AI` | `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, `ModelCapabilityDeclaration` |
+| `HoneyDrunk.Operator` | `ISafetyFilter`, `ICostGuard`, `IAuditLog` — conditional |
+| `Microsoft.Extensions.*` (DI/Hosting/Logging) | |
+
+Project reference: `HoneyDrunk.Evals.Abstractions`.
+
+### `HoneyDrunk.Evals.Providers.InMemory.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+
+Project reference: `HoneyDrunk.Evals.Abstractions`. **No reference to runtime / Kernel / AI / Operator.**
+
+### Test projects: standard + NSubstitute.
+
+## Boundary Check
+- [x] `HoneyDrunk.Evals.Abstractions` references only Abstractions-level packages: `HoneyDrunk.Standards`, `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.AI.Abstractions`, and `Microsoft.Extensions.*` — no runtime HoneyDrunk packages (invariant 1; explicitly permitted by ADR-0023 D2 line 59 and D5).
+- [x] `Providers.InMemory` references only `HoneyDrunk.Evals.Abstractions` plus `HoneyDrunk.Standards` (invariant 3).
+- [x] `IEvalTarget` is the router-bypass boundary — no other Node may compose `IModelProvider` directly outside this surface (invariant 72). `ChatTarget` legitimately composes `IModelProvider` through the host DI container because it implements `IEvalTarget` — this is exactly the sanctioned bypass (D6); `HoneyDrunk.Evals` runtime references `HoneyDrunk.AI` (table above) and `IModelProvider` is resolvable, so the path is intact.
+- [x] Operator primitives composed observation-only (invariant 68).
+- [x] `EvalReport` provenance fields populated on every report including typed `PinnedModelCapability` (invariant 69).
+- [x] `EvalReport` is durable (invariant 70 — at stand-up via `Providers.InMemory`).
+- [x] Content-carve-out flag honored (invariant 71).
+- [x] Multi-tenant identity uses Kernel's `TenantId` strong type per ADR-0026 (I3 cross-cutting alignment with Memory).
+- [x] Records drop `I`; interfaces keep it.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Evals.slnx` builds clean.
+- [ ] Six D3 surfaces present in Abstractions with XML docs.
+- [ ] `HoneyDrunk.Evals.Abstractions` PackageReference set is exactly: `HoneyDrunk.Standards`, `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.AI.Abstractions`, `Microsoft.Extensions.*` abstractions. No runtime HoneyDrunk package referenced. `IEvalTarget.PinnedModelCapability` is typed (`ModelCapabilityDeclaration?`). `EvalReport.PinnedModelCapability` is typed (`ModelCapabilityDeclaration?`). `EvalReport.TenantId` and `EvalCase.TenantId` are the `TenantId` strong type from `HoneyDrunk.Kernel.Abstractions` and default to `TenantId.Internal`.
+- [ ] `Providers.InMemory` references only `HoneyDrunk.Evals.Abstractions` plus `HoneyDrunk.Standards`.
+- [ ] `AddHoneyDrunkEvals()` resolves the four interfaces + default scorer set.
+- [ ] `DefaultEvaluator.RunAsync` builds an `EvalReport` with `SuiteId`, `SuiteVersion`, `TargetId`, `PinnedModelCapability` (the typed declaration when target pins one; null otherwise), `TenantId` (the ambient tenant from the operation context, falling back to `TenantId.Internal`), `StartedAt`/`CompletedAt`, `ScorerSet`. Unit test verifies provenance fields including typed pin and tenant carry-through.
+- [ ] `ChatTarget` wraps `IChatClient`. When `PinnedModelCapability` is non-null, it resolves `IModelProvider` for that capability declaration (router-bypass per D6) and the typed declaration is recorded on the resulting `EvalReport`. Unit test verifies pinning end-to-end and asserts on `report.PinnedModelCapability` equality with the input declaration.
+- [ ] `ModelAsJudgeScorer` composes `IChatClient` and is marked `IsDeterministic: false`. `AutomatedRubricScorer` is marked `IsDeterministic: true`. Unit test verifies.
+- [ ] `SafetyFilterObserver`, `CostGuardObserver`, `AuditLogObserver` each call the corresponding Operator primitive **observation-only** — they record what the primitive *would* do without invoking enforcement. Unit tests verify observation does not produce side effects on Operator's state.
+- [ ] `EvalsTelemetry` emits per-suite / per-case / per-regression activities. **When `suite.IsSensitive == false`, activity payloads MAY include case content** (deliberate carve-out per D10 / invariant 71). **When `suite.IsSensitive == true`, payloads contain only metadata.** Unit test verifies both modes.
+- [ ] `InMemoryReportStore` persists `EvalReport` for the process lifetime; cross-test isolation provided. Unit test verifies round-trip.
+- [ ] `InMemorySuiteRepository` provides suite fixture access. Unit test verifies.
+- [ ] All five `.github/workflows/*.yml` files present.
+- [ ] `api-compatibility.yml` path-filtered to Abstractions; scaffolding PR reports `status: skipped`.
+- [ ] `pr-core.yml` passes.
+- [ ] Repo + per-package `CHANGELOG.md` + `README.md` present.
+- [ ] All `src/*.csproj` Version 0.1.0.
+- [ ] Manual confirmation `v0.1.0` tag triggers `release.yml`.
+- [ ] **No concrete `AgentTarget`, `RetrievalTarget`, `MemoryTarget` in this packet** — deferred per D3.
+- [ ] **No Monte Carlo / N-trial distribution surface** — deferred per D3 / D14.
+- [ ] **No production report store** — only `Providers.InMemory` per D13.
+
+## Human Prerequisites
+- [ ] Packet 03 complete — repo exists, cloned, settings verified.
+- [ ] After merge, push tag `v0.1.0`.
+- [ ] **Upstream Abstractions check.** AI must be available (mandatory — `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, `ModelCapabilityDeclaration`). Operator's `ISafetyFilter`/`ICostGuard`/`IAuditLog` are optional — placeholder no-ops + warnings if missing.
+- [ ] **Branch protection sequencing.** Add `api-compatibility / abstractions-shape` to required checks post-merge.
+- [ ] No Azure provisioning required.
+- [ ] After merge + tag, file SonarCloud onboarding follow-up.
+- [ ] File `AgentTarget`, `RetrievalTarget`, `MemoryTarget` follow-up packets when downstream consumers drive the shape.
+- [ ] File production-report-store follow-up packet (Data, dedicated provider, Pulse-backed) when HoneyHub or a production workflow needs durable storage beyond `Providers.InMemory`.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions plus upstream `*.Abstractions` siblings are permitted. ADR-0023 D2 (line 59) and D5 explicitly permit `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.AI.Abstractions` as runtime references of `HoneyDrunk.Evals.Abstractions`.
+
+> **Invariant 3:** Providers reference parent Node's contracts, not internal implementation details.
+
+> **Invariant 11:** One repo per Node.
+
+> **Invariant 12, 13, 26, 27.** Standard.
+
+> **Evals downstream-coupling invariant (default 67):** Downstream Nodes runtime-depend only on Abstractions.
+
+> **Evals read-only-observer invariant (default 68):** No target mutation from harness side.
+
+> **Evals provenance invariant (default 69):** `EvalReport` records full provenance.
+
+> **Evals durable-not-ephemeral invariant (default 70):** `EvalReport` is durable; Pulse signals are complements, not substitutes.
+
+> **Evals content-carve-out invariant (default 71):** Eval-signal telemetry may carry content unless `IEvalSuite.IsSensitive == true`.
+
+> **Evals router-bypass invariant (default 72):** Bypass permitted only through `IEvalTarget`.
+
+> **Evals contract-shape canary invariant (default 73):** Canary on `IEvaluator`, `IEvalScorer`, `IEvalTarget`, `EvalReport`, and `IEvalSuite` (S1 — `IEvalSuite.IsSensitive` boolean is intentionally first-pass and expected to evolve to an enum; canary catches that drift).
+
+## Referenced ADR Decisions
+
+**ADR-0023 D1:** Evaluation and quality substrate.
+
+**ADR-0023 D2:** Three packages — Abstractions + runtime + Providers.InMemory.
+
+**ADR-0023 D3:** Six surfaces — four interfaces + two records.
+
+**ADR-0023 D5:** AI composition for `ChatTarget` + model-as-judge scorer.
+
+**ADR-0023 D6:** Router bypass via `IEvalTarget`. Pinning recorded on `EvalReport`.
+
+**ADR-0023 D7:** Operator primitives as observation-only scoring signals.
+
+**ADR-0023 D10:** Content carve-out — eval signals MAY carry content unless suite declares sensitive.
+
+**ADR-0023 D12:** `EvalReport` full provenance.
+
+**ADR-0023 D13:** `EvalReport` durable; storage substrate deferred.
+
+**ADR-0023 D14:** Canary on four hot-path surfaces.
+
+**ADR-0016 D3 (referenced):** `IChatClient`, `IEmbeddingGenerator`, `IModelProvider`, `ModelCapabilityDeclaration` from AI.
+
+**ADR-0018 D3 (referenced):** `ISafetyFilter`, `ICostGuard`, `IAuditLog` from Operator (the last per ADR-0030/0031 amendment lives in Audit Node).
+
+## Dependencies
+- `packet:01`, `packet:02`, `packet:03`
+
+## Labels
+`feature`, `tier-2`, `ai`, `scaffold`, `adr-0023`, `new-node`
+
+## Agent Handoff
+
+**Objective:** Ship `HoneyDrunk.Evals 0.1.0` with the six D3 surfaces, default runtime composing AI + Operator, `Providers.InMemory`, CI, canary.
+
+**Target:** HoneyDrunk.Evals, branch from `main`.
+
+**Constraints:**
+- **Invariant 1:** `HoneyDrunk.Evals.Abstractions` may reference `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.AI.Abstractions` per ADR-0023 D2 (line 59) and D5 — those are the upstream Abstractions siblings the contract surface is built on. No runtime HoneyDrunk packages (`HoneyDrunk.Kernel`, `HoneyDrunk.AI`, `HoneyDrunk.Operator`, etc.) may be referenced from `HoneyDrunk.Evals.Abstractions`.
+- **Invariant 3 applied to Providers.InMemory:** References only `HoneyDrunk.Evals.Abstractions` (plus `HoneyDrunk.Standards`).
+- **Invariant 71 (default):** Honor `IEvalSuite.IsSensitive` flag in telemetry — content carved out when sensitive, content included when not. Boolean is intentionally first-pass; an enum evolution is the canary-protected follow-up per S1.
+- **Invariant 72 (default):** `IEvalTarget` is the only router-bypass primitive in the Grid. Sim has a parallel-but-distinct `ISimulationTarget` per ADR-0025 D8; the two do not share types. `ChatTarget` composing `IModelProvider` directly is the sanctioned implementation of this bypass — `IModelProvider` is resolvable because `HoneyDrunk.Evals` runtime references `HoneyDrunk.AI` and `HoneyDrunk.AI.Abstractions`.
+- **Typed identity stance.** `IEvalTarget.PinnedModelCapability` is `ModelCapabilityDeclaration?` (typed; AI-Abstractions surface). `EvalReport.PinnedModelCapability` is `ModelCapabilityDeclaration?`. `EvalReport.TenantId` and `EvalCase.TenantId` are the Kernel-Abstractions `TenantId` strong type, defaulting to `TenantId.Internal` per ADR-0026.
+- **Records drop `I`; interfaces keep it.** `EvalCase`, `EvalReport`, `EvalScore`, `EvalCaseResult`, `EvalReportSummary`, `ObservedOperatorPrediction`, `RubricSpec` are records.
+- **Operator composition is observation-only.** Never call Operator primitives to enforce. `ObservedOperatorPrediction` properties default to `null` to distinguish "observer not wired" from "observer ran and recorded a value" (S2).
+- **No concrete `AgentTarget` / `RetrievalTarget` / `MemoryTarget` in this packet.** `ChatTarget` only.
+- **No Monte Carlo distribution surface.**
+- **Canary skip on scaffolding PR expected.** Canary scope per D14 includes `IEvalSuite` (S1 — to catch the future `IsSensitive` enum evolution) alongside `IEvaluator`, `IEvalScorer`, `IEvalTarget`, and `EvalReport`.
+- **Upstream conditional.** AI Abstractions is mandatory. Kernel Abstractions is mandatory (for `TenantId`). Operator Abstractions optional — placeholder no-ops if missing.
+
+**Key Files:**
+- `HoneyDrunk.Evals.slnx`, `Directory.Build.props`
+- `src/HoneyDrunk.Evals.Abstractions/` — 4 interfaces + 2 records + supporting records
+- `src/HoneyDrunk.Evals/` — `DefaultEvaluator`, `ChatTarget`, scorers, observers, `EvalsTelemetry`, `ServiceCollectionExtensions`
+- `src/HoneyDrunk.Evals.Providers.InMemory/` — `InMemoryReportStore`, `InMemorySuiteRepository`
+- `.github/workflows/*.yml`
+- `README.md`, `CHANGELOG.md` (repo + per-package)
+- `tests/`
+
+**Contracts:** Six D3 surfaces authored fresh.

--- a/generated/issue-packets/active/adr-0023-evals-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0023-evals-standup/dispatch-plan.md
@@ -1,0 +1,82 @@
+# Dispatch Plan — ADR-0023 HoneyDrunk.Evals Standup
+
+**Initiative:** `adr-0023-evals-standup`
+**Sector:** AI
+**Governing ADR:** [ADR-0023 — Stand Up the HoneyDrunk.Evals Node](../../../../adrs/ADR-0023-stand-up-honeydrunk-evals-node.md) (Proposed 2026-04-19; flips to Accepted after merge).
+**Trigger:** ADR-0023 in the Proposed queue. Agents (agent-behavior suites), Knowledge (retrieval-quality), Memory (memory-workflow), Flow (workflow-level), Sim, Lore, HoneyHub when live all need a shared evaluation substrate.
+**Type:** Multi-repo (3 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.Evals` creation chore + `HoneyDrunk.Evals` scaffold)
+**Site sync required:** No.
+**Rollback plan:** Pre-tag revert; post-tag fix-forward.
+
+## Summary
+
+ADR-0023 is the standup ADR for `HoneyDrunk.Evals`. Owns evaluation primitives — `IEvaluator`, `IEvalScorer`, `IEvalSuite`, `IEvalTarget`, `EvalCase`, `EvalReport`. **Six surfaces, four interfaces + two records, reconciles three-way drift** between `contracts.json` (three interfaces with wrong names), `relationships.json` (four interfaces with wrong types), repo overview (same four with wrong types). The D3 definitive set lands here.
+
+Three packages (`Abstractions`, runtime, `Providers.InMemory`). Composes AI (`IChatClient` + `IEmbeddingGenerator` + `IModelProvider` + `ModelCapabilityDeclaration` for `ChatTarget` + model-as-judge scorer) per D5. Composes Operator (`ISafetyFilter`, `ICostGuard`, `IAuditLog`) as observation-only scoring signals per D7. Router-bypass through `IEvalTarget` per D6 — `IEvalTarget` pins `ModelCapabilityDeclaration` for reproducible regression testing. Content-in-telemetry **carve-out** per D10 (eval signals may carry prompts and outputs unless the suite declares sensitive — deliberate carve-out from Knowledge/Memory's no-content rule for regression diagnosis). `EvalReport` durable per D13 (storage substrate deferred). Canary on four hot-path surfaces per D14.
+
+**The `HoneyDrunk.Evals` repo does NOT exist on GitHub yet.** A human-only **create + clone** chore is required (pattern matches ADR-0017 packet 03).
+
+Four packets land the work:
+
+1. **Architecture catalog registration + integration-points** — RECONCILE three-way drift: rename `IEvalRunner` → `IEvaluator`; rename `IEvalDataset` → `IEvalSuite`; promote `IEvalReport` → `EvalReport` record; add `EvalCase` record; add `IEvalTarget` interface. Update `relationships.json` to widen `consumes` (add Kernel, Agents, Capabilities, Operator, Knowledge, Memory; widen AI `consumes_detail`); update `exposes.contracts` to the D3 six-surface set. Reconcile `nodes.json` `roadmap_focus`. Refresh `grid-health.json`. Align `repos/HoneyDrunk.Evals/overview.md` (the Architecture-side repo doc; the GitHub repo does not exist yet). Align `constitution/ai-sector-architecture.md` Evals section. Add `integration-points.md` and `active-work.md` under `repos/HoneyDrunk.Evals/`.
+2. **Constitution invariants** — seven new invariants from D8, D11, D12, D13, D10, D6, D14.
+3. **Create the `HoneyDrunk.Evals` GitHub repo (human-only)** — org-admin action. Same pattern as `adr-0017-capabilities-standup/03-architecture-create-capabilities-repo.md` — but ALSO clones it locally so packet 04 has a working tree.
+4. **HoneyDrunk.Evals scaffold** — empty repo to first-shippable. Solution, three packages (`Abstractions`, runtime, `Providers.InMemory`), four interfaces + two records, default runtime with `ChatTarget` shape (router-bypass), `Providers.InMemory` backend for `EvalReport` persistence + suite fixtures, five CI workflow files with canary scoped to Abstractions.
+
+## Wave Diagram
+
+```
+Wave 1: Architecture catalog + constitution updates (parallel)
+   ├─ Architecture: 01-architecture-evals-catalog-registration
+   └─ Architecture: 02-architecture-evals-invariants
+       Blocked by: 01
+
+Wave 2: Create + clone repo (human)
+   └─ Architecture: 03-architecture-create-evals-repo
+       Blocked by: 01
+
+Wave 3: Evals repo scaffold
+   └─ HoneyDrunk.Evals: 04-evals-node-scaffold
+       Blocked by: 01, 02, 03
+```
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 01 | [Catalog registration + three-way drift reconciliation + integration-points](./01-architecture-evals-catalog-registration.md) | Architecture | 1 | Agent | — |
+| 02 | [Add seven new invariants for D8 / D11 / D12 / D13 / D10 / D6 / D14](./02-architecture-evals-invariants.md) | Architecture | 1 | Agent | 01 |
+| 03 | [Create `HoneyDrunk.Evals` GitHub repo + clone locally (human-only)](./03-architecture-create-evals-repo.md) | Architecture | 2 | Human | 01 |
+| 04 | [Stand up `HoneyDrunk.Evals` — solution, three packages, six surfaces, CI, InMemory provider](./04-evals-node-scaffold.md) | HoneyDrunk.Evals | 3 | Agent | 01, 02, 03 |
+
+## Filing-order rule
+
+Packet 04 hard-codes invariant numbers. **Packet 02 must merge first.** Packet 03 must close (repo exists) before packet 04 can be filed. Pre-filing amendment to packet 04 source permitted under invariant 24.
+
+**Packet 04 cannot be filed before packet 03 is closed** — `file-packets.sh` cannot create an issue on a repo that does not exist.
+
+## What This Initiative Does **NOT** Deliver
+
+- Downstream consumers not delivered.
+- Concrete `IEvalTarget` shapes (`AgentTarget`, `RetrievalTarget`, `MemoryTarget`) deferred to follow-up packets per D3.
+- `EvalReport` durable-storage **substrate** deferred per D13 (durability *principle* pinned; substrate choice — Data, Pulse-backed, dedicated provider — follows when a real production consumer drives shape).
+- Pulse signal ingress deferred (emit-only per D10).
+- Monte Carlo / N-trial distribution surfaces deferred per scaffold (D3 / D14).
+- Sensitivity-flag concrete shape on `IEvalSuite` is a scaffold decision (carve-out principle pinned at ADR).
+- No separate `HoneyDrunk.Evals.Testing` — `Providers.InMemory` plays that role per D2.
+
+## AI-sector standup wave sequencing
+
+Evals composes AI + Agents + Capabilities + Operator + Knowledge + Memory at the runtime level. Recommended order: AI → Capabilities → Operator → Knowledge + Memory → Agents → **Evals** + Flow → Sim. Evals's packet 04 cannot compile if any upstream Abstractions is missing — placeholder no-ops + follow-up packets bridge the gap.
+
+## Status flip
+
+ADR-0023 stays Proposed for duration.
+
+## Filing
+
+`file-packets.yml` auto-files. Packet 04 filing is gated on packet 03's repo creation (handled by the Next-Steps script inside packet 03).
+
+## Archival
+
+Per ADR-0008 D10, archive post-completion.


### PR DESCRIPTION
## Summary

Scopes four packets standing up `HoneyDrunk.Evals` per [ADR-0023](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0023-stand-up-honeydrunk-evals-node.md) — the AI sector's evaluation and quality substrate. Closes ADR-0016 D3's router-bypass follow-through via `IEvalTarget`. Claims invariants **67–73**.

### Wave 1 — Architecture-repo (parallel)
- **`01-catalog-registration`** — resolves three-way contract drift between `contracts.json` / `relationships.json` / repo overview; tightened `IEvalReport` regex to `\bIEvalReport\b` word-boundary; `rg` sweep over `repos/HoneyDrunk.Evals/**` catches stale `IEvalDataset` refs; nodes.json AI block records ADR-0016 D3 resolution via ADR-0023 D6.
- **`02-invariants`** — seven new constitution invariants (default 67–73) under `## AI Sector — Evals Invariants`. Includes router-bypass via `IEvalTarget`, content carve-out (eval signals may carry prompts/outputs unless suite declares sensitivity), `IEvalSuite` added to canary scope (five surfaces).
- **`03-create-evals-repo`** — human-only create-repo + clone chore. Evals repo doesn't exist yet.

### Wave 2 — Evals scaffold
- **`04-evals-node-scaffold`** — three packages, four frozen interfaces (`IEvaluator`, `IEvalScorer`, `IEvalSuite`, `IEvalTarget`), two records (`EvalCase`, `EvalReport`).

## Key surface decisions
- **ADR-0023 D2 honored**: `HoneyDrunk.Evals.Abstractions` references `HoneyDrunk.AI.Abstractions` (transitive `IEmbeddingGenerator`/`IChatClient`/`IModelProvider`/`ModelCapabilityDeclaration` deps).
- **`IEvalTarget.PinnedModelCapability`** typed as `ModelCapabilityDeclaration?` (not `string`).
- **`EvalReport.TenantId`** uses Kernel.Abstractions strong type per ADR-0026 — enables multi-tenant regression analysis.

## Conventions
- NuGet uses `.Abstractions` throughout (invariant 2).
- Records drop `I` (`EvalCase`, `EvalReport`); interfaces keep `I`.
- Each packet carries `accepts: ADR-0023`.

## Test plan
- [ ] After merge, four issues file with dependency edges
- [ ] Human chore (packet 03) creates the GitHub repo
- [ ] Wave 2 scaffold packet stays blocked until packets 01, 02, 03 close
- [ ] When all four close, hive-sync auto-flips ADR-0023 Proposed → Accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)