### PR TITLE
chore(hive-sync): refresh stale Grid state in CLAUDE.md + README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,26 +6,34 @@ You are operating inside `HoneyDrunk.Architecture`, the command center (Agent HQ
 
 **What is this repo?** The planning and governance surface for 13+ HoneyDrunk repos operated by one developer + AI agents. Not a code repo. No deployables live here.
 
-**Grid state as of 2026-04-12:**
-- **Live Nodes (8):** Kernel, Transport, Vault, Auth, Web.Rest, Data (all 0.4.0), Notify (undeployed), Actions
-- **Active initiatives:** ADR-0005/0006 Config+Secrets rollout (Wave 2 pending), ADR-0009 Package Scanning rollout, Vault.Rotation bring-up, Lore bring-up (on deck)
-- **Top open blockers:** *(this 2026-04-12 snapshot has drifted — ADR-0008 D6 batch-filing has shipped (`HoneyDrunk.Actions/scripts/file-packets.sh` + workflow), and Vault.Rotation has been scaffolded. See `initiatives/active-initiatives.md` for current initiative state; consider running `hive-sync` to refresh this section.)*
-- **AI sector:** 9 Nodes designed, 0 deployed — all Seed phase
+**Grid state as of 2026-05-21:**
+- **Live Nodes (12):** Kernel 0.7.0, Transport 0.6.0, Vault 0.5.0, Data 0.6.0, Web.Rest 0.5.0, Auth 0.4.0 (Core); Notify 0.3.0, Communications 0.2.0, Pulse 0.3.0, Actions (Ops); Architecture, Studios (Meta). All Core packages aligned to Kernel 0.7.0 / Transport 0.6.0 baseline (canaries passing).
+- **Seed Nodes (13):** Vault.Rotation, Audit (Core); Lore (Meta); AI, Agents, Memory, Knowledge, Evals, Capabilities, Flow, Operator, Sim (AI). Vault.Rotation is scaffolded but holds no package/tag by decision; Audit is governed by ADR-0030 (Accepted) + ADR-0031 standup (Proposed). The nine AI-sector Nodes are designed but not scaffolded — see `constitution/ai-sector-architecture.md`.
+- **Active initiatives:** Kernel Adoption Alignment (11/11 closed — exit review), ADR-0010 Observe & AI Routing Phase 1 (Observe#2 + AI routing reconciliation still open), ADR-0015 Container Apps Rollout (Notify/Pulse Azure bring-up still open), ADR-0030 Audit Substrate acceptance (2/2 closed — exit review), ADR-0032 PR Validation Policy (12/12 closed — packets do not declare `accepts:`, ADR stays Proposed until reconciled), ADR-0016 HoneyDrunk.AI standup. Multiple older rollouts (ADR-0005/0006, ADR-0009, ADR-0014, Lore) are 100% closed and queued for archive.
+- **Top open blockers:** Notify.Functions / Notify.Worker / Pulse.Collector Azure Container Apps bring-up (Notify#3, Notify#4, Pulse#3); ADR-0010 manifest drift around HoneyDrunk.AI#1 vs #3 (superseded routing-contract packet); Pulse container image publication still gated on upstream Ubuntu `sed` CVE-2026-5958. See `initiatives/current-focus.md` for the live primary list.
+- **AI sector:** 9 Nodes designed, 0 scaffolded — all Seed phase. HoneyDrunk.AI catalog/standup ADR-0016 Accepted; scaffold packets (Architecture#72, #73, AI#2) still open.
 
 **Top ADRs to know:**
-- ADR-0005/0006 — Config & secrets strategy (env-var-driven Vault bootstrap, per-Node Key Vaults)
-- ADR-0007 — `.claude/agents/` is the single source of truth for agent definitions
-- ADR-0008 — Work tracking (issue packets → GitHub Issues → org Project board → Codex execution); **read the Unresolved Consequences section before filing any issues**
-- ADR-0003 — HoneyHub control plane, now Accepted Phase 1 (domain model + knowledge graph API only)
-- ADR-0010 — Observation Layer + AI Routing (Proposed — blocked on Observe vs Pulse boundary decision; follow-up catalog work listed in ADR)
+- ADR-0005/0006 — Config & secrets strategy (env-var-driven Vault bootstrap, per-Node Key Vaults). **Accepted.**
+- ADR-0007 — `.claude/agents/` is the single source of truth for agent definitions. **Accepted.**
+- ADR-0008 — Work tracking (issue packets → GitHub Issues → org Project board → Codex execution). **Accepted.** D4/D5/D6 gaps all RESOLVED (2026-04-12 / 2026-05-20); see the 2026-05-21 D10 amendment for the initiative-slug naming convention (ADR-driven vs PDR-driven vs BDR-driven slugs).
+- ADR-0030 — Grid-Wide Audit Substrate (Audit Node, append-only-by-interface). **Accepted.** Standup governed by ADR-0031.
+- ADR-0019 — HoneyDrunk.Communications boundary refactor (decision/orchestration vs Notify intake/delivery). **Accepted.**
+- ADR-0010 — Observation Layer + AI Routing. **Accepted.** Phase 1 Observe-side scaffolding underway; AI routing parked on manifest reconciliation.
+- ADR-0003 — HoneyHub control plane. **Accepted (Phase 1)** — domain model + knowledge graph API only.
 
-**Key new files (2026-04-12):**
-- `catalogs/grid-health.json` — live Node health snapshot
+**Top BDRs to know:**
+- BDR-0001 — Mailbox Service Replacement (leave iPostal1 for VPM; Sunbiz amendment in flight before Oct 2026). **Accepted.** See `business/decisions/`.
+
+**Key files added since 2026-04-12:**
+- `catalogs/grid-health.json` — live Node health snapshot (updated 2026-05-18)
 - `catalogs/contracts.json` — public interface registry per Node
 - `constitution/agent-capability-matrix.md` — which agent does what (read before spawning an agent)
 - `constitution/sector-interaction-map.md` — how sectors communicate and blast-radius rules
 - `constitution/feature-flow-catalog.md` — named cross-repo flows (auth, notification, telemetry, secret resolution, etc.)
+- `business/` — Business Decision Records (BDRs) and operational context (entity, banking, vendors). Parallel to `adrs/` and `pdrs/`; same record shape, different scope.
 - `generated/incidents/` — post-mortem log for boundary failures
+- `initiatives/board-items.md`, `proposed-adrs.md`, `drift-report.md` — hive-sync-generated current-state surfaces
 
 **Before doing anything:** classify the request using `routing/request-types.md`. If cross-repo, run `netrunner` first.
 
@@ -86,6 +94,13 @@ For cross-sector work, also load:
 
 1. `pdrs/` — existing PDRs for precedent
 2. Output drafts to `generated/pdr-drafts/`
+
+## For Business Decisions
+
+1. `business/decisions/` — existing BDRs (operations: entity, banking, vendors, contracts, insurance)
+2. `business/context/` — current operational state (entity facts, vendor list, etc.)
+
+BDRs are scoped to studio-level operations, not Grid architecture or product strategy. Same record shape as ADRs/PDRs; use them when the decision is about how the LLC operates (mail/address, registered agent, accounting, payroll, banking, insurance, signed contracts) rather than about how the Grid is built.
 
 ## For HoneyHub Context
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Intent → Classify → Scope → Issue Packets → GitHub Issues → Execute �
 | `catalogs/` | JSON registries — nodes, packages, services, relationships, contracts, health, signals, compatibility |
 | `adrs/` | Architecture Decision Records governing Grid design |
 | `pdrs/` | Product Decision Records governing platform strategy |
-| `business/` | Business Decision Records and operational context — entity, banking, vendors, contracts |
+| `business/` | Business Decision Records (BDRs) and operational context — entity, banking, vendors, insurance, signed contracts |
 | `routing/` | Request classification, repo discovery, execution rules, SDLC lifecycle, site sync triggers |
 | `repos/` | Per-Node context — boundaries, invariants, overview, integration points for every Grid repo |
 | `initiatives/` | Active initiatives, current focus, roadmap, release history |
@@ -66,15 +66,15 @@ Intent → Classify → Scope → Issue Packets → GitHub Issues → Execute �
 | `issues/templates/` | Issue packet templates by type (feature, bug, cross-repo, CI, canary, etc.) |
 | `generated/` | Output directory for issue packets, ADR drafts, PDR drafts, site sync packets, incident logs |
 | `copilot/` | Agent behavior rules — issue authoring standards, PR review checklists, global instructions |
-| `.claude/agents/` | Claude Code agent definitions (scope, refine, review, node-audit, adr-composer, pdr-composer, netrunner, site-sync, file-issues) |
+| `.claude/agents/` | Claude Code agent definitions (scope, refine, review, node-audit, adr-composer, pdr-composer, netrunner, site-sync, file-issues, hive-sync) |
 | `scripts/` | Automation scripts for issue filing and board management |
 
 ## The Grid
 
 | Sector | Signal | Nodes |
 |--------|--------|-------|
-| **Core** | Live | Kernel, Transport, Vault, Auth, Web.Rest, Data |
-| **Ops** | Mixed | Pulse (Seed), Notify (Live), Actions (Live) |
+| **Core** | Mixed | Kernel (Live), Transport (Live), Vault (Live), Auth (Live), Web.Rest (Live), Data (Live), Vault.Rotation (Seed), Audit (Seed) |
+| **Ops** | Mixed | Pulse (Live), Notify (Live), Communications (Live), Actions (Live) |
 | **Meta** | Mixed | Architecture (Live), Studios (Live), Lore (Seed) |
 | **AI** | Seed | Agents, AI, Memory, Knowledge, Evals, Capabilities, Flow, Operator, Sim |
 | **HoneyNet** | Planned | — |

--- a/initiatives/drift-report.md
+++ b/initiatives/drift-report.md
@@ -5,7 +5,7 @@ inconsistencies between Accepted decisions and the rest of the Architecture
 repo. The agent surfaces these - it does not fix them. Resolution is the
 scope/adr-composer/human's responsibility.
 
-Last synced: 2026-05-21
+Last synced: 2026-05-21 (refresh run)
 
 ## Invariants Named in ADRs but Missing from `invariants.md`
 
@@ -24,6 +24,7 @@ _No drift detected._
 | Path | Issue | Detail | First Surfaced |
 |------|-------|--------|----------------|
 | `generated/issue-packets/active/adr-0010-observe-ai-routing-phase-1/04-ai-add-routing-contracts.md` | HoneyDrunk.AI#1 | Manifest references a packet file that no longer exists; a `.superseded.md` packet for the same original scope remains and is separately filed as HoneyDrunk.AI#3. Human/scope agent should reconcile duplicate open issues before executing ADR-0010/ADR-0016 AI work. | 2026-05-18 |
+| `generated/issue-packets/active/standalone/2026-05-20-actions-file-packets-body-length-precheck.md` | HoneyDrunkStudios/HoneyDrunk.Actions#83 | Standalone packet was filed (Actions#83) the day after `file-packets.sh` tripped GitHub's 65536-character body limit on ADR-0031 packets 03/04. Open/closed state could not be verified this run (GitHub API not reachable from the sync environment — see Auth Issues below). If Actions#83 is closed, the packet should move to `completed/standalone/` and the manifest entry pruned per the 30-day rule; if still open, leave active. Human/scope agent confirms once API access is restored. | 2026-05-21 |
 
 ## Nodes in `nodes.json` with Missing GitHub Repos
 
@@ -35,7 +36,9 @@ _No drift detected._
 
 ### Auth Issues (token-scope problems, not drift)
 
-_No drift detected._
+| Issue | Detail | First Surfaced |
+|-------|--------|----------------|
+| GitHub API unreachable | This run could not reach `api.github.com` or invoke `gh` — the sync environment exposes only a git-proxy endpoint, so Step 1b (issue-state pre-query), Step 1f (Hive board query), and the Step 12 GitHub-repo existence checks could not refresh their data. The packet lifecycle (Step 10), completed-manifest pruning (Step 11), and non-initiative board reconciliation (Step 8) were therefore skipped for this run; all other initiative-tracking edits are sourced from in-repo annotations already reconciled by the 2026-05-21 hive-sync run on main (#156). Re-run hive-sync once API access is restored. | 2026-05-21 |
 
 ## Nodes Named in ADRs but Missing from `nodes.json`
 


### PR DESCRIPTION
## Summary

Refresh of the 2026-04-12 Grid state snapshot in `CLAUDE.md` (now drifted) and a few related index updates. Companion to PR #158 (business/ section + ADR-0008 amendments).

## Changes

- **`CLAUDE.md`** — full rewrite of the "30-Second Context" block. Replaces the stale 2026-04-12 snapshot (8 Live Nodes all 0.4.0, Notify undeployed, D6 not built, Vault.Rotation not scaffolded) with current state:
  - 12 Live Nodes pinned to current package versions (Kernel 0.7.0, Transport 0.6.0, Vault 0.5.0, Data 0.6.0, Web.Rest 0.5.0, Auth 0.4.0, Notify 0.3.0, Communications 0.2.0, Pulse 0.3.0, Actions, Architecture, Studios)
  - 13 Seed Nodes (Vault.Rotation + Audit in Core, Lore in Meta, 9 AI Nodes)
  - Refreshed active initiatives, Top ADRs (now noting ADR-0008/0010/0019/0030 as Accepted)
  - New "Top BDRs" line for BDR-0001 + new "For Business Decisions" section pointing at `business/decisions/` and `business/context/` (lands cleanly when PR #158 merges)
- **`README.md`** — Directory Overview gets a `business/` row; agent inventory line now includes `hive-sync`; Grid sector table updated (Core lists Vault.Rotation + Audit Seed alongside the six Live Core Nodes, Ops includes Communications Live)
- **`initiatives/drift-report.md`** — two new entries: "Issue Packet Manifest Drift" row for standalone packet `2026-05-20-actions-file-packets-body-length-precheck.md` (HoneyDrunk.Actions#83 — couldn't verify open/closed without API access), and "Auth Issues" entry documenting the unreachable GitHub API and which sync steps were skipped (board reconciliation, packet active/completed moves, completed-manifest pruning).

## Sequencing with PR #158

This PR branches off `main`, so it does NOT include the `business/` directory or the ADR-0008 amendments — both live on `claude/cloud-agent-access-Pgjdh` (PR #158). The `business/` references in this PR's CLAUDE.md and README anticipate PR #158 merging. If this PR merges first, those references 404 until PR #158 lands. Intended to merge together.

## Environmental caveat

The sync environment had no GitHub API access this run (no `gh`, `api.github.com` returns 403, local proxy is git-protocol only). The board reconciliation, packet moves, and manifest pruning steps were deliberately skipped and surfaced in the drift report. The 2026-05-21 hive-sync run on `main` (#156) had already done those steps with live API access, so in-repo state is current.

## Test plan

- [ ] Diff CLAUDE.md "30-Second Context" against current Grid health (`catalogs/grid-health.json`, `catalogs/nodes.json`, `initiatives/active-initiatives.md`) — confirm Node versions and Live/Seed counts
- [ ] Confirm `business/` Directory Overview row + new `business/decisions/`+`business/context/` cross-references resolve once PR #158 merges
- [ ] Verify `initiatives/drift-report.md` "Auth Issues" entry documents the right blocked steps

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUZzubbvWcfHkx5W8bTRQZ)_