### PR TITLE
chore: scope ADR-0027 notify cloud standup (first commercial Node)

### DIFF
--- a/generated/issue-packets/active/adr-0027-notify-cloud-standup/01-architecture-notify-cloud-context-folder.md
+++ b/generated/issue-packets/active/adr-0027-notify-cloud-standup/01-architecture-notify-cloud-context-folder.md
@@ -1,0 +1,419 @@
+---
+name: Architecture Context Folder Registration
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ops", "adr-0027"]
+dependencies: []
+adrs: ["ADR-0027"]
+accepts: ADR-0027
+wave: 1
+initiative: adr-0027-notify-cloud-standup
+node: honeydrunk-notify-cloud
+---
+
+# Chore: Register HoneyDrunk.Notify.Cloud's standup decisions in Architecture context folder
+
+## Summary
+Create the standard `repos/HoneyDrunk.Notify.Cloud/` context folder with five files (`overview.md`, `boundaries.md`, `invariants.md`, `active-work.md`, `integration-points.md`) matching the template used by `repos/HoneyDrunk.Communications/`. Update `constitution/sectors.md` Ops-sector entry to include Notify Cloud as the commercial wrapper above Notify and Communications. **Do not touch `catalogs/*.json`, `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, or `adrs/README.md`** — hive-sync reconciles those shared indexes after the initiative completes.
+
+ADR-0027 stays at `Status: Proposed` for this packet — the Status flip is a separate post-merge housekeeping step the scope agent handles after the entire initiative completes, per the user's standing ADR acceptance workflow. This packet's body does not edit the ADR header.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+ADR-0027 is the standup ADR for `HoneyDrunk.Notify.Cloud` — the Grid's first commercial-revenue-bearing Node, its first private repo, and the first real (non-noop) consumer of ADR-0026's multi-tenant primitives. The ADR has been written but the Architecture repo carries no `repos/HoneyDrunk.Notify.Cloud/` context folder yet. Until that exists, downstream agents scoping their own work against Notify Cloud (the Stripe billing-adapter follow-up, the API key authentication ADR, the Communications decision-log persistence ADR, any future tool-registering domain Node) read incomplete metadata.
+
+This packet creates the standard five-file context folder. The shapes and section headings mirror `repos/HoneyDrunk.Communications/` (the most recent Ops-sector standup) so the two repos diff-read side-by-side. Content is derived directly from ADR-0027's D1–D13 — no new design choices are introduced.
+
+The packet also updates `constitution/sectors.md` so the Ops sector's published members list includes Notify Cloud.
+
+What this packet explicitly does **not** do:
+
+- **Catalog reconciliation.** `catalogs/nodes.json` (introducing the new `visibility: "private"` field), `catalogs/relationships.json` (the dependency edges from ADR-0027 D5), `catalogs/grid-health.json` (the per-Node row), `catalogs/contracts.json` (the four D4 contracts plus the consumed Kernel primitives), and `catalogs/modules.json` (the four package entries) are **deferred to the hive-sync agent's reconciliation pass** after the initiative completes. Per the user's standing instruction, scope agent does not touch shared catalog indexes.
+- **Initiative-list / ADR-index reconciliation.** `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, and `adrs/README.md` are also hive-sync-reconciled — this packet does not edit them.
+- **ADR Status flip.** ADR-0027 stays at `Status: Proposed`. The flip happens post-merge as a separate housekeeping step.
+
+## Proposed Implementation
+
+### `repos/HoneyDrunk.Notify.Cloud/overview.md` — new file
+
+```markdown
+# HoneyDrunk.Notify.Cloud - Overview
+
+**Sector:** Ops
+**Version:** 0.0.0 (pre-scaffold)
+**Framework:** .NET 10.0
+**Repo:** `HoneyDrunkStudios/HoneyDrunk.Notify.Cloud` (**private** — first private repo in the Grid; explicit revenue carve-out per ADR-0027 D2)
+
+## Purpose
+
+Multi-tenant commercial wrapper above the open-source Notify engine and the Communications orchestration layer. Notify Cloud accepts external API requests, authenticates them by API key, applies per-tenant rate limits and quota checks, attaches the resolved `TenantId` to the request, delegates orchestration to `ICommunicationOrchestrator`, and emits a `BillingEvent` on each successful delivery for Stripe to consume.
+
+It is a commercial wrapper, not a delivery engine. It does not call provider SDKs, render templates, manage queues, retry sends, or decide which user receives which message. Those mechanics stay in Notify and Communications.
+
+Grid-internal callers continue to use Notify (and Communications) directly. Notify Cloud does not interpose on the internal path. Internal callers acquire their `TenantId` (defaulting to `TenantId.Internal`) through the Grid's existing `IGridContext` and never traverse a Notify Cloud surface.
+
+## Packages
+
+| Package | Type | Description |
+|---------|------|-------------|
+| `HoneyDrunk.Notify.Cloud.Abstractions` | Abstractions | Notify-Cloud-specific contracts only (4 surfaces). Kernel multi-tenant primitives are consumed from `HoneyDrunk.Kernel.Abstractions.Tenancy`, not redeclared here. |
+| `HoneyDrunk.Notify.Cloud` | Runtime | Default `INotifyCloudGateway`, API key validation middleware, Notify-Cloud-specific `ITenantRateLimitPolicy` (replaces Kernel's `NoopTenantRateLimitPolicy`), billing-event emission tail, DI wiring. |
+| `HoneyDrunk.Notify.Cloud.Billing.Stripe` | Provider | Stripe-specific `IBillingEventEmitter` adapter for metered-billing webhook bridge. Provider-slot pattern. |
+| `HoneyDrunk.Notify.Cloud.Web` | Hosting | Multi-tenant management website (signup, billing, API key issuance, basic delivery logs). |
+
+## Key Contracts
+
+- `INotifyCloudGateway` — top-level entry point. Given an API-key-authenticated external request, resolves the tenant context, consults `ITenantRateLimitPolicy` (from Kernel), delegates orchestration to `ICommunicationOrchestrator`, and emits a `BillingEvent` on successful delivery.
+- `INotifyCloudApiKeyStore` — issuance and validation of per-tenant API keys. Issued keys returned plaintext exactly once at issuance; stored only as salted hashes; never logged, traced, or persisted in raw form.
+- `NotifyCloudTenantTier` — record. Notify-Cloud-specific tenant-tier descriptor (tier name `Free` / `Starter` / `Pro`, events-per-month ceiling, channels enabled, BYO-provider-key allowance). Value type, no `I` prefix per the Grid-wide naming rule.
+- `ApiKeyIssuance` — record. Returned exactly once at API key issuance — plaintext key (only at this moment), key id, bound tenant, issued-at timestamp. Never persisted in this shape; the runtime persists only the salted hash and the metadata.
+
+## Primitives Consumed (not redefined)
+
+Per ADR-0026, the following Kernel primitives are consumed by Notify Cloud:
+
+- `TenantId` and `TenantId.Internal` sentinel — live in `HoneyDrunk.Kernel.Abstractions.Identity` (ULID-backed `readonly record struct` per ADR-0026 D1). **Referenced directly by the four D4 contracts** in `HoneyDrunk.Notify.Cloud.Abstractions` — the Abstractions package PackageReferences `HoneyDrunk.Kernel.Abstractions` for this one type per ADR-0027 D3's explicit carve-out.
+- `ITenantRateLimitPolicy` and `TenantRateLimitDecision` — live in `HoneyDrunk.Kernel.Abstractions.Tenancy`. Consumed at the runtime layer (`HoneyDrunk.Notify.Cloud`), not in Abstractions. Notify Cloud ships a tier-driven implementation that replaces the `NoopTenantRateLimitPolicy` registration at host time.
+- `IBillingEventEmitter` and `BillingEvent` — live in `HoneyDrunk.Kernel.Abstractions.Tenancy`. Consumed at the runtime layer. Notify Cloud ships the Stripe implementation in `HoneyDrunk.Notify.Cloud.Billing.Stripe`.
+
+## Visibility and Licensing
+
+`HoneyDrunk.Notify.Cloud` is **private** — the first private repo in the Grid, justified by ADR-0027 D2's revenue carve-out (customer-data-adjacent infrastructure, hyperscaler defense, billing-system integrity).
+
+The repo's LICENSE is `LicenseRef-Proprietary` (all rights reserved by default of being private). The paired open-source repos (`HoneyDrunk.Notify`, `HoneyDrunk.Communications`) ship under the Functional Source License (FSL) with two-year auto-conversion to Apache 2.0, per ADR-0027 D11.
+
+The customer-facing SDK (`HoneyDrunk.Notify.Client`) lives in the open `HoneyDrunk.Notify` repo per ADR-0027 D6, not in this private repo. Customers install the SDK from NuGet without ever needing access to the wrapper's source.
+
+## Deployment
+
+- **Hosting platform:** Azure Container Apps (`ca-hd-notify-cloud-{env}`), per invariant 34.
+- **First deploy target:** `ca-hd-notify-cloud-stg` in East US (PDR-0002's single-region commitment).
+- **Container Registry:** the shared `acrhdshared{env}` per invariant 35.
+- **Environment:** the shared `cae-hd-{env}` per invariant 35.
+```
+
+### `repos/HoneyDrunk.Notify.Cloud/boundaries.md` — new file
+
+```markdown
+# HoneyDrunk.Notify.Cloud - Boundaries
+
+What Notify Cloud owns and does not own. Mirrors the boundary-discipline pattern from `repos/HoneyDrunk.Communications/boundaries.md`.
+
+## What Notify Cloud Owns
+
+- Multi-tenant commercial-product primitives for the Notify engine — the API gateway, API key issuance and validation (issuance is here; validation delegates to Auth per ADR-0027 D12), per-tenant rate-limit enforcement, tenant-scoped billing event emission, and the tenant management website.
+- The Notify-Cloud-specific `ITenantRateLimitPolicy` implementation (replaces Kernel's `NoopTenantRateLimitPolicy` at host time).
+- The Stripe `IBillingEventEmitter` adapter (in `HoneyDrunk.Notify.Cloud.Billing.Stripe`).
+- The management web app (signup, billing, API key issuance UI, basic delivery logs) — placeholder shape at v0.1.0; full surface lands in follow-up packets.
+- The four frozen contracts in `HoneyDrunk.Notify.Cloud.Abstractions`: `INotifyCloudGateway`, `INotifyCloudApiKeyStore`, `NotifyCloudTenantTier`, `ApiKeyIssuance`.
+
+## What Notify Cloud Does NOT Own
+
+- **Delivery mechanics.** Provider SDK calls (Resend, Twilio), template rendering, queue management, send retries — all stay in Notify.
+- **Decision logic.** Whether a given recipient should receive a given message, when, or as part of what sequence — all in Communications.
+- **Multi-tenant primitives.** `TenantId`, `ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, `BillingEvent` — all in `HoneyDrunk.Kernel.Abstractions.Tenancy` per ADR-0026.
+- **API key validation.** Validation is delegated to `HoneyDrunk.Auth`'s new `IApiKeyAuthenticator` middleware path (per ADR-0027 D12). Notify Cloud issues keys (a tenant lifecycle event); Auth validates them (a trust-boundary concern). The detailed middleware shape, hashing scheme, and rotation flow are a separate follow-up ADR.
+- **The customer-facing SDK.** `HoneyDrunk.Notify.Client` lives in the open `HoneyDrunk.Notify` repo per ADR-0027 D6. Customers install it from NuGet without access to Notify Cloud source.
+- **Internal Grid messaging.** Grid-internal callers use Notify and Communications directly; they do not traverse Notify Cloud. Internal callers acquire their `TenantId` (defaulting to `TenantId.Internal`) through `IGridContext`.
+
+## Decision Test — For Any Concern in the Notify Cloud Path
+
+1. Is it tenant-context resolution, API key authentication, per-tenant rate-limit enforcement, billing-event emission, or external-API surface shape? → **Notify Cloud**.
+2. Is it a decision about *whether* a given user should receive a given message, or *when*, or as part of *what sequence*? → **Communications**.
+3. Is it provider-side delivery (calling Resend, calling Twilio, retrying a transient failure)? → **Notify**.
+4. Is it tenant-aware, but Grid-wide (not commercial-wrapper-specific)? → **Kernel** (the multi-tenant primitives).
+5. Is it API key validation as opposed to issuance? → **Auth** (`IApiKeyAuthenticator` middleware path).
+
+## Dependency Direction (Strict, One-Way)
+
+```
+Notify Cloud
+  ├─ consumes ──► Communications (ICommunicationOrchestrator) — orchestration delegate (hot path)
+  ├─ consumes ──► Notify (INotificationSender) — diagnostic/smoke-test paths only; hot path is Notify Cloud → Communications → Notify
+  ├─ consumes ──► Auth (IApiKeyAuthenticator middleware path — new)
+  ├─ consumes ──► Vault (per-tenant secret scoping)
+  ├─ consumes ──► Web.Rest (response envelopes, correlation IDs)
+  ├─ consumes ──► Kernel (IGridContext, lifecycle, telemetry, TenantId)
+  └─ emits telemetry ──► Pulse (no runtime dependency; one-way emission per ADR-0027 D7)
+```
+
+Notify Cloud does **not** import Notify directly except through `INotificationSender` for diagnostic / smoke-test paths. The hot path is Notify Cloud → Communications → Notify. Notify Cloud does **not** consume HoneyHub, any AI-sector Node, or any package outside the Ops/Core/Infrastructure sectors at v1.
+
+### Invariant-2 exception: `HoneyDrunk.Vault` runtime reference
+
+`HoneyDrunk.Notify.Cloud` (runtime) PackageReferences `HoneyDrunk.Vault` (runtime) for `ISecretStore` and `IConfigProvider`. This is an acknowledged exception to invariant 2 ("Runtime packages depend on Abstractions, never on other runtime packages at the same layer"). The exception is grounded:
+
+- The Vault repo does not currently split a separate `HoneyDrunk.Vault.Abstractions` package — the `ISecretStore` / `IConfigProvider` interfaces live in the runtime `HoneyDrunk.Vault` package per the existing repo shape.
+- This is a Grid-wide acknowledged special case (the same exception is documented on every Node that consumes Vault — Auth, Communications, Data, etc.).
+- The path-forward is the Vault.Abstractions carve-out (separate follow-up packet, not bundled with this Node's stand-up). When that follow-up lands, every Vault-consuming Node migrates simultaneously.
+
+Until that carve-out lands, Notify Cloud's runtime PackageReference to `HoneyDrunk.Vault` is the established Grid pattern and is **not** an invariant-2 violation.
+```
+
+### `repos/HoneyDrunk.Notify.Cloud/invariants.md` — new file
+
+```markdown
+# HoneyDrunk.Notify.Cloud - Local Invariants
+
+Repo-scoped invariants supplementing `constitution/invariants.md`. The constitutional invariants from ADR-0027 (assigned numbers locked by packet 02 of the adr-0027-notify-cloud-standup initiative) also apply.
+
+1. **HoneyDrunk.Notify.Cloud.Abstractions runtime dependencies are limited to the three packages ADR-0027 D3 explicitly permits.** Per ADR-0027 D3: "Zero runtime dependencies beyond `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.Notify.Abstractions`, and `HoneyDrunk.Communications.Abstractions`." `HoneyDrunk.Kernel.Abstractions` is load-bearing at v0.1.0 — it carries the `TenantId` strong type (record-struct from `HoneyDrunk.Kernel.Abstractions.Identity` per ADR-0026 D1) that the four frozen contracts (`INotifyCloudGateway`, `INotifyCloudApiKeyStore`, `NotifyCloudTenantTier`, `ApiKeyIssuance`) consume as field types. The other two (`HoneyDrunk.Notify.Abstractions`, `HoneyDrunk.Communications.Abstractions`) are permitted by D3 but may be omitted at v0.1.0 if no contract consumes them — they stay reserved for future contract surfaces. The strict-Abstractions stance from sibling ADR-0016 / ADR-0017 standup packets does NOT apply here; this Node's contracts deliberately consume Kernel-Abstractions primitives. **`ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, `BillingEvent` are NOT redeclared here** — they live in `HoneyDrunk.Kernel.Abstractions.Tenancy` per ADR-0026 and are consumed at the runtime layer, not at the Notify-Cloud-Abstractions layer.
+
+2. **The hot delivery path is Notify Cloud → Communications → Notify.** Direct calls from Notify Cloud to Notify (`INotificationSender`) are restricted to diagnostic and smoke-test paths only — never the customer-facing hot path. The hot path always goes through `ICommunicationOrchestrator`.
+
+3. **API keys are stored only as salted hashes; raw key material is returned exactly once at issuance time.** No raw key is ever logged, traced, persisted in raw form, or returned in any subsequent API call. `ApiKeyIssuance` is the one-time issuance shape; subsequent reads return only the hash and metadata.
+
+4. **Every tool/external invocation passes through `INotifyCloudGateway`.** No bypass surface from external callers exists. The gateway is the single intake point that performs API key validation → rate-limit check → tenant context resolution → orchestration delegation → billing emission. New entry-point surfaces require an ADR.
+
+5. **Token costs, tenant tiers, and abuse heuristics are sourced from configuration (App Configuration via `IConfigProvider` from Vault), never hardcoded.** Hardcoded values in application code are a build failure. Operator-driven config refresh is the rotation path.
+
+6. **GridContext / CorrelationId propagation lives in the runtime package's `NotifyCloudTelemetry`, not in Abstractions.** Per ADR-0026 D1, `TenantId` IS a Kernel-Abstractions primitive and the four D4 contracts use the strong type — but `CorrelationId` stays string-typed at the contract boundary at v0.1.0 because promoting the Kernel `CorrelationId` record-struct into a public Abstractions surface is a Grid-wide decision separate from this Node's stand-up. `INotifyCloudGateway`'s request shape uses string-typed `CallerCorrelationId` (the string mirror); the runtime's `DefaultNotifyCloudGateway` reconciles the string against the ambient `IGridContext.CorrelationId`. `NotifyCloudGatewayRequest.TenantIdHint`, by contrast, uses the strong `TenantId` type per ADR-0026.
+
+7. **Tenant identifiers attached to telemetry are direct (not bucketed) at v1.** Per ADR-0027 D7's low-cardinality bound. Tens of paying customers at v1, low hundreds at the Pro ceiling — `tenant_id` is a safe label for direct emission. If Notify Cloud crosses into thousands of paying tenants, this discipline is revisited as a follow-up ADR (cardinality bucketing or tag rollup).
+
+8. **Cross-Node canaries cover the four frozen contract surfaces.** Contract-shape canary in CI fails the build if `INotifyCloudGateway`, `INotifyCloudApiKeyStore`, `NotifyCloudTenantTier`, or `ApiKeyIssuance` change shape without a version bump. Kernel primitives consumed here are covered by Kernel's own canary per ADR-0026.
+
+_Constitutional invariants from ADR-0027 (assigned numbers locked at packet 02 of adr-0027-notify-cloud-standup) also apply — see `constitution/invariants.md`._
+```
+
+### `repos/HoneyDrunk.Notify.Cloud/active-work.md` — new file
+
+```markdown
+# HoneyDrunk.Notify.Cloud - Active Work
+
+Tracking surface for in-flight work on the Notify Cloud Node. Mirrors the format used by `repos/HoneyDrunk.Communications/active-work.md`.
+
+## Status
+
+**Pre-scaffold.** The GitHub repo does not exist yet. The local working tree does not exist yet. The packages have not been authored. ADR-0027 (the standup ADR) is Proposed; the scope agent flips Status → Accepted after the entire adr-0027-notify-cloud-standup initiative's PRs merge.
+
+## In Progress
+
+- **adr-0027-notify-cloud-standup initiative** — six packets from the dispatch plan at `generated/issue-packets/active/adr-0027-notify-cloud-standup/dispatch-plan.md`. Tracks: context-folder registration (this file), constitution invariants, FSL on Notify, FSL on Communications, private repo creation (human-only), repo scaffold.
+
+## Follow-Up Work (post-stand-up)
+
+Each item below is its own future ADR or packet, sized after the stand-up lands:
+
+- **Stripe billing integration.** The `HoneyDrunk.Notify.Cloud.Billing.Stripe 0.1.0` package ships as a stub in the scaffold packet. The actual webhook bridge / metered-billing wiring is a separate ADR per PDR-0002's recommended follow-up artifacts.
+- **API key authentication ADR.** Per ADR-0027 D12. Validation is delegated to `HoneyDrunk.Auth`'s new `IApiKeyAuthenticator` middleware path; the detailed middleware shape, hashing scheme, and rotation flow are settled in a separate ADR.
+- **Communications decision-log persistence ADR.** Notify Cloud Pro tier exposes the decision log; that tightens the requirements on the persistence backend.
+- **Tenant onboarding and provisioning workflow design doc.** Has a concrete `INotifyCloudApiKeyStore` and tenant-context model to design the signup-to-API-key flow against.
+- **Full Web project surface.** Signup flow, billing dashboard, delivery logs, tenant management UI.
+- **Per-tenant AI cost rollups** (deferred to whichever Node first commercializes inference per ADR-0026 D10 / PDR-0002).
+- **Multi-region deployment** (deferred per PDR-0002 Phase 5 commitment to single-region East US at v1).
+
+## Active Blockers
+
+- GitHub repo `HoneyDrunkStudios/HoneyDrunk.Notify.Cloud` does not exist yet (Architecture#NN — packet 05 of the adr-0027-notify-cloud-standup initiative)
+- Scaffold packet (NotifyCloud#NN — packet 06 of the adr-0027-notify-cloud-standup initiative) not yet executed
+- Constitution invariants for ADR-0027 D2/D5/D6/D4+D12/D8/D11 not yet landed at final numbers (Architecture#NN — packet 02)
+```
+
+### `repos/HoneyDrunk.Notify.Cloud/integration-points.md` — new file
+
+```markdown
+# HoneyDrunk.Notify.Cloud - Integration Points
+
+How Notify Cloud connects to the rest of the Grid. Every item here represents a cross-Node boundary that requires a canary test or contract-shape discipline.
+
+## Consumes
+
+| Node | Contract | Purpose |
+|------|----------|---------|
+| **Kernel** | `IGridContext`, `INodeContext`, `IOperationContext` | Every gateway entry, key validation, rate-limit check, send delegation, and billing event runs inside a Grid context. |
+| **Kernel** | `TenantId`, `TenantId.Internal` | Tenant-context resolution and propagation. External requests resolve to an external `TenantId` ULID; the internal Grid path defaults to `TenantId.Internal`. |
+| **Kernel** | `ITenantRateLimitPolicy`, `TenantRateLimitDecision` | Notify Cloud ships a tier-driven implementation in the runtime package that replaces Kernel's `NoopTenantRateLimitPolicy` at host time. |
+| **Kernel** | `IBillingEventEmitter`, `BillingEvent` | Notify Cloud ships the Stripe implementation in `HoneyDrunk.Notify.Cloud.Billing.Stripe`. |
+| **Kernel** | `IStartupHook`, `IShutdownHook` | Gateway initialization at startup; graceful drain on shutdown. |
+| **Kernel** | `ITelemetryActivityFactory` | Emits per-call activities for gateway entry, key validation, rate-limit check, send delegation, billing event. |
+| **Communications** | `ICommunicationOrchestrator`, `IMessageIntent` | The hot path delegate. Notify Cloud resolves tenant context, then hands the orchestration call to Communications. |
+| **Notify** | `INotificationSender` | Diagnostic and smoke-test paths only — never the customer-facing hot path. |
+| **Auth** | `IApiKeyAuthenticator` (new — added by a follow-up ADR) | Validates inbound API keys. Notify Cloud issues keys; Auth validates them. |
+| **Vault** | `ISecretStore` | Per-tenant secret scoping using the `TenantScopedSecretResolver` pattern from invariant 9a. Also sources cost-rate tables, tenant-tier definitions, and abuse heuristics from App Configuration via `IConfigProvider`. |
+| **Web.Rest** | Response envelopes, correlation headers | Standard Grid HTTP shape for the external API. |
+
+## Exposes
+
+| Contract | Consumer | Notes |
+|----------|---------|-------|
+| `INotifyCloudGateway` | Notify Cloud Web (`HoneyDrunk.Notify.Cloud.Web`), future external integrations | Top-level entry — API key auth → rate-limit → tenant context → orchestration delegate → billing emission. |
+| `INotifyCloudApiKeyStore` | Notify Cloud Web (issuance flow), Auth (validation lookup) | Salted-hash storage; raw keys returned exactly once via `ApiKeyIssuance` at issuance time. |
+| `NotifyCloudTenantTier` | Notify Cloud runtime (rate-limit policy derivation), Notify Cloud Web (tier upgrade flow) | Value-type tier descriptor. |
+| `ApiKeyIssuance` | Issuance callers | One-time issuance shape — carries plaintext key only at the moment of issuance. |
+
+## Emits (no runtime dependency)
+
+| Signal | Consumer | Notes |
+|--------|----------|-------|
+| Gateway / validation / rate-limit / delegation / billing activities | **Pulse** | Emitted via Kernel's `ITelemetryActivityFactory`. `tenant_id` is attached directly as a low-cardinality label per ADR-0027 D7. API keys, raw secrets, message payloads, and recipient PII are **never** emitted (invariant 8 extended to API key material). |
+| `BillingEvent` per successful delivery | Stripe (via `HoneyDrunk.Notify.Cloud.Billing.Stripe` adapter implementing the Kernel `IBillingEventEmitter` interface) | Webhook bridge details deferred to the Stripe billing integration ADR. |
+
+## Customer-Facing Surface (External)
+
+The REST API is the public boundary external customers consume. Internally, the wrapper composes against the four exposed contracts; externally, customers see only the REST shape and the `HoneyDrunk.Notify.Client` SDK (which lives in the open `HoneyDrunk.Notify` repo, not here, per ADR-0027 D6).
+
+## Canary Coverage Required
+
+Before any Notify Cloud code can be considered production-ready:
+
+- `NotifyCloud.Canary` → Kernel: verifies `IGridContext` flows through gateway/validation/dispatch, CorrelationId is propagated to delegated orchestration calls, `TenantId` defaults to `TenantId.Internal` when no external tenant is resolved.
+- `NotifyCloud.Canary` → Communications: verifies `ICommunicationOrchestrator` is invoked with a populated `MessageIntent`, that the decision-log entry is recorded, and that delegated delivery returns to Notify Cloud for billing emission.
+- `NotifyCloud.Canary` → Auth: verifies `IApiKeyAuthenticator` is called with the raw API key from the request header, that an invalid key short-circuits with a 401, and that a valid key produces the bound `TenantId` for downstream resolution.
+- `NotifyCloud.Canary` → Kernel multi-tenant primitives: verifies the Notify-Cloud-specific `ITenantRateLimitPolicy` implementation correctly derives limits from `NotifyCloudTenantTier` and that `IBillingEventEmitter` emits a `BillingEvent` exactly once per successful delivery.
+- `NotifyCloud.Canary` → contract-shape: contract-shape canary in CI fails the build if `INotifyCloudGateway`, `INotifyCloudApiKeyStore`, `NotifyCloudTenantTier`, or `ApiKeyIssuance` change shape without a version bump (ADR-0027 D8 / contract-shape-canary invariant — number assigned at packet 02 of this initiative).
+
+## Dependency Order for Bring-Up
+
+Notify Cloud cannot be scaffolded until these Nodes have published their Abstractions packages:
+
+1. Kernel (already Live — `HoneyDrunk.Kernel.Abstractions` stable, includes ADR-0026 tenancy primitives)
+2. Communications (already Live — `HoneyDrunk.Communications.Abstractions` at 0.2.0)
+3. Notify (already Live — `HoneyDrunk.Notify.Abstractions` at 0.3.0)
+4. Auth (already Live — `HoneyDrunk.Auth.Abstractions` stable; `IApiKeyAuthenticator` middleware lands in a follow-up ADR, but the Auth Node itself is up)
+5. Vault (already Live — `HoneyDrunk.Vault` stable)
+6. Web.Rest (already Live — `HoneyDrunk.Web.Rest.AspNetCore` stable)
+
+Notify Cloud is a leaf in the Grid-internal dependency graph per ADR-0027 D9 — no Grid-internal Node consumes it. Its consumers are external customers via REST API or the `HoneyDrunk.Notify.Client` SDK.
+```
+
+### `constitution/sectors.md` — Ops-sector entry update
+
+The current Ops-sector entry must include Notify Cloud. Locate the Ops-sector row/block (header text typically reads `## Ops Sector` or similar; the file structure mirrors the AI-sector entry's pattern) and add an entry for HoneyDrunk.Notify.Cloud directly after HoneyDrunk.Communications. Suggested text:
+
+```markdown
+| **HoneyDrunk.Notify.Cloud** | private | First commercial Node (PDR-0002 implementation). Multi-tenant commercial wrapper above Notify and Communications — API gateway, API key issuance/validation, per-tenant rate limits, tenant-scoped billing-event emission, management website. Sits above Notify and Communications; does not interpose on Grid-internal callers. ADR-0027. |
+```
+
+If the file uses a list rather than a table, adapt the entry shape to match the existing format. The substantive content (commercial wrapper, four primitives owned, sits above Notify and Communications, ADR-0027 reference, private visibility) must be present in some form.
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the in-progress version entry (do not start a new `Unreleased` block — per the user's standing rule, no commits land under `Unreleased`; move to a dated versioned section with a SemVer bump before commit):
+
+`Architecture: Register HoneyDrunk.Notify.Cloud standup decisions in the Architecture context folder (new repos/HoneyDrunk.Notify.Cloud/ folder with five files: overview.md, boundaries.md, invariants.md, active-work.md, integration-points.md — all derived from ADR-0027 D1-D13). Update constitution/sectors.md Ops-sector entry to include Notify Cloud as the commercial wrapper above Notify and Communications. Does NOT touch catalogs/*.json, initiatives/*, or adrs/README.md — hive-sync reconciles those after the initiative completes. ADR-0027 stays Proposed in this packet — the Status flip is a separate post-merge housekeeping step.`
+
+## Affected Files
+- `repos/HoneyDrunk.Notify.Cloud/overview.md` (new file)
+- `repos/HoneyDrunk.Notify.Cloud/boundaries.md` (new file)
+- `repos/HoneyDrunk.Notify.Cloud/invariants.md` (new file)
+- `repos/HoneyDrunk.Notify.Cloud/active-work.md` (new file)
+- `repos/HoneyDrunk.Notify.Cloud/integration-points.md` (new file)
+- `constitution/sectors.md`
+- `CHANGELOG.md`
+
+`adrs/ADR-0027-stand-up-honeydrunk-notify-cloud-node.md` is **not** modified by this packet. Its Status header stays `Proposed`. `adrs/README.md`, `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/grid-health.json`, `catalogs/contracts.json`, `catalogs/modules.json` are all **explicitly NOT** edited by this packet — hive-sync reconciles those.
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo — no .NET projects.
+
+## Boundary Check
+- [x] All edits are inside the `HoneyDrunk.Architecture` repo.
+- [x] No code changes anywhere; metadata only.
+- [x] No contract bodies invented in this packet — content is derived directly from ADR-0027 D1-D13.
+- [x] Records lose the `I` prefix (`NotifyCloudTenantTier`, `ApiKeyIssuance`); interfaces keep it (`INotifyCloudGateway`, `INotifyCloudApiKeyStore`) per the Grid-wide naming rule.
+- [x] No edits to shared index files (`catalogs/*.json`, `initiatives/*`, `adrs/README.md`) — these are reconciled by hive-sync.
+- [x] No edits to `adrs/ADR-0027-stand-up-honeydrunk-notify-cloud-node.md`. The Status flip is a separate post-merge housekeeping step.
+
+## Acceptance Criteria
+- [ ] `repos/HoneyDrunk.Notify.Cloud/overview.md` exists with the structure described above. Visibility is documented as private with explicit reference to ADR-0027 D2 revenue carve-out.
+- [ ] `repos/HoneyDrunk.Notify.Cloud/overview.md` Key Contracts section lists exactly four contracts: `INotifyCloudGateway`, `INotifyCloudApiKeyStore`, `NotifyCloudTenantTier`, `ApiKeyIssuance`. Records have no `I` prefix; interfaces keep it.
+- [ ] `repos/HoneyDrunk.Notify.Cloud/overview.md` Primitives Consumed section lists `TenantId` as consumed from `HoneyDrunk.Kernel.Abstractions.Identity` (ADR-0026 D1) and `ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, `BillingEvent` as consumed from `HoneyDrunk.Kernel.Abstractions.Tenancy` per ADR-0026. None of the five are **declared** in Notify Cloud's own Abstractions package; `TenantId` is **referenced** as a field type (the Abstractions package PackageReferences `HoneyDrunk.Kernel.Abstractions` per ADR-0027 D3).
+- [ ] `repos/HoneyDrunk.Notify.Cloud/boundaries.md` exists with What Notify Cloud Owns / Does Not Own sections, the five-question Decision Test, and the dependency-direction block matching ADR-0027 D5.
+- [ ] `repos/HoneyDrunk.Notify.Cloud/invariants.md` exists with at least eight local invariants covering: zero HoneyDrunk dependencies in Abstractions, hot path through Communications, API key salted-hash storage, gateway as single intake point, config-sourced rates/tiers/heuristics, runtime-localized GridContext propagation, low-cardinality `tenant_id` discipline, contract-shape canary discipline.
+- [ ] `repos/HoneyDrunk.Notify.Cloud/active-work.md` exists with Status, In Progress, Follow-Up Work, and Active Blockers sections — substantively matching the template above.
+- [ ] `repos/HoneyDrunk.Notify.Cloud/integration-points.md` exists with Consumes / Exposes / Emits / Canary Coverage Required / Dependency Order for Bring-Up sections — substantively matching the template above. Emits section notes that `tenant_id` is a low-cardinality label per ADR-0027 D7, and that API keys / raw secrets / payloads / PII are never emitted (invariant 8 extension).
+- [ ] `constitution/sectors.md` Ops-sector entry includes HoneyDrunk.Notify.Cloud. Visibility is documented as private. Description names it as the commercial wrapper above Notify and Communications. ADR-0027 is referenced.
+- [ ] `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/grid-health.json`, `catalogs/contracts.json`, `catalogs/modules.json` are **not** modified by this packet. Confirm in diff. (These reconcile via hive-sync.)
+- [ ] `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, `adrs/README.md` are **not** modified by this packet. Confirm in diff.
+- [ ] `adrs/ADR-0027-stand-up-honeydrunk-notify-cloud-node.md` is **not** modified by this packet. (Verify in diff. The Status flip is deferred to post-merge housekeeping.)
+- [ ] `CHANGELOG.md` updated. Per the user's standing rule, the entry lands in the next dated versioned section with a SemVer bump if this is the first commit of that version; otherwise appends to the existing in-progress version entry. No commits land under `## [Unreleased]`.
+- [ ] PR body explicitly notes: (a) `repos/HoneyDrunk.Notify.Cloud/` is a new five-file context folder derived from ADR-0027 D1-D13, (b) ADR-0027 stays at `Status: Proposed` — the flip is a separate post-merge housekeeping step, (c) catalog and initiative-index reconciliation are deferred to hive-sync.
+
+## Human Prerequisites
+- [ ] None. ADR-0026 prerequisite is satisfied (Status: Accepted as of 2026-05-20). The packet does not require any Azure portal, GitHub UI, or external-system action.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — **ADR-0027 D3 carves out three explicit exceptions for `HoneyDrunk.Notify.Cloud.Abstractions`:** `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.Notify.Abstractions`, `HoneyDrunk.Communications.Abstractions`. The local invariant 1 in `repos/HoneyDrunk.Notify.Cloud/invariants.md` restates this carve-out; the overview's Primitives Consumed section makes clear that `ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, `BillingEvent` are consumed at the runtime layer (not in Abstractions), while `TenantId` is referenced as a contract field type via the permitted `HoneyDrunk.Kernel.Abstractions` PackageReference per ADR-0026 D1.
+
+> **Invariant 8:** Secret values never appear in logs, traces, exceptions, or telemetry. Only secret names/identifiers may be traced. — Extended in `repos/HoneyDrunk.Notify.Cloud/invariants.md` invariant 3 to cover API key material: no raw key is ever logged, traced, persisted in raw form, or returned in any subsequent API call.
+
+> **Invariant 11:** One repo per Node (or tightly coupled Node family). Each repo has its own solution, CI pipeline, and versioning. — Notify Cloud is its own Node, hence its own repo (created by packet 05).
+
+> **Invariant 39:** Tenant mechanics stay at intake and post-dispatch boundaries. Tenant resolution, tenant rate-limit checks, billing-event emission, and tenant-scoped secret lookup must live in intake middleware/orchestration edges or post-dispatch tails. Core dispatch paths for internal Grid callers must remain tenant-agnostic and default to `TenantId.Internal` without caller-specific branches. — Notify Cloud is the first real (non-noop) consumer of this invariant. The boundaries.md decision-test reinforces this; the integration-points.md Consumes/Exposes split reflects it.
+
+> **Invariant 40:** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Communications.Abstractions`. Composition against `HoneyDrunk.Communications` is a host-time concern; packaged testing fixtures, when introduced, are test-time only. — Notify Cloud takes the runtime dependency on `HoneyDrunk.Communications.Abstractions`, not on the runtime package directly. Composition happens at host time in the Container App.
+
+> **Invariant 41:** Preference enforcement, cadence rules, and suppression logic for outbound messages live in HoneyDrunk.Communications, not in HoneyDrunk.Notify. Notify owns delivery mechanics; Communications owns decision logic. — Extended naturally to Notify Cloud: commercial wrapper concerns (API keys, rate limits, billing) live in Notify Cloud; decision logic (whether/when/which recipient) stays in Communications; delivery mechanics (provider SDK calls, retries) stay in Notify. The boundaries.md decision-test makes this explicit.
+
+## Referenced ADR Decisions
+
+**ADR-0027 D1 (Notify Cloud is the Ops sector's multi-tenant commercial wrapper above Notify):** The Node owns commercial-product primitives (API gateway, API key issuance/validation, per-tenant rate limits, tenant-scoped billing event emission, management web app). It is a wrapper, not a delivery engine. Grid-internal callers continue to use Notify and Communications directly and never traverse a Notify Cloud surface.
+
+**ADR-0027 D2 (Private repo, revenue carve-out):** First private repo in the Grid. Justifications on the record: customer-data-adjacent infrastructure, hyperscaler defense, billing-system integrity. The catalog gains a `visibility` field on this Node (reconciled by hive-sync, not in this packet).
+
+**ADR-0027 D3 (Package families):** Four packages — `HoneyDrunk.Notify.Cloud.Abstractions` (zero runtime HoneyDrunk dependencies), `HoneyDrunk.Notify.Cloud` (runtime composition), `HoneyDrunk.Notify.Cloud.Billing.Stripe` (provider slot), `HoneyDrunk.Notify.Cloud.Web` (management website). No `Testing` package at stand-up — in-memory fixtures live as `internal` test helpers until a second consumer emerges.
+
+**ADR-0027 D4 (Exposed contracts):** Four surfaces — `INotifyCloudGateway` (interface), `INotifyCloudApiKeyStore` (interface), `NotifyCloudTenantTier` (record), `ApiKeyIssuance` (record). Multi-tenant primitives consumed from Kernel per ADR-0026, not redefined here.
+
+**ADR-0027 D5 (Boundary rule):** Strict one-way dependency direction documented in boundaries.md. Hot path is Notify Cloud → Communications → Notify. Direct calls from Notify Cloud to Notify are diagnostic/smoke-test only.
+
+**ADR-0027 D6 (SDK lives in open Notify repo):** Documented in overview.md visibility section. The SDK is identical for self-hosters and hosted-service customers; placing it in the open repo lets self-hosters consume it without a license seam.
+
+**ADR-0027 D7 (Telemetry direction):** Documented in integration-points.md Emits section. One-way emission to Pulse via Kernel's `ITelemetryActivityFactory`. `tenant_id` is a direct low-cardinality label at v1; API keys / raw secrets / payloads / PII are never emitted.
+
+**ADR-0027 D11 (FSL on open engine repos):** Documented in overview.md Visibility and Licensing section. Notify and Communications repos get FSL with two-year auto-conversion to Apache 2.0. The wrapper repo (Notify.Cloud, private) is `LicenseRef-Proprietary`. The FSL application is the substance of packets 03 and 04 of this initiative.
+
+## Dependencies
+None. This packet is the foundation of the initiative — it can land before the constitution invariants packet (02) and the FSL packets (03/04), because the content is design-decided already in ADR-0027. Packets 02, 03, 04, 05, and 06 reference this one as `packet:01`.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ops`, `adr-0027`
+
+## Agent Handoff
+
+**Objective:** Create the standard five-file `repos/HoneyDrunk.Notify.Cloud/` context folder and update `constitution/sectors.md` to reflect ADR-0027's standup decisions. Do **not** edit `catalogs/*.json`, `initiatives/*`, `adrs/README.md`, or the ADR file itself.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Context:**
+- Goal: ADR-0027 is the standup ADR for the Grid's first commercial Node and first private repo. Without the context folder, downstream agents scoping their own work against Notify Cloud read no metadata at all — this packet establishes the minimum viable surface.
+- Feature: ADR-0027 standup initiative, Wave 1, Packet 01.
+- ADRs: ADR-0027 (this packet implements the context-folder half of "If Accepted").
+- Prerequisite ADR: ADR-0026 (Accepted as of 2026-05-20).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None — this packet runs first.
+
+**Constraints:**
+
+- **Invariant 1 — ADR-0027 D3 carve-out:** Invariant 1 says Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. ADR-0027 D3 explicitly carves out three permitted Abstractions references for `HoneyDrunk.Notify.Cloud.Abstractions`: `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.Notify.Abstractions`, `HoneyDrunk.Communications.Abstractions`. The local invariant 1 in `repos/HoneyDrunk.Notify.Cloud/invariants.md` (this packet writes that file) restates the carve-out. `HoneyDrunk.Kernel.Abstractions` is load-bearing at v0.1.0 (for the `TenantId` record-struct per ADR-0026 D1); the other two are reserved by D3 for future contract surfaces. The strict-Abstractions stance from sibling ADR-0016 / ADR-0017 packets does NOT apply here.
+- **Invariant 8 extended to API keys:** Secret values never appear in logs, traces, exceptions, or telemetry. Only secret names/identifiers may be traced. — Local invariant 3 in `repos/HoneyDrunk.Notify.Cloud/invariants.md` extends this to API key material: no raw key is ever logged, traced, persisted in raw form, or returned in any subsequent API call. `ApiKeyIssuance` is the one-time issuance shape; subsequent reads return only the hash and metadata.
+- **Invariant 11:** One repo per Node. — Notify Cloud is its own Node, hence its own repo (private, created by packet 05).
+- **Invariant 39:** Tenant mechanics stay at intake and post-dispatch boundaries. — Notify Cloud is the first real consumer of this invariant. The boundaries.md decision-test enforces it.
+- **Invariant 40:** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Communications.Abstractions`. Composition against `HoneyDrunk.Communications` is a host-time concern. — Reflected in integration-points.md Consumes section.
+- **Records drop `I`; interfaces keep it.** `NotifyCloudTenantTier` (record) and `ApiKeyIssuance` (record) have no prefix; `INotifyCloudGateway` and `INotifyCloudApiKeyStore` (interfaces) keep it. Apply consistently across all five context files.
+- **Kernel multi-tenant primitives are CONSUMED, not redefined.** Per ADR-0027 D4 and ADR-0026: `TenantId` (the strong type used as a field type by the four D4 contracts) lives in `HoneyDrunk.Kernel.Abstractions.Identity` per ADR-0026 D1; `ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, `BillingEvent` live in `HoneyDrunk.Kernel.Abstractions.Tenancy` (consumed at the runtime layer, not in Notify Cloud's Abstractions). The overview and integration-points docs must clearly say none of these are declared in Notify Cloud's own Abstractions — `TenantId` is referenced via the permitted `HoneyDrunk.Kernel.Abstractions` PackageReference; the other four are runtime-layer consumption.
+- **No catalog edits.** Per the user's standing instruction at the time of this scoping run, do **not** edit `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/grid-health.json`, `catalogs/contracts.json`, or `catalogs/modules.json`. These are reconciled by the hive-sync agent after the initiative completes. The new `visibility` schema field documented in ADR-0027 D2's catalog README treatment is also hive-sync's concern.
+- **No initiative-list / ADR-index edits.** Do **not** edit `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, or `adrs/README.md`. These are hive-sync-reconciled.
+- **No ADR Status flip in this packet.** ADR-0027 stays at `Status: Proposed`. The flip is a separate post-merge housekeeping step the scope agent runs after the entire initiative completes, per the user's standing ADR acceptance workflow. Do not edit the ADR header in this PR.
+- **No commits under CHANGELOG `Unreleased`.** Per the user's standing rule, move to a dated versioned section with a SemVer bump before commit. The Architecture repo uses the CHANGELOG as a version of record.
+
+**Key Files:**
+- `repos/HoneyDrunk.Notify.Cloud/overview.md` (new file)
+- `repos/HoneyDrunk.Notify.Cloud/boundaries.md` (new file)
+- `repos/HoneyDrunk.Notify.Cloud/invariants.md` (new file)
+- `repos/HoneyDrunk.Notify.Cloud/active-work.md` (new file)
+- `repos/HoneyDrunk.Notify.Cloud/integration-points.md` (new file)
+- `constitution/sectors.md` (Ops-sector row update)
+- `CHANGELOG.md` (version entry)
+
+`adrs/ADR-0027-stand-up-honeydrunk-notify-cloud-node.md`, `adrs/README.md`, `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, and every file under `catalogs/` are explicitly **not** edited in this packet.
+
+**Contracts:**
+- This packet does not author any new contracts. It records ADR-0027 D4's four contracts in the context folder. Authoring of the actual `.cs` files happens in packet 06 (the scaffold).

--- a/generated/issue-packets/active/adr-0027-notify-cloud-standup/02-architecture-notify-cloud-invariants.md
+++ b/generated/issue-packets/active/adr-0027-notify-cloud-standup/02-architecture-notify-cloud-invariants.md
@@ -1,0 +1,260 @@
+---
+name: Constitution Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "ops", "adr-0027", "constitution"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0027"]
+accepts: ADR-0027
+wave: 1
+initiative: adr-0027-notify-cloud-standup
+node: honeydrunk-notify-cloud
+---
+
+# Chore: Add ADR-0027's six new invariants to the Grid constitution
+
+## Summary
+Add six new invariants to `constitution/invariants.md` derived from ADR-0027's Consequences section: D2 (repo public-default + revenue carve-out), D5 (hot delivery path goes through Communications), D6 (SDK lives in open Notify repo), D4+D12 (API keys stored as salted hashes; raw key returned exactly once), D8 (Notify Cloud contract-shape canary), D11 (FSL on open engine repos with two-year Apache 2.0 conversion).
+
+Assign the six new entries to the **next six free numbers** after the file's current highest at edit time. As of 2026-05-20 the file's highest assigned number visible in the published constitution is **46** (ADR-0016 AI canary). Several parallel standup initiatives also claim invariant slots that may or may not have landed by the time this packet executes:
+
+- **ADR-0016 (AI)** — claims 44/45/46 (already landed as of 2026-05-20).
+- **ADR-0017 (Capabilities)** — claims 47/48/49/50.
+- **ADR-0021 (Knowledge)** — pre-claims 55/56/57/58/59 in its "If Accepted" section. **This is a direct overlap with this packet's default 55/56 claims.** The two ADRs (Knowledge and Notify Cloud) are both Proposed and their ordering at acceptance is unknown.
+
+Default-assumption text in this packet uses **51-56** under the conservative assumption that ADR-0016's three invariants land at 44/45/46, ADR-0017's four invariants land at 47/48/49/50, and ADR-0021 has NOT landed first. If ADR-0021 lands first and claims 55/56/57/58/59, this packet must claim 60/61/62/63/64/65 (or the next free run after ADR-0017's block, depending on what else has landed). **Collision-check at edit time is a hard gate** — never just trust the 51-56 default; always verify against the live constitution file before editing.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+ADR-0027 explicitly delegates final invariant numbering to the scope agent at acceptance time. The six invariants the ADR proposes (in its "New invariants" section under Consequences, lines 257-263 of the ADR file) need to land in `constitution/invariants.md` so:
+
+- The contract-shape canary in packet 06 has a numbered, citable rule to reference.
+- The FSL LICENSE application packets (03 and 04) have a numbered rule to reference.
+- The private-repo carve-out (D2) has a Grid-wide constitutional record, not just an ADR-text justification.
+- The API-key-handling discipline (D4 + D12) is a constitutional rule, not just a Notify-Cloud-local invariant.
+- The hot-path-through-Communications rule (D5) generalizes a Notify Cloud-specific decision into a Grid principle about commercial wrappers above open engines.
+- The SDK-in-open-repo rule (D6) preempts future contributors from "tidying" the SDK into the private wrapper repo.
+
+These six rules govern Notify Cloud's first-shipping behavior and the licensing posture of its surrounding open repos. Without them, the canary infrastructure has no citable invariant, the FSL application has no constitutional anchor, and the private-repo decision sits only in an ADR — discoverable but not enforceable at the constitutional level.
+
+## Proposed Implementation
+
+### `constitution/invariants.md` — append six new entries
+
+The current state of the file (verified 2026-05-20):
+
+- Highest assigned number is **46** (ADR-0016 AI canary, in `## AI Invariants` section). ADR-0016 has already landed.
+- ADR-0026 took **39** (`## Multi-Tenant Boundary Invariants` section)
+- ADR-0019 took **40/41/42/43** (`## Communications Invariants` section)
+- ADR-0016 took **44/45/46** (`## AI Invariants` section — landed)
+- Numbers **29-30** are reserved for ADR-0010 placeholder; that placeholder stays
+- Numbers **31/32/33** are ADR-0011 Code Review Invariants
+
+**Working assumption:** ADR-0017's packet 02 lands before this packet (claiming 47/48/49/50) and ADR-0021 (Knowledge) has NOT landed first. This packet then claims **51, 52, 53, 54, 55, 56**.
+
+**Competing claim — ADR-0021 (Knowledge):** ADR-0021's "If Accepted" section pre-claims **55/56/57/58/59**. ADR-0021 is still Proposed at the time of this packet's draft, and the ordering at acceptance is unknown. If ADR-0021's invariants land first, this packet's claimed range shifts to whatever six contiguous numbers come next after the last assigned entry. Possible outcomes the executing agent may encounter:
+
+- **Neither ADR-0017 nor ADR-0021 has landed:** highest is 46. Claim 47-52 (and note in the PR body that ADR-0017's claim is pre-empted; the ADR-0017 packet will need to renumber when it executes).
+- **Only ADR-0017 has landed:** highest is 50. Claim 51-56 (the default).
+- **Only ADR-0021 has landed (claimed 55-59):** highest is 59. Claim 60-65.
+- **Both ADR-0017 and ADR-0021 have landed (50, then 55-59):** highest is 59. Claim 60-65.
+- **ADR-0017 lands after ADR-0021:** ordering is unusual but possible. Whatever the final state, scan for the actual highest before claiming.
+
+**Collision-check rule for the executing agent:** Before committing, scan `constitution/invariants.md` and confirm the actual highest existing number. **This is a hard gate, not a best-effort.** Use:
+
+```bash
+rg -nP '^\d+\.\s\*\*' constitution/invariants.md | tail -10
+```
+
+to confirm the highest number. Use ripgrep (`rg`), not `grep` — Windows Git Bash boundary semantics differ subtly.
+
+**Hard-coded references to fix in packet 06 if numbers shift.** Packet 06 (the scaffold) hard-codes the assumed invariant numbers 51-56 in roughly fifteen places. **Every one of those references must be updated in lockstep** before that packet is filed. The full list of hard-coded references in packet 06 (verified 2026-05-20 against `06-notify-cloud-node-scaffold.md`):
+
+- Referenced Invariants block — entries `default 51`, `default 52`, `default 53`, `default 54`, `default 55`, `default 56` (six narrative blocks at the bottom of the Referenced Invariants section).
+- Constraints block — `constitutional invariant 52`, `constitutional invariant 54`, `constitutional invariant 56` (three narrative references, plus parenthetical `(default-numbered)` annotations).
+- Body text — `local invariant 3 and constitutional invariant 54`, `invariant 8 and constitutional invariant 54`, `ADR-0027 D11 and constitutional invariant 56` (three more narrative references in the Constraints/Boundary Check sections).
+
+After picking the actually-assigned numbers, run the lockstep-rename query in this packet's "Lockstep renumber of packet 06 source file" section below.
+
+If the assigned numbers shift away from 51-56:
+
+- The corresponding bullets in ADR-0027's Consequences section ("New invariants (proposed for `constitution/invariants.md`)") at lines 257-263 are updated to state the assigned numbers.
+- The packet 06 source file at `generated/issue-packets/active/adr-0027-notify-cloud-standup/06-notify-cloud-node-scaffold.md` is amended in place before push. Per the dispatch plan's filing-order rule, packet 06 is not filed until this packet has merged, so the pre-filing carve-out under invariant 24 applies.
+- `repos/HoneyDrunk.Notify.Cloud/invariants.md` (created in packet 01) references the canary invariant by phrase ("number assigned at packet 02 of this initiative") rather than by number, so no edit is required there. If for some reason a number has been baked into that file already, update it.
+
+### Where the six entries land in `constitution/invariants.md`
+
+Two acceptable layouts:
+
+- **Option A (preferred): introduce a new `## Notify Cloud Invariants` section after `## Communications Invariants`.** Each Ops-sector substrate (Communications, Notify Cloud) gets its own section. Visually clusters the six new entries together and matches the pattern used by ADR-0026 (its own `## Multi-Tenant Boundary Invariants` section) and ADR-0019 (its own `## Communications Invariants` section). Notify Cloud is a distinct enough domain (commercial wrapper, private repo, FSL/proprietary licensing) to warrant its own section.
+- **Option B (acceptable fallback): append the six entries inside the existing `## Communications Invariants` section.** Acceptable if the file structure has otherwise drifted in unexpected ways, but suboptimal because Notify Cloud's concerns (private repo, FSL licensing, API key handling) are broader than Communications and reflect a separate substrate.
+
+The executing agent picks based on what the file looks like at edit time:
+
+- If `## Communications Invariants` already contains exactly four entries (40-43) and there is no `## Notify Cloud Invariants` section yet, **Option A** is preferred — start a new section.
+- If the file structure has drifted in unexpected ways, fall back to **Option B** and mention the deviation in the PR body.
+
+### Invariant text — assuming numbers 51-56
+
+Append the six entries as:
+
+```markdown
+## Notify Cloud Invariants
+
+51. **The HoneyDrunk Grid's repo default is public; private repos require an explicit ADR-recorded justification under the revenue/compliance/experiment carve-out.**
+    `HoneyDrunk.Notify.Cloud` is the first private repo; its justification (customer-data-adjacent infrastructure, hyperscaler defense, billing-system integrity) is recorded in ADR-0027 D2. Future private repos require a similar standup-ADR justification on the record. See ADR-0027 D2.
+
+52. **Commercial wrappers compose Communications, not Notify, for the hot delivery path.**
+    The dependency graph is `Commercial Wrapper → Communications → Notify`. Direct `Wrapper → Notify` calls are restricted to diagnostic and smoke-test paths only. This preserves Notify's invariant that delivery decisions are made by Communications, and it keeps commercial wrappers' view of tenancy at the orchestration boundary, not at the dispatch boundary. Applied first by `HoneyDrunk.Notify.Cloud` (the only commercial wrapper at v1); generalizes to any future commercial wrapper above an open engine. See ADR-0027 D5.
+
+53. **Customer-facing SDKs that cover both self-host and hosted-service consumers ship from the open engine repo, regardless of the wrapper's visibility.**
+    The `HoneyDrunk.Notify.Client` SDK lives in the open `HoneyDrunk.Notify` repo, not in `HoneyDrunk.Notify.Cloud`. Self-hosters and hosted-service customers call the same engine endpoints with the same request shapes; only the base URL and the API key change. Co-locating the SDK with the engine lets self-hosters consume it without a license seam and gives the marketing wedge a stable home (the engine repo is public and FSL-licensed). Future commercial-wrapper SDKs inherit the same rule. See ADR-0027 D6.
+
+54. **API keys are stored only as salted hashes; raw key material is returned to the caller exactly once at issuance time and is never logged, traced, or persisted in raw form.**
+    Extension of invariant 8 (secret values never appear in logs, traces, exceptions, or telemetry) to API key material. The one-time issuance shape carries the plaintext key only at the moment of issuance; subsequent reads return only the salted hash and the metadata. Applied first by `INotifyCloudApiKeyStore` and `ApiKeyIssuance` in Notify Cloud; generalizes to any future API key surface in the Grid. See ADR-0027 D4 and D12.
+
+55. **The HoneyDrunk.Notify.Cloud Node CI must include a contract-shape canary that fails the build on shape drift to `INotifyCloudGateway`, `INotifyCloudApiKeyStore`, `NotifyCloudTenantTier`, or `ApiKeyIssuance` without a corresponding version bump.**
+    These four are the hot path for every Notify Cloud composition (the runtime, the Stripe billing adapter, the management web app, and any future billing-provider package). Accidental shape drift on any of them breaks the wrapper's internal composition simultaneously. The canary makes this a compile-time failure at Notify Cloud's own CI, not a discovery at runtime in production. The implementation may be the existing `job-api-compatibility.yml` reusable workflow scoped to `HoneyDrunk.Notify.Cloud.Abstractions`; the obligation is to keep the gate, not to use any specific implementation. The Kernel multi-tenant primitives consumed by Notify Cloud (`TenantId`, `ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, `BillingEvent`) are guarded by Kernel's contract-shape canary per ADR-0026, not by this Node's canary. See ADR-0027 D8.
+
+56. **The open-source repos paired with `HoneyDrunk.Notify.Cloud` (`HoneyDrunk.Notify`, `HoneyDrunk.Communications`) ship under the Functional Source License (FSL) with two-year auto-conversion to Apache 2.0.**
+    The license file is committed at the repo root; every shipping `.csproj` declares `PackageLicenseFile` (or `PackageLicenseExpression = "LicenseRef-FSL-1.1-Apache-2.0"`). The wrapper repo (`HoneyDrunk.Notify.Cloud`, private) is `LicenseRef-Proprietary` (all rights reserved by default of being private). The license posture is the studio's commercial moat at the operational economics layer, not at the source-code-secrecy layer — the engine and SDK stay readable, modifiable, self-hostable, redistributable. The competitor restriction (block hyperscaler rehosting) is the only commercially load-bearing FSL clause. See ADR-0027 D11.
+```
+
+If Option B is chosen (append inside `## Communications Invariants`), drop the `## Notify Cloud Invariants` heading and place the six entries after the existing 40-43 block. The invariant numbers stay the same.
+
+### Notes for the executing agent
+
+- **None of the six new invariants carry the `(Proposed — this invariant takes effect when ADR-XXXX is accepted)` qualifier in this packet.** ADR-0027 is still at `Status: Proposed` at the time this packet's PR lands, but per the user's standing ADR acceptance workflow, the scope agent flips Status → Accepted after the entire initiative's PRs merge. The six invariants therefore become Accepted alongside the ADR. To match the pattern set by ADR-0016 packet 02 and ADR-0019 packet 02 (both of which omitted the `(Proposed)` qualifier on their new invariants because the ADR flipped concurrently), this packet also omits the qualifier. The Status flip itself is a separate post-merge housekeeping step that follows the initiative's completion.
+
+  However: if for any reason the executing agent observes that ADR-0027 has NOT yet been flipped to Accepted at the time of edit and the invariants do not have an immediate enforcement context, add the qualifier `(Proposed — this invariant takes effect when ADR-0027 is accepted)` at the end of each entry's body, matching the pattern from invariants 28 (ADR-0010) and 31/32/33 (ADR-0011). The qualifier is mechanical to remove later if needed.
+
+- Do not modify the existing entries (28, 29-30 reservation, 31-43) or any text outside the six new entries.
+
+- The new section heading (Option A) reads exactly `## Notify Cloud Invariants` — no parenthetical, no version qualifier, no ADR number in the heading text. Other section headings in this file follow the same pattern.
+
+### Lockstep renumber of packet 06 source file
+
+Packet 06 (the scaffold) hard-codes the assumed invariant numbers 51-56. If the collision check shifts the numbers away from 51-56, every reference in `06-notify-cloud-node-scaffold.md` must update in lockstep before that packet is filed. **Full hard-coded reference list (verified 2026-05-20):**
+
+- Referenced Invariants section — six narrative blocks at the bottom of the section, each annotated `(number assigned by packet 02 of this initiative — default 51)`, `(default 52)`, `(default 53)`, `(default 54)`, `(default 55)`, `(default 56)`. Update the parenthetical to reflect the actually-assigned number.
+- Constraints section in Agent Handoff — three narrative references: `constitutional invariant 52 (default-numbered)`, `constitutional invariant 54 (default-numbered)`, `constitutional invariant 56 (default-numbered)`.
+- Boundary Check section — narrative `local invariant 3 and constitutional invariant 54`.
+- Telemetry constraints — `Per invariant 8 and constitutional invariant 54`.
+- LICENSE constraints — `Per ADR-0027 D11 and constitutional invariant 56`.
+
+After determining the actually-assigned numbers, run:
+
+```bash
+rg -nP '\b5[1-6]\b' generated/issue-packets/active/adr-0027-notify-cloud-standup/06-notify-cloud-node-scaffold.md
+```
+
+Use ripgrep (`rg`), not `grep`. For each match, replace the old number with the assigned one. Verify by re-running the rg query and confirming zero hits at the old numbers and the expected count at the new numbers. Where a reference is purely narrative ("the Notify Cloud contract-shape canary invariant"), the number does not need to be there at all — those phrase-keyed references are preferred per the packet's existing pattern. The numbers stay in places where they are genuinely needed (e.g. parenthetical "default 55" annotations, the actual `constitution/invariants.md` insertion).
+
+**ADR-0021 cross-check.** If ADR-0021 landed first and claimed 55/56/57/58/59, the rg query above will find no matches at 51-56 (none of those would be Notify Cloud's anymore — they could be ADR-0017's, or unclaimed). The lockstep renumber still applies; just verify that the search for the new range (e.g. 60-65 if ADR-0021 took 55-59) finds the same six hard-coded reference sites listed above. The work is exactly the same, only the number values differ.
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the in-progress version entry (no commits under `Unreleased` per the user's standing rule):
+
+`Architecture: Add invariants 51 (private-repo carve-out requires ADR justification), 52 (commercial wrappers compose Communications not Notify on hot path), 53 (customer SDKs live in open engine repo regardless of wrapper visibility), 54 (API keys salted-hash only; raw returned exactly once at issuance), 55 (Notify Cloud contract-shape canary), 56 (FSL on open engine repos paired with Notify Cloud) per ADR-0027 D2, D5, D6, D4+D12, D8, D11. Numbers shift to next-available if collision check finds 51-56 taken.`
+
+If renumbered, update the changelog line to state the actually-assigned numbers.
+
+## Affected Files
+- `constitution/invariants.md`
+- `adrs/ADR-0027-stand-up-honeydrunk-notify-cloud-node.md` (only if the assigned numbers differ from 51-56 — update the Consequences "New invariants" bullets at lines 257-263)
+- `generated/issue-packets/active/adr-0027-notify-cloud-standup/06-notify-cloud-node-scaffold.md` (only if the assigned numbers differ from 51-56 — pre-filing amendment per invariant 24's carve-out)
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] No new design decisions — invariant text is taken from ADR-0027's "New invariants" section, with light wordsmithing for the constitution's voice.
+- [x] No existing invariants modified, only appended.
+- [x] Pre-filing amendment to packet 06's source file is permitted under invariant 24's carve-out; post-filing amendment is forbidden, so the dispatch plan's filing-order rule (packet 06 not filed until this packet's PR has merged) is the structural protection.
+- [x] No edits to `catalogs/*.json`, `initiatives/*`, `adrs/README.md` — those are hive-sync's concern.
+
+## Acceptance Criteria
+- [ ] Six new invariants present in `constitution/invariants.md` with text matching ADR-0027 D2, D5, D6, D4+D12, D8, D11.
+- [ ] Assigned numbers verified against the current highest number in the file using `rg -nP '^\d+\.\s\*\*' constitution/invariants.md | tail -10`. Default assumption is 51-56; the executing agent renumbers to the next six free numbers if anything has shifted. **Specifically check whether ADR-0021 (Knowledge) has landed first** — ADR-0021 pre-claims 55/56/57/58/59 in its "If Accepted" section, which directly overlaps with this packet's default 55/56. If ADR-0021 landed first, this packet's claim shifts to 60-65 (or whatever six contiguous free numbers come next after the actual highest).
+- [ ] Each invariant's body cites its source ADR decision.
+- [ ] **None of the new invariants carry a `(Proposed)` qualifier**, matching the pattern from ADR-0016 packet 02 and ADR-0019 packet 02 — unless the executing agent observes that ADR-0027 has not been flipped to Accepted at the time of edit AND has no immediate enforcement context, in which case the `(Proposed — this invariant takes effect when ADR-0027 is accepted)` qualifier is added at the end of each body. Document in the PR body which choice was made.
+- [ ] Existing entries (28, 29-30 reservation, 31-43) are unmodified.
+- [ ] If invariant numbers shifted away from 51-56, the corresponding bullets in ADR-0027's Consequences section ("New invariants (proposed for `constitution/invariants.md`)") at lines 257-263 are updated to match.
+- [ ] If invariant numbers shifted away from 51-56, the packet 06 source file is amended before that packet is filed. After determining the assigned numbers, run `rg -nP '\b5[1-6]\b' generated/issue-packets/active/adr-0027-notify-cloud-standup/06-notify-cloud-node-scaffold.md` and update each match to the actually-assigned number. After replacement, re-run the rg query and confirm zero hits at the old numbers. The dispatch plan's filing-order rule guarantees packet 06 has not been filed yet at the time this packet's PR merges.
+- [ ] Section heading choice (Option A new `## Notify Cloud Invariants` section vs Option B append-inside-Communications) documented in the PR body with the executing agent's rationale.
+- [ ] `CHANGELOG.md` in-progress version entry updated with the six invariant numbers actually assigned. No commits land under `## [Unreleased]`.
+- [ ] `catalogs/*.json`, `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, `adrs/README.md` are **not** modified. Confirm in diff.
+
+## Human Prerequisites
+- [ ] None. The constitution edit is purely textual; no portal action, GitHub UI action, or external-system action is required.
+
+## Referenced Invariants
+
+> **Invariant 8:** Secret values never appear in logs, traces, exceptions, or telemetry. Only secret names/identifiers may be traced. `VaultTelemetry` enforces this. — New invariant 54 (API keys salted-hash only) is a direct extension of this rule to API key material.
+
+> **Invariant 11:** One repo per Node (or tightly coupled Node family). Each repo has its own solution, CI pipeline, and versioning. — Reinforces why Notify Cloud is its own private repo (created by packet 05).
+
+> **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. Filing is the point of no return. Before a packet is filed, it may be amended to fill in missing operational context without violating this rule. — The pre-filing amendment to packet 06 (if invariant numbers shift) is permitted under this carve-out.
+
+> **Invariant 39:** Tenant mechanics stay at intake and post-dispatch boundaries. Tenant resolution, tenant rate-limit checks, billing-event emission, and tenant-scoped secret lookup must live in intake middleware/orchestration edges or post-dispatch tails. Core dispatch paths for internal Grid callers must remain tenant-agnostic and default to `TenantId.Internal` without caller-specific branches. — Notify Cloud is the first real (non-noop) consumer of this invariant; the new Notify Cloud invariants reinforce the boundary mechanics this rule sets at the Grid level.
+
+> **Invariant 40:** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Communications.Abstractions`. — Reinforces the rationale for new invariant 52 (commercial wrappers compose Communications, not Notify, on hot path) — invariant 52 is the commercial-wrapper-side projection of invariant 40's downstream-coupling discipline.
+
+## Referenced ADR Decisions
+
+**ADR-0027 D2 (Repo visibility — private with revenue carve-out):** First private repo in the Grid. Justifications: customer-data-adjacent infrastructure, hyperscaler defense, billing-system integrity. The catalog gains a `visibility` field on this Node (hive-sync-reconciled). — Source for invariant 51.
+
+**ADR-0027 D4 (Exposed contracts) and D12 (API key authentication routed through Auth):** API key issuance lives in Notify Cloud (`INotifyCloudApiKeyStore`); validation lives in `HoneyDrunk.Auth` (`IApiKeyAuthenticator` middleware path — added by a follow-up ADR). Keys are stored only as salted hashes; raw key material is returned exactly once via `ApiKeyIssuance` at issuance time and never logged, traced, or persisted in raw form. — Source for invariant 54.
+
+**ADR-0027 D5 (Boundary rule):** Hot path is Notify Cloud → Communications → Notify. Direct calls from Notify Cloud to Notify (via `INotificationSender`) are diagnostic/smoke-test only. — Source for invariant 52.
+
+**ADR-0027 D6 (SDK lives in open Notify repo):** The customer-facing `HoneyDrunk.Notify.Client` SDK lives in the public `HoneyDrunk.Notify` repo, not in the private `HoneyDrunk.Notify.Cloud` repo. Customers install it from NuGet without ever needing access to the wrapper's source. — Source for invariant 53.
+
+**ADR-0027 D8 (Contract-shape canary):** A contract-shape canary is added to the Notify Cloud Node's CI: it fails the build if any of `INotifyCloudGateway`, `INotifyCloudApiKeyStore`, `NotifyCloudTenantTier`, `ApiKeyIssuance` change shape without a corresponding version bump. The Kernel multi-tenant primitives consumed here are guarded by Kernel's canary per ADR-0026. — Source for invariant 55.
+
+**ADR-0027 D11 (Functional Source License — FSL — for open engine repos):** Open-source repos paired with Notify Cloud (`HoneyDrunk.Notify`, `HoneyDrunk.Communications`) ship under FSL with two-year auto-conversion to Apache 2.0. The wrapper repo (Notify Cloud, private) is `LicenseRef-Proprietary`. Rationale: solo-dev defaults beat configuration; two-year conversion matches the kill-clock cadence; the competitor restriction is the only commercially load-bearing FSL clause; Sentry's precedent is closer to Notify Cloud's buyer profile than HashiCorp's; FSL's plain-language alignment with build-in-public. — Source for invariant 56.
+
+## Dependencies
+- `packet:01` — packet 01 lands the context-folder content (especially the four D4 contract names and the four-package family list) that invariant 55's canary will guard and that invariant 54 (API key handling) refers to. Filing 02 before 01 would leave a forward-reference dangling in the new invariant bodies.
+
+## Labels
+`chore`, `tier-2`, `architecture`, `ops`, `adr-0027`, `constitution`
+
+## Agent Handoff
+
+**Objective:** Land six new ADR-0027-derived invariants in the Grid constitution at the next six available numbers, in a single edit. Update ADR-0027 Consequences bullets and packet 06's source file if the assigned numbers shift away from 51-56.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Context:**
+- Goal: ADR-0027's "New invariants" section is a placeholder with the qualifier "Numbering is tentative — scope agent finalizes at acceptance." This packet is the finalization.
+- Feature: ADR-0027 standup initiative, Wave 1, Packet 02.
+- ADRs: ADR-0027 (sole source).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packet 01 of this initiative (context-folder registration) must merge first.
+
+**Constraints:**
+
+- **None of the new invariants carry a `(Proposed)` qualifier in the default case.** Matches the pattern from ADR-0016 packet 02 and ADR-0019 packet 02. The Status flip for ADR-0027 is a separate post-merge housekeeping step the scope agent runs after the entire initiative completes; the qualifier-omission is consistent with that flip happening. If the executing agent observes ADR-0027 still at `Proposed` and judges the invariants need a qualifier for clarity, add `(Proposed — this invariant takes effect when ADR-0027 is accepted)` at the end of each entry's body, matching the pattern from invariants 28 (ADR-0010) and 31/32/33 (ADR-0011) — but the default is no-qualifier.
+- **Number collision check is a hard gate.** Default 51-56. Verify against the file's highest number at edit time using `rg -nP '^\d+\.\s\*\*' constitution/invariants.md | tail -10`. If shifted, update both ADR-0027's Consequences section (lines 257-263) and packet 06's source file. Do not file partial edits — either all six invariants land at consistent numbers across all three files, or none of them.
+- **Section choice (Option A vs Option B) is a stylistic call, not a correctness one.** Pick based on what the file looks like at edit time. Default to Option A (new `## Notify Cloud Invariants` section) since Notify Cloud is a distinct substrate with broad-reaching concerns (private repo, FSL licensing, API key handling) that extend beyond Communications.
+- **Verbatim alignment with ADR-0027.** The invariant bodies should restate D2/D5/D6/D4+D12/D8/D11 with constitutional voice, not introduce new requirements. Anything novel belongs in a follow-up ADR.
+- **Pre-filing amendment to packet 06 is the mechanism** for handling number shifts. Invariant 24: filed packets are immutable, but pre-filing edits are permitted. The dispatch plan's filing-order rule (packet 06 not filed until this packet's PR has merged) is what makes the carve-out applicable.
+- **No commits under CHANGELOG `Unreleased`.** Per the user's standing rule, move to a dated versioned section with a SemVer bump before commit. The Architecture repo uses the CHANGELOG as a version of record.
+- **No edits to shared catalog/index files.** `catalogs/*.json`, `initiatives/*`, `adrs/README.md` are reconciled by hive-sync, not this packet.
+
+**Key Files:**
+- `constitution/invariants.md` — append six entries (Option A: under a new `## Notify Cloud Invariants` section after `## Communications Invariants`; Option B: inside `## Communications Invariants`)
+- `adrs/ADR-0027-stand-up-honeydrunk-notify-cloud-node.md` — only edited if numbers shifted from 51-56 (lines 257-263 in the Consequences "New invariants" block)
+- `generated/issue-packets/active/adr-0027-notify-cloud-standup/06-notify-cloud-node-scaffold.md` — only edited if numbers shifted from 51-56
+- `CHANGELOG.md` — version entry (no `Unreleased`)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0027-notify-cloud-standup/03-notify-fsl-license.md
+++ b/generated/issue-packets/active/adr-0027-notify-cloud-standup/03-notify-fsl-license.md
@@ -1,0 +1,247 @@
+---
+name: FSL LICENSE Application
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["chore", "tier-2", "ops", "licensing", "adr-0027"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0027"]
+accepts: ADR-0027
+wave: 2
+initiative: adr-0027-notify-cloud-standup
+node: honeydrunk-notify
+---
+
+# Chore: Apply Functional Source License (FSL) to HoneyDrunk.Notify
+
+## Summary
+Apply the Functional Source License (FSL-1.1-Apache-2.0) to the `HoneyDrunk.Notify` repo per ADR-0027 D11. This covers both the engine (`HoneyDrunk.Notify`, `HoneyDrunk.Notify.Abstractions`, `HoneyDrunk.Notify.Functions`, `HoneyDrunk.Notify.Hosting.AspNetCore`) and the customer-facing SDK (`HoneyDrunk.Notify.Client` — lives in this repo per ADR-0027 D6).
+
+Commit the FSL-1.1-Apache-2.0 license text as `LICENSE` at the repo root, update the repo description to call out the FSL license, and configure every shipping `.csproj` to reference the license file in NuGet package metadata. **No code or contract changes.** This is a licensing-posture commit.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Notify`
+
+## Motivation
+PDR-0002 §M deferred the FSL-vs-BSL choice to the Notify Cloud standup ADR. ADR-0027 D11 picks **FSL** and identifies three repos to apply it to: `HoneyDrunk.Notify` (the engine + the SDK), `HoneyDrunk.Notify.Client` (lives inside `HoneyDrunk.Notify` per D6 but covered explicitly), and `HoneyDrunk.Communications` (the orchestration layer). This packet handles the Notify repo; packet 04 handles the Communications repo. Both packets land the same license text but in different target repos with different per-`.csproj` package metadata updates.
+
+The license decision must land before:
+
+- The first commercial Notify Cloud customer reads a marketing page that says "Notify is open source under FSL — read it, modify it, self-host it, redistribute it" (PDR-0002 §H framing).
+- `HoneyDrunk.Notify.Cloud` ships v0.1.0 of its scaffold (packet 06 of this initiative) — that packet's CHANGELOG and marketing-adjacent text reference FSL as a settled posture.
+- Any new contributor commits code expecting the repo to stay MIT or Apache-only — relicensing later is hostile to early contributors, so the license posture must be settled now.
+
+**Why FSL (the substance of ADR-0027 D11), restated briefly for the repo's commit message and PR body:**
+
+- Solo-dev defaults beat configuration. FSL is a single license file with a fixed two-year auto-conversion to Apache 2.0. BSL requires the licensor to specify a Change Date and Change License per release; the default Change Date is four years out.
+- Two-year conversion matches the kill-clock cadence (PDR-0002).
+- The competitor restriction is the only commercially load-bearing FSL clause — both FSL and BSL block "host this as a competing commercial service."
+- Sentry's precedent (developer-tooling SaaS sold to indies) is closer to Notify Cloud's buyer profile than HashiCorp's (enterprise infrastructure).
+- Build-in-public alignment — FSL text is short, plain-language, and easy for an indie .NET dev to read on a marketing site and trust.
+
+## Proposed Implementation
+
+### `LICENSE` file — new file at repo root
+
+Commit the canonical FSL-1.1-Apache-2.0 license text. The canonical source is https://fsl.software/ — fetch the FSL-1.1-Apache-2.0 variant (the Apache-2.0-convertible variant) and commit it verbatim.
+
+The FSL text has a header block that includes the licensor name and the "Change Date" / "Change License" parameters baked into the text — those are the two-year-from-publication date and Apache-2.0 respectively. Use:
+
+- **Licensor:** HoneyDrunk Studios
+- **Change Date:** Two years from the date of this commit (i.e., if this PR merges on 2026-MM-DD, the Change Date is 2028-MM-DD)
+- **Change License:** Apache License, Version 2.0
+
+The full FSL-1.1-Apache-2.0 text is approximately 600 words and can be fetched directly from https://fsl.software/FSL-1.1-Apache-2.0.template. Inline the canonical text in the commit — do not write a paraphrase or summary. The PR body should link to https://fsl.software/ for reviewers.
+
+### `README.md` — license section update
+
+Add or update a `## License` section near the bottom of the existing `README.md`:
+
+```markdown
+## License
+
+HoneyDrunk.Notify is released under the [Functional Source License v1.1](https://fsl.software/), with automatic conversion to the Apache License, Version 2.0 two years after the date of each release. See [LICENSE](./LICENSE) for the full text.
+
+The license permits any non-competing use — read, modify, self-host, redistribute. The only restriction is using HoneyDrunk.Notify to provide a hosted notification service that competes with HoneyDrunk Notify Cloud. After the two-year conversion date, even that restriction is lifted (under Apache 2.0).
+
+The customer-facing SDK `HoneyDrunk.Notify.Client` lives in this repo and ships under the same license.
+```
+
+If the README already has a license section (e.g., MIT or Apache), replace it with the FSL section above.
+
+### Update repo description (GitHub UI)
+
+The repo description should reference the license. Suggested text:
+
+> Channel-agnostic notification intake and delivery engine for .NET — multi-provider (Resend, Twilio, SMTP), queue-backed. Released under FSL-1.1-Apache-2.0. The hosted commercial service (HoneyDrunk Notify Cloud) sits above this engine.
+
+This is a GitHub UI update via Settings → Description; not a file commit. The packet's Human Prerequisites section calls it out.
+
+### Per-`.csproj` license metadata updates
+
+Every shipping `.csproj` in `src/*` must declare the license in its package metadata. Edit each `.csproj` to add (or update if a `PackageLicenseExpression` already exists):
+
+```xml
+<PropertyGroup>
+  <!-- existing properties -->
+  <PackageLicenseFile>LICENSE</PackageLicenseFile>
+</PropertyGroup>
+
+<ItemGroup>
+  <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+</ItemGroup>
+```
+
+(Adjust the `..\..\LICENSE` path relative to the project file location — depending on the project's depth in `src/`, the relative path may be `..\LICENSE` or `..\..\LICENSE`.)
+
+**Do not** use `PackageLicenseExpression` with an SPDX identifier — FSL is not in the SPDX list (as of 2026-05). The `LicenseRef-` extension exists for non-SPDX licenses but is less widely supported by NuGet tooling than `PackageLicenseFile`. The `<PackageLicenseFile>` + `<None Include=... Pack="true">` pattern packages the LICENSE file into the .nupkg and is the canonical NuGet shape for non-SPDX licenses.
+
+If the existing `.csproj` has a `<PackageLicenseExpression>MIT</PackageLicenseExpression>` or similar, remove that line. NuGet errors on having both `PackageLicenseExpression` and `PackageLicenseFile`.
+
+Apply to every `.csproj` under `src/`:
+
+- `src/HoneyDrunk.Notify.Abstractions/HoneyDrunk.Notify.Abstractions.csproj`
+- `src/HoneyDrunk.Notify/HoneyDrunk.Notify.csproj`
+- `src/HoneyDrunk.Notify.Functions/HoneyDrunk.Notify.Functions.csproj`
+- `src/HoneyDrunk.Notify.Hosting.AspNetCore/HoneyDrunk.Notify.Hosting.AspNetCore.csproj`
+- `src/HoneyDrunk.Notify.Client/HoneyDrunk.Notify.Client.csproj` (if it exists as a separate `src/` directory; otherwise it's part of the `HoneyDrunk.Notify` runtime project — confirm at edit time)
+
+Do **not** edit `tests/*.csproj` — test projects do not ship as NuGet packages.
+
+### Version bump
+
+Per invariant 27 ("All projects in a solution share one version and move together. The first packet to land on a solution in an initiative bumps the version; subsequent packets on the same solution append to the CHANGELOG only."), this is the bumping packet on the Notify solution for this initiative. Bump the solution version from 0.3.0 to **0.4.0** (minor bump — license change is a metadata addition to the package, not a breaking change to public API).
+
+Update the solution-shared `<Version>` in `Directory.Build.props` (or wherever the centralized version property lives — confirm by reading the file). Every `src/*.csproj` picks up the version from there per the existing solution pattern. If any project overrides the centralized version, fix that override so all shipping projects ship at 0.4.0.
+
+Test projects are excluded from the version bump per invariant 27.
+
+### Repo-level `CHANGELOG.md`
+
+Per invariant 12, this packet must create a new repo-level version entry. Add a `## [0.4.0] - 2026-MM-DD` block (replace `MM-DD` with the date the PR merges) with:
+
+```markdown
+## [0.4.0] - 2026-MM-DD
+
+### Added
+- FSL-1.1-Apache-2.0 license file at repo root. Two-year auto-conversion to Apache 2.0 per ADR-0027 D11.
+- README.md license section pointing at LICENSE.
+- Per-`.csproj` `PackageLicenseFile` metadata so NuGet packages declare the license.
+
+### Notes
+- This is a licensing-posture commit. No code or contract changes. All public APIs unchanged.
+- The customer-facing SDK `HoneyDrunk.Notify.Client` is covered by the same LICENSE (lives in this repo per ADR-0027 D6).
+- See [HoneyDrunk Architecture ADR-0027](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0027-stand-up-honeydrunk-notify-cloud-node.md) D11 for the rationale.
+```
+
+### Per-package `CHANGELOG.md`
+
+Per invariant 12, per-package changelogs are updated **only for packages with actual changes**. Since this packet adds the LICENSE file (a package-metadata change) to every shipping package, every shipping package gets an entry. The entry text is identical across packages — license metadata is the substance:
+
+```markdown
+## [0.4.0] - 2026-MM-DD
+
+### Added
+- `PackageLicenseFile` metadata declaring FSL-1.1-Apache-2.0 license.
+```
+
+Update each shipping package's `CHANGELOG.md` (whatever path the existing repo uses — typically `src/{Package}/CHANGELOG.md`). Do **not** add noise entries to per-package CHANGELOGs whose package metadata did not change — but every shipping `.csproj` in this packet's affected-files list got the metadata update, so every shipping package's CHANGELOG gets an entry.
+
+## Affected Files
+- `LICENSE` (new file at repo root)
+- `README.md` (license section update)
+- `Directory.Build.props` (version bump from 0.3.0 to 0.4.0)
+- Every shipping `.csproj` under `src/`:
+  - `src/HoneyDrunk.Notify.Abstractions/HoneyDrunk.Notify.Abstractions.csproj`
+  - `src/HoneyDrunk.Notify/HoneyDrunk.Notify.csproj`
+  - `src/HoneyDrunk.Notify.Functions/HoneyDrunk.Notify.Functions.csproj`
+  - `src/HoneyDrunk.Notify.Hosting.AspNetCore/HoneyDrunk.Notify.Hosting.AspNetCore.csproj`
+  - `src/HoneyDrunk.Notify.Client/HoneyDrunk.Notify.Client.csproj` (if it exists as a separate project)
+- Repo-level `CHANGELOG.md` (new `## [0.4.0]` entry)
+- Per-package `CHANGELOG.md` files (one entry per shipping package)
+
+## NuGet Dependencies
+None. This packet adds no PackageReference entries. It only updates existing `.csproj` metadata (`PackageLicenseFile`, version) and packages the LICENSE file into NuGet artifacts via `<None Include=... Pack="true">`.
+
+## Boundary Check
+- [x] All edits inside the `HoneyDrunk.Notify` repo.
+- [x] No code changes — `.cs` files are untouched.
+- [x] No contract changes — public API surface is unchanged at v0.4.0.
+- [x] Test projects are excluded from the version bump per invariant 27.
+- [x] License text is the canonical FSL-1.1-Apache-2.0 verbatim; no paraphrase, no studio-authored variant.
+
+## Acceptance Criteria
+- [ ] `LICENSE` file exists at repo root with the canonical FSL-1.1-Apache-2.0 text. The header parameters are set: Licensor = HoneyDrunk Studios, Change Date = two years from the PR merge date, Change License = Apache License, Version 2.0.
+- [ ] `README.md` has a `## License` section pointing at `LICENSE` with the FSL framing described above. Any pre-existing license section (e.g., MIT, Apache) is removed.
+- [ ] Every shipping `.csproj` under `src/` declares `<PackageLicenseFile>LICENSE</PackageLicenseFile>` and `<None Include="..\..\LICENSE" Pack="true" PackagePath="\" />` (path adjusted per project depth). No `.csproj` carries both `PackageLicenseExpression` and `PackageLicenseFile` — NuGet errors on that combination.
+- [ ] Solution version bumped from 0.3.0 to 0.4.0 in `Directory.Build.props` (or wherever the centralized version property lives). Every shipping `.csproj` resolves to 0.4.0 at build time. Test projects are unaffected (per invariant 27).
+- [ ] Repo-level `CHANGELOG.md` has a new `## [0.4.0] - YYYY-MM-DD` entry covering the license addition, with rationale link to ADR-0027 D11.
+- [ ] Per-package `CHANGELOG.md` files updated for every shipping package with the license-metadata entry.
+- [ ] `dotnet pack` runs clean across all shipping projects with no warnings about license metadata. The produced `.nupkg` files each contain the `LICENSE` file at the root.
+- [ ] Build is clean: `dotnet build` passes with no warnings (warnings-as-errors).
+- [ ] No `.cs` files are modified in the diff. License application is metadata-only.
+- [ ] `tests/*` are unchanged (no version bumps, no metadata changes).
+- [ ] PR body explicitly references ADR-0027 D11 with the link to the ADR file, and quotes the four FSL-vs-BSL rationales (solo-dev defaults beat configuration; two-year conversion matches kill-clock cadence; competitor restriction is the only commercially load-bearing clause; Sentry precedent; build-in-public alignment).
+
+## Human Prerequisites
+- [ ] Update the GitHub repo description via Settings → General → Description on https://github.com/HoneyDrunkStudios/HoneyDrunk.Notify. Suggested text: "Channel-agnostic notification intake and delivery engine for .NET — multi-provider (Resend, Twilio, SMTP), queue-backed. Released under FSL-1.1-Apache-2.0. The hosted commercial service (HoneyDrunk Notify Cloud) sits above this engine." This is a GitHub UI action; the agent cannot perform it.
+- [ ] After the PR merges, push tag `v0.4.0` from `main` to trigger the release workflow and publish the new packages to NuGet. Tags are human-pushed per invariant 27 — agents never push tags.
+- [ ] Confirm OIDC federated credential for `repo:HoneyDrunkStudios/HoneyDrunk.Notify:ref:refs/tags/v*` is in place for the NuGet publishing identity (almost certainly already configured for this repo, but worth a quick check). Cross-link: [infrastructure/walkthroughs/oidc-federated-credentials.md](../../../../infrastructure/walkthroughs/oidc-federated-credentials.md).
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node (or tightly coupled Node family). Each repo has its own solution, CI pipeline, and versioning. — Notify ships its own version cycle; the FSL application is a repo-local concern that does not propagate to other repos' versioning.
+
+> **Invariant 12:** Semantic versioning with CHANGELOG and README. Breaking changes bump major. New features bump minor. Fixes bump patch. Changelogs follow Keep a Changelog format. Two tiers: repo-level CHANGELOG.md (next to the .slnx file) is mandatory; per-package CHANGELOG.md (inside each package directory) is updated only when that specific package has functional changes. — License metadata change applies to every shipping package, so every shipping per-package CHANGELOG gets an entry.
+
+> **Invariant 27:** All projects in a solution share one version and move together. When a version bump is warranted, every .csproj in the solution (excluding test projects) is updated to the same new version in a single commit. Partial bumps — where some projects in a solution are on a different version than others — are forbidden. Releases are triggered by pushing a git tag; agents never push tags. The first packet to land on a solution in an initiative bumps the version; subsequent packets on the same solution append to the CHANGELOG only. The repo-level CHANGELOG.md must always get an entry for the new version. Per-package changelogs are updated only for packages with actual changes — do not add alignment-bump noise entries. — This is the bumping packet on the Notify solution for the adr-0027-notify-cloud-standup initiative. Every shipping project moves from 0.3.0 to 0.4.0 in this single commit. Test projects do not bump.
+
+> **Invariant 56 (assigned by packet 02 of this initiative — number subject to collision-check):** The open-source repos paired with `HoneyDrunk.Notify.Cloud` (`HoneyDrunk.Notify`, `HoneyDrunk.Communications`) ship under the Functional Source License (FSL) with two-year auto-conversion to Apache 2.0. The license file is committed at the repo root; every shipping `.csproj` declares `PackageLicenseFile` (or `PackageLicenseExpression = "LicenseRef-FSL-1.1-Apache-2.0"`). The wrapper repo (`HoneyDrunk.Notify.Cloud`, private) is `LicenseRef-Proprietary`. — This packet is the application of that invariant to the Notify repo. The invariant number is subject to collision-check by packet 02; if the number shifts, this packet's body and acceptance criteria refer to the rule by phrase rather than by number ("the FSL invariant landed by packet 02 of this initiative").
+
+## Referenced ADR Decisions
+
+**ADR-0027 D6 (SDK lives in open Notify repo):** The customer-facing SDK `HoneyDrunk.Notify.Client` lives in the public `HoneyDrunk.Notify` repo, not in `HoneyDrunk.Notify.Cloud`. — The SDK is covered by the same FSL LICENSE as the rest of this repo. No separate license commit needed; the LICENSE file at the repo root applies to every package shipped from this repo, SDK included.
+
+**ADR-0027 D11 (FSL on open engine repos):** Open-source repos paired with Notify Cloud ship under FSL with two-year auto-conversion to Apache 2.0. The competitor restriction (block hyperscaler rehosting) is the only commercially load-bearing FSL clause. Both FSL and BSL produce the same protection; the trade is configurability vs simplicity — FSL is a single global default (two years, Apache), BSL is per-release configurable. Solo-dev defaults beat configuration; Sentry's precedent (developer-tooling SaaS) is closer to Notify Cloud's buyer profile than HashiCorp's enterprise-infrastructure precedent. — This packet is the substance of D11 applied to the Notify repo.
+
+## Dependencies
+- `packet:01` — packet 01 lands the new constitution language and context-folder content (especially `repos/HoneyDrunk.Notify.Cloud/overview.md`'s Visibility and Licensing section that references FSL). Filing 03 before 01 would mean the FSL commit lands without a constitutional anchor describing why.
+
+## Labels
+`chore`, `tier-2`, `ops`, `licensing`, `adr-0027`
+
+## Agent Handoff
+
+**Objective:** Apply the Functional Source License (FSL-1.1-Apache-2.0) to the `HoneyDrunk.Notify` repo. Commit the canonical license text at the repo root, update README, update every shipping `.csproj`'s license metadata, bump the solution version from 0.3.0 to 0.4.0, update CHANGELOGs.
+
+**Target:** HoneyDrunk.Notify, branch from `main`.
+
+**Context:**
+- Goal: Settle the license posture for the engine + SDK before the first commercial Notify Cloud customer reads marketing copy that says "Notify is open source under FSL." Relicensing later is hostile to early contributors; picking now means the first customer reads a stable license.
+- Feature: ADR-0027 standup initiative, Wave 2, Packet 03.
+- ADRs: ADR-0027 (sole governing ADR for the license choice).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packet 01 of this initiative must merge first (so the constitutional context for FSL is in place).
+
+**Constraints:**
+
+- **The license text is canonical FSL-1.1-Apache-2.0 verbatim.** Fetch from https://fsl.software/ — do not write a paraphrase, do not author a studio-specific variant. The only customization is the three header parameters (Licensor, Change Date, Change License); the body text is the canonical license.
+- **No code or contract changes in this packet.** `.cs` files are untouched. The public API surface at v0.4.0 is identical to v0.3.0. The version bump is solely a metadata change.
+- **Invariant 12:** Semantic versioning with CHANGELOG and README. Breaking changes bump major. New features bump minor. Fixes bump patch. Every repo must have a repo-level CHANGELOG.md; per-package CHANGELOG.md is updated only when that specific package has functional changes. — License metadata change applies to every shipping package; every shipping per-package CHANGELOG gets an entry.
+- **Invariant 27:** All projects in a solution share one version and move together. Test projects are excluded. Releases are triggered by pushing a git tag; agents never push tags. The first packet to land on a solution in an initiative bumps the version. — This is the bumping packet. Every shipping `.csproj` resolves to 0.4.0 from `Directory.Build.props` (or wherever the centralized version lives). No partial bumps.
+- **FSL is not in the SPDX list.** Use `<PackageLicenseFile>LICENSE</PackageLicenseFile>` plus `<None Include=... Pack="true">` to package the LICENSE into each `.nupkg`. Do not use `<PackageLicenseExpression>` with FSL — NuGet will error or warn. If the existing `.csproj` has a `PackageLicenseExpression`, remove that line so the metadata is unambiguous.
+- **The SDK ships from this repo per ADR-0027 D6.** `HoneyDrunk.Notify.Client` is covered by the same LICENSE; do not author a separate license file or metadata for it.
+- **Test projects are excluded.** Do not edit `tests/*.csproj`. They do not ship as NuGet packages and do not need license metadata.
+- **No commits under CHANGELOG `Unreleased`.** Per the user's standing rule, commits land under a dated versioned entry — `## [0.4.0] - YYYY-MM-DD`.
+
+**Key Files:**
+- `LICENSE` (new file at repo root — canonical FSL-1.1-Apache-2.0 text from https://fsl.software/)
+- `README.md` (replace any existing license section with the FSL section described above)
+- `Directory.Build.props` (or wherever the centralized version property lives — bump 0.3.0 → 0.4.0)
+- Every shipping `.csproj` under `src/` (add `<PackageLicenseFile>` and `<None Include=... Pack="true">`; remove any `<PackageLicenseExpression>`)
+- Repo-level `CHANGELOG.md` (new `## [0.4.0]` entry)
+- Per-package `CHANGELOG.md` files (one entry per shipping package)
+
+**Contracts:** None. This packet does not modify any contracts or any code. The public API surface at 0.4.0 is identical to 0.3.0.

--- a/generated/issue-packets/active/adr-0027-notify-cloud-standup/04-communications-fsl-license.md
+++ b/generated/issue-packets/active/adr-0027-notify-cloud-standup/04-communications-fsl-license.md
@@ -1,0 +1,233 @@
+---
+name: FSL LICENSE Application
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Communications
+labels: ["chore", "tier-2", "ops", "licensing", "adr-0027"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0027"]
+accepts: ADR-0027
+wave: 2
+initiative: adr-0027-notify-cloud-standup
+node: honeydrunk-communications
+---
+
+# Chore: Apply Functional Source License (FSL) to HoneyDrunk.Communications
+
+## Summary
+Apply the Functional Source License (FSL-1.1-Apache-2.0) to the `HoneyDrunk.Communications` repo per ADR-0027 D11. Commit the FSL-1.1-Apache-2.0 license text as `LICENSE` at the repo root, update README, configure every shipping `.csproj` to reference the license file in NuGet package metadata, bump the solution from 0.2.0 to 0.3.0.
+
+This is the Communications-side application of the same FSL choice ADR-0027 D11 commits to for both `HoneyDrunk.Notify` (packet 03) and `HoneyDrunk.Communications` (this packet). The license text is identical between the two repos; the per-`.csproj` updates and the version bump are repo-specific.
+
+**No code or contract changes.** This is a licensing-posture commit.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Communications`
+
+## Motivation
+ADR-0027 D11 identifies three repos for the FSL license application — `HoneyDrunk.Notify`, `HoneyDrunk.Notify.Client` (lives in `HoneyDrunk.Notify` per D6), and `HoneyDrunk.Communications`. This packet handles Communications.
+
+Communications is the decision-layer orchestration substrate that sits between Notify Cloud and Notify. Per ADR-0027 D5, the hot delivery path is Notify Cloud → Communications → Notify — Communications is on the customer-facing critical path for every paying Notify Cloud tenant. Its license posture must match the engine's posture (FSL with two-year Apache 2.0 conversion) so:
+
+- A self-hoster reading the public Notify engine can also self-host the Communications layer above it under the same license terms.
+- The "Notify is open source under FSL" marketing-page framing (PDR-0002 §H) accurately covers the full self-hostable stack — engine + decision layer + SDK.
+- Future contributors to Communications read the same license posture they read for the engine.
+
+Same rationale as packet 03: relicensing later is hostile to early contributors; picking now means the first commercial Notify Cloud customer reads a stable license across both repos.
+
+## Proposed Implementation
+
+### `LICENSE` file — new file at repo root
+
+Commit the canonical FSL-1.1-Apache-2.0 license text. Same text as packet 03 — fetch from https://fsl.software/FSL-1.1-Apache-2.0.template and inline verbatim.
+
+Header parameters:
+
+- **Licensor:** HoneyDrunk Studios
+- **Change Date:** Two years from the date of this commit (e.g., if this PR merges on 2026-MM-DD, the Change Date is 2028-MM-DD)
+- **Change License:** Apache License, Version 2.0
+
+If packets 03 and 04 land on the same calendar day, both repos' LICENSE files will carry the same Change Date — that is fine and expected.
+
+### `README.md` — license section update
+
+Add or update a `## License` section near the bottom of the existing `README.md`:
+
+```markdown
+## License
+
+HoneyDrunk.Communications is released under the [Functional Source License v1.1](https://fsl.software/), with automatic conversion to the Apache License, Version 2.0 two years after the date of each release. See [LICENSE](./LICENSE) for the full text.
+
+The license permits any non-competing use — read, modify, self-host, redistribute. The only restriction is using HoneyDrunk.Communications to provide a hosted commercial messaging-orchestration service that competes with HoneyDrunk Notify Cloud. After the two-year conversion date, even that restriction is lifted (under Apache 2.0).
+
+This matches the license posture of [HoneyDrunk.Notify](https://github.com/HoneyDrunkStudios/HoneyDrunk.Notify) — the two repos are designed to be consumed together for a self-hosted notification stack.
+```
+
+If the README already has a license section (e.g., MIT or Apache), replace it with the FSL section above.
+
+### Update repo description (GitHub UI)
+
+The repo description should reference the license. Suggested text:
+
+> Outbound-messaging orchestration substrate above HoneyDrunk.Notify — recipient resolution, preference enforcement, cadence policy, decision logs. Released under FSL-1.1-Apache-2.0. Composed by HoneyDrunk Notify Cloud (commercial wrapper) and self-hosting consumers alike.
+
+This is a GitHub UI update via Settings → Description; not a file commit. The packet's Human Prerequisites section calls it out.
+
+### Per-`.csproj` license metadata updates
+
+Every shipping `.csproj` in `src/*` must declare the license in its package metadata. Edit each `.csproj` to add (or update if a `PackageLicenseExpression` already exists):
+
+```xml
+<PropertyGroup>
+  <!-- existing properties -->
+  <PackageLicenseFile>LICENSE</PackageLicenseFile>
+</PropertyGroup>
+
+<ItemGroup>
+  <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+</ItemGroup>
+```
+
+(Adjust the `..\..\LICENSE` path relative to the project file location.)
+
+Same reasoning as packet 03: do not use `PackageLicenseExpression` with an SPDX identifier — FSL is not in the SPDX list. `PackageLicenseFile` + `<None Include=... Pack="true">` packages the LICENSE into the .nupkg. If the existing `.csproj` has a `<PackageLicenseExpression>` declaration, remove it.
+
+Apply to every `.csproj` under `src/`:
+
+- `src/HoneyDrunk.Communications.Abstractions/HoneyDrunk.Communications.Abstractions.csproj`
+- `src/HoneyDrunk.Communications/HoneyDrunk.Communications.csproj`
+
+(If additional shipping projects exist in `src/` — confirm at edit time by listing the directory — apply the metadata update to each.)
+
+Do **not** edit `tests/*.csproj` — test projects do not ship as NuGet packages.
+
+### Version bump
+
+Per invariant 27 ("All projects in a solution share one version and move together"), this is the bumping packet on the Communications solution for this initiative. Bump from 0.2.0 to **0.3.0** (minor bump — license addition is a package-metadata addition, not a breaking API change).
+
+Update the solution-shared `<Version>` in `Directory.Build.props` (or wherever the centralized version property lives — confirm by reading the file). Every `src/*.csproj` picks up the version from there per the existing solution pattern. Test projects are excluded.
+
+### Repo-level `CHANGELOG.md`
+
+Per invariant 12, this packet creates a new repo-level version entry. Add a `## [0.3.0] - 2026-MM-DD` block (replace `MM-DD` with the date the PR merges) with:
+
+```markdown
+## [0.3.0] - 2026-MM-DD
+
+### Added
+- FSL-1.1-Apache-2.0 license file at repo root. Two-year auto-conversion to Apache 2.0 per ADR-0027 D11.
+- README.md license section pointing at LICENSE.
+- Per-`.csproj` `PackageLicenseFile` metadata so NuGet packages declare the license.
+
+### Notes
+- This is a licensing-posture commit. No code or contract changes. All public APIs unchanged.
+- Matches the license posture applied to HoneyDrunk.Notify v0.4.0 (the two repos ship together as a self-hostable notification stack).
+- See [HoneyDrunk Architecture ADR-0027](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0027-stand-up-honeydrunk-notify-cloud-node.md) D11 for the rationale.
+```
+
+### Per-package `CHANGELOG.md`
+
+Per invariant 12, per-package changelogs are updated only for packages with actual changes. Both shipping packages (`HoneyDrunk.Communications.Abstractions`, `HoneyDrunk.Communications`) receive the license-metadata update, so both get an entry:
+
+```markdown
+## [0.3.0] - 2026-MM-DD
+
+### Added
+- `PackageLicenseFile` metadata declaring FSL-1.1-Apache-2.0 license.
+```
+
+## Affected Files
+- `LICENSE` (new file at repo root)
+- `README.md` (license section update)
+- `Directory.Build.props` (version bump from 0.2.0 to 0.3.0)
+- Every shipping `.csproj` under `src/`:
+  - `src/HoneyDrunk.Communications.Abstractions/HoneyDrunk.Communications.Abstractions.csproj`
+  - `src/HoneyDrunk.Communications/HoneyDrunk.Communications.csproj`
+  - (and any other shipping projects discovered at edit time)
+- Repo-level `CHANGELOG.md` (new `## [0.3.0]` entry)
+- Per-package `CHANGELOG.md` files (one entry per shipping package)
+
+## NuGet Dependencies
+None. This packet adds no PackageReference entries. It only updates `.csproj` metadata (`PackageLicenseFile`, version) and packages the LICENSE file into NuGet artifacts via `<None Include=... Pack="true">`.
+
+## Boundary Check
+- [x] All edits inside the `HoneyDrunk.Communications` repo.
+- [x] No code changes — `.cs` files are untouched.
+- [x] No contract changes — public API surface is unchanged at v0.3.0.
+- [x] Test projects are excluded from the version bump per invariant 27.
+- [x] License text is the canonical FSL-1.1-Apache-2.0 verbatim; no paraphrase.
+
+## Acceptance Criteria
+- [ ] `LICENSE` file exists at repo root with the canonical FSL-1.1-Apache-2.0 text. Header parameters set: Licensor = HoneyDrunk Studios, Change Date = two years from the PR merge date, Change License = Apache License, Version 2.0.
+- [ ] `README.md` has a `## License` section pointing at `LICENSE` with the FSL framing described above. Any pre-existing license section is removed.
+- [ ] Every shipping `.csproj` under `src/` declares `<PackageLicenseFile>LICENSE</PackageLicenseFile>` and `<None Include="..\..\LICENSE" Pack="true" PackagePath="\" />` (path adjusted per project depth). No `.csproj` carries both `PackageLicenseExpression` and `PackageLicenseFile`.
+- [ ] Solution version bumped from 0.2.0 to 0.3.0 in `Directory.Build.props`. Every shipping `.csproj` resolves to 0.3.0 at build time. Test projects are unaffected.
+- [ ] Repo-level `CHANGELOG.md` has a new `## [0.3.0] - YYYY-MM-DD` entry covering the license addition, with rationale link to ADR-0027 D11.
+- [ ] Per-package `CHANGELOG.md` files (`HoneyDrunk.Communications.Abstractions`, `HoneyDrunk.Communications`, and any other shipping packages) each have a `## [0.3.0]` entry with the license-metadata text.
+- [ ] `dotnet pack` runs clean across all shipping projects with no warnings about license metadata. The produced `.nupkg` files each contain the `LICENSE` file at the root.
+- [ ] Build is clean: `dotnet build` passes with no warnings (warnings-as-errors).
+- [ ] No `.cs` files are modified. License application is metadata-only.
+- [ ] `tests/*` are unchanged (no version bumps, no metadata changes).
+- [ ] PR body explicitly references ADR-0027 D11 with the link to the ADR file.
+
+## Human Prerequisites
+- [ ] Update the GitHub repo description via Settings → General → Description on https://github.com/HoneyDrunkStudios/HoneyDrunk.Communications. Suggested text: "Outbound-messaging orchestration substrate above HoneyDrunk.Notify — recipient resolution, preference enforcement, cadence policy, decision logs. Released under FSL-1.1-Apache-2.0. Composed by HoneyDrunk Notify Cloud (commercial wrapper) and self-hosting consumers alike."
+- [ ] After the PR merges, push tag `v0.3.0` from `main` to trigger the release workflow and publish the new packages to NuGet. Tags are human-pushed per invariant 27 — agents never push tags.
+- [ ] Confirm OIDC federated credential for `repo:HoneyDrunkStudios/HoneyDrunk.Communications:ref:refs/tags/v*` is in place for the NuGet publishing identity.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node (or tightly coupled Node family). Each repo has its own solution, CI pipeline, and versioning. — Communications ships its own version cycle; the FSL application is a repo-local concern.
+
+> **Invariant 12:** Semantic versioning with CHANGELOG and README. Two tiers: repo-level CHANGELOG.md (next to the .slnx file) is mandatory; per-package CHANGELOG.md is updated only when that specific package has functional changes. — License metadata change applies to every shipping package; every shipping per-package CHANGELOG gets an entry.
+
+> **Invariant 27:** All projects in a solution share one version and move together. Test projects are excluded. Releases are triggered by pushing a git tag; agents never push tags. The first packet to land on a solution in an initiative bumps the version. — This is the bumping packet on the Communications solution for the adr-0027-notify-cloud-standup initiative. Every shipping project moves from 0.2.0 to 0.3.0 in this single commit.
+
+> **Invariant 56 (assigned by packet 02 of this initiative — number subject to collision-check):** The open-source repos paired with `HoneyDrunk.Notify.Cloud` (`HoneyDrunk.Notify`, `HoneyDrunk.Communications`) ship under the Functional Source License (FSL) with two-year auto-conversion to Apache 2.0. The license file is committed at the repo root; every shipping `.csproj` declares `PackageLicenseFile` (or `PackageLicenseExpression = "LicenseRef-FSL-1.1-Apache-2.0"`). The wrapper repo (`HoneyDrunk.Notify.Cloud`, private) is `LicenseRef-Proprietary`. — This packet is the application of that invariant to the Communications repo.
+
+## Referenced ADR Decisions
+
+**ADR-0027 D5 (Boundary rule):** The hot delivery path for Notify Cloud customers is Notify Cloud → Communications → Notify. Communications is on the customer-facing critical path; its license must match the engine's so the full self-hostable stack reads with one license posture. — Reinforces the substance of D11 applied to this repo.
+
+**ADR-0027 D11 (FSL on open engine repos):** Open-source repos paired with Notify Cloud ship under FSL with two-year auto-conversion to Apache 2.0. Three repos identified: `HoneyDrunk.Notify` (engine + SDK), `HoneyDrunk.Notify.Client` (lives in `HoneyDrunk.Notify` per D6), `HoneyDrunk.Communications` (this repo). — This packet is the substance of D11 applied to the Communications repo. Identical license text to packet 03; different target repo, different per-`.csproj` updates, different version bump.
+
+## Dependencies
+- `packet:01` — packet 01 lands the new constitution language and context-folder content that references FSL. Filing 04 before 01 would mean the FSL commit lands without a constitutional anchor describing why.
+
+## Labels
+`chore`, `tier-2`, `ops`, `licensing`, `adr-0027`
+
+## Agent Handoff
+
+**Objective:** Apply the Functional Source License (FSL-1.1-Apache-2.0) to the `HoneyDrunk.Communications` repo. Commit the canonical license text at the repo root, update README, update every shipping `.csproj`'s license metadata, bump the solution version from 0.2.0 to 0.3.0, update CHANGELOGs.
+
+**Target:** HoneyDrunk.Communications, branch from `main`.
+
+**Context:**
+- Goal: Match the license posture applied to `HoneyDrunk.Notify` (packet 03). The two repos ship together as a self-hostable notification stack and must read with one license posture.
+- Feature: ADR-0027 standup initiative, Wave 2, Packet 04.
+- ADRs: ADR-0027 (sole governing ADR for the license choice).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packet 01 of this initiative must merge first (constitutional context for FSL).
+
+**Constraints:**
+
+- **The license text is canonical FSL-1.1-Apache-2.0 verbatim.** Fetch from https://fsl.software/. Identical body text to packet 03; only the three header parameters (Licensor, Change Date, Change License) are customized — and those values match packet 03.
+- **No code or contract changes in this packet.** `.cs` files are untouched. Public API surface at v0.3.0 is identical to v0.2.0.
+- **Invariant 12:** Semantic versioning with CHANGELOG and README. Two tiers — repo-level mandatory, per-package only when the package has functional changes. — License metadata change applies to every shipping package; every shipping per-package CHANGELOG gets an entry.
+- **Invariant 27:** All projects share one version. Test projects excluded. Releases are triggered by pushing a git tag; agents never push tags. — This is the bumping packet. Every shipping `.csproj` resolves to 0.3.0.
+- **FSL is not in the SPDX list.** Use `<PackageLicenseFile>LICENSE</PackageLicenseFile>` plus `<None Include=... Pack="true">`. Do not use `<PackageLicenseExpression>`. If one exists in any `.csproj`, remove it.
+- **Test projects are excluded.** No edits to `tests/*.csproj`.
+- **No commits under CHANGELOG `Unreleased`.** Per the user's standing rule, commits land under a dated versioned entry — `## [0.3.0] - YYYY-MM-DD`.
+
+**Key Files:**
+- `LICENSE` (new file at repo root — canonical FSL-1.1-Apache-2.0 text)
+- `README.md` (replace any existing license section)
+- `Directory.Build.props` (or wherever the centralized version property lives — bump 0.2.0 → 0.3.0)
+- Every shipping `.csproj` under `src/` (add `<PackageLicenseFile>` and `<None Include=... Pack="true">`; remove any `<PackageLicenseExpression>`)
+- Repo-level `CHANGELOG.md` (new `## [0.3.0]` entry)
+- Per-package `CHANGELOG.md` files (one entry per shipping package)
+
+**Contracts:** None. Public API surface at 0.3.0 is identical to 0.2.0.

--- a/generated/issue-packets/active/adr-0027-notify-cloud-standup/05-architecture-create-notify-cloud-repo.md
+++ b/generated/issue-packets/active/adr-0027-notify-cloud-standup/05-architecture-create-notify-cloud-repo.md
@@ -1,0 +1,155 @@
+---
+name: Repo Chore (Private — First in the Grid)
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "new-node", "adr-0027", "human-only", "wave-3"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0027"]
+accepts: ADR-0027
+wave: 3
+initiative: adr-0027-notify-cloud-standup
+node: honeydrunk-architecture
+actor: human
+---
+
+# Chore: Create `HoneyDrunk.Notify.Cloud` GitHub repo as PRIVATE (human-only) — first private repo in the Grid
+
+## Summary
+Create the `HoneyDrunkStudios/HoneyDrunk.Notify.Cloud` repo on GitHub. **CRITICAL: select PRIVATE visibility, not the org default of Public.** This is the Grid's first private repo. The decision and its justification are recorded in ADR-0027 D2 (revenue carve-out: customer-data-adjacent infrastructure, hyperscaler defense, billing-system integrity).
+
+This packet is an org-admin action that cannot be delegated to an agent — it gates packet 06 (the scaffold packet), which cannot be filed until the repo exists.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture` (this is where the tracking issue lives; the actual work happens on GitHub at the org level)
+
+## Actor
+**`Human`.** This entire work item is human-only. Org-admin rights on `HoneyDrunkStudios` are required to create a new repo. Selecting "Private" visibility is a deliberate, ADR-recorded carve-out from the Grid's public-by-default posture — the human must consciously click "Private" rather than letting GitHub default to Public. Frontmatter sets `actor: human` and labels include `human-only`; the filing pipeline mirrors `Actor=Human` onto The Hive.
+
+## Motivation
+`06-notify-cloud-node-scaffold.md` defines the solution, four packages, four contracts, default `INotifyCloudGateway`, in-memory API key store, Notify-Cloud-specific rate-limit policy, Stripe billing-adapter stub, Web placeholder, full CI including the contract-shape canary, and Container Apps deployment configuration for `HoneyDrunk.Notify.Cloud` — but cannot be filed as a GitHub issue until the target repo exists.
+
+This chore is also the **first time in the Grid's history that a private repo is being created**. The repo policy (memory: "new HoneyDrunk repos are public unless revenue/compliance/experiment") admits a revenue carve-out, and Notify Cloud sits squarely in it per ADR-0027 D2. The justification, on the record:
+
+- **Customer-data-adjacent infrastructure.** Tenant isolation enforcement, abuse heuristics, billing-fraud detection, and per-tenant Vault path resolution are concerns where public scrutiny of half-baked states actively harms customers. These are not educational primitives that benefit from community contribution.
+- **Hyperscaler defense.** Open-sourcing the multi-tenant gateway produces an AWS-style "host Notify Cloud for cheaper" competitor against a solo developer who cannot match infra economics. The OSS-engine + private-wrapper split (FSL on Notify and Communications, proprietary on Notify Cloud) puts the moat in operational reliability and economy-of-scale infrastructure, not in closed-source secrets.
+- **Billing-system integrity.** Stripe webhook signing keys, internal billing-event shapes, and abuse-rate thresholds lose value the moment they go public.
+
+Surfacing this as an explicit Wave-3 work item keeps it visible on The Hive board as a human-only blocker (with the `human-only` label so the board surfaces `Actor=Human`) rather than an implicit prerequisite of packet 06. Same pattern as `adr-0017-capabilities-standup/03-architecture-create-capabilities-repo.md`, except the visibility selection differs.
+
+## Steps (portal)
+
+1. Navigate to https://github.com/organizations/HoneyDrunkStudios/repositories/new
+2. **Repository name:** `HoneyDrunk.Notify.Cloud`
+3. **Description:** `Multi-tenant commercial wrapper above HoneyDrunk.Notify (the open engine) and HoneyDrunk.Communications (the orchestration layer). Owns API gateway, API key issuance/validation, per-tenant rate-limit enforcement, tenant-scoped billing-event emission, and the management website. Private repo (revenue carve-out per ADR-0027 D2). All rights reserved.`
+4. **Visibility:** **PRIVATE.** (Critical — do NOT accept the GitHub default of Public.) This is the Grid's first private repo. ADR-0027 D2 records the justification: customer-data-adjacent infrastructure, hyperscaler defense, billing-system integrity.
+5. **Initialize with:**
+   - [x] Add a README file (initial placeholder — the scaffold packet replaces it)
+   - [x] Add `.gitignore` → `VisualStudio` template
+   - [ ] **Do NOT choose a public license.** The repo is private and proprietary — `LicenseRef-Proprietary` (all rights reserved by default of being private). Leave the GitHub license picker blank. The scaffold packet (06) commits a `LICENSE` file at the repo root with the proprietary stance.
+6. Click **Create repository**
+7. After creation, apply per-repo defaults:
+   - **Default branch:** `main`
+   - **Branch protection on `main`:**
+     - Require a pull request before merging
+     - Require status checks to pass before merging
+     - Required status checks: `pr-core / core` (the `api-compatibility / abstractions-shape` check will be added to required-checks in a follow-up branch-protection update *after* the scaffold packet's throwaway breaking-change PR confirms the canary fires post-merge — see packet 06 Human Prerequisites)
+     - Disallow force pushes
+     - Disallow deletions
+     - Require signed commits: off (matches other Grid repos)
+   - **Features:** Issues enabled, Actions enabled, Discussions optional
+   - **Secrets and variables → nothing to seed yet.** Notify Cloud Container Apps deployment uses OIDC federated credentials to the Grid's deployment identity, not a per-repo PAT. The Stripe webhook signing key is held in the Notify Cloud Node's Key Vault (`kv-hd-notify-cloud-{env}`), not as a GitHub Action secret.
+8. Open https://github.com/HoneyDrunkStudios/HoneyDrunk.Notify.Cloud/settings/security_analysis and confirm Dependabot alerts are enabled (org default — should already be on for private repos too); CodeQL default-setup stays off per the org "HoneyDrunk Grid — public default" config.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunkStudios/HoneyDrunk.Notify.Cloud` exists and is accessible to the org owner.
+- [ ] **Visibility is PRIVATE** (confirmed by browsing to the repo's homepage and observing the "Private" badge next to the repo name — verify; if it reads "Public," delete and recreate as Private before proceeding).
+- [ ] Default branch is `main` with a placeholder README committed.
+- [ ] No public license selected during repo creation (LICENSE file is the scaffold packet's concern, and it carries `LicenseRef-Proprietary`).
+- [ ] Branch protection rules on `main` match the Grid standard: require PR, require `pr-core / core` check, no force-pushes, no deletions.
+- [ ] `.gitignore` committed (VisualStudio template).
+- [ ] Dependabot alerts enabled (verify in Settings → Security & analysis).
+- [ ] "Next Steps" script below has been run, filing `06-notify-cloud-node-scaffold.md` as an issue on the new repo (assuming packet 02 has merged and any required invariant-number amendments to packet 06 have been applied).
+- [ ] This chore issue is closed after the Next Steps script completes.
+
+## Next Steps (run immediately after the repo exists *and* packet 02 has merged)
+
+These commands seed labels on the new repo, file `06-notify-cloud-node-scaffold.md` against it, add the resulting issue to The Hive, and prepare for the board-field population step. Run from the `HoneyDrunk.Architecture` repo root.
+
+**Important order-of-operations:** Per the dispatch plan's filing-order rule, packet 06 cannot be filed until packet 02's PR has merged (so the assigned invariant numbers are locked in `constitution/invariants.md`) and any required pre-filing amendments to `06-notify-cloud-node-scaffold.md` have been applied. If packet 02 has not yet merged at the time this chore is being closed, file packet 06 **after** packet 02 lands — not now.
+
+```bash
+PACKETS="generated/issue-packets/active/adr-0027-notify-cloud-standup"
+
+# 1. Seed the new repo with the labels the filing command needs.
+#    Color choices follow the existing convention used by other Grid repos:
+#    feature=green, tier-2=yellow, tier-3=purple, new-node=light-blue, ops=cyan,
+#    scaffolding=pale-cyan, commercial=orange, adr-0027=mid-blue, wave-4=yellow.
+for label in "feature:0E8A16" "tier-2:FBCA04" "tier-3:5319E7" "new-node:C5DEF5" "ops:0E7C7B" "scaffolding:BFDADC" "commercial:F8A93C" "adr-0027:1D76DB" "wave-4:FBCA04"; do
+  name="${label%:*}"; color="${label#*:}"
+  gh label create "$name" --repo HoneyDrunkStudios/HoneyDrunk.Notify.Cloud --color "$color" 2>/dev/null
+done
+
+# 2. File the scaffold packet as an issue on the new repo
+ISSUE_URL=$(gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Notify.Cloud \
+  --title "Scaffold HoneyDrunk.Notify.Cloud — solution, four packages, contracts, CI, Container Apps wiring" \
+  --body-file "$PACKETS/06-notify-cloud-node-scaffold.md" \
+  --label "feature,tier-2,new-node,ops,scaffolding,commercial,adr-0027,wave-4")
+echo "Filed: $ISSUE_URL"
+
+# 3. Add to The Hive — field IDs per infrastructure/github-projects-field-ids.md
+gh project item-add 4 --owner HoneyDrunkStudios --url "$ISSUE_URL"
+
+# 4. Set board fields (Wave 4 / Initiative adr-0027-notify-cloud-standup / Node honeydrunk-notify-cloud / Tier 2 / Actor Agent)
+# See infrastructure/github-projects-field-ids.md for current option IDs; apply via `gh project item-edit`.
+# (If that file does not exist yet, copy field option IDs from another already-filed packet's project-item state, e.g. an ADR-0016 or ADR-0017 issue.)
+```
+
+After this runs, `06-notify-cloud-node-scaffold.md` is filed against the new private repo and is the next Wave-4 agent-eligible work item. Close this chore issue afterwards.
+
+## Human Prerequisites
+- [ ] Org-admin role on `HoneyDrunkStudios` (required to create new repos under the org)
+- [ ] Browser with GitHub session logged in as the org owner
+- [ ] `gh` CLI installed locally and authenticated as the org owner (for the Next Steps script)
+- [ ] Confirm packet 02 (invariants) has merged before running the Next Steps script — if not, defer the script run until it has
+- [ ] **Conscious decision to click "Private" rather than the GitHub default "Public" — this is the Grid's first private repo and the choice is recorded by ADR-0027 D2.** If unsure, re-read ADR-0027 D2 (lines 47-59) before proceeding.
+
+## Dependencies
+- `packet:01` — context-folder registration packet must merge first so the catalogs and `repos/HoneyDrunk.Notify.Cloud/integration-points.md` already point at the eventual repo. (Note: `catalogs/*.json` itself is hive-sync-reconciled, not packet-01-edited, but the context-folder content from packet 01 is what gives external scoping agents something to read about the repo.)
+- `packet:02` — constitution invariants must land before the scaffold packet is filed against the new repo (the scaffold packet's body cites assigned invariant numbers).
+
+## Downstream Unblocks
+- `06-notify-cloud-node-scaffold.md` — becomes fileable and executable the moment this chore is Done **and** packet 02 has merged (whichever happens later)
+
+## Referenced ADR Decisions
+
+**ADR-0027 D1 (Notify Cloud is the Ops sector's multi-tenant commercial wrapper above Notify):** New Node ⇒ new repo per invariant 11.
+
+**ADR-0027 D2 (Repo visibility — private, with explicit justification):** First private repo in the Grid. Three justifications on the record:
+- Customer-data-adjacent infrastructure (tenant isolation enforcement, abuse heuristics, billing-fraud detection, per-tenant Vault path resolution — concerns where public scrutiny of half-baked states actively harms customers).
+- Hyperscaler defense (open-sourcing the multi-tenant gateway produces an AWS-style rehosting competitor; the OSS-engine + private-wrapper split puts the moat at operational economics).
+- Billing-system integrity (Stripe webhook signing keys, internal billing-event shapes, and abuse-rate thresholds lose value the moment they go public).
+
+The catalog `visibility` schema field introduction is hive-sync's concern, not this packet's — the human-only action here is the repo-creation portal click with the "Private" selection.
+
+**ADR-0027 D3 (Package families):** Four packages — `HoneyDrunk.Notify.Cloud.Abstractions`, `HoneyDrunk.Notify.Cloud`, `HoneyDrunk.Notify.Cloud.Billing.Stripe`, `HoneyDrunk.Notify.Cloud.Web` — all live in this single repo per invariant 11.
+
+**ADR-0027 D11 (FSL on open engine repos, proprietary on the wrapper):** The wrapper repo is not licensed publicly. Access is granted only to the studio. License is "All rights reserved" by default of being private. The scaffold packet (06) commits a `LICENSE` file with `LicenseRef-Proprietary` content; this packet only commits the placeholder README and `.gitignore`.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node (or tightly coupled Node family). Each repo has its own solution, CI pipeline, and versioning.
+
+> **Invariant 51 (assigned by packet 02 of this initiative — number subject to collision-check):** The HoneyDrunk Grid's repo default is public; private repos require an explicit ADR-recorded justification under the revenue/compliance/experiment carve-out. `HoneyDrunk.Notify.Cloud` is the first private repo; its justification (customer-data-adjacent infrastructure, hyperscaler defense, billing-system integrity) is recorded in ADR-0027 D2. — This packet is the application of that invariant: the human selects "Private" rather than the org default of "Public," with ADR-0027 D2 as the recorded justification.
+
+## Labels
+`chore`, `tier-1`, `meta`, `new-node`, `adr-0027`, `human-only`, `wave-3`
+
+## Notes for the human executing this chore
+
+- This is a 5-minute portal task. The only twist vs prior repo-creation chores is the visibility selection: **click "Private," not the GitHub default "Public."** Every prior repo in the Grid has been public; this is the first private one.
+- After the repo is created, run the Next Steps script above to file `06-notify-cloud-node-scaffold.md`, then close this chore issue.
+- Do NOT provision Azure resources in this packet. The scaffold packet (06) provisions the Container App (`ca-hd-notify-cloud-stg`), the shared `cae-hd-stg` Container Apps Environment (if not already in place), and any Key Vault (`kv-hd-notify-cloud-stg`) required by the deployment. Those are scaffold concerns.
+- The repo will eventually need a Key Vault per invariant 17 (`kv-hd-notify-cloud-{env}`) once the Container App is provisioned — that is scaffold-packet (06) work, not repo-creation work.
+- If you decide to defer Notify Cloud standup, close this as "not planned" with a note pointing at the deferral decision — do not delete the packet. A future acceptance can revive it.
+- **Confirm the repo is private before pushing any code to it.** If a "Public" badge appears next to the repo name on the homepage after creation, delete the repo and recreate as Private. The error of pushing wrapper code to a public repo would expose customer-data-adjacent surfaces against ADR-0027 D2's recorded justification — recoverable only with effort, not zero-cost.

--- a/generated/issue-packets/active/adr-0027-notify-cloud-standup/06-notify-cloud-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0027-notify-cloud-standup/06-notify-cloud-node-scaffold.md
@@ -1,0 +1,1080 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify.Cloud
+labels: ["feature", "tier-2", "ops", "scaffolding", "new-node", "commercial", "adr-0027"]
+dependencies: ["packet:01", "packet:02", "packet:05"]
+adrs: ["ADR-0027", "ADR-0026", "ADR-0019", "ADR-0015"]
+accepts: ADR-0027
+wave: 4
+initiative: adr-0027-notify-cloud-standup
+node: honeydrunk-notify-cloud
+---
+
+# Feature: Stand up the HoneyDrunk.Notify.Cloud repo — solution, four packages, contracts, CI, Container Apps wiring
+
+## Summary
+Bring the empty `HoneyDrunk.Notify.Cloud` repo (private; created by packet 05) from zero to first-shippable state per ADR-0027 D13. Land the solution layout, four package families (`HoneyDrunk.Notify.Cloud.Abstractions`, `HoneyDrunk.Notify.Cloud`, `HoneyDrunk.Notify.Cloud.Billing.Stripe`, `HoneyDrunk.Notify.Cloud.Web`), the four D4 contracts inside `HoneyDrunk.Notify.Cloud.Abstractions`, the default `INotifyCloudGateway` wiring API-key-validation → rate-limit → tenant-context resolution → orchestration-delegation → billing-emission, an in-memory `INotifyCloudApiKeyStore` for tests, the Notify-Cloud-specific `ITenantRateLimitPolicy` implementation that replaces Kernel's `NoopTenantRateLimitPolicy` at host time, the Stripe billing-adapter stub implementing the Kernel `IBillingEventEmitter` interface, the Web placeholder (signup form scaffold + health endpoint), the full CI pipeline (PR core + release + nightly + security + contract-shape canary scoped to `HoneyDrunk.Notify.Cloud.Abstractions`), the proprietary LICENSE file (`LicenseRef-Proprietary`), and Container Apps deployment configuration referencing ADR-0015's reusable `job-deploy-container-app.yml` workflow targeting `ca-hd-notify-cloud-stg` in East US.
+
+This is the substrate stand-up. It does not ship the actual Stripe webhook bridge, the full Web project surface, or the API key authentication middleware in Auth — those are explicit follow-ups per ADR-0027 D13's "scaffold packet does not include" list.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Notify.Cloud` (private — first private repo in the Grid)
+
+## Motivation
+ADR-0027 establishes *what* HoneyDrunk.Notify.Cloud is and what contracts it exposes. The repo is created by packet 05 (carrying only `.gitignore` and a placeholder README) but is otherwise empty — no `.slnx`, no projects, no CI, no contracts. Without this scaffold, PDR-0002's Phase 3 (Notify Cloud scaffold, weeks 10-14) cannot begin: there is no compile target for the Stripe billing-integration follow-up ADR, no production consumer for the Communications decision-log persistence ADR, and no concrete `INotifyCloudApiKeyStore` for the tenant onboarding workflow design doc to design against.
+
+This packet is the unblocker. After it merges and a `0.1.0` tag lands, the entire Phase 3 follow-up surface becomes scopable: Stripe integration ADR, API key authentication ADR, Communications decision-log persistence ADR, tenant onboarding workflow doc, Web project full-surface packets.
+
+The scaffold is intentionally bundled into one packet because:
+
+- The Node has four packages, all of which must compile together to give the contract-shape canary a coherent baseline.
+- The four D4 contracts must all land in the first commit so the canary baseline against `HoneyDrunk.Notify.Cloud.Abstractions` is complete from PR #1.
+- The default `INotifyCloudGateway` wiring threads through four cross-Node consumers (Communications, Notify, Auth, Kernel multi-tenant primitives) — fragmenting that across packets creates ordering hazards.
+- Per the user's standing convention, a new Node's scaffold work bundles into one packet rather than fragmenting across many.
+
+## Proposed Implementation
+
+### Repository layout
+
+```
+HoneyDrunk.Notify.Cloud/
+├── HoneyDrunk.Notify.Cloud.slnx
+├── Directory.Build.props
+├── CHANGELOG.md
+├── README.md
+├── LICENSE                                  (LicenseRef-Proprietary; all rights reserved)
+├── .editorconfig                            (from HoneyDrunk.Standards)
+├── .gitignore                               (preserved from packet 05; VisualStudio template)
+├── .github/
+│   └── workflows/
+│       ├── pr-core.yml                      (calls Actions/pr-core.yml)
+│       ├── release.yml                      (calls Actions/release.yml — private feed, not public NuGet per ADR-0027)
+│       ├── nightly-deps.yml                 (calls Actions/nightly-deps.yml)
+│       ├── nightly-security.yml             (calls Actions/nightly-security.yml)
+│       ├── api-compatibility.yml            (calls Actions/job-api-compatibility.yml — D8 canary)
+│       └── deploy-stg.yml                   (calls Actions/job-deploy-container-app.yml per ADR-0015 — first deploy target)
+├── src/
+│   ├── HoneyDrunk.Notify.Cloud.Abstractions/
+│   │   ├── HoneyDrunk.Notify.Cloud.Abstractions.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── INotifyCloudGateway.cs
+│   │   ├── INotifyCloudApiKeyStore.cs
+│   │   ├── NotifyCloudTenantTier.cs                  (record, no I prefix)
+│   │   ├── ApiKeyIssuance.cs                         (record, no I prefix)
+│   │   └── (supporting record/enum types — see "Contract details")
+│   ├── HoneyDrunk.Notify.Cloud/
+│   │   ├── HoneyDrunk.Notify.Cloud.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── ServiceCollectionExtensions.cs           (AddHoneyDrunkNotifyCloud)
+│   │   ├── Gateway/
+│   │   │   └── DefaultNotifyCloudGateway.cs         (the full pipeline)
+│   │   ├── ApiKeys/
+│   │   │   └── HashingNotifyCloudApiKeyStore.cs     (production-shape implementation; backend is hash-table-in-Data per D9 default)
+│   │   ├── RateLimiting/
+│   │   │   └── TierDrivenTenantRateLimitPolicy.cs   (replaces Kernel's NoopTenantRateLimitPolicy at host time)
+│   │   ├── Billing/
+│   │   │   └── BillingEventEmissionTail.cs          (post-dispatch tail wired into the worker pipeline)
+│   │   └── Telemetry/
+│   │       └── NotifyCloudTelemetry.cs              (uses ITelemetryActivityFactory; GridContext propagation)
+│   ├── HoneyDrunk.Notify.Cloud.Billing.Stripe/
+│   │   ├── HoneyDrunk.Notify.Cloud.Billing.Stripe.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   └── StripeBillingEventEmitter.cs             (stub: implements Kernel IBillingEventEmitter; throws NotImplementedException on EmitAsync with TODO pointing at the Stripe billing integration ADR follow-up)
+│   └── HoneyDrunk.Notify.Cloud.Web/
+│       ├── HoneyDrunk.Notify.Cloud.Web.csproj
+│       ├── README.md
+│       ├── CHANGELOG.md
+│       ├── Program.cs                                (ASP.NET Core minimal API host + Blazor Server registration per ADR-0027 D3 default)
+│       ├── Pages/
+│       │   └── Health.razor                          (basic health endpoint; placeholder)
+│       └── Components/
+│           └── SignupPlaceholder.razor               (scaffold-only signup form; non-functional)
+└── tests/
+    ├── HoneyDrunk.Notify.Cloud.Abstractions.Tests/   (compile-only smoke tests)
+    ├── HoneyDrunk.Notify.Cloud.Tests/                (DefaultNotifyCloudGateway end-to-end smoke; HashingNotifyCloudApiKeyStore tests; TierDrivenTenantRateLimitPolicy tests)
+    ├── HoneyDrunk.Notify.Cloud.Billing.Stripe.Tests/ (smoke tests; stub asserts NotImplementedException with the right TODO)
+    └── HoneyDrunk.Notify.Cloud.Web.Tests/            (placeholder; minimal page-renders-without-error tests)
+```
+
+### Solution
+
+`HoneyDrunk.Notify.Cloud.slnx` references all four `src/*` projects and all four `tests/*` projects. Solution-level `Directory.Build.props` sets:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Authors>HoneyDrunk Studios</Authors>
+    <Company>HoneyDrunk Studios</Company>
+    <Copyright>Copyright (c) HoneyDrunk Studios. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Notify.Cloud</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Notify.Cloud</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <!-- Private feed only — these packages do NOT publish to public NuGet per ADR-0027 -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="\" Visible="false" />
+  </ItemGroup>
+
+  <!-- Version applies to shipping projects only. Test projects are excluded from
+       the solution-shared-version rule per invariant 27. -->
+  <PropertyGroup Condition="'$(IsTestProject)' != 'true'">
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+</Project>
+```
+
+Per invariant 27, every src project carries the same `Version` (0.1.0 for this initial release). Test projects are excluded via the `Condition="'$(IsTestProject)' != 'true'"` wrapper. The proprietary LICENSE is packed into every `.nupkg` via the `<None Include=... Pack="true">` block.
+
+### `LICENSE` — proprietary
+
+Create a `LICENSE` file at the repo root with proprietary content:
+
+```
+HoneyDrunk.Notify.Cloud
+Copyright (c) 2026 HoneyDrunk Studios. All rights reserved.
+
+All rights reserved. This software is the proprietary property of HoneyDrunk Studios.
+No part of this repository may be copied, redistributed, or used without prior
+written permission of HoneyDrunk Studios.
+
+For licensing inquiries, contact oleg@honeydrunkstudios.com.
+```
+
+NuGet license identification: the `Directory.Build.props` declares `<PackageLicenseFile>LICENSE</PackageLicenseFile>` and the file is packed. Some NuGet tooling may also benefit from `<PackageLicenseExpression>LicenseRef-Proprietary</PackageLicenseExpression>` — but since `PackageLicenseFile` and `PackageLicenseExpression` cannot coexist, use the `PackageLicenseFile` form for clarity. The license-text inclusion in the package is the authoritative declaration.
+
+### Contract details — `HoneyDrunk.Notify.Cloud.Abstractions`
+
+All four D4 contracts. Records drop the `I` prefix; interfaces keep it (Grid-wide naming rule).
+
+**Abstractions reference policy.** Per ADR-0027 D3, `HoneyDrunk.Notify.Cloud.Abstractions` has zero runtime dependencies beyond the three `*.Abstractions` packages the ADR explicitly allows:
+
+- `HoneyDrunk.Kernel.Abstractions` — for `TenantId` (the strong ULID-backed record-struct type from `HoneyDrunk.Kernel.Abstractions.Identity` per ADR-0026 D1). `TenantId` is the canonical Grid tenant identifier; the strict-Abstractions stance from ADR-0016 / ADR-0017 / ADR-0019 packets does NOT apply here because ADR-0027 D3 explicitly enumerates this reference as permitted, and the existing Communications.Abstractions package (the most-recent sibling) already PackageReferences `HoneyDrunk.Kernel.Abstractions`.
+- `HoneyDrunk.Notify.Abstractions` — permitted per ADR-0027 D3 for any Notify-side contract surfaces the gateway needs to reference at compile time (diagnostic / smoke-test paths only per ADR-0027 D5).
+- `HoneyDrunk.Communications.Abstractions` — permitted per ADR-0027 D3 for `MessageIntent` / `ICommunicationOrchestrator` surfaces.
+
+What stays string-typed in v0.1.0 (with a follow-up flag, not as a permanent decision):
+
+- `ApiKeyId` / `KeyId` — strings at v0.1.0. The canonical TODO lives on the `ApiKeyMetadata.KeyId` field declaration (see below); no other TODO redundancy is needed elsewhere in the contracts. The API key authentication ADR follow-up settles whether to promote to a record-struct identifier on a level with `TenantId`.
+
+What is consumed from Kernel at the runtime layer but **not** declared in Notify Cloud Abstractions (per ADR-0027 D4 and ADR-0026):
+
+- `ITenantRateLimitPolicy`, `TenantRateLimitDecision` — live in `HoneyDrunk.Kernel.Abstractions.Tenancy`. The runtime package implements `ITenantRateLimitPolicy` and consumes `TenantRateLimitDecision`; Notify Cloud Abstractions does NOT redeclare either type.
+- `IBillingEventEmitter`, `BillingEvent` — live in `HoneyDrunk.Kernel.Abstractions.Tenancy`. The Stripe provider package implements `IBillingEventEmitter`; Notify Cloud Abstractions does NOT redeclare either type.
+
+`TenantId` (the type itself, not the policy/decision surrounding it) is referenced by `INotifyCloudGateway` and `INotifyCloudApiKeyStore` and is part of the four-contract public surface. Field types use the strong `TenantId` type, not `string`.
+
+```csharp
+// INotifyCloudGateway.cs
+namespace HoneyDrunk.Notify.Cloud.Abstractions;
+
+using HoneyDrunk.Kernel.Abstractions.Identity;   // TenantId per ADR-0026 D1
+
+public interface INotifyCloudGateway
+{
+    Task<NotifyCloudGatewayResult> ProcessAsync(
+        NotifyCloudGatewayRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record NotifyCloudGatewayRequest(
+    string ApiKey,                            // raw key from the request header
+    TenantId? TenantIdHint,                   // strong type per ADR-0026; nullable because `default(TenantId)` collides with `TenantId.Internal` (both have Ulid.Empty) — a `null` hint means "no hint", not "Internal tenant". The runtime cross-checks against the TenantId resolved from the validated key.
+    string CapabilityKey,                     // which delivery surface — e.g., "send.email" or "send.sms"
+    string PayloadJson,                       // JSON-encoded request payload, forwarded to ICommunicationOrchestrator
+    string CallerCorrelationId);              // string mirror; the runtime reconciles against IGridContext.CorrelationId. CorrelationId stays string for v0.1.0 — promoting the Kernel CorrelationId record-struct into Abstractions is a separate Grid-wide decision, not bundled with this Node's stand-up.
+
+public sealed record NotifyCloudGatewayResult(
+    bool Success,
+    string? DeliveryId,                       // Communications-generated delivery id on success
+    NotifyCloudGatewayError? Error);
+
+public sealed record NotifyCloudGatewayError(
+    NotifyCloudGatewayErrorCode Code,
+    string Message,
+    int? RetryAfterSeconds);                  // populated on 429 RateLimited only
+
+public enum NotifyCloudGatewayErrorCode
+{
+    /// <summary>API key is invalid or expired.</summary>
+    Unauthorized = 0,
+    /// <summary>API key is valid but the tenant has exceeded its rate-limit ceiling.</summary>
+    RateLimited = 1,
+    /// <summary>Capability key is unknown or the tenant's tier does not include it.</summary>
+    CapabilityNotAvailable = 2,
+    /// <summary>Payload JSON does not validate against the expected shape for this capability.</summary>
+    InvalidPayload = 3,
+    /// <summary>Communications orchestrator denied the send (e.g., recipient opt-out, cadence violation).</summary>
+    OrchestrationDenied = 4,
+    /// <summary>Internal error in the orchestration or delivery pipeline.</summary>
+    InternalError = 5,
+    /// <summary>The request was cancelled before completion.</summary>
+    Cancelled = 6,
+}
+```
+
+The `Code` field is a typed enum (not a string with a comment listing values) so the contract-shape canary catches accidental additions/removals as breaking changes. Each enum member carries XML doc summarizing when the runtime emits it.
+
+```csharp
+// INotifyCloudApiKeyStore.cs
+// TenantId is the Kernel strong type per ADR-0026 D1.
+// The canonical KeyId-stays-string TODO lives on ApiKeyMetadata.KeyId below.
+using HoneyDrunk.Kernel.Abstractions.Identity;   // TenantId per ADR-0026 D1
+
+public interface INotifyCloudApiKeyStore
+{
+    /// <summary>
+    /// Issue a new API key for the specified tenant. The plaintext key in the returned
+    /// ApiKeyIssuance is the only time the raw key material is ever exposed to a caller;
+    /// the store persists only the salted hash and the metadata.
+    /// </summary>
+    Task<ApiKeyIssuance> IssueAsync(
+        TenantId tenantId,
+        string label,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validate a raw API key against the store. Returns the bound TenantId (Kernel strong type)
+    /// on success, or null if the key is unknown, expired, or revoked.
+    /// </summary>
+    Task<TenantId?> ValidateAsync(
+        string apiKey,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revoke an issued key by its id. Subsequent ValidateAsync calls for the raw key
+    /// return null.
+    /// </summary>
+    Task RevokeAsync(
+        string keyId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// List the metadata (no raw key, no hash) for all keys issued to a tenant.
+    /// Used by the Web project's API key management UI.
+    /// </summary>
+    Task<IReadOnlyList<ApiKeyMetadata>> ListForTenantAsync(
+        TenantId tenantId,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record ApiKeyMetadata(
+    // CANONICAL TODO (API key authentication ADR follow-up): `KeyId` is `string` at v0.1.0. Promotion
+    // to a record-struct `ApiKeyId` on a level with `TenantId` is settled by the API key authentication
+    // ADR jointly with the Auth-side middleware shape. This is the one and only place this TODO lives —
+    // ApiKeyIssuance.KeyId, INotifyCloudApiKeyStore.RevokeAsync(string keyId), and ApiKeyRecord (runtime
+    // persistence record) all reference this decision point but do not repeat the TODO comment.
+    string KeyId,
+    TenantId TenantId,                        // strong type per ADR-0026
+    string Label,
+    DateTimeOffset IssuedAt,
+    DateTimeOffset? RevokedAt);
+```
+
+```csharp
+// NotifyCloudTenantTier.cs (record — no I prefix)
+public sealed record NotifyCloudTenantTier(
+    string Name,                                  // "Free", "Starter", "Pro"
+    int EventsPerMonth,                           // ceiling (e.g., 1000 for Free, 10000 for Starter)
+    IReadOnlyList<string> EnabledChannels,        // which delivery channels are available — "email", "sms", "webhook". IReadOnlyList per Grid convention (matches BillingEvent.Attributes IReadOnlyDictionary style); mutable arrays on public records are a footgun.
+    bool BringYourOwnProviderKey);                // whether the tenant can bring their own Resend/Twilio key (Pro tier)
+```
+
+The tier is the source of truth that the runtime's `TierDrivenTenantRateLimitPolicy` consumes to derive per-tenant limits. Tier definitions are sourced from Azure App Configuration via `IConfigProvider` (not hardcoded in code per the local invariant 5).
+
+```csharp
+// ApiKeyIssuance.cs (record — no I prefix; returned exactly once at issuance)
+// KeyId stays string at v0.1.0 — see the canonical TODO on ApiKeyMetadata.KeyId.
+using HoneyDrunk.Kernel.Abstractions.Identity;   // TenantId per ADR-0026 D1
+
+public sealed record ApiKeyIssuance(
+    string KeyId,                            // stable id; safe to persist and reference. v0.1.0 string.
+    string PlaintextKey,                     // only at this moment — never persisted, never returned again
+    TenantId TenantId,                       // the tenant this key is bound to — Kernel strong type per ADR-0026
+    DateTimeOffset IssuedAt);
+```
+
+Local invariant 3 in `repos/HoneyDrunk.Notify.Cloud/invariants.md` (landed by packet 01) requires: "API keys are stored only as salted hashes; raw key material is returned exactly once at issuance time." The `PlaintextKey` field on `ApiKeyIssuance` is the one-time-only carrier; after the issuance call returns, the runtime has no path to retrieve the raw key again.
+
+### Primitives consumed (NOT redeclared here)
+
+Per ADR-0027 D4 and ADR-0026, the following live in Kernel and are **consumed**, not redeclared in Notify Cloud Abstractions:
+
+- `TenantId` — lives in `HoneyDrunk.Kernel.Abstractions.Identity` (record-struct, ULID-backed). The four D4 contracts use this strong type directly. `HoneyDrunk.Notify.Cloud.Abstractions` PackageReferences `HoneyDrunk.Kernel.Abstractions` to bring the type in. Per ADR-0027 D3, this is one of the three permitted Abstractions references for this package.
+- `TenantId.Internal` sentinel — same package. Notify Cloud's gateway (`DefaultNotifyCloudGateway` steps 1a, 8) rejects Internal at the validation step and skips billing emission for Internal as defense-in-depth; `TierDrivenTenantRateLimitPolicy.EvaluateAsync` returns `Outcome: Allow` immediately when `tenantId.IsInternal`. Note that Kernel's `NoopBillingEventEmitter` does NOT itself short-circuit on Internal — it null-checks and returns — so the gateway-side guard is where the Internal-skip discipline lives, not at the emitter implementation.
+- `ITenantRateLimitPolicy` and `TenantRateLimitDecision` — live in `HoneyDrunk.Kernel.Abstractions.Tenancy`. These are runtime-composition surfaces; the Notify Cloud runtime package implements `ITenantRateLimitPolicy` but `HoneyDrunk.Notify.Cloud.Abstractions` does NOT reference these types directly.
+- `IBillingEventEmitter` and `BillingEvent` — live in `HoneyDrunk.Kernel.Abstractions.Tenancy`. The Stripe provider package implements `IBillingEventEmitter`; `HoneyDrunk.Notify.Cloud.Abstractions` does NOT reference these types directly.
+
+`HoneyDrunk.Notify.Cloud.Abstractions.csproj` therefore PackageReferences `HoneyDrunk.Kernel.Abstractions` (for `TenantId`). The runtime package (`HoneyDrunk.Notify.Cloud`) **also** PackageReferences `HoneyDrunk.Kernel.Abstractions` — not the Kernel runtime — for `IGridContext`, `ITelemetryActivityFactory`, the rate-limit / billing-event policy surfaces in `HoneyDrunk.Kernel.Abstractions.Tenancy`, and the noop-registration replacement targets. Per invariant 2, runtime packages depend only on Abstractions, never on other runtime packages at the same layer. The Kernel runtime composition is wired at host time by the Container App's startup, not via a runtime PackageReference.
+
+### Runtime details — `HoneyDrunk.Notify.Cloud`
+
+`HoneyDrunk.Notify.Cloud` references:
+
+- `HoneyDrunk.Notify.Cloud.Abstractions` (project reference)
+- `HoneyDrunk.Kernel.Abstractions` (for `IGridContext`, `IOperationContext`, `ITelemetryActivityFactory`, and the multi-tenant primitives from `HoneyDrunk.Kernel.Abstractions.Tenancy`: `ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, `BillingEvent`, and from `HoneyDrunk.Kernel.Abstractions.Identity`: `TenantId`). Per invariant 2, runtime packages depend on Abstractions, not on other runtime packages.
+- `HoneyDrunk.Communications.Abstractions` (for `ICommunicationOrchestrator`, `IMessageIntent`, `MessageIntent` — hot-path delegate per ADR-0027 D5; uses Abstractions per invariant 40)
+- `HoneyDrunk.Notify.Abstractions` (for `INotificationSender` — diagnostic/smoke-test paths only)
+- `HoneyDrunk.Auth.Abstractions` (for `IApiKeyAuthenticator` middleware path — TODO: this interface lands in a follow-up ADR per ADR-0027 D12; the scaffold can reference a placeholder or proceed without the import and stub the validation call in `DefaultNotifyCloudGateway` until the Auth-side ADR lands)
+- `HoneyDrunk.Vault` (for `ISecretStore` access via `TenantScopedSecretResolver`, and for `IConfigProvider` reads of tenant-tier definitions, cost-rate tables, abuse heuristics — `HoneyDrunk.Vault` is the runtime package because Vault does not split a separate `.Abstractions` package; interfaces live in the runtime per the existing repo shape)
+- `Microsoft.Extensions.DependencyInjection.Abstractions`
+- `Microsoft.Extensions.Hosting.Abstractions`
+- `Microsoft.Extensions.Logging.Abstractions`
+
+Key implementations:
+
+**`DefaultNotifyCloudGateway`** — the full pipeline per ADR-0027 D5:
+
+```csharp
+public sealed class DefaultNotifyCloudGateway : INotifyCloudGateway
+{
+    public async Task<NotifyCloudGatewayResult> ProcessAsync(
+        NotifyCloudGatewayRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        // 1. Validate API key via the Notify-Cloud-local INotifyCloudApiKeyStore (salted-hash lookup).
+        //    Once the API key authentication ADR lands, Auth's IApiKeyAuthenticator middleware will wrap
+        //    this call for trust-boundary discipline; until then the gateway calls the store directly.
+        //    ValidateAsync returns the strong TenantId on success per the Abstractions contract.
+        TenantId? resolvedTenantId = await _apiKeyStore.ValidateAsync(request.ApiKey, cancellationToken);
+        if (resolvedTenantId is null)
+        {
+            return new(false, null, new(NotifyCloudGatewayErrorCode.Unauthorized, "Invalid API key.", null));
+        }
+        TenantId tenantId = resolvedTenantId.Value;
+
+        // 1a. Defense-in-depth: reject any path where the validated key resolves to TenantId.Internal.
+        //     `default(TenantId).Value == Ulid.Empty == TenantId.Internal` — so an unset/zeroed TenantId
+        //     could otherwise sneak through as "Internal", which is a sentinel reserved for Grid-internal
+        //     callers that never traverse the Notify Cloud gateway. HashingNotifyCloudApiKeyStore.IssueAsync
+        //     also rejects TenantId.Internal at issuance time, but the gateway re-checks here as a
+        //     belt-and-suspenders boundary.
+        if (tenantId.IsInternal)
+        {
+            return new(false, null, new(
+                NotifyCloudGatewayErrorCode.Unauthorized,
+                "Internal tenant cannot transact via the Notify Cloud gateway.",
+                null));
+        }
+
+        // 1b. Cross-check the caller-supplied TenantIdHint against the resolved tenant. `TenantIdHint`
+        //     is `TenantId?` (nullable) — `null` means "no hint" (the common case). A non-null hint that
+        //     disagrees with the validated key is a client-side bug; the validated key is authoritative.
+        if (request.TenantIdHint is TenantId hint && !hint.Equals(tenantId))
+        {
+            return new(false, null, new(
+                NotifyCloudGatewayErrorCode.Unauthorized,
+                "TenantIdHint does not match the tenant bound to the API key.",
+                null));
+        }
+
+        // 2. Resolve tenant tier from config (via IConfigProvider read). The tier resolver is registered
+        //    AddScoped, so this read populates the per-request scoped cache; TierDrivenTenantRateLimitPolicy
+        //    later reads from the same cached value in step 4 without a duplicate IConfigProvider call.
+        //    See "Tier resolution caching" below for the scoped-cache pattern.
+        NotifyCloudTenantTier tier = await _tierResolver.GetTierForTenantAsync(tenantId, cancellationToken);
+
+        // 3. Capability-availability check. Tier gates which delivery surfaces a tenant may use.
+        //    This lives in the gateway (not in TierDrivenTenantRateLimitPolicy) so that the rate-limit
+        //    policy stays a pure rate-limit policy — concerns stay separated. Surfaces the dedicated
+        //    CapabilityNotAvailable error code.
+        if (!tier.EnabledChannels.Contains(ChannelForCapability(request.CapabilityKey), StringComparer.Ordinal))
+        {
+            return new(false, null, new(
+                NotifyCloudGatewayErrorCode.CapabilityNotAvailable,
+                $"Tier {tier.Name} does not include channel {ChannelForCapability(request.CapabilityKey)}.",
+                null));
+        }
+
+        // 4. Consult ITenantRateLimitPolicy (Kernel contract; our TierDrivenTenantRateLimitPolicy replaces
+        //    Kernel's NoopTenantRateLimitPolicy at host time). Kernel signature:
+        //      ValueTask<TenantRateLimitDecision> EvaluateAsync(TenantId, string operationKey, CancellationToken)
+        //    The Kernel contract uses `operationKey`; we map our `request.CapabilityKey` to that slot.
+        //    TenantRateLimitDecision shape: (TenantRateLimitOutcome Outcome, TimeSpan? RetryAfter, string? Reason).
+        TenantRateLimitDecision rateLimitDecision = await _rateLimitPolicy.EvaluateAsync(
+            tenantId,
+            operationKey: request.CapabilityKey,
+            cancellationToken);
+        if (rateLimitDecision.Outcome == TenantRateLimitOutcome.Reject
+            || rateLimitDecision.Outcome == TenantRateLimitOutcome.Throttle)
+        {
+            // Convert TimeSpan? RetryAfter from Kernel's shape to int? RetryAfterSeconds at the gateway
+            // boundary. The Notify Cloud Abstractions contract keeps int? for HTTP Retry-After-Header
+            // semantics; the Kernel-layer TimeSpan is more precise but the public REST API surface uses
+            // integer seconds. Both Reject and Throttle surface as RateLimited to the external caller —
+            // the distinction lives in tracing/telemetry, not in the public error envelope.
+            int? retryAfterSeconds = rateLimitDecision.RetryAfter is { } ts
+                ? (int)Math.Ceiling(ts.TotalSeconds)
+                : null;
+            return new(false, null, new(
+                NotifyCloudGatewayErrorCode.RateLimited,
+                rateLimitDecision.Reason ?? "Tenant rate limit exceeded.",
+                retryAfterSeconds));
+        }
+        // rateLimitDecision.Outcome == TenantRateLimitOutcome.Allow — fall through.
+
+        // 5. Reconcile correlation IDs (string mirror vs ambient IGridContext.CorrelationId).
+        //    Same pattern as Capabilities's DefaultCapabilityInvoker. CorrelationId stays string-typed
+        //    in the request because promoting the Kernel CorrelationId record-struct into Abstractions
+        //    is a Grid-wide decision not bundled with this Node's stand-up.
+        var ambientCorrelationId = _gridContextAccessor.GridContext.CorrelationId;
+        if (!string.IsNullOrEmpty(request.CallerCorrelationId)
+            && !string.Equals(request.CallerCorrelationId, ambientCorrelationId.ToString(), StringComparison.Ordinal))
+        {
+            return new(false, null, new(
+                NotifyCloudGatewayErrorCode.InvalidPayload,
+                "CallerCorrelationId disagrees with ambient context.",
+                null));
+        }
+
+        // 6. Open telemetry activity, propagating GridContext tags.
+        using var activity = _telemetry.StartGatewayActivity(tenantId, request.CapabilityKey);
+
+        // 7. Build the MessageIntent and delegate to ICommunicationOrchestrator (hot-path; per ADR-0027 D5).
+        //    MessageIntent shape from HoneyDrunk.Communications.Abstractions is a positional record:
+        //      MessageIntent(string IntentKind, string TriggerEventId, RecipientHandle Recipient,
+        //                    IReadOnlyDictionary<string, string> Payload).
+        //    The Recipient and Payload fields are populated from the JSON payload (e.g., the JSON contains
+        //    a recipient email + per-channel parameters); the exact deserialization shape is implementation
+        //    detail, but the gateway constructs MessageIntent inline rather than going through an injected
+        //    factory. If a follow-up packet introduces an IMessageIntentFactory, this becomes _intentFactory.Create(...).
+        var intent = BuildMessageIntent(request.CapabilityKey, request.PayloadJson, ambientCorrelationId);
+        var orchestrationResult = await _orchestrator.OrchestrateAsync(intent, cancellationToken);
+        if (!orchestrationResult.Success)
+        {
+            return new(false, null, new(
+                NotifyCloudGatewayErrorCode.OrchestrationDenied,
+                orchestrationResult.DenyReason ?? "Communications orchestration denied the send.",
+                null));
+        }
+
+        // 8. Emit BillingEvent for successful delivery (post-dispatch tail; per invariant 39). Goes through
+        //    IBillingEventEmitter (Kernel interface). Default registration at scaffold time is the Stripe
+        //    stub (StripeBillingEventEmitter) — production composition swaps in the real implementation
+        //    when the Stripe billing integration ADR lands.
+        //
+        //    Defense-in-depth: even though step 1a already rejects TenantId.Internal at the top of the
+        //    pipeline, the BillingEvent emission step double-checks. Kernel's NoopBillingEventEmitter does
+        //    NOT short-circuit on Internal — it null-checks the event and returns; so any responsibility
+        //    to skip Internal sits on the gateway, not on the emitter implementation.
+        //
+        //    BillingEvent shape from Kernel (7-positional):
+        //      (TenantId, string EventType, string OperationKey, long Units, DateTimeOffset OccurredAtUtc,
+        //       string CorrelationId, IReadOnlyDictionary<string, string> Attributes)
+        if (!tenantId.IsInternal)
+        {
+            await _billingEmitter.EmitAsync(new BillingEvent(
+                TenantId:        tenantId,
+                EventType:       "notify.delivery.success",
+                OperationKey:    request.CapabilityKey,
+                Units:           1,
+                OccurredAtUtc:   DateTimeOffset.UtcNow,
+                CorrelationId:   _gridContextAccessor.GridContext.CorrelationId.ToString(),
+                Attributes:      ImmutableDictionary<string, string>.Empty), cancellationToken);
+        }
+
+        return new(true, orchestrationResult.DeliveryId, null);
+    }
+
+    // ... constructor with all injected dependencies, fields, etc.
+    // BuildMessageIntent, ChannelForCapability are private helpers.
+}
+```
+
+The full implementation handles error cases, telemetry enrichment, and the dependency-injection wiring; the snippet above captures the pipeline shape.
+
+**Tier resolution caching (per-request scoped pattern).** `_tierResolver` is a Notify-Cloud-private DI service backed by `IConfigProvider`, registered as `AddScoped`. Both the gateway (step 2) and `TierDrivenTenantRateLimitPolicy` (step 4 internals) inject the same scoped instance and therefore share its per-request cached read of the `NotifyCloudTenantTier` for the current request's `TenantId`. The policy does NOT call back into the keystore for tier data, and does NOT issue a duplicate `IConfigProvider` read; it reads from the shared scoped cache. This prevents the agent implementing the policy from inventing a worse pattern (e.g., second IConfigProvider call, or worse, a callback into the keystore).
+
+**`HashingNotifyCloudApiKeyStore`** — production-shape implementation per local invariant 3:
+
+```csharp
+using HoneyDrunk.Kernel.Abstractions.Identity;   // TenantId per ADR-0026 D1
+
+public sealed class HashingNotifyCloudApiKeyStore : INotifyCloudApiKeyStore
+{
+    public async Task<ApiKeyIssuance> IssueAsync(TenantId tenantId, string label, CancellationToken ct)
+    {
+        // Defense-in-depth: issuance against the Internal sentinel is forbidden. `default(TenantId).Value
+        // == Ulid.Empty == TenantId.Internal`, so a caller that omits/zeros the tenantId would otherwise
+        // sneak through as "Internal". The Internal sentinel is reserved for Grid-internal callers that
+        // never traverse the Notify Cloud gateway and have no API keys. The gateway also rejects Internal
+        // at the validation step, but rejecting at issuance closes the loop.
+        if (tenantId.IsInternal)
+        {
+            throw new ArgumentException(
+                "API keys may not be issued against TenantId.Internal — the Internal sentinel is reserved for Grid-internal callers.",
+                nameof(tenantId));
+        }
+
+        var rawKey = GenerateSecureRandomKey();     // 32-byte URL-safe base64 string
+        var salt = GenerateSalt();
+        var hash = ComputeHash(rawKey, salt);
+        var keyId = GenerateKeyId();
+
+        // Persist salt + hash + metadata. NEVER persist rawKey.
+        // ApiKeyRecord stores TenantId as the strong type (ULID) — the repository serializes ULID
+        // to the column-typed representation used by HoneyDrunk.Data.
+        await _repository.AddAsync(new ApiKeyRecord(keyId, tenantId, label, salt, hash, DateTimeOffset.UtcNow, null), ct);
+
+        // Return rawKey to caller exactly once — this is the only path it ever leaves the runtime.
+        return new ApiKeyIssuance(keyId, rawKey, tenantId, DateTimeOffset.UtcNow);
+    }
+
+    public async Task<TenantId?> ValidateAsync(string apiKey, CancellationToken ct)
+    {
+        // Hash-compare lookup against the store. Constant-time comparison avoids timing leaks.
+        var candidates = await _repository.ListActiveAsync(ct);
+        foreach (var record in candidates)
+        {
+            if (CryptographicOperations.FixedTimeEquals(ComputeHash(apiKey, record.Salt), record.Hash))
+            {
+                return record.TenantId;
+            }
+        }
+        return null;
+    }
+
+    public Task RevokeAsync(string keyId, CancellationToken ct)
+        => _repository.SetRevokedAsync(keyId, DateTimeOffset.UtcNow, ct);
+
+    public Task<IReadOnlyList<ApiKeyMetadata>> ListForTenantAsync(TenantId tenantId, CancellationToken ct)
+        => _repository.ListMetadataForTenantAsync(tenantId, ct);
+
+    // ... ComputeHash, GenerateSecureRandomKey, GenerateSalt helpers.
+    // ComputeHash uses Argon2id or PBKDF2 (caller-configurable; default Argon2id) per cryptographic best practice
+    // for password-style hashing. Don't use plain SHA-256 — the salt-and-stretch is the point. Comparison uses
+    // System.Security.Cryptography.CryptographicOperations.FixedTimeEquals for timing-attack resistance.
+}
+```
+
+The repository (`_repository`) is `HoneyDrunk.Data`-backed in production composition. For the in-memory test fixture path (see "Testing fixture" below), a simpler in-memory backend is used.
+
+**`TierDrivenTenantRateLimitPolicy`** — replaces Kernel's `NoopTenantRateLimitPolicy` at host time:
+
+```csharp
+public sealed class TierDrivenTenantRateLimitPolicy : ITenantRateLimitPolicy
+{
+    // Signature matches Kernel exactly:
+    //   ValueTask<TenantRateLimitDecision> EvaluateAsync(TenantId, string operationKey, CancellationToken)
+    // The parameter is `operationKey` per the Kernel contract. Notify Cloud's gateway maps
+    // `request.CapabilityKey` to this slot at the call site.
+    public async ValueTask<TenantRateLimitDecision> EvaluateAsync(
+        TenantId tenantId,
+        string operationKey,
+        CancellationToken cancellationToken)
+    {
+        // ADR-0026 D4: short-circuit on TenantId.Internal so Grid-internal traffic never consults the
+        // tier resolver (which would have no tier entry for it anyway). The gateway's step 1a already
+        // rejects Internal upstream of this call for external customer traffic, but this policy is a
+        // Kernel-contract surface that can be invoked from other code paths too — the local guard stays.
+        if (tenantId.IsInternal)
+        {
+            return new TenantRateLimitDecision(
+                Outcome: TenantRateLimitOutcome.Allow,
+                RetryAfter: null,
+                Reason: null);
+        }
+
+        // Read the tier from the per-request scoped cache that the gateway already populated. _tierResolver
+        // is registered AddScoped so this is the same instance the gateway used in step 2 — no duplicate
+        // IConfigProvider call, no callback into the keystore. See "Tier resolution caching" in the
+        // DefaultNotifyCloudGateway section.
+        var tier = await _tierResolver.GetTierForTenantAsync(tenantId, cancellationToken);
+
+        // Derive limits from tier — e.g., Free = 1000 events/month, Starter = 10000, Pro = unlimited.
+        // NOTE: Capability-availability (channel-in-tier) is checked at the gateway, not here. This policy
+        // is a pure rate-limit policy; the gateway is responsible for capability gating and surfaces the
+        // dedicated CapabilityNotAvailable error code for that case.
+        var monthlyLimit = tier.EventsPerMonth;
+        var currentMonthCount = await _usageCounter.GetMonthlyCountAsync(tenantId, cancellationToken);
+
+        if (currentMonthCount >= monthlyLimit)
+        {
+            // Reject (hard limit reached). RetryAfter is a TimeSpan? per the Kernel contract — the gateway
+            // converts to int seconds at the public boundary if needed.
+            return new TenantRateLimitDecision(
+                Outcome: TenantRateLimitOutcome.Reject,
+                RetryAfter: TimeUntilNextMonthStart(),
+                Reason: $"Tenant on tier {tier.Name} has used {currentMonthCount} of {monthlyLimit} events this month.");
+        }
+
+        return new TenantRateLimitDecision(
+            Outcome: TenantRateLimitOutcome.Allow,
+            RetryAfter: null,
+            Reason: null);
+    }
+
+    // TimeUntilNextMonthStart() returns the TimeSpan from "now" to the start of the next calendar month
+    // (UTC). Used as the RetryAfter advisory when a tenant hits the monthly ceiling.
+}
+```
+
+DI registration replaces the Kernel-default `NoopTenantRateLimitPolicy` registration:
+
+```csharp
+// in ServiceCollectionExtensions.cs
+services.Replace(ServiceDescriptor.Scoped<ITenantRateLimitPolicy, TierDrivenTenantRateLimitPolicy>());
+```
+
+The `Replace` (rather than `Add`) ensures Notify Cloud's policy supersedes Kernel's noop registration in any host that composes Notify Cloud — per invariant 39's discipline ("Core dispatch paths for internal Grid callers must remain tenant-agnostic and default to `TenantId.Internal` without caller-specific branches"), the noop is what fires for Grid-internal callers, and Notify Cloud's policy fires for external callers.
+
+**`BillingEventEmissionTail`** — Notify Cloud's invariant-39-compliant post-dispatch tail. Wired into the worker pipeline as a fire-after-success delegate that calls `IBillingEventEmitter.EmitAsync`. The default registered implementation is the Stripe stub at scaffold time; production composition wires the real Stripe emitter.
+
+**`NotifyCloudTelemetry`** — emits `NotifyCloud.Gateway.Process` activity per call with tags: `tenant_id` (direct per ADR-0027 D7 low-cardinality bound), `capability_key`, `outcome` (Success / error code), `latency_ms`. The CorrelationId / CausationId / NodeId propagation from `IGridContext` is enriched on every activity. **No** raw API keys, no plaintext payloads, no recipient PII — only metadata.
+
+### Provider details — `HoneyDrunk.Notify.Cloud.Billing.Stripe`
+
+`HoneyDrunk.Notify.Cloud.Billing.Stripe` references:
+
+- `HoneyDrunk.Kernel.Abstractions` (for `IBillingEventEmitter`, `BillingEvent` per ADR-0026 — the Stripe adapter implements the Kernel-defined interface, not a Notify-Cloud-defined one). No reference to `HoneyDrunk.Notify.Cloud.Abstractions` is required for the stub; if a future Stripe-adapter feature needs `NotifyCloudTenantTier` or similar Notify-Cloud-shaped data, add the project reference then.
+- `HoneyDrunk.Vault` (for resolving the Stripe webhook signing key at runtime — eventually; the stub doesn't yet)
+- `Microsoft.Extensions.Logging.Abstractions`
+
+Single class:
+
+```csharp
+public sealed class StripeBillingEventEmitter : IBillingEventEmitter
+{
+    // Signature matches Kernel exactly: ValueTask EmitAsync(BillingEvent, CancellationToken).
+    public ValueTask EmitAsync(BillingEvent billingEvent, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(billingEvent);
+
+        // TODO (Stripe billing integration ADR follow-up): implement the webhook bridge.
+        // For v0.1.0 (this scaffold), the emitter is a stub. It satisfies the IBillingEventEmitter
+        // contract — a Stripe-shaped implementation exists — but the actual Stripe metered-billing
+        // call is deferred to the follow-up ADR per ADR-0027 D13.
+        throw new NotImplementedException(
+            "StripeBillingEventEmitter is a v0.1.0 stub. Stripe webhook bridge implementation is "
+            + "deferred to the Stripe billing integration ADR (PDR-0002 recommended follow-up).");
+    }
+}
+```
+
+The stub is **functional for tests** in the sense that it can be DI-registered and verified to throw; downstream code that calls `EmitAsync` and expects it to succeed is broken until the follow-up ADR lands. Composition at scaffold time uses a different default emitter for end-to-end smoke tests (an in-memory `LoggingBillingEventEmitter` lives in the runtime project's test project as an `internal` test helper per D3).
+
+### Web project — `HoneyDrunk.Notify.Cloud.Web`
+
+`HoneyDrunk.Notify.Cloud.Web` is an ASP.NET Core minimal-API host with Blazor Server pages per ADR-0027 D3 default. References:
+
+- `HoneyDrunk.Notify.Cloud` (project reference — composes the runtime)
+- `HoneyDrunk.Web.Rest.AspNetCore` (for response envelopes, correlation headers per invariant 18-style consistency)
+- `Microsoft.AspNetCore.App` (framework reference — pulls in Blazor Server)
+- `HoneyDrunk.Kernel.Abstractions` (for `IGridContext` propagation through the ASP.NET Core pipeline; Abstractions reference per invariant 2 — the runtime composition is brought in transitively via the project reference to `HoneyDrunk.Notify.Cloud`)
+
+Three things ship at scaffold time:
+
+- A health endpoint at `/health` returning `200 OK` with a tiny JSON body confirming the gateway is composed.
+- A non-functional signup form at `/signup` (Blazor Server) — just the form scaffold, no backing API. Per ADR-0027 D13, the full signup flow lands in a follow-up packet.
+- The standard ASP.NET Core pipeline wiring (`AddHoneyDrunkNotifyCloud()`, `AddRouting()`, `AddRazorComponents()`, etc.) in `Program.cs`.
+
+The web project's full surface (full signup, billing dashboard, delivery logs, tenant management UI) is **explicitly out of scope for this scaffold** per ADR-0027 D13. The placeholder is enough to confirm the deployment path compiles and the `ca-hd-notify-cloud-stg` Container App can serve requests.
+
+### CI workflows
+
+All six workflow files are thin callers of `HoneyDrunk.Actions` reusable workflows. No bespoke CI logic in the Notify Cloud repo.
+
+```yaml
+# .github/workflows/pr-core.yml
+name: PR Core
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  core:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    with:
+      dotnet-version: '10.0.x'
+```
+
+```yaml
+# .github/workflows/api-compatibility.yml — ADR-0027 D8 / Notify Cloud contract-shape canary invariant
+name: API Compatibility (Abstractions)
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/HoneyDrunk.Notify.Cloud.Abstractions/**'
+jobs:
+  abstractions-shape:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml@main
+    with:
+      project-path: src/HoneyDrunk.Notify.Cloud.Abstractions/HoneyDrunk.Notify.Cloud.Abstractions.csproj
+```
+
+The path filter ensures the canary only runs when Abstractions changes — keeps PR feedback fast for runtime/Web-only changes. The whole-assembly diff produced by `job-api-compatibility.yml` is sufficient to enforce D8: the four frozen contracts plus their supporting records and the `NotifyCloudGatewayErrorCode` enum are all in `HoneyDrunk.Notify.Cloud.Abstractions`, so any shape drift in any public type in Abstractions counts.
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  release:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/release.yml@main
+    with:
+      dotnet-version: '10.0.x'
+      # Notify Cloud packages publish to the private feed only — see release.yml composite action
+      # for the feed-URL parameterization. Do NOT publish to public NuGet per ADR-0027.
+    secrets: inherit
+```
+
+Tags are human-pushed per invariant 27 — agents do not push tags. The release workflow packs and publishes all four `src/*` projects to the private NuGet feed in a single tag-driven run. **The release workflow must be configured to publish to the private feed, not public NuGet** — this is a critical safeguard against accidentally publishing the wrapper packages publicly.
+
+```yaml
+# .github/workflows/deploy-stg.yml — ADR-0015 container-app deployment
+# Phase 0 stance: workflow_dispatch only at v0.1.0. The full ADR-0033 trigger model
+# (dev push-to-main, staging tag-push) lands in a follow-up packet — Notify Cloud
+# is in Phase 0 alongside the ADR-0033 follow-up packet from the ADR-0024 fix pass.
+# Per ADR-0033 D5, an explicit per-environment concurrency group is required.
+name: Deploy (stg)
+on:
+  workflow_dispatch:                   # manual trigger only at v0.1.0 (see Phase 0 note above)
+concurrency:
+  group: deploy-stg-notify-cloud       # ADR-0033 D5: per-environment concurrency group
+  cancel-in-progress: false
+jobs:
+  deploy:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-deploy-container-app.yml@main
+    with:
+      service-name: notify-cloud
+      environment: stg
+      image-tag: ${{ github.sha }}
+    secrets: inherit
+```
+
+This is the first deploy target per ADR-0027 D13: `ca-hd-notify-cloud-stg` in East US. Production deployment (`ca-hd-notify-cloud-prd`) is a follow-up; staging is enough to prove the deployment path compiles. The `job-deploy-container-app.yml` reusable workflow handles the Container Apps provisioning per ADR-0015 (shared `cae-hd-stg` environment, shared `acrhdsharedstg` registry, system-assigned Managed Identity, `Multiple` revision mode per invariants 34-36).
+
+**Environment model — `dev` deferred to follow-up.** Notify Cloud at v0.1.0 has no `dev` environment; staging (`ca-hd-notify-cloud-stg`) is both the dev cadence and the first promotion target until customer onboarding begins. A `dev` environment (`ca-hd-notify-cloud-dev`, with the ADR-0033 D1 push-to-main auto-deploy trigger) will be added in a follow-up packet when external preview begins.
+
+**ADR-0033 trigger model — staged.** At v0.1.0 only `workflow_dispatch` is configured. The ADR-0033 D1 trigger model (`push: tags: ['v*.*.*']` mapping to staging, `push: branches: [main]` mapping to dev) lands in a follow-up packet that is co-scheduled with the ADR-0033 follow-up packet from the ADR-0024 fix pass. The follow-up packet adds the tag-push trigger to `deploy-stg.yml` and introduces `deploy-dev.yml` alongside.
+
+`nightly-deps.yml` and `nightly-security.yml` follow the same thin-caller pattern — copy the configurations from `HoneyDrunk.Auth` or `HoneyDrunk.Vault` for reference.
+
+### `HoneyDrunk.Standards` wiring
+
+Each `.csproj` references `HoneyDrunk.Standards` with `PrivateAssets="all"` per invariant 26:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="HoneyDrunk.Standards" Version="*" PrivateAssets="all" />
+</ItemGroup>
+```
+
+This pulls in the StyleCop ruleset, `.editorconfig`, and analyzer suite that every Grid repo uses.
+
+### Documentation
+
+- **Repo `README.md`** — purpose statement, "Private repo" badge, package matrix, "How Notify Cloud composes Communications and Notify" pipeline diagram, link to ADR-0027.
+- **Repo `CHANGELOG.md`** — `## [0.1.0] - 2026-MM-DD` entry covering the entire scaffold landing.
+- **Per-package `README.md`** — purpose, public API surface summary. Required by invariant 12 for new packages.
+- **Per-package `CHANGELOG.md`** — `## [0.1.0]` entry for each package introduced in this packet.
+
+## Affected Files
+Entire repo is created from this packet (the empty repo from packet 05 had only `.gitignore` and a placeholder README). Notable new files:
+- `HoneyDrunk.Notify.Cloud.slnx`, `Directory.Build.props`, `README.md`, `CHANGELOG.md`, `LICENSE`, `.editorconfig`
+- `src/HoneyDrunk.Notify.Cloud.Abstractions/` — four contract files + supporting record/enum files + `.csproj` + `README.md` + `CHANGELOG.md`
+- `src/HoneyDrunk.Notify.Cloud/` — `.csproj`, `ServiceCollectionExtensions.cs`, `Gateway/DefaultNotifyCloudGateway.cs`, `ApiKeys/HashingNotifyCloudApiKeyStore.cs`, `RateLimiting/TierDrivenTenantRateLimitPolicy.cs`, `Billing/BillingEventEmissionTail.cs`, `Telemetry/NotifyCloudTelemetry.cs`, `README.md`, `CHANGELOG.md`
+- `src/HoneyDrunk.Notify.Cloud.Billing.Stripe/` — `.csproj`, `StripeBillingEventEmitter.cs`, `README.md`, `CHANGELOG.md`
+- `src/HoneyDrunk.Notify.Cloud.Web/` — `.csproj`, `Program.cs`, `Pages/Health.razor`, `Components/SignupPlaceholder.razor`, `README.md`, `CHANGELOG.md`
+- `tests/*` — four test projects with at least smoke-test coverage
+- `.github/workflows/` — 6 workflow files
+
+## NuGet Dependencies
+
+Every new `.csproj` lists `HoneyDrunk.Standards` (`PrivateAssets="all"`) per invariant 26.
+
+### `HoneyDrunk.Notify.Cloud.Abstractions.csproj`
+
+**v0.1.0 decision — single, explicit choice.** v0.1.0 PackageReferences `HoneyDrunk.Kernel.Abstractions` **only**. `HoneyDrunk.Notify.Abstractions` and `HoneyDrunk.Communications.Abstractions` are reserved by ADR-0027 D3 for future contract surfaces and will be added in a follow-up packet when a contract first consumes them. Do not add them at v0.1.0 — that creates dead references the agent can't justify.
+
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | For the `TenantId` record-struct from `HoneyDrunk.Kernel.Abstractions.Identity` per ADR-0026 D1. Load-bearing at v0.1.0. ADR-0027 D3 explicitly enumerates this as one of the three permitted Abstractions references for this package. Matches the established pattern from `HoneyDrunk.Communications.Abstractions` (also references `HoneyDrunk.Kernel.Abstractions`). |
+
+Notes on Abstractions references — ADR-0027 D3 reads: "Zero runtime dependencies beyond `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.Notify.Abstractions`, and `HoneyDrunk.Communications.Abstractions`." The strict-Abstractions stance applied in some ADR-0016 / ADR-0017 packets does NOT apply here — the ADR explicitly carved out these three. At v0.1.0 only `HoneyDrunk.Kernel.Abstractions` is actually consumed (for `TenantId`); `HoneyDrunk.Notify.Abstractions` and `HoneyDrunk.Communications.Abstractions` are reserved by D3 for future contract surfaces and are added by the follow-up packet that introduces the first contract consuming them.
+
+### `HoneyDrunk.Notify.Cloud.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | For `IGridContext`, `IOperationContext`, `ITelemetryActivityFactory`, and the multi-tenant primitives in `HoneyDrunk.Kernel.Abstractions.Tenancy` (`ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, `BillingEvent`) plus the `TenantId` strong type in `HoneyDrunk.Kernel.Abstractions.Identity` per ADR-0026. Per invariant 2, runtime packages depend on Abstractions, not on other runtime packages — so this is the Abstractions reference, not `HoneyDrunk.Kernel` (runtime). |
+| `HoneyDrunk.Communications.Abstractions` | For `ICommunicationOrchestrator`, `IMessageIntent`, `MessageIntent` per ADR-0027 D5 (hot path) and invariant 40. `MessageIntent` is a positional record with shape `(string IntentKind, string TriggerEventId, RecipientHandle Recipient, IReadOnlyDictionary<string, string> Payload)` — the gateway constructs it inline via a `BuildMessageIntent` private helper (deserializing `request.PayloadJson` into the `Recipient` + `Payload` slots), NOT through an injected `_intentFactory`. The factory pattern would be premature at v0.1.0; if a follow-up packet introduces an `IMessageIntentFactory`, the helper graduates to that. |
+| `HoneyDrunk.Notify.Abstractions` | For `INotificationSender` — diagnostic/smoke-test paths only per ADR-0027 D5 |
+| `HoneyDrunk.Auth.Abstractions` | For `IApiKeyAuthenticator` middleware path (Auth-side surface to be finalized in a follow-up ADR per ADR-0027 D12) |
+| `HoneyDrunk.Vault` | For `ISecretStore`, `IConfigProvider` (tenant tier definitions, cost-rate tables, abuse heuristics). The Vault repo does not split a separate `.Abstractions` package — the interfaces live in the runtime `HoneyDrunk.Vault` package per the existing repo shape. Confirm at implementation time; if a `.Abstractions` package has materialized by then, prefer it. |
+| `HoneyDrunk.Data.Abstractions` | For the `HashingNotifyCloudApiKeyStore` repository backend per ADR-0027 D9 default ("hashed table in HoneyDrunk.Data") |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | DI registration helpers |
+| `Microsoft.Extensions.Hosting.Abstractions` | For startup hook integration |
+| `Microsoft.Extensions.Logging.Abstractions` | Logger contracts |
+
+Project reference: `HoneyDrunk.Notify.Cloud.Abstractions`.
+
+**Note on Kernel runtime vs Abstractions choice.** Earlier drafts listed `HoneyDrunk.Kernel` (the runtime package). Per invariant 2 (Runtime packages depend on Abstractions, never on other runtime packages at the same layer), the correct dependency is `HoneyDrunk.Kernel.Abstractions`. Composition against the Kernel runtime is a host-time concern; the runtime ServiceCollectionExtensions wire concrete implementations at the Container App composition point, not via a PackageReference from the Notify Cloud runtime to the Kernel runtime.
+
+### `HoneyDrunk.Notify.Cloud.Billing.Stripe.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | For `IBillingEventEmitter`, `BillingEvent` per ADR-0026 |
+| `HoneyDrunk.Vault` | For Stripe webhook signing key resolution (eventually — stub doesn't use it yet) |
+| `Microsoft.Extensions.Logging.Abstractions` | Logger contracts |
+| `Stripe.net` | Reserved for the follow-up Stripe integration ADR — the v0.1.0 stub does not import it. Document as a planned reference in the project's README. |
+
+(Project reference: none required for the stub — `StripeBillingEventEmitter` implements `IBillingEventEmitter` from `HoneyDrunk.Kernel.Abstractions.Tenancy` directly. If the stub somehow needs `NotifyCloudTenantTier`, add a project reference to `HoneyDrunk.Notify.Cloud.Abstractions`; otherwise omit.)
+
+### `HoneyDrunk.Notify.Cloud.Web.csproj`
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `Microsoft.AspNetCore.App` | Framework reference (Blazor Server, minimal API) |
+| `HoneyDrunk.Kernel.Abstractions` | For `IGridContext` propagation through the ASP.NET Core pipeline — Abstractions reference per invariant 2. The runtime composition (concrete Kernel implementations) is brought in transitively via the project reference to `HoneyDrunk.Notify.Cloud`. |
+| `HoneyDrunk.Web.Rest.AspNetCore` | Response envelopes, correlation headers — hosting-layer ASP.NET Core integration. This package is a hosting-tier sibling to runtime; ASP.NET Core hosting projects reference it directly per the existing Grid pattern. |
+
+Project references: `HoneyDrunk.Notify.Cloud` (the runtime).
+
+### Test projects
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `Microsoft.NET.Test.Sdk` | Standard |
+| `xunit` | Standard |
+| `xunit.runner.visualstudio` | Standard |
+| `Microsoft.Extensions.DependencyInjection` | For DI in gateway/store/rate-limit policy tests |
+| `NSubstitute` | For mocking `ICommunicationOrchestrator`, `IBillingEventEmitter`, `IApiKeyAuthenticator` |
+
+Project references as appropriate to each `.Tests` project.
+
+## Boundary Check
+- [x] All work inside `HoneyDrunk.Notify.Cloud`. No edits to other Grid repos.
+- [x] `HoneyDrunk.Notify.Cloud.Abstractions` `HoneyDrunk.*` PackageReferences are limited to the three explicitly permitted by ADR-0027 D3: `HoneyDrunk.Kernel.Abstractions` (load-bearing for `TenantId`), `HoneyDrunk.Notify.Abstractions` (reserved; may be omitted if no v0.1.0 consumer), `HoneyDrunk.Communications.Abstractions` (reserved; may be omitted if no v0.1.0 consumer). The strict-Abstractions stance from sibling ADR-0016 / ADR-0017 packets does NOT apply here — ADR-0027 D3 explicitly carves out these three references.
+- [x] `ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, `BillingEvent` are **not** redeclared in Notify Cloud Abstractions — they live in `HoneyDrunk.Kernel.Abstractions.Tenancy` per ADR-0026 and the runtime package consumes them.
+- [x] `TenantId` is referenced (not redeclared) — it is the canonical Kernel record-struct from `HoneyDrunk.Kernel.Abstractions.Identity` per ADR-0026 D1. The four D4 contracts use the strong type, not `string`.
+- [x] Records (`NotifyCloudTenantTier`, `ApiKeyIssuance`, `NotifyCloudGatewayRequest`, `NotifyCloudGatewayResult`, `NotifyCloudGatewayError`, `ApiKeyMetadata`) all drop the `I` prefix; interfaces (`INotifyCloudGateway`, `INotifyCloudApiKeyStore`) keep it (Grid-wide naming rule).
+- [x] No secrets in code. Stripe webhook signing key resolution is deferred to `IConfigProvider` / `ISecretStore` — the scaffold does not commit a key value.
+- [x] The Auth dependency in `DefaultNotifyCloudGateway` uses a placeholder reference to `IApiKeyAuthenticator` (the actual interface signature is finalized in the follow-up ADR per ADR-0027 D12) — `HashingNotifyCloudApiKeyStore` is the Notify-Cloud-local salted-hash store; Auth's middleware wraps it for the trust-boundary discipline.
+- [x] API keys are stored as salted hashes only (Argon2id or PBKDF2 by configuration); raw key material is returned exactly once via `ApiKeyIssuance` at issuance time. No path retrieves the raw key after `IssueAsync` returns.
+- [x] The Notify-Cloud-specific `ITenantRateLimitPolicy` implementation uses `services.Replace(...)` to supersede Kernel's `NoopTenantRateLimitPolicy` registration at host time per invariant 39's intake/post-dispatch discipline.
+- [x] LICENSE is `LicenseRef-Proprietary` (all rights reserved by default of being private) per ADR-0027 D11. The wrapper is private; the public FSL applies only to the engine repos (Notify, Communications — handled by packets 03 and 04).
+- [x] Release workflow publishes to the private NuGet feed only — packages are NOT pushed to public NuGet per ADR-0027 D2's confidentiality framing.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Notify.Cloud.slnx` builds clean from a fresh clone via `dotnet build` with no warnings (warnings-as-errors).
+- [ ] All four D4 contracts present in `HoneyDrunk.Notify.Cloud.Abstractions` with XML documentation per invariant 13.
+- [ ] `HoneyDrunk.Notify.Cloud.Abstractions` PackageReferences at v0.1.0 are **exactly**: `HoneyDrunk.Standards` (`PrivateAssets="all"`) and `HoneyDrunk.Kernel.Abstractions` (for `TenantId`). `HoneyDrunk.Notify.Abstractions` and `HoneyDrunk.Communications.Abstractions` are reserved by ADR-0027 D3 but NOT added at v0.1.0 — they are added in a follow-up packet when a contract first consumes them. No other `HoneyDrunk.*` references at v0.1.0.
+- [ ] `HoneyDrunk.Notify.Cloud.Abstractions` references `TenantId` from `HoneyDrunk.Kernel.Abstractions.Identity` and does NOT redeclare it. Verify by searching the Abstractions project source: `rg -n 'record\s+TenantId|struct\s+TenantId' src/HoneyDrunk.Notify.Cloud.Abstractions/` should return zero matches.
+- [ ] `HoneyDrunk.Notify.Cloud.Abstractions` does NOT declare `ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, or `BillingEvent`. Those live in `HoneyDrunk.Kernel.Abstractions.Tenancy` per ADR-0026. Verify by searching the Abstractions project source.
+- [ ] The four D4 contracts use the strong `TenantId` type (from `HoneyDrunk.Kernel.Abstractions.Identity`) for every TenantId-shaped field. No `string` typed TenantId fields remain on `INotifyCloudGateway.NotifyCloudGatewayRequest`, `INotifyCloudApiKeyStore` method parameters, `ApiKeyMetadata`, or `ApiKeyIssuance`. Verify by `rg -n '\bstring\s+TenantId\b|\bstring\s+tenantId\b' src/HoneyDrunk.Notify.Cloud.Abstractions/` returning zero matches.
+- [ ] `NotifyCloudGatewayRequest.TenantIdHint` is declared as `TenantId?` (nullable), NOT `TenantId`. This is the security fix for the `default(TenantId) == TenantId.Internal` aliasing collision: a `null` hint unambiguously means "no hint", whereas a bare `TenantId` field with a `default` value would alias to the Internal sentinel. Verify by `rg -n 'TenantId\??\s+TenantIdHint' src/HoneyDrunk.Notify.Cloud.Abstractions/INotifyCloudGateway.cs` returning the nullable form.
+- [ ] `NotifyCloudTenantTier.EnabledChannels` is declared as `IReadOnlyList<string>` (or `ImmutableArray<string>`), NOT `string[]`. Mutable arrays on public records are a footgun; the read-only collection form matches Grid convention (compare to `BillingEvent.Attributes: IReadOnlyDictionary<string, string>`).
+- [ ] `KeyId` / `ApiKeyId` stay `string` at v0.1.0 with a TODO comment near the type declaration in `INotifyCloudApiKeyStore` pointing at the follow-up API key authentication ADR for the eventual strong-type promotion. Promotion is not bundled with this scaffold.
+- [ ] `HoneyDrunk.Notify.Cloud` runtime exposes `AddHoneyDrunkNotifyCloud()` extension; `INotifyCloudGateway`, `INotifyCloudApiKeyStore` resolve from DI after registration. Kernel's `ITenantRateLimitPolicy` registration is superseded via `services.Replace(...)` with `TierDrivenTenantRateLimitPolicy`.
+- [ ] `HashingNotifyCloudApiKeyStore.IssueAsync` returns an `ApiKeyIssuance` containing the plaintext key exactly once. The repository persists only `(KeyId, TenantId, Label, Salt, Hash, IssuedAt, RevokedAt)` — never the raw key. A unit test verifies that no path retrieves the raw key after `IssueAsync` returns (e.g., `ListForTenantAsync` returns only metadata without any raw-key field).
+- [ ] `HashingNotifyCloudApiKeyStore.IssueAsync` throws `ArgumentException` (paramName `nameof(tenantId)`) when called with `TenantId.Internal`. A unit test verifies this — the Internal sentinel is reserved for Grid-internal callers and may not be issued API keys. This closes the loop with the gateway's step 1a Internal-rejection: issuance refuses Internal, and validation/transaction refuses Internal even if a malformed key ever made it past issuance.
+- [ ] `HashingNotifyCloudApiKeyStore.ValidateAsync` uses constant-time comparison (e.g., `CryptographicOperations.FixedTimeEquals` from `System.Security.Cryptography`) for the hash comparison. A unit test verifies validation succeeds with a freshly issued raw key and fails with a tampered key.
+- [ ] `DefaultNotifyCloudGateway.ProcessAsync` runs the full pipeline in this order: API key validation → Internal-sentinel rejection → TenantIdHint cross-check → tier resolution → **capability-availability check** → rate-limit evaluation → correlation reconciliation → telemetry activity → orchestration delegation → billing emission. Capability-availability (channel-in-tier) lives at the gateway, NOT inside `TierDrivenTenantRateLimitPolicy`. The call to `_rateLimitPolicy.EvaluateAsync(tenantId, operationKey: request.CapabilityKey, ct)` uses the Kernel `ITenantRateLimitPolicy.EvaluateAsync` signature exactly (returns `ValueTask<TenantRateLimitDecision>`). Tests cover: invalid API key → `Unauthorized`; validated key resolving to `TenantId.Internal` → `Unauthorized` with the "Internal tenant cannot transact" message; non-null `TenantIdHint` disagreeing with the validated tenant → `Unauthorized`; null `TenantIdHint` (the common case) → no rejection; capability not in tier's `EnabledChannels` → `CapabilityNotAvailable` (NOT `RateLimited`); `Outcome: TenantRateLimitOutcome.Reject` → `RateLimited` with `RetryAfterSeconds = (int)Math.Ceiling(decision.RetryAfter.Value.TotalSeconds)`; `Outcome: TenantRateLimitOutcome.Throttle` → `RateLimited` (same envelope as Reject); orchestration denial → `OrchestrationDenied`; mismatched `CallerCorrelationId` → `InvalidPayload`.
+- [ ] **Happy-path billing-event acceptance.** A unit test verifies that on a successful end-to-end gateway run, `IBillingEventEmitter.EmitAsync` was called exactly once with a `BillingEvent` whose: `TenantId` matches the validated key's tenant; `EventType == "notify.delivery.success"`; `OperationKey == request.CapabilityKey`; `Units == 1`; `CorrelationId` matches `_gridContextAccessor.GridContext.CorrelationId.ToString()`; `Attributes` is non-null (defaults to `ImmutableDictionary<string, string>.Empty`). The test uses `NSubstitute.Received()` against a mocked `IBillingEventEmitter`. A second test verifies that when the resolved `TenantId.IsInternal` is true (a path that the gateway's step 1a should already reject — this is a belt-and-suspenders test against direct invocation), `EmitAsync` is NOT called.
+- [ ] `TierDrivenTenantRateLimitPolicy.EvaluateAsync(TenantId, string operationKey, CancellationToken)` returns `ValueTask<TenantRateLimitDecision>` matching the Kernel `ITenantRateLimitPolicy` signature exactly. `TenantRateLimitDecision` is constructed positionally as `(TenantRateLimitOutcome Outcome, TimeSpan? RetryAfter, string? Reason)` per the Kernel record shape — no `Allowed:` / `DenyReason:` / `RetryAfterSeconds:` legacy field names. Derives the monthly ceiling from `NotifyCloudTenantTier.EventsPerMonth` (sourced from `IConfigProvider` via the per-request scoped `_tierResolver`, mocked in tests). Unit tests cover: Free tier exceeding `EventsPerMonth` → `Outcome: TenantRateLimitOutcome.Reject` with a non-null `RetryAfter` advisory; Pro tier under the ceiling → `Outcome: TenantRateLimitOutcome.Allow` with `RetryAfter: null`, `Reason: null`; `TenantId.Internal` short-circuit → `Outcome: TenantRateLimitOutcome.Allow`. Capability-availability (channel-in-tier) is NOT tested in this policy — that lives at the gateway with `CapabilityNotAvailable` error code.
+- [ ] `StripeBillingEventEmitter.EmitAsync` signature returns `ValueTask` (matching the Kernel `IBillingEventEmitter.EmitAsync(BillingEvent, CancellationToken) → ValueTask` shape exactly — NOT `Task`). The body null-checks `billingEvent` via `ArgumentNullException.ThrowIfNull(billingEvent)` then throws `NotImplementedException` with the TODO referencing the follow-up Stripe billing integration ADR. A unit test verifies (a) the throw on a non-null event, and (b) that `ArgumentNullException` (not `NotImplementedException`) fires when `billingEvent` is null. The scaffold's end-to-end smoke test does NOT call this emitter directly — composition uses an in-memory `LoggingBillingEventEmitter` internal test helper for the smoke path.
+- [ ] `NotifyCloudTelemetry` emits `NotifyCloud.Gateway.Process` activity per call with tags `tenant_id`, `capability_key`, `outcome`, `latency_ms`. No raw API keys, no plaintext payloads, no recipient PII. Verified by a test using `TestActivityListener`-style fixture.
+- [ ] `HoneyDrunk.Notify.Cloud.Web` exposes `/health` returning `200 OK` with a JSON body confirming the gateway is composed. A `/signup` page exists as a Blazor Server placeholder (renders the form scaffold but performs no backing API call).
+- [ ] `LICENSE` file exists at repo root with the proprietary-license text. `Directory.Build.props` declares `<PackageLicenseFile>LICENSE</PackageLicenseFile>` and the file is packed into every `.nupkg` via `<None Include=... Pack="true">`.
+- [ ] All six `.github/workflows/*.yml` files present and reference `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/*@main`.
+- [ ] `release.yml` is configured to publish to the **private** NuGet feed only. **No path publishes Notify.Cloud packages to public NuGet.** Verify the feed-URL parameter in the workflow file matches the private feed. If accidentally configured for public NuGet, the workflow itself must be rejected and reauthored.
+- [ ] `deploy-stg.yml` calls `job-deploy-container-app.yml` per ADR-0015 with `service-name: notify-cloud`, `environment: stg`. Verifies the deployment path compiles even if not executed. (Actually running the deployment requires Azure resources from the Human Prerequisites.)
+- [ ] **Service-name length check.** Verify `"notify-cloud".Length` is 12 — fits inside invariant 19's ≤ 13 character limit for Azure resource naming. The full resource name `ca-hd-notify-cloud-stg` is 23 characters (under Container Apps' 32-char limit); `kv-hd-notify-cloud-stg` is 23 characters (under Key Vault's 24-char limit). Document the count in `HoneyDrunk.Notify.Cloud/README.md` so a future Node author sees the precedent.
+- [ ] `deploy-stg.yml` declares an explicit per-environment `concurrency` group keyed by environment name (`deploy-stg-notify-cloud`) with `cancel-in-progress: false` per ADR-0033 D5. Verify the workflow has the `concurrency:` block at the top level, not inside the job.
+- [ ] `api-compatibility.yml` runs on PR. On the scaffolding PR itself the workflow runs against an absent `main` baseline and reports `status: skipped` per the `HoneyDrunk.Actions/.github/actions/api/check-compatibility/action.yml` missing-baseline path — that is correct first-build behavior, not a failure. **Verify post-merge** by opening a throwaway PR that removes a public member from `INotifyCloudGateway` (or any other frozen contract); the workflow must fail with breaking-changes-detected. Revert the throwaway PR after observation.
+- [ ] `pr-core.yml` passes on the initial scaffolding PR (build + tests + analyzers + dependency scan + secret scan).
+- [ ] Repo-level `CHANGELOG.md` has a `## [0.1.0] - YYYY-MM-DD` entry covering the scaffold; per-package `CHANGELOG.md` files each have their own `## [0.1.0]` entry naming the package's specific introductions (per invariants 12 and 27).
+- [ ] Repo-level `README.md` and per-package `README.md` files all present per invariant 12.
+- [ ] Test suite runs and passes — minimum coverage as described in the Acceptance Criteria above.
+- [ ] All projects in the solution carry the same `Version` (0.1.0), excluding test projects (invariant 27).
+- [ ] Manual confirmation that pushing tag `v0.1.0` from `main` would trigger `release.yml` and produce private-feed packages for the four `src/*` projects (do not actually push the tag — verify the workflow exists and a tag-push trigger is configured against the private feed).
+
+## Human Prerequisites
+- [ ] **Provision the shared Container Apps Environment `cae-hd-stg` (first-Container-App bundle).** Per ADR-0015 and the user's standing rule "Provision Azure resources when first needed; CAE has no standalone portal Create — bundle with first Container App." Notify Cloud is the first containerized Node deploying to `stg`, so the CAE provisioning happens here. Cross-link: see `infrastructure/walkthroughs/` for any container-apps-environment walkthrough doc (e.g., `infrastructure/walkthroughs/container-apps-environment-stg.md` if it has been authored; if not, create it as part of this prerequisite and capture the portal steps for the next Node to consume).
+- [ ] **Provision Azure resources for the `stg` deployment.** Per ADR-0015 and ADR-0027 D13:
+  - Resource group `rg-hd-notify-cloud-stg` in East US (create via Azure portal: Resource Groups → Create)
+  - Container App `ca-hd-notify-cloud-stg` in the `cae-hd-stg` environment provisioned above, with system-assigned Managed Identity (per invariant 34).
+  - Key Vault `kv-hd-notify-cloud-stg` with Azure RBAC enabled (per invariant 17). Service name `notify-cloud` is 12 characters — fits within invariant 19's 13-char limit. Diagnostic settings routed to the shared Log Analytics workspace per invariant 22.
+  - App Service configuration: `AZURE_KEYVAULT_URI` and `AZURE_APPCONFIG_ENDPOINT` set as environment variables (per invariant 18, never derived by convention, never hardcoded).
+  - OIDC federated credential for `repo:HoneyDrunkStudios/HoneyDrunk.Notify.Cloud:ref:refs/heads/main` (for the `workflow_dispatch`-triggered deploy) and `repo:HoneyDrunkStudios/HoneyDrunk.Notify.Cloud:ref:refs/tags/v*` (for the tag-triggered release publish) against the deployment identity. Cross-link: [infrastructure/walkthroughs/oidc-federated-credentials.md](../../../../infrastructure/walkthroughs/oidc-federated-credentials.md).
+  - Lean Azure tag scheme per user preference: `env=stg`, `node=notify-cloud`, no `initiative` tag. Default cheapest viable tier for `stg` (Container App: Consumption plan; Key Vault: Standard; App Config: Free if available).
+  - Use Azure Portal walkthroughs rather than CLI per user preference. Cross-link any relevant `infrastructure/walkthroughs/` doc.
+- [ ] **Post-merge canary verification.** After the scaffolding PR merges, open a throwaway PR that removes a public member from `INotifyCloudGateway` (e.g., delete the `CancellationToken cancellationToken = default` parameter), observe `api-compatibility / abstractions-shape` fail with breaking-changes-detected, record the failing run URL in a comment on the throwaway PR, then revert the throwaway PR. Once observed, update branch protection to add `api-compatibility / abstractions-shape` to the required-checks list. The scaffolding PR's merge establishes the `main` baseline; until that exists, the canary correctly reports `status: skipped` on every PR — that is not a misconfiguration.
+- [ ] **Push tag `v0.1.0`** from `main` to trigger the release workflow and publish the four packages to the private NuGet feed. Tags are human-pushed per invariant 27 — agents never push tags. **Confirm the release workflow is publishing to the private feed, not public NuGet, before pushing.**
+- [ ] **No Stripe API key seeding required at v0.1.0** — the Stripe billing emitter is a stub that throws. The follow-up Stripe billing integration ADR carries the API key provisioning step.
+- [ ] **No tenant-tier definitions seeded at v0.1.0** — `IConfigProvider` reads of `tenant-tier-{tenantId}` keys will return empty / default until a tenant is provisioned in App Configuration. That is fine for scaffold; tenant provisioning is a follow-up workflow (tenant onboarding doc per ADR-0027 unblocks list).
+- [ ] **Follow-up tracking: hive-sync catalog reconciliation.** After all six packets in this initiative merge, open a tracking issue against `HoneyDrunk.Architecture` titled "hive-sync: reconcile catalogs/*.json + initiatives/* + adrs/README.md after ADR-0027 standup" so that the explicitly-deferred index-file updates land as a single hive-sync pass. Per the standing convention, scope-agent-authored packets do not touch shared index files; hive-sync owns that step.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — `HoneyDrunk.Notify.Cloud.Abstractions.csproj` must contain no `HoneyDrunk.*` PackageReference or ProjectReference. The `HoneyDrunk.Standards` reference uses `PrivateAssets="all"` so it does not propagate.
+
+> **Invariant 2:** Runtime packages depend on Abstractions, never on other runtime packages at the same layer. — `HoneyDrunk.Notify.Cloud` references `HoneyDrunk.Communications.Abstractions`, `HoneyDrunk.Notify.Abstractions`, `HoneyDrunk.Auth.Abstractions`, `HoneyDrunk.Kernel.Abstractions` directly — not the runtime packages of any of those Nodes. Composition of the concrete runtimes happens at host time in the Container App.
+
+> **Invariant 3:** Provider packages depend on their parent Node's contracts, not internal implementation details. — `HoneyDrunk.Notify.Cloud.Billing.Stripe` references `HoneyDrunk.Kernel.Abstractions` (for the parent contract `IBillingEventEmitter` it implements) — that "parent" here is Kernel, not Notify Cloud, because the contract being implemented lives in Kernel per ADR-0026.
+
+> **Invariant 4:** No circular dependencies. The dependency graph is a DAG. Kernel is always at the root. — Notify Cloud references Communications, Notify, Auth, Vault, Kernel, Data; none of those reference Notify Cloud back. Notify Cloud is a leaf per ADR-0027 D9.
+
+> **Invariant 8:** Secret values never appear in logs, traces, exceptions, or telemetry. Only secret names/identifiers may be traced. `VaultTelemetry` enforces this. — Extended to API key material by local invariant 3 and constitutional invariant 54 (number assigned by packet 02). Raw API keys, plaintext payloads, and recipient PII are never logged or emitted to telemetry.
+
+> **Invariant 9:** Vault is the only source of secrets. — Stripe webhook signing key (when the Stripe stub becomes a real implementation), per-tenant secret scoping, tenant-tier definitions, cost-rate tables, abuse heuristics are all sourced from Vault's `ISecretStore` and `IConfigProvider`. Not from environment variables, not from config files, not from provider SDKs.
+
+> **Invariant 11:** One repo per Node. Each repo has its own solution, CI pipeline, and versioning. — This packet is the establishment of HoneyDrunk.Notify.Cloud's solution and CI pipeline.
+
+> **Invariant 12:** Semantic versioning with CHANGELOG and README. New projects must have both files from the first commit. — Every one of the four `src/*` projects ships a `README.md` and `CHANGELOG.md` in the same commit it is added.
+
+> **Invariant 13:** All public APIs have XML documentation. Enforced by HoneyDrunk.Standards analyzers. — Every public type/member in `HoneyDrunk.Notify.Cloud.Abstractions` carries `///` summaries. StyleCop rules from `HoneyDrunk.Standards` enforce this.
+
+> **Invariant 17:** One Key Vault per deployable Node per environment. Named `kv-hd-{service}-{env}`, with Azure RBAC enabled. Access policies are forbidden. — `kv-hd-notify-cloud-stg` provisioned per Human Prerequisites. Service name `notify-cloud` is 12 characters, fits within invariant 19's 13-char limit.
+
+> **Invariant 18:** Vault URIs and App Configuration endpoints reach Nodes via environment variables. `AZURE_KEYVAULT_URI` and `AZURE_APPCONFIG_ENDPOINT` are set as App Service config at deploy time. Never derived by convention, never hardcoded. — Set in the Container App's environment variables, not in code.
+
+> **Invariant 19:** Service names in Azure resource naming must be ≤ 13 characters. — `notify-cloud` is 12 characters, satisfies this.
+
+> **Invariant 22:** Every Key Vault must have diagnostic settings routed to the shared Log Analytics workspace. — Provisioned per Human Prerequisites.
+
+> **Invariant 26:** Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section. `HoneyDrunk.Standards` must be on every new .NET project. — Confirmed in the NuGet Dependencies section above.
+
+> **Invariant 27:** All projects in a solution share one version. — Every `src/*.csproj` ships at `0.1.0`. Test projects do not bump.
+
+> **Invariant 34:** Containerized deployable Nodes run on Azure Container Apps, named `ca-hd-{service}-{env}`, one per Node per environment, with system-assigned Managed Identity. — `ca-hd-notify-cloud-stg` per Human Prerequisites.
+
+> **Invariant 35:** One shared Container Apps Environment (`cae-hd-{env}`) and one shared Azure Container Registry (`acrhdshared{env}`) serve every containerized Node within a given environment. — `cae-hd-stg` and `acrhdsharedstg` per Human Prerequisites.
+
+> **Invariant 36:** Container App revision mode is `Multiple` with explicit traffic splitting on deploy. — Configured in the deployment workflow inputs.
+
+> **Invariant 39:** Tenant mechanics stay at intake and post-dispatch boundaries. Tenant resolution, tenant rate-limit checks, billing-event emission, and tenant-scoped secret lookup must live in intake middleware/orchestration edges or post-dispatch tails. Core dispatch paths for internal Grid callers must remain tenant-agnostic and default to `TenantId.Internal` without caller-specific branches. — `DefaultNotifyCloudGateway` is the intake middleware (resolves tenant from API key); `BillingEventEmissionTail` is the post-dispatch tail. Internal Grid callers never traverse Notify Cloud and continue to use `TenantId.Internal` through Kernel's `IGridContext` directly.
+
+> **Invariant 40:** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Communications.Abstractions`. Composition against `HoneyDrunk.Communications` is a host-time concern. — Notify Cloud runtime PackageReferences `HoneyDrunk.Communications.Abstractions`, not the runtime. The Container App composes the Communications runtime at host time.
+
+> **Notify Cloud private-repo carve-out invariant (number assigned by packet 02 of this initiative — default 51):** The HoneyDrunk Grid's repo default is public; private repos require an explicit ADR-recorded justification under the revenue/compliance/experiment carve-out. — This repo is private per ADR-0027 D2; LICENSE is `LicenseRef-Proprietary`.
+
+> **Notify Cloud hot-path invariant (number assigned by packet 02 of this initiative — default 52):** Commercial wrappers compose Communications, not Notify, for the hot delivery path. — `DefaultNotifyCloudGateway` calls `ICommunicationOrchestrator`, not `INotificationSender`. The Notify reference is `INotificationSender` for diagnostic/smoke-test paths only.
+
+> **Notify Cloud SDK-in-open-repo invariant (number assigned by packet 02 of this initiative — default 53):** Customer-facing SDKs that cover both self-host and hosted-service consumers ship from the open engine repo. — No SDK source files in this repo. `HoneyDrunk.Notify.Client` lives in `HoneyDrunk.Notify`.
+
+> **Notify Cloud API-key-hashing invariant (number assigned by packet 02 of this initiative — default 54):** API keys are stored only as salted hashes; raw key material is returned to the caller exactly once at issuance time and is never logged, traced, or persisted in raw form. — `HashingNotifyCloudApiKeyStore` enforces salted-hash storage; `ApiKeyIssuance` is the one-time issuance shape carrying the plaintext key.
+
+> **Notify Cloud contract-shape canary invariant (number assigned by packet 02 of this initiative — default 55):** The HoneyDrunk.Notify.Cloud Node CI must include a contract-shape canary that fails the build on shape drift to `INotifyCloudGateway`, `INotifyCloudApiKeyStore`, `NotifyCloudTenantTier`, or `ApiKeyIssuance` without a corresponding version bump. — `api-compatibility.yml` covers this by scoping to `HoneyDrunk.Notify.Cloud.Abstractions`.
+
+> **Notify Cloud FSL-on-engines invariant (number assigned by packet 02 of this initiative — default 56):** The open-source repos paired with `HoneyDrunk.Notify.Cloud` (`HoneyDrunk.Notify`, `HoneyDrunk.Communications`) ship under the Functional Source License (FSL) with two-year auto-conversion to Apache 2.0. The wrapper repo (`HoneyDrunk.Notify.Cloud`, private) is `LicenseRef-Proprietary`. — This repo's LICENSE is `LicenseRef-Proprietary` per ADR-0027 D11. The FSL application to the Notify and Communications repos is the substance of packets 03 and 04 of this initiative.
+
+## Referenced ADR Decisions
+
+**ADR-0027 D1 (Notify Cloud is the Ops sector's multi-tenant commercial wrapper above Notify):** Substrate stand-up. Owns API gateway, API key issuance/validation, per-tenant rate-limit enforcement, tenant-scoped billing-event emission, management website.
+
+**ADR-0027 D2 (Private repo + revenue carve-out):** LICENSE is `LicenseRef-Proprietary`. Release workflow publishes to private feed only. Repo description marks the repo as private.
+
+**ADR-0027 D3 (Package families):** Four packages — `HoneyDrunk.Notify.Cloud.Abstractions`, `HoneyDrunk.Notify.Cloud`, `HoneyDrunk.Notify.Cloud.Billing.Stripe`, `HoneyDrunk.Notify.Cloud.Web`. No `Testing` package at stand-up; in-memory fixtures live as `internal` test helpers until a second consumer emerges. Web stack default is Blazor Server per D3.
+
+**ADR-0027 D4 (Exposed contracts):** Four surfaces — `INotifyCloudGateway`, `INotifyCloudApiKeyStore`, `NotifyCloudTenantTier`, `ApiKeyIssuance`. Records drop `I`; interfaces keep it. Multi-tenant primitives consumed from Kernel per ADR-0026.
+
+**ADR-0027 D5 (Boundary rule):** `DefaultNotifyCloudGateway` delegates to `ICommunicationOrchestrator` for the hot path. Direct calls to `INotificationSender` are diagnostic/smoke-test only.
+
+**ADR-0027 D6 (SDK in open Notify repo):** No SDK source in this packet. `HoneyDrunk.Notify.Client` lives in `HoneyDrunk.Notify`.
+
+**ADR-0027 D7 (Telemetry direction):** `NotifyCloudTelemetry` emits via `ITelemetryActivityFactory` (Kernel). No Pulse PackageReference. Pulse consumes downstream. `tenant_id` is a direct low-cardinality label per the v1 cardinality bound.
+
+**ADR-0027 D8 (Contract-shape canary):** `api-compatibility.yml` is the canary. Scoped to `HoneyDrunk.Notify.Cloud.Abstractions` since per D9 that is the only public-boundary package.
+
+**ADR-0027 D9 (Downstream coupling — leaf node):** Notify Cloud is a leaf in the Grid-internal dependency graph. Its consumers are external customers via REST API or the SDK in the open Notify repo. Production composition is a host-time concern.
+
+**ADR-0027 D11 (FSL on open engine repos, proprietary on the wrapper):** This repo's LICENSE is `LicenseRef-Proprietary`. The FSL application to Notify and Communications is the substance of packets 03 and 04.
+
+**ADR-0027 D12 (API key authentication via Auth):** Validation primitive lives in `HoneyDrunk.Auth` as a new `IApiKeyAuthenticator` middleware path. Issuance lives in Notify Cloud (`INotifyCloudApiKeyStore.IssueAsync`). The Auth-side middleware shape, hashing scheme, and rotation flow are a separate follow-up ADR — this scaffold references `IApiKeyAuthenticator` as a placeholder and the runtime stubs the validation call until the follow-up ADR lands.
+
+**ADR-0027 D13 (Standup checklist):** This packet authors exactly the artifacts listed in D13 — solution layout, `HoneyDrunk.Standards` wiring, CI pipeline, README/CHANGELOG/LICENSE files, in-memory `INotifyCloudApiKeyStore`, default `INotifyCloudGateway`, Container Apps deployment configuration targeting `ca-hd-notify-cloud-stg`. Per D13 the scaffold does NOT include: the Stripe billing adapter implementation (stub only), the Web project's full surface (placeholder only), the API key authentication middleware in Auth (separate ADR), production tenant data (none).
+
+**ADR-0026 (Grid Multi-Tenant Primitives):** Accepted as of 2026-05-20. `TenantId`, `ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, `BillingEvent` consumed from `HoneyDrunk.Kernel.Abstractions.Tenancy`. Notify Cloud is the first real (non-noop) consumer of these primitives.
+
+**ADR-0019 (Communications standup):** `HoneyDrunk.Communications.Abstractions` at v0.2.0 carries `ICommunicationOrchestrator`, `IMessageIntent`, `MessageIntent`. Notify Cloud's hot path delegates here.
+
+**ADR-0015 (Container Hosting Platform):** `job-deploy-container-app.yml` reusable workflow handles Container Apps provisioning. `ca-hd-notify-cloud-stg` is the first deploy target; `cae-hd-stg` shared environment, `acrhdsharedstg` shared registry, system-assigned Managed Identity, `Multiple` revision mode.
+
+## Dependencies
+- `packet:01` — context-folder registration must land first so the Architecture repo's `repos/HoneyDrunk.Notify.Cloud/` matches what this packet ships.
+- `packet:02` — the six Notify Cloud invariants (private-repo carve-out, hot-path-through-Communications, SDK-in-open-repo, API-key-hashing, contract-shape canary, FSL-on-engines) must exist in `constitution/invariants.md` at their assigned numbers before this packet's acceptance criteria reference them.
+- `packet:05` — the GitHub repo must exist before this packet can be filed against it.
+
+## Labels
+`feature`, `tier-2`, `ops`, `scaffolding`, `new-node`, `commercial`, `adr-0027`
+
+## Agent Handoff
+
+**Objective:** Take the empty private `HoneyDrunk.Notify.Cloud` repo (created by packet 05) and ship version 0.1.0 with the four D4 contracts, default `INotifyCloudGateway` wiring API key validation → rate-limit → orchestration delegation → billing emission, salted-hash API key store, Notify-Cloud-specific rate-limit policy replacing Kernel's noop, Stripe billing-adapter stub, Web placeholder, full CI including the contract-shape canary, proprietary LICENSE, and Container Apps deployment configuration targeting `ca-hd-notify-cloud-stg`.
+
+**Target:** HoneyDrunk.Notify.Cloud (private), branch from `main`. The repo exists at this point — packet 05 created it Private with an initial README. Branch from `main` for the first feature commit; do not push directly to `main`.
+
+**Context:**
+- Goal: Unblock PDR-0002 Phase 3 (Notify Cloud scaffold, weeks 10-14). Without this scaffold, the entire Phase 3 follow-up surface (Stripe integration ADR, API key authentication ADR, Communications decision-log persistence ADR, tenant onboarding workflow doc, Web full-surface packets) has no compile target.
+- **Strategic positioning (PDR-0002).** Notify Cloud is the Grid's first commercial Node — the wrapper that converts the open-source Notify and Communications engines into a multi-tenant paid product. PDR-0002 commits to a single-region East US deployment at v1, a private-feed-only release path, and a Stripe-mediated billing model. This packet is the substrate stand-up; the commercial surface (Stripe webhook bridge, signup, billing dashboard) is staged across follow-up packets per PDR-0002 Phase 3. Treat the scaffold quality as the Grid's first impression — every shortcut compounds.
+- Feature: ADR-0027 standup initiative — this is the substrate scaffold, the largest packet of the initiative.
+- ADRs: ADR-0027 (sole governing ADR for the standup); ADR-0026 (multi-tenant primitives consumed); ADR-0019 (Communications hot-path delegate); ADR-0015 (Container Apps hosting platform); ADR-0033 (deploy-trigger model — staged to follow-up per the Phase 0 note in the deploy-stg.yml block).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packets 01, 02, and 05 of this initiative must complete first.
+
+**Constraints:**
+
+- **Invariant 1 — ADR-0027 D3 carve-out:** Invariant 1 says Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. **ADR-0027 D3 explicitly carves out three permitted Abstractions references for `HoneyDrunk.Notify.Cloud.Abstractions`:** `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.Notify.Abstractions`, `HoneyDrunk.Communications.Abstractions`. This is the same pattern `HoneyDrunk.Communications.Abstractions` already follows (it PackageReferences `HoneyDrunk.Kernel.Abstractions`). The strict-Abstractions stance from sibling ADR-0016 / ADR-0017 packets does NOT apply here. Only `HoneyDrunk.Kernel.Abstractions` is load-bearing at v0.1.0 (for `TenantId`); the other two may be omitted if no v0.1.0 contract consumes them. `HoneyDrunk.Standards` is the only `PrivateAssets="all"` reference.
+- **Invariant 2 — runtime packages reference Abstractions, not other runtime packages.** `HoneyDrunk.Notify.Cloud.csproj` PackageReferences `HoneyDrunk.Kernel.Abstractions`, NOT `HoneyDrunk.Kernel` (the runtime). The Kernel runtime is composed at host time by the Container App's startup; the Notify Cloud runtime depends only on Abstractions per invariant 2.
+- **Kernel multi-tenant primitives are CONSUMED.** Per ADR-0027 D4 and ADR-0026 (Accepted), `ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, `BillingEvent` live in `HoneyDrunk.Kernel.Abstractions.Tenancy`. **Do not redeclare any of these in `HoneyDrunk.Notify.Cloud.Abstractions`.** The Notify Cloud Abstractions package references `HoneyDrunk.Kernel.Abstractions` for `TenantId` only (the type, used as field types on the four D4 contracts). The policy/decision/emitter/event types are consumed at the runtime layer, where `HoneyDrunk.Notify.Cloud` references `HoneyDrunk.Kernel.Abstractions` to pull in `HoneyDrunk.Kernel.Abstractions.Tenancy`.
+- **`TenantId` is the strong type, not `string`.** Per ADR-0026 D1, `TenantId` is the canonical Grid tenant identifier — a ULID-backed `readonly record struct` in `HoneyDrunk.Kernel.Abstractions.Identity`. The four D4 contracts use the strong type for every TenantId-shaped field: `NotifyCloudGatewayRequest.TenantIdHint` is `TenantId?` (nullable — see the next constraint); `INotifyCloudApiKeyStore.IssueAsync(TenantId tenantId, ...)`; `INotifyCloudApiKeyStore.ValidateAsync` returns `TenantId?`; `INotifyCloudApiKeyStore.ListForTenantAsync(TenantId tenantId, ...)`; `ApiKeyMetadata.TenantId` is `TenantId`; `ApiKeyIssuance.TenantId` is `TenantId`. **The string-typed boundary is a sibling-packet artifact, not the ADR's intent.**
+- **`TenantIdHint` is `TenantId?` (nullable), `TenantId.Internal` is forbidden at the gateway, and `IssueAsync(TenantId.Internal, ...)` throws.** `default(TenantId).Value == Ulid.Empty == TenantId.Internal` — the Internal sentinel and an unset/zeroed `TenantId` are byte-identical. Three layered defenses close the aliasing security hole: (1) `NotifyCloudGatewayRequest.TenantIdHint` is declared `TenantId?` so `null` unambiguously means "no hint" rather than "Internal tenant"; (2) `DefaultNotifyCloudGateway.ProcessAsync` step 1a explicitly rejects validated keys that resolve to `TenantId.Internal` with the `Unauthorized` error code; (3) `HashingNotifyCloudApiKeyStore.IssueAsync` throws `ArgumentException` when called with `TenantId.Internal`. The Internal sentinel is reserved for Grid-internal callers that never traverse the Notify Cloud gateway and have no API keys.
+- **`KeyId` / `ApiKeyId` stay `string` at v0.1.0.** Promotion to a record-struct `ApiKeyId` is a follow-up — the API key authentication ADR per ADR-0027 D12 settles it jointly with the Auth-side middleware shape. Leave `KeyId` as `string` with a TODO comment near `INotifyCloudApiKeyStore` pointing at the follow-up ADR.
+- **`CallerCorrelationId` stays `string` at v0.1.0.** Promoting the Kernel `CorrelationId` record-struct into Abstractions is a separate Grid-wide decision, not bundled with this Node's stand-up. The runtime's `DefaultNotifyCloudGateway` reconciles the string against the ambient `IGridContext.CorrelationId` via `IGridContextAccessor` (Kernel Abstractions).
+- **Records drop `I`; interfaces keep it.** `NotifyCloudTenantTier`, `ApiKeyIssuance`, `NotifyCloudGatewayRequest`, `NotifyCloudGatewayResult`, `NotifyCloudGatewayError`, `ApiKeyMetadata` are all records. `INotifyCloudGateway`, `INotifyCloudApiKeyStore` are interfaces.
+- **API keys are salted-hash only, returned exactly once.** Per local invariant 3 and constitutional invariant 54 (default-numbered): `HashingNotifyCloudApiKeyStore.IssueAsync` returns the plaintext via `ApiKeyIssuance` exactly once; the repository persists only `(KeyId, TenantId, Label, Salt, Hash, IssuedAt, RevokedAt)`. No path retrieves the raw key after issuance. Use Argon2id or PBKDF2 (caller-configurable; default Argon2id) for hashing; do not use plain SHA-256. Use `System.Security.Cryptography.CryptographicOperations.FixedTimeEquals` for hash comparison.
+- **Hot path goes through Communications.** Per ADR-0027 D5 and constitutional invariant 52 (default-numbered): `DefaultNotifyCloudGateway.ProcessAsync` calls `ICommunicationOrchestrator.OrchestrateAsync` for delivery. The `HoneyDrunk.Notify.Abstractions` reference (for `INotificationSender`) is only for diagnostic/smoke-test paths — do NOT call it from the gateway's customer-facing pipeline.
+- **`ITenantRateLimitPolicy` is replaced via `services.Replace(...)`, not added.** Kernel registers `NoopTenantRateLimitPolicy` as the default; Notify Cloud's `TierDrivenTenantRateLimitPolicy` must supersede it, not be added alongside (which would leave the noop in service-resolution order and produce inconsistent enforcement). Per invariant 39, the core dispatch path stays tenant-agnostic for internal callers (using the noop); Notify Cloud's external-call path uses the tier-driven policy.
+- **Kernel signature compliance — exact match.** `TierDrivenTenantRateLimitPolicy` MUST implement `ITenantRateLimitPolicy.EvaluateAsync(TenantId tenantId, string operationKey, CancellationToken cancellationToken) → ValueTask<TenantRateLimitDecision>` exactly. NOT `CheckAsync`. NOT `Task<...>`. The parameter is named `operationKey` per the Kernel contract; the gateway maps `request.CapabilityKey` to that slot at the call site. `TenantRateLimitDecision` is positional `(TenantRateLimitOutcome Outcome, TimeSpan? RetryAfter, string? Reason)` — NOT `(bool Allowed, string? DenyReason, int? RetryAfterSeconds)`. Similarly, `IBillingEventEmitter.EmitAsync(BillingEvent, CancellationToken) → ValueTask` (NOT `Task`). `BillingEvent` is 7-positional `(TenantId, string EventType, string OperationKey, long Units, DateTimeOffset OccurredAtUtc, string CorrelationId, IReadOnlyDictionary<string, string> Attributes)`. Conversion from `TenantRateLimitDecision.RetryAfter` (`TimeSpan?`) to `NotifyCloudGatewayError.RetryAfterSeconds` (`int?`) happens at the gateway boundary via `(int)Math.Ceiling(ts.TotalSeconds)`. Kernel's `NoopBillingEventEmitter` does NOT short-circuit on `TenantId.Internal` (it null-checks and returns) — so the gateway itself is responsible for skipping emission on Internal; see `DefaultNotifyCloudGateway` step 8.
+- **Capability-availability lives at the gateway, not the rate-limit policy.** The channel-in-tier check (`tier.EnabledChannels.Contains(...)`) is a gateway concern that surfaces the dedicated `CapabilityNotAvailable` error code, not part of `TierDrivenTenantRateLimitPolicy.EvaluateAsync`. The rate-limit policy stays a pure rate-limit policy.
+- **Tier resolver is `AddScoped`.** `_tierResolver` is a Notify-Cloud-private DI service backed by `IConfigProvider`, registered as `AddScoped` so that the gateway's read (step 2) and the policy's read share the same scoped instance within a request scope. No duplicate `IConfigProvider` calls; no callback into the keystore for tier data.
+- **Tenant tier definitions, cost rates, abuse heuristics are config-sourced.** Per local invariant 5: these come from Azure App Configuration via `IConfigProvider`. Do not hardcode tier definitions, event ceilings, or rate-table values in code. Use `IConfigProvider` reads and document the App Configuration keys in `HoneyDrunk.Notify.Cloud/README.md`.
+- **GridContext propagation lives in the runtime, not Abstractions.** `NotifyCloudGatewayRequest.CallerCorrelationId` is `string`, not `Kernel.CorrelationId`. The runtime's `DefaultNotifyCloudGateway` reconciles the string against the ambient `IGridContext.CorrelationId` via `IGridContextAccessor` (Kernel). Same pattern as Capabilities's `DefaultCapabilityInvoker`.
+- **No raw API keys, payloads, or PII in telemetry.** Per invariant 8 and constitutional invariant 54 (default-numbered): only metadata (tenant_id, capability_key, outcome, latency_ms). `NotifyCloudTelemetry` activities carry no plaintext request body, no `request.ApiKey`, no recipient details.
+- **LICENSE is proprietary.** Per ADR-0027 D11 and constitutional invariant 56 (default-numbered): LICENSE file at repo root with `LicenseRef-Proprietary` content (all rights reserved by default of being private). `<PackageLicenseFile>LICENSE</PackageLicenseFile>` packs into every `.nupkg`. Do NOT use FSL on this repo — FSL applies to the engine repos (Notify, Communications) handled by packets 03 and 04. The wrapper is proprietary.
+- **Release workflow publishes to private feed only.** Per ADR-0027 D2 confidentiality: `release.yml` must be configured for the private NuGet feed, not public NuGet. Verify the feed-URL parameter in the workflow before merging. If accidentally configured for public NuGet, reject the workflow and reauthor.
+- **Stripe billing-adapter is a stub.** Per ADR-0027 D13: `StripeBillingEventEmitter.EmitAsync` throws `NotImplementedException` with the TODO referencing the follow-up Stripe billing integration ADR. The scaffold's end-to-end smoke test uses an in-memory `LoggingBillingEventEmitter` (internal test helper in the runtime project's test project, per D3 "in-memory fixtures live as `internal` test helpers until a second consumer emerges").
+- **Web project is a placeholder.** Per ADR-0027 D13: health endpoint + signup form scaffold (Blazor Server) only. Do NOT implement signup logic, billing dashboard, or delivery logs — those are follow-up packets.
+- **API key authentication middleware in Auth is a follow-up.** Per ADR-0027 D12: the `IApiKeyAuthenticator` interface exists in `HoneyDrunk.Auth.Abstractions` (or will, once the follow-up ADR lands). For v0.1.0, the gateway calls `_apiKeyStore.ValidateAsync(request.ApiKey, ct)` directly (the Notify-Cloud-local store), with a TODO comment marking the spot where `IApiKeyAuthenticator` middleware will wrap this call once the follow-up ADR lands. The TODO must reference ADR-0027 D12.
+- **Container App service name must be ≤ 13 characters per invariant 19.** `notify-cloud` is 12 characters — fits. `ca-hd-notify-cloud-{env}` per invariant 34; `kv-hd-notify-cloud-{env}` per invariant 17.
+- **Canary on the scaffolding PR is expected to report `status: skipped`, not fail.** The shared `HoneyDrunk.Actions/.github/actions/api/check-compatibility/action.yml` emits `::warning::` and exits 0 with `status: skipped` when `git worktree add` against the baseline ref fails — which it always does on a first PR against a near-empty repo. Do not treat the skip as a misconfiguration. The scaffolding PR's merge establishes the `main` baseline; verification of the canary actually firing happens **post-merge** via a throwaway breaking-change PR that is reverted after observation.
+- **Notify Cloud Abstractions reference policy is ADR-0027 D3, not the strict-Abstractions stance from sibling packets.** ADR-0027 D3 reads: "Zero runtime dependencies beyond `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.Notify.Abstractions`, and `HoneyDrunk.Communications.Abstractions`." This is a deliberate carve-out — the Communications.Abstractions package (closest sibling) already PackageReferences `HoneyDrunk.Kernel.Abstractions` and that is the established Ops-sector pattern. Concretely: `NotifyCloudGatewayRequest.TenantIdHint` is `TenantId` (the Kernel strong type from `HoneyDrunk.Kernel.Abstractions.Identity` per ADR-0026 D1); `NotifyCloudGatewayRequest.CallerCorrelationId` stays `string` at v0.1.0 (promoting `CorrelationId` to a record-struct in Kernel.Abstractions is a separate Grid-wide decision); the four contracts PackageReference `HoneyDrunk.Kernel.Abstractions`. The other two carved-out references (`HoneyDrunk.Notify.Abstractions`, `HoneyDrunk.Communications.Abstractions`) may be omitted at v0.1.0 if no contract consumes them; both stay permitted by D3 for future extension.
+
+**Key Files:**
+- `HoneyDrunk.Notify.Cloud.slnx`, `Directory.Build.props`, `LICENSE` (proprietary)
+- `src/HoneyDrunk.Notify.Cloud.Abstractions/INotifyCloudGateway.cs`, `INotifyCloudApiKeyStore.cs`, `NotifyCloudTenantTier.cs`, `ApiKeyIssuance.cs`, supporting record/enum types
+- `src/HoneyDrunk.Notify.Cloud/ServiceCollectionExtensions.cs`, `Gateway/DefaultNotifyCloudGateway.cs`, `ApiKeys/HashingNotifyCloudApiKeyStore.cs`, `RateLimiting/TierDrivenTenantRateLimitPolicy.cs`, `Billing/BillingEventEmissionTail.cs`, `Telemetry/NotifyCloudTelemetry.cs`
+- `src/HoneyDrunk.Notify.Cloud.Billing.Stripe/StripeBillingEventEmitter.cs` (stub)
+- `src/HoneyDrunk.Notify.Cloud.Web/Program.cs`, `Pages/Health.razor`, `Components/SignupPlaceholder.razor`
+- `.github/workflows/{pr-core,release,nightly-deps,nightly-security,api-compatibility,deploy-stg}.yml`
+- `README.md`, `CHANGELOG.md` (repo-level), per-package `README.md` and `CHANGELOG.md`
+- `tests/HoneyDrunk.Notify.Cloud.Tests/`, `tests/HoneyDrunk.Notify.Cloud.Billing.Stripe.Tests/`, etc.
+
+**Contracts:**
+- All four D4 contracts authored fresh in this packet inside `HoneyDrunk.Notify.Cloud.Abstractions`. The contracts use the strong `TenantId` type (`HoneyDrunk.Kernel.Abstractions.Identity.TenantId`) for every TenantId-shaped field per ADR-0026 D1; `KeyId` stays `string` at v0.1.0 with a TODO referencing the API key authentication ADR follow-up.
+- The contract-shape canary establishes its baseline against this packet's commit. Future shape changes to any public type in Abstractions trigger the canary.
+- **Do NOT redeclare** `TenantId`, `ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, or `BillingEvent` in this repo. `TenantId` lives in `HoneyDrunk.Kernel.Abstractions.Identity`; the policy / decision / emitter / event types live in `HoneyDrunk.Kernel.Abstractions.Tenancy`. All five are consumed via the `HoneyDrunk.Kernel.Abstractions` PackageReference per ADR-0026.

--- a/generated/issue-packets/active/adr-0027-notify-cloud-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0027-notify-cloud-standup/dispatch-plan.md
@@ -1,0 +1,138 @@
+# Dispatch Plan — ADR-0027 HoneyDrunk.Notify.Cloud Standup
+
+**Initiative:** `adr-0027-notify-cloud-standup`
+**Sector:** Ops
+**Governing ADR:** [ADR-0027 — Stand Up the HoneyDrunk.Notify.Cloud Node](../../../../adrs/ADR-0027-stand-up-honeydrunk-notify-cloud-node.md) (Proposed 2026-05-02; flips to Accepted only after every packet in this initiative is closed, as a separate post-merge housekeeping step the scope agent runs. None of the packets in this initiative flip ADR-0027's status.)
+**Prerequisite ADR:** [ADR-0026 — Grid Multi-Tenant Primitives](../../../../adrs/ADR-0026-grid-multi-tenant-primitives.md) (**Accepted** as of 2026-05-20 — confirmed at scoping time). Notify Cloud is the first real (non-noop) consumer of `ITenantRateLimitPolicy` and `IBillingEventEmitter`. Per ADR-0027 D10 the standup ADR cannot flip Accepted until ADR-0026 is Accepted; that gate is now satisfied.
+**Trigger:** PDR-0002 commits HoneyDrunk Notify as the Grid's first commercial product. ADR-0027 is the standup ADR that decides what the Notify Cloud Node owns, its package families, its four exposed contracts, its private-repo visibility, and the FSL license posture of the surrounding open-source engine repos. This initiative is the follow-up work.
+**Type:** Multi-repo (4 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.Notify` + `HoneyDrunk.Communications` + `HoneyDrunk.Notify.Cloud` (new, private))
+**Site sync required:** No (scaffold + license-application only; no Studios website content depends on this initiative yet — marketing-site copy that mentions FSL on Notify is a separate PDR-0002 follow-up doc tracked elsewhere)
+**Rollback plan:**
+- **Pre-tag rollback** (before `v0.1.0` of `HoneyDrunk.Notify.Cloud` is pushed): `git revert` each PR independently. Packets 01–03 are reverts in the Architecture, Notify, and Communications repos respectively. Packet 04 is the human-only chore; reverting it means deleting the private repo (org-admin action). Packet 05's scaffold reverts as a single PR.
+- **Post-tag rollback** (after `v0.1.0` of Notify.Cloud is pushed but before customers consume): The private feed packages are unconsumed at this stage. Pull from the feed or fix-forward as `0.1.1`. The FSL LICENSE commits on Notify and Communications are pure additions; reverting them is a clean revert. Once a customer is paying against the hosted service, rollback is no longer a clean option — treat any defect as forward-only.
+- **`file-packets.yml` lifecycle gotcha:** after this initiative's packets have moved through The Hive, hive-sync may move source packet files from `active/` to `completed/` per invariant 37. A `git revert` only undoes code changes, not packet-file moves. If a revert is needed after lifecycle moves, restore the packet files manually as part of the revert PR.
+
+## Summary
+
+ADR-0027 is the standup ADR for `HoneyDrunk.Notify.Cloud` — the Grid's first commercial-revenue-bearing Node and its first private repo. It decides what the Node owns (D1), the private-repo visibility carve-out (D2), the four package families (D3 — Abstractions / runtime / Stripe billing / Web), the four frozen contracts (D4 — `INotifyCloudGateway`, `INotifyCloudApiKeyStore`, `NotifyCloudTenantTier`, `ApiKeyIssuance`), the boundary rule with Notify and Communications (D5), the SDK-stays-in-open-Notify-repo rule (D6), one-way telemetry to Pulse (D7), the contract-shape canary (D8), the leaf-node downstream coupling (D9), the hard prerequisite on ADR-0026 (D10), the Functional Source License (FSL) for the open engine repos (D11), API key validation routed through Auth (D12), and the first-PR scaffold checklist (D13). None of that has been built — the Node does not exist on disk and the GitHub repo does not exist yet.
+
+Five packets land the work:
+
+1. **Architecture context-folder + sector-map registration** — create the standard `repos/HoneyDrunk.Notify.Cloud/` folder with five files (`overview.md`, `boundaries.md`, `invariants.md`, `active-work.md`, `integration-points.md`), update `constitution/sectors.md` Ops-sector entry to include Notify Cloud. **Does NOT touch `catalogs/*.json` or shared initiative/ADR index files** — hive-sync reconciles those after the initiative completes. Does **not** flip ADR-0027's Status — that is a separate post-merge housekeeping step.
+2. **Constitution invariants** — six new invariants from ADR-0027's "New invariants (proposed for `constitution/invariants.md`)" section: D2 (repo public-default + revenue carve-out), D5 (hot-path goes through Communications), D6 (SDK lives in open Notify repo), D4/D12 (API key hashed-only / returned-once), D8 (contract-shape canary), D11 (FSL on engine repos). Assigned to the next six free numbers after the file's current highest, with a hard collision-check gate at edit time.
+3. **FSL LICENSE for `HoneyDrunk.Notify`** — apply the Functional Source License (two-year auto-conversion to Apache 2.0) to the open Notify engine + SDK repo per ADR-0027 D11. Includes `LICENSE` file commit, repo description update, and `PackageLicenseExpression` / `PackageLicenseFile` settings in every shipping `.csproj`. **The SDK package (`HoneyDrunk.Notify.Client`) lives in this repo per D6 and ships under the same FSL** — no separate package metadata required.
+4. **FSL LICENSE for `HoneyDrunk.Communications`** — same change applied to the Communications repo per ADR-0027 D11. Separate packet from 03 because target repos differ; both packets ship the same license text but the target file paths and `.csproj` updates are repo-specific.
+5. **Create `HoneyDrunk.Notify.Cloud` GitHub repo as PRIVATE (human-only)** — org-admin chore. The Grid's first private repo. Explicit revenue carve-out from the public-by-default policy per ADR-0027 D2.
+6. **HoneyDrunk.Notify.Cloud scaffold** — empty repo to first-shippable state per ADR-0027 D13. Solution layout, four projects (`HoneyDrunk.Notify.Cloud.Abstractions`, `HoneyDrunk.Notify.Cloud`, `HoneyDrunk.Notify.Cloud.Billing.Stripe`, `HoneyDrunk.Notify.Cloud.Web`) plus matching `.Tests` projects, the four D4 contracts in Abstractions, default `INotifyCloudGateway` wiring API-key-validation → rate-limit → orchestration-delegation → billing-emission, in-memory `INotifyCloudApiKeyStore` for tests, Notify-Cloud-specific `ITenantRateLimitPolicy` implementation replacing Kernel's noop, Stripe billing-adapter stub, Web project placeholder (signup form scaffold + health endpoint), five CI workflows including the contract-shape canary scoped to `HoneyDrunk.Notify.Cloud.Abstractions`, Container Apps deployment configuration referencing ADR-0015's `job-deploy-container-app.yml` workflow targeting `ca-hd-notify-cloud-stg`, proprietary `LICENSE` file (`LicenseRef-Proprietary`).
+
+## Wave Diagram
+
+```
+Wave 1: Architecture context + constitution updates (sequential)
+   ├─ Architecture: 01-architecture-notify-cloud-context-folder
+   └─ Architecture: 02-architecture-notify-cloud-invariants
+       Blocked by: 01 (so the invariant text aligns with the context-folder content 01 lands)
+
+Wave 2: FSL on open engine repos (parallel — independent target repos)
+   ├─ Notify: 03-notify-fsl-license
+   │   Blocked by: 01 (so the new constitution language about FSL is present before the LICENSE file references it)
+   └─ Communications: 04-communications-fsl-license
+       Blocked by: 01
+
+Wave 3: Private repo creation (human-only)
+   └─ Architecture: 05-architecture-create-notify-cloud-repo
+       Blocked by: 01, 02
+
+Wave 4: Notify.Cloud scaffold (the substrate stand-up)
+   └─ Notify.Cloud: 06-notify-cloud-node-scaffold
+       Blocked by: 01, 02, 05
+```
+
+Packets 03 and 04 can ship in parallel — same change to different repos. Packet 05 is human-only and gates packet 06 because the private repo it creates is the target repo of packet 06 — `file-packets.sh` cannot file an issue against a repo that does not exist yet.
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 01 | [Architecture context-folder + sector-map registration](./01-architecture-notify-cloud-context-folder.md) | Architecture | 1 | Agent | — |
+| 02 | [Add six new invariants for D2 / D5 / D6 / D4+D12 / D8 / D11](./02-architecture-notify-cloud-invariants.md) | Architecture | 1 | Agent | 01 |
+| 03 | [Apply FSL LICENSE to `HoneyDrunk.Notify`](./03-notify-fsl-license.md) | Notify | 2 | Agent | 01 |
+| 04 | [Apply FSL LICENSE to `HoneyDrunk.Communications`](./04-communications-fsl-license.md) | Communications | 2 | Agent | 01 |
+| 05 | [Create `HoneyDrunk.Notify.Cloud` GitHub repo as PRIVATE (human-only)](./05-architecture-create-notify-cloud-repo.md) | Architecture (tracking issue) | 3 | Human | 01, 02 |
+| 06 | [Stand up `HoneyDrunk.Notify.Cloud` — solution, four packages, contracts, CI, Container Apps wiring](./06-notify-cloud-node-scaffold.md) | HoneyDrunk.Notify.Cloud | 4 | Agent | 01, 02, 05 |
+
+## Phase Mapping
+
+- **Wave 1 (packets 01 + 02) = ADR-0027's "If Accepted" obligations on the Architecture repo, minus catalog reconciliation.**
+  - Packet 01 covers the new `repos/HoneyDrunk.Notify.Cloud/` context folder (five files matching the template used by `repos/HoneyDrunk.Communications/`) and the sector-map row in `constitution/sectors.md`. It explicitly does **not** touch `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/grid-health.json`, `catalogs/contracts.json`, or `catalogs/modules.json` per the user's standing instruction that hive-sync reconciles shared catalog indexes after standup initiatives complete. The same instruction applies to `initiatives/active-initiatives.md`, `initiatives/proposed-adrs.md`, and `adrs/README.md`.
+  - Packet 02 covers the six new invariants ADR-0027 explicitly delegates to the scope agent at acceptance.
+- **Wave 2 (packets 03 + 04) = the FSL license obligation from D11.** Two separate packets because target repos differ. The license text is identical; the per-`.csproj` `PackageLicenseExpression`/`PackageLicenseFile` updates and the repo-level LICENSE file commits are repo-specific. Both packets reference the FSL invariant landed by packet 02.
+- **Wave 3 (packet 05) = the human-only private repo creation chore.** Surfaced as its own packet so it lives on The Hive board with `Actor=Human` and the `human-only` label. **First private repo in the Grid** — the packet must explicitly call this out so the human selects "Private" rather than the org default of Public.
+- **Wave 4 (packet 06) = the standup itself.** Four packages, four contracts, in-memory API key store, Notify-Cloud-specific rate-limit policy replacing Kernel's noop, Stripe billing-adapter stub, Web placeholder, full CI including the contract-shape canary, and Container Apps deployment config referencing ADR-0015's reusable workflow.
+
+## Filing-order rule
+
+Packet 06 hard-codes invariant numbers in its body and acceptance criteria. Filed packets are immutable (invariant 24). Therefore:
+
+**Packet 02 must be filed, its PR merged, and the assigned invariant numbers locked in `constitution/invariants.md` before packet 06 is filed.**
+
+The invariants this packet adds are sized as the next six free numbers after the file's current highest. As of 2026-05-20, the file's highest assigned number is **43** (ADR-0019 Communications canary). However, two in-flight initiatives — ADR-0016 AI standup and ADR-0017 Capabilities standup — are also waiting to land three and four new invariants respectively. Their packet 02s claim 44/45/46 and 47/48/49/50 (or whatever the next-free sequence is at the moment each lands; collision-check is in their dispatch plans).
+
+**Working assumption for this initiative's packet 02:** the file's highest existing number at the time this packet lands could be anywhere from 43 (none of ADR-0016/0017 have landed yet) to 50 (both have landed and claimed 44-46 and 47-50). Packet 02's `Proposed Implementation` section explicitly says "scan the file at edit time; claim the next six free numbers regardless of what they are." Default-assumption text in this dispatch plan uses **51-56** under the conservative assumption that ADR-0016 and ADR-0017 both land first.
+
+**Packets 02 and 06 cannot be filed in the same push.** Concretely:
+
+1. Push packets 01, 02, 03, 04 (they may travel together — packet 02 / 03 / 04's `dependencies: ["packet:01"]` wire the blocking edges automatically).
+2. Push packet 05 in the same wave or shortly after (it depends on 01 and 02).
+3. Wait for packet 02's PR to merge so the assigned invariant numbers actually land in `constitution/invariants.md`.
+4. Wait for packet 05 to close (the private repo must exist before packet 06 can be filed against it).
+5. If the numbers shifted away from the assumed 51-56, edit `06-notify-cloud-node-scaffold.md` in place to match (pre-filing carve-out under invariant 24).
+6. Push packet 06.
+
+Packet 02's acceptance criteria call this out; packet 06's body assumes the lock has happened.
+
+## Sequencing vs ADR-0016 and ADR-0017
+
+Three standup initiatives are in flight concurrently and each claims the next available invariant numbers:
+
+- **ADR-0016 (AI standup):** three invariants. Packet 02's default is 44/45/46.
+- **ADR-0017 (Capabilities standup):** four invariants. Packet 02's default is 43/44/45/46 (per its dispatch plan note that ADR-0019's 43 may already be taken — collision-check at edit time wins).
+- **ADR-0027 (this initiative, Notify Cloud standup):** six invariants. Default 51-56 assuming the two above land first.
+
+Whichever lands first takes the lowest numbers; the others shift. ADR-0027's packet 02 explicitly uses runtime collision-check rather than hard-coded numbers, and its packet 06 source file is amended in place if the numbers shift (pre-filing carve-out under invariant 24).
+
+The user's instruction during scoping is that this race is resolved by whichever PR merges first — no hard sequencing requirement between the three standup initiatives at the invariant-numbering layer. The substantive work of each initiative is independent and can ship in any order.
+
+## What This Initiative Does **NOT** Deliver
+
+- **The Stripe billing-adapter implementation.** Per ADR-0027 D13, the `HoneyDrunk.Notify.Cloud.Billing.Stripe 0.1.0` package ships as a *stub* — the interface is implemented but the actual webhook bridge / metered-billing wiring is deferred to a follow-up ADR (per PDR-0002's recommended follow-up artifacts: Stripe billing integration ADR). The stub satisfies the contract-shape canary; production wiring lands later.
+- **The Web project's full surface.** D13 says the `HoneyDrunk.Notify.Cloud.Web 0.1.0` ships as a placeholder — health endpoint + signup form scaffold only. Signup flow, billing dashboard, delivery logs, and tenant management UI all land in follow-up packets.
+- **API key authentication middleware in `HoneyDrunk.Auth`.** Per ADR-0027 D12, the validation primitive lives in Auth as a new `IApiKeyAuthenticator` middleware path. The detailed mechanism (middleware shape, hashing scheme, rotation flow) is a separate follow-up ADR. This stand-up commits to the boundary; the mechanism is settled later.
+- **The Communications decision-log persistence backend.** Per ADR-0027's "Unblocks" section, Notify Cloud Pro tier exposes the decision log, which tightens the requirements on the persistence backend. That is a separate ADR (Communications decision-log persistence ADR).
+- **Per-tenant AI cost rollups, Pro-tier preference learning, multi-region deployment.** All explicitly out of scope at v1 per ADR-0027 D5's "v1 dependencies" framing and PDR-0002 Phase 5.
+- **Production tenant data, real Stripe integration, real Auth API-key middleware.** The scaffold proves the contract surface compiles, the canary catches drift, and the in-memory composition runs end-to-end. Production-shape work follows.
+- **Catalog reconciliation in `catalogs/*.json`, the `nodes.json` `visibility` schema-field introduction, sector index updates, ADR README index updates, initiative tracking entries.** These are deferred to the hive-sync agent's next run after this initiative's PRs merge. Per the user's standing instruction, scope agent does not touch shared index files.
+
+## Notes
+
+- **First private repo in the Grid.** The whole Grid has been public-by-default since inception. Packet 05's body explicitly documents (a) the revenue carve-out from D2, (b) the customer-data-adjacent-infrastructure / hyperscaler-defense / billing-integrity justifications, (c) the human-only step of clicking "Private" rather than letting GitHub default to Public, and (d) the LicenseRef-Proprietary stance (no public license file).
+- **The SDK stays in the open Notify repo per D6.** Packet 03's FSL LICENSE application covers the SDK as a same-repo artifact — no separate license commit for `HoneyDrunk.Notify.Client`. Future contributors must not relocate the SDK into the private Notify.Cloud repo. The scaffold packet (06) does not author SDK source files.
+- **Two-stage license posture.** Open engine repos (Notify + Communications) get FSL (two-year auto-conversion to Apache 2.0). The private wrapper repo (Notify.Cloud) gets `LicenseRef-Proprietary` — all rights reserved by default of being private. Both stances are recorded by ADR-0027 D11 and packet 02's FSL invariant.
+- **Contract-shape canary needs no Actions repo change.** Per ADR-0027 D8 and the pattern established in ADR-0016 D8 / ADR-0017 D8 / ADR-0019 D8, the existing `HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml` already supports `project-path`-scoped diffing. Packet 06 wires a single `.github/workflows/api-compatibility.yml` file inside HoneyDrunk.Notify.Cloud itself, scoped to `HoneyDrunk.Notify.Cloud.Abstractions`. No Actions repo change required.
+- **Kernel multi-tenant primitives are CONSUMED, not redefined.** ADR-0027 D4 is explicit: `TenantId`, `ITenantRateLimitPolicy`, `TenantRateLimitDecision`, `IBillingEventEmitter`, `BillingEvent` all live in `HoneyDrunk.Kernel.Abstractions.Tenancy` per ADR-0026 (now Accepted). Packet 06 does **not** declare any of these in `HoneyDrunk.Notify.Cloud.Abstractions`. Notify Cloud is the first *real* (non-noop) consumer of `ITenantRateLimitPolicy` and the first *real* implementation of `IBillingEventEmitter` in the Grid — but it does not own those contracts.
+- **Records drop `I`; interfaces keep it.** Per the Grid-wide naming rule set 2026-04-19. `NotifyCloudTenantTier` (record) and `ApiKeyIssuance` (record) drop the prefix; `INotifyCloudGateway` and `INotifyCloudApiKeyStore` (interfaces) keep it.
+- **ADR-0026 prerequisite is satisfied.** Confirmed at scoping time (2026-05-20): `adrs/ADR-0026-grid-multi-tenant-primitives.md` line 3 reads `**Status:** Accepted`. The hard prerequisite from ADR-0027 D10 is met — this initiative can proceed without waiting on ADR-0026.
+- **Container Apps deployment is staged for `stg` only.** Per ADR-0027 D13 and PDR-0002's single-region commitment, the first deploy target is `ca-hd-notify-cloud-stg` in East US. Production (`prd`) Container App provisioning follows in a deploy-the-stage packet downstream of this initiative; staging is sufficient to prove the deployment path compiles.
+- **Status flip happens after merge, not now.** ADR-0027 stays Proposed for this scoping run. The user's standing workflow says the scope agent flips Status → Accepted after the follow-up PRs merge. None of the six packets in this initiative flip ADR-0027's status — that is a separate housekeeping step the scope agent handles when the initiative completes.
+
+## Filing
+
+The `file-packets.yml` workflow in `HoneyDrunk.Architecture` triggers automatically on push to `generated/issue-packets/active/**/*.md`. No `gh issue create` commands in this dispatch plan — the pipeline handles filing, project-board addition, field population, and `addBlockedBy` wiring from the `dependencies:` frontmatter on each packet. Verify after push by checking The Hive (org Project #4) for the six new items and their blocking edges.
+
+The exception is packet 05 (the human chore), which itself contains a "Next Steps" script the human runs after creating the private repo. That script is the path by which packet 06 is filed against the new repo.
+
+## Archival
+
+Per ADR-0008 D10, when every packet in this initiative reaches `Done` on the org Project board and `HoneyDrunk.Notify.Cloud 0.1.0` is published to the private feed, the entire `active/adr-0027-notify-cloud-standup/` folder moves to `archive/adr-0027-notify-cloud-standup/` in a single commit. Partial archival is forbidden.
+
+The hive-sync agent moves individual closed packet files from `active/` to `completed/` per invariant 37 — that is per-packet lifecycle. Initiative-level archival is the post-completion sweep that follows after the whole folder reaches `Done`. Catalog reconciliation (`catalogs/nodes.json` visibility-field introduction, the new Node entry, `catalogs/relationships.json` dependency edges, `catalogs/grid-health.json` row, `catalogs/contracts.json` four-contract block, `catalogs/modules.json` package entries) also happens during hive-sync's reconciliation pass after the initiative completes — scope agent does not author those edits.


### PR DESCRIPTION
## Summary

Scopes six packets standing up [HoneyDrunk.Notify.Cloud](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0027-stand-up-honeydrunk-notify-cloud-node.md) — the Grid's **first commercial Node** and **first private repo** (revenue carve-out from public-by-default per ADR-0027 D2). Claims invariants **51–56** (collision-check vs ADR-0021's 55–59 noted in packet 02).

### Wave 1 — Architecture-repo (parallel)
- **`01-context-folder`** — new `repos/HoneyDrunk.Notify.Cloud/` context folder (5 files) + sectors.md Ops row.
- **`02-invariants`** — six new constitution invariants under `## Ops Sector — Notify Cloud Invariants`. Collision-check explicitly names ADR-0021 as competing claim.

### Wave 2 — Notify + Communications (parallel)
- **`03-notify-fsl-license`** — Apply FSL-1.1-Apache-2.0 to Notify; bump 0.3.0 → 0.4.0.
- **`04-communications-fsl-license`** — Apply FSL-1.1-Apache-2.0 to Communications; bump 0.2.0 → 0.3.0.

### Wave 3 — Human-only PRIVATE repo creation
- **`05-create-notify-cloud-repo`** — `actor: human`, `human-only` label, explicit PRIVATE-not-Public warning repeated four times. First private repo in the Grid.

### Wave 4 — Notify.Cloud scaffold
- **`06-node-scaffold`** — four packages (Abstractions, runtime, Web, Providers.Stripe.Billing). Two frozen interfaces (`INotifyCloudGateway`, `INotifyCloudApiKeyStore`) + four records (`NotifyCloudTenantTier`, `ApiKeyIssuance`, `ApiKeyMetadata`, `NotifyCloudGatewayRequest`). Container Apps deploy-stg per ADR-0015 (`ca-hd-notify-cloud-stg`).

## Multi-tenant primitives consumed from Kernel

Per ADR-0026: `TenantId`, `ITenantRateLimitPolicy`, `IBillingEventEmitter`, `BillingEvent` — **consumed, not redefined**. Surface verified against actual Kernel.Abstractions:
- `ITenantRateLimitPolicy.EvaluateAsync` (not `CheckAsync`) returning `ValueTask<TenantRateLimitDecision>`
- `TenantRateLimitDecision(Outcome, RetryAfter, Reason)` — Outcome is tri-state (`Allow`/`Throttle`/`Reject`)
- `BillingEvent` 7-positional shape (`TenantId, EventType, OperationKey, Units, OccurredAtUtc, CorrelationId, Attributes`)
- `IBillingEventEmitter.EmitAsync` returns `ValueTask`

## Internal-tenant defense-in-depth

`default(TenantId).Value == TenantId.Internal` aliasing closed with three layers:
1. `NotifyCloudGatewayRequest.TenantIdHint` typed as `TenantId?` (nullable, no default sentinel collision)
2. Gateway rejects `tenantId.IsInternal` between key validation and tier resolution (Unauthorized)
3. `HashingNotifyCloudApiKeyStore.IssueAsync` throws `ArgumentException` on `TenantId.Internal`

## D3 Abstractions carve-out

`HoneyDrunk.Notify.Cloud.Abstractions` references `HoneyDrunk.Kernel.Abstractions` at v0.1.0 (for `TenantId`). `Notify.Abstractions` and `Communications.Abstractions` reserved for future contract surfaces per D3.

## Conventions
- NuGet uses `.Abstractions` throughout (invariant 2).
- Records drop `I`; interfaces keep `I`.
- Each packet carries `accepts: ADR-0027`.
- LICENSE on Notify.Cloud is proprietary (all-rights-reserved); FSL on Notify + Communications engines.

## Test plan
- [ ] After merge, six issues file with cross-init + cross-wave dep edges
- [ ] Wave 4 stays blocked until Wave 3 PRIVATE repo creation completes
- [ ] When all six close, hive-sync auto-flips ADR-0027 Proposed → Accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)