### PR TITLE
chore: scope ADR-0031 audit node standup (final initiative)

### DIFF
--- a/generated/issue-packets/active/adr-0031-audit-node-standup/01-architecture-audit-coupling-and-canary-invariants.md
+++ b/generated/issue-packets/active/adr-0031-audit-node-standup/01-architecture-audit-coupling-and-canary-invariants.md
@@ -1,0 +1,230 @@
+---
+name: Constitution Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "constitution", "audit", "adr-0031"]
+dependencies: ["Architecture#109"]
+adrs: ["ADR-0031", "ADR-0030"]
+accepts: ADR-0031
+wave: 1
+initiative: adr-0031-audit-node-standup
+node: honeydrunk-audit
+---
+
+# Chore: Add ADR-0031's two new invariants (next two free slots) to the Grid constitution
+
+## Summary
+Add two new invariants to `constitution/invariants.md` derived from ADR-0031 D9 (downstream Abstractions-only coupling) and ADR-0031 D8 (Audit contract-shape canary requirement). Assign them the next two free slots under the existing `## Audit Invariants` section, which already carries the substrate-level audit-emission boundary invariant landed by ADR-0030 packet 02. Update ADR-0031's Consequences section to finalize the invariant numbers (replace the tentative-numbering preamble), and update `repos/HoneyDrunk.Audit/invariants.md` to cite the now-final invariant numbers in its trailing cross-reference paragraph.
+
+**Collision reality at edit time (2026-05-20):** ADR-0030 packet 02 was originally drafted assuming 44 was free and reserved 45/46 for this packet. As of 2026-05-20, `constitution/invariants.md` already has invariants 44/45/46 occupied by ADR-0016 (AI sector) — see the `## AI Invariants` section: `44.` Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`; `45.` Token cost rates / routing policies / capability declarations sourced from App Configuration via Vault's `IConfigProvider`; `46.` HoneyDrunk.AI Node CI contract-shape canary. The real high-water mark is **46**. The next two free slots **at this packet's edit time** are therefore **47** and **48** (or higher if ADR-0018 packet 02 — which claims 47-50 — lands first; or higher still if any other ADR's invariant-numbering packet lands between this scoping and this packet's edit time). See the §Collision-Check Protocol below.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+ADR-0031 explicitly delegates final invariant numbering to the scope agent at acceptance time ("Numbering is tentative — scope agent finalizes at acceptance" in the §New invariant subsection; "Scope agent assigns final invariant numbers when flipping Status → Accepted" in the "If Accepted" checklist). The two invariants ADR-0031 restates (the substrate-level audit-emission boundary belongs to ADR-0030 and lands separately) need numbered constitutional homes so:
+
+- **The downstream-coupling rule (D9)** has a constitutional anchor the review agent can cite when an emitter or reader takes a runtime dependency on `HoneyDrunk.Audit.Data` (a future bug we want to catch at PR time, not at downstream-canary failure time).
+- **The contract-shape canary requirement (D8)** outlives any single CI workflow file. The api-compatibility workflow is what enforces the rule today; the constitutional invariant makes the *obligation* outlast workflow rewrites. ADR-0016 (AI), ADR-0017 (Capabilities), ADR-0018 (Operator), and ADR-0019 (Communications) all carry analogous canary invariants for the same reason.
+
+ADR-0030 packet 02 lands the substrate-level audit-emission boundary invariant (auditable security events emitted to the Audit substrate via `IAuditLog` on a durable channel separate from observability; Phase 1 append-only-by-interface, NOT tamper-evident) in a new `## Audit Invariants` section, with a reservation note for the next two slots. This packet redeems that reservation: the first of the new entries = downstream Abstractions-only coupling, the second = contract-shape canary. The reservation note is replaced by the actual numbered entries.
+
+The dispatch plan for ADR-0030 originally recorded the allocation as **44 → ADR-0030 (already landed); 45 → ADR-0031 D9; 46 → ADR-0031 D8**. That allocation **no longer holds** — invariants 44/45/46 are occupied by ADR-0016 AI standup as of 2026-05-20 (and the AI section landed before ADR-0030 packet 02 will). The same logical cross-ADR allocation still applies, but with the assigned numbers shifted to the next two free slots after the substrate-level invariant lands. This packet honors the allocation in *content* (downstream coupling first, canary second, immediately after the substrate-level invariant inside `## Audit Invariants`) — the numeric assignment is whatever is actually free at edit time.
+
+## Collision-Check Protocol (Hard Gate, Run Before Any Edit)
+
+Before authoring any of the edits below, run:
+
+```bash
+rg -n '^[0-9]+\.' constitution/invariants.md | tail -n 20
+```
+
+Identify the current high-water mark across the entire file (not just the `## Audit Invariants` section — invariants are numbered globally, not per-section). The next two free slots after that high-water mark are this packet's assignments. Throughout this packet's edits, treat the assignments as **`N` (downstream coupling) and `N+1` (contract-shape canary)** where `N` = current high-water mark + 1.
+
+**Known existing claims on the 44-50 range as of scoping time (2026-05-20):**
+
+| Range | Owner ADR | Section in `constitution/invariants.md` | Status |
+|---|---|---|---|
+| 44 / 45 / 46 | **ADR-0016** (AI standup, Accepted) | `## AI Invariants` | **Landed** — visible in `constitution/invariants.md` at scoping time |
+| 44 | **ADR-0030 packet 02** (audit substrate) | `## Audit Invariants` (new section, with reservation note for 45-46) | Pre-claim — will collide; ADR-0030 packet 02 must self-shift to the next free slot per its own collision-check protocol. The reservation note that packet writes is the substrate's "reserve next two for ADR-0031" promise — this packet redeems the next two slots after whatever ADR-0030 packet 02 actually lands |
+| 47 / 48 / 49 / 50 | **ADR-0018 packet 02** (Operator standup) | `## AI Sector — Operator Invariants` (new section) | Pre-claim — has not landed yet at scoping time; if it lands before this packet, the assignments here shift up by four |
+| Future AI-sector standups (ADR-0020 Agents, ADR-0021 Knowledge, ADR-0022 Memory, ADR-0023 Evals, ADR-0024 Flow, ADR-0025 Sim) | Each carries its own invariant-numbering packet | Various new sections | Pre-claims — unknown order of landing; this packet's filing-order rule (see Filing-order rule below) protects against ADR-0030 packet 02 specifically; AI-sector pre-claims are not blocking gates on this packet, but collision-check still applies |
+
+The high-water mark at this packet's actual edit time is whatever it is — the agent runs the `rg` command above, identifies the highest existing number, and assigns this packet's two invariants to `high-water + 1` and `high-water + 2`.
+
+**Filing-order rule (hard, enforced by `dependencies:` frontmatter):**
+
+This packet depends on `Architecture#109` (ADR-0030 packet 02). ADR-0030 packet 02 must merge first. After it merges, this packet's agent reads `constitution/invariants.md` to find the actual `## Audit Invariants` section + the actual number ADR-0030 packet 02 landed at + the actual reservation note for the next two slots. This packet appends to that section using the two slots that the reservation note explicitly identifies.
+
+**If the reservation note in `## Audit Invariants` after ADR-0030 packet 02 merges does NOT match the high-water mark + 1 / + 2 (because some other ADR-0018 or AI-sector standup packet 02 squeezed in between),** then ADR-0030 packet 02's own self-shift collision check failed and the dispatch plan's narrative needs honest updating before this packet's PR opens. Stop, surface, fix ADR-0030 packet 02 forward (a new packet, not an amendment — invariant 24), and re-run the collision check.
+
+**Cross-references to update with the assigned numbers (in lockstep, before commit):**
+
+- `adrs/ADR-0031-stand-up-honeydrunk-audit-node.md` — Consequences §New invariant subsection (see implementation block below).
+- `repos/HoneyDrunk.Audit/invariants.md` — trailing cross-reference paragraph (see implementation block below).
+- `03-audit-node-scaffold.md` source file (this initiative's packet 03) — its acceptance criteria, constraints, and Referenced-Invariants sections currently template `{N-coupling}` and `{N-canary}` placeholders for the two assigned numbers. Substitute the assigned numbers in place pre-push under invariant 24's pre-filing carve-out. **Packets 01 and 03 cannot be filed in the same push** because packet 03's placeholders depend on packet 01's actual assignment.
+- `04-auth-wire-first-emitter.md` source file (this initiative's packet 04) — same templating applies. Same pre-push substitution rule under invariant 24.
+
+## Proposed Implementation
+
+### `constitution/invariants.md` — extend the existing `## Audit Invariants` section with the two new invariants; remove the reservation note
+
+After ADR-0030 packet 02 merges (the dependency on this packet — `Architecture#109`), the relevant block in `constitution/invariants.md` reads roughly (the exact numbers depend on what ADR-0030 packet 02's own collision-check assigned — could be 47, 48, 49, or higher depending on what else lands in between; the structure is what matters):
+
+```markdown
+## Audit Invariants
+
+{N-substrate}. **Durable, attributable security and action events are emitted to the `HoneyDrunk.Audit` substrate via `IAuditLog`, on a durable channel separate from observability telemetry.**
+    Login attempts, authorization grants and denials, and privileged-action execution are recorded durably and attributably through `IAuditLog`. Auditable security events routed only to sampled or retention-bounded observability (Pulse / Loki) are a boundary violation — observability answers "is the system healthy in aggregate," audit answers "who did what, when, against what, and was it allowed." The audit channel and the telemetry channel are never merged: audit *records* are not telemetry and never flow to Pulse, and the Audit Node's own operational telemetry flows one-way to Pulse with no runtime dependency on Pulse. Phase-1 audit integrity is append-only-by-interface (`IAuditLog` exposes no update and no delete method); it is explicitly **not** tamper-evident, and Phase 1 must not be documented or marketed as such. See ADR-0030 D1, D6, D7, D9.
+
+_Invariants {N-coupling} and {N-canary} are reserved for the HoneyDrunk.Audit stand-up (ADR-0031): the Audit downstream Abstractions-only coupling rule (D9) and the Audit contract-shape canary requirement (D8). They will be added here when the ADR-0031 standup initiative is scoped and executed — deliberately not landed with the substrate-level invariant, to keep ADR-0030 and ADR-0031 from double-numbering._
+```
+
+Where `{N-substrate}` is whatever number ADR-0030 packet 02 actually assigned (per its own collision-check) and `{N-coupling}` / `{N-canary}` are the two numbers it reserved (typically `{N-substrate}+1` and `{N-substrate}+2`).
+
+This packet makes two edits:
+
+1. **Remove the reservation paragraph** (the `_Invariants {N-coupling} and {N-canary} are reserved..._` italic block).
+2. **Append two new invariants `{N-coupling}` and `{N-canary}`** in its place, preserving the section header and the substrate-level invariant above unchanged.
+
+After this packet's edit, the same section reads:
+
+```markdown
+## Audit Invariants
+
+{N-substrate}. **Durable, attributable security and action events are emitted to the `HoneyDrunk.Audit` substrate via `IAuditLog`, on a durable channel separate from observability telemetry.**
+    Login attempts, authorization grants and denials, and privileged-action execution are recorded durably and attributably through `IAuditLog`. Auditable security events routed only to sampled or retention-bounded observability (Pulse / Loki) are a boundary violation — observability answers "is the system healthy in aggregate," audit answers "who did what, when, against what, and was it allowed." The audit channel and the telemetry channel are never merged: audit *records* are not telemetry and never flow to Pulse, and the Audit Node's own operational telemetry flows one-way to Pulse with no runtime dependency on Pulse. Phase-1 audit integrity is append-only-by-interface (`IAuditLog` exposes no update and no delete method); it is explicitly **not** tamper-evident, and Phase 1 must not be documented or marketed as such. See ADR-0030 D1, D6, D7, D9.
+
+{N-coupling}. **Downstream Nodes take a runtime dependency only on `HoneyDrunk.Audit.Abstractions`.**
+    Emitters (Auth, Operator, any Node recording a security or privileged-action event) and readers compile against `HoneyDrunk.Audit.Abstractions`. Composition against `HoneyDrunk.Audit.Data` — which store backing is active, which retention policy is loaded — is a host-time concern resolved at application startup from App Configuration. Production references to `HoneyDrunk.Audit.Data` from consumer Nodes are forbidden; test-time fixtures, when packaged as a future `HoneyDrunk.Audit.Testing` artifact, remain test-time only. See ADR-0031 D9.
+
+{N-canary}. **The HoneyDrunk.Audit Node CI must include a contract-shape canary for `IAuditLog`, `IAuditQuery`, and `AuditEntry`.**
+    Shape drift on any of the three frozen contracts — method signatures, parameter shapes, record members — is a build failure unless paired with an intentional version bump. `IAuditLog` is on the write path of every security and privileged-action event in the Grid; `AuditEntry` is its payload; `IAuditQuery` is the contract every forensic reader (and the future tenant-facing forensics Service) compiles against. The whole public surface of `HoneyDrunk.Audit.Abstractions` is exactly these three contracts; the canary is scoped to the Abstractions assembly and the whole-assembly diff produced by `HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml` is sufficient to enforce shape stability. See ADR-0031 D8.
+```
+
+Notes for the executing agent:
+
+- **Number-collision check is a hard gate.** Per the §Collision-Check Protocol above, run `rg -n '^[0-9]+\.' constitution/invariants.md | tail -n 20` and identify the actual high-water mark **after** ADR-0030 packet 02 has merged. Use the two slots that the reservation note left by ADR-0030 packet 02 explicitly identifies — those are `{N-coupling}` and `{N-canary}` for this packet's substitutions throughout the edits below.
+- **The substrate invariant's number is also dynamic.** ADR-0030 packet 02's own collision check may have shifted it from the originally-planned 44 to a higher number (47, 51, etc.) depending on what other invariant-numbering packets landed before it. This packet's edits to ADR-0031 Consequences and to `repos/HoneyDrunk.Audit/invariants.md` must reference the *actual* substrate number (`{N-substrate}`), not a hardcoded 44.
+- **Do not introduce a new section header.** Invariants `{N-coupling}` and `{N-canary}` extend the existing `## Audit Invariants` section. The next section after Audit is whatever ADR-0030 packet 02 left in place.
+- **No `(Proposed)` qualifier on the two new invariants.** ADR-0031 is flipped to Accepted (eventually) by the scope agent housekeeping at initiative completion — after this packet's PR + packets 02/03/04 merge. The invariants read as fully active from day one; the standup ADR's "Done When" gate carries the qualifier semantics, not the constitutional text.
+- **Preserve the substrate-level invariant unchanged.** This packet does not touch the text of `{N-substrate}` — only removes the reservation paragraph and appends `{N-coupling}` / `{N-canary}` after it.
+
+### `adrs/ADR-0031-stand-up-honeydrunk-audit-node.md` — finalize the invariant numbers in Consequences
+
+In ADR-0031's Consequences section, the §New invariant (proposed for `constitution/invariants.md`) subsection currently opens with: `Numbering is tentative — scope agent finalizes at acceptance. Proposed by ADR-0030 and restated here for the stand-up's contract-coupling rule:` followed by two bullet points (the downstream coupling rule and the contract-shape canary requirement), and ends with a parenthetical noting that the audit-emission boundary invariant is proposed in ADR-0030's Consequences and is not restated here.
+
+Replace the opening sentence so the subsection reads (substitute the actual `{N-coupling}`, `{N-canary}`, and `{N-substrate}` numbers from this packet's collision check):
+
+> `Assigned invariant numbers: **{N-coupling}** (downstream Abstractions-only coupling, ADR-0031 D9) and **{N-canary}** (contract-shape canary, ADR-0031 D8). See \`constitution/invariants.md\`, \`## Audit Invariants\`. The substrate-level audit-emission boundary invariant is **{N-substrate}**, landed separately by ADR-0030 packet 02.`
+
+Leave the two bullet points and the trailing parenthetical unchanged — only the preamble sentence flips from tentative to assigned.
+
+### `repos/HoneyDrunk.Audit/invariants.md` — update the trailing cross-reference
+
+The repo-local invariants file at `repos/HoneyDrunk.Audit/invariants.md` currently ends (as of scoping time, 2026-05-20) with the trailing paragraph:
+
+> `_Constitutional invariant 44 (the audit-emission boundary invariant, in \`constitution/invariants.md\`) is the Grid-level rule this Node exists to enforce. The Audit-specific downstream-coupling and contract-shape-canary invariants are introduced by the standup ADR and assigned their final constitutional numbers when that standup initiative lands._`
+
+**The literal `44` here is stale.** It was authored when `repos/HoneyDrunk.Audit/` was first sketched (under the assumption that 44 was the next free constitutional slot) and was never re-checked when ADR-0016 AI-sector landed at 44/45/46. Treat the on-disk literal `44` as wrong on sight — the real substrate-level number is whatever ADR-0030 packet 02's own collision-check protocol assigns at its edit time (i.e., `{N-substrate}`), **regardless of what `44` says here**. This is an instance of the cross-cutting collision-check-stale-source protocol: when a repo-local file pre-cites a constitutional number, the constitutional file is authoritative and the repo-local cite must be rewritten to match.
+
+Replace the paragraph with (substitute the actual numbers from this packet's collision check):
+
+> `_Constitutional invariants {N-substrate} (audit-emission boundary), {N-coupling} (downstream Abstractions-only coupling), and {N-canary} (Audit contract-shape canary) in \`constitution/invariants.md\` are the Grid-level rules this Node exists to enforce. {N-substrate} was landed by ADR-0030's acceptance initiative; {N-coupling} and {N-canary} were landed by ADR-0031's stand-up initiative._`
+
+If the substrate-level invariant landed at a number other than what ADR-0030 packet 02's reservation note records (i.e., the reservation note already lies), do not proceed — the collision check has caught a stale state. Stop, surface, and unwind ADR-0030 packet 02 forward (a new packet, not an amendment — invariant 24).
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the current in-progress version section (per memory `feedback_no_unreleased_commits` — no entries under `## Unreleased`; use the existing dated SemVer-bumped section or create a new one if this commit bumps the version), substituting the actual assigned numbers: `Architecture: Add invariants {N-coupling} (downstream Nodes take a runtime dependency only on HoneyDrunk.Audit.Abstractions; HoneyDrunk.Audit.Data is host-time composition) and {N-canary} (HoneyDrunk.Audit CI must include a contract-shape canary for IAuditLog/IAuditQuery/AuditEntry — shape drift is a build failure) under the existing ## Audit Invariants section per ADR-0031 D9 and D8. Removes the reservation paragraph ADR-0030 packet 02 left in place; finalizes the invariant numbers in ADR-0031 Consequences; updates repos/HoneyDrunk.Audit/invariants.md cross-reference.`
+
+## Affected Files
+
+- `constitution/invariants.md` (remove the two-slot reservation paragraph in `## Audit Invariants`; append invariants `{N-coupling}` and `{N-canary}`)
+- `adrs/ADR-0031-stand-up-honeydrunk-audit-node.md` (Consequences §New invariant subsection — finalize the numbers, replace the tentative-numbering preamble)
+- `repos/HoneyDrunk.Audit/invariants.md` (update the trailing cross-reference paragraph)
+- `CHANGELOG.md` (entry under the current dated SemVer-bumped section)
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo — no .NET projects.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture` — correct repo per routing rules.
+- [x] No new design decision — invariant text is taken from ADR-0031 D8 and D9 with light wordsmithing for the constitution's voice.
+- [x] The substrate-level audit-emission boundary invariant `{N-substrate}` (landed by ADR-0030 packet 02) is preserved unchanged.
+- [x] No double-numbering — the 45/46 reservation was set by ADR-0030 packet 02 explicitly for this packet to redeem.
+- [x] No new ADR file. This packet does not draft ADR text; it numbers ADR-0031's existing tentative invariants.
+
+## Acceptance Criteria
+
+- [ ] **Collision check performed at edit time** using `rg -n '^[0-9]+\.' constitution/invariants.md | tail -n 20`. The actual assigned numbers (`{N-coupling}` = downstream coupling; `{N-canary}` = contract-shape canary) are recorded in the PR body and substituted into every cross-reference target. **Hardcoding 45/46 is wrong** — those slots are occupied by ADR-0016 (AI standup) as of 2026-05-20.
+- [ ] `constitution/invariants.md` `## Audit Invariants` section no longer contains the two-slot reservation italic block left by ADR-0030 packet 02.
+- [ ] `constitution/invariants.md` `## Audit Invariants` section carries the substrate-level invariant (unchanged, at whatever number ADR-0030 packet 02 actually landed it at), invariant `{N-coupling}` (downstream Abstractions-only coupling per ADR-0031 D9), and invariant `{N-canary}` (Audit contract-shape canary per ADR-0031 D8) in that order, monotonically numbered.
+- [ ] Invariant `{N-coupling}`'s text states the runtime-dependency restriction is on `HoneyDrunk.Audit.Abstractions` only, forbids consumer references to `HoneyDrunk.Audit.Data` in production composition, and notes that test-time fixtures (future `HoneyDrunk.Audit.Testing`) remain test-time only.
+- [ ] Invariant `{N-canary}`'s text names all three frozen contracts (`IAuditLog`, `IAuditQuery`, `AuditEntry`), states that shape drift is a build failure unless paired with an intentional version bump, and references the api-compatibility canary scoped to `HoneyDrunk.Audit.Abstractions`.
+- [ ] **All cross-reference targets updated in lockstep with the assigned numbers:** ADR-0031 Consequences, `repos/HoneyDrunk.Audit/invariants.md`, this initiative's packet 03 source file (pre-filing under invariant 24's carve-out), this initiative's packet 04 source file (pre-filing).
+- [ ] `adrs/ADR-0031-stand-up-honeydrunk-audit-node.md` Consequences §New invariant subsection has its preamble sentence replaced — "Numbering is tentative…" → "Assigned invariant numbers: **{N-coupling}**…**{N-canary}**…". The two bullet points and the trailing parenthetical about the substrate-level invariant remain unchanged.
+- [ ] `repos/HoneyDrunk.Audit/invariants.md` trailing paragraph is updated to cite the three numbers with brief parenthetical descriptions, naming ADR-0030 as the source of the substrate-level invariant and ADR-0031 as the source of the other two.
+- [ ] `CHANGELOG.md` carries an entry under the current dated SemVer-bumped section describing the invariant additions (not under `## Unreleased`).
+- [ ] PR body explicitly notes: (1) reservation paragraph removed, (2) the two new invariants landed at `{N-coupling}` and `{N-canary}` under `## Audit Invariants`, (3) ADR-0031 Consequences finalized, (4) `repos/HoneyDrunk.Audit/invariants.md` cross-reference updated, (5) packets 03 and 04 source files were edited in place pre-filing to substitute the assigned numbers.
+
+## Human Prerequisites
+
+- [ ] **`Architecture#109` placeholder substituted with the real GitHub issue number** in this packet's `dependencies:` frontmatter pre-push. See the dispatch plan's PRE-FILING REWRITE REQUIRED warning. `file-packets.sh` cannot resolve the literal placeholder string.
+- [ ] ADR-0030 packet 02 (whatever real issue number it gets) merged to `main` before this packet's PR is opened. Without that merge, this packet has no `## Audit Invariants` section to extend and no substrate-level invariant to slot next to.
+- [ ] Confirm the assigned-number text in ADR-0031 Consequences matches the user's understanding of D8 (canary requirement) and D9 (downstream coupling) — both are mechanical text edits, but ADR Consequences edits warrant a quick eye before merge.
+
+## Referenced Invariants
+
+> **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. Pre-filing amendments are permitted; post-filing corrections require a new packet. — Packets 03 and 04 of this initiative cite the two invariant numbers this packet assigns. Both packets must be amended in place pre-filing once this packet's PR merges and the actual assigned numbers are known. Packets 01 and 03 (and 04) cannot be filed in the same push.
+
+## Referenced ADR Decisions
+
+**ADR-0031 D9 (Downstream coupling rule):** Emitters and readers compile only against `HoneyDrunk.Audit.Abstractions`. They do not take a runtime dependency on `HoneyDrunk.Audit.Data` in production composition. Composition — which store backing is active, which retention policy is loaded — is a host-time concern resolved at application startup from App Configuration. This is the same abstraction/runtime split applied for AI, Capabilities, Operator, Vault, and Transport. Restated as constitutional invariant `{N-coupling}` by this packet.
+
+**ADR-0031 D8 (Contract-shape canary):** A contract-shape canary is added to the Audit Node's CI; it fails the build if any of `IAuditLog`, `IAuditQuery`, or `AuditEntry` change shape without a corresponding version bump. All three are the hot path for every emitter and reader. Because the public surface is exactly three contracts, all three are frozen from the first scaffold rather than a four-of-N hot subset. Restated as constitutional invariant `{N-canary}` by this packet.
+
+**ADR-0030 packet 02 (the predecessor packet, must land first):** Adds the substrate-level audit-emission boundary invariant in a new `## Audit Invariants` section with a reservation paragraph for the next two slots. This packet redeems that reservation. ADR-0030 packet 02's own collision-check protocol determines the substrate-level number; this packet's collision-check protocol determines the two redemption numbers.
+
+**ADR-0031 §New invariant (proposed for `constitution/invariants.md`):** Numbering is tentative; scope agent finalizes at acceptance. This packet performs that finalization.
+
+## Dependencies
+
+- `Architecture#109` (PLACEHOLDER — substitute real issue number pre-push) — ADR-0030 packet 02 adds the substrate-level audit-emission boundary invariant in a new `## Audit Invariants` section with a reservation for the next two slots. This packet extends that section. Without the substrate-level invariant + the reservation in place, this packet has nothing to redeem.
+
+## Labels
+
+`chore`, `tier-2`, `architecture`, `constitution`, `audit`, `adr-0031`
+
+## Agent Handoff
+
+**Objective:** Add two new invariants — downstream Abstractions-only coupling (ADR-0031 D9) and Audit contract-shape canary (ADR-0031 D8) — to `constitution/invariants.md` under the existing `## Audit Invariants` section, at the next two free slots identified by collision check at edit time. Remove the two-slot reservation paragraph ADR-0030 packet 02 left in place. Finalize the invariant numbers in ADR-0031's Consequences §New invariant subsection. Update `repos/HoneyDrunk.Audit/invariants.md`'s trailing cross-reference.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Context:**
+- Goal: Land the two constitutional invariants ADR-0031 restates so packet 03 of this initiative (the HoneyDrunk.Audit scaffold) can cite them by number, and so the review agent has citable rules for downstream-coupling and canary-requirement enforcement.
+- Feature: ADR-0031 standup initiative — this is the first packet (constitution side).
+- ADRs: ADR-0031 (this packet finalizes its two restated invariants); ADR-0030 (predecessor — packet 02 of that initiative lands the substrate-level invariant and reserves two slots for this packet).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** `Architecture#109` (ADR-0030 packet 02, real issue number substituted pre-push) must be merged to `main` before this packet's PR is authored — that packet creates the `## Audit Invariants` section, lands the substrate-level audit-emission boundary invariant, and reserves the next two slots for this packet.
+
+**Constraints:**
+
+- **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. Before a packet is filed, it may be amended to fill in missing operational context without violating this rule. After filing, state lives on the org Project board, never in the packet file. — Concretely: packets 03 and 04 of this initiative cite the two invariant numbers assigned here. Both must be amended in place pre-filing once this packet's PR merges and the actual assigned numbers are known. **Packets 01 and 03 cannot be filed in the same push, and neither can 01 and 04.**
+- **The assignment is dynamic — do NOT hardcode 45/46.** At scoping time (2026-05-20), invariants 44/45/46 are occupied by ADR-0016 AI standup. The real assignments depend on what ADR-0030 packet 02's own collision check lands at + what else gets in between. Use the actual assigned numbers from the §Collision-Check Protocol.
+- **Preserve the substrate-level invariant unchanged.** This packet does not touch the substrate-level invariant's text or number — only removes the reservation paragraph and appends the two new entries after it.
+- **No new section header.** The two new invariants extend the existing `## Audit Invariants` section.
+- **No `(Proposed)` qualifier on the new invariants.** ADR-0031 is Accepted-eligible the moment this initiative's PRs merge and the scope agent flips Status. The invariants read as fully active. (The ADR-0031 §New invariant subsection is what carries the tentative-numbering semantics; that gets finalized by this packet too.)
+
+**Key Files:**
+- `constitution/invariants.md` — remove the two-slot reservation italic block; append the two new invariants in monotonic order after the substrate-level invariant under the `## Audit Invariants` section
+- `adrs/ADR-0031-stand-up-honeydrunk-audit-node.md` — Consequences §New invariant subsection preamble sentence (replace "Numbering is tentative…" with "Assigned invariant numbers: **{N-coupling}**…**{N-canary}**…")
+- `repos/HoneyDrunk.Audit/invariants.md` — trailing cross-reference paragraph (update to cite the three numbers with brief parentheticals)
+- `CHANGELOG.md` — append entry under the current dated SemVer section
+
+**Contracts:**
+- This packet does not author any new contracts. It records the two constitutional rules. Authoring of the actual `.cs` files (`IAuditLog`, `IAuditQuery`, `AuditEntry`) happens in packet 03 (the scaffold).

--- a/generated/issue-packets/active/adr-0031-audit-node-standup/02-architecture-create-audit-repo.md
+++ b/generated/issue-packets/active/adr-0031-audit-node-standup/02-architecture-create-audit-repo.md
@@ -1,0 +1,167 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "audit", "adr-0031", "human-only", "wave-1"]
+dependencies: ["Architecture#108"]
+adrs: ["ADR-0031", "ADR-0030"]
+accepts: ADR-0031
+wave: 1
+initiative: adr-0031-audit-node-standup
+node: honeydrunk-audit
+actor: human
+---
+
+# Chore: Create `HoneyDrunk.Audit` public GitHub repo + branch protection + labels + OIDC + clone locally (human-only)
+
+## Summary
+Create the public `HoneyDrunkStudios/HoneyDrunk.Audit` GitHub repo, apply the Grid's per-repo standard settings (branch protection, default branch, labels, Actions enabled, security analysis), wire the OIDC federated credential for tag-driven NuGet publishing, and clone the repo locally so packet 03's scaffolding agent has a working tree to author into. This is an org-admin / human action that cannot be delegated to an agent — it gates packet 03.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture` (this is where the tracking issue lives; the actual work happens on GitHub at the org level + locally on the user's machine)
+
+## Actor
+**`Human`.** Org-admin rights on `HoneyDrunkStudios` are required to create the repo, apply branch protection, seed labels, configure the OIDC federated credential, and clone the repo locally. Frontmatter sets `actor: human` and labels include `human-only`; the filing pipeline mirrors `Actor=Human` onto The Hive.
+
+## Motivation
+`03-audit-node-scaffold.md` defines the solution, two packages, three contracts, Data-backed append-only store, in-memory test fixture, and CI pipeline for `HoneyDrunk.Audit` but cannot be executed by the scaffolding agent until:
+
+1. The `HoneyDrunkStudios/HoneyDrunk.Audit` GitHub repo exists. As of 2026-05-20 it does not (confirmed pre-scoping — the catalog entries exist via ADR-0030 packet 01, but the actual GitHub repo has not been created).
+2. The local working tree at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Audit/` exists. As of 2026-05-20 it does not.
+3. Branch protection rules are applied so the scaffolding PR cannot be force-pushed to `main` and `pr-core` is required.
+4. Labels needed for issue filing exist on the repo (`feature`, `chore`, `tier-1`, `tier-2`, `audit`, `scaffold`, `adr-0031`, `wave-2`, `wave-3`, `human-only`, `out-of-band`).
+5. The Grid's NuGet publishing OIDC federated credential has `repo:HoneyDrunkStudios/HoneyDrunk.Audit:ref:refs/tags/v*` in its subject list so `release.yml` can publish at first tag push.
+
+Surfacing this as an explicit Wave-1 work item keeps it visible on The Hive board as a human-only blocker on packet 03 instead of an implicit prerequisite. Same shape as `adr-0017-capabilities-standup/03-architecture-create-capabilities-repo.md` — create-and-configure, not verify-and-clone (the HoneyDrunk.Audit repo was not pre-created during ADR-0031 drafting, unlike the AI repo).
+
+## Steps
+
+### Step 1 — Create the public repo (portal)
+
+1. Open https://github.com/organizations/HoneyDrunkStudios/repositories/new
+2. Fill in:
+   - **Repository name:** `HoneyDrunk.Audit`
+   - **Description:** `Grid-wide durable, attributable security and action record. Append-only by interface; Data-backed; audit-class retention distinct from observability.`
+   - **Visibility:** **Public** (per memory `project_repos_public_by_default` — audit substrate is a Core primitive, no carve-out applies)
+   - **Initialize this repository with:** check `.gitignore` (template: `VisualStudio`), check `LICENSE` (template: `MIT` — matches other Grid repos; confirm with the Grid's existing LICENSE choice), do **not** add a README (packet 03 will author the README so it lands with the scaffold; if GitHub forces a README at create-time, that initial placeholder is overwritten by packet 03's commit)
+3. Click **Create repository**.
+4. Open https://github.com/HoneyDrunkStudios/HoneyDrunk.Audit/settings — confirm:
+   - **Default branch:** `main`
+   - **Visibility:** Public
+   - **Features:** Issues enabled, Actions enabled, Discussions optional (off by default is fine)
+
+### Step 2 — Branch protection on `main`
+
+Open https://github.com/HoneyDrunkStudios/HoneyDrunk.Audit/settings/branches and create a branch protection rule on `main`:
+
+- **Require a pull request before merging:** on
+- **Require approvals:** off (solo developer; matches other Grid repos)
+- **Require status checks to pass before merging:** on
+- **Required status checks:** `pr-core / core` only for now. The `api-compatibility / abstractions-shape` check will be added to required-checks in a **follow-up branch-protection update** after the throwaway breaking-change PR confirms the canary fires post-merge — see packet 03 Human Prerequisites for the rationale (same first-PR `status: skipped` behavior as the AI scaffold).
+- **Allow force pushes:** off
+- **Allow deletions:** off
+- **Require signed commits:** off (matches other Grid repos)
+
+Mirror the settings on `HoneyDrunkStudios/HoneyDrunk.Auth` if any field is unclear.
+
+### Step 3 — Security analysis settings
+
+Open https://github.com/HoneyDrunkStudios/HoneyDrunk.Audit/settings/security_analysis and confirm:
+
+- **Dependabot alerts:** Enabled (org default — should already be on)
+- **Dependabot security updates:** **Off** (per memory `project_adr_0009_dependabot_stance` — alerts yes, auto-PRs no; grouped nightly-deps workflow replaces per-package Dependabot PRs)
+- **CodeQL default-setup:** **Off** (per memory `project_github_security_configuration` — the org "HoneyDrunk Grid — public default" config keeps CodeQL default-setup off)
+- **Secret scanning:** Enabled (org default)
+- **Push protection:** Enabled
+
+### Step 4 — Seed labels (CLI)
+
+Run the following from any local directory with `gh` CLI authenticated as the org owner. Color choices follow the existing convention used by other Grid repos. **Per memory `project_windows_crlf_gotcha`, on Windows Git Bash the `gh` and `jq` output is CRLF — when piping through bash, `tr -d '\r'` may be needed. For this loop the labels are inline strings, so CRLF is not a risk; but if a label name appears mangled, that is the cause.**
+
+```bash
+for label in "feature:0E8A16" "chore:CCCCCC" "tier-1:E99695" "tier-2:FBCA04" "audit:5319E7" "scaffold:BFDADC" "adr-0031:1D76DB" "wave-2:FBCA04" "wave-3:FBCA04" "human-only:B60205" "out-of-band:D4C5F9"; do
+  name="${label%:*}"; color="${label#*:}"
+  gh label create "$name" --repo HoneyDrunkStudios/HoneyDrunk.Audit --color "$color" 2>/dev/null
+done
+```
+
+If `gh label create` errors with "already exists" for any label, that is fine — it is idempotent for our purposes.
+
+### Step 5 — Clone the repo locally
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/
+git clone https://github.com/HoneyDrunkStudios/HoneyDrunk.Audit.git
+cd HoneyDrunk.Audit
+git status
+```
+
+The clone should land at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Audit/`. After cloning, confirm the working tree contains `.gitignore`, `LICENSE`, and possibly a placeholder `README.md` from the GitHub create step — and nothing else. Packet 03's scaffolding agent will overwrite the placeholder README and create everything else (`.slnx`, `src/`, `tests/`, `.github/workflows/`, `CHANGELOG.md`, etc.).
+
+### Step 6 — Confirm OIDC federated credential
+
+Cross-link: [`infrastructure/walkthroughs/oidc-federated-credentials.md`](../../../../infrastructure/walkthroughs/oidc-federated-credentials.md).
+
+Confirm the Grid's NuGet publishing identity has `repo:HoneyDrunkStudios/HoneyDrunk.Audit:ref:refs/tags/v*` in its federated credential subject list. If not, add it via the Azure portal (Microsoft Entra → App registrations → the Grid's NuGet publishing app registration → Certificates & secrets → Federated credentials → Add credential). Without this, `release.yml` will fail to obtain a token at first tag-push.
+
+### Step 7 — Confirm Architecture-side prereq
+
+Confirm Architecture#108 (ADR-0030 packet 01) has merged to `main`. That packet creates the `repos/HoneyDrunk.Audit/` context folder, registers `honeydrunk-audit` in the catalogs, adds the Core-sector Audit row to `sectors.md`, flips ADR-0030 Status to Accepted, and registers the initiative + roadmap bullet. If ADR-0030 packet 01 has not merged, this chore can still proceed (the GitHub-side actions are independent of Architecture-repo state) — but packet 03 (the scaffold) cannot proceed until ADR-0030 packet 01 is in.
+
+## Acceptance Criteria
+
+- [ ] `HoneyDrunkStudios/HoneyDrunk.Audit` repo exists on GitHub, is public, has default branch `main`, has Issues + Actions enabled.
+- [ ] Repo initialized with `.gitignore` (VisualStudio template) and `LICENSE` (matching the Grid's existing LICENSE choice on other public repos — MIT unless verified otherwise).
+- [ ] Branch protection on `main` requires `pr-core / core`, no force-pushes, no deletions, signed commits not required.
+- [ ] Dependabot alerts: Enabled. Dependabot security updates: Off. CodeQL default-setup: Off. Secret scanning + push protection: Enabled.
+- [ ] Labels `feature`, `chore`, `tier-1`, `tier-2`, `audit`, `scaffold`, `adr-0031`, `wave-2`, `wave-3`, `human-only`, `out-of-band` all exist on the repo.
+- [ ] Local working tree at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Audit/` exists, is a clean clone, contains `.gitignore` + `LICENSE` + at most a placeholder `README.md`.
+- [ ] OIDC federated credential `repo:HoneyDrunkStudios/HoneyDrunk.Audit:ref:refs/tags/v*` exists on the Grid's NuGet publishing identity in Microsoft Entra.
+- [ ] Architecture#108 merged to `main` (confirmation step — not blocked by it for these GitHub-side actions, but packet 03 is).
+- [ ] This chore issue is closed after all checks above are verified.
+- [ ] After this chore is Done **and** packet 01 of this initiative has merged, packet 03 (`03-audit-node-scaffold.md`) is fileable.
+
+## Human Prerequisites
+
+- [ ] Org-admin role on `HoneyDrunkStudios` (required to create the repo, set branch protection, and seed labels)
+- [ ] Browser with GitHub session logged in as the org owner
+- [ ] `gh` CLI installed locally and authenticated as the org owner
+- [ ] Azure portal access for the OIDC federated credential check (Microsoft Entra → App registrations → NuGet publishing identity → Certificates & secrets → Federated credentials)
+- [ ] Architecture#108 (ADR-0030 packet 01) merged to `main` — confirms `repos/HoneyDrunk.Audit/` context folder is registered and `honeydrunk-audit` is in `catalogs/nodes.json`
+
+## Dependencies
+
+- `Architecture#108` — ADR-0030 packet 01 must have merged to `main` so the Architecture-side registration (catalog, sectors, context folder, ADR-0018 amendment verification, initiative + roadmap bullets) is in place. The GitHub-side actions in this chore are technically independent of ADR-0030 packet 01's merge, but the scaffold (packet 03) is not — surfacing the dependency here keeps the chain visible on The Hive board.
+
+## Downstream Unblocks
+
+- Packet 03 of this initiative (`03-audit-node-scaffold.md`) becomes fileable the moment this chore is Done **and** packet 01 of this initiative has merged.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node (or tightly coupled Node family). Each repo has its own solution, CI pipeline, and versioning. — New Node ⇒ new repo. This chore creates that repo.
+
+> **Invariant 24:** Issue packets are immutable once filed. Pre-filing amendments are permitted; post-filing corrections require a new packet. — This chore packet is filed in Wave 1 alongside packet 01; pre-filing amendments to packet 03 (the scaffold) are permitted under invariant 24 if invariant numbers shift in packet 01.
+
+## Referenced ADR Decisions
+
+**ADR-0031 D1 (Audit Node ownership):** `HoneyDrunk.Audit` is the Core sector's single Node owning the Grid's durable, attributable security-and-action record. New Node ⇒ new repo per invariant 11.
+
+**ADR-0031 §If Accepted — Required Follow-Up Work (line 12):** "Create the `HoneyDrunk.Audit` GitHub repo as **public** (Grid default; no revenue/compliance/experiment carve-out applies — audit substrate is a reusable Core primitive)." This chore executes that checklist item.
+
+**ADR-0009 (Dependabot stance, Accepted):** Dependabot alerts on, auto-PRs off. The grouped nightly-deps workflow replaces per-package Dependabot PRs. This chore configures the security_analysis settings accordingly in Step 3.
+
+**Org GitHub security configuration (memory `project_github_security_configuration`):** "HoneyDrunk Grid — public default" config; CodeQL default-setup stays off (the Grid uses its own CodeQL invocation pattern, not the default-setup flow). Step 3 reflects this.
+
+## Labels
+
+`chore`, `tier-1`, `meta`, `audit`, `adr-0031`, `human-only`, `wave-1`
+
+## Notes for the human executing this chore
+
+- This is a 10-minute task split across portal + CLI + Azure portal (for OIDC) + a single `git clone`. Most of the work is one-time configuration that establishes the repo for the rest of the initiative.
+- The OIDC federated credential step (Step 6) is the only Azure portal step. The Grid has a standard NuGet publishing identity used by every Node; if this is the first new repo since the credential was set up, confirm the subject pattern allows tag-pushes from `HoneyDrunk.Audit`.
+- If GitHub forces a README at repo creation time, that placeholder is fine — packet 03 will overwrite it with the real scaffold README. Do not waste effort writing a temporary README here.
+- Per memory `project_repos_public_by_default`: the Audit Node is a reusable Core primitive (durable, attributable Grid-wide security record). No revenue-stream secret-sauce, no compliance carve-out (this is the foundation that compliance would build on), no experimental branding worth hiding. Public is the right call.
+- Per memory `feedback_provision_when_needed`: no Azure resources to provision yet. HoneyDrunk.Audit is a library Node at Phase 1 (both `Abstractions` and `Data` packages are libraries). Managed identity, Container Apps, App Configuration keys for retention — all deferred until the first deployable host composes `HoneyDrunk.Audit.Data`. Step 6's OIDC credential is the only Azure-side touch in this chore, and that is on Microsoft Entra (no resource provisioning).

--- a/generated/issue-packets/active/adr-0031-audit-node-standup/03-audit-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0031-audit-node-standup/03-audit-node-scaffold.md
@@ -1,0 +1,792 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Audit
+labels: ["feature", "tier-2", "audit", "scaffold", "adr-0031"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0031", "ADR-0030", "ADR-0026", "ADR-0027", "ADR-0009", "ADR-0005"]
+accepts: ADR-0031
+wave: 2
+initiative: adr-0031-audit-node-standup
+node: honeydrunk-audit
+---
+
+# Feature: Stand up the HoneyDrunk.Audit repo — solution, two packages, three contracts, Data-backed append-only store, CI, in-memory fixture, smoke test
+
+## Summary
+Bring the empty `HoneyDrunk.Audit` repo from zero to first-shippable state per ADR-0031 D11. Land the solution layout, the two package families (`HoneyDrunk.Audit.Abstractions` + `HoneyDrunk.Audit.Data`), the three D3 contracts inside `Abstractions` (`IAuditLog`, `IAuditQuery`, `AuditEntry`), the Data-backed append-only `IAuditLog` writer and `IAuditQuery` reader over `HoneyDrunk.Data`'s `IRepository`/`IUnitOfWork` with the audit-class retention hook (App Config-sourced), the in-memory `IAuditLog`/`IAuditQuery` fixture (internal to the runtime package's test project — deliberately not a `Testing` package per ADR-0027 precedent), the end-to-end smoke test that writes through `IAuditLog` and reads back through `IAuditQuery` against the in-memory fixture, the standard CI pipeline (PR core + release + nightly deps + nightly security), and the contract-shape canary scoped to `HoneyDrunk.Audit.Abstractions` per ADR-0031 D8 / invariant `{N-canary}`.
+
+This is the unblocker for `HoneyDrunk.Auth` (packet 04 of this initiative) and any future Node recording security or privileged-action events. After this packet merges and `v0.1.0` tags, Auth can take a `HoneyDrunk.Audit.Abstractions 0.1.0` PackageReference and wire the first emitter.
+
+**Pre-filing invariant-number substitution required.** This packet's body uses `{N-coupling}` and `{N-canary}` placeholders for the two invariant numbers landed by packet 01 of this initiative (downstream coupling + contract-shape canary). After packet 01 merges and the actual assigned numbers are known, edit this file in place pre-push (invariant 24's pre-filing carve-out) to substitute the real numbers. Hardcoding 45/46 here is WRONG — those slots are occupied by ADR-0016 AI standup as of 2026-05-20.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Audit`
+
+## Motivation
+ADR-0031 establishes *what* HoneyDrunk.Audit is, what it owns, what contracts it exposes, and what scaffolds in the first PR (D11). The `HoneyDrunkStudios/HoneyDrunk.Audit` GitHub repo was created by packet 02 of this initiative (`02-architecture-create-audit-repo.md`); the local working tree at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Audit/` was cloned by the same chore. The repo currently contains only `.gitignore`, `LICENSE`, and possibly a placeholder `README.md` — no `.slnx`, no projects, no contracts, no store, no CI. The substrate has been registered in the Architecture catalogs (by ADR-0030 packet 01) and the three Audit-related constitutional invariants are in place under `## Audit Invariants` — the substrate-level invariant (audit-emission boundary, by ADR-0030 packet 02) plus `{N-coupling}` (downstream Abstractions-only coupling) and `{N-canary}` (contract-shape canary, both by packet 01 of this initiative). What is missing is the code.
+
+Until this packet ships:
+
+- `HoneyDrunk.Auth` cannot wire the first emitter — the package it would reference (`HoneyDrunk.Audit.Abstractions 0.1.0`) does not exist on the NuGet feed.
+- The contract-shape canary's baseline does not exist; there is nothing to diff against on future PRs.
+- The Phase-1 append-only-by-interface promise (ADR-0030 D9 / the substrate-level audit-emission boundary invariant landed by ADR-0030 packet 02) is not actually enforced anywhere — the contract that enforces it (`IAuditLog` with no update/delete method) has not been authored.
+- Operator's eventual reconciliation (D5 / D6) has nothing to consume.
+
+This packet is intentionally larger than typical bring-up packets because:
+
+- ADR-0031 D11 explicitly lists everything the first PR must produce; splitting it across multiple packets would conflate "the substrate exists and compiles" with "two specific Nodes are migrated onto it" — exactly the bundling the standup-ADR convention exists to prevent (the Auth emitter wiring lives in packet 04, separately).
+- All three D3 contracts must land in the first commit so the contract-shape canary has a coherent baseline.
+- The Data-backed store and the in-memory fixture together prove the round-trip — writing the contracts without proving they round-trip would ship dead code.
+
+## Proposed Implementation
+
+### Repository layout
+
+```
+HoneyDrunk.Audit/
+├── HoneyDrunk.Audit.slnx
+├── Directory.Build.props
+├── CHANGELOG.md
+├── README.md
+├── LICENSE                          (placed by packet 02; verify content matches Grid LICENSE)
+├── .editorconfig                    (from HoneyDrunk.Standards)
+├── .gitignore                       (from packet 02; extend as needed)
+├── .github/
+│   └── workflows/
+│       ├── pr-core.yml              (calls Actions/pr-core.yml)
+│       ├── release.yml              (calls Actions/release.yml)
+│       ├── nightly-deps.yml         (calls Actions/nightly-deps.yml)
+│       ├── nightly-security.yml     (calls Actions/nightly-security.yml)
+│       └── api-compatibility.yml    (calls Actions/job-api-compatibility.yml — D8 / invariant {N-canary} canary)
+├── src/
+│   ├── HoneyDrunk.Audit.Abstractions/
+│   │   ├── HoneyDrunk.Audit.Abstractions.csproj
+│   │   ├── README.md
+│   │   ├── CHANGELOG.md
+│   │   ├── IAuditLog.cs             (append-only — no update method, no delete method)
+│   │   ├── IAuditQuery.cs           (time-ordered + filtered forensic reads)
+│   │   └── AuditEntry.cs            (record — drops the I prefix per Grid-wide naming rule)
+│   └── HoneyDrunk.Audit.Data/
+│       ├── HoneyDrunk.Audit.Data.csproj
+│       ├── README.md
+│       ├── CHANGELOG.md
+│       ├── ServiceCollectionExtensions.cs    (AddHoneyDrunkAuditData)
+│       ├── DataAuditLog.cs                   (IAuditLog impl over IRepository/IUnitOfWork — append-only)
+│       ├── DataAuditQuery.cs                 (IAuditQuery impl — time-ordered + filtered reads)
+│       ├── AuditRetentionPolicy.cs           (audit-class retention sourced from IConfigProvider)
+│       └── AuditTelemetry.cs                 (operational telemetry via ITelemetryActivityFactory)
+└── tests/
+    ├── HoneyDrunk.Audit.Abstractions.Tests/
+    │   ├── HoneyDrunk.Audit.Abstractions.Tests.csproj
+    │   ├── ContractSurfaceTests.cs            (compile-only + shape assertions on IAuditLog/IAuditQuery/AuditEntry)
+    │   └── AppendOnlyAtInterfaceTests.cs      (reflection check: IAuditLog has no update/delete method)
+    └── HoneyDrunk.Audit.Data.Tests/
+        ├── HoneyDrunk.Audit.Data.Tests.csproj
+        ├── Fixtures/
+        │   ├── InMemoryAuditLog.cs            (internal — the in-memory IAuditLog fixture; D2)
+        │   └── InMemoryAuditQuery.cs          (internal — the in-memory IAuditQuery fixture; D2)
+        ├── DataAuditLogTests.cs               (append behavior, retention hook, telemetry emission)
+        ├── DataAuditQueryTests.cs             (time-ordered reads, filtered reads)
+        └── SmokeTests.cs                      (end-to-end: write via IAuditLog → read via IAuditQuery against in-memory)
+```
+
+**Why the in-memory fixtures live `internal` to `HoneyDrunk.Audit.Data.Tests/Fixtures/` and not as a published `HoneyDrunk.Audit.Testing` package:** per ADR-0031 D2 and ADR-0031 §Alternatives Considered ("Ship a `HoneyDrunk.Audit.Testing` package at stand-up (ADR-0017 pattern) — rejected for this Node"), the consumer set at stand-up is small and known (Auth, Operator). ADR-0027 D3 is the precedent: a speculative `Testing` package is not shipped when the consumer set is small and known; the fixture is cut into a package as a non-breaking change when a third consumer emerges. Auth (packet 04) writes its own narrowly-scoped test double rather than taking a dependency on a non-existent `HoneyDrunk.Audit.Testing` package.
+
+### Solution
+
+`HoneyDrunk.Audit.slnx` references both `src/*` projects and both `tests/*` projects. Solution-level `Directory.Build.props` sets:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Version>0.1.0</Version>
+    <Authors>HoneyDrunk Studios</Authors>
+    <PackageProjectUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Audit</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Audit</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>
+```
+
+Per invariant 27 (all projects in a solution share one version and move together), both `src/*.csproj` files carry the same `Version` (0.1.0 for this initial release). Test projects are excluded from version-bump scope.
+
+### Contract details — `HoneyDrunk.Audit.Abstractions`
+
+All three D3 contracts. Records drop the `I` prefix per the Grid-wide naming rule (memory `project_naming_rule_records`); interfaces keep it.
+
+**`HoneyDrunk.Audit.Abstractions` carries exactly ONE `HoneyDrunk.*` reference: `HoneyDrunk.Kernel.Abstractions`**, for the `TenantId` strong type. This is permitted by ADR-0031 D2 ("Zero runtime dependencies beyond `HoneyDrunk.Kernel` abstractions"). The Data/Vault/Pulse/runtime references all live in `HoneyDrunk.Audit.Data`, not here.
+
+**Deliberate departure from the ADR-0016 AI standup's zero-`HoneyDrunk` strict stance.** ADR-0026 (Accepted) promoted `IGridContext.TenantId` from `string?` to the strong type `HoneyDrunk.Kernel.Abstractions.Identity.TenantId` with a non-null `Internal` sentinel. The Audit Node will be queried for **per-tenant compliance and forensic retrieval**. Stringly-typing tenancy at this contract surface would re-introduce exactly the footgun ADR-0026 closed: every consumer parsing `string` → `TenantId` at use site, malformed values silently swallowed, the Internal default handled inconsistently across consumers. The trade for taking a `Kernel.Abstractions` dependency is: every downstream emitter and reader already has Kernel in its closure (Auth has it, Operator will have it, any Grid Node by definition does), so this introduces zero new transitively-pinned `HoneyDrunk.*` package — just the one already-universal Abstractions package whose entire purpose is grid-wide primitives like this.
+
+**`CorrelationId` stays `string` at v0.1.0 with a follow-up flagged.** Kernel.Abstractions also exposes `CorrelationId` as a strong type. The same anti-footgun argument applies in principle, but `CorrelationId` has lower stakes at the Audit surface — forensic queries are not typically filtered by correlation id (they're filtered by actor, action, tenant, time-window), and the read path treats correlation id as an opaque tracer rather than a queried dimension. To keep the contract-shape canary baseline small at v0.1.0 and avoid a contract-shape change immediately after the canary establishes its baseline, ship `CorrelationId` as `string` now. Follow-up packet: promote `CorrelationId` to `Kernel.Abstractions.Identity.CorrelationId` at v0.2.0 as a single intentional contract-shape bump — that's the right moment to also revisit any other first-pass `AuditQueryFilter` member shapes (see "First-pass shape" note below).
+
+**`AuditEntry.Id` is a strong type `AuditEntryId` from v0.1.0.** Define `AuditEntryId` as a `readonly record struct` in `HoneyDrunk.Audit.Abstractions/AuditEntryId.cs`, matching the Kernel pattern that produced `TenantId` and `CorrelationId`:
+
+```csharp
+namespace HoneyDrunk.Audit.Abstractions;
+
+/// <summary>
+/// Strong-typed identifier for an <see cref="AuditEntry"/>. Wraps a ULID-shaped string
+/// assigned by the writer at append time. Construct via <see cref="New"/> for a freshly
+/// generated id, or via the explicit string ctor for round-trip reads.
+/// </summary>
+public readonly record struct AuditEntryId(string Value)
+{
+    public static AuditEntryId New() => new(System.Guid.NewGuid().ToString("N"));
+    // (Or use a ULID library — match whichever ID strategy DataAuditLog actually uses.)
+
+    public static AuditEntryId Empty { get; } = new(string.Empty);
+
+    public bool IsEmpty => string.IsNullOrEmpty(Value);
+
+    public override string ToString() => Value;
+}
+```
+
+Why strong-type `Id` at v0.1.0 even though `CorrelationId` stays string until v0.2.0:
+
+- **`Id` is writer-assigned, not propagated.** The promotion-cost trade-off that pushes `CorrelationId` to v0.2.0 (every emitter passes a string from `IGridContext.CorrelationId`, which itself is `string`; the wrapping has to happen at the *boundary* per-emitter) doesn't apply to `Id`. `Id` is assigned inside `DataAuditLog.AppendAsync`, so the construction is single-site and internal.
+- **`Id` is the *primary key shape* in the storage layer.** Strong-typing it at v0.1.0 means storage code, query code, and future `IAuditQuery.GetByIdAsync` (if ever added) all see the same type. Migrating it later would be a much wider contract-shape change than promoting `CorrelationId`.
+- **Matches the Kernel template.** `TenantId` and `CorrelationId` in `HoneyDrunk.Kernel.Abstractions.Identity` are both `readonly record struct` wrappers over ULID-shaped strings. `AuditEntryId` follows the same shape so consumers see a consistent idiom.
+
+`AuditEntry.Id` is therefore `AuditEntryId` (the strong type), not `string`. Consumers create entries with `Id: AuditEntryId.Empty` (the writer overwrites at append time). The in-memory fixture and the smoke test use the typed sentinel.
+
+Update the `AuditEntry` record definition below to reflect this.
+
+```csharp
+// IAuditLog.cs
+namespace HoneyDrunk.Audit.Abstractions;
+
+/// <summary>
+/// Append-only write surface for the Grid's durable, attributable security and action record.
+/// Exposes no update method and no delete method — append-only is enforced at the interface
+/// surface, not only at the storage layer.
+/// </summary>
+public interface IAuditLog
+{
+    /// <summary>
+    /// Append a single audit entry to the durable record. The entry is immutable once appended.
+    /// </summary>
+    Task AppendAsync(AuditEntry entry, CancellationToken cancellationToken = default);
+}
+```
+
+```csharp
+// IAuditQuery.cs
+namespace HoneyDrunk.Audit.Abstractions;
+
+using HoneyDrunk.Kernel.Abstractions.Identity;
+
+/// <summary>
+/// Time-ordered and filtered read surface for incident reconstruction and forensic retrieval
+/// over the durable audit record. The contract the future tenant-facing forensics Service
+/// will compile against without any contract migration.
+/// </summary>
+public interface IAuditQuery
+{
+    /// <summary>
+    /// Read entries within the given time window, optionally filtered by actor, action,
+    /// correlation id, or tenant, in time order (earliest first).
+    /// </summary>
+    Task<IReadOnlyList<AuditEntry>> ReadAsync(
+        AuditQueryFilter filter,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Forensic query filter. Null fields are ignored (no filter on that dimension).
+/// </summary>
+public sealed record AuditQueryFilter(
+    DateTimeOffset Since,
+    DateTimeOffset Until,
+    string? Actor = null,
+    string? Action = null,
+    string? CorrelationId = null,
+    TenantId? TenantId = null,
+    int? Limit = null);
+```
+
+```csharp
+// AuditEntry.cs (record — drops I prefix per Grid-wide naming rule)
+namespace HoneyDrunk.Audit.Abstractions;
+
+using HoneyDrunk.Kernel.Abstractions.Identity;
+
+/// <summary>
+/// Canonical append-only audit record. Generalized Grid-wide from the original
+/// Operator-scoped shape per ADR-0030 D5.
+/// </summary>
+/// <param name="Id">Unique identifier for the audit entry. Strong-typed <c>AuditEntryId</c> (ULID-shaped). Pass <see cref="AuditEntryId.Empty"/> at construction; the writer overwrites at append time.</param>
+/// <param name="OccurredAt">Wall-clock time the audited action occurred.</param>
+/// <param name="Actor">Identifier for who performed the action (user id, system id, etc.).</param>
+/// <param name="Action">Identifier for what action was performed (e.g. "auth.login.attempt").</param>
+/// <param name="Outcome">Outcome of the action (e.g. "granted", "denied", "succeeded", "failed").</param>
+/// <param name="CorrelationId">Correlation identifier tying this entry to a broader operation. Stays string at v0.1.0; promoted to <c>Kernel.Abstractions.Identity.CorrelationId</c> at v0.2.0 (follow-up packet).</param>
+/// <param name="TenantId">Tenant scope of the entry. Uses the Kernel strong type per ADR-0026; use <c>TenantId.Internal</c> for non-tenant-scoped Grid events.</param>
+/// <param name="Context">Free-form JSON-shaped context payload (action-specific detail).</param>
+public sealed record AuditEntry(
+    AuditEntryId Id,
+    DateTimeOffset OccurredAt,
+    string Actor,
+    string Action,
+    string Outcome,
+    string CorrelationId,
+    TenantId TenantId,
+    string? Context = null);
+```
+
+**First-pass shape; subject to refinement before v0.2.0 baseline lock.** The exact member set of `AuditQueryFilter` (specifically whether to include richer predicates like `outcome` filtering or tag-based search) is first-pass. The contract-shape canary established in this packet makes any post-v0.1.0 change a deliberate version-bump event, so the executing agent should land workable shapes here without overdesigning — refinement before Operator (the second consumer) locks against v0.2.0 is expected. The three names `IAuditLog`, `IAuditQuery`, `AuditEntry` are stable across refinement; only `AuditQueryFilter` is on the negotiable list.
+
+**`Id` and `OccurredAt` assignment policy.** `Id` is assigned by the writer (`DataAuditLog.AppendAsync` generates a ULID and overwrites whatever value is passed in via the `AuditEntry` record). `OccurredAt` is set by the caller (Auth, Operator) at the moment the audited action happened — Audit does not overwrite it. The XML docs above reflect this; the `Id` parameter on the record carries a comment that consumers may pass `string.Empty` and the writer will assign.
+
+**Abstractions stance — exactly one `HoneyDrunk.*` reference, for `Kernel.Abstractions.Identity.TenantId`.** `HoneyDrunk.Audit.Abstractions.csproj` carries exactly one `HoneyDrunk.*` PackageReference: `HoneyDrunk.Kernel.Abstractions`. No `HoneyDrunk.Kernel` (runtime), no `HoneyDrunk.Data*`, no `HoneyDrunk.Vault*`, no `HoneyDrunk.Pulse*`. The `HoneyDrunk.Standards` reference uses `PrivateAssets="all"` so analyzers do not propagate (allowed; that is the standard pattern). Any GridContext propagation, telemetry, or App Config sourcing lives in `HoneyDrunk.Audit.Data`, not in `Abstractions`. The `TenantId` field on `AuditEntry` and `AuditQueryFilter` is the Kernel strong type per ADR-0026; the `CorrelationId` field stays `string` at v0.1.0 with a v0.2.0 promotion flagged. (This is a **deliberate departure** from the ADR-0016 AI standup's zero-`HoneyDrunk` strict stance — driven by ADR-0026's per-tenant typing requirement. See "Contract details — `HoneyDrunk.Audit.Abstractions`" section above for the rationale.)
+
+### Runtime details — `HoneyDrunk.Audit.Data`
+
+`HoneyDrunk.Audit.Data` references:
+- `HoneyDrunk.Audit.Abstractions` (project reference)
+- `HoneyDrunk.Kernel.Abstractions` (for `ITelemetryActivityFactory`, `IGridContext`, `IOperationContext` — these are interfaces, compile-time contract consumption; per invariant 2, depend on Abstractions not runtime)
+- `HoneyDrunk.Kernel` (for the lifecycle / health registration extensions and any runtime concrete types — only if needed; prefer dropping this row if `Kernel.Abstractions` is sufficient and the host wires concrete Kernel lifecycle separately)
+- `HoneyDrunk.Data.Abstractions` (for `IRepository`, `IUnitOfWork`)
+- `HoneyDrunk.Vault` (for `IConfigProvider` to read App Config — audit-class retention value per D4. **Note:** `IConfigProvider` lives in the `HoneyDrunk.Vault.Abstractions` *namespace* but is shipped as part of the `HoneyDrunk.Vault` *package* — Vault does not ship a separate `.Abstractions` NuGet, so the package reference is unavoidably `HoneyDrunk.Vault`. If Vault later splits to a separate `.Abstractions` package, switch to it.)
+- `Microsoft.Extensions.DependencyInjection.Abstractions`
+- `Microsoft.Extensions.Hosting.Abstractions`
+- `Microsoft.Extensions.Logging.Abstractions`
+- `Microsoft.Extensions.Options.ConfigurationExtensions` (bind options from `IConfigProvider`)
+
+**`DataAuditLog`** — implements `IAuditLog.AppendAsync(AuditEntry, CancellationToken)`:
+- Assigns the entry's `Id` (ULID) at write time, overwriting any caller-passed value.
+- Enriches the entry with the caller's `IGridContext.CorrelationId` and `TenantId` if the entry's fields are empty (defensive — callers should pass them, but Audit is the durable-record-of-last-resort; an unattributable audit entry is worse than a redundantly-attributed one).
+- Persists via `IRepository<AuditEntry>.AddAsync` + `IUnitOfWork.SaveChangesAsync`. No update path. No delete path. The contract has none; the implementation must have none either.
+- Emits operational telemetry via `ITelemetryActivityFactory` (`audit.log.append`, latency, byte size). Telemetry direction is **one-way to Pulse** per D7 — `HoneyDrunk.Audit.Data` does not reference any `HoneyDrunk.Pulse` package.
+
+**`DataAuditQuery`** — implements `IAuditQuery.ReadAsync(AuditQueryFilter, CancellationToken)`:
+- **Composes the filter as a single `Expression<Func<AuditEntry, bool>>` and calls `IReadOnlyRepository<AuditEntry>.FindAsync(predicate, ct)`.** Per the actual `HoneyDrunk.Data.Abstractions/Repositories/IReadOnlyRepository.cs` surface (the public read methods are `FindByIdAsync(object id, ct)`, `FindAsync(Expression<Func<TEntity,bool>>, ct)`, `FindOneAsync(...)`, `ExistsAsync(...)`, `CountAsync(...)`), there is **no `Query()` method** on either `IRepository<T>` or `IReadOnlyRepository<T>` at v0.1.0. `FindAsync` is the supported predicate-based read path; the implementation builds the time-window + optional `Actor`/`Action`/`CorrelationId`/`TenantId` predicate at the C# `Expression` level and passes it to `FindAsync`, which the Data backing translates to a backing-store query.
+- **Ordering and `Limit` happen post-fetch, in memory.** `FindAsync` returns `IReadOnlyList<TEntity>` without exposing order-by or take semantics at the abstraction. `DataAuditQuery` does the `OrderBy(e => e.OccurredAt)` and the `Take(limit)` after `FindAsync` returns. This is a **known Phase-1 inefficiency** for very large result sets — the entire filtered set is materialized in memory, then ordered and truncated. Acceptable at v0.1.0 because forensic queries are low-volume and the time-window predicate already bounds the result set. **Phase-2 hardening item:** when `IReadOnlyRepository<T>` ships order-by/take primitives (or `DataAuditQuery` switches to direct `DbContext`-internal access), revisit this; tracked as a known gap, not shipped at v0.1.0.
+- Honors the optional `Limit` field (default if unset: 1000; cap if set above: 10000 — these are constants in the class, not App-Config-sourced, because they are query-shape concerns not retention concerns).
+- Emits operational telemetry (`audit.query.read`, latency, result count).
+
+**Open question for the executing agent:** if `IReadOnlyRepository<T>.FindAsync` materializes the *entire matching set* before in-memory ordering proves too costly on a real backing (large time-windows over months of audit), the alternative is to drop down to **direct `DbContext` access inside `DataAuditQuery`** with an explicit "intentional Data-internal coupling at Phase-1; rotate to public read surface when Data ships order-by/take primitives" comment in the class file. This is acceptable for the Audit Node specifically because (a) Audit's reads are forensic — bounded by user-supplied time-window — not a hot path, and (b) the boundary violation is contained to one class file with an inline TODO. **Pick `FindAsync` + in-memory order/take at v0.1.0 unless the executing agent's `dotnet build` profiles show >1s latency at realistic forensic volumes**, in which case fall back to direct `DbContext` access with the inline rationale. Either path satisfies the contract — `IAuditQuery.ReadAsync` returns a correctly time-ordered, optionally limited `IReadOnlyList<AuditEntry>`.
+
+**`AuditRetentionPolicy`** — Sources the audit-class retention value (in days) from App Configuration via `IConfigProvider.GetValueAsync` **once at startup**. Default if the key is unset: **365 days**, with a `::warning::` logged ("audit:retention:days not configured; defaulting to 365d. Set this in App Configuration per the consuming deployable's policy."). The retention enforcement itself (whether implemented as a background job or as a query-time filter on reads) is a Phase-2 concern — Phase 1 lands the policy *value* and the read of it, not the enforcement loop. The class exposes a public `int RetentionDays { get; }` property populated at startup. **`IConfigProvider` does not expose change-events at v0.1.0** (see `HoneyDrunk.Vault.Abstractions/IConfigProvider.cs` — the surface is `GetValueAsync` / `TryGetValueAsync` / typed `GetValueAsync<T>`; no observable/change-token contract). Configuration changes therefore require a host restart to take effect at v0.1.0. **Hot-reload is a follow-up concern not in this packet's scope** — it requires either Vault adding a change-token surface to `IConfigProvider` or Audit subscribing to its own out-of-band notification channel. Neither is in scope here.
+
+**Per ADR-0030 D4 and ADR-0031 D4: audit-class retention is distinct from observability retention; the two regimes are not shared and not interchangeable.** The default 365d is a sensible audit-class baseline (a full year of forensic depth) and is intentionally an order of magnitude longer than observability defaults — observability defaults are typically days/weeks for traces and a few months for sampled logs.
+
+**`AuditTelemetry`** — Convenience helpers for `DataAuditLog` and `DataAuditQuery` to emit consistent activity names and tags. Wraps `ITelemetryActivityFactory`. **GridContext / CorrelationId propagation onto telemetry activities lives here** (not in `Abstractions`).
+
+**Host registration of `IConfigProvider`, `IRepository`, `IUnitOfWork`.** All three are host concerns — the deployable host is responsible for `services.AddVault().AddAppConfigurationProvider(...)`, `services.AddData(...)`, and any `IUnitOfWork` registration. `HoneyDrunk.Audit.Data` references the contracts (`HoneyDrunk.Vault` for `IConfigProvider`, `HoneyDrunk.Data.Abstractions` for `IRepository`/`IUnitOfWork`); it does not reference any specific Data backing or Vault provider package. `AddHoneyDrunkAuditData()` throws a clear `InvalidOperationException` at first resolution if any of `IConfigProvider`, `IRepository<AuditEntry>`, or `IUnitOfWork` is missing, so a misconfigured host fails fast with a useful message.
+
+Service registration:
+
+```csharp
+// ServiceCollectionExtensions.cs
+namespace HoneyDrunk.Audit.Data;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddHoneyDrunkAuditData(this IServiceCollection services)
+    {
+        services.AddSingleton<AuditRetentionPolicy>();
+        services.AddSingleton<IAuditLog, DataAuditLog>();      // Singleton — see lifetime story below
+        services.AddSingleton<IAuditQuery, DataAuditQuery>();  // Singleton — same reason
+        services.AddSingleton<AuditTelemetry>();
+        return services;
+    }
+}
+```
+
+### Lifetime story — `DataAuditLog` and `DataAuditQuery` are Singleton
+
+`IAuditLog` and `IAuditQuery` are both registered as Singleton. This is deliberate and matches the in-memory fixture pattern (the `InMemoryAuditLog` test double uses `List<AuditEntry>` + `lock(_gate)` for thread-safe append; the production class follows the same shape — internal locking around the durable backing call). The reasons:
+
+1. **Auth's emitters are Singleton.** `BearerTokenAuthenticationProvider` and `DefaultAuthorizationPolicy` are registered as Singleton by `HoneyDrunkAuthServiceCollectionExtensions.AddHoneyDrunkAuth()` (see packet 04 §Lifetime story). If `IAuditLog` were Scoped, Auth's Singleton emitters injecting it would create a **captive dependency** — the Singleton would close over the first scope's `IAuditLog` instance, and every subsequent emit would write to a disposed/stale scoped instance. Scoped → Singleton dep is the classic ASP.NET Core lifetime trap.
+
+2. **`DataAuditLog.AppendAsync` does not hold scoped state across calls.** It receives the `AuditEntry` and the `IGridContext`-derived `CorrelationId`/`TenantId` per call (resolved via `IGridContextAccessor.GridContext` ambient access, **not** via direct `IGridContext` ctor injection — same captive-dep avoidance pattern as Auth's emitters). The `IRepository<AuditEntry>` and `IUnitOfWork` it consumes are resolved fresh per call via `IServiceScopeFactory` (Singleton-friendly resolver) — Data's `IRepository`/`IUnitOfWork` are themselves typically Scoped, so `DataAuditLog` creates a short-lived scope for each `AppendAsync` and disposes it after `SaveChangesAsync` returns. The per-call scope churn is the cost of keeping `IAuditLog` Singleton; it is paid per audit emit, which is low-frequency relative to per-request work.
+
+3. **Append is single-row.** `IAuditLog` exposes exactly `AppendAsync(AuditEntry, CancellationToken)`. There is no batching, no bulk insert, no transaction spanning multiple appends. A per-call scope is the right unit of work.
+
+The class-level shape:
+
+```csharp
+public sealed class DataAuditLog : IAuditLog
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IGridContextAccessor _gridContextAccessor;
+    private readonly AuditTelemetry _telemetry;
+
+    public async Task AppendAsync(AuditEntry entry, CancellationToken cancellationToken = default)
+    {
+        // Stamp Id, enrich CorrelationId/TenantId from ambient grid context, etc.
+        // ...
+
+        using var scope = _scopeFactory.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IRepository<AuditEntry>>();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+        await repo.AddAsync(stamped, cancellationToken);
+        await uow.SaveChangesAsync(cancellationToken);
+    }
+}
+```
+
+`DataAuditQuery` follows the same per-call-scope pattern for its `FindAsync` call.
+
+**`IConfigProvider` lifetime.** `IConfigProvider` is host-side registered (via Vault); Audit consumes it from `AuditRetentionPolicy`'s ctor at the Singleton's first resolution to read `audit:retention:days` once at startup. No per-call resolution needed since the value is read-once. If `IConfigProvider` is itself Scoped in some Vault providers, the Singleton-resolving-Scoped captive-dep trap applies — `AuditRetentionPolicy` resolves it via `IServiceScopeFactory` at startup to be safe.
+
+**Alternative rejected — Scoped `IAuditLog` with per-call resolution from Singleton emitters.** Could have kept `IAuditLog` Scoped and asked Auth's Singleton emitters to resolve it per-call via `IServiceScopeFactory.CreateAsyncScope()`. Rejected: pushes the scope-creation cost to every emitting Node, multiplies the per-call scope churn (Auth creates one for IAuditLog, then DataAuditLog creates one for IRepository — two scopes per emit), and makes the lifetime contract harder to reason about. Singleton-with-internal-scope-factory is simpler and matches the in-memory fixture's threading model.
+
+### In-memory fixture details — `tests/HoneyDrunk.Audit.Data.Tests/Fixtures/`
+
+The in-memory fixture exists for two distinct consumers:
+
+- **Audit's own `.Tests` projects** — for the end-to-end smoke test that proves the contracts round-trip without a database backing.
+- **Future downstream consumers** that need a deterministic test double **eventually** — but not at v0.1.0. Per D2 / ADR-0027 D3 precedent, the fixture stays `internal` until a third consumer needs it; at that point it is cut into `HoneyDrunk.Audit.Testing` as a non-breaking change.
+
+Implementation:
+
+```csharp
+// tests/HoneyDrunk.Audit.Data.Tests/Fixtures/InMemoryAuditLog.cs
+namespace HoneyDrunk.Audit.Data.Tests.Fixtures;
+
+internal sealed class InMemoryAuditLog : IAuditLog
+{
+    private readonly List<AuditEntry> _entries = new();
+    private readonly object _gate = new();
+
+    public Task AppendAsync(AuditEntry entry, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            // Assign Id at append time, like the real DataAuditLog does.
+            var stamped = entry with { Id = entry.Id.IsEmpty ? AuditEntryId.New() : entry.Id };
+            _entries.Add(stamped);
+        }
+        return Task.CompletedTask;
+    }
+
+    internal IReadOnlyList<AuditEntry> Snapshot()
+    {
+        lock (_gate) { return _entries.ToArray(); }
+    }
+}
+```
+
+```csharp
+// tests/HoneyDrunk.Audit.Data.Tests/Fixtures/InMemoryAuditQuery.cs
+namespace HoneyDrunk.Audit.Data.Tests.Fixtures;
+
+internal sealed class InMemoryAuditQuery : IAuditQuery
+{
+    private readonly InMemoryAuditLog _backing;
+
+    public InMemoryAuditQuery(InMemoryAuditLog backing) => _backing = backing;
+
+    public Task<IReadOnlyList<AuditEntry>> ReadAsync(AuditQueryFilter filter, CancellationToken cancellationToken = default)
+    {
+        var snapshot = _backing.Snapshot();
+        IEnumerable<AuditEntry> q = snapshot
+            .Where(e => e.OccurredAt >= filter.Since && e.OccurredAt <= filter.Until);
+        if (filter.Actor is not null) q = q.Where(e => e.Actor == filter.Actor);
+        if (filter.Action is not null) q = q.Where(e => e.Action == filter.Action);
+        if (filter.CorrelationId is not null) q = q.Where(e => e.CorrelationId == filter.CorrelationId);
+        if (filter.TenantId is TenantId t) q = q.Where(e => e.TenantId == t);
+        q = q.OrderBy(e => e.OccurredAt);
+        if (filter.Limit is int limit) q = q.Take(limit);
+        return Task.FromResult<IReadOnlyList<AuditEntry>>(q.ToArray());
+    }
+}
+```
+
+### Smoke test — `tests/HoneyDrunk.Audit.Data.Tests/SmokeTests.cs`
+
+```csharp
+namespace HoneyDrunk.Audit.Data.Tests;
+
+public class SmokeTests
+{
+    [Fact]
+    public async Task WriteThroughIAuditLog_ReadBackThroughIAuditQuery_RoundTrips()
+    {
+        var fixture = new InMemoryAuditLog();
+        IAuditLog log = fixture;
+        IAuditQuery query = new InMemoryAuditQuery(fixture);
+
+        var occurredAt = DateTimeOffset.UtcNow;
+        var entry = new AuditEntry(
+            Id: AuditEntryId.Empty, // writer assigns
+            OccurredAt: occurredAt,
+            Actor: "user:42",
+            Action: "auth.login.attempt",
+            Outcome: "granted",
+            CorrelationId: "corr-abc",
+            TenantId: TenantId.Internal);
+
+        await log.AppendAsync(entry);
+
+        var results = await query.ReadAsync(new AuditQueryFilter(
+            Since: occurredAt.AddMinutes(-1),
+            Until: occurredAt.AddMinutes(1)));
+
+        Assert.Single(results);
+        Assert.Equal("user:42", results[0].Actor);
+        Assert.Equal("auth.login.attempt", results[0].Action);
+        Assert.Equal("granted", results[0].Outcome);
+        Assert.False(results[0].Id.IsEmpty);
+    }
+}
+```
+
+Per ADR-0031 D11: "An `AuditEntry` written through `IAuditLog` is read back through `IAuditQuery` against the in-memory fixture." This satisfies that requirement.
+
+### Append-only-at-interface enforcement test
+
+`tests/HoneyDrunk.Audit.Abstractions.Tests/AppendOnlyAtInterfaceTests.cs` uses reflection to prove `IAuditLog` exposes exactly one method (`AppendAsync`) — no `UpdateAsync`, no `DeleteAsync`, no `ReplaceAsync`. This is a build-time defense against accidental future addition of an update/delete method that would silently break the substrate-level audit-emission boundary invariant (ADR-0030 packet 02; numbered `{N-substrate}` in the constitution at this packet's edit time).
+
+```csharp
+[Fact]
+public void IAuditLog_HasOnlyAppendAsync_NoUpdateOrDelete()
+{
+    var methods = typeof(IAuditLog).GetMethods().Select(m => m.Name).ToHashSet(StringComparer.Ordinal);
+    Assert.Contains("AppendAsync", methods);
+    Assert.DoesNotContain("UpdateAsync", methods);
+    Assert.DoesNotContain("ReplaceAsync", methods);
+    Assert.DoesNotContain("DeleteAsync", methods);
+    Assert.DoesNotContain("RemoveAsync", methods);
+    Assert.Equal(1, methods.Count);
+}
+```
+
+### CI workflows
+
+All five workflow files are thin callers of `HoneyDrunk.Actions` reusable workflows. No bespoke CI logic in the Audit repo.
+
+```yaml
+# .github/workflows/pr-core.yml
+name: PR Core
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  core:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
+    with:
+      dotnet-version: '10.0.x'
+```
+
+```yaml
+# .github/workflows/api-compatibility.yml — ADR-0031 D8 / invariant {N-canary}
+name: API Compatibility (Abstractions)
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/HoneyDrunk.Audit.Abstractions/**'
+      - 'Directory.Build.props'
+jobs:
+  abstractions-shape:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml@main
+    with:
+      project-path: src/HoneyDrunk.Audit.Abstractions/HoneyDrunk.Audit.Abstractions.csproj
+```
+
+The path filter ensures the canary only runs when `Abstractions` changes **or when the solution-level version moves** (a `Directory.Build.props` edit). Version bumps are the intentional contract-shape change events — leaving them out of the trigger means a `<Version>0.1.0 → 0.2.0</Version>` bump that accompanies a contract-shape change could merge without the canary running, leaving the baseline unverified. Mirror this in any AI-sector / Capabilities canary precedents if they are not already similar. The whole-assembly diff produced by `job-api-compatibility.yml` is sufficient to enforce D8 / invariant `{N-canary}`: per D9 / invariant `{N-coupling}`, `Abstractions` is the only thing downstream Nodes compile against, so any shape drift in any public type in `Abstractions` (`IAuditLog`, `IAuditQuery`, `AuditEntry`, `AuditQueryFilter`, `AuditEntryId`) counts. There is no low-traffic remainder to leave un-frozen.
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  release:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/release.yml@main
+    with:
+      dotnet-version: '10.0.x'
+      enable-nuget-publish: true
+    secrets:
+      nuget-api-key: ${{ secrets.NUGET_API_KEY }}
+```
+
+The reusable `release.yml` in `HoneyDrunk.Actions` declares a named optional secret `nuget-api-key` (and authenticates ACR via OIDC, which is what `id-token: write` in the reusable workflow's permissions block enables). **No `secrets: inherit`** — the caller passes only what `release.yml` actually declares. The packet 02 chore that created the `HoneyDrunk.Audit` repo must seed the `NUGET_API_KEY` repository secret (or org-level secret available to this repo) for `dotnet nuget push` to succeed; if the secret is missing, `release.yml`'s `nuget/push` action falls through and the publish step fails with a clear "API key not set" message. Tags are human-pushed per invariant 27 — agents do not push tags. The release workflow packs and publishes both `src/*` projects in a single tag-driven run.
+
+`nightly-deps.yml` and `nightly-security.yml` follow the same thin-caller pattern — copy the configurations from `HoneyDrunk.Vault` or `HoneyDrunk.Auth` for reference. The exact `with:` and `secrets:` blocks should match those repos verbatim so nightly runs converge across Grid Nodes.
+
+### `HoneyDrunk.Standards` wiring
+
+Each `.csproj` references `HoneyDrunk.Standards` with `PrivateAssets="all"` per invariant 26:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="HoneyDrunk.Standards" Version="*" PrivateAssets="all" />
+</ItemGroup>
+```
+
+This pulls in the StyleCop ruleset, `.editorconfig`, and analyzer suite that every Grid repo uses.
+
+### Documentation
+
+- **Repo `README.md`** — purpose statement, package matrix, link to the active-work tracker in `repos/HoneyDrunk.Audit/active-work.md` (or to GitHub issues), plus a dedicated `## For downstream consumers — minimal wiring` section showing the host-side `services.AddVault().AddData(...).AddHoneyDrunkAuditData()` snippet. This snippet is copy-pasteable into a downstream Node's deployable host. Also include a "Phase-1 honest limitation" section that names two distinct, intentional gaps:
+  1. **The interface is append-only; the underlying storage is not cryptographically tamper-evident.** Hash-chain / WORM tamper-evidence is deferred behind the boundary.
+  2. **Append-only is enforced at the `IAuditLog` interface surface (no `Update`/`Delete` methods exposed). At the storage layer, `DataAuditLog` consumes `IRepository<AuditEntry>` which technically exposes `Update`/`Remove`/`UpdateRange`/`RemoveRange` methods inherited from `HoneyDrunk.Data.Abstractions/Repositories/IRepository.cs`.** `DataAuditLog`'s source code does not call any of those methods (and the `AppendOnlyAtInterfaceTests` reflection check on `IAuditLog` enforces the contract at the interface). A stronger compile-time guarantee — e.g., an `IAppendOnlyRepository<T>` carve-out from `HoneyDrunk.Data.Abstractions` that exposes only `AddAsync`/`AddRangeAsync` + the read methods — is a **Phase-2 hardening item**, not shipped at v0.1.0. The boundary at v0.1.0 is enforced by (a) the `IAuditLog` interface shape, (b) `DataAuditLog`'s reviewed source code, and (c) the Audit Node's dedicated managed identity (per ADR-0031 D5) which scopes who can perform storage-layer writes regardless of the C# surface.
+
+  **Per memory `feedback_no_adr_in_docs`, the README does not cite "ADR-0031" by number in its narrative.** It explains what the package does and what its honest limitations are.
+- **Repo `CHANGELOG.md`** — `## [0.1.0] - YYYY-MM-DD` entry covering the entire scaffold landing. **Per memory `feedback_no_unreleased_commits`, do not land entries under `## Unreleased` — use the dated, SemVer-bumped section.**
+- **Per-package `README.md`** — purpose, public API surface summary, install command. Required by invariant 12 for new packages.
+- **Per-package `CHANGELOG.md`** — `## [0.1.0]` entry for each package introduced in this packet.
+
+## Affected Files
+Entire repo is created from this packet. Notable new files:
+- `HoneyDrunk.Audit.slnx`, `Directory.Build.props`, `README.md`, `CHANGELOG.md`, `.editorconfig`
+- `src/HoneyDrunk.Audit.Abstractions/` — `.csproj`, `IAuditLog.cs`, `IAuditQuery.cs`, `AuditEntry.cs`, `AuditEntryId.cs` (record-struct, strong-typed id per Kernel template), `README.md`, `CHANGELOG.md`
+- `src/HoneyDrunk.Audit.Data/` — `.csproj`, `ServiceCollectionExtensions.cs`, `DataAuditLog.cs`, `DataAuditQuery.cs`, `AuditRetentionPolicy.cs`, `AuditTelemetry.cs`, `README.md`, `CHANGELOG.md`
+- `tests/HoneyDrunk.Audit.Abstractions.Tests/` — `.csproj`, `ContractSurfaceTests.cs`, `AppendOnlyAtInterfaceTests.cs`
+- `tests/HoneyDrunk.Audit.Data.Tests/` — `.csproj`, `Fixtures/InMemoryAuditLog.cs`, `Fixtures/InMemoryAuditQuery.cs`, `DataAuditLogTests.cs`, `DataAuditQueryTests.cs`, `SmokeTests.cs`
+- `.github/workflows/` — 5 workflow files (`pr-core.yml`, `release.yml`, `nightly-deps.yml`, `nightly-security.yml`, `api-compatibility.yml`)
+
+## NuGet Dependencies
+
+Every new `.csproj` lists `HoneyDrunk.Standards` (`PrivateAssets="all"`) per invariant 26.
+
+### `HoneyDrunk.Audit.Abstractions.csproj`
+
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | For `TenantId` strong type per ADR-0026. **Deliberate departure** from ADR-0016's zero-`HoneyDrunk` strict stance in Abstractions — see Abstractions stance section above. ADR-0031 D2 explicitly permits "zero runtime dependencies beyond `HoneyDrunk.Kernel` abstractions" for this Node's `Abstractions`. |
+
+(No `HoneyDrunk.Kernel` runtime reference — `Kernel.Abstractions` carries the contracts including `TenantId`. Per invariant 2, `Abstractions` references `Abstractions`, never runtime.)
+
+### `HoneyDrunk.Audit.Data.csproj`
+
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `HoneyDrunk.Kernel.Abstractions` | For `ITelemetryActivityFactory`, `IGridContext`, `IOperationContext`, `TenantId` — compile-time contract consumption. Per invariant 2, depend on Abstractions not runtime where the consumed surface is interfaces. |
+| `HoneyDrunk.Kernel` | Optional — only if Data needs concrete Kernel runtime types (lifecycle registration extensions, concrete `IGridContext` builder). If only the interfaces from `Kernel.Abstractions` are used, **drop this row** and let the composing host wire Kernel. Audit a similar Grid-Node `Data` package (e.g. `HoneyDrunk.Communications`, `HoneyDrunk.Notify`) to confirm which pattern it follows; mirror that pattern. |
+| `HoneyDrunk.Data.Abstractions` | For `IRepository`, `IUnitOfWork` |
+| `HoneyDrunk.Vault` | For `IConfigProvider` (D4 — App Config sourcing for audit-class retention). The interface namespace is `HoneyDrunk.Vault.Abstractions` but the package is `HoneyDrunk.Vault` — Vault does not ship a separate `.Abstractions` NuGet. If a future Vault refactor splits Abstractions out, switch this row to `HoneyDrunk.Vault.Abstractions`. |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | DI registration helpers |
+| `Microsoft.Extensions.Hosting.Abstractions` | For startup hook integration |
+| `Microsoft.Extensions.Logging.Abstractions` | Logger contracts |
+| `Microsoft.Extensions.Options.ConfigurationExtensions` | Bind options from `IConfigProvider` |
+
+Project reference: `HoneyDrunk.Audit.Abstractions`.
+
+### Test projects
+
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `Microsoft.NET.Test.Sdk` | Standard |
+| `xunit` | Standard |
+| `xunit.runner.visualstudio` | Standard |
+| `Microsoft.Extensions.DependencyInjection` | For DI in Data tests |
+
+Project references as appropriate to each `.Tests` project:
+- `HoneyDrunk.Audit.Abstractions.Tests` → `HoneyDrunk.Audit.Abstractions`
+- `HoneyDrunk.Audit.Data.Tests` → `HoneyDrunk.Audit.Data` and `HoneyDrunk.Audit.Abstractions`
+
+## Boundary Check
+
+- [x] All work inside `HoneyDrunk.Audit`. No edits to other Grid repos.
+- [x] `HoneyDrunk.Audit.Abstractions` carries exactly ONE `HoneyDrunk.*` reference: `HoneyDrunk.Kernel.Abstractions` (for `TenantId`). Per ADR-0031 D2's "zero runtime dependencies beyond `HoneyDrunk.Kernel` abstractions" allowance, and ADR-0026's per-tenant strong typing requirement. No `HoneyDrunk.Kernel` runtime ref; no `HoneyDrunk.Data*`, no `HoneyDrunk.Vault*`, no `HoneyDrunk.Pulse*` from Abstractions.
+- [x] `HoneyDrunk.Audit.Data` references `HoneyDrunk.Audit.Abstractions` (project reference), `HoneyDrunk.Kernel.Abstractions` (for interfaces), `HoneyDrunk.Data.Abstractions`, `HoneyDrunk.Vault` — and **no** `HoneyDrunk.Pulse`. Optional `HoneyDrunk.Kernel` runtime reference dropped if not needed (audit a peer `Data` package to confirm). Telemetry is one-way to Pulse per D7; Audit has no runtime dependency on Pulse.
+- [x] No secrets in code. The retention value is read via `IConfigProvider` from App Configuration (ADR-0005 host composition); no key vault access is needed from this runtime (the retention value is non-secret configuration).
+- [x] `IAuditLog` exposes exactly `AppendAsync` — no update, no replace, no delete. Append-only is enforced at the interface surface per the substrate-level audit-emission boundary invariant `{N-substrate}` (ADR-0030 packet 02) and repo-local invariant 2.
+- [x] `AuditEntry` is a record (no `I` prefix). `IAuditLog` and `IAuditQuery` are interfaces (with `I`). `AuditQueryFilter` is a record (no `I`). Per Grid-wide naming rule (memory `project_naming_rule_records`).
+- [x] In-memory fixtures live `internal` to the test project — not packaged. Per D2 + ADR-0027 D3 precedent.
+- [x] The scaffold does NOT include hash-chain / WORM tamper-evidence (deferred per D9 / ADR-0030 D8a). The scaffold does NOT include the deployable tenant-facing forensics Service (deferred per ADR-0030 D8b). The scaffold does NOT include the Auth emitter wiring (packet 04 — separate). The scaffold does NOT include Operator reconciliation (Operator scaffolding initiative — separate).
+- [x] Per ADR-0030 D9 / D4: the store is **not** documented or described as tamper-evident. Repo README's "Phase-1 honest limitation" section names this explicitly.
+
+## Acceptance Criteria
+
+- [ ] `HoneyDrunk.Audit.slnx` builds clean from a fresh clone via `dotnet build` with no warnings (warnings-as-errors).
+- [ ] All three D3 contracts present in `HoneyDrunk.Audit.Abstractions` with XML documentation per invariant 13. Records (`AuditEntry`, `AuditQueryFilter`) drop the `I` prefix; interfaces (`IAuditLog`, `IAuditQuery`) keep it. The strong-typed identifier `AuditEntryId` is also a record-struct without `I` (Grid-wide naming rule).
+- [ ] `HoneyDrunk.Audit.Abstractions` has exactly ONE `HoneyDrunk.*` PackageReference: `HoneyDrunk.Kernel.Abstractions` (for `TenantId`). Per ADR-0031 D2's "zero runtime dependencies beyond `HoneyDrunk.Kernel` abstractions" allowance. No `HoneyDrunk.Kernel` runtime ref; no `HoneyDrunk.Data*` / `HoneyDrunk.Vault*` / `HoneyDrunk.Pulse*` refs. Constitutional invariants `{N-coupling}` and 1 (downstream Abstractions-only coupling; Abstractions stay near-minimal) are satisfied — the single Kernel-Abstractions reference is an intentional, ADR-permitted exception.
+- [ ] `IAuditLog` exposes exactly one method, `AppendAsync(AuditEntry, CancellationToken)`. No `UpdateAsync`, no `ReplaceAsync`, no `DeleteAsync`, no `RemoveAsync`. The reflection test `AppendOnlyAtInterfaceTests.cs` asserts this and passes.
+- [ ] `HoneyDrunk.Audit.Data` exposes `AddHoneyDrunkAuditData()` extension; `IAuditLog` and `IAuditQuery` resolve from DI after registration.
+- [ ] `DataAuditLog.AppendAsync` persists via `IRepository<AuditEntry>.AddAsync` + `IUnitOfWork.SaveChangesAsync`. **No source-code call to `Update`/`Remove`/`UpdateRange`/`RemoveRange`** on `IRepository<AuditEntry>` — even though those methods exist on the inherited `IRepository<T>` interface (per `HoneyDrunk.Data.Abstractions/Repositories/IRepository.cs`), `DataAuditLog`'s source does not invoke any of them. Code review enforces this at v0.1.0; the README's Phase-1 honest limitation section explicitly names the storage-layer gap (`IAppendOnlyRepository<T>` carve-out is a Phase-2 hardening item).
+- [ ] `DataAuditLog.AppendAsync` assigns the entry's `Id` at write time as a fresh `AuditEntryId` (ULID-shaped strong type) and overwrites any caller-passed value (caller passes `AuditEntryId.Empty`); sets `CorrelationId`/`TenantId` defensively from `IGridContextAccessor.GridContext` if the entry's fields are empty.
+- [ ] `DataAuditLog` and `DataAuditQuery` resolve `IGridContext` via `IGridContextAccessor.GridContext` (ambient per-call), **not** via direct `IGridContext` ctor injection. The classes are Singleton; `IGridContext` is Scoped — direct injection would be a captive-dep.
+- [ ] `DataAuditLog` and `DataAuditQuery` resolve `IRepository<AuditEntry>` / `IReadOnlyRepository<AuditEntry>` / `IUnitOfWork` via `IServiceScopeFactory.CreateAsyncScope()` per call (the classes are Singleton; Data abstractions are typically Scoped — same captive-dep avoidance pattern).
+- [ ] `IAuditLog`, `IAuditQuery`, `AuditRetentionPolicy`, `AuditTelemetry`, `DataAuditLog`, `DataAuditQuery` are all registered as `Singleton` in `AddHoneyDrunkAuditData()`. Lifetime story is documented in the repo README and matches the Singleton-emitters-in-Auth lifetime (per packet 04).
+- [ ] `DataAuditQuery.ReadAsync` is implemented over `IReadOnlyRepository<AuditEntry>.FindAsync(predicate, ct)` (the actual public read method on the Data abstraction at v0.1.0; there is no `Query()` method). Time ordering and `Limit` are applied post-fetch, in memory. The class file carries a `// Phase-1: FindAsync + in-memory order/take. Phase-2: switch to a public order-by/take primitive when Data ships one.` comment near the read site.
+- [ ] **`AuditEntryId` strong type lives at `src/HoneyDrunk.Audit.Abstractions/AuditEntryId.cs`** as a `readonly record struct` matching the Kernel template (`TenantId`, `CorrelationId`). Exposes `AuditEntryId.New()`, `AuditEntryId.Empty`, `IsEmpty` property, and `ToString()` returning the wrapped string. `AuditEntry.Id` is typed as `AuditEntryId`, not `string`.
+- [ ] `DataAuditLog` and `DataAuditQuery` emit operational telemetry via `ITelemetryActivityFactory` (activities `audit.log.append`, `audit.query.read`). No `HoneyDrunk.Pulse.*` reference anywhere in `HoneyDrunk.Audit.Data.csproj`.
+- [ ] `AuditRetentionPolicy.RetentionDays` is sourced from `IConfigProvider.GetValueAsync` (key `audit:retention:days`) **once at startup**; defaults to 365d with a `::warning::` log if unset. No hardcoded retention literal in code. **No subscription to change-events** — `IConfigProvider` does not expose a change-token / observable surface at v0.1.0 (see `HoneyDrunk.Vault.Abstractions/IConfigProvider.cs`). Configuration changes require a host restart; hot-reload is an out-of-scope follow-up.
+- [ ] The scaffold's `README.md` includes a "Phase-1 honest limitation" section that explicitly states the store is **append-only-by-interface and NOT tamper-evident**, hash-chain/WORM is deferred behind the boundary. No language describing the store as tamper-evident appears anywhere in the repo.
+- [ ] In-memory fixtures `InMemoryAuditLog` and `InMemoryAuditQuery` exist under `tests/HoneyDrunk.Audit.Data.Tests/Fixtures/` with `internal` visibility. **No `src/HoneyDrunk.Audit.Testing/` project exists** — the fixture is not packaged at v0.1.0.
+- [ ] `SmokeTests.WriteThroughIAuditLog_ReadBackThroughIAuditQuery_RoundTrips` passes, proving the contracts round-trip through the in-memory fixture (per D11).
+- [ ] All five `.github/workflows/*.yml` files present and reference `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/*@main`.
+- [ ] `api-compatibility.yml` runs on PR. On the scaffolding PR itself the workflow runs against an absent `main` baseline and reports `status: skipped` per the `HoneyDrunk.Actions/.github/actions/api/check-compatibility/action.yml` missing-baseline path (it emits a `::warning::` and exits 0 when `git worktree add` against the baseline ref fails) — that is correct first-build behavior, not a failure. The scaffolding PR merge establishes the `main` baseline. **Verify post-merge** by opening a throwaway PR that removes the `AppendAsync` method from `IAuditLog` (or any member of `IAuditQuery` / `AuditEntry`); the workflow must fail with breaking-changes-detected. Revert the throwaway PR after observation.
+- [ ] `pr-core.yml` passes on the initial scaffolding PR (build + tests + analyzers + dependency scan + secret scan).
+- [ ] Repo-level `CHANGELOG.md` has a `## [0.1.0] - YYYY-MM-DD` entry covering the scaffold (per invariants 12, 27, and memory `feedback_no_unreleased_commits` — no `## Unreleased` block at commit time).
+- [ ] Per-package `CHANGELOG.md` files each have their own `## [0.1.0]` entry naming the package's specific introductions (per invariants 12 and 27).
+- [ ] Repo-level `README.md` and per-package `README.md` files all present per invariant 12.
+- [ ] Test suite runs and passes — minimum coverage: `AppendOnlyAtInterfaceTests` (reflection assertion on `IAuditLog`), `DataAuditLogTests` (append + Id assignment + retention hook + telemetry emission), `DataAuditQueryTests` (time-ordered reads + each filter dimension + Limit honored), `SmokeTests` (round-trip via in-memory fixture).
+- [ ] Both projects in the solution carry the same `Version` (0.1.0), excluding test projects (invariant 27).
+- [ ] Manual confirmation that pushing tag `v0.1.0` triggers `release.yml` and produces NuGet packages for both `src/*` projects (do not actually push the tag — verify the workflow exists and a tag-push trigger is configured).
+- [ ] **No `.github/dependabot.yml` file exists.** Per ADR-0009, dependency-scanning lives in the nightly workflows; no Dependabot config file is committed.
+- [ ] **`AuditEntry.TenantId` is the Kernel `TenantId` strong type** (from `HoneyDrunk.Kernel.Abstractions.Identity`), per ADR-0026. `AuditQueryFilter.TenantId` is `TenantId?` (nullable for "no filter on tenant"). **`CorrelationId` stays `string` at v0.1.0** (with a v0.2.0 promotion to the Kernel strong type flagged in a follow-up packet). The trade is explicit: per-tenant compliance/forensic queries justify the contract dependency on `Kernel.Abstractions`; correlation id is lower-stakes for filtering and stays string until the v0.2.0 bump can carry the promotion as one intentional contract-shape change.
+- [ ] **Repo `README.md` includes a `## For downstream consumers — minimal wiring` section** showing the host-side `services.AddVault().AddData(...).AddHoneyDrunkAuditData()` snippet, copy-pasteable. This is load-bearing for packet 04 (Auth emitter wiring) and future Operator reconciliation.
+- [ ] **The README does NOT cite "ADR-0031" by number in narrative paragraphs.** Per memory `feedback_no_adr_in_docs`. (Runtime metadata references — catalog entries elsewhere — are fine; the README is user-facing narrative.)
+
+## Human Prerequisites
+
+- [ ] Packet 02 of this initiative complete — `HoneyDrunkStudios/HoneyDrunk.Audit` repo exists on GitHub with org-default branch protection, labels seeded, OIDC federated credential wired, and the local working tree cloned at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Audit/`.
+- [ ] Packet 01 of this initiative merged — the two new Audit invariants exist in `constitution/invariants.md` so this packet's acceptance criteria reference them by number. **This packet's source file uses `{N-coupling}`, `{N-canary}`, and `{N-substrate}` placeholders** for the three Audit-related invariant numbers; substitute the real numbers in place pre-push under invariant 24's pre-filing carve-out, **after** packet 01 merges and the assigned numbers are known. Hardcoding 45/46 is wrong — those slots are occupied by ADR-0016 AI standup at scoping time.
+- [ ] After this packet's PR merges, push tag `v0.1.0` from `main` to trigger the first NuGet publish. Tags are human-pushed per invariant 27.
+- [ ] **`NUGET_API_KEY` repository (or org-level) secret is available to the `HoneyDrunk.Audit` repo before `v0.1.0` is tagged.** The reusable `release.yml` in `HoneyDrunk.Actions` declares `nuget-api-key` as a named secret (no `secrets: inherit` pattern). If packet 02's repo-creation chore did not seed this secret, the first `release.yml` run will surface the missing-key failure clearly. Org-level `NUGET_API_KEY` (shared with other HoneyDrunk repos publishing to nuget.org) is the standard approach — verify it's bound to this repo before tagging. (Container-registry publish via OIDC does not need a secret.)
+- [ ] **Branch protection sequencing.** Branch protection on `main` was set by packet 02 requiring only `pr-core / core` for the initial scaffolding PR (the `api-compatibility / abstractions-shape` check reports `status: skipped` on the first PR — see acceptance criteria). After the throwaway breaking-change PR confirms the canary fires post-merge, add `api-compatibility / abstractions-shape` to required checks in a follow-up branch-protection update.
+- [ ] **No Azure resource provisioning required for this packet.** HoneyDrunk.Audit is a library Node at Phase 1, not a deployable. The Audit Node's own dedicated managed identity (per ADR-0031 D5) belongs with whichever packet first deploys an Audit-composing host. Same for the App Configuration key `audit:retention:days` — seeding it for real in App Config is the responsibility of the first consuming deployable, not this scaffold. The scaffold ships the *read* path and a 365d startup default with a `::warning::` if the key is unset. Cross-link: [`infrastructure/walkthroughs/azure-provisioning-guide.md`](../../../../infrastructure/walkthroughs/azure-provisioning-guide.md) for when that work lands.
+- [ ] After this packet's PR merges and `v0.1.0` ships, file a small follow-up to add `HoneyDrunk.Audit` to the grid-health aggregator's watched-repos list in `HoneyDrunk.Actions` — only if the aggregator does not auto-discover from `catalogs/nodes.json`. Verify which behavior is in place at the time this prereq is being checked. (If auto-discovery is wired, ADR-0030 packet 01's `grid-health.json` edit is sufficient and this prereq is satisfied automatically.)
+- [ ] After this packet's PR merges, file a SonarCloud onboarding follow-up packet for `HoneyDrunk.Audit` modeled on `generated/issue-packets/active/adr-0011-code-review-pipeline/06-kernel-sonarcloud-onboarding.md` (or whichever ADR-0011 onboarding packet is the closest match in shape).
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — `HoneyDrunk.Audit.Abstractions.csproj` must contain zero `HoneyDrunk.*` references. The `HoneyDrunk.Standards` analyzer reference uses `PrivateAssets="all"` so it does not propagate.
+
+> **Invariant 2:** Runtime packages depend on Abstractions, never on other runtime packages at the same layer. — `HoneyDrunk.Audit.Data` references `HoneyDrunk.Audit.Abstractions` (project reference) and `HoneyDrunk.Kernel.Abstractions`, `HoneyDrunk.Data.Abstractions`, `HoneyDrunk.Vault` for runtime needs; the layered structure is preserved. The `HoneyDrunk.Kernel` runtime row in the NuGet table is optional — only added if Data needs concrete Kernel runtime types beyond the interfaces from `Kernel.Abstractions`.
+
+> **Invariant 3:** Provider packages depend on their parent Node's contracts, not internal implementation details. — Not directly applicable here (Audit has no provider packages at Phase 1). A future sibling backing slot (e.g. `HoneyDrunk.Audit.Cosmos`) would reference `HoneyDrunk.Audit.Abstractions` only, per this rule.
+
+> **Invariant 4:** No circular dependencies. The dependency graph is a DAG. Kernel is always at the root. — `HoneyDrunk.Audit.Data` references Kernel and Data; nothing in `HoneyDrunk.Audit.*` is referenced back from Kernel or Data. Audit → Data → Kernel and Audit → Kernel are all DAG-consistent per ADR-0031 D10.
+
+> **Invariant 5:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null `TenantId`. — `DataAuditLog.AppendAsync` resolves `IGridContext` from DI to enrich the entry's `CorrelationId` and `TenantId` defensively. Callers are expected to populate the fields themselves; Audit is the durable-record-of-last-resort and enriches when the fields are empty to avoid unattributable entries.
+
+> **Invariant 6:** CorrelationId is never null or empty, and TenantId is never absent, in a live GridContext. — `DataAuditLog` honors this by enriching empty entry fields from `IGridContext` rather than persisting unattributable entries. Per `repos/HoneyDrunk.Audit/integration-points.md`: "an audit entry without correlation and tenant is unattributable, which defeats the substrate's purpose."
+
+> **Invariant 9:** Vault is the only source of secrets. No Node reads secrets directly from environment variables, config files, or provider SDKs. All access goes through `ISecretStore`. — The retention value is non-secret configuration, sourced via `IConfigProvider` (App Configuration), not via `ISecretStore`. This is the App-Configuration-via-Vault pattern per ADR-0005, not a secret read.
+
+> **Invariant 11:** One repo per Node. Each repo has its own solution, CI pipeline, and versioning. — This packet establishes HoneyDrunk.Audit's solution and CI pipeline. Per the new-Node convention, the standup is itself ADR-governed (ADR-0031).
+
+> **Invariant 12:** Semantic versioning with CHANGELOG and README. New projects must have both files from the first commit. — Both `src/*` projects ship `README.md` and `CHANGELOG.md` in the same commit. Repo-level `CHANGELOG.md` and `README.md` also present.
+
+> **Invariant 13:** All public APIs have XML documentation. Enforced by HoneyDrunk.Standards analyzers. — All three D3 contracts and `AuditQueryFilter` carry `///` summaries.
+
+> **Invariant 14:** Canary tests validate cross-Node boundaries. Each Node that depends on another has a `.Canary` project verifying integration assumptions. — Future-facing: downstream Nodes (Auth at packet 04, eventually Operator) will add `.Canary` projects against `HoneyDrunk.Audit.Abstractions`. This packet does not author those — they belong with each consuming Node's wiring packet. **Audit itself does not need a `.Canary` project at this scaffold** because it consumes Kernel and Data via well-established contracts; the dependency-direction canaries on Kernel/Data would catch any boundary drift on the *consumed* side. (If invariant 14's intent is interpreted as requiring every consuming Node to ship a `.Canary` project even when its consumed contracts are pre-stable, raise that as a follow-up — this packet ships the round-trip smoke test as the equivalent boundary-verification shape.)
+
+> **Invariant 15:** Tests never depend on external services. Use InMemory providers for isolation. — The in-memory `IAuditLog`/`IAuditQuery` fixture exists specifically to satisfy this for Audit's own tests at v0.1.0, and (eventually, via a future `HoneyDrunk.Audit.Testing` package) for downstream Nodes' tests.
+
+> **Invariant 16:** No test code in runtime packages. Tests live in dedicated `.Tests` or `.Canary` projects only. — Fixtures live under `tests/HoneyDrunk.Audit.Data.Tests/Fixtures/`, not in `src/HoneyDrunk.Audit.Data/`.
+
+> **Invariant 26:** Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section. `HoneyDrunk.Standards` must be on every new .NET project. — This packet's NuGet Dependencies section enumerates all four new `.csproj` references plus the two test-project reference sets.
+
+> **Invariant 27:** All projects in a solution share one version and move together. When a version bump is warranted, every `.csproj` in the solution (excluding test projects) is updated to the same new version in a single commit. — Initial scaffold ships at `0.1.0` across both `src/*` packages.
+
+> **Invariant `{N-substrate}` (ADR-0030 packet 02):** Durable, attributable security and action events are emitted to the `HoneyDrunk.Audit` substrate via `IAuditLog`, on a durable channel separate from observability telemetry. Phase-1 audit integrity is append-only-by-interface (`IAuditLog` exposes no update and no delete method); it is explicitly **not** tamper-evident, and Phase 1 must not be documented or marketed as such. — This scaffold IS the durable substrate this invariant references. `IAuditLog` exposes no update or delete method (proven by `AppendOnlyAtInterfaceTests`); the README's "Phase-1 honest limitation" section names the not-tamper-evident reality.
+
+> **Invariant `{N-coupling}` (this initiative, packet 01):** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Audit.Abstractions`. Composition against `HoneyDrunk.Audit.Data` is a host-time concern resolved at application startup from App Configuration. — Reinforced in this scaffold by keeping `Abstractions` near-minimal (one `HoneyDrunk.Kernel.Abstractions` reference for `TenantId`; nothing else) so consumers (Auth at packet 04, Operator later) don't transit unintended pins through.
+
+> **Invariant `{N-canary}` (this initiative, packet 01):** The HoneyDrunk.Audit Node CI must include a contract-shape canary for `IAuditLog`, `IAuditQuery`, and `AuditEntry`. Shape drift on any of the three is a build failure unless paired with an intentional version bump. — `api-compatibility.yml` calls `HoneyDrunk.Actions/job-api-compatibility.yml` scoped to `HoneyDrunk.Audit.Abstractions`. The whole-assembly diff covers all three contracts plus `AuditQueryFilter`.
+
+## Referenced ADR Decisions
+
+**ADR-0031 D1 (Audit Node ownership):** HoneyDrunk.Audit is the Core sector's single Node owning the Grid's durable, attributable security-and-action record. It is a record substrate, not a control plane and not an observability pipeline. This scaffold ships only the substrate — no allow/deny decision logic, no sampling/aggregation.
+
+**ADR-0031 D2 (Package families):** Two packages — `HoneyDrunk.Audit.Abstractions` + `HoneyDrunk.Audit.Data`. The runtime is named for its backing per the §Alternatives Considered rejection of a bare runtime package; a future sibling backing slot is left open. In-memory fixtures live `internal` to the test project per ADR-0027 D3 precedent.
+
+**ADR-0031 D3 (Exposed contracts):** Three contracts — `IAuditLog` (interface), `IAuditQuery` (interface), `AuditEntry` (record). Records drop `I`; interfaces keep it.
+
+**ADR-0031 D4 (Storage is Data-backed; append-only enforced at the interface):** `HoneyDrunk.Audit.Data` implements the store over `HoneyDrunk.Data`'s `IRepository`/`IUnitOfWork`. The append-only guarantee is enforced at the interface surface: `IAuditLog` exposes no update and no delete method. Audit data carries an audit-class retention policy distinct from observability retention; the retention value is sourced via the App Configuration pattern (ADR-0005), not hardcoded. **Phase-1 integrity is append-only-by-interface, not tamper-evident** (D9 / ADR-0030 D9) — this is the stated, accepted limitation and the standup must not document or describe the store as tamper-evident.
+
+**ADR-0031 D5 (Managed identity):** The Audit Node runs under its own dedicated managed identity, distinct from Auth's and Operator's. **This scaffold is a library Node** — both packages are libraries, not deployables. The managed identity provisioning belongs with whichever packet first deploys an Audit-composing host. Cross-link the Azure provisioning walkthroughs at that future point. This packet's Human Prerequisites note the deferral.
+
+**ADR-0031 D6 (First emitter Auth; Operator reconciled):** Auth is the first emitter — that work lands in packet 04 of this initiative against the `Abstractions` this scaffold ships. Operator reconciliation lands with Operator's own scaffolding initiative (Operator is not yet scaffolded as of 2026-05-20).
+
+**ADR-0031 D7 (Telemetry direction):** `DataAuditLog` and `DataAuditQuery` emit operational telemetry via `ITelemetryActivityFactory` (Kernel). No Pulse package reference. Pulse consumes downstream — out of scope for this packet. **Audit *records* are not telemetry and never flow to Pulse.**
+
+**ADR-0031 D8 (Contract-shape canary):** `api-compatibility.yml` is the canary. Scoped to `HoneyDrunk.Audit.Abstractions` since per D9 that is the only public-boundary package. All three contracts plus `AuditQueryFilter` are frozen from the first scaffold.
+
+**ADR-0031 D9 (Downstream coupling):** Emitters and readers (Auth, Operator, future) compile only against `HoneyDrunk.Audit.Abstractions`. `Abstractions` is HoneyDrunk-dependency-free so consumers don't pull Kernel/Data/Vault transitively.
+
+**ADR-0031 D10 (Kernel and Data as first-class):** Audit takes runtime dependencies on Kernel (for `IGridContext`, lifecycle, telemetry) and Data (for `IRepository`/`IUnitOfWork`). New edges in `catalogs/relationships.json` were landed by ADR-0030 packet 01.
+
+**ADR-0031 D11 (Standup checklist):** This packet implements the full D11 first-PR checklist: solution layout, HoneyDrunk.Standards wiring, CI via Actions reused workflows, per-package README/CHANGELOG, LICENSE, Data-backed append-only store, the Node's managed identity *deferred* per the library-Node rationale above (D5), in-memory fixture, end-to-end smoke test.
+
+**ADR-0030 D4 (Audit-class retention distinct from observability):** The `AuditRetentionPolicy` class lands in this scaffold; the value is sourced from `IConfigProvider`, default 365d, with a `::warning::` if unset. The retention enforcement loop is a Phase-2 concern; the *value* and the *read path* land here.
+
+**ADR-0030 D5 (Contract relocation + Operator reconciliation):** `IAuditLog` and `AuditEntry` are authored in `HoneyDrunk.Audit.Abstractions` here (not relocated from existing Operator code, because Operator was never scaffolded — the relocation is a conceptual catalog-level move). Operator's eventual reconciliation is a separate packet against this `Abstractions`.
+
+**ADR-0030 D9 (Phase-1 honest limitation):** Phase 1 is append-only-by-interface, NOT tamper-evident. The scaffold must not document or describe the store as tamper-evident. The repo `README.md` carries a `## Phase-1 honest limitation` section naming this explicitly.
+
+**ADR-0026 (Grid Multi-Tenant Primitives — `TenantId` strong type, Accepted):** `IGridContext.TenantId` is the non-nullable `HoneyDrunk.Kernel.Abstractions.Identity.TenantId` ULID record struct with a well-known `Internal` sentinel for non-multi-tenant operations. The Audit Node is queried for per-tenant compliance and forensic retrieval — re-introducing `string`-typed tenancy at the Audit contract surface would re-create exactly the consumer-side parse-and-default footgun ADR-0026 closed. This scaffold uses the `TenantId` strong type on `AuditEntry.TenantId` and `AuditQueryFilter.TenantId` (nullable on the filter for "no filter on tenant"), taking a single, well-bounded `HoneyDrunk.Kernel.Abstractions` reference on `HoneyDrunk.Audit.Abstractions.csproj`. The same argument applies to `CorrelationId`; at v0.1.0 the trade is to keep correlation `string` and promote to the Kernel strong type at v0.2.0 as one intentional contract-shape change (flagged as a follow-up).
+
+**ADR-0027 (No speculative Testing package; cut later as non-breaking):** ADR-0031 D2 + §Alternatives Considered explicitly invoke this precedent. The in-memory `IAuditLog`/`IAuditQuery` fixture lives `internal` to `tests/HoneyDrunk.Audit.Data.Tests/Fixtures/`; no `HoneyDrunk.Audit.Testing` package is shipped at v0.1.0.
+
+**ADR-0009 (Dependabot stance, Accepted):** No `.github/dependabot.yml` is created. Dependency-scanning is delegated to `nightly-deps.yml` and `nightly-security.yml` calling `HoneyDrunk.Actions` reusable workflows.
+
+**ADR-0005 (App Configuration via Vault, Accepted):** `HoneyDrunk.Audit.Data` reads the retention value through `IConfigProvider` from `HoneyDrunk.Vault`, not via direct App Configuration SDK calls. The composing host wires the App Configuration provider; this scaffold consumes the abstraction.
+
+## Dependencies
+
+- `packet:01` — the two new Audit invariants (downstream coupling + contract-shape canary) must exist in `constitution/invariants.md` before this packet's acceptance criteria reference them by number. Substitute the assigned `{N-coupling}` and `{N-canary}` numbers in this packet's source file in place pre-push under invariant 24's pre-filing carve-out, **after** packet 01 merges.
+- `packet:02` — the `HoneyDrunk.Audit` GitHub repo must exist with branch protection, labels, OIDC, and the local working tree cloned. The scaffolding agent has nowhere to author into without packet 02 done.
+
+## Labels
+
+`feature`, `tier-2`, `audit`, `scaffold`, `adr-0031`
+
+## Agent Handoff
+
+**Objective:** Take the empty `HoneyDrunk.Audit` repo and ship version 0.1.0 with the three D3 contracts, Data-backed append-only `IAuditLog` writer + `IAuditQuery` reader, audit-class retention policy hook (App Config-sourced), in-memory fixture (internal to the test project), end-to-end smoke test proving round-trip, full CI, and the contract-shape canary scoped to `Abstractions`.
+
+**Target:** HoneyDrunk.Audit, branch from `main`. (Packet 02 ensures `main` exists with `.gitignore`/`LICENSE` already in place.)
+
+**Context:**
+- Goal: Unblock HoneyDrunk.Auth (packet 04 of this initiative — first emitter) and any future Node that needs to record durable, attributable security or privileged-action events. Establish the contract-shape canary baseline that protects the surface from drift.
+- Feature: ADR-0031 standup initiative — this is the substrate scaffold, the third packet of the initiative (after the two new Audit invariants `{N-coupling}` / `{N-canary}` in packet 01 and the repo creation in packet 02).
+- ADRs: ADR-0031 (sole governing standup ADR); ADR-0030 (the driving capability/decision ADR — Phase-1 honest limitation, contract relocation, retention regime, Operator reconciliation framing all come from there); ADR-0005 (App Config-via-Vault pattern that D4 builds on); ADR-0009 (no Dependabot config file).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packets 01 and 02 of this initiative must merge / be Done first.
+
+**Constraints:**
+
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — `HoneyDrunk.Audit.Abstractions.csproj` must contain no `HoneyDrunk.*` PackageReference or ProjectReference. The `HoneyDrunk.Standards` reference uses `PrivateAssets="all"` so it does not propagate.
+- **Invariant 4:** No circular dependencies. The dependency graph is a DAG. Kernel is always at the root. — Audit → Data → Kernel and Audit → Kernel are DAG-consistent. The rejected Kernel-hosted alternative (per ADR-0030) would have created a Kernel → Data → Kernel cycle; this Node placement specifically avoids that.
+- **Invariant 5/6:** GridContext + CorrelationId + TenantId must be present in every scoped operation. — `DataAuditLog.AppendAsync` enriches the entry from `IGridContext` defensively when caller-passed fields are empty.
+- **Invariant 9:** Vault is the only source of secrets. — The retention value is non-secret configuration, sourced via `IConfigProvider` from App Configuration per ADR-0005. No `ISecretStore` calls are needed in this scaffold.
+- **Invariant 12:** Semantic versioning with CHANGELOG and README. New projects must have both files from the first commit. — Both `src/*` projects ship `README.md` and `CHANGELOG.md` in the same commit.
+- **Invariant 13:** All public APIs have XML documentation. — Every public type/member in `HoneyDrunk.Audit.Abstractions` carries `///` summaries. StyleCop rules from `HoneyDrunk.Standards` enforce this.
+- **Invariant 26:** Packets for .NET code work must include `## NuGet Dependencies`. `HoneyDrunk.Standards` must be on every new .NET project. — Confirmed in the NuGet Dependencies section above.
+- **Invariant 27:** All projects in a solution share one version. — Both `src/*.csproj` ship at `0.1.0`. Test projects do not bump.
+- **Invariant `{N-substrate}` (substrate-level audit-emission boundary, ADR-0030 packet 02):** Durable, attributable security and action events are emitted to the `HoneyDrunk.Audit` substrate via `IAuditLog`, on a durable channel separate from observability telemetry. Phase-1 audit integrity is append-only-by-interface (`IAuditLog` exposes no update and no delete method); it is explicitly **not** tamper-evident, and Phase 1 must not be documented or marketed as such. — `IAuditLog` exposes exactly `AppendAsync`. The reflection test `AppendOnlyAtInterfaceTests` makes accidental future addition of an update/delete method a build failure. The README's "Phase-1 honest limitation" section names the not-tamper-evident reality.
+- **Invariant `{N-coupling}`:** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Audit.Abstractions`. Composition against `HoneyDrunk.Audit.Data` is a host-time concern. — Reinforced by keeping `Abstractions` near-minimal (one `HoneyDrunk.Kernel.Abstractions` reference for `TenantId`).
+- **Invariant `{N-canary}`:** The HoneyDrunk.Audit Node CI must include a contract-shape canary for `IAuditLog`, `IAuditQuery`, and `AuditEntry`. Shape drift is a build failure unless paired with an intentional version bump. — `api-compatibility.yml` covers this by scoping to `HoneyDrunk.Audit.Abstractions`.
+- **Canary on the scaffolding PR is expected to report `status: skipped`, not fail.** The shared `HoneyDrunk.Actions/.github/actions/api/check-compatibility/action.yml` emits `::warning::` and exits 0 with `status: skipped` when `git worktree add` against the baseline ref fails — which it always does on a first PR against a near-empty repo. Do not treat the skip as a misconfiguration and do not chase it. The scaffolding PR's merge establishes the `main` baseline; verification of the canary actually firing happens **post-merge** via a throwaway breaking-change PR that is reverted after observation.
+- **Abstractions stance — exactly one `HoneyDrunk.*` reference, intentional.** `HoneyDrunk.Audit.Abstractions` ships with exactly one `HoneyDrunk.*` reference: `HoneyDrunk.Kernel.Abstractions`, for the `TenantId` strong type per ADR-0026. This is a **deliberate departure** from the ADR-0016 AI standup's zero-`HoneyDrunk` stance, justified by ADR-0026's per-tenant typing requirement and ADR-0031 D2's explicit allowance ("zero runtime dependencies beyond `HoneyDrunk.Kernel` abstractions"). Concretely: `AuditEntry.TenantId` and `AuditQueryFilter.TenantId` are the Kernel `TenantId` strong type (not `string`); `AuditEntry.CorrelationId` and `AuditQueryFilter.CorrelationId` stay `string` at v0.1.0 with a v0.2.0 promotion to the Kernel strong type flagged as a follow-up. Do NOT add any other `HoneyDrunk.*` reference to `HoneyDrunk.Audit.Abstractions.csproj` — not `HoneyDrunk.Kernel` (runtime), not `HoneyDrunk.Data*`, not `HoneyDrunk.Vault*`, not `HoneyDrunk.Pulse*`.
+- **Records drop `I`; interfaces keep it.** `AuditEntry` is a record (no `I`). `AuditQueryFilter` is a record (no `I`). `IAuditLog` and `IAuditQuery` are interfaces (with `I`). Per Grid-wide naming rule (memory `project_naming_rule_records`).
+- **Per ADR-0009, no `.github/dependabot.yml` is created.** Dependency-scanning is delegated to `nightly-deps.yml` and `nightly-security.yml` calling `HoneyDrunk.Actions` reusable workflows. GitHub Dependabot security alerts remain enabled at repo settings (org default — packet 02 confirms). No grouped or per-package `dependabot.yml` configuration file is committed to this repo.
+- **Phase-1 store is NOT tamper-evident.** Per ADR-0030 D9 / ADR-0031 §Negative: hash-chain/WORM is deferred behind the boundary. The scaffold must not document, describe, or market the store as tamper-evident anywhere — in code comments, in package descriptions (`<Description>` in csproj), in READMEs, or in CHANGELOG entries. The repo `README.md` carries a `## Phase-1 honest limitation` section that names this explicitly. Do not soften, hedge, or marketize the limitation.
+- **`IAuditLog` has exactly one method — `AppendAsync`.** No `UpdateAsync`, no `ReplaceAsync`, no `DeleteAsync`, no `RemoveAsync`, no `AppendBatchAsync` (the contract is single-entry append; batching is a future-version concern). The `AppendOnlyAtInterfaceTests` reflection test makes this a build-time gate.
+- **`AuditEntry.Id` is writer-assigned at append time.** `DataAuditLog.AppendAsync` overwrites whatever value the caller passed in via the `AuditEntry.Id` field with a freshly-generated ULID. Callers may pass `string.Empty` (the in-memory fixture and the smoke test both do this). The XML docs on `AuditEntry.Id` reflect this convention.
+- **`AuditEntry.OccurredAt` is caller-assigned and never overwritten.** The caller (Auth, Operator, future) sets `OccurredAt` at the moment the audited action occurred. `DataAuditLog` does not touch it.
+- **No `HoneyDrunk.Pulse.*` reference anywhere in this repo.** Telemetry direction is one-way to Pulse per D7; Audit emits via Kernel's `ITelemetryActivityFactory`, and Pulse observes downstream. `HoneyDrunk.Audit.Data.csproj` must not contain a `HoneyDrunk.Pulse.*` PackageReference.
+- **In-memory fixtures stay `internal` to the test project.** Per D2 + ADR-0027 D3: no `src/HoneyDrunk.Audit.Testing/` project at v0.1.0. The fixture files live under `tests/HoneyDrunk.Audit.Data.Tests/Fixtures/` with `internal` visibility. Future cutting into a `HoneyDrunk.Audit.Testing` package is a non-breaking change when a third consumer needs it — out of scope here.
+
+**Key Files:**
+- `HoneyDrunk.Audit.slnx`, `Directory.Build.props`
+- `src/HoneyDrunk.Audit.Abstractions/IAuditLog.cs`, `IAuditQuery.cs`, `AuditEntry.cs` (the record + the `AuditQueryFilter` record)
+- `src/HoneyDrunk.Audit.Data/ServiceCollectionExtensions.cs`, `DataAuditLog.cs`, `DataAuditQuery.cs`, `AuditRetentionPolicy.cs`, `AuditTelemetry.cs`
+- `tests/HoneyDrunk.Audit.Abstractions.Tests/ContractSurfaceTests.cs`, `AppendOnlyAtInterfaceTests.cs`
+- `tests/HoneyDrunk.Audit.Data.Tests/Fixtures/InMemoryAuditLog.cs`, `Fixtures/InMemoryAuditQuery.cs`, `DataAuditLogTests.cs`, `DataAuditQueryTests.cs`, `SmokeTests.cs`
+- `.github/workflows/{pr-core,release,nightly-deps,nightly-security,api-compatibility}.yml`
+- `README.md`, `CHANGELOG.md` (repo-level), per-package `README.md` and `CHANGELOG.md`
+
+**Contracts:**
+- All three D3 contracts (`IAuditLog`, `IAuditQuery`, `AuditEntry`) plus the supporting `AuditQueryFilter` record authored fresh in this packet inside `HoneyDrunk.Audit.Abstractions`.
+- The contract-shape canary establishes its baseline against this packet's commit. Future shape changes to any public type in `Abstractions` trigger the canary.

--- a/generated/issue-packets/active/adr-0031-audit-node-standup/04-auth-wire-first-emitter.md
+++ b/generated/issue-packets/active/adr-0031-audit-node-standup/04-auth-wire-first-emitter.md
@@ -1,0 +1,473 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Auth
+labels: ["feature", "tier-2", "auth", "audit", "adr-0031"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0031", "ADR-0030", "ADR-0026", "ADR-0027"]
+accepts: ADR-0031
+wave: 3
+initiative: adr-0031-audit-node-standup
+node: honeydrunk-auth
+---
+
+# Feature: Wire HoneyDrunk.Auth as the first `IAuditLog` emitter — durable security events (login attempts, authz grants/denials)
+
+## Summary
+Wire `HoneyDrunk.Auth` to emit durable `AuditEntry` records via `IAuditLog` for the two event classes ADR-0030 D6 names — token-validation outcomes (login-attempt analogue: bearer-token validation success/failure) and authorization-policy decisions (grants and denials). Auth becomes the first real emitter against the substrate stood up by packet 03. The emission is **additive** to Auth's existing OTel traces, on the separate durable channel per the substrate-level audit-emission boundary invariant `{N-substrate}` (landed by ADR-0030 packet 02) — Auth's identity-out-of-traces invariant is untouched (audit records are out-of-band of traces, and the existing trace enrichment is not changed; what Auth was already tracing it continues to trace, and the new audit emission lives in parallel).
+
+This packet does **not** introduce identity-bearing PII into Auth's OTel traces; audit records carry actor/correlation/tenant in their own durable channel.
+
+**Pre-filing invariant-number substitution required.** This packet uses `{N-substrate}` (substrate-level audit-emission boundary, ADR-0030 packet 02) and `{N-coupling}` (downstream Abstractions-only coupling, this initiative's packet 01) placeholders. After packets 01 and the ADR-0030 acceptance initiative merge and the actual numbers are known, edit this file in place pre-push (invariant 24's pre-filing carve-out). Hardcoding 44/45 is WRONG — those slots are occupied by ADR-0016 AI standup as of 2026-05-20.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Auth`
+
+## Motivation
+
+Per ADR-0030 D6 and ADR-0031 D6, Auth is the first real emitter wired against the stood-up `HoneyDrunk.Audit.Abstractions`. The two event classes Auth must durably record are:
+
+- **Token validation outcomes** — every time `BearerTokenAuthenticationProvider` validates a bearer token, the outcome (`granted` for a valid token; `denied` for an invalid/expired/missing-claim token) is a security-relevant event that today evaporates into sampled OTel traces (and identity is deliberately kept *out* of those traces per Auth's identity-out-of-traces invariant — so an incident reconstruction has to correlate token-id against external systems). A durable, attributable audit record solves this without compromising the trace-side identity-out invariant.
+- **Authorization-policy decisions** — every time `DefaultAuthorizationPolicy.EvaluateAsync` returns an `AuthorizationDecision` (Allow or Deny), that's a security-relevant event that today is similarly trace-only. Durable record matters here too: "user X was denied access to resource Y at time T" is exactly the kind of question audit answers. **The emission lives on `DefaultAuthorizationPolicy`, NOT on `AuthorizationPolicyEvaluator`.** `AuthorizationPolicyEvaluator` is a `public sealed class` whose single method `Evaluate(AuthenticatedIdentity?, AuthorizationRequest)` is `static` — it's the pure, side-effect-free decision core. `DefaultAuthorizationPolicy` is the I/O-side decorator (Singleton, DI-resolvable, implements `IAuthorizationPolicy`) that wraps the pure evaluator and already adds telemetry/logging. Audit emission is another I/O-side cross-cutting concern and belongs in the same decorator alongside the existing telemetry tagging. Attempting to inject `IAuditLog` into the static evaluator is structurally impossible (no constructor, no instance state) and would defeat the deliberate purity of the static method.
+
+Per ADR-0030 D6: "recording durable attributable security events additively to its existing OTel traces, on a separate durable channel, with Auth's identity-out-of-traces invariant untouched." This packet implements that.
+
+Until this packet ships, the substrate-level audit-emission boundary invariant `{N-substrate}` (auditable security events emitted to the Audit substrate via `IAuditLog`) has a substrate but no first compliant emitter. Auth not emitting is exactly the kind of gap that invariant exists to make visible — and this packet closes it for Auth.
+
+## Proposed Implementation
+
+### Add `HoneyDrunk.Audit.Abstractions` PackageReference
+
+In `HoneyDrunk.Auth/HoneyDrunk.Auth.csproj`, add:
+
+```xml
+<PackageReference Include="HoneyDrunk.Audit.Abstractions" Version="0.1.0" />
+```
+
+**Per invariant `{N-coupling}` (this initiative, packet 01): downstream Nodes take a runtime dependency only on `HoneyDrunk.Audit.Abstractions`.** Do not add `HoneyDrunk.Audit.Data` — composition is a host-time concern. The host that deploys Auth registers `IAuditLog` and `IAuditQuery` via `services.AddHoneyDrunkAuditData()` (or whichever backing-slot composition the host chooses); Auth just consumes `IAuditLog` from DI.
+
+### Inject `IAuditLog` into the two emitting classes
+
+**`BearerTokenAuthenticationProvider`** — Add two constructor-injected dependencies alongside the existing parameters: `IAuditLog` and `IGridContextAccessor`. The `IAuditLog` injection is **optional** at the DI-resolution layer: if no `IAuditLog` is registered in the host's container, Auth resolves a no-op stub and logs a `::warning::` at startup ("HoneyDrunk.Audit.Abstractions.IAuditLog is not registered; security event audit emission is disabled. Compose HoneyDrunk.Audit.Data (or another IAuditLog backing) in the host to enable durable security-event audit per the Grid's audit-emission boundary invariant."). The Hive board can carry a follow-up "wire Audit composition in host X" item if a host ships Auth-with-audit without an `IAuditLog` registration.
+
+**Why optional rather than required.** Auth ships as a library Node consumed by multiple hosts; some hosts (e.g., the canary project at v0.4.0) may not have an audit backing wired yet. Hard-failing on `IAuditLog` missing would break those hosts' first build against `HoneyDrunk.Auth` v0.5.0. The no-op stub + startup `::warning::` is the same pattern Communications uses for optional decision-log composition (ADR-0019); see `HoneyDrunk.Communications` for reference.
+
+**`DefaultAuthorizationPolicy`** — Same pattern: add `IAuditLog` and `IGridContextAccessor` to the existing primary-constructor parameter list (`ITelemetryActivityFactory telemetryFactory, ILogger<DefaultAuthorizationPolicy> logger, IAuditLog auditLog, IGridContextAccessor gridContextAccessor`). Emission lands inside `EvaluateAsync` after the existing `RecordTelemetry`/`LogDecision` calls, on the same return path that already returns `Task.FromResult(decision)`. The pure static `AuthorizationPolicyEvaluator.Evaluate` is **not** touched — keeping it pure is the whole reason `DefaultAuthorizationPolicy` exists.
+
+### Lifetime story — Singleton emitters with ambient grid-context access (avoiding captive-dep)
+
+Both `BearerTokenAuthenticationProvider` and `DefaultAuthorizationPolicy` are registered as `Singleton` by `HoneyDrunkAuthServiceCollectionExtensions.AddHoneyDrunkAuth()` (lines 83 and 86 of `HoneyDrunkAuthServiceCollectionExtensions.cs`). `IGridContext` is registered as `Scoped` (one instance per DI scope, populated by middleware at request intake per the Kernel ownership model). **Directly injecting `IGridContext` into a Singleton is the captive-dep anti-pattern** — the Singleton would close over the first scope's `IGridContext` and every subsequent request would see stale or invalid context.
+
+Auth already solves this exact problem with `IOperationContextAccessor` and `IGridContextAccessor` — both live in `HoneyDrunk.Kernel.Abstractions.Context` and were designed for this case. Per `IGridContextAccessor`'s own XML docs: "Provides ambient access to the current DI-scoped Grid context. … Use sparingly — prefer explicit `IGridContext` injection via constructor when possible. The accessor exists for scenarios where constructor injection is not feasible (e.g., static methods, cross-cutting concerns)." Singleton-emitters resolving Scoped context per-call is exactly that case.
+
+Concretely, in both emitters:
+
+```csharp
+// Constructor (DefaultAuthorizationPolicy, BearerTokenAuthenticationProvider)
+private readonly IGridContextAccessor _gridContextAccessor;
+private readonly IAuditLog _auditLog;
+
+// At each emit site, inside the method that already exists (EvaluateAsync / AuthenticateAsync):
+var gridContext = _gridContextAccessor.GridContext; // resolves the current scope's instance
+// ...build AuditEntry using gridContext.CorrelationId, gridContext.TenantId...
+```
+
+`IGridContextAccessor` is already in `services.ValidateKernelServices()`'s required list (`HoneyDrunkAuthServiceCollectionExtensions.cs:99`) — the host is guaranteed to have it registered before `AddHoneyDrunkAuth()` runs, so the new constructor parameter is always resolvable.
+
+**Do NOT add `IGridContext` directly to either constructor.** The build will succeed but every request after the first will read stale context.
+
+### Emission shape
+
+**On token validation in `BearerTokenAuthenticationProvider`:**
+
+After the existing `ValidateTokenAsync(...)` returns its `AuthenticationResult`, and before `AuthenticateAsync` returns it to the caller, emit an `AuditEntry`. Inspect the actual `AuthenticationResult` shape at `HoneyDrunk.Auth.Abstractions/AuthenticationResult.cs` before authoring — the success-discriminator is `IsAuthenticated` (a `bool` property), `Identity` is a nullable `AuthenticatedIdentity?` populated only on success, and `Identity.SubjectId` is the non-null `string` on a successful identity:
+
+```csharp
+var gridContext = _gridContextAccessor.GridContext;
+try
+{
+    await _auditLog.AppendAsync(new AuditEntry(
+        Id: string.Empty, // writer assigns at append time
+        OccurredAt: DateTimeOffset.UtcNow,
+        Actor: result.Identity?.SubjectId ?? "anonymous",
+        Action: "auth.token.validate",
+        Outcome: result.IsAuthenticated ? "granted" : "denied",
+        CorrelationId: gridContext.CorrelationId,  // IGridContext.CorrelationId is already string; no .ToString()
+        TenantId: gridContext.TenantId,            // Kernel strong type per ADR-0026 — pass through, do not stringify
+        Context: BuildValidationContext(result)
+    ), cancellationToken);
+}
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Audit emission failed for token validation; authentication outcome is unchanged");
+}
+```
+
+Where `BuildValidationContext` produces a JSON-shaped string containing **non-identity-bearing** metadata: token-id (`jti` claim if present), issuer (`iss`), audience (`aud`), expiration (`exp`), and the `FailureCode` enum value + `FailureMessage` string when `IsAuthenticated` is false. **No raw token text. No bearer-token contents. No claim values beyond the standard identifier claims.** Use the static whitelist `AuditAllowedClaims` constant defined on the class (see "AuditAllowedClaims whitelist" below) so the allow-list is exactly one source of truth that both production code and tests reference.
+
+**Failure to emit must not fail the request.** As shown above, the `AppendAsync` call is wrapped in try/catch that logs the exception to the existing `ILogger<BearerTokenAuthenticationProvider>` and continues. A flaky audit store should not break authentication — the existing trace-side telemetry is the secondary observability, and a failed durable audit emission is a problem for the audit substrate's own SLO, not Auth's request handling.
+
+**Note on `IGridContext.CorrelationId` shape at v0.1.0.** `IGridContext.CorrelationId` is already declared as `string` (see `HoneyDrunk.Kernel.Abstractions/Context/IGridContext.cs:52`). The emission pass-through is direct — no `.ToString()` call, that would be redundant. **v0.2.0 follow-up:** when `AuditEntry.CorrelationId` is promoted from `string` to the strong type `HoneyDrunk.Kernel.Abstractions.Identity.CorrelationId` (flagged in packet 03 §Contract details — `HoneyDrunk.Audit.Abstractions`), the boundary cannot stay a pass-through — Kernel's `IGridContext.CorrelationId` will still be `string` for back-compat, so Auth's emission site will need to wrap explicitly: `CorrelationId: new CorrelationId(gridContext.CorrelationId)`. That construction is the v0.2.0 packet's job, not this packet's.
+
+**On authorization-policy decision in `DefaultAuthorizationPolicy`:**
+
+After the existing `RecordTelemetry(activity, decision)` and `LogDecision(request, decision)` calls inside `EvaluateAsync`, and before `return Task.FromResult(decision);`, emit:
+
+```csharp
+var gridContext = _gridContextAccessor.GridContext;
+try
+{
+    await _auditLog.AppendAsync(new AuditEntry(
+        Id: string.Empty,
+        OccurredAt: DateTimeOffset.UtcNow,
+        Actor: identity?.SubjectId ?? "anonymous",
+        Action: $"auth.authorize.{request.Action}",
+        Outcome: decision.IsAllowed ? "granted" : "denied",
+        CorrelationId: gridContext.CorrelationId,
+        TenantId: gridContext.TenantId,
+        Context: BuildAuthorizationContext(decision, request)
+    ), cancellationToken);
+}
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Audit emission failed for authorization decision; decision outcome is unchanged");
+}
+return decision;
+```
+
+Verify against the actual shape at `HoneyDrunk.Auth/Authorization/DefaultAuthorizationPolicy.cs`:
+
+- `EvaluateAsync` receives `(AuthenticatedIdentity? identity, AuthorizationRequest request, CancellationToken)` and currently `return Task.FromResult(decision)` is the last statement. The new emit-and-await happens between `LogDecision(...)` and the return; the method changes from `Task<AuthorizationDecision>` returning a completed-task to a `Task<AuthorizationDecision> await`-on-emit-then-return (so the method body becomes `await _auditLog.AppendAsync(...); return decision;` instead of `return Task.FromResult(decision);`).
+- `decision.IsAllowed` is the success-discriminator on `AuthorizationDecision` (already used at line 67 of the existing `RecordTelemetry`). It is `IsAllowed`, NOT `IsGranted`.
+- The actor is `identity?.SubjectId` (the parameter the method already receives), not a property of `AuthorizationDecision`. If `identity` is null the request was never authenticated and the policy already short-circuits to a `NotAuthenticated` deny in the static evaluator — but for audit-record purposes the emission still happens with `Actor="anonymous"` so the denied attempt is durably recorded.
+- `request.Action` (a `string` property on `AuthorizationRequest`) is the verb being authorized — e.g., `read`, `write`, `delete` — and is the conventional first half of the action name. Use it directly in the `Action` string interpolation (`auth.authorize.{request.Action}`); the policy name itself is captured in `Context` rather than the `Action` string because `PolicyName` is always `"Default"` on `DefaultAuthorizationPolicy` and adds no information at this site.
+
+The `Context` carries the policy name, the `request.Resource` identifier (non-PII; if a resource ID happens to be a tenant-scoped identifier, that is data the resource already carries — Auth is not introducing new identity surface, it is recording the decision against existing identifiers), the `decision.SatisfiedRequirements` collection, and the deny-reason codes from `decision.DenyReasons` (codes, not raw messages, since the messages can contain subject IDs per the existing `LogDecision` comment).
+
+### `AuditAllowedClaims` whitelist — production constant, not just a test convention
+
+In `BearerTokenAuthenticationProvider`, add a `private static readonly HashSet<string>` constant near the top of the class:
+
+```csharp
+private static readonly HashSet<string> AuditAllowedClaims = new(StringComparer.Ordinal)
+{
+    "jti",
+    "iss",
+    "aud",
+    "exp",
+};
+```
+
+`BuildValidationContext` iterates the result's claims and emits only entries whose key matches `AuditAllowedClaims` into the JSON-shaped context string. The test `BearerTokenAuthenticationProvider_AuditContext_ContainsNoTokenText` (renamed accordingly) verifies the whitelist constant is the single source of truth — it constructs a token whose claims include `"jti"`, `"iss"`, `"sub"`, `"name"`, and a fabricated `"secret-claim"` value, asserts that the emitted `Context` JSON contains `jti`/`iss` and does NOT contain `sub`/`name`/`secret-claim`/the raw token string. **Production code and test reference the same constant; a future PR adding a new claim to the allow-list updates one place.**
+
+### `Context` size limit and defensive truncation (Phase-1)
+
+`AuditEntry.Context` is unbounded `string?` at the contract surface. To prevent a pathological token (an attacker-crafted JWT with a 10MB `iss` claim) from blowing up a single audit row, both emission sites cap the serialized `Context` JSON at **4096 bytes** (4 KiB). If the JSON exceeds the cap, truncate to 4096 bytes, append a sentinel `"...[truncated]"`, and continue. The truncation happens inside `BuildValidationContext` / `BuildAuthorizationContext` — the `AppendAsync` call never sees an over-sized payload.
+
+```csharp
+private const int AuditContextMaxBytes = 4096;
+
+private static string CapContext(string json)
+{
+    if (System.Text.Encoding.UTF8.GetByteCount(json) <= AuditContextMaxBytes) return json;
+    var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+    return System.Text.Encoding.UTF8.GetString(bytes, 0, AuditContextMaxBytes - 16) + "...[truncated]";
+}
+```
+
+The 4 KiB cap is a Phase-1 defensive measure; revisit when Audit ships its own context-size policy (Phase-2 concern). Acceptance criterion verifies the cap is enforced.
+
+### No-op stub class
+
+Add `HoneyDrunk.Auth/Authentication/NullAuditLog.cs` (or similar location):
+
+```csharp
+internal sealed class NullAuditLog : IAuditLog
+{
+    public Task AppendAsync(AuditEntry entry, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}
+```
+
+This is the fallback registered by `HoneyDrunkAuthServiceCollectionExtensions.AddHoneyDrunkAuth()` when no `IAuditLog` is already in the container. The registration uses `services.TryAddSingleton<IAuditLog, NullAuditLog>()` so a host-side `AddHoneyDrunkAuditData()` (or any other backing) takes precedence — the `Try` semantics mean Auth's stub only wins if nothing else is registered.
+
+### Startup warning when `NullAuditLog` is active
+
+The startup hook is `HoneyDrunk.Auth/Lifecycle/AuthStartupHook.cs` — the existing `IStartupHook` registered by `HoneyDrunkAuthServiceCollectionExtensions.AddHoneyDrunkAuth()` at line 89 of `HoneyDrunkAuthServiceCollectionExtensions.cs`. It already validates Auth's signing-key/issuer/audience configuration via `ExecuteAsync` and throws `InvalidOperationException` on fatal misconfiguration. Extend its constructor to also accept `IAuditLog` (resolved from the same scope), and at the end of `ExecuteAsync` — after the existing validation succeeds — check if the resolved `IAuditLog` is the `NullAuditLog` stub. If so, log a `::warning::` (do NOT throw — a missing audit backing is a degraded state, not a fatal one; Auth still validates tokens). The check itself is `auditLog is NullAuditLog` — internal-sealed type so the cast works inside the Auth assembly; `InternalsVisibleTo` is not needed because both classes live in the same `HoneyDrunk.Auth` assembly.
+
+The warning text:
+
+```
+WARN HoneyDrunk.Audit.Abstractions.IAuditLog is not registered in the host container; security event audit emission is disabled (NullAuditLog stub active). Compose HoneyDrunk.Audit.Data (or another IAuditLog backing) in the host to enable durable security-event audit per the Grid's audit-emission boundary invariant. See https://github.com/HoneyDrunkStudios/HoneyDrunk.Audit#for-downstream-consumers---minimal-wiring.
+```
+
+This is a startup-time signal that a deployed host is non-compliant with the substrate-level audit-emission boundary invariant `{N-substrate}` (auditable security events emitted to the Audit substrate). The Hive can carry a follow-up to enforce this at host-level CI later; for now it is a developer-visible warning.
+
+### Tests
+
+Add tests under `HoneyDrunk.Auth.Tests/`:
+
+- `BearerTokenAuthenticationProvider_EmitsAuditEntry_OnValidToken` — sets up an `InMemoryAuditLog` (Auth's own narrowly-scoped test double — see "Test double policy" below), runs a valid-token validation, asserts an `AuditEntry` with `Action=auth.token.validate` and `Outcome=granted` was appended.
+- `BearerTokenAuthenticationProvider_EmitsAuditEntry_OnInvalidToken` — same but invalid-token path; asserts `Outcome=denied`.
+- `BearerTokenAuthenticationProvider_DoesNotFailRequest_WhenAuditLogThrows` — sets up an `IAuditLog` stub that throws; asserts authentication still completes and the throw is logged at `Error` level.
+- `BearerTokenAuthenticationProvider_AuditContext_ContainsNoTokenText` — asserts the `AuditEntry.Context` JSON does NOT contain the literal token string or any claim value beyond `jti`, `iss`, `aud`, `exp`.
+- `DefaultAuthorizationPolicy_EmitsAuditEntry_OnAllow` — sets up an in-memory audit log, runs `EvaluateAsync` against an identity that satisfies the policy, asserts `Action=auth.authorize.{request.Action}` with `Outcome=granted` (matching `decision.IsAllowed == true`).
+- `DefaultAuthorizationPolicy_EmitsAuditEntry_OnDeny` — same but with an identity that fails the policy; asserts `Outcome=denied` (matching `decision.IsAllowed == false`).
+- `NullAuditLog_IsDefault_WhenNothingElseRegistered` — verifies `TryAddSingleton<IAuditLog, NullAuditLog>` wires the stub when the host hasn't registered anything; verifies that a host-side `services.AddSingleton<IAuditLog, SomeOtherImpl>()` BEFORE `AddHoneyDrunkAuth()` is preserved (the `Try` semantics).
+- `Startup_LogsWarning_WhenNullAuditLogIsActive` — verifies the `::warning::` is emitted at startup when no `IAuditLog` backing is composed.
+
+### Test double policy
+
+**Auth does NOT take a dependency on a `HoneyDrunk.Audit.Testing` package** — per ADR-0031 D2 and the dispatch plan, no such package exists at Audit v0.1.0. Auth writes its own narrowly-scoped in-memory `IAuditLog` test double inside `HoneyDrunk.Auth.Tests/Fakes/InMemoryAuditLog.cs` (≈ 20 lines: a `List<AuditEntry>` + lock + `AppendAsync` that adds to the list + a `Snapshot()` helper for assertions). This is the same pattern Communications uses for testing decision-log emission. Cutting `HoneyDrunk.Audit.Testing` later (when a third consumer needs it) is a non-breaking change; Auth can swap its local fake for the package then if it wants — out of scope here.
+
+### Canary project update
+
+`HoneyDrunk.Auth.Canary` is the existing canary against Auth's boundaries. Add a single test there that exercises the audit-emission path end-to-end using the in-memory test double (so the canary doesn't require an audit backing wired). The canary's purpose is to keep the cross-Node assumption (that Auth emits the right shape on `IAuditLog`) compiled and tested even as Audit's contract evolves.
+
+### Version bump
+
+Per invariant 27 (one solution version), this is a minor feature addition — bump every `src/*.csproj` `<Version>` from `0.4.0` to `0.5.0` in a single commit. Test projects do not bump.
+
+### CHANGELOG entries (repo-level + per-package)
+
+**Per memory `feedback_no_unreleased_commits`: no `## Unreleased` block at commit time.** Land entries under `## [0.5.0] - YYYY-MM-DD`.
+
+**Repo-level `CHANGELOG.md`:**
+
+```
+## [0.5.0] - YYYY-MM-DD
+
+### Added
+- HoneyDrunk.Auth now emits durable AuditEntry records via IAuditLog for token-validation outcomes (auth.token.validate) and authorization-policy decisions (auth.authorize.{policyName}). The emission is additive to existing OTel traces, on the separate durable audit channel per the Grid's audit-emission boundary invariant. Auth's identity-out-of-traces invariant is untouched — audit records are out-of-band of traces and carry no token text, claim values, or other PII beyond the actor identifier.
+- HoneyDrunk.Audit.Abstractions 0.1.0 added as a PackageReference (the only Audit dependency Auth takes, per the downstream-Abstractions-only coupling invariant).
+- NullAuditLog stub registered via TryAddSingleton; hosts that do not compose an IAuditLog backing get a no-op fallback with a startup warning.
+```
+
+**Per-package `CHANGELOG.md` for `HoneyDrunk.Auth`:** mirror the same entry (this package has the actual code change).
+
+**Per-package `CHANGELOG.md` for `HoneyDrunk.Auth.Abstractions` and `HoneyDrunk.Auth.AspNetCore`:** these did not change in this packet (the actual code change is in `HoneyDrunk.Auth`). Per invariant 27 ("per-package CHANGELOG.md updated only for packages with actual changes — do not add alignment-bump noise entries"), do not add a `## [0.5.0]` entry to these. They are version-bumped to 0.5.0 in the same commit per invariant 27's single-solution-version rule, but the changelogs do not get noise entries.
+
+### README updates
+
+Update `HoneyDrunk.Auth/README.md` to mention the audit emission. Add a short section (≈ 5 lines) describing what Auth records to `IAuditLog`, that it requires a host-side `AddHoneyDrunkAuditData()` (or other backing) to actually persist, and that the emission is additive (Auth's identity-out-of-traces invariant is preserved). **Per memory `feedback_no_adr_in_docs`, do not cite "ADR-0030" or "ADR-0031" by number in the README narrative** — describe what the package does. Link to `HoneyDrunk.Audit`'s README for downstream-consumer wiring guidance.
+
+### Architecture-side: `repos/HoneyDrunk.Auth/integration-points.md` follow-up (separate packet)
+
+**This packet is Auth-only.** `file-packets.yml`'s `target_repo: HoneyDrunkStudios/HoneyDrunk.Auth` opens the PR in the Auth repo — it cannot cross-commit to the Architecture repo in the same push. The Architecture-side edit (`repos/HoneyDrunk.Auth/integration-points.md` — add an Audit row under "Upstream Dependencies" naming `IAuditLog` as the consumed contract) is captured as a small Architecture follow-up packet rather than crammed into this packet's PR.
+
+The follow-up packet shape, for the user / a future scope pass:
+
+- Target repo: `HoneyDrunkStudios/HoneyDrunk.Architecture`
+- One-file edit: `repos/HoneyDrunk.Auth/integration-points.md` — add the Audit row in the "Upstream Dependencies" table.
+- Adjacent CHANGELOG entry under the current dated SemVer section noting the integration-points reconciliation.
+- Filed after packet 04's PR merges (so the row reflects reality on `main`, not a pre-emptive claim).
+- Listed in this initiative's dispatch-plan §What This Initiative Does NOT Deliver as a known small follow-up.
+
+The row to add looks like:
+
+| Node | Contract | Usage |
+|------|----------|-------|
+| **HoneyDrunk.Audit** | `IAuditLog` (`HoneyDrunk.Audit.Abstractions`) | Durable, attributable security event emission — token-validation outcomes and authorization-policy decisions. Additive to existing OTel traces, on the separate durable channel per the Grid's audit-emission boundary invariant. NullAuditLog stub registered via TryAddSingleton; hosts without a composed IAuditLog backing get a no-op with a startup warning. |
+
+## Affected Files
+
+All edits live inside `HoneyDrunkStudios/HoneyDrunk.Auth`. The Architecture-side `repos/HoneyDrunk.Auth/integration-points.md` reconciliation is a separate follow-up packet (see "Architecture-side" section above) — it does not appear here because `target_repo` is Auth.
+
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/HoneyDrunk.Auth.csproj` — add `HoneyDrunk.Audit.Abstractions` PackageReference; bump `<Version>` to 0.5.0
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Abstractions/HoneyDrunk.Auth.Abstractions.csproj` — bump `<Version>` to 0.5.0 (alignment, per invariant 27)
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.AspNetCore/HoneyDrunk.Auth.AspNetCore.csproj` — bump `<Version>` to 0.5.0 (alignment, per invariant 27)
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/Authentication/BearerTokenAuthenticationProvider.cs` — add `IAuditLog` + `IGridContextAccessor` to the primary constructor's parameter list (the class uses primary-constructor syntax); add `AuditAllowedClaims` static readonly HashSet constant + `AuditContextMaxBytes` const + `CapContext` helper + `BuildValidationContext` method that consults the whitelist; insert the audit emit + try/catch inside `AuthenticateAsync` between the existing `ValidateTokenAsync` call result and the return-to-caller path
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/Authorization/DefaultAuthorizationPolicy.cs` — add `IAuditLog` + `IGridContextAccessor` to the existing primary-constructor parameter list (next to `telemetryFactory`/`logger`); add `BuildAuthorizationContext` helper; insert the audit emit + try/catch inside `EvaluateAsync` between `LogDecision(...)` and the existing return; the method body's last two statements change from `return Task.FromResult(decision);` to `await _auditLog.AppendAsync(...); return decision;` (the method becomes truly `async`). **Note: `AuthorizationPolicyEvaluator.cs` (the pure static decision core) is NOT touched.**
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/Authentication/NullAuditLog.cs` (new) — no-op `IAuditLog` stub, `internal sealed`
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/DependencyInjection/HoneyDrunkAuthServiceCollectionExtensions.cs` — add `services.TryAddSingleton<IAuditLog, NullAuditLog>()` registration inside `AddHoneyDrunkAuth(IServiceCollection, Action<AuthOptions>)`, alongside the existing `BearerTokenAuthenticationProvider` and `DefaultAuthorizationPolicy` registrations (lines 83 and 86 of the existing file)
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/Lifecycle/AuthStartupHook.cs` — extend existing class: add `IAuditLog` to the primary-constructor parameter list, and at the end of `ExecuteAsync` (after the existing signing-key/issuer/audience validation succeeds) check `auditLog is NullAuditLog` and `_logger.LogWarning(...)` the deferred-composition message
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Tests/Fakes/InMemoryAuditLog.cs` (new) — narrowly-scoped test double
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Tests/Authentication/BearerTokenAuthenticationProviderTests.cs` — add the four audit-emission tests; the no-token-text test verifies the `AuditAllowedClaims` whitelist constant is the source of truth
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Tests/Authorization/DefaultAuthorizationPolicyTests.cs` — add the two audit-emission tests (grant, deny). (If the test file currently exists under a different name following the production-class name change — e.g., the historical `AuthorizationPolicyEvaluatorTests.cs` against the static class — verify and add tests to whichever file covers `DefaultAuthorizationPolicy.EvaluateAsync`.)
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Tests/Lifecycle/AuthStartupHookTests.cs` — add `AuthStartupHook_LogsWarning_WhenAuditLogIsNullAuditLog` (the existing file is confirmed at this path; verify ctor signature in the test matches the new IAuditLog parameter)
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Tests/DependencyInjection/HoneyDrunkAuthServiceCollectionExtensionsTests.cs` — add `NullAuditLog_IsDefault_WhenNothingElseRegistered` + `HostRegisteredIAuditLog_TakesPrecedenceOverNullAuditLog`
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Canary/` — add a single end-to-end audit-emission canary test
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/README.md` — short section describing audit emission
+- `HoneyDrunk.Auth/CHANGELOG.md` — `## [0.5.0]` entry (repo-level)
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/CHANGELOG.md` — `## [0.5.0]` entry (per-package, the only one that changed)
+
+## NuGet Dependencies
+
+### `HoneyDrunk.Auth/HoneyDrunk.Auth.csproj` (modified)
+
+| Package | Version | Notes |
+|---|---|---|
+| `HoneyDrunk.Audit.Abstractions` | `0.1.0` | **NEW** — per invariant `{N-coupling}` (downstream Abstractions-only coupling), the only Audit dependency Auth takes. Do not add `HoneyDrunk.Audit.Data` (composition is host-time). |
+| `HoneyDrunk.Kernel.Abstractions` | `0.7.0` | unchanged |
+| `HoneyDrunk.Standards` | `0.2.7` | `PrivateAssets="all"` — unchanged |
+| `HoneyDrunk.Vault` | `0.5.0` | unchanged |
+| `HoneyDrunk.Vault.Providers.AppConfiguration` | `0.5.0` | unchanged |
+| `HoneyDrunk.Vault.Providers.AzureKeyVault` | `0.5.0` | unchanged |
+| `Microsoft.Extensions.Configuration.Binder` | `10.0.6` | unchanged |
+| `Microsoft.IdentityModel.JsonWebTokens` | `8.17.0` | unchanged |
+
+### `HoneyDrunk.Auth/HoneyDrunk.Auth.Tests` (modified — new tests added but no PackageReference additions)
+
+The test project already references `xunit`, `Microsoft.NET.Test.Sdk`, etc. No new PackageReferences needed — the `InMemoryAuditLog` test double is a hand-written class file.
+
+## Boundary Check
+
+- [x] Auth references `HoneyDrunk.Audit.Abstractions` only — **NOT** `HoneyDrunk.Audit.Data`. Invariant `{N-coupling}` (downstream Abstractions-only coupling) honored.
+- [x] Audit emission is additive to existing OTel traces. Auth's existing trace enrichment is unchanged; no identity-bearing PII is added to traces. Invariant `{N-substrate}` (audit-emission boundary, durable channel separate from observability) honored.
+- [x] No token text or claim values beyond the `AuditAllowedClaims` static whitelist (`jti`, `iss`, `aud`, `exp`) appear in `AuditEntry.Context`. Production code reads the whitelist constant; the test `BearerTokenAuthenticationProvider_AuditContext_RespectsAllowedClaimsWhitelist` verifies the constant is the single source of truth.
+- [x] `AuditEntry.Context` is capped at 4096 bytes via `CapContext` (Phase-1 defensive truncation). A pathological token cannot blow up a single audit row.
+- [x] Audit emit failure does not fail the request. Wrapped in try/catch with error log. Test `BearerTokenAuthenticationProvider_DoesNotFailRequest_WhenAuditLogThrows` enforces this.
+- [x] `NullAuditLog` stub is the fallback when no host-side backing is composed. Registered via `TryAddSingleton` so host-side registrations win. Startup `::warning::` makes the no-op state visible.
+- [x] Test double lives in `HoneyDrunk.Auth.Tests/Fakes/`, hand-written, NOT taken from a `HoneyDrunk.Audit.Testing` package (no such package exists at Audit v0.1.0; per ADR-0031 D2 and ADR-0027 D3 precedent).
+- [x] Single solution version per invariant 27 — both `Abstractions` and `Auth.AspNetCore` `.csproj` `<Version>` bumped to 0.5.0 even though only `HoneyDrunk.Auth` changed. Per-package CHANGELOG updates land only for the package that actually changed (`HoneyDrunk.Auth`), per invariant 27's no-alignment-noise rule.
+- [x] **Lifetime story documented — both Auth emitters are Singleton; ambient grid-context resolution avoids captive-dep on Scoped `IGridContext`.** `BearerTokenAuthenticationProvider` and `DefaultAuthorizationPolicy` remain registered as Singleton by `AddHoneyDrunkAuth()` (lines 83 and 86 of `HoneyDrunkAuthServiceCollectionExtensions.cs` unchanged). Both classes inject `IGridContextAccessor` (a Singleton-friendly ambient accessor that resolves the current scope's `IGridContext` lazily per call) rather than `IGridContext` directly. Direct `IGridContext` injection into a Singleton is the captive-dep anti-pattern — the Singleton would close over the first scope's context and serve stale `CorrelationId`/`TenantId` to every subsequent request. The accessor pattern is exactly the workaround `IGridContextAccessor`'s own XML docs name as the intended use. `IGridContextAccessor` is already in `ValidateKernelServices()`'s required list at line 99 of the DI extensions file — every Auth-composing host already has it registered.
+- [x] **`AuthorizationPolicyEvaluator` (the pure static decision core) is not touched.** Audit emission lands on `DefaultAuthorizationPolicy.EvaluateAsync` (the I/O-side decorator that wraps the static evaluator with telemetry and logging — the same place existing cross-cutting concerns live). The static evaluator stays pure, deterministic, and side-effect-free per its file's own XML docs.
+
+## Acceptance Criteria
+
+- [ ] `HoneyDrunk.Auth/HoneyDrunk.Auth.csproj` contains `<PackageReference Include="HoneyDrunk.Audit.Abstractions" Version="0.1.0" />`.
+- [ ] `HoneyDrunk.Auth/HoneyDrunk.Auth.csproj` does NOT contain `HoneyDrunk.Audit.Data` (invariant `{N-coupling}` — downstream Abstractions-only coupling — enforced).
+- [ ] `BearerTokenAuthenticationProvider.AuthenticateAsync` emits an `AuditEntry` with `Action=auth.token.validate` after every `ValidateTokenAsync` returns. `Outcome=granted` on `result.IsAuthenticated == true`, `Outcome=denied` otherwise (invalid signature/issuer/audience, expired, missing-claim, unsupported scheme — all fall under `IsAuthenticated == false`). **`result.IsValid` is NOT the property name — `AuthenticationResult` exposes `IsAuthenticated`** (see `HoneyDrunk.Auth.Abstractions/AuthenticationResult.cs:23`).
+- [ ] `DefaultAuthorizationPolicy.EvaluateAsync` emits an `AuditEntry` with `Action=auth.authorize.{request.Action}` after `AuthorizationPolicyEvaluator.Evaluate(...)` returns and the existing telemetry/logging side-effects run. `Outcome=granted` on `decision.IsAllowed == true`, `Outcome=denied` otherwise. **`AuthorizationDecision.IsGranted` is NOT the property name — the existing field is `IsAllowed`** (see `HoneyDrunk.Auth/Authorization/DefaultAuthorizationPolicy.cs:67` where it's already used by `RecordTelemetry`).
+- [ ] **The static `AuthorizationPolicyEvaluator` is not touched.** Audit emission lands in `DefaultAuthorizationPolicy` (the I/O-side decorator), not in the pure static class. Verified by `git diff` showing no edits under `Authorization/AuthorizationPolicyEvaluator.cs`.
+- [ ] `AuditEntry.Actor` is set from `result.Identity?.SubjectId` (for authentication) or `identity?.SubjectId` (for authorization, where `identity` is the `AuthenticatedIdentity?` parameter of `EvaluateAsync`), falling back to `"anonymous"` only when no subject is resolved.
+- [ ] `AuditEntry.CorrelationId` comes from `gridContext.CorrelationId` resolved via `_gridContextAccessor.GridContext` at emit time — **no `.ToString()` call** (`IGridContext.CorrelationId` is already declared as `string` per `IGridContext.cs:52`). The v0.2.0 follow-up to wrap with `new CorrelationId(...)` when `AuditEntry.CorrelationId` promotes to the Kernel strong type is captured in packet 03's contract notes and is not part of this packet.
+- [ ] `AuditEntry.TenantId` is passed through directly from `gridContext.TenantId` as the Kernel `TenantId` strong type (per ADR-0026; `AuditEntry.TenantId` is the typed value, not stringified). The non-null `TenantId.Internal` sentinel handles header-less internal callers — Auth does not need any null-handling or default-fallback at the emission site.
+- [ ] `AuditEntry.Context` is a JSON-shaped string containing only non-PII metadata. **The `AuditAllowedClaims` static readonly HashSet constant (= `{ "jti", "iss", "aud", "exp" }`, ordinal comparer)** is the single source of truth — `BuildValidationContext` reads from it; the test `BearerTokenAuthenticationProvider_AuditContext_RespectsAllowedClaimsWhitelist` reads the same constant. Token text, claim values beyond identifier claims, and bearer-token contents NEVER appear in `Context`.
+- [ ] **`AuditEntry.Context` is capped at 4096 bytes via `CapContext`.** A test verifies that a token with a fabricated 10 KB `iss` claim produces an `AuditEntry.Context` of at most 4096 bytes ending in the `"...[truncated]"` sentinel.
+- [ ] Audit emission failures (e.g., `IAuditLog.AppendAsync` throws) are caught, logged at `Error` level via the existing `ILogger<BearerTokenAuthenticationProvider>` / `ILogger<DefaultAuthorizationPolicy>`, and do **not** fail authentication or authorization. The existing request handling continues to return the `AuthenticationResult`/`AuthorizationDecision` it would have returned without the emit step.
+- [ ] **Both emitting classes inject `IGridContextAccessor`, NOT `IGridContext` directly.** `git diff` shows the constructor parameter lists for `BearerTokenAuthenticationProvider` and `DefaultAuthorizationPolicy` include `IGridContextAccessor gridContextAccessor` (and `IAuditLog auditLog`). Neither class takes a direct `IGridContext` ctor parameter — that would be a captive-dep on a Scoped dependency in a Singleton.
+- [ ] `NullAuditLog` stub class exists at `HoneyDrunk.Auth/Authentication/NullAuditLog.cs`, is `internal sealed`, implements `IAuditLog` with `AppendAsync` returning `Task.CompletedTask`.
+- [ ] `HoneyDrunkAuthServiceCollectionExtensions.AddHoneyDrunkAuth()` calls `services.TryAddSingleton<IAuditLog, NullAuditLog>()` — `Try` semantics so host-side `AddHoneyDrunkAuditData()` (or any other backing) takes precedence.
+- [ ] A startup `::warning::` is logged when the resolved `IAuditLog` is the `NullAuditLog` stub. **The warning lives at the end of `AuthStartupHook.ExecuteAsync` (file: `HoneyDrunk.Auth/Lifecycle/AuthStartupHook.cs`)** — `AuthStartupHook` is the existing `IStartupHook` registered at line 89 of `HoneyDrunkAuthServiceCollectionExtensions.cs`. It does NOT throw on the no-op-stub case; missing audit composition is degraded-state, not fatal. The warning text directs the operator to compose `HoneyDrunk.Audit.Data` (or another backing). The warning may name the audit-emission boundary invariant by number (`{N-substrate}`) once the actual assigned number is substituted pre-push.
+- [ ] All eight new tests pass: four BearerToken emission tests (valid path, invalid path, throw-resilience, context-respects-whitelist+truncation), two DefaultAuthorizationPolicy emission tests (grant via `IsAllowed==true`, deny via `IsAllowed==false`), one DI test (`NullAuditLog_IsDefault_WhenNothingElseRegistered`), and one AuthStartupHook test (`AuthStartupHook_LogsWarning_WhenAuditLogIsNullAuditLog`).
+- [ ] `HoneyDrunk.Auth.Tests/Fakes/InMemoryAuditLog.cs` exists as a hand-written test double. **No PackageReference to a `HoneyDrunk.Audit.Testing` package** (none exists at Audit v0.1.0).
+- [ ] `HoneyDrunk.Auth.Canary` carries a single end-to-end audit-emission test using the in-memory test double.
+- [ ] Every `src/*.csproj` in the solution carries `<Version>0.5.0</Version>` (invariant 27 — `HoneyDrunk.Auth`, `HoneyDrunk.Auth.Abstractions`, `HoneyDrunk.Auth.AspNetCore`). Test projects do not bump.
+- [ ] Repo-level `CHANGELOG.md` has a `## [0.5.0] - YYYY-MM-DD` entry covering the audit emission (per invariants 12, 27, and memory `feedback_no_unreleased_commits` — no `## Unreleased` block at commit time).
+- [ ] `HoneyDrunk.Auth/HoneyDrunk.Auth/CHANGELOG.md` (the per-package CHANGELOG of the only package that changed) has a `## [0.5.0]` entry.
+- [ ] `HoneyDrunk.Auth.Abstractions/CHANGELOG.md` and `HoneyDrunk.Auth.AspNetCore/CHANGELOG.md` are **NOT** updated with a `## [0.5.0]` noise entry — per invariant 27's no-alignment-noise rule.
+- [ ] `HoneyDrunk.Auth/HoneyDrunk.Auth/README.md` carries a short section describing audit emission (what events are emitted, that host-side composition is required, that the emission is additive and Auth's identity-out-of-traces invariant is untouched). **No ADR numbers in the README narrative** (memory `feedback_no_adr_in_docs`).
+- [ ] **`repos/HoneyDrunk.Auth/integration-points.md` is NOT edited in this packet's PR.** That reconciliation is a separate follow-up Architecture packet (see §"Architecture-side" — flagged in the dispatch plan under "What This Initiative Does NOT Deliver"). Cross-repo PRs are unsupported by `file-packets.yml`'s single-`target_repo` model.
+- [ ] `pr-core.yml` passes on the PR.
+- [ ] The contract-shape canary on `HoneyDrunk.Audit.Abstractions` (in the HoneyDrunk.Audit repo) is **not** triggered by this packet — Auth's emission shape is downstream code, not Abstractions code. The canary protects against shape drift in `IAuditLog.AppendAsync` / `AuditEntry` member set / `IAuditQuery` — none of those change in this packet.
+
+## Human Prerequisites
+
+- [ ] Packet 03 of this initiative complete — `HoneyDrunk.Audit 0.1.0` published to NuGet with `HoneyDrunk.Audit.Abstractions 0.1.0` discoverable on the consumer feed. Auth's PackageReference resolves against the public NuGet feed; if the feed has not propagated the package yet, the build fails and this packet must wait.
+- [ ] After this packet's PR merges, push tag `v0.5.0` from `main` in `HoneyDrunk.Auth` to trigger the NuGet release of the new Auth version. Tags are human-pushed per invariant 27.
+- [ ] **Host composition follow-up.** Auth's new emission requires the consuming host to compose an `IAuditLog` backing (e.g., `HoneyDrunk.Audit.Data` plus `HoneyDrunk.Data` registration) for durable persistence. Without that, the `NullAuditLog` stub is active and the startup warning fires. File a small follow-up packet per host that ships HoneyDrunk.Auth (Web.Rest deployable, future Auth-consuming Container Apps) to wire `AddHoneyDrunkAuditData()` and seed the App Config `audit:retention:days` key. **Not in scope for this packet** — this packet ships the emission; host wiring is per-host.
+- [ ] Confirm a follow-up Architecture packet is filed to update `repos/HoneyDrunk.Auth/integration-points.md` with the Audit row (this packet is Auth-only; cross-repo PRs are unsupported by `file-packets.yml`). Do not silently skip it — that file is the canonical record of Auth's integration boundaries. The follow-up should land soon after this PR merges so the catalog reflects reality on `main`.
+- [ ] **Managed-identity note for the future deployable-host packet.** The host that first composes `HoneyDrunk.Audit.Data` (e.g., a Container App that links Auth-plus-Audit at deploy time) should provision a **dedicated managed identity for Audit**, distinct from the host's own identity and distinct from Auth's identity, per ADR-0031 D5 (recorder-is-not-the-actor). Inheriting the host's identity collapses the durable-record-attribution layer into the requesting layer — the same boundary ADR-0030 D2 (recorder ≠ actor) prevents. This is **not in scope for this packet** (Auth is a library, not a deployable; no managed identity provisioning happens here). Cross-link [`infrastructure/walkthroughs/azure-provisioning-guide.md`](../../../../infrastructure/walkthroughs/azure-provisioning-guide.md) in the future deployable-host packet for the portal walkthrough.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — Reinforces why Auth's reference is to `HoneyDrunk.Audit.Abstractions` (zero-`HoneyDrunk` package) rather than `HoneyDrunk.Audit.Data` (which would transit Kernel/Data/Vault pins through Auth's dependency closure).
+
+> **Invariant 5:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null `TenantId`. — `BearerTokenAuthenticationProvider` and `DefaultAuthorizationPolicy` resolve the current scope's `IGridContext` via `IGridContextAccessor.GridContext` (the Singleton-safe accessor) to populate the `AuditEntry`'s `CorrelationId` and `TenantId`. **Direct `IGridContext` ctor injection is avoided** because both classes are Singleton-registered — a Scoped `IGridContext` injected into a Singleton would be captive on the first scope.
+
+> **Invariant 6:** CorrelationId is never null or empty, and TenantId is never absent, in a live GridContext. — Audit entries inherit valid correlation + tenant from `IGridContext`. Empty values are a Kernel-layer invariant violation that should not happen at the Auth-emission point.
+
+> **Invariant 8:** Secret values never appear in logs, traces, exceptions, or telemetry. Only secret names/identifiers may be traced. — Extended in spirit to audit emission: token text and raw claim values are not in `AuditEntry.Context`. `Context` carries only identifier claims (`jti`, `iss`, `aud`, `exp`) and the failure-reason string.
+
+> **Invariant 10:** Auth tokens are validated, never issued. HoneyDrunk.Auth validates JWT Bearer tokens. It is not an identity provider. — Unchanged. The audit emission records the *validation outcome*; it does not record token issuance because Auth does not issue tokens.
+
+> **Invariant 12:** Semantic versioning with CHANGELOG and README. Every version that ships must have an entry in the repo-level CHANGELOG. — Both repo-level and the affected per-package CHANGELOG land `## [0.5.0]` entries; alignment-bumped packages do NOT get noise entries (invariant 27).
+
+> **Invariant 26:** Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section. — Section above lists the one PackageReference addition (`HoneyDrunk.Audit.Abstractions 0.1.0`).
+
+> **Invariant 27:** All projects in a solution share one version and move together. Per-package changelogs are updated only for packages with actual changes — do not add alignment-bump noise entries. — All three `src/*.csproj` bump to 0.5.0; only `HoneyDrunk.Auth/CHANGELOG.md` gets a per-package entry (the other two are alignment bumps).
+
+> **Invariant `{N-substrate}` (ADR-0030 packet 02 — substrate-level audit-emission boundary):** Durable, attributable security and action events are emitted to the `HoneyDrunk.Audit` substrate via `IAuditLog`, on a durable channel separate from observability telemetry. Login attempts, authorization grants and denials, and privileged-action execution are recorded durably and attributably through `IAuditLog`. Phase-1 audit integrity is append-only-by-interface (`IAuditLog` exposes no update and no delete method); it is explicitly **not** tamper-evident, and Phase 1 must not be documented or marketed as such. — This packet IS the first compliant emitter against `{N-substrate}`. Token-validation outcomes (login-attempt analogue) and authorization-policy decisions are durably recorded.
+
+> **Invariant `{N-coupling}` (this initiative, packet 01 — downstream Abstractions-only coupling):** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Audit.Abstractions`. Composition against `HoneyDrunk.Audit.Data` is a host-time concern resolved at application startup from App Configuration. — Auth's PackageReference is `HoneyDrunk.Audit.Abstractions 0.1.0` only. Composition (which backing actually persists) is the host's job.
+
+> **Invariant `{N-canary}` (this initiative, packet 01 — contract-shape canary):** The HoneyDrunk.Audit Node CI must include a contract-shape canary for `IAuditLog`, `IAuditQuery`, and `AuditEntry`. — Not directly enforced by this packet (the canary lives in the HoneyDrunk.Audit repo's CI), but this packet is what *consumes* the canary-protected surface, so the existence of the canary protects Auth from accidental upstream shape drift. If Audit's canary catches a breaking change, Auth's build against the unshipped change is the second line of defense.
+
+> **Invariant 39 (Tenant mechanics stay at intake and post-dispatch boundaries — ADR-0026):** `IGridContext.TenantId` carries the strong-typed Kernel `TenantId` (the `Internal` sentinel for header-less requests). — This packet passes `gridContext.TenantId` (resolved via `_gridContextAccessor.GridContext`) through to `AuditEntry.TenantId` as the typed value; it does not stringify, default, or re-parse. Per ADR-0026, the consumer site (Auth's emission point) never re-introduces a `?? TenantId.Internal` fallback.
+
+## Referenced ADR Decisions
+
+**ADR-0030 D6 (First emitter Auth; observability identity-out-of-traces preserved):** "The first real emitter wired at stand-up is `HoneyDrunk.Auth`, recording durable attributable security events additively to its existing OTel traces, on a separate durable channel, with Auth's identity-out-of-traces invariant untouched." This packet implements that decision.
+
+**ADR-0030 D1 (Audit substrate ownership):** Audit owns the durable, attributable record. Auth, by emitting via `IAuditLog`, becomes a producer against the substrate — not a co-owner. Boundary preserved: Auth still owns authentication and authorization decisions; it now also durably records those decisions.
+
+**ADR-0030 D2 (Recorder ≠ actor):** Auth makes the allow/deny decision; Audit records it. The two are structurally separate even though both run under their own managed identities. This packet preserves that — Auth records *its own outcomes* via the Audit substrate, but Auth is not the recorder of itself in the trust sense (the Audit Node's managed identity is what writes; Auth's identity is what *originated* the record).
+
+**ADR-0030 D7 / ADR-0031 D7 (Telemetry one-way to Pulse; audit records are not telemetry):** Audit *records* never flow to Pulse — they live on the durable audit channel. Auth's existing OTel traces are unchanged by this packet; the new emission goes to `IAuditLog`, not to Pulse. The two channels stay separate.
+
+**ADR-0031 D6 (First emitter Auth; Operator reconciled):** Same as ADR-0030 D6, restated in the stand-up ADR's terms. This packet is the implementation.
+
+**ADR-0031 D9 (Downstream coupling):** Auth takes a PackageReference on `HoneyDrunk.Audit.Abstractions` only. Composition against `HoneyDrunk.Audit.Data` is a host-time concern.
+
+**ADR-0027 D3 (No speculative Testing package; cut later as non-breaking):** Auth writes its own narrowly-scoped in-memory `IAuditLog` test double inside `HoneyDrunk.Auth.Tests/Fakes/` rather than depending on a `HoneyDrunk.Audit.Testing` package (which does not exist at Audit v0.1.0). When a third consumer needs the fixture, it is cut into `HoneyDrunk.Audit.Testing` as a non-breaking change — Auth can switch then if it wants. Out of scope here.
+
+**ADR-0026 D1/D2/D3 (TenantId strong type, non-nullable, propagation via `IGridContext`):** `IGridContext.TenantId` is the non-null Kernel `TenantId` strong type with the `Internal` sentinel for header-less requests. — This packet passes `gridContext.TenantId` (resolved via `_gridContextAccessor.GridContext` per-call from the Singleton emitter) through directly to `AuditEntry.TenantId` (the Kernel strong type on the `AuditEntry` record per packet 03's contract). No stringification, no null-handling, no `?? TenantId.Internal` consumer-site fallback. Per invariant 39, tenant mechanics stay at intake (`GridContextMiddleware`) and at post-dispatch boundaries — Auth's emission point is a consumer of the already-resolved `IGridContext.TenantId`.
+
+## Dependencies
+
+- `packet:03` — `HoneyDrunk.Audit 0.1.0` (specifically the `HoneyDrunk.Audit.Abstractions` package) must be published to the consumer NuGet feed. Auth references the package by version pin; it cannot resolve `0.1.0` against an unpublished package.
+
+## Labels
+
+`feature`, `tier-2`, `auth`, `audit`, `adr-0031`
+
+## Agent Handoff
+
+**Objective:** Wire `HoneyDrunk.Auth` v0.5.0 to emit durable `AuditEntry` records via `IAuditLog` for token-validation outcomes and authorization-policy decisions, additively to existing OTel traces, on the separate durable audit channel per the substrate-level audit-emission boundary invariant `{N-substrate}`. Auth's identity-out-of-traces invariant remains untouched.
+
+**Target:** HoneyDrunk.Auth, branch from `main`.
+
+**Context:**
+- Goal: Land the first compliant emitter against the Audit substrate (packet 03 of this initiative shipped `HoneyDrunk.Audit.Abstractions 0.1.0`). Token-validation and authorization-policy decisions are exactly the event classes invariant `{N-substrate}` (audit-emission boundary) names; this packet records them durably.
+- Feature: ADR-0031 standup initiative — this is the consumer-side packet that gives the substrate its first real producer.
+- ADRs: ADR-0031 (D6 — first emitter); ADR-0030 (D6 — same decision in the capability ADR; D2 — recorder ≠ actor); ADR-0027 D3 (no speculative `HoneyDrunk.Audit.Testing` package — write a hand-written test double).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packet 03 of this initiative must merge and `v0.1.0` must publish to NuGet first.
+
+**Constraints:**
+
+- **Invariant 5:** GridContext must be present in every scoped operation. Every HTTP request, message handler, and background job must have a populated `IGridContext`, including a non-null `TenantId`. — `BearerTokenAuthenticationProvider` and `DefaultAuthorizationPolicy` resolve the current-scope `IGridContext` via `IGridContextAccessor.GridContext` (the Singleton-safe ambient accessor) and use `CorrelationId`/`TenantId` from it.
+- **Invariant 8:** Secret values never appear in logs, traces, exceptions, or telemetry. — Extended to audit: no token text or claim values beyond `jti`/`iss`/`aud`/`exp` in `AuditEntry.Context`. A test enforces this.
+- **Invariant 10:** Auth tokens are validated, never issued. HoneyDrunk.Auth validates JWT Bearer tokens. It is not an identity provider. — Unchanged. The audit emission records validation outcomes, not issuance.
+- **Invariant 12:** Semantic versioning with CHANGELOG and README. — Repo-level `CHANGELOG.md` gets a `## [0.5.0] - YYYY-MM-DD` entry. `HoneyDrunk.Auth/CHANGELOG.md` (per-package, the only package that changed) gets the same entry.
+- **Invariant 26:** Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section. `HoneyDrunk.Standards` must be on every new .NET project. — Section above lists the single PackageReference addition.
+- **Invariant 27:** All projects in a solution share one version and move together. Per-package changelogs are updated only for packages with actual changes — do not add alignment-bump noise entries. — `HoneyDrunk.Auth`, `HoneyDrunk.Auth.Abstractions`, and `HoneyDrunk.Auth.AspNetCore` all bump to 0.5.0; only `HoneyDrunk.Auth/CHANGELOG.md` (the one with the actual change) gets a per-package entry. The other two `.csproj` are alignment bumps without changelog noise.
+- **Invariant `{N-substrate}` (audit-emission boundary):** Durable, attributable security and action events are emitted to the `HoneyDrunk.Audit` substrate via `IAuditLog`, on a durable channel separate from observability telemetry. Phase-1 audit integrity is append-only-by-interface; it is explicitly **not** tamper-evident, and Phase 1 must not be documented or marketed as such. — Auth's emission is on `IAuditLog`, not on Pulse. The OTel-trace path stays unchanged.
+- **Invariant `{N-coupling}` (downstream Abstractions-only coupling):** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Audit.Abstractions`. Composition against `HoneyDrunk.Audit.Data` is a host-time concern resolved at application startup from App Configuration. — Add `HoneyDrunk.Audit.Abstractions 0.1.0` only. **DO NOT** add `HoneyDrunk.Audit.Data` to `HoneyDrunk.Auth.csproj`.
+- **Invariant 39 (Tenant mechanics — ADR-0026):** Tenant resolution and the `Internal` sentinel default happen at intake (`GridContextMiddleware`), not at the consumer site. `IGridContext.TenantId` is the non-null Kernel `TenantId` strong type. — Pass `gridContext.TenantId` (resolved via `_gridContextAccessor.GridContext`) through to `AuditEntry.TenantId` directly. No `.ToString()`, no `?? TenantId.Internal` fallback, no null-handling. Stringly-typing tenancy at this emission site re-introduces ADR-0026's footgun.
+- **Auth's identity-out-of-traces invariant is untouched.** Existing OTel trace enrichment is not changed by this packet. No identity-bearing fields are added to traces. Audit emission lives entirely on the durable audit channel, in parallel.
+- **Emission failures must not fail the request.** Wrap `IAuditLog.AppendAsync` in try/catch with error log + continue. A flaky audit store is the audit substrate's SLO problem; it should not break authentication.
+- **`Context` carries no PII.** Token text, claim values beyond identifier claims, and bearer-token contents NEVER appear in `AuditEntry.Context`. Test `BearerTokenAuthenticationProvider_AuditContext_ContainsNoTokenText` enforces this.
+- **`TryAddSingleton<IAuditLog, NullAuditLog>` is the registration pattern.** Hosts that compose `AddHoneyDrunkAuditData()` (or any other backing) take precedence. Hosts that don't get the no-op stub plus a startup `::warning::`. The `Try` semantics are load-bearing — without them, Auth would clobber host-side registrations.
+- **Hand-written test double, NOT a `HoneyDrunk.Audit.Testing` package.** No such package exists at Audit v0.1.0 per ADR-0031 D2 and ADR-0027 D3. The test double lives at `HoneyDrunk.Auth.Tests/Fakes/InMemoryAuditLog.cs` as ≈ 20 lines of hand-written code.
+- **No ADR numbers in `HoneyDrunk.Auth/README.md` narrative.** Per memory `feedback_no_adr_in_docs`, the README describes what the package does; it does not cite "ADR-0030" or "ADR-0031" by number.
+- **`Action` strings are namespaced.** Use `auth.token.validate` and `auth.authorize.{policyName}` — the prefix establishes the emitting Node (Auth) and the verb names the operation. Future emitters (Operator's AI-runtime decisions, future privileged-action emitters) follow the same `{node}.{verb}` shape.
+
+**Key Files:**
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/HoneyDrunk.Auth.csproj` — add PackageReference, bump Version to 0.5.0
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/Authentication/BearerTokenAuthenticationProvider.cs` — add `IAuditLog` + `IGridContextAccessor` to primary-ctor params; add `AuditAllowedClaims` static readonly HashSet, `AuditContextMaxBytes` const, `CapContext` helper, `BuildValidationContext`; emit `AuditEntry` post-`ValidateTokenAsync` with try/catch
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/Authorization/DefaultAuthorizationPolicy.cs` — add `IAuditLog` + `IGridContextAccessor` to existing primary-ctor params (next to `telemetryFactory`, `logger`); add `BuildAuthorizationContext`; emit `AuditEntry` between existing `LogDecision` and return; method body becomes `await _auditLog.AppendAsync(...); return decision;`. **`AuthorizationPolicyEvaluator.cs` (the pure static class) is NOT touched** — emission goes on the I/O-side decorator alongside the existing telemetry/logging.
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/Authentication/NullAuditLog.cs` (new) — internal sealed no-op stub
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/DependencyInjection/HoneyDrunkAuthServiceCollectionExtensions.cs` — add `TryAddSingleton<IAuditLog, NullAuditLog>()` alongside existing registrations at lines 83/86
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/Lifecycle/AuthStartupHook.cs` — add `IAuditLog` to primary-ctor; at end of `ExecuteAsync`, after the existing signing-key/issuer/audience validation succeeds, check `auditLog is NullAuditLog` and `_logger.LogWarning(...)`; do NOT throw on the no-op case (degraded ≠ fatal)
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Tests/Fakes/InMemoryAuditLog.cs` (new) — hand-written test double
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Tests/Authentication/BearerTokenAuthenticationProviderTests.cs` — four new tests (the AuditContext-whitelist test verifies the `AuditAllowedClaims` constant is the single source of truth)
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Tests/Authorization/DefaultAuthorizationPolicyTests.cs` — two new tests (grant via `IsAllowed==true`, deny via `IsAllowed==false`)
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Tests/Lifecycle/AuthStartupHookTests.cs` — one new test (`AuthStartupHook_LogsWarning_WhenAuditLogIsNullAuditLog`); the file already exists at this path
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Tests/DependencyInjection/HoneyDrunkAuthServiceCollectionExtensionsTests.cs` — one new test (`NullAuditLog_IsDefault_WhenNothingElseRegistered`)
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Canary/` — one end-to-end canary test
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/README.md` — short audit-emission section (no ADR numbers in narrative)
+- `HoneyDrunk.Auth/CHANGELOG.md` — repo-level [0.5.0] entry
+- `HoneyDrunk.Auth/HoneyDrunk.Auth/CHANGELOG.md` — per-package [0.5.0] entry (only this package gets one)
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.Abstractions/HoneyDrunk.Auth.Abstractions.csproj` — bump Version (alignment)
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.AspNetCore/HoneyDrunk.Auth.AspNetCore.csproj` — bump Version (alignment)
+
+(`repos/HoneyDrunk.Auth/integration-points.md` in the Architecture repo is a separate follow-up Architecture packet — see §"Architecture-side" in this packet's body. `file-packets.yml` only opens PRs against `target_repo`, which here is `HoneyDrunkStudios/HoneyDrunk.Auth`.)
+
+**Contracts:**
+- This packet consumes `IAuditLog` and `AuditEntry` from `HoneyDrunk.Audit.Abstractions 0.1.0`. It does not author any new contracts.
+- The audit emission shape (`Action=auth.token.validate`, `Action=auth.authorize.{policyName}`, `Outcome=granted|denied`, no-PII `Context`) is a convention this packet establishes. Future emitters in Auth (or in other Nodes) should follow the same `{node}.{verb}` `Action` naming and the same no-PII `Context` discipline.

--- a/generated/issue-packets/active/adr-0031-audit-node-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0031-audit-node-standup/dispatch-plan.md
@@ -1,0 +1,225 @@
+# Dispatch Plan — ADR-0031 Stand Up the HoneyDrunk.Audit Node
+
+> ## ⚠ PRE-FILING REWRITE REQUIRED — Do Not Push This Initiative Until Both Steps Are Complete
+>
+> The packets in this initiative reference upstream ADR-0030 issues that **do not exist yet** as GitHub issues. The dependency frontmatter currently contains literal placeholder strings — `Architecture#108` and `Architecture#109` — which `file-packets.sh` cannot resolve. If you push as-is, the `addBlockedBy` wiring will silently skip those edges and the wave gate will not exist on The Hive.
+>
+> **Required sequence before pushing this initiative's packets:**
+>
+> 1. **File AND merge** the ADR-0030 acceptance initiative (`generated/issue-packets/active/adr-0030-audit-substrate/`). Both packets — `01-architecture-adr-0030-acceptance.md` and `02-architecture-audit-emission-invariant.md` — must reach `main`. That run produces two real GitHub issue numbers on `HoneyDrunkStudios/HoneyDrunk.Architecture`.
+> 2. **Look up the assigned issue numbers** via The Hive or `gh issue list -R HoneyDrunkStudios/HoneyDrunk.Architecture` after that initiative files.
+> 3. **Substitute the real issue numbers** in three places in this initiative's packet sources, in place, pre-push (invariant 24's pre-filing carve-out applies — none of these packets have been filed yet at that point):
+>    - `01-architecture-audit-coupling-and-canary-invariants.md` frontmatter `dependencies:` — replace `"Architecture#109"` with `"Architecture#<real-number>"` for ADR-0030 packet 02.
+>    - `02-architecture-create-audit-repo.md` frontmatter `dependencies:` — replace `"Architecture#108"` with `"Architecture#<real-number>"` for ADR-0030 packet 01.
+>    - Every prose mention of `Architecture#108` / `Architecture#109` in packet bodies and in this dispatch plan (search-and-replace the two distinct placeholder strings across the initiative folder).
+> 4. **Then push** this initiative's packets per the filing-order rule below (packets 01 + 02 together, wait for merge, then packet 03, then packet 04).
+>
+> The placeholder strings are forbidden in `dependencies:` per the scope agent's own rules — `file-packets.sh` accepts only integer-valued `{Repo}#N` references and silently skips unrecognized forms. A pushed-as-is state would file these packets onto The Hive with no upstream blocker — exactly the failure mode `addBlockedBy` exists to prevent.
+
+**Initiative:** `adr-0031-audit-node-standup`
+**Sector:** Core
+**Governing ADR:** [ADR-0031 — Stand Up the HoneyDrunk.Audit Node](../../../../adrs/ADR-0031-stand-up-honeydrunk-audit-node.md) (Proposed 2026-05-16; flips to Accepted after this initiative's PRs merge per the user's ADR acceptance workflow — scope agent flips Status, never on first draft)
+**Driving Decision ADR:** [ADR-0030 — Grid-Wide Audit Substrate](../../../../adrs/ADR-0030-grid-wide-audit-substrate.md) (must be Accepted before ADR-0031 can flip; gated by the [ADR-0030 acceptance initiative](../adr-0030-audit-substrate/dispatch-plan.md))
+**Trigger:** ADR-0030 records that Grid-wide durable, attributable audit is a first-class concern homed in a new dedicated `HoneyDrunk.Audit` Node. ADR-0031 is the stand-up ADR — what the Node owns, the package shape, the three frozen contracts, the contract-shape canary, the downstream coupling rule, and what the first PR scaffolds. Two of ADR-0030's eventual consumers — HoneyDrunk.Auth (durable security-event emitter) and a future tenant-facing forensics surface (built over `IAuditQuery`) — are blocked on `HoneyDrunk.Audit.Abstractions` existing. This initiative builds the substrate that unblocks them.
+**Type:** Multi-repo (3 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.Audit` (new) + `HoneyDrunk.Auth`)
+**Site sync required:** No (scaffold-only; no public-API surface change needs site update yet — when `HoneyDrunk.Audit 0.1.0` ships and Auth wires the first emitter, a site-sync follow-up may be warranted)
+**Rollback plan:**
+- **Pre-tag rollback** (before `v0.1.0` is pushed in Audit): `git revert` of each PR. Packets 01/02 are independent reverts; packet 03 reverts the entire scaffold as a single PR; packet 04 reverts the Auth emitter change.
+- **Post-tag rollback** (after `v0.1.0` is pushed in Audit but before Auth consumes it): NuGet packages are immutable. Either `dotnet nuget delete` if the packages were just pushed and pre-discovery, or fix-forward as `0.1.1`. Practical hard rollback after a tag is messy — prefer fix-forward.
+- **After Auth consumes (packet 04 merged):** rollback of Audit Abstractions is no longer a clean option — Auth has a compile-time reference. Treat any defect as forward-only.
+- **`file-packets.yml` lifecycle gotcha:** after this initiative's packets have moved through The Hive, hive-sync may move source packet files from `active/` to `completed/` per invariant 37. A `git revert` only undoes code changes, not packet-file moves. If a revert is needed after lifecycle moves, restore the packet files manually as part of the revert PR.
+
+## Sequencing Against ADR-0030 Acceptance — HARD BLOCKER
+
+This initiative is **gated** on ADR-0030's acceptance initiative completing. The acceptance initiative writes two packets (filed in `generated/issue-packets/active/adr-0030-audit-substrate/`):
+
+- [`01-architecture-adr-0030-acceptance.md`](../adr-0030-audit-substrate/01-architecture-adr-0030-acceptance.md) — registers `honeydrunk-audit` Node in catalogs, adds Core-sector row, flips ADR-0030 Status to Accepted, verifies the ADR-0018 amendment, creates the `repos/HoneyDrunk.Audit/` context folder (already on disk), registers the bring-up initiative + roadmap bullet.
+- [`02-architecture-audit-emission-invariant.md`](../adr-0030-audit-substrate/02-architecture-audit-emission-invariant.md) — lands the substrate-level audit-emission boundary invariant `{N-substrate}` (originally drafted as 44; the collision-check protocol in that packet shifts to the next free slot at edit time — likely 47 or higher, since 44/45/46 are claimed by ADR-0016 AI standup), with two slots reserved for this initiative.
+
+Both ADR-0030 packets must merge to `main` before this initiative's packets can usefully execute, because:
+
+- Without ADR-0030 packet 01: `catalogs/nodes.json` has no `honeydrunk-audit` row, ADR-0030 still reads Proposed, and the ADR-0031 acceptance flip later in this initiative would chain through an un-Accepted driving ADR — invalid per ADR-0031's own "Done When" gate.
+- Without ADR-0030 packet 02: the substrate-level audit-emission boundary invariant `{N-substrate}` does not exist in `constitution/invariants.md`, the `## Audit Invariants` section does not exist, and this initiative's packet 01 (which adds the two new invariants `{N-coupling}` + `{N-canary}` to that section) has no section to append to and no substrate-level invariant to slot next to.
+
+**Filing rule:** the user authorizes filing this initiative's packets **only after** Architecture#108 (ADR-0030 packet 01) and Architecture#109 (ADR-0030 packet 02) are merged. The dependency frontmatter on packets 01 and 02 of this initiative will resolve to those issue numbers at filing time using the qualified `Architecture#NN` form — the numbers below are placeholders updated pre-push.
+
+## Summary
+
+ADR-0031 is the stand-up ADR for `HoneyDrunk.Audit`. It decides what the Node owns (D1), the package families (D2: `HoneyDrunk.Audit.Abstractions` + `HoneyDrunk.Audit.Data`), the three exposed contracts (D3: `IAuditLog`, `IAuditQuery`, `AuditEntry`), Data-backed append-only storage (D4), the Node's own managed identity (D5), Auth as the first emitter with Operator reconciled (D6), one-way telemetry to Pulse (D7), the contract-shape canary (D8), the downstream coupling rule (D9), and what scaffolds in the first PR (D11). None of that has been built — the `HoneyDrunkStudios/HoneyDrunk.Audit` repo does not exist yet.
+
+Four packets land the work:
+
+1. **Constitution invariants** — two new invariants from D9 and D8 added to `constitution/invariants.md` at numbers **45** and **46** (the slots reserved by ADR-0030 packet 02). 45 = downstream Abstractions-only coupling. 46 = Audit contract-shape canary requirement.
+2. **Create HoneyDrunk.Audit GitHub repo (human-only)** — create the public repo on `HoneyDrunkStudios`, apply branch protection, seed labels, configure OIDC federated credential, clone locally. Same shape as the Capabilities create-repo packet — except this one is brand-new creation, not verify-and-clone.
+3. **HoneyDrunk.Audit scaffold** — empty repo to first-shippable state. Solution, two packages (`Abstractions` + `Data`), three contracts, Data-backed append-only `IAuditLog` writer + `IAuditQuery` reader over `IRepository`/`IUnitOfWork`, audit-class retention hook (App Config-sourced), in-memory `IAuditLog`/`IAuditQuery` fixture living `internal` to the runtime package's test project (D2 — deliberately not a `Testing` package per ADR-0027 precedent), end-to-end smoke test (write through `IAuditLog`, read back through `IAuditQuery` against the in-memory fixture), full CI including the D8 contract-shape canary scoped to `HoneyDrunk.Audit.Abstractions`, `README`/`CHANGELOG`/`LICENSE` per package.
+4. **Auth as first emitter** — wire `HoneyDrunk.Auth` to emit durable `AuditEntry` records for login attempts and authorization grants/denials via `IAuditLog`, additively to its existing OTel traces, on the separate durable channel per ADR-0030 D6 and the substrate-level audit-emission boundary invariant `{N-substrate}` (landed by ADR-0030 packet 02). Auth's identity-out-of-traces invariant is untouched — audit records are out-of-band of traces. **Per ADR-0026, Auth passes the Kernel `TenantId` strong type from `IGridContext.TenantId` directly to `AuditEntry.TenantId` — no stringification at the emission site.**
+
+## Wave Diagram
+
+```
+Wave 1: Architecture audit invariants (next two free slots — `{N-coupling}` and `{N-canary}`) + create HoneyDrunk.Audit repo (parallel)
+   ├─ Architecture: 01-architecture-audit-coupling-and-canary-invariants
+   │     Blocked by: Architecture#109 (ADR-0030 packet 02 must merge so the
+   │                 `## Audit Invariants` section and the substrate-level audit-emission
+   │                 boundary invariant `{N-substrate}` exist).
+   └─ Architecture: 02-architecture-create-audit-repo  (human-only)
+         Blocked by: Architecture#108 (catalog must register `honeydrunk-audit`
+                     and create `repos/HoneyDrunk.Audit/` first — already in place).
+
+Wave 2: HoneyDrunk.Audit scaffold
+   └─ HoneyDrunk.Audit: 03-audit-node-scaffold
+         Blocked by: packet 01 (invariant number placeholders `{N-coupling}` and `{N-canary}` are referenced in the scaffold's
+                                 acceptance criteria and CHANGELOG)
+                     packet 02 (the GitHub repo must exist and the local working tree
+                                must be cloned before scaffolding can run)
+
+Wave 3: Auth wired as first emitter
+   └─ HoneyDrunk.Auth: 04-auth-wire-first-emitter
+         Blocked by: packet 03 (Auth needs `HoneyDrunk.Audit.Abstractions 0.1.0`
+                                 published to NuGet — Auth references it as a
+                                 PackageReference, not a ProjectReference)
+```
+
+In practice packets 01 and 02 can be filed in the same push — both target Architecture and touch different files (`constitution/invariants.md` vs. GitHub portal/CLI). The `dependencies:` frontmatter wires the blocking edges to the upstream ADR-0030 packets automatically.
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 01 | [Add two new Audit invariants (downstream Abstractions-only coupling + contract-shape canary, assigned `{N-coupling}` and `{N-canary}`) to the constitution](./01-architecture-audit-coupling-and-canary-invariants.md) | Architecture | 1 | Agent | Architecture#109 |
+| 02 | [Create `HoneyDrunkStudios/HoneyDrunk.Audit` public repo, branch protection, labels, OIDC, clone locally (human-only)](./02-architecture-create-audit-repo.md) | Architecture (tracking issue) | 1 | Human | Architecture#108 |
+| 03 | [Stand up `HoneyDrunk.Audit` — solution, two packages, three contracts, Data-backed append-only store, CI with canary, in-memory fixture, smoke test](./03-audit-node-scaffold.md) | HoneyDrunk.Audit | 2 | Agent | 01, 02 |
+| 04 | [Wire `HoneyDrunk.Auth` as the first `IAuditLog` emitter — durable login attempts, authz grants/denials, identity-out-of-traces invariant untouched](./04-auth-wire-first-emitter.md) | HoneyDrunk.Auth | 3 | Agent | 03 |
+
+## Phase Mapping (ADR-0031 "If Accepted" checklist → packets)
+
+ADR-0031's "If Accepted — Required Follow-Up Work" checklist, mapped to packets:
+
+| Checklist item | Packet |
+|---|---|
+| Create the `HoneyDrunk.Audit` GitHub repo as **public** | packet 02 |
+| Add `honeydrunk-audit` Node entry to `catalogs/nodes.json` | ADR-0030 packet 01 (already on disk; the row was authored in that scoping pass) |
+| Add `honeydrunk-audit` entries and the new edges to `catalogs/relationships.json` | ADR-0030 packet 01 |
+| Add `IAuditLog`, `IAuditQuery`, `AuditEntry` to `catalogs/contracts.json` under `honeydrunk-audit`; mark Operator's existing entries relocated | ADR-0030 packet 01 |
+| Add the `honeydrunk-audit` row to `catalogs/grid-health.json` | ADR-0030 packet 01 |
+| Add `honeydrunk-audit` entries to `catalogs/modules.json` for `HoneyDrunk.Audit.Abstractions` and `HoneyDrunk.Audit.Data` | ADR-0030 packet 01 (already on disk in `catalogs/modules.json` — verified pre-scoping) |
+| Update `constitution/sectors.md` Core-sector table to add the **Audit** row | ADR-0030 packet 01 |
+| Append the additive amendment note to `adrs/ADR-0018-stand-up-honeydrunk-operator-node.md` | ADR-0030 packet 01 (the 2026-05-16 amendment is already on disk; ADR-0030 packet 01 verifies, does not re-author) |
+| Wire the contract-shape canary into Actions for the three frozen contracts | packet 03 (CI file inside HoneyDrunk.Audit, not in HoneyDrunk.Actions — the reusable workflow already exists per `HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml`) |
+| Create `repos/HoneyDrunk.Audit/` context folder in the Architecture repo | already on disk — verified pre-scoping (`overview.md`, `boundaries.md`, `invariants.md`, `active-work.md`, `integration-points.md`) |
+| File the HoneyDrunk.Audit scaffold packet | packet 03 |
+| Reference ADR-0030 (Grid-Wide Audit Substrate) as the driving decision | this dispatch plan + every packet's `adrs:` frontmatter |
+| Scope agent assigns final invariant numbers when flipping Status → Accepted | packet 01 (assigns 45 and 46); ADR-0030 packet 02 already assigned 44 |
+
+ADR-0030 packets 01 and 02 carry the catalog, sectors, ADR-0018-amendment, and substrate-invariant work. This initiative is responsible for the **packaging/CI/scaffold half** of ADR-0031's "If Accepted" checklist — the constitutional invariants for the standup's two rules (D8 + D9), the public repo, the scaffold itself, and the first emitter (Auth). The Operator reconciliation half of D5 is **not** in this initiative — see "What This Initiative Does NOT Deliver" below.
+
+## What This Initiative Does NOT Deliver
+
+The following are explicitly out of scope for this initiative. Each becomes a separate packet at the appropriate time:
+
+- **HoneyDrunk.Operator reconciliation as `IAuditLog`/`IAuditQuery` consumer.** Per ADR-0030 D5 and ADR-0031 D6, Operator is reclassified from owner to consumer/emitter of the relocated contracts. The catalog-side reconciliation (marking `IAuditLog`/`AuditEntry` relocated in `contracts.json`, adding the `honeydrunk-operator → honeydrunk-audit` edge, appending the additive amendment note to ADR-0018) lands in ADR-0030 packet 01 — already scoped. The **code-side** reconciliation does not exist yet because **HoneyDrunk.Operator is not yet scaffolded** (the repo carries only `LICENSE`, `README.md`, `contracts/`, `docs/`, `policies/`, `prompts/`, `staging/` — no `.slnx`, no `.csproj`, no source). When Operator's own stand-up initiative scaffolds it, that scaffolding packet must add the `HoneyDrunk.Audit.Abstractions` PackageReference and emit `AuditEntry` for its AI-runtime decisions via `IAuditLog`. Surfacing it here for traceability; not authoring a packet that has nothing to edit.
+
+- **`repos/HoneyDrunk.Operator/boundaries.md` "Audit trail" + "Decision authority" cleanup.** The Operator boundaries doc currently lists "Audit trail — immutable log of every AI decision, tool invocation, and human override" under "What Operator Owns." Per ADR-0030 D5, Operator is no longer the owner — Audit is. This doc reconciliation lands with Operator's stand-up initiative, not here. Flagging so it does not get lost.
+
+- **Hash-chain / WORM tamper-evidence.** Per ADR-0030 D8a / D9 and ADR-0031 §Negative, Phase 1 is append-only-by-interface, NOT tamper-evident. Hash-chain/WORM is deferred behind the boundary until a stated trigger fires (compliance, customer-contract, or incident-class requirement). The scaffold must not document or describe the store as tamper-evident.
+
+- **The deployable tenant-facing forensics read Service.** Per ADR-0030 D8b, deferred behind the boundary; built later over the existing `IAuditQuery` with no contract change. Not in scope here.
+
+- **The `HoneyDrunk.Audit.Testing` package.** Per ADR-0031 D2 and ADR-0027 D3 precedent, the in-memory `IAuditLog`/`IAuditQuery` fixture ships `internal` to the runtime package's test project. When a third consumer (beyond Auth and Operator) needs it, it is cut into a `HoneyDrunk.Audit.Testing` package as a non-breaking change. Not in this initiative.
+
+- **The Audit Node's own managed identity (Azure provisioning).** Per ADR-0031 D5, the Audit Node runs under its own dedicated managed identity, distinct from Auth's and Operator's. **`HoneyDrunk.Audit` is a library Node at Phase 1** — both `Abstractions` and `Data` are library packages, not deployables. The managed identity is needed at the moment Audit's `Data` composition first runs in a deployable host (i.e., when a Container App composes `HoneyDrunk.Audit.Data`). At that point the host's managed identity assumes Audit's identity scope. Provisioning the user-assigned managed identity and applying RBAC against Key Vault / App Configuration belongs with whichever packet first deploys an Audit-composing host — not this scaffold. Same precedent as ADR-0016 AI standup, which deferred Azure provisioning ("HoneyDrunk.AI is a library Node, not a deployable. There is no Key Vault, no Container App, no resource group to create."). Cross-link the Azure walkthroughs at [`infrastructure/walkthroughs/azure-provisioning-guide.md`](../../../../infrastructure/walkthroughs/azure-provisioning-guide.md) for when this work lands.
+
+- **App Configuration seeding for the audit-class retention policy.** Per ADR-0031 D4, the retention value is sourced via App Configuration through Vault's `IConfigProvider` — not hardcoded. The `HoneyDrunk.Audit.Data` runtime reads `audit:retention:days` (and any related keys) from `IConfigProvider`. **Seeding the actual value in Azure App Configuration** is a deploy-time concern carried by whichever host first composes `HoneyDrunk.Audit.Data` — not by this scaffold. Packet 03 ships the read path and a sensible startup default if the key is unset (a long retention, e.g. 365d, with a `::warning::` if the key is missing). Setting it for real in App Config is a Human Prerequisite of the first consuming deployable, not of this scaffold.
+
+- **SonarCloud onboarding for HoneyDrunk.Audit.** Follows the pattern from `generated/issue-packets/active/adr-0011-code-review-pipeline/06-kernel-sonarcloud-onboarding.md`. Separate follow-up packet, post-`v0.1.0`. Flagged in packet 03's Human Prerequisites.
+
+- **Grid-health aggregator wiring** for the new repo: if `HoneyDrunk.Actions/.github/workflows/grid-health-aggregator.yml` auto-discovers from `catalogs/nodes.json`, ADR-0030 packet 01's edit is sufficient. If not, packet 03's Human Prerequisites flag a small follow-up to add `HoneyDrunk.Audit` to the watched-repos list. Confirm which behavior is in place at execution time.
+
+- **`repos/HoneyDrunk.Auth/integration-points.md` update with the Audit row.** Packet 04 wires Auth as the first emitter (a code change inside `HoneyDrunk.Auth`), but the corresponding catalog-side reconciliation — adding an "Audit" row under "Upstream Dependencies" in `repos/HoneyDrunk.Auth/integration-points.md` (in `HoneyDrunk.Architecture`) — is a separate follow-up Architecture packet. `file-packets.yml` opens PRs against a single `target_repo`; packet 04 targets Auth, so the Architecture-side edit cannot ride along in the same PR. The follow-up is one paragraph + a CHANGELOG entry; file it as a small Architecture chore packet after packet 04's PR merges so the catalog reflects shipped reality, not a pre-emptive claim.
+
+## Cross-ADR Invariant Numbering — Coordination Honored (Collision-Aware)
+
+The dispatch plan for ADR-0030 originally reserved invariants **45** and **46** for this initiative, assuming 44 was free for the substrate. **That assumption no longer holds.** As of 2026-05-20, `constitution/invariants.md` carries:
+
+- `## AI Invariants` section, **44 / 45 / 46** = ADR-0016 AI standup (downstream Abstractions-only coupling, App-Config sourcing, AI Node contract-shape canary). **Already landed.**
+
+This means ADR-0030 packet 02's own collision-check protocol will shift the substrate-level audit-emission boundary invariant to whatever is the next free slot at its edit time (typically **47** if no other invariant-numbering packet lands between, or higher if e.g. ADR-0018 packet 02's 47-50 claim lands first). The two slots reserved for this initiative will be the next two after that.
+
+The logical allocation is therefore:
+
+- **`{N-substrate}` = audit-emission boundary invariant** (substrate-level, lands with ADR-0030 packet 02). Auditable security events emitted to the Audit substrate via `IAuditLog`, on a durable channel separate from observability. Phase 1 append-only-by-interface, NOT tamper-evident.
+- **`{N-coupling}` = downstream Abstractions-only coupling** (ADR-0031 D9). This initiative, packet 01.
+- **`{N-canary}` = Audit contract-shape canary requirement** (ADR-0031 D8). This initiative, packet 01.
+
+Where the three concrete numbers are determined by collision check at each packet's actual edit time, in landing order. Throughout this initiative's packet sources, the three placeholders `{N-substrate}`, `{N-coupling}`, `{N-canary}` are used so packets 01/02/03/04 can be filed without prematurely committing to numeric assignments that may shift.
+
+Packet 01 of this initiative reads `## Audit Invariants` section from `constitution/invariants.md` post-ADR-0030-merge, finds the substrate-level invariant + its reservation note for two slots, and appends the two new invariants under the same section. If the reservation note no longer matches the next two free slots (because another invariant-numbering packet landed between ADR-0030 packet 02's merge and packet 01's edit), packet 01 stops, surfaces, and waits for ADR-0030 packet 02 to be fixed-forward in a new packet (invariant 24's no-amendment rule applies).
+
+Packet 01 then updates three cross-references in lockstep with the assigned numbers:
+
+- `adrs/ADR-0031-stand-up-honeydrunk-audit-node.md` — the "New invariant (proposed for `constitution/invariants.md`)" subsection in Consequences (replace the tentative-numbering preamble with the assigned numbers).
+- `repos/HoneyDrunk.Audit/invariants.md` — the trailing cross-reference paragraph (update with the assigned numbers).
+- Packets 03 and 04 source files of this initiative — their `{N-substrate}` / `{N-coupling}` / `{N-canary}` placeholders are substituted with the assigned numbers in place pre-push. **Packets 03 and 04 cannot be filed in the same push as packet 01** for this reason: the invariant numbers in 03 and 04 must match what packet 01 actually landed.
+
+**Collision pre-claims to be aware of (do not block on, but check):**
+
+- **ADR-0018 packet 02 (Operator standup invariants)** pre-claims slots **47–50**. If ADR-0018 packet 02 lands between this initiative's packet 01 and ADR-0030 packet 02, the substrate's next-free-slot calculation shifts. If ADR-0018 packet 02 lands between this initiative's packet 01 edit time and its push, this initiative's two slots shift.
+- **AI-sector standups in flight** (ADR-0020 Agents, ADR-0021 Knowledge, ADR-0022 Memory, ADR-0023 Evals, ADR-0024 Flow, ADR-0025 Sim) — each carries its own invariant-numbering packet. None are pre-claimed at scoping time but landing order is uncertain.
+
+**Filing-order rule (hard):**
+
+1. Push packets 01 and 02 in the same push (they may travel together — packet 02 is human-only, packet 01 is agent; both reference Architecture#108/#109 issues that must already be merged on `main`).
+2. Wait for packet 01's PR to merge so the assigned numbers actually land in `constitution/invariants.md`.
+3. Wait for packet 02's chore issue to be Done so the public repo exists, branch protection is applied, labels are seeded, OIDC is wired, and the local working tree at `c:/.../HoneyDrunkStudios/HoneyDrunk.Audit/` exists.
+4. **Substitute the actual assigned numbers** for `{N-substrate}`, `{N-coupling}`, `{N-canary}` in `03-audit-node-scaffold.md` and `04-auth-wire-first-emitter.md` source files in place pre-push (invariant 24's pre-filing carve-out applies; packets 03 and 04 have not been filed yet).
+5. Push packet 03.
+6. Wait for packet 03's PR to merge and for `HoneyDrunk.Audit 0.1.0` to publish to NuGet.
+7. Push packet 04 (Auth emitter) once `HoneyDrunk.Audit.Abstractions 0.1.0` is discoverable on the consumer feed.
+
+Packet 04 cannot be filed before packet 03's PR is merged and `v0.1.0` is tagged-and-published — Auth needs to add a `PackageReference` that resolves on the consumer feed.
+
+## Asymmetry vs ADR-0016 AI / ADR-0017 Capabilities standups
+
+Three deliberate asymmetries are worth recording:
+
+1. **Two packages, not six.** The AI standup ships `Abstractions` + runtime + four provider slots (six packages). Capabilities ships `Abstractions` + runtime + `Testing` (three). Audit ships **two**: `HoneyDrunk.Audit.Abstractions` and `HoneyDrunk.Audit.Data`. No provider slots — there is no "router," "policy evaluator," or "provider-axis runtime" in Audit. The store *is* the runtime concern (per ADR-0031 §Alternatives Considered).
+
+2. **`HoneyDrunk.Audit.Data` is a backing-slot name, not a bare runtime.** Per ADR-0031 D2 (and §Alternatives Considered: "Bare `HoneyDrunk.Audit` runtime package…rejected"), the runtime package is named for its backing. A future alternative backing would be a sibling slot (`HoneyDrunk.Audit.Cosmos`, `HoneyDrunk.Audit.S3`, etc.), not a replacement of a bare runtime. This matches `HoneyDrunk.Data.*` and `HoneyDrunk.Vault.Providers.*` precedents and is the only Grid Node where the runtime package is backing-named. **Do not** rename to bare `HoneyDrunk.Audit` later — that would close off the sibling-slot path.
+
+3. **No `Testing` package at stand-up.** Per ADR-0031 D2 + §Alternatives Considered ("Ship a `HoneyDrunk.Audit.Testing` package at stand-up (ADR-0017 pattern) — rejected") and ADR-0027 D3 precedent, the in-memory `IAuditLog`/`IAuditQuery` fixture lives **`internal` to the runtime package's test project** until a third consumer (beyond Auth and Operator) needs it. This is a deliberate departure from ADR-0017's ship-`Testing`-at-stand-up pattern, justified by the same reasoning ADR-0027 used: the consumer set is small (2) and known (Auth, Operator). Cutting `HoneyDrunk.Audit.Testing` later is non-breaking. Packet 03 must keep the fixture under `tests/HoneyDrunk.Audit.Data.Tests/Fixtures/` (or equivalent) with `internal` visibility — explicitly NOT a `src/HoneyDrunk.Audit.Testing/` project.
+
+4. **All three contracts frozen, not a four-of-N hot subset.** Per ADR-0031 D8 + §Alternatives Considered ("Freeze only a hot subset of contracts in the canary — rejected"). The Audit public surface is exactly three contracts and all three are on the hot path. There is no low-traffic remainder to leave un-frozen. The canary in packet 03 covers `IAuditLog`, `IAuditQuery`, and `AuditEntry` from the first scaffold.
+
+## Archival
+
+Per ADR-0008 D10, when every packet in this initiative reaches `Done` on the org Project board AND `HoneyDrunk.Audit 0.1.0` is published to NuGet AND `HoneyDrunk.Auth 0.x.0` ships its first emitter version, the entire `active/adr-0031-audit-node-standup/` folder moves to `archive/adr-0031-audit-node-standup/` in a single commit. Partial archival is forbidden.
+
+The hive-sync agent moves individual closed packet files from `active/` to `completed/` per invariant 37 — that is per-packet lifecycle. Initiative-level archival is the post-completion sweep that follows after the whole folder reaches `Done` and the version bump in the consuming repo (Auth) lands.
+
+## Notes
+
+- **Why packet 02 is its own item.** The `HoneyDrunk.Audit` GitHub repo does not exist yet. Creation is org-admin only (Org-owner role on `HoneyDrunkStudios`) — it cannot be delegated to an agent. Surfacing it as a Wave-1 work item with `Actor=Human` keeps it visible on The Hive board as a blocker on packet 03 instead of being a hidden prereq buried in the scaffold packet's body. Same shape as `adr-0017-capabilities-standup/03-architecture-create-capabilities-repo.md`. (The ADR-0016 AI standup used "verify-and-clone" packet 02b because the AI repo had been created during ADR-0016 drafting; the Audit repo was not pre-created.)
+
+- **Why the scaffold packet keeps the in-memory fixture internal.** ADR-0031 D2 + §Alternatives Considered explicitly reject shipping `HoneyDrunk.Audit.Testing` at stand-up because the consumer set (Auth, Operator) is small and known. ADR-0027 D3 is the precedent. The fixture lives at `tests/HoneyDrunk.Audit.Data.Tests/Fixtures/InMemoryAuditLog.cs` (or equivalent) with `internal` visibility. Downstream consumers (Auth at packet 04, eventually Operator) write their own narrowly-scoped test doubles or wait for the eventual `HoneyDrunk.Audit.Testing` package — that follow-up packet will not block.
+
+- **Why all three contracts are frozen in the canary.** ADR-0031 D8 + §Alternatives Considered: the public surface is exactly three contracts and all three are on the hot path (`IAuditLog` on the write path of every security/privileged-action event, `AuditEntry` as its payload, `IAuditQuery` on every forensic read). There is no low-traffic remainder to leave un-frozen; freezing all three from the first scaffold costs nothing and removes the "which one slipped through" failure mode. Packet 03's CI scopes the api-compatibility canary to the `HoneyDrunk.Audit.Abstractions` assembly — the whole-assembly diff covers all three.
+
+- **Status flip happens after merge, not now.** ADR-0031 stays Proposed for this scoping run. The user's standing workflow says the scope agent flips Status → Accepted after the follow-up PRs merge. None of the four packets here flip ADR-0031's Status — that is a separate housekeeping step the scope agent handles when the initiative completes. **And** ADR-0031 cannot flip to Accepted until ADR-0030 is also Accepted (per ADR-0031's own "Done When" gate). The order is: ADR-0030 packets merge → ADR-0030 flips Accepted (ADR-0030 packet 01 does this) → this initiative's four packets merge → ADR-0031 flips Accepted (scope agent housekeeping after this initiative completes).
+
+- **`accepts: ADR-0031` frontmatter.** Every packet in this initiative carries `accepts: ADR-0031` so the hive-sync agent's auto-flip mechanic recognizes the initiative as the ADR's acceptance work. Per user constraint, this is mandatory and is checked at filing.
+
+- **Repo is public by default.** Per memory `project_repos_public_by_default`, HoneyDrunk repos are public unless a revenue/compliance/experiment carve-out applies. Audit substrate is a Core primitive — no carve-out applies. Packet 02's portal step specifies Visibility = Public.
+
+- **No ADR numbers in user-facing docs or code comments.** Per memory `feedback_no_adr_in_docs`, the scaffold's README and per-package READMEs do **not** cite "ADR-0031" by number in their narrative — the README explains what the package does. Runtime / packet-data references (catalog entries, frontmatter, this dispatch plan, the CHANGELOG) are fine to cite ADRs by number.
+
+- **No commits under CHANGELOG Unreleased.** Per memory `feedback_no_unreleased_commits`, the scaffold's first commit lands under `## [0.1.0] - YYYY-MM-DD`, not under `## Unreleased`. The tag push happens after merge — but the version section in CHANGELOG is dated and Semver-bumped before the commit. Packet 03's acceptance criteria call this out.
+
+- **No manual packet filing.** Per memory `feedback_no_manual_packet_filing`, file-packets.yml auto-files on push to main. Do not run `gh issue create` against these packets. Filing happens by pushing the packet files into `generated/issue-packets/active/adr-0031-audit-node-standup/`. The filing-order rule above governs which packets land in which push.
+
+- **Auth → Audit edge direction (unambiguous).** Throughout this initiative, the dependency direction is **Auth → Audit, never the reverse**. `HoneyDrunk.Auth` references `HoneyDrunk.Audit.Abstractions` (added by packet 04). `HoneyDrunk.Audit` does not reference any `HoneyDrunk.Auth.*` package — its `Abstractions` carries only `HoneyDrunk.Kernel.Abstractions`, and its `Data` carries Kernel + Data + Vault, with no Auth reference anywhere. The phrase **"first emitter Auth"** in ADR-0030 D6 and ADR-0031 D6 means Auth is the first *producer* of `AuditEntry` records — Audit's catalog row gains an inbound edge from `honeydrunk-auth`, not an outbound edge to it. The DAG stays acyclic: `auth → audit → kernel`, `auth → audit → data → kernel`.
+
+- **ADR-0018 amendment pre-flight check.** ADR-0018 (Operator standup) was amended on 2026-05-16 to acknowledge that `IAuditLog` and `AuditEntry` relocate from Operator's ownership to the new `HoneyDrunk.Audit` Node, and that Operator is reclassified from owner to consumer/emitter. Before pushing this initiative's packets, **verify the amendment is on `main`** in `HoneyDrunk.Architecture` — `git log -- adrs/ADR-0018-stand-up-honeydrunk-operator-node.md` should show the 2026-05-16 amendment commit. If it is missing (e.g., still in a feature branch), ADR-0030 packet 01 is not safe to merge yet and this initiative is not safe to file. The amendment is a documentation-only change (no contract or code edits) but it is the ADR-side anchor for the relocation that ADR-0030 packet 01 records in the catalogs. Pre-flight: `git -C HoneyDrunk.Architecture log --oneline -- adrs/ADR-0018-stand-up-honeydrunk-operator-node.md | head -5` and visually confirm a 2026-05-16 commit naming the audit relocation.
+
+## Filing
+
+The `file-packets.yml` workflow in `HoneyDrunk.Architecture` triggers automatically on push to `generated/issue-packets/active/**/*.md`. No `gh issue create` commands in this dispatch plan — the pipeline handles filing, project-board addition, field population, and `addBlockedBy` wiring from the `dependencies:` frontmatter on each packet. Verify after push by checking The Hive (org Project #4) for the new items and their blocking edges.


### PR DESCRIPTION
## Summary

Scopes four packets standing up `HoneyDrunk.Audit` per [ADR-0031](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0031-stand-up-honeydrunk-audit-node.md) — the Grid's dedicated audit substrate driven by ADR-0030's relocation decision. **Final initiative in this scoping wave.**

### Wave 1 — Architecture-repo (parallel)
- **`01-coupling-and-canary-invariants`** — two new constitution invariants (named-token placeholders so collision-driven renumbering is mechanical). Blocked by `Architecture#109` (closed).
- **`02-create-audit-repo`** — human-only chore: PUBLIC `HoneyDrunk.Audit` repo + clone. Blocked by `Architecture#108` (closed).

### Wave 2 — Audit Node scaffold
- **`03-audit-node-scaffold`** — two-package family (`Abstractions`, `Data` per the `HoneyDrunk.Data.*` backing-slot precedent). Three frozen contracts (`IAuditLog`, `IAuditQuery`, `AuditEntry` + `AuditQueryFilter` supporting record).

### Wave 3 — Auth wires first emitter
- **`04-auth-wire-first-emitter`** — `BearerTokenAuthenticationProvider` + `DefaultAuthorizationPolicy` emit `AuditEntry` via `IAuditLog`.

## Upstream blockers — closed manually

ADR-0030's acceptance packets (`Architecture#108`, `Architecture#109`) were filed by hive-sync *after* PR #107 had already delivered the work — leaving the issues stale-open. Closed them manually with comments referencing #107, then substituted the placeholder strings (`Architecture#<adr-0030#01>` → `Architecture#108`, etc.) throughout this initiative.

## Surface alignment vs real codebase

Refine pass found multiple drift cases against actual upstream surfaces; this initiative's scaffold reflects the corrected shapes:
- **`AuthorizationPolicyEvaluator` is static** — retargeted to `DefaultAuthorizationPolicy` (DI-resolvable decorator). Authorization decision uses `IsAllowed`, not `IsGranted`.
- **`AuthenticationResult.IsAuthenticated`**, not invented `IsValid`.
- **`IGridContextAccessor` ambient pattern** for Singleton emitters (avoids captive-dep with Scoped `IGridContext`).
- **`IReadOnlyRepository<T>` at v0.1.0** has no `Query()` — `DataAuditQuery` uses real `FindAsync`/`FindByIdAsync`.
- **`IConfigProvider` has no change-events** — `AuditRetentionPolicy` reads once at startup, restart-to-refresh.
- **`DataAuditLog` registered Singleton with internal locking** — avoids captive-dep with Singleton `BearerTokenAuthenticationProvider`.
- **`secrets: inherit`** replaced with explicit `secrets: { nuget-api-key: ... }`.

## Strong-typed identifiers
- `AuditEntry.TenantId` uses Kernel.Abstractions `TenantId` per ADR-0026.
- `AuditEntryId` strong type at v0.1.0 (record-struct over ULID).
- `CorrelationId` stays `string` at v0.1.0 with follow-up to v0.2.0.

## Phase-1 honesty
README explicitly states **"NOT tamper-evident"** — hash-chain/WORM and the tenant-facing forensics Service deferred behind the substrate boundary per ADR-0030 D9. Append-only enforced at the `IAuditLog` interface surface; storage-side append-only is code-review-enforced at v0.1.0 with a Phase-2 hardening follow-up flagged.

## Operator reconciliation
Out of scope for this initiative — Operator hasn't been scaffolded yet. Filed as a follow-up when Operator's standup completes (ADR-0018 PR #120 merged earlier in this wave).

Each packet carries `accepts: ADR-0031` for hive-sync auto-flip.

## Test plan
- [ ] After merge, four issues file with `addBlockedBy` edges to closed `Architecture#108`/`#109` (so they unblock immediately)
- [ ] Wave 2 scaffold stays blocked on Wave 1
- [ ] Wave 3 Auth wire-up stays blocked on Wave 2
- [ ] When all four close, hive-sync auto-flips ADR-0031 Proposed → Accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)