### PR TITLE
chore: scope ADR-0025 sim node standup (closes AI-sector wave)

### DIFF
--- a/generated/issue-packets/active/adr-0025-sim-standup/01-architecture-sim-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0025-sim-standup/01-architecture-sim-catalog-registration.md
@@ -1,0 +1,227 @@
+---
+name: Architecture Catalog Registration
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0025"]
+dependencies: []
+adrs: ["ADR-0025", "ADR-0024"]
+accepts: ADR-0025
+wave: 1
+initiative: adr-0025-sim-standup
+node: honeydrunk-sim
+---
+
+# Chore: Register HoneyDrunk.Sim's standup decisions in Architecture catalogs + reconcile three-way drift
+
+## Summary
+
+Reflect ADR-0025 in catalogs. **Reconcile three-way drift** across `contracts.json` (two interfaces — `ISimulator`, `ISimulationResult`), `relationships.json` `exposes.contracts` (four interfaces — `ISimulator`, `IScenario`, `IRiskAssessment`, `IPlanValidator`), and `repos/HoneyDrunk.Sim/overview.md` (same four). Land the D3 six-surface definitive set: three interfaces (`ISimulator`, `IPlanValidator`, `ISimulationTarget`) + three records (`Scenario`, `RiskAssessment`, `SimulationResult`).
+
+Widen `consumes` to add Kernel + Flow + Memory + Operator (four missing edges per D4). Widen AI `consumes_detail` per D8. Update `roadmap_focus` prose to drop the "Optional for initial AI sector delivery" framing and reflect Sim as the closing Node. Align `repos/HoneyDrunk.Sim/` docs and AI sector doc. Add `integration-points.md` and `active-work.md`.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+Drift items:
+
+1. **`contracts.json`** lists two interfaces. Missing four surfaces vs D3.
+2. **`relationships.json` `exposes.contracts`** lists four — but `IScenario`, `IRiskAssessment` should be records (`Scenario`, `RiskAssessment`); `ISimulationTarget` is missing.
+3. **`relationships.json` `consumes`** lists `["honeydrunk-ai", "honeydrunk-knowledge", "honeydrunk-agents"]`. Missing Kernel, Flow, Memory, Operator.
+4. **`nodes.json roadmap_focus`** says "Optional for initial AI sector delivery" — wrong framing per D1 (closing Node of the wave).
+5. **Repo docs** drift.
+
+## Proposed Implementation
+
+### `catalogs/contracts.json` — `honeydrunk-sim` block
+
+Replace existing two-interface seed with six surfaces:
+
+```json
+{
+  "node": "honeydrunk-sim",
+  "node_name": "HoneyDrunk.Sim",
+  "package": "HoneyDrunk.Sim.Abstractions",
+  "status": "seed",
+  "interfaces": [
+    { "name": "ISimulator", "kind": "interface", "description": "Run a Scenario against an ISimulationTarget, collect the projected outcome, produce a SimulationResult. The top-level orchestration surface. ADR-0025 D3." },
+    { "name": "IPlanValidator", "kind": "interface", "description": "Validate a proposed plan (a Scenario paired with a candidate execution shape) before real execution. Composes ISimulator internally; returns a RiskAssessment plus a go/no-go verdict. ADR-0025 D3." },
+    { "name": "ISimulationTarget", "kind": "interface", "description": "The thing being simulated — a chat model, a workflow definition, an agent, a retrieval pipeline. Abstracts over what the scenario is run against. Parallel in shape to Evals's IEvalTarget per ADR-0023 D3 but does NOT share the type — Sim owns ISimulationTarget to avoid creating a Sim → Evals runtime edge. Router-bypass boundary per ADR-0025 D8." },
+    { "name": "Scenario", "kind": "type", "description": "Record. A single simulation scenario — initial state fixture, proposed actions or workflow under test, constraints, per-scenario metadata. Replaces the previous prose-level IScenario. ADR-0025 D3." },
+    { "name": "RiskAssessment", "kind": "type", "description": "Record. Structured risk evaluation — identified failure modes, per-mode probability, per-mode mitigation, confidence level, aggregate severity. Replaces the previous prose-level IRiskAssessment. ADR-0025 D3." },
+    { "name": "SimulationResult", "kind": "type", "description": "Record. Structured simulation results — projected outcome payload, per-step trace, observed Operator-primitive firings (per ADR-0025 D9), a RiskAssessment, run provenance (target identity, ModelCapabilityDeclaration identity when pinned, scenario version, timestamps, reproducibility seed per ADR-0025 D7). Replaces the previous ISimulationResult interface. ADR-0025 D3 / D12." }
+  ]
+}
+```
+
+### `catalogs/relationships.json` — `honeydrunk-sim` block
+
+**(a) `consumes` widening.** Replace with:
+
+```json
+"consumes": ["honeydrunk-kernel", "honeydrunk-ai", "honeydrunk-knowledge", "honeydrunk-agents", "honeydrunk-flow", "honeydrunk-memory", "honeydrunk-operator"]
+```
+
+**(b) `consumes_detail`.** Add per-edge entries:
+
+```json
+"honeydrunk-kernel": ["IGridContext", "IOperationContext", "ITelemetryActivityFactory", "HoneyDrunk.Kernel.Abstractions"],
+"honeydrunk-ai": ["IChatClient", "IModelProvider", "ModelCapabilityDeclaration", "HoneyDrunk.AI.Abstractions"],
+"honeydrunk-knowledge": ["HoneyDrunk.Knowledge.Abstractions", "HoneyDrunk.Knowledge.Providers.InMemory"],
+"honeydrunk-agents": ["IAgent", "HoneyDrunk.Agents.Abstractions"],
+"honeydrunk-flow": ["IWorkflow", "IWorkflowStep", "HoneyDrunk.Flow.Abstractions"],
+"honeydrunk-memory": ["IMemoryStore", "IMemoryScope", "HoneyDrunk.Memory.Abstractions", "HoneyDrunk.Memory.Providers.InMemory"],
+"honeydrunk-operator": ["ICostGuard", "ISafetyFilter", "IApprovalGate", "HoneyDrunk.Operator.Abstractions"]
+```
+
+**(c) `exposes.contracts`.** Replace with D3 set:
+
+```json
+"contracts": ["ISimulator", "IPlanValidator", "ISimulationTarget", "Scenario", "RiskAssessment", "SimulationResult"]
+```
+
+**(d) `exposes.packages`.** Replace with:
+
+```json
+"packages": ["HoneyDrunk.Sim.Abstractions", "HoneyDrunk.Sim", "HoneyDrunk.Sim.Providers.InMemory"]
+```
+
+### `catalogs/grid-health.json` — `honeydrunk-sim` block
+
+Standup block naming D3 six surfaces; scaffold packet as blocker; closing-of-the-wave note.
+
+### `catalogs/nodes.json` — `honeydrunk-sim` block
+
+**(a) `roadmap_focus`.** Drop "Optional for initial AI sector delivery." Replace with text naming Sim as the closing Node of the AI-sector stand-up wave and naming the D3 six surfaces.
+
+**(b) `grid_relationship`.** Replace to reflect D4 — explicitly name Flow + Memory + Operator + Knowledge edges, and the parallel-but-distinct relationship to Evals's `IEvalTarget` per D8.
+
+### `constitution/ai-sector-architecture.md` — Sim section
+
+Update Key Contracts to D3 six surfaces. Depends-on / Emits-to split:
+
+> `**Depends on:** Kernel, AI (IChatClient, IModelProvider, ModelCapabilityDeclaration for ChatTarget + model pinning per D8), Flow (IWorkflow, IWorkflowStep — read-only per D5), Agents (IAgent — for AgentTarget when scaffolded), Knowledge (Providers.InMemory for fixture composition per D11), Memory (Providers.InMemory for fixture composition per D11), Operator (ICostGuard, ISafetyFilter, IApprovalGate — observation-only per D9 — runtime edge).`
+>
+> `**Emits to (no runtime dependency):** Pulse (simulation lifecycle, step-trace, risk-assessment telemetry — metadata only per D10, following the Memory/Knowledge no-content rule rather than Evals's carve-out).`
+
+Note the side-effect-freedom rule (D6) and the router-bypass via `ISimulationTarget` (D8 — parallel to Evals's `IEvalTarget` but distinct types).
+
+### `repos/HoneyDrunk.Sim/overview.md`
+
+Replace `IScenario`, `IRiskAssessment`, `ISimulationResult` references with the records `Scenario`, `RiskAssessment`, `SimulationResult`. Add `IPlanValidator` and `ISimulationTarget` to Key Contracts. Add `HoneyDrunk.Sim.Providers.InMemory` to Packages table. Note the side-effect-freedom rule (D6) and the router-bypass primitive (D8).
+
+### `repos/HoneyDrunk.Sim/boundaries.md`
+
+Align to D4 boundary decision test. Note Sim-vs-Evals (side-effect-freedom per D6), Sim-vs-Flow (read-only consumption per D5), Sim-vs-Operator (observation-only per D9), Sim-vs-Memory (fixture composition only per D11).
+
+### `repos/HoneyDrunk.Sim/invariants.md`
+
+Update to align with the new D3 contract names. Confirm item 2 (no side effects), item 3 (confidence level), item 5 (GridContext flagging) are still consistent.
+
+### `repos/HoneyDrunk.Sim/integration-points.md` — new file
+
+Standard template; reflect D4 + D5 + D6 + D8 + D9 + D10 + D11.
+
+### `repos/HoneyDrunk.Sim/active-work.md` — new file
+
+### `initiatives/active-initiatives.md` — new entry
+
+Standard format. Note Sim as the closing Node of the AI-sector wave.
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append standard entry naming the three-way drift reconciliation and the closing-of-the-wave milestone.
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+- `catalogs/grid-health.json`
+- `catalogs/nodes.json`
+- `constitution/ai-sector-architecture.md`
+- `repos/HoneyDrunk.Sim/overview.md`
+- `repos/HoneyDrunk.Sim/boundaries.md`
+- `repos/HoneyDrunk.Sim/invariants.md`
+- `repos/HoneyDrunk.Sim/integration-points.md` (new)
+- `repos/HoneyDrunk.Sim/active-work.md` (new)
+- `initiatives/active-initiatives.md`
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] D3 six-surface set canonical (three interfaces + three records).
+- [x] Three-way drift reconciled in single PR.
+- [x] Records drop `I`; interfaces keep it.
+- [x] `ISimulationTarget` is distinct from `IEvalTarget` — no Sim→Evals edge in `consumes`.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` `honeydrunk-sim` lists exactly the D3 six surfaces — three interfaces + three records. No `ISimulationResult`, no `IScenario`, no `IRiskAssessment`.
+- [ ] Records use `kind: "type"`.
+- [ ] `relationships.json` `consumes` includes Kernel + AI + Knowledge + Agents + Flow + Memory + Operator. Does NOT include `honeydrunk-evals` (per D8 — no Sim→Evals edge).
+- [ ] `consumes_detail` per edge.
+- [ ] `exposes.contracts` matches D3 six-set.
+- [ ] `exposes.packages` includes `HoneyDrunk.Sim.Providers.InMemory`.
+- [ ] `grid-health.json` reflects standup + closing-of-the-wave note.
+- [ ] `nodes.json roadmap_focus` does NOT say "Optional"; names Sim as closing Node.
+- [ ] `nodes.json grid_relationship` reflects D4/D5/D8/D9/D11.
+- [ ] `ai-sector-architecture.md` Sim section reads D3 six surfaces; Depends-on / Emits-to split present; side-effect-freedom and router-bypass noted.
+- [ ] `repos/HoneyDrunk.Sim/overview.md`, `boundaries.md`, `invariants.md` aligned to D3 + D4.
+- [ ] `integration-points.md` and `active-work.md` exist.
+- [ ] `initiatives/active-initiatives.md` includes new entry, notes Sim as closing Node.
+- [ ] `CHANGELOG.md` updated.
+- [ ] `grep -rn "IScenario\|IRiskAssessment\|ISimulationResult" catalogs/ repos/HoneyDrunk.Sim/ constitution/` returns zero matches (the records `Scenario`, `RiskAssessment`, `SimulationResult` should appear; their interface-prefix versions should not).
+- [ ] ADR-0025 NOT modified — Status stays Proposed.
+
+## Human Prerequisites
+None.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.
+
+> **Invariant 11:** One repo per Node.
+
+## Referenced ADR Decisions
+
+**ADR-0025 D3:** Six surfaces — three interfaces + three records.
+
+**ADR-0025 D4:** Boundary decision test against every adjacent Node.
+
+**ADR-0025 D5:** Flow consumption is compile-time, read-only.
+
+**ADR-0025 D6:** Side-effect-freedom is the Sim-Evals boundary primitive.
+
+**ADR-0025 D8:** Router bypass via `ISimulationTarget`; distinct from `IEvalTarget`.
+
+**ADR-0025 D9:** Operator composition is observation-only — runtime edge.
+
+**ADR-0025 D10:** Telemetry metadata-only (Memory/Knowledge rule, not Evals's carve-out).
+
+**ADR-0025 D11:** Fixture composition via `Providers.InMemory` of Memory + Knowledge.
+
+**ADR-0024 D4/D6 (referenced):** Flow-side reciprocal — Sim consumes `IWorkflow` read-only.
+
+## Dependencies
+None.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0025`
+
+## Agent Handoff
+
+**Objective:** Reconcile three-way drift. Land D3 six-surface set + new consumes edges. No Sim→Evals edge.
+
+**Constraints:**
+- **D3 is canonical.** Six surfaces — three interfaces, three records.
+- **Records use `kind: "type"`.**
+- **No Sim→Evals edge.** `ISimulationTarget` is parallel-but-distinct from `IEvalTarget` per D8.
+- **No code; catalog + docs only.**
+- **No ADR Status flip.**
+
+**Key Files:** All listed above.
+
+**Contracts:** None authored.

