### PR TITLE
chore: scope ADR-0024 flow node standup

### DIFF
--- a/generated/issue-packets/active/adr-0024-flow-standup/01-architecture-flow-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0024-flow-standup/01-architecture-flow-catalog-registration.md
@@ -1,0 +1,226 @@
+---
+name: Architecture Catalog Registration
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0024"]
+dependencies: []
+adrs: ["ADR-0024", "ADR-0019"]
+accepts: ADR-0024
+wave: 1
+initiative: adr-0024-flow-standup
+node: honeydrunk-flow
+---
+
+# Chore: Register HoneyDrunk.Flow's standup decisions in Architecture catalogs + reconcile three-way drift
+
+## Summary
+
+Reflect ADR-0024 in catalogs. **Reconcile three-way drift** between `contracts.json` (three interfaces: `IWorkflow`, `IWorkflowEngine`, `IWorkflowStep`), `relationships.json` `exposes.contracts` (five interfaces), and repo overview (five interfaces). Land the D3 five-interface definitive set: `IWorkflowEngine`, `IWorkflow`, `IWorkflowStep`, `IWorkflowState`, `ICompensation`. No records at stand-up.
+
+Add `honeydrunk-operator` and `honeydrunk-communications` to `consumes` per D7 / D8 (runtime-only edges; `Abstractions` does not transit them — D2). Add `honeydrunk-sim` and `honeydrunk-evals` to `consumed_by_planned` per D4. Coordinate bidirectional Flow ↔ Communications edge with ADR-0019 D10. Update `grid-health.json`. Align `repos/HoneyDrunk.Flow/{overview,boundaries,invariants}.md` and AI sector doc to D3 + D4. Add `integration-points.md` and `active-work.md`.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+Drift items:
+
+1. **`contracts.json`** lists `IWorkflow`, `IWorkflowEngine`, `IWorkflowStep`. Add `IWorkflowState`, `ICompensation` per D3.
+2. **`relationships.json` `consumes`** lists `["honeydrunk-kernel", "honeydrunk-agents", "honeydrunk-data", "honeydrunk-transport"]`. Add `honeydrunk-operator`, `honeydrunk-communications` per D7 / D8.
+2a. **`relationships.json` `consumes_detail.honeydrunk-kernel`** currently reads `["IGridContext", "IStartupHook", "HoneyDrunk.Kernel"]` (line 287) — drift. Correct the package suffix to `HoneyDrunk.Kernel.Abstractions` per ADR-0024 D2, which explicitly permits Kernel Abstractions on Flow's Abstractions edge.
+3. **`relationships.json` `consumed_by_planned`** missing `honeydrunk-sim` and `honeydrunk-evals`.
+4. **ADR-0019 D10** pinned Communications-side "Communications planned as consumed by Flow." This ADR pins Flow's reciprocal at the runtime level. Both sides of the edge must be coherent.
+5. **`grid-health.json`** stub. Refresh.
+6. **Repo docs** may have minor drift; align to D3 + D4.
+
+## Proposed Implementation
+
+### `catalogs/contracts.json` — `honeydrunk-flow` block
+
+Replace existing three-interface seed with five interfaces:
+
+```json
+{
+  "node": "honeydrunk-flow",
+  "node_name": "HoneyDrunk.Flow",
+  "package": "HoneyDrunk.Flow.Abstractions",
+  "status": "seed",
+  "interfaces": [
+    { "name": "IWorkflowEngine", "kind": "interface", "description": "Top-level orchestration surface — start, pause, resume, cancel, compensate, query workflow instance status. The per-instance engine lifecycle entry point. ADR-0024 D3." },
+    { "name": "IWorkflow", "kind": "interface", "description": "A named, versioned workflow definition — its steps, transitions, compensation mapping, metadata. Declarative; describes the pipeline shape. ADR-0024 D3." },
+    { "name": "IWorkflowStep", "kind": "interface", "description": "A single unit of work — execute, compensate, retry-policy declaration. Steps may invoke agents, call tools, wait for external events, or emit messages. ADR-0024 D3." },
+    { "name": "IWorkflowState", "kind": "interface", "description": "Persistent state for a running workflow instance — current step, step outputs carried forward, checkpoints, compensation log, correlation identity, causation chain. The durable between-step data. ADR-0024 D3 / D12 (durable per principle; storage substrate deferred to scaffold)." },
+    { "name": "ICompensation", "kind": "interface", "description": "Rollback logic for a failed step — declared alongside a step's forward execution and invoked in reverse order when the workflow fails or is cancelled after the step completed. ADR-0024 D3 / D6 (orchestration-based)." }
+  ]
+}
+```
+
+No records at stand-up per D3.
+
+### `catalogs/relationships.json` — `honeydrunk-flow` block
+
+**(a) `consumes`.** Add `honeydrunk-operator` and `honeydrunk-communications`:
+
+```json
+"consumes": ["honeydrunk-kernel", "honeydrunk-agents", "honeydrunk-data", "honeydrunk-transport", "honeydrunk-operator", "honeydrunk-communications"]
+```
+
+**(b) `consumes_detail`.** Correct the existing Kernel entry (drift fix) and add new edges:
+
+```json
+"honeydrunk-kernel": ["IGridContext", "IStartupHook", "HoneyDrunk.Kernel.Abstractions"],
+"honeydrunk-operator": ["IApprovalGate", "ICircuitBreaker", "ICostGuard", "IAuditLog", "HoneyDrunk.Operator.Abstractions"],
+"honeydrunk-communications": ["ICommunicationOrchestrator", "HoneyDrunk.Communications.Abstractions"]
+```
+
+(`honeydrunk-kernel` previously read `HoneyDrunk.Kernel`; corrected to `HoneyDrunk.Kernel.Abstractions` per ADR-0024 D2. `honeydrunk-agents`, `honeydrunk-data`, `honeydrunk-transport` keep current detail.)
+
+(Note: `IAuditLog` is a **transitional Operator binding** at v0.1.0. Rotates to `HoneyDrunk.Audit.Abstractions` after Audit Node stand-up ships per ADR-0031 — separate follow-up packet against Flow. The catalog edge stays on `honeydrunk-operator` for v0.1.0; a future packet flips it.)
+
+**(c) `consumed_by_planned`.** Add `honeydrunk-sim` and `honeydrunk-evals`:
+
+```json
+"consumed_by_planned": ["honeydrunk-lore", "honeydrunk-sim", "honeydrunk-evals", "honeydrunk-honeyhub"]
+```
+
+`consumed_by_planned` is a list of node names only — the existing schema convention does NOT carry `consumes_detail` reverse-records under `consumed_by_planned`. Typed-edge detail (which contracts Sim / Evals / HoneyHub will consume) lives in each consumer's own forward `consumes_detail` block when that consumer's stand-up ADR pins the edge.
+
+**(d) `exposes.contracts`.** Replace with:
+
+```json
+"contracts": ["IWorkflowEngine", "IWorkflow", "IWorkflowStep", "IWorkflowState", "ICompensation"]
+```
+
+**(e) `exposes.packages`.** Replace with:
+
+```json
+"packages": ["HoneyDrunk.Flow.Abstractions", "HoneyDrunk.Flow", "HoneyDrunk.Flow.Providers.InMemory"]
+```
+
+### Bidirectional Flow ↔ Communications edge coordination
+
+Verify `catalogs/relationships.json` `honeydrunk-communications.consumed_by_planned` contains `honeydrunk-flow` per ADR-0019 D10. That single check is the entire bidirectional reconciliation on the Communications side — the existing schema convention does NOT carry `consumes_detail` reverse-records under `consumed_by_planned`. If `honeydrunk-flow` is missing from `honeydrunk-communications.consumed_by_planned`, add it; do not add a reverse `consumes_detail` block.
+
+The Flow-side `consumes_detail.honeydrunk-communications` entry above (`["ICommunicationOrchestrator", "HoneyDrunk.Communications.Abstractions"]`) is the only typed-edge detail; it lives on the Flow side only.
+
+### `catalogs/grid-health.json` — `honeydrunk-flow` block
+
+Standup-aware block naming D3 contracts, scaffold packet as blocker.
+
+### `catalogs/nodes.json` — `honeydrunk-flow` block
+
+Update `grid_relationship` to reflect D4 — explicitly note: no direct `honeydrunk-flow` → `honeydrunk-memory` edge per D9; Memory access flows indirectly through Agents.
+
+### `constitution/ai-sector-architecture.md` — Flow section
+
+Update Key Contracts to five D3 interfaces. Depends-on / Emits-to split:
+
+> `**Depends on:** Kernel (HoneyDrunk.Kernel.Abstractions — IGridContext, IStartupHook), Agents (IAgent from HoneyDrunk.Agents.Abstractions — agent-step composition), Operator (IApprovalGate, ICircuitBreaker, ICostGuard, IAuditLog — synchronous on critical path per D7; IAuditLog is transitional Operator binding pending ADR-0031 Audit relocation), Communications (ICommunicationOrchestrator — runtime-only edge; Abstractions stays clean per D2/D8), Data (IRepository from HoneyDrunk.Data.Abstractions for state persistence), Transport (event-out resume mechanism per D7).`
+>
+> `**Emits to (no runtime dependency):** Pulse (workflow lifecycle, step, compensation, state-persistence telemetry — metadata only per D10).`
+
+Note "No direct Flow → Memory edge" per D9.
+
+### `repos/HoneyDrunk.Flow/{overview,boundaries,invariants}.md`
+
+Align to D3 five-interface set and D4 boundary test. Update any references to absent surfaces. Add Packages-table row for `HoneyDrunk.Flow.Providers.InMemory`.
+
+### `repos/HoneyDrunk.Flow/integration-points.md` — new file
+
+Standard template; reflect D4 (boundary against Agents/Operator/Communications/Memory/Knowledge/Evals/Sim/Lore/Pulse/HoneyHub), D7 (event-out resume), D8 (Communications runtime-only edge), D9 (state boundary including no direct Memory edge).
+
+### `repos/HoneyDrunk.Flow/active-work.md` — new file
+
+### `initiatives/active-initiatives.md` — new entry
+
+Standard format. Note the bidirectional Flow ↔ Communications edge coordination.
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append standard entry naming the drift reconciliation and the new edges.
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+- `catalogs/grid-health.json`
+- `catalogs/nodes.json`
+- `constitution/ai-sector-architecture.md`
+- `repos/HoneyDrunk.Flow/overview.md`
+- `repos/HoneyDrunk.Flow/boundaries.md`
+- `repos/HoneyDrunk.Flow/invariants.md`
+- `repos/HoneyDrunk.Flow/integration-points.md` (new)
+- `repos/HoneyDrunk.Flow/active-work.md` (new)
+- `initiatives/active-initiatives.md`
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] D3 five-interface set canonical.
+- [x] No `honeydrunk-flow → honeydrunk-memory` edge in `consumes` per D9.
+- [x] Communications edge marked as runtime-only (does not transit through Abstractions per D2 / D8).
+- [x] Three-way drift reconciled in single PR.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` `honeydrunk-flow` lists exactly five D3 interfaces.
+- [ ] `catalogs/relationships.json` `honeydrunk-flow.consumes` includes `honeydrunk-operator` and `honeydrunk-communications`. Does NOT include `honeydrunk-memory` per D9.
+- [ ] `consumes_detail` entries per edge.
+- [ ] `consumed_by_planned` includes `honeydrunk-sim` and `honeydrunk-evals`.
+- [ ] `exposes.contracts` matches D3 five-set.
+- [ ] `exposes.packages` includes `HoneyDrunk.Flow.Providers.InMemory`.
+- [ ] Communications-side reciprocal edge is coherent with Flow-side.
+- [ ] `grid-health.json` reflects standup.
+- [ ] `nodes.json` `grid_relationship` reflects D4/D7/D8/D9.
+- [ ] `ai-sector-architecture.md` Flow section reads D3 + D9 (no direct Memory edge).
+- [ ] `repos/HoneyDrunk.Flow/` docs aligned to D3.
+- [ ] `integration-points.md` and `active-work.md` exist.
+- [ ] `initiatives/active-initiatives.md` includes new entry.
+- [ ] `CHANGELOG.md` updated.
+- [ ] ADR-0024 NOT modified — Status stays Proposed.
+
+## Human Prerequisites
+None.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.
+
+> **Invariant 11:** One repo per Node.
+
+## Referenced ADR Decisions
+
+**ADR-0024 D3:** Five interfaces; no records at stand-up.
+
+**ADR-0024 D4:** Boundary decision test.
+
+**ADR-0024 D7:** Operator composition synchronous on critical path; approval-resume event-out.
+
+**ADR-0024 D8:** Communications runtime-only edge; `Abstractions` stays clean.
+
+**ADR-0024 D9:** No direct Flow → Memory edge.
+
+**ADR-0019 D10 (referenced):** Communications-side reciprocal of the Flow ↔ Communications edge.
+
+## Dependencies
+None.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0024`
+
+## Agent Handoff
+
+**Objective:** Reconcile three-way drift. Land D3 five-interface set + new consumes / consumed_by_planned edges. Coordinate Flow ↔ Communications bidirectional edge.
+
+**Constraints:**
+- **D3 is canonical.** Five interfaces, no records at stand-up.
+- **No direct `honeydrunk-flow → honeydrunk-memory` edge.** Per D9, Memory access flows indirectly through Agents.
+- **Communications edge is runtime-only.** Documented in `consumes_detail` but `HoneyDrunk.Flow.Abstractions` does not take a compile-time dependency on `HoneyDrunk.Communications.Abstractions`.
+- **No ADR Status flip.**
+
+**Key Files:** All listed above.
+
+**Contracts:** None authored.

--- a/generated/issue-packets/active/adr-0024-flow-standup/02-architecture-flow-invariants.md
+++ b/generated/issue-packets/active/adr-0024-flow-standup/02-architecture-flow-invariants.md
@@ -1,0 +1,133 @@
+---
+name: Constitution Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0024", "constitution"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0024"]
+accepts: ADR-0024
+wave: 1
+initiative: adr-0024-flow-standup
+node: honeydrunk-flow
+---
+
+# Chore: Add ADR-0024's nine new invariants to the Grid constitution
+
+## Summary
+
+Add nine new invariants from ADR-0024: downstream-coupling (D2/D8), multi-step-coordination-loop-lives-in-Flow-only (D1+D4), Flow-holds-coordination-state-only (D9), no-direct-Flow-Memory-edge (D9), Flow-delegates-outbound-messaging-to-Communications (D8), approval-pause-durable-no-sync-block (D7), `IWorkflowState`-durable-not-ephemeral (D12), Flow-Abstractions-no-Operator-or-Communications-dependency (D2+D8), contract-shape-canary-on-four-hot-paths (D11).
+
+Default numbers **74-82** (assumes prior AI-sector initiatives landed claiming 44-73; collision check decides).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Proposed Implementation
+
+### `constitution/invariants.md` — append nine new entries
+
+```markdown
+## AI Sector — Flow Invariants
+
+74. **Downstream Nodes take a runtime dependency only on `HoneyDrunk.Flow.Abstractions`.**
+    Composition against `HoneyDrunk.Flow` and any `HoneyDrunk.Flow.Providers.*` package is a host-time concern. See ADR-0024 D2, D8 (Proposed — this invariant takes effect when ADR-0024 is accepted).
+
+75. **The multi-step coordination loop lives in `HoneyDrunk.Flow` and nowhere else.**
+    No other AI-sector Node may introduce an equivalent loop of "step 1 → pause → step 2 → human approval → step 3." This parallels the function-calling loop rule in `HoneyDrunk.Agents` per ADR-0020 D12 / invariant 52 — each major coordination loop lives in one Node. See ADR-0024 D1, D4 (Proposed — this invariant takes effect when ADR-0024 is accepted).
+
+76. **Flow holds coordination state only.**
+    Agent state lives on `IAgentExecutionContext` (Agents per ADR-0020 D8); long-term agent memory lives in Memory; audit trail lives in Operator (or Audit per the ADR-0030/0031 amendment); knowledge sources live in Knowledge; outbound message history lives in Communications (and Notify). Flow's `IWorkflowState` records only the pipeline's own shape — current step, step outputs, checkpoints, compensation log, correlation chain. See ADR-0024 D9 (Proposed — this invariant takes effect when ADR-0024 is accepted).
+
+77. **There is no direct `honeydrunk-flow` → `honeydrunk-memory` edge in `catalogs/relationships.json`.**
+    When a workflow step invokes an agent, that agent writes Memory during its own execution — Memory is on Agents's runtime edge, not on Flow's. Adding a direct Flow → Memory edge would either duplicate Memory writes Agents already owns (drift) or give Flow a second Memory-access path that sees scopes Agents does not see (boundary violation). The edge, where it exists functionally, is indirect through Agents. See ADR-0024 D9 (Proposed — this invariant takes effect when ADR-0024 is accepted).
+
+78. **Flow delegates outbound messaging to Communications.**
+    No workflow step invokes `INotificationSender` directly; all message steps compose `ICommunicationOrchestrator` from `HoneyDrunk.Communications.Abstractions`. Channel selection, recipient resolution, preference checking, and cadence policy belong to Communications per ADR-0019. Bypassing Communications would either re-implement those concerns or skip them entirely. See ADR-0024 D8 (Proposed — this invariant takes effect when ADR-0024 is accepted).
+
+79. **Approval-gated workflows pause durably; no synchronous block on `IApprovalGate`.**
+    A `while (!await approvalGate.HasDecision()) { ... }` path kills durable workflow semantics — the blocked thread cannot survive a process restart. The event-out resume pattern is the correct shape: Flow records the pause in `IWorkflowState`, releases the thread, subscribes to the approval-decision event Operator emits per ADR-0018 D8. When the event lands, the engine rehydrates state and resumes from the step after the approval gate. See ADR-0024 D7 (Proposed — this invariant takes effect when ADR-0024 is accepted).
+
+80. **`IWorkflowState` is durable, not ephemeral telemetry.**
+    A workflow that pauses for human approval can wait hours or days; the state must survive process restart, deployment, host failover. Pulse signals record *that* a lifecycle event happened; `IWorkflowState` is the full artifact that resume must rehydrate. The storage substrate is deferred to scaffold per D12; the durability principle is not. See ADR-0024 D12 (Proposed — this invariant takes effect when ADR-0024 is accepted).
+
+81. **`HoneyDrunk.Flow.Abstractions` does not take compile-time dependencies on `HoneyDrunk.Operator.Abstractions` or `HoneyDrunk.Communications.Abstractions`.**
+    Both are runtime-only edges consumed inside the default `HoneyDrunk.Flow` runtime package. Consumers compiling against `HoneyDrunk.Flow.Abstractions` do not inherit Operator or Communications transitively. The Agents `Abstractions` edge IS permitted per D2 because agent-step shapes legitimately need `IAgent`. The split between "agent shape lives in Abstractions" and "Operator / Communications composition lives in runtime" is deliberate and load-bearing for the downstream coupling rule. See ADR-0024 D2, D8 (Proposed — this invariant takes effect when ADR-0024 is accepted).
+
+82. **The HoneyDrunk.Flow Node CI must include a contract-shape canary that fails the build on shape drift to `IWorkflowEngine`, `IWorkflow`, `IWorkflowStep`, or `ICompensation` without a corresponding version bump.**
+    These four are the hot path for every real consumer (Lore wiki, HoneyHub dispatch, application pipelines, Sim read-only, Evals workflow-target). `IWorkflowState` is not in the canary at stand-up because its shape is expected to evolve as the production state store lands and reveals persistence-layer requirements; it becomes a canary candidate later. See ADR-0024 D11 (Proposed — this invariant takes effect when ADR-0024 is accepted).
+```
+
+### Collision check
+
+Default 74-82. Run `rg "^[0-9]+\\." constitution/invariants.md` to enumerate existing numbers; if 74-82 are not free, shift this block to the next free run and update **all** downstream references in lockstep.
+
+**Downstream references to fix on shift** (exact lines in packet 03 source — verify before editing):
+
+In `generated/issue-packets/active/adr-0024-flow-standup/03-flow-node-scaffold.md`:
+- Line 167 — body prose: `(invariant 81)`
+- Line 187 — body prose: `Per D8 / invariant 78`
+- Line 229 — NuGet table: `accepted compile-time transitive reference per invariant 81`
+- Line 257 — Boundary Check: `invariant 81 (ADR-0024 D2)`
+- Line 259 — Boundary Check: `(invariant 77)`
+- Line 260 — Boundary Check: `(invariant 78)`
+- Line 261 — Boundary Check: `(invariant 79)`
+- Line 262 — Boundary Check: `(invariant 80; production substrate follow-up)`
+- Line 263 — Boundary Check: `(invariant 75)`
+- Line 314 — Referenced Invariants: `(default 74)`
+- Line 316 — Referenced Invariants: `(default 75)`
+- Line 318 — Referenced Invariants: `(default 76)`
+- Line 320 — Referenced Invariants: `(default 77)`
+- Line 322 — Referenced Invariants: `(default 78)`
+- Line 324 — Referenced Invariants: `(default 79)`
+- Line 326 — Referenced Invariants: `(default 80)`
+- Line 328 — Referenced Invariants: `(default 81)`
+- Line 330 — Referenced Invariants: `(default 82)`
+- Line 379 — Agent Handoff Constraints: `Invariant 81 (ADR-0024 D2)`
+- Line 382 — Agent Handoff Constraints: `Invariant 77`
+- Line 383 — Agent Handoff Constraints: `Invariant 78`
+- Line 384 — Agent Handoff Constraints: `Invariant 79`
+
+(Line numbers are as of this packet's authoring; re-run `rg -n "invariant 7[4-9]|invariant 8[0-2]|default 7[4-9]|default 8[0-2]" generated/issue-packets/active/adr-0024-flow-standup/03-flow-node-scaffold.md` immediately before editing to pick up any drift.)
+
+Also update ADR-0024 source (any `Invariant 74-82` text in the `ADR-0024-stand-up-honeydrunk-flow-node.md` body) in the same PR. `rg` only.
+
+### `CHANGELOG.md`
+
+Append: `Architecture: Add invariants 74-82 (Flow downstream coupling, multi-step coordination loop in Flow only, Flow holds coordination state only, no direct Flow→Memory edge, Flow delegates outbound to Communications, approval-pause durable no synchronous block, IWorkflowState durable, Abstractions stays Operator/Communications-free, Flow contract-shape canary on four hot-path surfaces) per ADR-0024.`
+
+## Affected Files
+- `constitution/invariants.md`
+- `adrs/ADR-0024-stand-up-honeydrunk-flow-node.md` (only on shift)
+- `generated/issue-packets/active/adr-0024-flow-standup/03-flow-node-scaffold.md` (only on shift)
+- `CHANGELOG.md`
+
+## Acceptance Criteria
+- [ ] Nine invariants present matching ADR-0024.
+- [ ] Numbers verified; default 74-82.
+- [ ] `(Proposed — this invariant takes effect when ADR-0024 is accepted)` qualifier on each.
+- [ ] On shift, ADR-0024 + packet 03 updated lockstep.
+- [ ] `CHANGELOG.md` updated.
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0024 D1, D2, D4, D7, D8, D9, D11, D12.** Sources for invariants 74-82.
+
+## Dependencies
+- `packet:01`
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0024`, `constitution`
+
+## Agent Handoff
+
+**Objective:** Nine new invariants. Default 74-82.
+
+**Constraints:** `(Proposed)` qualifier each. `rg` only.
+
+**Key Files:** `constitution/invariants.md`; conditional ADR-0024 + packet 03; `CHANGELOG.md`.
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0024-flow-standup/02b-architecture-verify-flow-repo.md
+++ b/generated/issue-packets/active/adr-0024-flow-standup/02b-architecture-verify-flow-repo.md
@@ -1,0 +1,102 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "ai", "adr-0024", "human-only", "wave-2"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0024"]
+accepts: ADR-0024
+wave: 2
+initiative: adr-0024-flow-standup
+node: honeydrunk-architecture
+actor: human
+---
+
+# Chore: Verify `HoneyDrunk.Flow` GitHub repo settings + local clone (human-only)
+
+## Summary
+
+Confirm `HoneyDrunkStudios/HoneyDrunk.Flow` matches Grid-standard settings; confirm local clone is on `main` clean; confirm OIDC. Repo and clone already exist (LICENSE + README).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Actor
+**`Human`.**
+
+## Steps
+
+### Step 0 — Reconcile local `chore/wire-standard-workflows` branch (if present)
+
+The Flow clone may carry a stale `chore/wire-standard-workflows` branch from earlier scaffold prep. The clone is currently LICENSE + README only, so the branch may not exist on remote at all. **Run only if the branch exists locally** — verify with `git branch` first.
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Flow
+git status                                          # confirm clean
+git branch                                          # if no `chore/wire-standard-workflows`, skip to Step 1
+git checkout chore/wire-standard-workflows         # if present, confirm current branch
+# If the chore PR has merged to main on remote:
+git checkout main 2>/dev/null || git checkout -b main origin/main
+git pull --ff-only origin main
+git branch -d chore/wire-standard-workflows        # delete local chore branch
+```
+
+If `chore/wire-standard-workflows` exists on remote and is unmerged, delete the remote branch before the scaffold packet lands (`git push origin --delete chore/wire-standard-workflows` after confirming the work is captured elsewhere or abandoned). Packet 03's scaffold lands on `main` and assumes no parallel chore branch is in flight.
+
+### Step 1 — Verify repo settings (portal)
+- /settings — default branch `main`, Public, Issues + Actions on.
+- /settings/branches — PR required, `pr-core / core` required, no force pushes, no deletions.
+- /settings/security_analysis — Dependabot alerts on.
+
+### Step 2 — Seed labels
+
+```bash
+for label in "feature:0E8A16" "chore:CCCCCC" "tier-1:E99695" "tier-2:FBCA04" "ai:D946EF" "scaffold:BFDADC" "adr-0024:1D76DB" "wave-3:FBCA04" "human-only:B60205" "out-of-band:D4C5F9"; do
+  name="${label%:*}"; color="${label#*:}"
+  gh label create "$name" --repo HoneyDrunkStudios/HoneyDrunk.Flow --color "$color" 2>/dev/null
+done
+```
+
+### Step 3 — Verify local clone
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Flow
+git status; git fetch origin; git checkout main; git pull --ff-only origin main; ls
+```
+
+### Step 4 — OIDC
+
+Cross-link: [`infrastructure/walkthroughs/oidc-federated-credentials.md`](../../../../infrastructure/walkthroughs/oidc-federated-credentials.md). Confirm `repo:HoneyDrunkStudios/HoneyDrunk.Flow:ref:refs/tags/v*`.
+
+## Acceptance Criteria
+- [ ] Branch protection configured.
+- [ ] Labels seeded.
+- [ ] Local clone on `main`, clean.
+- [ ] OIDC verified.
+- [ ] Chore closed.
+
+## Human Prerequisites
+- [ ] Org-admin role; browser; gh CLI; Azure portal access for Step 4 if needed.
+
+## Dependencies
+- `packet:01`
+
+## Downstream Unblocks
+- `03-flow-node-scaffold.md` — fileable after this chore Done + packet 02 merged.
+
+## Referenced ADR Decisions
+
+**ADR-0024 D1 / D2:** Substrate Node, three packages.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node.
+
+> **Invariant 24:** Pre-filing amendments to packet 03 permitted if invariant numbers shift in packet 02.
+
+## Labels
+`chore`, `tier-1`, `meta`, `ai`, `adr-0024`, `human-only`, `wave-2`
+
+## Notes
+- ~5-minute verification. No commits to clone. No Azure provisioning.

--- a/generated/issue-packets/active/adr-0024-flow-standup/03-flow-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0024-flow-standup/03-flow-node-scaffold.md
@@ -1,0 +1,403 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Flow
+labels: ["feature", "tier-2", "ai", "scaffold", "adr-0024"]
+dependencies: ["packet:01", "packet:02", "packet:02b"]
+adrs: ["ADR-0024", "ADR-0020", "ADR-0018", "ADR-0019"]
+accepts: ADR-0024
+wave: 3
+initiative: adr-0024-flow-standup
+node: honeydrunk-flow
+---
+
+# Feature: Stand up the HoneyDrunk.Flow repo — solution, three packages, five interfaces, CI, InMemory state provider
+
+## Summary
+
+Bring `HoneyDrunk.Flow` from zero to first-shippable per ADR-0024. Land solution, three packages (`Abstractions`, runtime, `Providers.InMemory` for state), five D3 interfaces in Abstractions, default `IWorkflowEngine` with in-process coordination per D14, default `IWorkflowStep` adapters (agent-step composing Agents per D5; message-step composing Communications at **runtime** per D8), orchestration-based compensation per D6, event-out approval-resume mechanism per D7, the workflow-definition authoring shape (scaffold-agent decides — see Constraints), `Providers.InMemory` state backend, standard CI, contract-shape canary scoped to Abstractions per D11 (number assigned by packet 02).
+
+Unblocks Lore (already declares Flow consumer), HoneyHub when live, application Nodes, Sim (read-only consumer), Evals (workflow-target).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Flow`
+
+## Motivation
+
+ADR-0024 establishes Flow's contract surface. Repo cloned (LICENSE + README only). Lore's `consumes` edge already declares `IWorkflowEngine`; standing Flow up unblocks it.
+
+## Proposed Implementation
+
+### Repository layout
+
+```
+HoneyDrunk.Flow/
+├── HoneyDrunk.Flow.slnx
+├── Directory.Build.props
+├── CHANGELOG.md
+├── README.md
+├── .editorconfig
+├── .gitignore
+├── .github/workflows/{pr-core,release,nightly-deps,nightly-security,api-compatibility}.yml
+├── src/
+│   ├── HoneyDrunk.Flow.Abstractions/
+│   │   ├── HoneyDrunk.Flow.Abstractions.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── IWorkflowEngine.cs
+│   │   ├── IWorkflow.cs
+│   │   ├── IWorkflowStep.cs
+│   │   ├── IWorkflowState.cs
+│   │   ├── ICompensation.cs
+│   │   └── (request/response/result records — minimum needed)
+│   ├── HoneyDrunk.Flow/
+│   │   ├── HoneyDrunk.Flow.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── ServiceCollectionExtensions.cs
+│   │   ├── Engine/DefaultWorkflowEngine.cs        (in-process coordination per D14)
+│   │   ├── Steps/AgentStepAdapter.cs               (composes IAgent per D5)
+│   │   ├── Steps/MessageStepAdapter.cs             (composes ICommunicationOrchestrator per D8)
+│   │   ├── Steps/WaitEventStepAdapter.cs           (human-in-the-loop event-out resume target per D7)
+│   │   ├── Compensation/CompensationWalker.cs     (orchestration-based per D6)
+│   │   ├── Approval/ApprovalResumeEmitter.cs       (event-out per D7)
+│   │   ├── Approval/ApprovalDecisionSubscriber.cs  (subscribes to Operator approval-decision events)
+│   │   ├── Authoring/WorkflowBuilder.cs            (D13 — fluent C# builder; scaffold agent's choice)
+│   │   └── Telemetry/FlowTelemetry.cs
+│   └── HoneyDrunk.Flow.Providers.InMemory/
+│       ├── HoneyDrunk.Flow.Providers.InMemory.csproj
+│       ├── README.md
+│       ├── CHANGELOG.md
+│       └── InMemoryWorkflowStateStore.cs
+└── tests/
+    ├── HoneyDrunk.Flow.Abstractions.Tests/
+    ├── HoneyDrunk.Flow.Tests/
+    └── HoneyDrunk.Flow.Providers.InMemory.Tests/
+```
+
+### Contract details — `HoneyDrunk.Flow.Abstractions`
+
+```csharp
+// IWorkflowEngine.cs
+namespace HoneyDrunk.Flow.Abstractions;
+
+public interface IWorkflowEngine
+{
+    Task<WorkflowHandle> StartAsync(IWorkflow workflow, WorkflowStartRequest request, CancellationToken cancellationToken = default);
+    Task PauseAsync(string instanceId, CancellationToken cancellationToken = default);
+    Task ResumeAsync(string instanceId, ResumeRequest? request = null, CancellationToken cancellationToken = default);
+    Task CancelAsync(string instanceId, string reason, CancellationToken cancellationToken = default);
+    Task CompensateAsync(string instanceId, CancellationToken cancellationToken = default);
+    Task<WorkflowStatus> GetStatusAsync(string instanceId, CancellationToken cancellationToken = default);
+}
+
+public sealed record WorkflowHandle(string InstanceId, string CorrelationId, WorkflowStatus InitialStatus);
+public sealed record WorkflowStartRequest(string InitialPayloadJson, IReadOnlyDictionary<string, string> Metadata);
+public sealed record ResumeRequest(string EventTypeId, string PayloadJson);
+public sealed record WorkflowStatus(string InstanceId, WorkflowPhase Phase, string? CurrentStepId, string? PauseReason);
+
+public enum WorkflowPhase { NotStarted = 0, Running = 1, PausedAwaitingApproval = 2, PausedAwaitingEvent = 3, Compensating = 4, Completed = 5, Failed = 6, Cancelled = 7 }
+```
+
+```csharp
+// IWorkflow.cs
+public interface IWorkflow
+{
+    string WorkflowId { get; }
+    string WorkflowVersion { get; }
+    IReadOnlyList<IWorkflowStep> Steps { get; }
+    IReadOnlyDictionary<string, string> Metadata { get; }
+}
+```
+
+```csharp
+// IWorkflowStep.cs
+public interface IWorkflowStep
+{
+    string StepId { get; }
+    string StepKind { get; }                    // "agent", "message", "wait-event", "custom"
+    RetryPolicy RetryPolicy { get; }
+    Task<StepResult> ExecuteAsync(StepContext context, CancellationToken cancellationToken = default);
+    ICompensation? Compensation { get; }         // null if step is not compensable
+}
+
+public sealed record StepContext(string InstanceId, string CorrelationId, string? PreviousStepOutputJson, IReadOnlyDictionary<string, string> WorkflowBag);
+public sealed record StepResult(StepOutcome Outcome, string? OutputJson, string? FailureReason, bool ShouldPause, string? PauseReason);
+public enum StepOutcome { Succeeded = 0, Failed = 1, Paused = 2, Skipped = 3 }
+public sealed record RetryPolicy(int MaxAttempts, TimeSpan InitialBackoff, double BackoffMultiplier);
+```
+
+```csharp
+// IWorkflowState.cs
+public interface IWorkflowState
+{
+    string InstanceId { get; }
+    string WorkflowId { get; }
+    string WorkflowVersion { get; }
+    WorkflowPhase Phase { get; }
+    string? CurrentStepId { get; }
+    IReadOnlyList<CompletedStepRecord> CompletedSteps { get; }
+    IReadOnlyList<CompensationRecord> CompensationLog { get; }
+    string CorrelationId { get; }
+    string? CausationChain { get; }
+    DateTimeOffset StartedAt { get; }
+    DateTimeOffset LastUpdatedAt { get; }
+
+    Task<IWorkflowState> AppendCompletedStepAsync(CompletedStepRecord record, CancellationToken cancellationToken = default);
+    Task<IWorkflowState> AppendCompensationAsync(CompensationRecord record, CancellationToken cancellationToken = default);
+    Task<IWorkflowState> TransitionAsync(WorkflowPhase nextPhase, string? currentStepId, CancellationToken cancellationToken = default);
+}
+
+public sealed record CompletedStepRecord(string StepId, string OutputJson, DateTimeOffset CompletedAt, int Attempts);
+public sealed record CompensationRecord(string StepId, bool Succeeded, string? FailureReason, DateTimeOffset CompletedAt);
+```
+
+```csharp
+// ICompensation.cs
+public interface ICompensation
+{
+    Task<CompensationResult> CompensateAsync(CompensationContext context, CancellationToken cancellationToken = default);
+}
+
+public sealed record CompensationContext(string InstanceId, string StepId, string? StepOutputJson, string FailureReason);
+public sealed record CompensationResult(bool Succeeded, string? FailureReason);
+```
+
+`HoneyDrunk.Flow.Abstractions` references **`HoneyDrunk.Kernel.Abstractions`** (for `IGridContext`-style scoped operations — explicitly permitted per ADR-0024 D2) and **`HoneyDrunk.Agents.Abstractions`** (for `IAgent` references in agent-step shapes per D5). **Does NOT** reference `HoneyDrunk.Operator.Abstractions` or `HoneyDrunk.Communications.Abstractions` per D2 / D8 — those are runtime-only edges (invariant 81).
+
+**Strict Abstractions stance.** Identity / correlation fields are `string` at v0.1.0 (deliberate stand-up simplification — follow-up packet at v0.2.0 rotates to strong types per the cross-cutting decision). Workflow-record shapes are first-pass; subject to evolution before v0.2.0.
+
+### Runtime details — `HoneyDrunk.Flow`
+
+`HoneyDrunk.Flow` references:
+- `HoneyDrunk.Flow.Abstractions` (project)
+- `HoneyDrunk.Kernel` (telemetry, context)
+- `HoneyDrunk.Agents` (composition target for agent steps per D5)
+- `HoneyDrunk.Operator` (composition for `IApprovalGate`, `ICircuitBreaker`, `ICostGuard`, `IAuditLog` per D7 — `IAuditLog` is a **transitional Operator binding** at v0.1.0; rotates to `HoneyDrunk.Audit.Abstractions` after Audit Node stand-up per ADR-0031 ships, separate follow-up packet)
+- `HoneyDrunk.Communications` (composition for `ICommunicationOrchestrator` per D8)
+- `HoneyDrunk.Data` (for `IRepository` / `IUnitOfWork` — non-in-memory state persistence)
+- `HoneyDrunk.Transport` (for event-out approval-resume per D7 — pub/sub of approval-decision events)
+- `Microsoft.Extensions.*`
+
+Implementations:
+
+- **`DefaultWorkflowEngine`** — in-process coordination per D14. Orchestrates the step sequence: load `IWorkflowState` (or create), iterate `IWorkflow.Steps`, for each step (a) run `ICostGuard.CheckBudgetAsync` + `ICircuitBreaker.IsAllowedAsync` per D7, (b) execute step, (c) if step returns `ShouldPause: true` and `PauseReason` indicates approval — record pause, release thread, exit. Resume on `ApprovalDecisionSubscriber` event landing.
+- **`AgentStepAdapter`** — wraps `IAgent.ExecuteAsync` as an `IWorkflowStep`. Marshals step input → `AgentRequest`; agent result → `StepResult.OutputJson`.
+- **`MessageStepAdapter`** — wraps `ICommunicationOrchestrator` as an `IWorkflowStep`. Step input → `MessageIntent`; orchestrator result → `StepResult`. Per D8 / invariant 78, no direct `INotificationSender` invocation.
+- **`WaitEventStepAdapter`** — wraps the event-out wait-and-resume pattern as an `IWorkflowStep`. Returns `StepResult` with `ShouldPause: true` and `PauseReason` indicating event-wait; the actual event-landing → resume is wired through `ApprovalDecisionSubscriber`-style transport subscribers. This is the human-in-the-loop event-out target per D7. The wire shape is deferred to a follow-up packet (same as `ApprovalResumeEmitter` — leave a TODO + extension seam).
+- **`CompensationWalker`** — orchestration-based per D6. On step failure (post-retry-exhaustion), walks `IWorkflowState.CompletedSteps` in reverse order, invokes each step's `ICompensation`. Idempotent — already-compensated steps skip.
+- **`ApprovalResumeEmitter`** — emits an approval-needed marker (via the configured transport — D7 mechanism deferred; this scaffold supplies an `ITransportPublisher`-backed default with the wire shape to be revised in a follow-up).
+- **`ApprovalDecisionSubscriber`** — subscribes to Operator's approval-decision events. On event landing, looks up the paused workflow by correlation, rehydrates `IWorkflowState`, calls `IWorkflowEngine.ResumeAsync`.
+- **`WorkflowBuilder`** — fluent C# builder for authoring `IWorkflow` instances per D13. The scaffold agent picks the fluent-builder shape; alternatives (config-bound, YAML, attribute-based) deferred to follow-up packets.
+- **`FlowTelemetry`** — emits per-lifecycle / per-step / per-compensation / per-state-persistence activities. **Metadata only** per D10 (workflow content not carried).
+
+**`IAuditLog` provenance — TODO at every call site.** At v0.1.0, `IAuditLog` is sourced from `HoneyDrunk.Operator.Abstractions` (transitional Operator binding). Every `IAuditLog` call site in `DefaultWorkflowEngine`, `CompensationWalker`, `ApprovalResumeEmitter`, and `ApprovalDecisionSubscriber` MUST carry an inline comment:
+
+```csharp
+// TODO(audit-relocation): IAuditLog consumed from Operator.Abstractions transitionally.
+// Rotate to HoneyDrunk.Audit.Abstractions once Audit Node stand-up ships (ADR-0031).
+// Tracked in follow-up packet against HoneyDrunk.Flow.
+```
+
+### Providers.InMemory details
+
+`InMemoryWorkflowStateStore` — in-process dictionary keyed by `instanceId`. Persistence within process lifetime; `Providers.SqlServer` / `Providers.CosmosDB` (or `Providers.Data`-backed) ship in follow-up packets.
+
+### CI workflows
+
+Five files; `api-compatibility.yml` path-filtered to `src/HoneyDrunk.Flow.Abstractions/**`.
+
+### `HoneyDrunk.Standards`
+
+Per invariant 26.
+
+### Documentation
+
+Repo README — purpose, package matrix, "How to consume" snippet with `AddHoneyDrunkFlow()` + a simple two-step workflow example, link to ADR-0024. Note that `HoneyDrunk.Flow.Abstractions` does NOT transit Operator or Communications — those are runtime-only edges. Per-package README + CHANGELOG.
+
+## Affected Files
+Entire repo. See layout.
+
+## NuGet Dependencies
+
+### `HoneyDrunk.Flow.Abstractions.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | For `IGridContext`-style scoped operations — explicitly permitted per ADR-0024 D2 |
+| `HoneyDrunk.Agents.Abstractions` | For `IAgent` references in agent-step shapes per D5 — accepted compile-time transitive reference per invariant 81 |
+
+**No** `HoneyDrunk.Operator.Abstractions`. **No** `HoneyDrunk.Communications.Abstractions`. Kernel + Agents Abstractions are the only HoneyDrunk family references per ADR-0024 D2.
+
+### `HoneyDrunk.Flow.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel` | Telemetry, context |
+| `HoneyDrunk.Agents` | Composition (agent-step) |
+| `HoneyDrunk.Operator` | Composition (gates, breakers, audit) |
+| `HoneyDrunk.Communications` | Composition (message-step) |
+| `HoneyDrunk.Data` | State persistence (non-in-memory) |
+| `HoneyDrunk.Transport` | Event-out approval-resume |
+| `Microsoft.Extensions.*` | |
+
+Project reference: `HoneyDrunk.Flow.Abstractions`.
+
+### `HoneyDrunk.Flow.Providers.InMemory.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+
+Project reference: `HoneyDrunk.Flow.Abstractions`. No reference to runtime, no reference to Agents / Operator / Communications.
+
+### Test projects: standard + NSubstitute.
+
+## Boundary Check
+- [x] `HoneyDrunk.Flow.Abstractions` references only `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.Agents.Abstractions` from the HoneyDrunk family (plus `HoneyDrunk.Standards`). No Operator, no Communications — invariant 81 (ADR-0024 D2).
+- [x] `Providers.InMemory` references only `HoneyDrunk.Flow.Abstractions`.
+- [x] No direct Flow → Memory edge anywhere (invariant 77).
+- [x] No `INotificationSender` invocation anywhere; messaging goes through `ICommunicationOrchestrator` (invariant 78).
+- [x] No synchronous block on `IApprovalGate` for long-running approvals (invariant 79).
+- [x] `IWorkflowState` durable through `Providers.InMemory` (invariant 80; production substrate follow-up).
+- [x] Multi-step coordination loop lives only here (invariant 75).
+- [x] Records drop `I`; interfaces keep it.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Flow.slnx` builds clean.
+- [ ] Five D3 interfaces present with XML docs.
+- [ ] `HoneyDrunk.Flow.Abstractions` has zero `HoneyDrunk.Operator.Abstractions` or `HoneyDrunk.Communications.Abstractions` PackageReference. `rg` over `.csproj` verifies.
+- [ ] `HoneyDrunk.Flow.Abstractions` references exactly `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.Agents.Abstractions` from the HoneyDrunk family (plus `HoneyDrunk.Standards`) — per ADR-0024 D2.
+- [ ] `Providers.InMemory` references only `HoneyDrunk.Flow.Abstractions`.
+- [ ] `AddHoneyDrunkFlow()` resolves `IWorkflowEngine` and the three step adapters (`AgentStepAdapter`, `MessageStepAdapter`, `WaitEventStepAdapter`) from DI.
+- [ ] `DefaultWorkflowEngine.StartAsync` orchestrates a multi-step workflow end-to-end with `AgentStepAdapter` and `MessageStepAdapter`. Unit test covers happy-path two-step workflow.
+- [ ] `WaitEventStepAdapter` returns `StepResult { Outcome: Paused, ShouldPause: true, PauseReason: "wait-event:..." }` and the engine releases the thread without blocking. Unit test verifies non-blocking pause for the `wait-event` StepKind. Wire-shape TODO + extension seam present.
+- [ ] `MessageIntent` shape from `HoneyDrunk.Communications.Abstractions` is verified stable (record with `kind: "type"`, not interface) at scaffold time. If `MessageIntent` is missing or has shifted to an interface, ship `MessageStepAdapter` as a placeholder no-op with structured warning and file follow-up.
+- [ ] `DefaultWorkflowEngine` consults `ICostGuard` and `ICircuitBreaker` before each step per D7. Unit test verifies — `Unauthorized` cost or `Open` breaker short-circuits.
+- [ ] Approval-pause path: when a step returns `ShouldPause: true` with approval reason, `DefaultWorkflowEngine` (a) persists pause via `IWorkflowState`, (b) emits via `ApprovalResumeEmitter`, (c) releases the thread without blocking. Unit test verifies non-blocking pause.
+- [ ] `ApprovalDecisionSubscriber` rehydrates and resumes on event landing. Unit test verifies resume from a persisted paused state.
+- [ ] `CompensationWalker` walks completed steps in reverse and invokes each step's `ICompensation`. Idempotent on already-compensated. Unit test verifies a 3-step workflow's compensation order on third-step failure.
+- [ ] `MessageStepAdapter` invokes `ICommunicationOrchestrator`. **No invocation of `INotificationSender` anywhere.** Unit test verifies via mock and `rg "INotificationSender" src/` returning zero matches.
+- [ ] Every `IAuditLog` call site carries a `TODO(audit-relocation):` comment referencing ADR-0031 / follow-up packet (transitional Operator binding at v0.1.0). `rg "TODO\(audit-relocation\)" src/` returns at least one match per file that consumes `IAuditLog`.
+- [ ] `FlowTelemetry` emits per-lifecycle / per-step / per-compensation activities. Metadata only — no step input/output payloads in tags.
+- [ ] `WorkflowBuilder` fluent API builds an `IWorkflow` instance. Unit test verifies builder produces a valid two-step workflow.
+- [ ] `InMemoryWorkflowStateStore` persists and rehydrates `IWorkflowState` across simulated process restarts (in-process: just dispose and recreate the store + verify state survives via a new engine instance over the same store). Unit test verifies.
+- [ ] All five `.github/workflows/*.yml` present.
+- [ ] `api-compatibility.yml` path-filtered to Abstractions; scaffolding PR reports `status: skipped`.
+- [ ] `pr-core.yml` passes.
+- [ ] Repo + per-package `CHANGELOG.md` + `README.md` present.
+- [ ] All `src/*.csproj` Version 0.1.0.
+- [ ] Manual confirmation `v0.1.0` tag triggers `release.yml`.
+- [ ] **No `IWorkflowState` in the contract-shape canary** per D11 — only `IWorkflowEngine`, `IWorkflow`, `IWorkflowStep`, `ICompensation`. `IWorkflowState` becomes canary later.
+- [ ] **No production state store** in this packet — only `Providers.InMemory` per D12.
+
+## Human Prerequisites
+- [ ] Packet 02b complete.
+- [ ] After merge, push tag `v0.1.0`.
+- [ ] **Upstream Abstractions check.** Agents Abstractions mandatory (compile-time); Operator + Communications + Transport runtime-mandatory. If any is missing at edit time, ship placeholder no-op step adapters with structured warnings.
+- [ ] **Branch protection sequencing.** Add `api-compatibility / abstractions-shape` to required checks post-merge.
+- [ ] No Azure provisioning required at stand-up. Future production state-store packet may add a deployable component.
+- [ ] After merge + tag, file SonarCloud onboarding follow-up.
+- [ ] File event-out transport-mechanism follow-up packet to make the wire shape concrete (per D7 — wire-shape deferred to follow-up).
+- [ ] File `Providers.SqlServer` / `Providers.CosmosDB` / `Providers.Data` follow-ups once production workflow consumers drive shape.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages, except where another `*.Abstractions` package is the cleanest way to type a member signature (Agents Abstractions is permitted here for `IAgent` shape).
+
+> **Invariant 3:** Providers reference parent Node's contracts, not internal implementation details.
+
+> **Invariant 11:** One repo per Node.
+
+> **Invariant 12, 13, 26, 27.** Standard.
+
+> **Flow downstream-coupling invariant (default 74):** Runtime-depend only on Abstractions.
+
+> **Flow loop-lives-here invariant (default 75):** Multi-step coordination loop lives only in Flow.
+
+> **Flow coordination-state-only invariant (default 76):** Flow holds only coordination state.
+
+> **Flow no-direct-Memory invariant (default 77):** No `honeydrunk-flow → honeydrunk-memory` edge.
+
+> **Flow delegates-to-Communications invariant (default 78):** No direct `INotificationSender` invocation.
+
+> **Flow approval-pause-durable invariant (default 79):** No synchronous block on `IApprovalGate`.
+
+> **Flow IWorkflowState-durable invariant (default 80):** State survives process restart.
+
+> **Flow Abstractions-stays-clean invariant (default 81):** No `Operator.Abstractions` / `Communications.Abstractions` compile-time deps in Flow Abstractions.
+
+> **Flow contract-shape canary invariant (default 82):** Canary on `IWorkflowEngine`, `IWorkflow`, `IWorkflowStep`, `ICompensation`.
+
+## Referenced ADR Decisions
+
+**ADR-0024 D1:** First Node above the foundation — workflow-orchestration substrate.
+
+**ADR-0024 D2:** Three packages; runtime is the **only** package that takes Operator and Communications deps.
+
+**ADR-0024 D3:** Five interfaces; no records at stand-up.
+
+**ADR-0024 D5:** Agent-step composes `IAgent`.
+
+**ADR-0024 D6:** Orchestration-based compensation (saga-style deferred).
+
+**ADR-0024 D7:** Approval-pause via event-out; no synchronous block.
+
+**ADR-0024 D8:** Communications composition is runtime-only; `Abstractions` does not transit it.
+
+**ADR-0024 D9:** No direct Flow → Memory edge.
+
+**ADR-0024 D10:** Metadata-only telemetry.
+
+**ADR-0024 D11:** Canary on four hot-path surfaces.
+
+**ADR-0024 D12:** `IWorkflowState` durable; storage substrate deferred.
+
+**ADR-0024 D13:** Authoring shape decided at scaffold; this packet picks fluent C# builder.
+
+**ADR-0024 D14:** In-process coordination at stand-up.
+
+**ADR-0020 D3 (referenced):** `IAgent` from Agents.
+
+**ADR-0018 D3 (referenced):** Operator primitives.
+
+**ADR-0019 D3 (referenced):** `ICommunicationOrchestrator`.
+
+## Dependencies
+- `packet:01`, `packet:02`, `packet:02b`
+
+## Labels
+`feature`, `tier-2`, `ai`, `scaffold`, `adr-0024`
+
+## Agent Handoff
+
+**Objective:** Ship `HoneyDrunk.Flow 0.1.0` with five D3 interfaces, default in-process engine, three step adapters (agent / message / wait-event), orchestration-based compensation, event-out approval-resume, `Providers.InMemory` state, fluent `WorkflowBuilder`, CI, canary.
+
+**Target:** HoneyDrunk.Flow, branch from `main`.
+
+**Constraints:**
+- **`HoneyDrunk.Flow.Abstractions` references only `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.Agents.Abstractions`** from the HoneyDrunk family (plus `HoneyDrunk.Standards`). No Operator, no Communications, no Data, no Transport in Abstractions. Invariant 81 (ADR-0024 D2).
+- **`Providers.InMemory` references only Abstractions.**
+- **String-typed IDs at v0.1.0.** `string InstanceId`, `string WorkflowId`, `string StepId`, `string CorrelationId` are deliberate stand-up simplifications. Follow-up packet at v0.2.0 rotates to strong types per the cross-cutting decision.
+- **No direct Flow → Memory edge anywhere.** Memory access is indirect through Agents. Invariant 77.
+- **No `INotificationSender` invocation anywhere.** Messaging through `ICommunicationOrchestrator` only. Invariant 78.
+- **No synchronous block on `IApprovalGate`.** Approval-pause flow records state, releases thread, subscribes to event. Invariant 79.
+- **`DefaultWorkflowEngine` consults Operator before every step:** `ICostGuard.CheckBudgetAsync`, `ICircuitBreaker.IsAllowedAsync` per D7.
+- **Compensation is orchestration-based, not choreography-based.** No saga-style event publishing for compensation in this packet. Invariant — orchestration-based per D6.
+- **In-process coordination only.** No distributed-engine code paths. Invariant — D14.
+- **Authoring shape: fluent C# builder (`WorkflowBuilder`).** YAML / attribute / config-bound deferred to follow-up packets.
+- **Transport mechanism for event-out:** the scaffold supplies an `ITransportPublisher`-backed default. The wire shape is deferred to a follow-up packet — leave a TODO + a clear extension seam.
+- **Records drop `I`; interfaces keep it.** All step / state / compensation records drop `I`.
+- **Canary skip on scaffolding PR expected.**
+- **Upstream conditional.** Agents Abstractions mandatory; Operator + Communications + Transport runtime — placeholder no-ops if any is missing at edit time.
+
+**Key Files:**
+- `HoneyDrunk.Flow.slnx`, `Directory.Build.props`
+- `src/HoneyDrunk.Flow.Abstractions/` — 5 interfaces + supporting records
+- `src/HoneyDrunk.Flow/` — `DefaultWorkflowEngine`, `AgentStepAdapter`, `MessageStepAdapter`, `WaitEventStepAdapter`, `CompensationWalker`, `ApprovalResumeEmitter`, `ApprovalDecisionSubscriber`, `WorkflowBuilder`, `FlowTelemetry`, `ServiceCollectionExtensions`
+- `src/HoneyDrunk.Flow.Providers.InMemory/` — `InMemoryWorkflowStateStore`
+- `.github/workflows/*.yml`
+- `README.md`, `CHANGELOG.md`
+- `tests/`
+
+**Contracts:** Five D3 interfaces authored fresh.

--- a/generated/issue-packets/active/adr-0024-flow-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0024-flow-standup/dispatch-plan.md
@@ -1,0 +1,89 @@
+# Dispatch Plan — ADR-0024 HoneyDrunk.Flow Standup
+
+**Initiative:** `adr-0024-flow-standup`
+**Sector:** AI
+**Governing ADR:** [ADR-0024 — Stand Up the HoneyDrunk.Flow Node](../../../../adrs/ADR-0024-stand-up-honeydrunk-flow-node.md) (Proposed 2026-04-19; flips to Accepted after merge).
+**Trigger:** ADR-0024 in the Proposed queue. Lore (already declares `consumes` Flow for wiki-compilation workflow), Sim (read-only `IWorkflow`/`IWorkflowStep` per ADR-0025 D5), Evals (`IWorkflowEngine` as `IEvalTarget`), HoneyHub when live, application Nodes with domain pipelines blocked on `HoneyDrunk.Flow.Abstractions`.
+**Type:** Multi-repo (2 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.Flow`)
+**Site sync required:** No.
+**Rollback plan:** Pre-tag revert; post-tag fix-forward.
+
+## Summary
+
+ADR-0024 is the standup ADR for `HoneyDrunk.Flow`. The first Node above the AI-sector foundation — composes Agents (single-agent execution), Operator (policy gates synchronously per D7), Communications (outbound message steps per D8, **runtime-only edge — Abstractions stays clean**), Memory (indirectly via Agents — **no direct Flow → Memory edge** per D9).
+
+Owns workflow-orchestration primitives — five interfaces (`IWorkflowEngine`, `IWorkflow`, `IWorkflowStep`, `IWorkflowState`, `ICompensation`). Three packages (`Abstractions`, runtime, `Providers.InMemory` for state). Orchestration-based compensation per D6. Event-out resume mechanism for approval-pause workflows per D7 — paused workflows are durable; no synchronous block on `IApprovalGate`. Communications composition is runtime-only — `HoneyDrunk.Flow.Abstractions` does NOT take a compile-time dependency on `HoneyDrunk.Communications.Abstractions` per D2 / D8. In-process engine at stand-up per D14; cross-host distributed engine deferred. Workflow-definition authoring shape deferred to scaffold per D13. `IWorkflowState` durable per D12; storage substrate deferred. Canary on four hot-path surfaces per D11.
+
+Catalog drift: three-way between `contracts.json` (three interfaces), `relationships.json` (five interfaces), repo overview (five interfaces). D3 pins the five-interface definitive set.
+
+Four packets land the work:
+
+1. **Architecture catalog registration + integration-points + drift reconciliation** — bring `contracts.json` to the five-interface D3 set; add Operator + Communications to `consumes`; add Sim + Evals to `consumed_by_planned`; coordinate the bidirectional Flow ↔ Communications edge with ADR-0019; align repo docs + AI sector doc; add `integration-points.md` and `active-work.md`.
+2. **Constitution invariants** — nine new invariants from D2/D8, D1/D4, D9, D9, D8, D7, D12, D2+D8 (Abstractions-stays-clean), D11.
+2b. **Verify `HoneyDrunk.Flow` repo + local clone (human-only)**.
+3. **HoneyDrunk.Flow scaffold** — empty repo to first-shippable. Solution, three packages (`Abstractions`, runtime, `Providers.InMemory` for state), five interfaces in Abstractions, default `IWorkflowEngine` with in-process coordination, default `IWorkflowStep` adapters (agent-step composing Agents, message-step composing Communications at the **runtime** layer), retry + orchestration-based compensation, event-out approval-resume mechanism, `Providers.InMemory` backend, five CI workflow files with canary scoped to Abstractions.
+
+## Wave Diagram
+
+```
+Wave 1: Architecture catalog + constitution updates (parallel)
+   ├─ Architecture: 01-architecture-flow-catalog-registration
+   └─ Architecture: 02-architecture-flow-invariants
+       Blocked by: 01
+
+Wave 2: Verify repo + clone (human)
+   └─ Architecture: 02b-architecture-verify-flow-repo
+       Blocked by: 01
+
+Wave 3: Flow repo scaffold
+   └─ HoneyDrunk.Flow: 03-flow-node-scaffold
+       Blocked by: 01, 02, 02b
+```
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 01 | [Catalog registration + drift reconciliation + integration-points](./01-architecture-flow-catalog-registration.md) | Architecture | 1 | Agent | — |
+| 02 | [Add nine new invariants for D2/D8 / D1+D4 / D9 / D9 / D8 / D7 / D12 / D2+D8 / D11](./02-architecture-flow-invariants.md) | Architecture | 1 | Agent | 01 |
+| 02b | [Verify HoneyDrunk.Flow repo + clone (human-only)](./02b-architecture-verify-flow-repo.md) | Architecture | 2 | Human | 01 |
+| 03 | [Stand up `HoneyDrunk.Flow` — solution, three packages, five interfaces, CI, InMemory state provider](./03-flow-node-scaffold.md) | HoneyDrunk.Flow | 3 | Agent | 01, 02, 02b |
+
+## Filing-order rule
+
+Packet 03 hard-codes invariant numbers. Packet 02 merges first; collision-shift packet 03 source pre-filing under invariant 24.
+
+## What This Initiative Does **NOT** Deliver
+
+- Downstream consumers (Lore wiki workflow, HoneyHub dispatch workflows, application pipelines) not delivered.
+- Choreography-based saga primitives deferred per D6 (orchestration-based at stand-up).
+- Cross-host distributed engine deferred per D14 (in-process at stand-up).
+- Workflow-definition authoring shape decided **inside packet 03** per D13 — fluent builder / config-bound record graph / declarative YAML / attribute-based: scaffold agent picks one.
+- Event-out **transport mechanism** deferred to follow-up packet per D7 (principle pinned; wire shape next).
+- `IWorkflowState` production storage substrate deferred per D12.
+- Pulse signal ingress deferred (emit-only per D10).
+- No separate `HoneyDrunk.Flow.Testing` — `Providers.InMemory` plays that role per D2.
+
+### Explicit follow-up packets to file against `HoneyDrunk.Flow`
+
+- **Rotate `IAuditLog` consumption to `HoneyDrunk.Audit.Abstractions`** after Audit Node stand-up (ADR-0031) ships. Transitional Operator binding at v0.1.0 — flip to Audit Abstractions in a v0.1.x patch packet. Update Flow runtime composition + the `consumes_detail` edge in `relationships.json` (move `IAuditLog` off `honeydrunk-operator` onto `honeydrunk-audit`).
+- **Rotate string-typed identifiers to strong types at v0.2.0.** `string InstanceId`, `string WorkflowId`, `string StepId`, `string CorrelationId` are deliberate v0.1.0 simplifications. Follow-up packet introduces strong-typed identity records (consistent with the cross-cutting decision applied across the Grid).
+- **Event-out transport-mechanism wire-shape packet** (per D7 — `ApprovalResumeEmitter` + `WaitEventStepAdapter` ship with `ITransportPublisher`-backed defaults + extension seams; wire shape pinned in follow-up).
+- **`Providers.SqlServer` / `Providers.CosmosDB` / `Providers.Data` state-store packet** (per D12 — durable substrate driven by first production consumer's shape).
+- **`IWorkflowState` canary-promotion packet** — fold `IWorkflowState` into the contract-shape canary once the production state store lands per D11.
+
+## AI-sector standup wave sequencing
+
+Flow requires `HoneyDrunk.Agents.Abstractions` (mandatory — agent-step composition), `HoneyDrunk.Operator.Abstractions` (mandatory — gate composition), `HoneyDrunk.Communications.Abstractions` (mandatory — outbound message steps). Recommended order: AI → Capabilities → Operator → Knowledge + Memory → Agents → Evals → **Flow** + Communications → Sim.
+
+## Status flip
+
+ADR-0024 stays Proposed for duration.
+
+## Filing
+
+`file-packets.yml` auto-files.
+
+## Archival
+
+Per ADR-0008 D10, archive post-completion.


### PR DESCRIPTION
## Summary

Scopes four packets standing up [HoneyDrunk.Flow](https://github.com/HoneyDrunkStudios/HoneyDrunk.Flow) per [ADR-0024](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0024-stand-up-honeydrunk-flow-node.md) — the AI sector's workflow-orchestration substrate. Claims invariants **74–82**.

### Wave 1 — Architecture-repo (parallel)
- **`01-catalog-registration`** — reconciles existing `consumes_detail` Kernel/Data drift (`HoneyDrunk.Kernel` → `.Abstractions`); `IAuditLog` transitional Operator binding noted with `TODO(audit-relocation)` at every call site; bidirectional Flow↔Communications edge made concrete; `consumed_by_planned` schema cleanup (no reverse `consumes_detail`).
- **`02-invariants`** — nine new constitution invariants (default 74–82) under `## AI Sector — Flow Invariants`.
- **`02b-verify-flow-repo`** — human-only chore + chore-branch reconcile.

### Wave 2 — Flow scaffold
- **`03-flow-node-scaffold`** — three packages, five frozen interfaces (`IWorkflowEngine`, `IWorkflow`, `IWorkflowStep`, `IWorkflowState`, `ICompensation`). `HoneyDrunk.Kernel.Abstractions` restored per ADR-0024 D2 (consistent across NuGet table, Boundary Check, Acceptance, Agent Handoff). Three step adapters: `AgentStepAdapter`, `MessageStepAdapter`, `WaitEventStepAdapter` (D7 human-in-the-loop resume).

## `IAuditLog` transitional binding

ADR-0030 D5 relocated `IAuditLog` from Operator to the future `HoneyDrunk.Audit` Node. At v0.1.0, Flow consumes the contract from `HoneyDrunk.Operator.Abstractions` (transitional). Every call site marked with `TODO(audit-relocation)` referencing the follow-up rotation packet, explicitly listed in dispatch-plan: "Rotate `IAuditLog` consumption to `HoneyDrunk.Audit.Abstractions` after Audit Node stand-up (ADR-0031) ships."

## Boundary discipline

- **Orchestration-based compensation only** (no saga primitives).
- **Flow holds durable workflow state** — no Memory edge.
- **Human-in-the-loop resume** via method on `IWorkflowEngine` (not subscribed event in Abstractions).
- **No `IRepository`** at v0.1.0 (durability seam deferred).

## Conventions
- NuGet uses `.Abstractions` throughout (invariant 2).
- String-typed IDs at v0.1.0 are deliberate; v0.2.0 follow-up to rotate to strong types per ADR-0026.
- Each packet carries `accepts: ADR-0024`.

## Test plan
- [ ] After merge, four issues file with dependency edges
- [ ] Wave 2 stays blocked on Wave 1 + Operator scaffold
- [ ] When all four close, hive-sync auto-flips ADR-0024 Proposed → Accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)