--- a/generated/issue-packets/active/adr-0025-sim-standup/02-architecture-sim-invariants.md
+++ b/generated/issue-packets/active/adr-0025-sim-standup/02-architecture-sim-invariants.md
@@ -1,0 +1,106 @@
+---
+name: Constitution Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ai", "adr-0025", "constitution"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0025"]
+accepts: ADR-0025
+wave: 1
+initiative: adr-0025-sim-standup
+node: honeydrunk-sim
+---
+
+# Chore: Add ADR-0025's ten new invariants to the Grid constitution
+
+## Summary
+
+Add ten new invariants from ADR-0025: downstream-coupling (D2), side-effect-freedom (D6), Flow-read-only consumption (D5), Operator-observation-only (D9), router-bypass-via-ISimulationTarget (D8), `SimulationResult` provenance (D12), fixture-composition-via-Providers.InMemory (D11), telemetry-metadata-only-no-carve-out (D10), Sim-Abstractions-no-Operator-or-Memory deps (D2+D9+D11), contract-shape canary on four hot-path surfaces (D13).
+
+Default numbers **83-92** (assumes all prior AI-sector initiatives landed claiming 44-82; collision check decides).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Proposed Implementation
+
+### `constitution/invariants.md` — append ten new entries
+
+```markdown
+## AI Sector — Sim Invariants
+
+83. **Downstream Nodes take a runtime dependency only on `HoneyDrunk.Sim.Abstractions`.**
+    Composition against `HoneyDrunk.Sim` and any `HoneyDrunk.Sim.Providers.*` package is a host-time concern. See ADR-0025 D2 (Proposed — this invariant takes effect when ADR-0025 is accepted).
+
+84. **Side-effect-freedom is the Sim–Evals boundary primitive.**
+    If it writes to any Grid-durable surface, it is not Sim. Evals reads what the target actually did; Sim substitutes for that real behavior to predict what would happen. Sim's `ISimulator.SimulateAsync` does not take writer surfaces as parameters and does not compose writer surfaces in its default runtime path. This extends `repos/HoneyDrunk.Sim/invariants.md` item 2 to the Grid level. See ADR-0025 D6 (Proposed — this invariant takes effect when ADR-0025 is accepted).
+
+85. **Sim consumes `IWorkflow` and `IWorkflowStep` as read-only authoring surfaces, never `IWorkflowEngine`.**
+    This is the reciprocal of ADR-0024 D4/D6's Flow-side pin. A simulation of a workflow is a walk over the definition with substituted target behavior, not an execution of the engine. See ADR-0025 D5 (Proposed — this invariant takes effect when ADR-0025 is accepted).
+
+86. **Sim composes Operator primitives as observation-only prediction inputs.**
+    `ISafetyFilter`, `ICostGuard`, `IApprovalGate` are called to predict what Operator would do; Sim never enforces. Sim never writes to `IAuditLog`. The observes-vs-enforces distinction mirrors ADR-0023 D7 (Evals-style) with a shift in framing — Sim predicts, Evals observes. See ADR-0025 D9 (Proposed — this invariant takes effect when ADR-0025 is accepted).
+
+87. **Router bypass is permitted only through `ISimulationTarget`.**
+    Parallel to Evals's `IEvalTarget` bypass per ADR-0023 D6, but `ISimulationTarget` does NOT share the `IEvalTarget` type — Sim and Evals do not compose, so coupling the types would create a runtime edge neither Node needs. Every bypass is recorded on `SimulationResult.ModelCapabilityDeclarationIdentifier` per D12. See ADR-0025 D8 (Proposed — this invariant takes effect when ADR-0025 is accepted).
+
+88. **Every `SimulationResult` records the full run provenance — scenario identity and version, `ISimulationTarget` identity, `ModelCapabilityDeclaration` identity (when a model was pinned), reproducibility seed (per D7), timestamps.**
+    `SimulationResult` without provenance is not a valid result. A risk assessment is a decision input — without the provenance fields, the consumer cannot reproduce or audit the projection. See ADR-0025 D7, D12 (Proposed — this invariant takes effect when ADR-0025 is accepted).
+
+89. **Sim seeds Memory and Knowledge state via `Providers.InMemory`, never production backends.**
+    The production Memory and Knowledge stores are not on Sim's runtime edge. Scenario seeds compose the in-memory provider with the fixture state at simulation-start and discard it at simulation-end. See ADR-0025 D11 (Proposed — this invariant takes effect when ADR-0025 is accepted).
+
+90. **Simulation telemetry is metadata-only and follows the Memory/Knowledge content-in-telemetry rule, not the Evals carve-out.**
+    Scenario inputs and predicted outputs are not carried in Pulse signals; they are recoverable through `SimulationResult` if an investigator needs them. The actionable information in a Pulse signal is the identity, score, and confidence — not the payload. Stripping content from simulation telemetry does not degrade actionability the way it would degrade eval triage. See ADR-0025 D10 (Proposed — this invariant takes effect when ADR-0025 is accepted).
+
+91. **`HoneyDrunk.Sim.Abstractions` does not take compile-time dependencies on `HoneyDrunk.Operator.Abstractions` or `HoneyDrunk.Memory.Abstractions`.**
+    Both are runtime-only edges consumed inside the default `HoneyDrunk.Sim` package. The compile-time `HoneyDrunk.Sim.Abstractions` → `HoneyDrunk.Flow.Abstractions` edge IS permitted because Flow shapes legitimately need to be readable on member signatures (D5). The split between "Flow shape in Abstractions" and "Operator / Memory composition in runtime" is deliberate and load-bearing for the downstream coupling rule. See ADR-0025 D2, D9, D11 (Proposed — this invariant takes effect when ADR-0025 is accepted).
+
+92. **The HoneyDrunk.Sim Node CI must include a contract-shape canary that fails the build on shape drift to `ISimulator`, `IPlanValidator`, `ISimulationTarget`, or `SimulationResult` without a corresponding version bump.**
+    These four are the hot path for every real consumer (Flow workflow-dry-run, Agents agent-plan, Lore wiki-plan validation, HoneyHub when live, application Nodes with commit-to-real gates). `Scenario` and `RiskAssessment` are not in the stand-up canary because their shapes are expected to evolve modestly as concrete `ISimulationTarget` shapes land at scaffold; they become canary candidates once scaffold lands and shapes settle. See ADR-0025 D13 (Proposed — this invariant takes effect when ADR-0025 is accepted).
+```
+
+### Collision check
+
+Default 83-92. Shift on collision; update ADR-0025 + packet 04 source in lockstep. `rg` only.
+
+### `CHANGELOG.md`
+
+Append: `Architecture: Add invariants 83-92 (Sim downstream coupling, side-effect-freedom Sim-Evals boundary, Sim consumes IWorkflow read-only, Sim observes Operator without enforcing, router-bypass via ISimulationTarget only, SimulationResult full provenance, fixture composition via Providers.InMemory of Memory + Knowledge, telemetry metadata-only following Memory/Knowledge rule, Sim Abstractions stays Operator/Memory-free, Sim contract-shape canary) per ADR-0025. **Closes the AI-sector standup invariant wave at 92.**`
+
+## Affected Files
+- `constitution/invariants.md`
+- `adrs/ADR-0025-stand-up-honeydrunk-sim-node.md` (only on shift)
+- `generated/issue-packets/active/adr-0025-sim-standup/04-sim-node-scaffold.md` (only on shift)
+- `CHANGELOG.md`
+
+## Acceptance Criteria
+- [ ] Ten invariants present matching ADR-0025.
+- [ ] Numbers verified; default 83-92.
+- [ ] `(Proposed — this invariant takes effect when ADR-0025 is accepted)` qualifier on each.
+- [ ] On shift, ADR-0025 + packet 04 updated lockstep.
+- [ ] `CHANGELOG.md` updated.
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0025 D2, D5, D6, D7, D8, D9, D10, D11, D12, D13.** Sources for invariants 83-92.
+
+## Dependencies
+- `packet:01`
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ai`, `adr-0025`, `constitution`
+
+## Agent Handoff
+
+**Objective:** Ten new invariants. Default 83-92. Closes AI-sector standup invariant wave.
+
+**Constraints:** `(Proposed)` qualifier each. `rg` only.
+
+**Key Files:** `constitution/invariants.md`; conditional ADR-0025 + packet 04; `CHANGELOG.md`.
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0025-sim-standup/03-architecture-create-sim-repo.md
+++ b/generated/issue-packets/active/adr-0025-sim-standup/03-architecture-create-sim-repo.md
@@ -1,0 +1,108 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "ai", "adr-0025", "human-only", "wave-2", "new-node"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0025"]
+accepts: ADR-0025
+wave: 2
+initiative: adr-0025-sim-standup
+node: honeydrunk-architecture
+actor: human
+---
+
+# Chore: Create `HoneyDrunk.Sim` GitHub repo + clone locally (human-only)
+
+## Summary
+
+Create `HoneyDrunkStudios/HoneyDrunk.Sim` repo on GitHub and clone locally. Same pattern as `adr-0023-evals-standup/03-architecture-create-evals-repo.md` — the repo does NOT yet exist.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Actor
+**`Human`.** Org-admin rights required.
+
+## Motivation
+
+Packet 04 cannot be filed against a repo that does not exist. Surfaces this as Wave-2 human-only work.
+
+## Steps
+
+### Step 1 — Create repo (portal)
+
+1. https://github.com/organizations/HoneyDrunkStudios/repositories/new
+2. **Repository name:** `HoneyDrunk.Sim`
+3. **Description:** `Simulation and plan-evaluation substrate for the AI sector — predicts what would happen when a workflow / agent plan / retrieval pipeline is run, without touching live state. Side-effect-free by construction. Router-bypass via ISimulationTarget for reproducible projections. Closing Node of the AI-sector standup wave.`
+4. **Visibility:** Public.
+5. **Initialize with:**
+   - [x] Add a README file
+   - [x] `.gitignore` → `VisualStudio`
+   - [x] License — match `HoneyDrunk.Auth/LICENSE` shape
+6. **Create repository**
+7. Apply org defaults — branch protection on `main` (PR required, `pr-core / core` required (canary post-merge), no force pushes, no deletions), default branch `main`, Actions enabled.
+
+### Step 2 — Seed labels
+
+```bash
+for label in "feature:0E8A16" "chore:CCCCCC" "tier-1:E99695" "tier-2:FBCA04" "ai:D946EF" "scaffold:BFDADC" "adr-0025:1D76DB" "wave-3:FBCA04" "human-only:B60205" "out-of-band:D4C5F9" "new-node:C5DEF5"; do
+  name="${label%:*}"; color="${label#*:}"
+  gh label create "$name" --repo HoneyDrunkStudios/HoneyDrunk.Sim --color "$color" 2>/dev/null
+done
+```
+
+### Step 3 — Clone locally
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/
+git clone https://github.com/HoneyDrunkStudios/HoneyDrunk.Sim.git
+cd HoneyDrunk.Sim
+git status
+ls
+```
+
+Confirm `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Sim/` exists with `.gitignore`, `LICENSE`, `README.md`.
+
+### Step 4 — OIDC
+
+Cross-link: [`infrastructure/walkthroughs/oidc-federated-credentials.md`](../../../../infrastructure/walkthroughs/oidc-federated-credentials.md). Confirm `repo:HoneyDrunkStudios/HoneyDrunk.Sim:ref:refs/tags/v*` in NuGet publishing identity's federated credential list.
+
+## Acceptance Criteria
+- [ ] Repo exists, Public, default branch `main`.
+- [ ] Branch protection configured.
+- [ ] Labels seeded.
+- [ ] Local clone at `c:/.../HoneyDrunkStudios/HoneyDrunk.Sim/` with starter files.
+- [ ] OIDC verified.
+- [ ] Chore closed.
+
+## Human Prerequisites
+- [ ] Org-admin role
+- [ ] Browser; gh CLI authenticated
+- [ ] Azure portal access if Step 4 needs work
+
+## Dependencies
+- `packet:01`
+
+## Downstream Unblocks
+- `04-sim-node-scaffold.md` — fileable after this chore Done + packet 02 merged.
+
+## Referenced ADR Decisions
+
+**ADR-0025 D1 / D2:** Sim is the simulation substrate (closing Node of the AI-sector wave). New Node ⇒ new repo per invariant 11.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node.
+
+> **Invariant 24:** Pre-filing amendments to packet 04 permitted if invariant numbers shift in packet 02.
+
+## Labels
+`chore`, `tier-1`, `meta`, `ai`, `adr-0025`, `human-only`, `wave-2`, `new-node`
+
+## Notes
+- ~5-minute portal task + one `git clone`.
+- Do not commit anything to the local clone — scaffolding agent in packet 04 authors all source files.
+- No Azure provisioning required.
+- **Sim closes the AI-sector standup wave** — after Sim's 0.1.0 ships, every cataloged AI-sector Node has a published Abstractions.

--- a/generated/issue-packets/active/adr-0025-sim-standup/04-sim-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0025-sim-standup/04-sim-node-scaffold.md
@@ -1,0 +1,402 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Sim
+labels: ["feature", "tier-2", "ai", "scaffold", "adr-0025", "new-node"]
+dependencies: ["packet:01", "packet:02", "packet:03"]
+adrs: ["ADR-0025", "ADR-0016", "ADR-0024", "ADR-0023"]
+accepts: ADR-0025
+wave: 3
+initiative: adr-0025-sim-standup
+node: honeydrunk-sim
+---
+
+# Feature: Stand up the HoneyDrunk.Sim repo — solution, three packages, six surfaces, CI, InMemory provider
+
+## Summary
+
+Bring the newly-created `HoneyDrunk.Sim` repo from zero to first-shippable per ADR-0025. Land solution, three packages (`Abstractions`, runtime, `Providers.InMemory` scenario-execution backend), six D3 surfaces in Abstractions (three interfaces + three records), default `ISimulator` + `IPlanValidator` + `ISimulationTarget` chat-backed shape with router-bypass per D8, reproducibility primitives per D7 (seed, deterministic-vs-non-deterministic flag), observation-only Operator composition per D9, fixture composition with Memory + Knowledge `Providers.InMemory` per D11, `Providers.InMemory` scenario-execution backend, standard CI, contract-shape canary scoped to Abstractions per D13 (number assigned by packet 02).
+
+**Closes the AI-sector stand-up wave** — Sim is the ninth and final standup of the wave.
+
+Unblocks Flow (workflow-dry-run scenarios), Agents (agent-plan scenarios), Lore, HoneyHub when live, application Nodes with commit-to-real-execution gates.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Sim`
+
+## Motivation
+
+ADR-0025 establishes Sim's contract surface. Repo created in packet 03 (LICENSE + README only).
+
+## Proposed Implementation
+
+### Repository layout
+
+```
+HoneyDrunk.Sim/
+├── HoneyDrunk.Sim.slnx
+├── Directory.Build.props
+├── CHANGELOG.md
+├── README.md
+├── .editorconfig
+├── .gitignore
+├── .github/workflows/{pr-core,release,nightly-deps,nightly-security,api-compatibility}.yml
+├── src/
+│   ├── HoneyDrunk.Sim.Abstractions/
+│   │   ├── HoneyDrunk.Sim.Abstractions.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── ISimulator.cs
+│   │   ├── IPlanValidator.cs
+│   │   ├── ISimulationTarget.cs
+│   │   ├── Scenario.cs
+│   │   ├── RiskAssessment.cs
+│   │   └── SimulationResult.cs
+│   ├── HoneyDrunk.Sim/
+│   │   ├── HoneyDrunk.Sim.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── ServiceCollectionExtensions.cs
+│   │   ├── Orchestration/DefaultSimulator.cs
+│   │   ├── Validation/DefaultPlanValidator.cs
+│   │   ├── Targets/ChatTarget.cs                       (D8 router-bypass)
+│   │   ├── ObserverPrediction/SafetyFilterPredictor.cs (D9 observation-only)
+│   │   ├── ObserverPrediction/CostGuardPredictor.cs    (D9 observation-only)
+│   │   ├── ObserverPrediction/ApprovalGatePredictor.cs (D9 observation-only)
+│   │   ├── FixtureComposition/MemoryFixtureLoader.cs    (D11 — composes Memory.Providers.InMemory)
+│   │   ├── FixtureComposition/KnowledgeFixtureLoader.cs (D11 — composes Knowledge.Providers.InMemory)
+│   │   ├── Reproducibility/SeededRng.cs                 (D7)
+│   │   └── Telemetry/SimTelemetry.cs                    (D10 metadata-only)
+│   └── HoneyDrunk.Sim.Providers.InMemory/
+│       ├── HoneyDrunk.Sim.Providers.InMemory.csproj
+│       ├── README.md
+│       ├── CHANGELOG.md
+│       └── InMemoryScenarioExecutor.cs
+└── tests/
+    ├── HoneyDrunk.Sim.Abstractions.Tests/
+    ├── HoneyDrunk.Sim.Tests/
+    └── HoneyDrunk.Sim.Providers.InMemory.Tests/
+```
+
+### Contract details — `HoneyDrunk.Sim.Abstractions`
+
+```csharp
+// ISimulator.cs
+namespace HoneyDrunk.Sim.Abstractions;
+
+public interface ISimulator
+{
+    Task<SimulationResult> SimulateAsync(Scenario scenario, ISimulationTarget target, CancellationToken cancellationToken = default);
+}
+```
+
+```csharp
+// IPlanValidator.cs
+public interface IPlanValidator
+{
+    Task<PlanValidationResult> ValidateAsync(Scenario scenario, ISimulationTarget target, CancellationToken cancellationToken = default);
+}
+
+public sealed record PlanValidationResult(SimulationResult Simulation, RiskAssessment RiskAssessment, PlanVerdict Verdict);
+public enum PlanVerdict { Go = 0, NoGo = 1, RequiresApproval = 2 }
+```
+
+```csharp
+// ISimulationTarget.cs (D8 router-bypass)
+public interface ISimulationTarget
+{
+    string TargetId { get; }
+    string TargetKind { get; }                              // "chat", "workflow", "agent", "retrieval", "transcript-replay"
+    string? PinnedModelCapabilityIdentifier { get; }        // D8 — non-null when target pins a model
+    bool IsDeterministic { get; }                            // D7 — non-deterministic targets flagged
+    Task<TargetInvocationResult> InvokeAsync(SimulationStepInput input, CancellationToken cancellationToken = default);
+}
+
+public sealed record SimulationStepInput(string ScenarioId, string StepId, string InputJson, long Seed);
+public sealed record TargetInvocationResult(string OutputJson, IReadOnlyDictionary<string, string> Metadata);
+```
+
+```csharp
+// Scenario.cs (record — no I prefix)
+public sealed record Scenario(
+    string ScenarioId,
+    string ScenarioVersion,
+    string InitialStateFixtureJson,
+    IReadOnlyList<ProposedAction> ProposedActions,
+    IReadOnlyDictionary<string, string> Constraints,
+    IReadOnlyDictionary<string, string> Tags);
+
+public sealed record ProposedAction(string ActionId, string ActionKind, string PayloadJson);
+```
+
+```csharp
+// RiskAssessment.cs (record — no I prefix)
+public sealed record RiskAssessment(
+    IReadOnlyList<RiskFailureMode> IdentifiedFailureModes,
+    double ConfidenceLevel,
+    double AggregateSeverity);
+
+public sealed record RiskFailureMode(string ModeId, string Description, double Probability, string? Mitigation);
+```
+
+```csharp
+// SimulationResult.cs (record — no I prefix; D12)
+public sealed record SimulationResult(
+    string ResultId,
+    string ScenarioId,
+    string ScenarioVersion,
+    string TargetId,
+    string? PinnedModelCapabilityIdentifier,
+    long ReproducibilitySeed,                          // D7
+    DateTimeOffset StartedAt,
+    DateTimeOffset CompletedAt,
+    string ProjectedOutcomeJson,
+    IReadOnlyList<SimulationStepTrace> StepTrace,
+    ObservedOperatorPredictions OperatorObservations,   // D9
+    RiskAssessment RiskAssessment,
+    bool ContainsNonDeterministicSteps);
+
+public sealed record SimulationStepTrace(string StepId, string TargetId, string OutputJson, TimeSpan Duration, bool IsDeterministic);
+
+public sealed record ObservedOperatorPredictions(
+    bool? PredictedSafetyFilterFiring,
+    string? PredictedSafetyFilterRule,
+    decimal? PredictedCostMarker,
+    bool? PredictedCostThresholdCrossing,
+    bool? PredictedApprovalRequired,
+    string? PredictedPauseLocation);
+```
+
+`HoneyDrunk.Sim.Abstractions` references **`HoneyDrunk.Flow.Abstractions`** per D5 (compile-time, accepted for read-only consumption of `IWorkflow`/`IWorkflowStep` shapes in concrete `WorkflowTarget` when scaffolded — first-pass shape may not actually need this if `WorkflowTarget` is deferred). If the executing agent can keep Flow out of Abstractions surface signatures (defer `WorkflowTarget` shape), prefer that. **Does NOT** reference `HoneyDrunk.Operator.Abstractions` or `HoneyDrunk.Memory.Abstractions` per D2 — those are runtime-only edges per the Sim Abstractions-stays-clean invariant (default 91).
+
+**Strict Abstractions stance.** Identity / capability / correlation fields are `string`. Records first-pass.
+
+**Deliberate stand-up simplification — stringly-typed JSON payloads.** `SimulationStepInput.InputJson`, `TargetInvocationResult.OutputJson`, `Scenario.InitialStateFixtureJson`, `SimulationResult.ProjectedOutcomeJson`, and `SimulationStepTrace.OutputJson` are all `string` (raw JSON) at stand-up. This is intentional — the structure of these payloads depends on the concrete `ISimulationTarget` shape (chat, workflow, agent, retrieval), none of which exist beyond `ChatTarget` at stand-up. Once `WorkflowTarget`, `AgentTarget`, and `RetrievalTarget` crystallize, a follow-up packet introduces structured payload records and a generic discriminator on the interface. Do not bake structured payload types in at stand-up.
+
+### Runtime details — `HoneyDrunk.Sim`
+
+`HoneyDrunk.Sim` references (Abstractions only per ADR-0025 D2 and `consumes_detail` in catalog packet 01 — never runtime packages of other Nodes):
+- `HoneyDrunk.Sim.Abstractions` (project)
+- `HoneyDrunk.Kernel.Abstractions` (telemetry, context)
+- `HoneyDrunk.AI.Abstractions` (`IChatClient`, `IModelProvider`, `ModelCapabilityDeclaration` for `ChatTarget` per D8)
+- `HoneyDrunk.Flow.Abstractions` (runtime — only if scaffolding agent ships a `WorkflowTarget`; otherwise defer; read-only `IWorkflow`/`IWorkflowStep` per D5)
+- `HoneyDrunk.Operator.Abstractions` (`ISafetyFilter`, `ICostGuard`, `IApprovalGate` per D9 — observation-only)
+- `HoneyDrunk.Memory.Abstractions` + `HoneyDrunk.Memory.Providers.InMemory` (Abstractions for typing, `Providers.InMemory` for fixture composition per D11)
+- `HoneyDrunk.Knowledge.Abstractions` + `HoneyDrunk.Knowledge.Providers.InMemory` (Abstractions for typing, `Providers.InMemory` for fixture composition per D11)
+- `Microsoft.Extensions.*`
+
+Implementations:
+
+- **`DefaultSimulator`** — orchestrates: loads scenario fixtures via `MemoryFixtureLoader` + `KnowledgeFixtureLoader` (D11), invokes target per step, predicts Operator behavior via the three predictor classes (D9), builds `SimulationResult` with full provenance (D12) and reproducibility seed (D7).
+- **`DefaultPlanValidator`** — composes `DefaultSimulator` internally, runs simulation, evaluates risk via aggregating failure modes, returns `PlanValidationResult` with go/no-go/requires-approval verdict.
+- **`ChatTarget`** — wraps `IChatClient`. When `PinnedModelCapabilityIdentifier` non-null, resolves `IModelProvider` directly for that capability (router-bypass per D8). Pinning recorded on `SimulationResult`.
+- **`SafetyFilterPredictor` / `CostGuardPredictor` / `ApprovalGatePredictor`** — invoke the respective Operator primitive in a way that records *what it would do* without producing enforcement-side effects. Implementation note: predictor classes call the primitive's read/check method (e.g. `ISafetyFilter.CheckAsync`) which is by nature non-mutating; the prediction is just observing the result and recording it on `ObservedOperatorPredictions`.
+- **`MemoryFixtureLoader` / `KnowledgeFixtureLoader`** — at simulation start, composes `Providers.InMemory` with the scenario's fixture state. Discards at simulation end. Per D11, never touches production backends.
+- **`SeededRng`** — deterministic RNG instance keyed by `SimulationResult.ReproducibilitySeed`. Used everywhere randomness is needed (target selection, scenario-step ordering when applicable). When a target is non-deterministic (e.g. live `IChatClient` without seed), the simulation marks `ContainsNonDeterministicSteps: true`.
+- **`SimTelemetry`** — emits per-lifecycle / per-step-trace / per-risk-aggregate activities. **Metadata only** per D10 — no scenario input, target output, or projected payload content in tags.
+
+### Providers.InMemory details
+
+`InMemoryScenarioExecutor` — in-process scenario-execution backend. Direct implementation of `ISimulator` (and optionally `IPlanValidator`) against `HoneyDrunk.Sim.Abstractions` only. It does NOT reference or compose the `HoneyDrunk.Sim` runtime package — that would create a `Providers.InMemory` → runtime edge in violation of the layout (line 245 below). Implementation reproduces the minimum mechanics needed for a deterministic, in-memory scenario walk: iterate over `Scenario.ProposedActions`, invoke `ISimulationTarget.InvokeAsync` per step against a seeded RNG, accumulate `SimulationStepTrace` entries, build a `SimulationResult`. Side-effect-free by construction. The full-featured `DefaultSimulator` (with Operator-observation predictors, Memory + Knowledge fixture composition, etc.) lives in `HoneyDrunk.Sim`; `InMemoryScenarioExecutor` is a smaller, Abstractions-only alternative suitable for tests and seed runs.
+
+### CI workflows
+
+Five files; `api-compatibility.yml` path-filtered to `src/HoneyDrunk.Sim.Abstractions/**`.
+
+### `HoneyDrunk.Standards`
+
+Per invariant 26.
+
+### Documentation
+
+Repo README — purpose, package matrix, "How to consume" snippet with `AddHoneyDrunkSim()` + `AddChatTarget()` example, link to ADR-0025. Note side-effect-freedom (D6), router-bypass via `ISimulationTarget` (D8 — and the parallel-but-distinct relationship to `IEvalTarget`), closing-of-the-wave milestone. Per-package README + CHANGELOG.
+
+## Affected Files
+Entire repo. See layout.
+
+## NuGet Dependencies
+
+### `HoneyDrunk.Sim.Abstractions.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Flow.Abstractions` | **Conditional** — only if `WorkflowTarget` lands in this packet and needs `IWorkflow`/`IWorkflowStep` shapes on a public member signature. Prefer deferring. |
+
+**No** `HoneyDrunk.Operator.Abstractions`. **No** `HoneyDrunk.Memory.Abstractions`. Per the Sim Abstractions-stays-clean invariant (default 91).
+
+### `HoneyDrunk.Sim.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | Telemetry, context |
+| `HoneyDrunk.AI.Abstractions` | `IChatClient`, `IModelProvider`, `ModelCapabilityDeclaration` for ChatTarget per D8 |
+| `HoneyDrunk.Flow.Abstractions` | Only if `WorkflowTarget` ships in this packet — read-only `IWorkflow` / `IWorkflowStep` per D5 |
+| `HoneyDrunk.Operator.Abstractions` | `ISafetyFilter`, `ICostGuard`, `IApprovalGate` per D9 — observation-only |
+| `HoneyDrunk.Memory.Abstractions` + `HoneyDrunk.Memory.Providers.InMemory` | Abstractions for typing, `Providers.InMemory` for fixture composition per D11 |
+| `HoneyDrunk.Knowledge.Abstractions` + `HoneyDrunk.Knowledge.Providers.InMemory` | Abstractions for typing, `Providers.InMemory` for fixture composition per D11 |
+| `Microsoft.Extensions.*` | |
+
+Project reference: `HoneyDrunk.Sim.Abstractions`.
+
+### `HoneyDrunk.Sim.Providers.InMemory.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+
+Project reference: `HoneyDrunk.Sim.Abstractions`. **No reference to runtime / Kernel / AI / Operator / Memory / Knowledge.**
+
+### Test projects: standard + NSubstitute.
+
+## Boundary Check
+- [x] `HoneyDrunk.Sim.Abstractions` references at most `HoneyDrunk.Flow.Abstractions` (and only conditionally per WorkflowTarget). No Operator, no Memory references. Sim Abstractions-stays-clean invariant (default 91).
+- [x] `Providers.InMemory` references only Abstractions.
+- [x] Side-effect-freedom: `ISimulator.SimulateAsync` does not take writer surfaces; runtime composes `Providers.InMemory` not production stores. Sim side-effect-freedom invariant (default 84).
+- [x] Sim consumes `IWorkflow` read-only — no `IWorkflowEngine.StartAsync` invocation. Sim read-only-IWorkflow invariant (default 85).
+- [x] Operator primitives observation-only — never trip a breaker, write to `IAuditLog`, or block a real output. Sim observation-only invariant (default 86).
+- [x] Router-bypass only via `ISimulationTarget`. Sim router-bypass invariant (default 87).
+- [x] `SimulationResult` provenance fields populated on every report. Sim provenance invariant (default 88).
+- [x] Memory + Knowledge fixture composition via `Providers.InMemory` only. Sim fixture-composition invariant (default 89).
+- [x] Telemetry metadata-only — no content payloads. Sim telemetry-metadata-only invariant (default 90).
+- [x] Records drop `I`; interfaces keep it.
+- [x] `ISimulationTarget` does NOT extend or share `IEvalTarget` from Evals.
+- [x] Verify `IModelProvider` exposes a public capability-resolution method usable from `HoneyDrunk.Sim` outside `HoneyDrunk.AI` runtime — `ChatTarget` is the first cross-Node consumer of `IModelProvider`. If `HoneyDrunk.AI.Abstractions` does not expose a public capability-resolution surface usable by `ChatTarget`, file a follow-up packet against `HoneyDrunk.AI` to widen the public surface before completing this packet's `ChatTarget` implementation.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Sim.slnx` builds clean.
+- [ ] Six D3 surfaces present with XML docs.
+- [ ] `HoneyDrunk.Sim.Abstractions` has zero `HoneyDrunk.Operator.Abstractions` and zero `HoneyDrunk.Memory.Abstractions` PackageReference. `HoneyDrunk.Flow.Abstractions` reference is conditional (only if `WorkflowTarget` ships here). `grep -rn` over `.csproj` verifies.
+- [ ] `Providers.InMemory` references only `HoneyDrunk.Sim.Abstractions`.
+- [ ] `AddHoneyDrunkSim()` resolves `ISimulator`, `IPlanValidator`, the three predictors, the two fixture loaders.
+- [ ] `DefaultSimulator.SimulateAsync` produces a `SimulationResult` with all provenance fields populated (`ScenarioId`, `ScenarioVersion`, `TargetId`, `PinnedModelCapabilityIdentifier` if applicable, `ReproducibilitySeed`, `StartedAt`/`CompletedAt`, `OperatorObservations`). Unit test verifies all fields non-null/non-default.
+- [ ] **`ISimulator.SimulateAsync` does NOT take `IMemoryStore`, `ICommunicationOrchestrator`, `IWorkflowEngine`, or `IAuditLog` as parameters.** Verified by inspecting the interface signature.
+- [ ] `ChatTarget` with non-null `PinnedModelCapabilityIdentifier` resolves `IModelProvider` directly (router-bypass per D8) and the identifier is recorded on `SimulationResult`. Unit test verifies.
+- [ ] Predictor classes call only Operator surfaces documented as non-mutating per ADR-0018 — verify by reading Operator's contract XML docs or runtime behavior. If any Operator surface used by a predictor is mutating (writes to `IAuditLog`, trips a breaker, or otherwise alters Operator state as part of its `CheckAsync` / equivalent), file a follow-up packet against `HoneyDrunk.Operator` to add a non-mutating predicate variant (e.g., `WouldBlock` / `WouldHalt` / `WouldRequireApproval`) before completing the predictor implementation.
+- [ ] `SafetyFilterPredictor`, `CostGuardPredictor`, `ApprovalGatePredictor` produce observation results without modifying Operator state (no writes to `IAuditLog`, no breaker trips, no actual safety blocks). Unit tests verify observation-only via mocks that assert no mutating calls were made.
+- [ ] `MemoryFixtureLoader` and `KnowledgeFixtureLoader` compose `Providers.InMemory` only — verified by mocking + ensuring no production-store interface is touched. Unit tests verify.
+- [ ] `SeededRng` produces deterministic output given the same seed. Unit test runs same scenario+seed twice and confirms identical `SimulationResult.ProjectedOutcomeJson`.
+- [ ] `SimTelemetry` emits per-lifecycle / per-step / per-risk activities. **Activity tags / attributes contain only metadata.** Unit test asserts no scenario/target/projection payload content in any activity.
+- [ ] `InMemoryScenarioExecutor` produces deterministic simulation results given a seeded scenario. Unit test verifies.
+- [ ] All five `.github/workflows/*.yml` files present.
+- [ ] `api-compatibility.yml` path-filtered; scaffolding PR reports `status: skipped`.
+- [ ] `pr-core.yml` passes.
+- [ ] Repo + per-package `CHANGELOG.md` + `README.md` present. Repo README notes Sim closes the AI-sector wave.
+- [ ] All `src/*.csproj` Version 0.1.0.
+- [ ] Manual confirmation `v0.1.0` tag triggers `release.yml`.
+- [ ] **No concrete `WorkflowTarget`, `AgentTarget`, `RetrievalTarget`, `MemoryTarget` in this packet** unless trivially decidable. `ChatTarget` only. Concrete others ship in follow-up packets.
+- [ ] **No Monte Carlo / N-trial distribution surface.**
+- [ ] **No production scenario-execution backend.**
+- [ ] **`ISimulationTarget` does NOT extend or share `IEvalTarget`.** `grep -rn "IEvalTarget" src/` returns zero matches.
+
+## Human Prerequisites
+- [ ] Packet 03 complete — repo exists, cloned, settings verified.
+- [ ] After merge, push tag `v0.1.0`.
+- [ ] **Upstream Abstractions check.** AI mandatory; Flow conditional (only if `WorkflowTarget` ships); Operator + Memory + Knowledge runtime-mandatory. Placeholder no-ops + follow-up packets for any missing.
+- [ ] **Branch protection sequencing.** Add `api-compatibility / abstractions-shape` to required checks post-merge.
+- [ ] No Azure provisioning required.
+- [ ] After merge + tag, file SonarCloud onboarding follow-up.
+- [ ] File concrete `ISimulationTarget` shape packets (`WorkflowTarget`, `AgentTarget`, `RetrievalTarget`, transcript-replay) as downstream consumers drive shape.
+- [ ] **After this packet ships**, complete the wave-closing housekeeping board item tracked in `dispatch-plan.md` — update `initiatives/active-initiatives.md`, update `constitution/ai-sector-architecture.md`, run the AI-sector-wide site sync covering ADR-0016 through ADR-0025, and file the structured-payload-records follow-up packet plus the concrete `ISimulationTarget` shape packets. These are explicitly out of scope for the scaffold packet itself — the executing agent in `HoneyDrunk.Sim` does not touch the Architecture repo.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages, except where another `*.Abstractions` package is the cleanest way to type a member signature (Flow Abstractions permitted conditionally).
+
+> **Invariant 3:** Providers reference parent Node's contracts, not internal implementation details.
+
+> **Invariant 11:** One repo per Node.
+
+> **Invariant 12, 13, 26, 27.** Standard.
+
+> **Sim downstream-coupling invariant (default 83):** Runtime-depend only on Abstractions.
+
+> **Sim side-effect-freedom invariant (default 84):** If it writes to any Grid-durable surface, it is not Sim.
+
+> **Sim read-only-IWorkflow invariant (default 85):** Sim consumes `IWorkflow`/`IWorkflowStep` read-only; never `IWorkflowEngine`.
+
+> **Sim observation-only invariant (default 86):** Operator primitives composed observation-only.
+
+> **Sim router-bypass invariant (default 87):** Bypass only via `ISimulationTarget`.
+
+> **Sim provenance invariant (default 88):** Every `SimulationResult` records full provenance.
+
+> **Sim fixture-composition invariant (default 89):** Memory + Knowledge fixtures via `Providers.InMemory` only.
+
+> **Sim telemetry-metadata-only invariant (default 90):** Memory/Knowledge rule, not Evals's carve-out.
+
+> **Sim Abstractions-stays-clean invariant (default 91):** No Operator / Memory deps in Abstractions.
+
+> **Sim contract-shape canary invariant (default 92):** Canary on `ISimulator`, `IPlanValidator`, `ISimulationTarget`, `SimulationResult`.
+
+## Referenced ADR Decisions
+
+**ADR-0025 D1:** Simulation + plan-evaluation substrate. Closing Node of the AI-sector standup wave.
+
+**ADR-0025 D2:** Three packages — Abstractions + runtime + Providers.InMemory.
+
+**ADR-0025 D3:** Six surfaces — three interfaces + three records.
+
+**ADR-0025 D5:** Flow consumption is compile-time, read-only of `IWorkflow`/`IWorkflowStep`.
+
+**ADR-0025 D6:** Side-effect-freedom is the Sim-Evals boundary primitive.
+
+**ADR-0025 D7:** Reproducibility seed on every `SimulationResult`.
+
+**ADR-0025 D8:** Router bypass via `ISimulationTarget`. Parallel to Evals's `IEvalTarget` but distinct type.
+
+**ADR-0025 D9:** Operator composition as observation-only prediction inputs.
+
+**ADR-0025 D10:** Telemetry metadata-only (no Evals-style carve-out).
+
+**ADR-0025 D11:** Fixture composition via Memory + Knowledge `Providers.InMemory`.
+
+**ADR-0025 D12:** `SimulationResult` full provenance.
+
+**ADR-0025 D13:** Canary on four hot-path surfaces.
+
+**ADR-0023 D6 (referenced, parallel pattern):** Evals's `IEvalTarget` is the analog of `ISimulationTarget` — same shape, different types.
+
+**ADR-0024 D4/D6 (referenced):** Flow's side of "Sim consumes IWorkflow read-only" edge.
+
+**ADR-0016 D3 (referenced):** `IChatClient`, `IModelProvider`, `ModelCapabilityDeclaration` from AI.
+
+## Dependencies
+- `packet:01`, `packet:02`, `packet:03`
+
+## Labels
+`feature`, `tier-2`, `ai`, `scaffold`, `adr-0025`, `new-node`
+
+## Agent Handoff
+
+**Objective:** Ship `HoneyDrunk.Sim 0.1.0` with the six D3 surfaces, default runtime composing AI / Flow / Operator / Memory / Knowledge runtime edges (Memory + Knowledge via Providers.InMemory only), `Providers.InMemory` scenario-execution backend, CI, canary. **Close the AI-sector standup wave.**
+
+**Target:** HoneyDrunk.Sim, branch from `main`.
+
+**Constraints:**
+- **`HoneyDrunk.Sim.Abstractions` does NOT reference `HoneyDrunk.Operator.Abstractions` or `HoneyDrunk.Memory.Abstractions`.** Sim Abstractions-stays-clean invariant (default 91).
+- **Conditional Flow Abstractions reference.** Only if `WorkflowTarget` ships in this packet. Prefer to defer WorkflowTarget to follow-up — keep Sim Abstractions HoneyDrunk-free.
+- **Side-effect-freedom is non-negotiable.** `ISimulator.SimulateAsync` does not take writer parameters. Runtime composes `Providers.InMemory` of Memory + Knowledge, never production backends. Operator primitives invoked observation-only.
+- **`ISimulationTarget` does NOT extend or share `IEvalTarget`.** Parallel shape, distinct type, no Sim→Evals coupling.
+- **Provenance fields on every `SimulationResult`.** ScenarioId, ScenarioVersion, TargetId, PinnedModelCapabilityIdentifier (if applicable), ReproducibilitySeed, timestamps.
+- **Reproducibility:** every simulation uses `SeededRng` keyed by `SimulationResult.ReproducibilitySeed`. Non-deterministic targets flagged on `ContainsNonDeterministicSteps`.
+- **Telemetry metadata-only.** No content payloads.
+- **Records drop `I`; interfaces keep it.** `Scenario`, `RiskAssessment`, `SimulationResult`, `SimulationStepInput`, `TargetInvocationResult`, `ObservedOperatorPredictions`, `RiskFailureMode`, `ProposedAction`, `PlanValidationResult`, `SimulationStepTrace` are records.
+- **Strict Abstractions stance.** `string` identifiers throughout.
+- **Stringly-typed JSON payloads are deliberate.** `*Json` fields (`InputJson`, `OutputJson`, `InitialStateFixtureJson`, `ProjectedOutcomeJson` on records) stay `string` at stand-up. Structured payload records land in a follow-up packet once concrete `ISimulationTarget` shapes crystallize. Do not introduce structured payload types in this packet.
+- **First cross-Node `IModelProvider` consumer.** `ChatTarget` is the first consumer of `IModelProvider` from outside `HoneyDrunk.AI`. If `HoneyDrunk.AI.Abstractions` does not expose a public capability-resolution surface usable by `ChatTarget`, file a follow-up packet against `HoneyDrunk.AI` to widen the public surface before completing `ChatTarget`.
+- **Predictors call only non-mutating Operator surfaces.** If any Operator surface used by a predictor turns out to be mutating in practice (writes to `IAuditLog`, trips a breaker), file a follow-up packet against `HoneyDrunk.Operator` to add a non-mutating predicate variant (`WouldBlock` / `WouldHalt` / `WouldRequireApproval`) before completing the predictor implementation.
+- **`InMemoryScenarioExecutor` implements `ISimulator` directly against Abstractions.** It does NOT reference or compose the `HoneyDrunk.Sim` runtime package — `Providers.InMemory` is Abstractions-only by layout rule.
+- **Canary skip on scaffolding PR expected.**
+- **Upstream conditional.** AI mandatory; others placeholder if missing.
+- **Closing-of-the-wave note in repo README.**
+
+**Key Files:**
+- `HoneyDrunk.Sim.slnx`, `Directory.Build.props`
+- `src/HoneyDrunk.Sim.Abstractions/` — 3 interfaces + 3 records + supporting records
+- `src/HoneyDrunk.Sim/` — `DefaultSimulator`, `DefaultPlanValidator`, `ChatTarget`, predictor classes, fixture loaders, `SeededRng`, `SimTelemetry`, `ServiceCollectionExtensions`
+- `src/HoneyDrunk.Sim.Providers.InMemory/` — `InMemoryScenarioExecutor`
+- `.github/workflows/*.yml`
+- `README.md`, `CHANGELOG.md`
+- `tests/`
+
+**Contracts:** Six D3 surfaces authored fresh. Closes the AI-sector wave.

--- a/generated/issue-packets/active/adr-0025-sim-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0025-sim-standup/dispatch-plan.md
@@ -1,0 +1,93 @@
+# Dispatch Plan — ADR-0025 HoneyDrunk.Sim Standup
+
+**Initiative:** `adr-0025-sim-standup`
+**Sector:** AI
+**Governing ADR:** [ADR-0025 — Stand Up the HoneyDrunk.Sim Node](../../../../adrs/ADR-0025-stand-up-honeydrunk-sim-node.md) (Proposed 2026-04-19; flips to Accepted after merge).
+**Trigger:** ADR-0025 in the Proposed queue. **Closes the AI-sector stand-up wave.** Flow (workflow-dry-run scenarios), Agents (agent-plan scenarios), Lore (wiki-compilation plan validation), HoneyHub when live, application Nodes with commit-to-real-execution gates blocked on `HoneyDrunk.Sim.Abstractions`.
+**Type:** Multi-repo (3 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.Sim` creation chore + `HoneyDrunk.Sim` scaffold)
+**Site sync required:** Deferred — see "What This Initiative Does NOT Deliver" below. Sim closes the AI-sector stand-up wave; a single AI-sector-wide site-sync (covering ADR-0016 through ADR-0025) is the cleaner unit of work than a per-stand-up sync, and lands as wave-closing housekeeping rather than inside this initiative.
+**Rollback plan:** Pre-tag revert; post-tag fix-forward.
+
+## Summary
+
+ADR-0025 is the standup ADR for `HoneyDrunk.Sim`. The **closing Node** of the AI-sector stand-up wave (ADR-0016 + 0017 + 0018 + 0020-0025 = 9 stand-ups complete).
+
+Owns simulation primitives — three interfaces (`ISimulator`, `IPlanValidator`, `ISimulationTarget`) + three records (`Scenario`, `RiskAssessment`, `SimulationResult`). **Reconciles three-way drift** between `contracts.json` (two interfaces — `ISimulator`, `ISimulationResult`), `relationships.json` (four interfaces), repo overview (four interfaces). D3 pins the six-surface definitive set.
+
+Three packages (`Abstractions`, runtime, `Providers.InMemory` scenario-execution backend). Composes Flow's `IWorkflow`/`IWorkflowStep` at Abstractions level (compile-time, read-only per D5). Composes AI (chat-backed targets + model pinning per D8). Composes Operator (observation-only prediction per D9 — runtime only). Composes Memory + Knowledge `Providers.InMemory` for fixtures per D11 (runtime only). Side-effect-freedom is the Sim-Evals boundary primitive per D6. `ISimulationTarget` is parallel-but-distinct from `IEvalTarget` per D8 — no Sim→Evals runtime edge. Content-in-telemetry follows the Memory/Knowledge no-content rule per D10 (different from Evals's carve-out — Sim's payloads have no regression-diagnosis pressure). Reproducibility via `SimulationResult.Seed` per D7. Provenance fields on every `SimulationResult` per D12. Canary on four hot-path surfaces per D13.
+
+**The `HoneyDrunk.Sim` repo does NOT exist on GitHub yet.** A human-only **create + clone** chore is required.
+
+Four packets land the work:
+
+1. **Architecture catalog registration + three-way drift reconciliation + integration-points** — RECONCILE: rename `ISimulationResult` → `SimulationResult` record; promote `IScenario` → `Scenario` record; promote `IRiskAssessment` → `RiskAssessment` record; add `IPlanValidator` (currently in relationships.json + overview, missing from contracts.json); add `ISimulationTarget` interface. Widen `consumes` to add Kernel + Flow + Memory + Operator; widen AI `consumes_detail`. Update `roadmap_focus` prose (drop "Optional for initial AI sector delivery" framing). Align `repos/HoneyDrunk.Sim/{overview,boundaries,invariants}.md` and Sim section of AI sector doc. Add `integration-points.md` and `active-work.md`.
+2. **Constitution invariants** — ten new invariants from D2, D6, D5, D9, D8, D12, D11, D10, D2+D9+D11, D13.
+3. **Create `HoneyDrunk.Sim` GitHub repo + clone locally (human-only)** — same pattern as ADR-0023 packet 03.
+4. **HoneyDrunk.Sim scaffold** — empty repo to first-shippable. Solution, three packages (`Abstractions`, runtime, `Providers.InMemory` scenario-execution backend), three interfaces + three records in Abstractions, default `ISimulator` + `IPlanValidator` + `ISimulationTarget` chat-backed shape per D8, reproducibility primitives per D7, observation-only Operator composition per D9, fixture composition with Memory + Knowledge `Providers.InMemory` per D11, five CI workflow files with canary scoped to Abstractions.
+
+## Wave Diagram
+
+```
+Wave 1: Architecture catalog + constitution updates (parallel)
+   ├─ Architecture: 01-architecture-sim-catalog-registration
+   └─ Architecture: 02-architecture-sim-invariants
+       Blocked by: 01
+
+Wave 2: Create + clone repo (human)
+   └─ Architecture: 03-architecture-create-sim-repo
+       Blocked by: 01
+
+Wave 3: Sim repo scaffold
+   └─ HoneyDrunk.Sim: 04-sim-node-scaffold
+       Blocked by: 01, 02, 03
+```
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 01 | [Catalog registration + three-way drift reconciliation + integration-points](./01-architecture-sim-catalog-registration.md) | Architecture | 1 | Agent | — |
+| 02 | [Add ten new invariants for D2 / D6 / D5 / D9 / D8 / D12 / D11 / D10 / D2+D9+D11 / D13](./02-architecture-sim-invariants.md) | Architecture | 1 | Agent | 01 |
+| 03 | [Create `HoneyDrunk.Sim` GitHub repo + clone (human-only)](./03-architecture-create-sim-repo.md) | Architecture | 2 | Human | 01 |
+| 04 | [Stand up `HoneyDrunk.Sim` — solution, three packages, six surfaces, CI, InMemory provider](./04-sim-node-scaffold.md) | HoneyDrunk.Sim | 3 | Agent | 01, 02, 03 |
+
+## Filing-order rule
+
+Packet 04 hard-codes invariant numbers. **Packet 02 must merge first.** Packet 03 must close (repo exists) before packet 04 can be filed.
+
+## What This Initiative Does **NOT** Deliver
+
+- Concrete `ISimulationTarget` shapes (`WorkflowTarget`, `AgentTarget`, `RetrievalTarget`, transcript-replay) deferred to scaffold or follow-up packets per D3.
+- Monte Carlo / N-trial distribution surfaces deferred per D3 / D14.
+- Production scenario-execution backend (rule-based, model-backed, replay-transcript) deferred — `Providers.InMemory` only at stand-up per D2.
+- Pulse signal ingress into Sim deferred (emit-only per D10).
+- No separate `HoneyDrunk.Sim.Testing` — `Providers.InMemory` plays that role per D2.
+- **Structured payload records.** Stand-up uses stringly-typed JSON for `SimulationStepInput.InputJson`, `TargetInvocationResult.OutputJson`, `Scenario.InitialStateFixtureJson`, `SimulationResult.ProjectedOutcomeJson`, `SimulationStepTrace.OutputJson`. Follow-up packet introduces structured payload records once concrete `ISimulationTarget` shapes (`WorkflowTarget`, `AgentTarget`, `RetrievalTarget`) crystallize and the per-target payload structure can be designed coherently.
+- **AI-sector-wide site sync.** Single sync covering ADR-0016 through ADR-0025 lands as wave-closing housekeeping after packet 04 merges and ADR-0025 flips to Accepted. Tracked in the wave-closing housekeeping board item below, not inside this initiative.
+- **`active-initiatives.md` + `ai-sector-architecture.md` post-merge updates.** Tracked as the wave-closing housekeeping board item; not a packet in this initiative's filing pipeline.
+
+## AI-sector standup wave sequencing
+
+Sim is the closing Node. Requires Flow Abstractions (mandatory — compile-time per D5), AI Abstractions (mandatory — chat-backed target per D8), Operator + Memory + Knowledge Abstractions (runtime per D9/D11). Land Sim last in the wave: AI → Capabilities → Operator → Memory + Knowledge → Agents → Evals → Flow → **Sim**.
+
+## Status flip
+
+ADR-0025 stays Proposed for duration. Closing-the-wave note: when Sim's status flips to Accepted (post-completion), the AI sector's stand-up wave is closed and `initiatives/active-initiatives.md` should reflect that milestone.
+
+## Wave-closing housekeeping (board-item, post-merge)
+
+Tracked as a single follow-up board item on The Hive once packet 04 merges and ADR-0025 flips to Accepted. NOT a packet in this initiative — these are post-completion housekeeping steps that touch shared index files outside the scope agent's allowed surface for this initiative:
+
+- [ ] Update `initiatives/active-initiatives.md` — mark Sim standup complete, mark AI-sector stand-up wave (ADR-0016 + 0017 + 0018 + 0020-0025) closed.
+- [ ] Update `constitution/ai-sector-architecture.md` — Sim section reflects shipped surface (six D3 surfaces), wave-closing milestone called out.
+- [ ] AI-sector-wide site sync — single sync run covering ADR-0016 through ADR-0025 wave-closing state.
+- [ ] File follow-up packet: "Introduce structured payload records on Sim Abstractions once concrete `ISimulationTarget` shapes (`WorkflowTarget`, `AgentTarget`, `RetrievalTarget`) crystallize" — replaces stringly-typed JSON payloads with structured records per the deliberate stand-up simplification noted in packet 04.
+- [ ] File concrete `ISimulationTarget` shape packets (`WorkflowTarget`, `AgentTarget`, `RetrievalTarget`, transcript-replay) as downstream consumers drive shape.
+
+## Filing
+
+`file-packets.yml` auto-files. Packet 04 filing gated on packet 03's repo creation.
+
+## Archival
+
+Per ADR-0008 D10, archive post-completion.


### PR DESCRIPTION
## Summary

Scopes four packets standing up `HoneyDrunk.Sim` per [ADR-0025](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0025-stand-up-honeydrunk-sim-node.md) — the AI sector's simulation and plan-evaluation substrate. **Closes the AI-sector stand-up wave (9th of 9)** — every AI-sector Node now has a standup ADR and an initiative. Claims invariants **83–92**.

### Wave 1 — Architecture-repo (parallel)
- **`01-catalog-registration`** — `.Abstractions` naming throughout `consumes_detail`.
- **`02-invariants`** — ten new constitution invariants (default 83–92). Includes side-effect-freedom (THE boundary against Evals), router-bypass via `ISimulationTarget` parallel-but-distinct to Evals' `IEvalTarget`.
- **`03-create-sim-repo`** — human-only create-repo + clone chore. Sim repo doesn't exist yet.

### Wave 2 — Sim scaffold
- **`04-sim-node-scaffold`** — three packages, three frozen interfaces (`ISimulator`, `IPlanValidator`, `ISimulationTarget`), three records (`Scenario`, `RiskAssessment`, `SimulationResult`).

## Side-effect-freedom (THE Sim/Evals distinction)

Enforced at interface signatures: `ISimulator.SimulateAsync` does NOT take `IMemoryStore`, `ICommunicationOrchestrator`, `IWorkflowEngine`, or `IAuditLog` as parameters (acceptance criterion). Sim composes Operator primitives (`ICostGuard`, `ISafetyFilter`, `IApprovalGate`) to **predict** real-execution policy outcomes — not enforce. Acceptance criteria verify non-mutating Operator surface usage.

## Notable surface decisions

- **`Providers.InMemory`** restated as direct `ISimulationTarget` implementation against `Abstractions` only (not a runtime composition).
- **`IModelProvider` direct consumption** documented as first cross-Node user outside AI itself; follow-up flag noted.
- **Stringly-typed JSON payloads** at v0.1.0 (`InputJson`, `OutputJson`, `ProjectedOutcomeJson`, etc.) flagged as deliberate stand-up simplification; structured payload records deferred behind concrete target shapes (`WorkflowTarget`/`AgentTarget`/`RetrievalTarget`).

## Conventions
- NuGet uses `.Abstractions` throughout (invariant 2).
- Invariant numeric references replaced with named-token form so collision-driven renumbering is mechanical.
- Records drop `I` (`Scenario`, `RiskAssessment`, `SimulationResult`); interfaces keep `I`.
- Each packet carries `accepts: ADR-0025`.

## Wave-closing housekeeping

Dispatch plan lists a post-merge board-item to update `initiatives/active-initiatives.md` + `constitution/ai-sector-architecture.md` (AI-sector-wide reconciliation when this initiative closes).

## Test plan
- [ ] After merge, four issues file with dependency edges
- [ ] Packet 03 (human chore) creates the GitHub repo
- [ ] Wave 2 scaffold stays blocked on packets 01, 02, 03
- [ ] When all four close, hive-sync auto-flips ADR-0025 Proposed → Accepted
- [ ] AI-sector wave closes; site-sync + ai-sector-architecture.md follow-up board-item

🤖 Generated with [Claude Code](https://claude.com/claude-code)