### PR TITLE
Clarify Audit event taxonomy before scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Amended Audit ADR/standup scope so `HoneyDrunk.Audit` v0.1.0 explicitly supports both activity/security audit and data-change audit via category/outcome/target/change value types, with redaction guidance before scaffold.
 - Reconciled ADR-0010 Phase 1 after Observe PR #3 merge: marked Architecture#35/#36 and Observe#2 complete, moved completed/superseded ADR-0010 packets to `completed/`, removed the stale missing packet-04 manifest entry, closed duplicate AI routing issues superseded by ADR-0016, and refreshed roadmap/initiative tracking for Phase 2 scoping.
 - Accepted ADR-0010 Phase 1 in Architecture: registered `honeydrunk-observe` across catalogs, added Observe repo context, finalized Observation invariants 29-30, refreshed sector boundaries, and kept AI routing contract catalog alignment without touching package code.
 - Registered ADR-0016 HoneyDrunk.AI architecture prerequisites: corrected the AI contract catalog to D3 (`ICostLedger` instead of stale `IInferenceResult`), replaced retired `Providers.Local` references with `Providers.InMemory`, clarified AI emits telemetry consumed by Pulse without a Pulse runtime dependency, added invariants 44-46 for downstream AI coupling, App Config-sourced AI rates/policies, and the AI contract-shape canary, and dropped invariant 28's stale ADR-0010 Proposed qualifier, and flipped ADR-0016 to Accepted in the ADR index/proposed-ADR tracker.

--- a/adrs/ADR-0030-grid-wide-audit-substrate.md
+++ b/adrs/ADR-0030-grid-wide-audit-substrate.md
@@ -42,7 +42,7 @@ Durable, attributable recording of "actor X attempted or executed action Y" — 
 
 ### D2. The substrate is a new dedicated HoneyDrunk.Audit Node — not Operator, not Kernel
 
-Grid-wide audit is homed in a **new dedicated `HoneyDrunk.Audit` Node** in the Core sector. It is the single Node that owns the Grid's durable, attributable security-and-action record.
+Grid-wide audit is homed in a **new dedicated `HoneyDrunk.Audit` Node** in the Core sector. It is the single Node that owns the Grid's durable, attributable security, action, and data-change record.
 
 **Why not Operator (ADR-0018):**
 
@@ -61,13 +61,20 @@ Every `*.Abstractions` package in the Grid is co-located inside its owning Node'
 
 ### D3. Exposed contracts
 
-The Audit Node's public boundary at stand-up is three surfaces — **two interfaces and one record**:
+The Audit Node's public boundary at stand-up is three primary surfaces — **two interfaces and one canonical record envelope** — plus small supporting value types/enums needed to keep the envelope explicit:
 
 | Contract | Kind | Purpose |
 |---|---|---|
 | `IAuditLog` | interface | Append-only write of an `AuditEntry`. No update method. No delete method. Append-only is enforced **at the interface surface**, not only at the storage layer. |
 | `IAuditQuery` | interface | Read and forensic-retrieval surface over the durable audit record — time-ordered and filtered reads for incident reconstruction and (later) tenant-facing forensics. New contract introduced by this ADR; has no precedent on Operator. |
-| `AuditEntry` | record | Canonical append-only audit record — actor, action, context, outcome, correlation id, tenant. Generalized Grid-wide from the Operator-scoped shape. Drops the `I` prefix per the grid-wide naming rule (records drop `I`, interfaces keep it). |
+| `AuditEntry` | record | Canonical append-only audit record envelope — category, event name/action, actor, target/resource, outcome, correlation id, tenant, metadata, and optional data-change details. Generalized Grid-wide from the Operator-scoped shape. Drops the `I` prefix per the grid-wide naming rule (records drop `I`, interfaces keep it). |
+
+`AuditEntry` supports two first-class audit families from v0.1.0:
+
+1. **Activity/security/system audit** — what an actor attempted or did in the system: login attempts, authorization grants/denials, purchases, workflow starts, agent/operator decisions, privileged actions, integration callbacks.
+2. **Data-change audit** — what durable record changed: entity created/updated/deleted, entity/resource type, entity/resource id, changed fields, and optional before/after values.
+
+The supporting contract shape includes category/outcome/target/change metadata so data-change audit is not bolted on later as an unstructured string. Sensitive before/after values must be redacted by policy before append; the Audit substrate stores the record it is given and must not become a secret/PII leak path.
 
 `IAuditLog` and `AuditEntry` are **generalizations of** the Operator-scoped contracts of the same names — promoted out of `HoneyDrunk.Operator.Abstractions` and into `HoneyDrunk.Audit.Abstractions` (D5). `IAuditQuery` is net-new: Operator's stand-up never carried a read/forensics contract because Operator's audit was write-one-shape self-recording.
 
@@ -91,6 +98,8 @@ This keeps the trust boundary correct: Operator decides and acts; Audit records.
 ### D6. First emitter is HoneyDrunk.Auth, additively
 
 The first real emitter into the Audit substrate is `HoneyDrunk.Auth`, recording durable attributable security events — login attempts, authorization grants, authorization denials. This is **additive to Auth's existing OTel traces** and does **not** change Auth's rule that telemetry stays observational and identity stays out of traces. The audit path is a *separate durable channel*: Auth continues to emit identity-free observational telemetry to Pulse exactly as before, and additionally emits attributable `AuditEntry` records to the Audit substrate. The two channels do not merge; the Auth-traces invariant is untouched.
+
+Data-change emitters are additive and follow the same durable channel: persistence/domain code records create/update/delete events through `IAuditLog` with category `DataChange`, target entity identity, and redacted changed-field details. Automatic Data-layer interception is allowed only when the redaction policy is explicit; business-intent events still belong in application/domain code so the record explains *why* the mutation occurred, not only that a row changed.
 
 ### D7. Telemetry emission — Pulse consumes, Audit does not depend
 
@@ -120,13 +129,13 @@ Stated plainly so it is not oversold: **Phase-1 audit integrity is append-only-b
 
 ### D10. Downstream coupling rule
 
-Emitters and readers (Auth, Operator first; any Node recording a security or privileged-action event later) compile **only** against `HoneyDrunk.Audit.Abstractions`. They do not take a runtime dependency on the Audit runtime package or its Data-backed store in production composition. Composition — which store backend is active, which retention policy is loaded — is a host-time concern. This is the same abstraction/runtime split applied for AI, Capabilities, Operator, Vault, and Transport, restated here because it is the rule that lets Auth and Operator proceed against `Abstractions` alone.
+Emitters and readers (Auth, Operator first; any Node recording a security, privileged-action, activity, system, integration, or data-change event later) compile **only** against `HoneyDrunk.Audit.Abstractions`. They do not take a runtime dependency on the Audit runtime package or its Data-backed store in production composition. Composition — which store backend is active, which retention policy is loaded — is a host-time concern. This is the same abstraction/runtime split applied for AI, Capabilities, Operator, Vault, and Transport, restated here because it is the rule that lets Auth and Operator proceed against `Abstractions` alone.
 
 ## Consequences
 
 ### Unblocks
 
-- **The Grid gains a durable, attributable security and action record** — login attempts, authz denials, and privileged actions are recorded somewhere addressable for the first time.
+- **The Grid gains a durable, attributable security, action, and data-change record** — login attempts, authz denials, privileged actions, and record create/update/delete events are recorded somewhere addressable for the first time.
 - **HoneyDrunk.Auth** can emit durable attributable security events without violating its identity-out-of-traces invariant (separate durable channel, D6).
 - **HoneyDrunk.Operator** keeps recording its AI-runtime decisions, now against a generalized contract it consumes — and sheds the structural problem of being both the actor and the ledger (D2, D5).
 - **A future tenant-facing forensics Service** has a contract (`IAuditQuery`) to build against the moment its trigger fires — no extraction, no contract migration (D8b).
@@ -139,7 +148,7 @@ Emitters and readers (Auth, Operator first; any Node recording a security or pri
 
 Numbering is tentative — scope agent finalizes at acceptance.
 
-- **Durable, attributable security and action events (login attempts, authorization denials, privileged actions) are emitted to the `HoneyDrunk.Audit` substrate via `IAuditLog`, on a durable channel separate from observability telemetry.** Auditable security events routed only to sampled/retention-bounded observability (Pulse/Loki) are a boundary violation. The audit channel and the telemetry channel are never merged. See D1, D6.
+- **Durable, attributable security, action, and data-change events (login attempts, authorization denials, privileged actions, record create/update/delete events) are emitted to the `HoneyDrunk.Audit` substrate via `IAuditLog`, on a durable channel separate from observability telemetry.** Auditable events routed only to sampled/retention-bounded observability (Pulse/Loki) are a boundary violation. Data-change details that include sensitive fields must be redacted before append. The audit channel and the telemetry channel are never merged. See D1, D3, D6.
 
 ### Negative
 

--- a/adrs/ADR-0031-stand-up-honeydrunk-audit-node.md
+++ b/adrs/ADR-0031-stand-up-honeydrunk-audit-node.md
@@ -37,7 +37,7 @@ This ADR is the **stand-up decision** for the Audit Node — what it owns, what 
 
 ### D1. HoneyDrunk.Audit is the Core sector's Grid-wide durable security and action record
 
-`HoneyDrunk.Audit` is the single Node in the Core sector that owns the Grid's **durable, attributable security-and-action record** — the contract and runtime machinery that durably records "actor X attempted or executed action Y" (login attempts, authorization grants and denials, privileged-action execution) and serves that record back for incident reconstruction and forensics.
+`HoneyDrunk.Audit` is the single Node in the Core sector that owns the Grid's **durable, attributable security, action, and data-change record** — the contract and runtime machinery that durably records "actor X attempted or executed action Y" and "actor X changed record Y" (login attempts, authorization grants and denials, privileged-action execution, purchases, workflow starts, integration callbacks, and entity create/update/delete records) and serves that record back for incident reconstruction and forensics.
 
 It is a record substrate, not a control plane and not an observability pipeline. It does not decide whether an action is allowed (that is Auth and Operator). It does not sample, aggregate, or surface health signal (that is Pulse). It owns the durable write, the append-only guarantee, the audit-class retention, and the forensic read surface. The boundary against Operator (recorder ≠ actor) and against Pulse (durable attributable record ≠ sampled observability) is pinned by ADR-0030 D1/D2 and is not re-opened here.
 
@@ -54,13 +54,20 @@ An in-memory `IAuditLog`/`IAuditQuery` fixture for deterministic downstream test
 
 ### D3. Exposed contracts
 
-Three surfaces form the Audit Node's public boundary — **two interfaces and one record**. These are the surfaces downstream Nodes are allowed to compile against:
+Three primary surfaces form the Audit Node's public boundary — **two interfaces and one canonical record envelope** — plus supporting value types/enums required by that envelope. These are the surfaces downstream Nodes are allowed to compile against:
 
 | Contract | Kind | Purpose |
 |---|---|---|
 | `IAuditLog` | interface | Append-only write of an `AuditEntry`. No update method. No delete method. Append-only is enforced at the interface surface, not only at storage (ADR-0030 D4). |
 | `IAuditQuery` | interface | Time-ordered and filtered read/forensic retrieval over the durable record. Net-new contract (ADR-0030 D3); has no Operator precedent. Satisfies ADR-0018 D9's "work off the read surface" commitment. |
-| `AuditEntry` | record | Canonical append-only audit record — actor, action, context, outcome, correlation id, tenant. Generalized Grid-wide from the Operator-scoped shape. Drops the `I` prefix per the grid-wide naming rule; `IAuditLog` and `IAuditQuery` retain it. |
+| `AuditEntry` | record | Canonical append-only audit record envelope — category, event name/action, actor, target/resource, outcome, correlation id, tenant, structured metadata, and optional data-change details. Generalized Grid-wide from the Operator-scoped shape. Drops the `I` prefix per the grid-wide naming rule; `IAuditLog` and `IAuditQuery` retain it. |
+
+`AuditEntry` explicitly supports both major audit families from v0.1.0:
+
+1. **Activity/security/system audit** — what an actor attempted or did: login attempts, authorization grants/denials, purchases, workflow starts, integration callbacks, agent/operator decisions, and privileged actions.
+2. **Data-change audit** — what durable record changed: entity created/updated/deleted, entity/resource type, entity/resource id, changed fields, and optional before/after values.
+
+The supporting shape includes `AuditCategory`, `AuditOutcome`, `AuditTarget`, and `AuditChange` so data-change audit is first-class and queryable instead of buried in an opaque context string. `AuditChange` values may carry before/after values, but sensitive fields must be redacted before append. The Audit substrate is durable and queryable; it must not become a secret/PII leak path.
 
 `IAuditLog` and `AuditEntry` are **relocated** from `HoneyDrunk.Operator.Abstractions` to `HoneyDrunk.Audit.Abstractions` and generalized Grid-wide per ADR-0030 D5. The existing `honeydrunk-operator` catalog entries for these two are marked relocated as part of the follow-up work. `IAuditQuery` is added new here. This mirrors the contract-reconciliation pattern ADR-0017 used (`ICapability`/`ICapabilityPermission` superseded by a corrected surface) and ADR-0018 used (`ICostController` → `ICostGuard`).
 
@@ -76,23 +83,31 @@ The Audit Node runs under its **own dedicated managed identity**, distinct from 
 
 The first real emitter wired at stand-up is `HoneyDrunk.Auth`, recording durable attributable security events additively to its existing OTel traces, on a separate durable channel, with Auth's identity-out-of-traces invariant untouched (ADR-0030 D6). `HoneyDrunk.Operator` is reconciled from owner to consumer/emitter of the generalized contracts (ADR-0030 D5): it continues recording its AI-runtime decisions, now by emitting `AuditEntry` against the `IAuditLog` it consumes from `HoneyDrunk.Audit.Abstractions`. ADR-0018 receives an additive amendment note recording the relocation and reclassification (additive only; ADR-0018 Status and decision content unchanged).
 
+Data-change emitters are also first-class consumers of the same `IAuditLog` surface. Automatic Data-layer interception can emit `AuditCategory.DataChange` events only when a redaction policy is explicit; application/domain code remains responsible for business-intent activity events so the Grid can distinguish "row changed" from "purchase completed" or "workflow started."
+
 ### D7. Telemetry emission — Pulse consumes, Audit does not depend
 
 Audit emits its own operational telemetry (write latency, query latency, append throughput) via Kernel's `ITelemetryActivityFactory`; Pulse consumes it downstream. **Audit has no runtime dependency on Pulse.** The direction is one-way by contract: Audit emits operational telemetry, Pulse observes. Same rule as ADR-0016 D7 (AI), ADR-0017 D7 (Capabilities), and ADR-0018 D7 (Operator). Audit *records* are not telemetry and never flow to Pulse — the durable audit channel and the observability channel stay separate (ADR-0030 D1).
 
 ### D8. Contract-shape canary
 
-A contract-shape canary is added to the Audit Node's CI: it fails the build if any of the three frozen contracts change shape (method signatures, parameter shapes, record members) without a corresponding version bump:
+A contract-shape canary is added to the Audit Node's CI: it fails the build if the `HoneyDrunk.Audit.Abstractions` public surface changes shape (method signatures, parameter shapes, record members, enum members, supporting value types) without a corresponding version bump. The protected surface includes:
 
 - `IAuditLog`
 - `IAuditQuery`
 - `AuditEntry`
+- `AuditEntryId`
+- `AuditQueryFilter`
+- `AuditCategory`
+- `AuditOutcome`
+- `AuditTarget`
+- `AuditChange`
 
-All three are the hot path for every emitter and reader. `IAuditLog` is on the write path of every security and privileged-action event in the Grid; `AuditEntry` is its payload; `IAuditQuery` is the contract every forensic reader (and the future tenant-facing forensics Service, ADR-0030 D8b) compiles against. Accidental shape drift on any of them breaks every emitter and reader simultaneously. The canary makes this a compile-time failure at Audit's own CI, not a discovery at consumer sites. This matches the stand-up-time canary requirement established by ADR-0016 D8, ADR-0017 D8, and ADR-0018 D10. Because the public surface is only three contracts, all three are frozen from the first scaffold rather than a four-of-N hot subset.
+These are the hot path for every emitter and reader. `IAuditLog` is on the write path of every security, activity, privileged-action, and data-change event in the Grid; `AuditEntry` and its supporting value types are the payload; `IAuditQuery`/`AuditQueryFilter` are the contracts every forensic reader (and the future tenant-facing forensics Service, ADR-0030 D8b) compiles against. Accidental shape drift breaks emitters/readers simultaneously. The canary makes this a compile-time failure at Audit's own CI, not a discovery at consumer sites.
 
 ### D9. Downstream coupling rule
 
-Emitters and readers (Auth and Operator first; any Node recording a security or privileged-action event later) compile **only** against `HoneyDrunk.Audit.Abstractions`. They do not take a runtime dependency on `HoneyDrunk.Audit.Data` in production composition. Composition — which store backing is active, which retention policy is loaded — is a host-time concern, resolved at application startup from App Configuration. This is the same abstraction/runtime split applied for AI, Capabilities, Operator, Vault, and Transport, restated here because it is the rule that lets Auth and Operator proceed against `Abstractions` alone without waiting for the Data-backed runtime.
+Emitters and readers (Auth and Operator first; any Node recording a security, privileged-action, activity, system, integration, or data-change event later) compile **only** against `HoneyDrunk.Audit.Abstractions`. They do not take a runtime dependency on `HoneyDrunk.Audit.Data` in production composition. Composition — which store backing is active, which retention policy is loaded — is a host-time concern, resolved at application startup from App Configuration. This is the same abstraction/runtime split applied for AI, Capabilities, Operator, Vault, and Transport, restated here because it is the rule that lets Auth and Operator proceed against `Abstractions` alone without waiting for the Data-backed runtime.
 
 ### D10. Dependencies on Kernel and Data are first-class
 
@@ -130,7 +145,7 @@ This ADR is "Done" when all of the following are true:
 
 - [ ] ADR-0030 (Grid-Wide Audit Substrate) is Accepted (driving decision; this stand-up does not flip Accepted before it).
 - [ ] `HoneyDrunk.Audit` public repo created with the structure described in D11.
-- [ ] `HoneyDrunk.Audit.Abstractions 0.1.0` published with the three contracts in D3.
+- [ ] `HoneyDrunk.Audit.Abstractions 0.1.0` published with the D3 public surface and supporting value types.
 - [ ] `HoneyDrunk.Audit.Data 0.1.0` ships with the Data-backed append-only composition and the in-memory test fixture.
 - [ ] Audit's CI includes the D8 contract-shape canary and it is green.
 - [ ] The Node's own managed identity is provisioned per D5.
@@ -146,7 +161,7 @@ Accepting this ADR — and landing the follow-up scaffold packet that produces a
 
 - **HoneyDrunk.Auth** — can wire the first durable attributable security-event emitter against `IAuditLog`, additively, without touching its identity-out-of-traces invariant.
 - **HoneyDrunk.Operator** — can be reconciled from owner to consumer of `IAuditLog`/`AuditEntry`, shedding the recorder-is-also-the-actor structural problem (ADR-0030 D2/D5).
-- **Any Node recording security or privileged-action events** — has a durable, attributable target instead of a lossy log or a sampled trace.
+- **Any Node recording security, activity, system, integration, privileged-action, or data-change events** — has a durable, attributable target instead of a lossy log, sampled trace, or ad-hoc table.
 - **The future tenant-facing forensics Service** — has `IAuditQuery` to build against the moment its trigger fires (ADR-0030 D8b), with no extraction and no contract migration.
 
 ### New invariant (proposed for `constitution/invariants.md`)
@@ -154,9 +169,9 @@ Accepting this ADR — and landing the follow-up scaffold packet that produces a
 Numbering is tentative — scope agent finalizes at acceptance. Proposed by ADR-0030 and restated here for the stand-up's contract-coupling rule:
 
 - **Downstream Nodes take a runtime dependency only on `HoneyDrunk.Audit.Abstractions`.** Composition against `HoneyDrunk.Audit.Data` is a host-time concern. See D9.
-- **The Audit Node CI must include a contract-shape canary for `IAuditLog`, `IAuditQuery`, and `AuditEntry`.** Shape drift on any of the three is a build failure, not a downstream discovery. See D8.
+- **The Audit Node CI must include a contract-shape canary for the `HoneyDrunk.Audit.Abstractions` public surface.** Shape drift on `IAuditLog`, `IAuditQuery`, `AuditEntry`, or the supporting query/category/outcome/target/change value types is a build failure, not a downstream discovery. See D8.
 
-(The audit-emission boundary invariant — auditable security events must be emitted to the Audit substrate on a durable channel separate from observability — is proposed in ADR-0030's Consequences and is the substrate-level invariant; it is not restated here to avoid double-numbering. The scope agent assigns final numbers across both ADRs at acceptance.)
+(The audit-emission boundary invariant — auditable security, action, and data-change events must be emitted to the Audit substrate on a durable channel separate from observability — is proposed in ADR-0030's Consequences and is the substrate-level invariant; it is not restated here to avoid double-numbering. The scope agent assigns final numbers across both ADRs at acceptance.)
 
 ### Contract-shape canary becomes a requirement
 
@@ -188,7 +203,7 @@ Rejected for this Node. ADR-0017 ships `Testing` at stand-up because Capabilitie
 
 ### Freeze only a hot subset of contracts in the canary (ADR-0016/0018 four-of-N pattern)
 
-Rejected. ADR-0016 and ADR-0018 freeze four of a larger surface because the hot subset is a fraction of the public contracts. The Audit public surface is exactly three contracts and all three are on the write/read hot path. There is no low-traffic remainder to leave un-frozen; freezing all three from the first scaffold costs nothing and removes the "which one slipped through" failure mode entirely.
+Rejected. ADR-0016 and ADR-0018 freeze four of a larger surface because the hot subset is a fraction of the public contracts. The Audit public surface is still intentionally small, but data-change support adds supporting value types that are every bit as load-bearing as the primary `AuditEntry` envelope. Freezing the whole `HoneyDrunk.Audit.Abstractions` public surface from the first scaffold costs little and removes the "which one slipped through" failure mode entirely.
 
 ### Defer the Auth emitter and Operator reconciliation into this stand-up
 

--- a/generated/issue-packets/active/adr-0031-audit-node-standup/03-audit-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0031-audit-node-standup/03-audit-node-scaffold.md
@@ -12,12 +12,12 @@ initiative: adr-0031-audit-node-standup
 node: honeydrunk-audit
 ---
 
-# Feature: Stand up the HoneyDrunk.Audit repo — solution, two packages, three contracts, Data-backed append-only store, CI, in-memory fixture, smoke test
+# Feature: Stand up the HoneyDrunk.Audit repo — solution, two packages, audit contracts, Data-backed append-only store, CI, in-memory fixture, smoke test
 
 ## Summary
-Bring the empty `HoneyDrunk.Audit` repo from zero to first-shippable state per ADR-0031 D11. Land the solution layout, the two package families (`HoneyDrunk.Audit.Abstractions` + `HoneyDrunk.Audit.Data`), the three D3 contracts inside `Abstractions` (`IAuditLog`, `IAuditQuery`, `AuditEntry`), the Data-backed append-only `IAuditLog` writer and `IAuditQuery` reader over `HoneyDrunk.Data`'s `IRepository`/`IUnitOfWork` with the audit-class retention hook (App Config-sourced), the in-memory `IAuditLog`/`IAuditQuery` fixture (internal to the runtime package's test project — deliberately not a `Testing` package per ADR-0027 precedent), the end-to-end smoke test that writes through `IAuditLog` and reads back through `IAuditQuery` against the in-memory fixture, the standard CI pipeline (PR core + release + nightly deps + nightly security), and the contract-shape canary scoped to `HoneyDrunk.Audit.Abstractions` per ADR-0031 D8 / invariant `{N-canary}`.
+Bring the empty `HoneyDrunk.Audit` repo from zero to first-shippable state per ADR-0031 D11. Land the solution layout, the two package families (`HoneyDrunk.Audit.Abstractions` + `HoneyDrunk.Audit.Data`), the D3 public surface inside `Abstractions` (`IAuditLog`, `IAuditQuery`, `AuditEntry`, plus the supporting category/outcome/target/change/query value types), the Data-backed append-only `IAuditLog` writer and `IAuditQuery` reader over `HoneyDrunk.Data`'s `IRepository`/`IUnitOfWork` with the audit-class retention hook (App Config-sourced), the in-memory `IAuditLog`/`IAuditQuery` fixture (internal to the runtime package's test project — deliberately not a `Testing` package per ADR-0027 precedent), the end-to-end smoke test that writes through `IAuditLog` and reads back through `IAuditQuery` against the in-memory fixture, the standard CI pipeline (PR core + release + nightly deps + nightly security), and the contract-shape canary scoped to the full `HoneyDrunk.Audit.Abstractions` public surface per ADR-0031 D8 / invariant `{N-canary}`.
 
-This is the unblocker for `HoneyDrunk.Auth` (packet 04 of this initiative) and any future Node recording security or privileged-action events. After this packet merges and `v0.1.0` tags, Auth can take a `HoneyDrunk.Audit.Abstractions 0.1.0` PackageReference and wire the first emitter.
+This is the unblocker for `HoneyDrunk.Auth` (packet 04 of this initiative), future data-change emitters, and any future Node recording security, activity, system, integration, or privileged-action events. After this packet merges and `v0.1.0` tags, Auth can take a `HoneyDrunk.Audit.Abstractions 0.1.0` PackageReference and wire the first emitter.
 
 **Pre-filing invariant-number substitution required.** This packet's body uses `{N-coupling}` and `{N-canary}` placeholders for the two invariant numbers landed by packet 01 of this initiative (downstream coupling + contract-shape canary). After packet 01 merges and the actual assigned numbers are known, edit this file in place pre-push (invariant 24's pre-filing carve-out) to substitute the real numbers. Hardcoding 45/46 here is WRONG — those slots are occupied by ADR-0016 AI standup as of 2026-05-20.
 
@@ -25,9 +25,9 @@ This is the unblocker for `HoneyDrunk.Auth` (packet 04 of this initiative) and a
 `HoneyDrunkStudios/HoneyDrunk.Audit`
 
 ## Motivation
-ADR-0031 D11 specifies the first-PR scaffold for HoneyDrunk.Audit. Packet 02 created the GitHub repo and cloned the local tree at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Audit/` (`.gitignore`, `LICENSE`, placeholder `README.md` only). Catalogs and Audit invariants (`{N-substrate}`, `{N-coupling}`, `{N-canary}`) are already in place. This packet ships the code.
+ADR-0031 D11 specifies the first-PR scaffold for HoneyDrunk.Audit. Packet 02 created the GitHub repo and cloned the local tree at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Audit/` (`.gitignore`, `LICENSE`, placeholder `README.md` only). Catalogs and Audit invariants (`{N-substrate}`, `{N-coupling}`, `{N-canary}`) are already in place. This packet ships the code and freezes a contract shape that supports both activity/security audit and data-change audit from v0.1.0.
 
-Until this packet ships: Auth (packet 04) has no `HoneyDrunk.Audit.Abstractions 0.1.0` to reference; the contract-shape canary has no baseline; the Phase-1 append-only-by-interface guarantee is unenforced; Operator's eventual reconciliation has nothing to consume. ADR-0031 D11 explicitly requires all three D3 contracts + round-trip proof in the first commit so the canary has a coherent baseline.
+Until this packet ships: Auth (packet 04) has no `HoneyDrunk.Audit.Abstractions 0.1.0` to reference; data-change emitters have no canonical target; the contract-shape canary has no baseline; the Phase-1 append-only-by-interface guarantee is unenforced; Operator's eventual reconciliation has nothing to consume. ADR-0031 D11 explicitly requires the D3 surface + round-trip proof in the first commit so the canary has a coherent baseline.
 
 ## Proposed Implementation
 
@@ -56,7 +56,12 @@ HoneyDrunk.Audit/
 │   │   ├── CHANGELOG.md
 │   │   ├── IAuditLog.cs             (append-only — no update method, no delete method)
 │   │   ├── IAuditQuery.cs           (time-ordered + filtered forensic reads)
-│   │   └── AuditEntry.cs            (record — drops the I prefix per Grid-wide naming rule)
+│   │   ├── AuditEntry.cs            (record envelope — drops the I prefix per Grid-wide naming rule)
+│   │   ├── AuditEntryId.cs          (strong-typed id)
+│   │   ├── AuditCategory.cs         (Security/UserActivity/DataChange/SystemAction/AgentAction/Integration)
+│   │   ├── AuditOutcome.cs          (Succeeded/Denied/Failed/Pending)
+│   │   ├── AuditTarget.cs           (resource/entity target identity)
+│   │   └── AuditChange.cs           (data-change field diff with redaction flag)
 │   └── HoneyDrunk.Audit.Data/
 │       ├── HoneyDrunk.Audit.Data.csproj
 │       ├── README.md
@@ -69,7 +74,7 @@ HoneyDrunk.Audit/
 └── tests/
     ├── HoneyDrunk.Audit.Abstractions.Tests/
     │   ├── HoneyDrunk.Audit.Abstractions.Tests.csproj
-    │   ├── ContractSurfaceTests.cs            (compile-only + shape assertions on IAuditLog/IAuditQuery/AuditEntry)
+    │   ├── ContractSurfaceTests.cs            (compile-only + shape assertions on Abstractions public surface)
     │   └── AppendOnlyAtInterfaceTests.cs      (reflection check: IAuditLog has no update/delete method)
     └── HoneyDrunk.Audit.Data.Tests/
         ├── HoneyDrunk.Audit.Data.Tests.csproj
@@ -166,8 +171,8 @@ using HoneyDrunk.Kernel.Abstractions.Identity;
 public interface IAuditQuery
 {
     /// <summary>
-    /// Read entries within the given time window, optionally filtered by actor, action,
-    /// correlation id, or tenant, in time order (earliest first).
+    /// Read entries within the given time window, optionally filtered by actor, category,
+    /// event name, target, correlation id, or tenant, in time order (earliest first).
     /// </summary>
     Task<IReadOnlyList<AuditEntry>> ReadAsync(
         AuditQueryFilter filter,
@@ -181,10 +186,75 @@ public sealed record AuditQueryFilter(
     DateTimeOffset Since,
     DateTimeOffset Until,
     string? Actor = null,
-    string? Action = null,
+    AuditCategory? Category = null,
+    string? EventName = null,
+    string? TargetType = null,
+    string? TargetId = null,
     string? CorrelationId = null,
     TenantId? TenantId = null,
     int? Limit = null);
+```
+
+```csharp
+// AuditCategory.cs
+namespace HoneyDrunk.Audit.Abstractions;
+
+/// <summary>
+/// Broad audit event family. Used for routing, retention review, and forensic filters.
+/// </summary>
+public enum AuditCategory
+{
+    Security = 0,
+    UserActivity = 1,
+    DataChange = 2,
+    SystemAction = 3,
+    AgentAction = 4,
+    Integration = 5,
+}
+```
+
+```csharp
+// AuditOutcome.cs
+namespace HoneyDrunk.Audit.Abstractions;
+
+/// <summary>
+/// Outcome of the audited event.
+/// </summary>
+public enum AuditOutcome
+{
+    Succeeded = 0,
+    Denied = 1,
+    Failed = 2,
+    Pending = 3,
+}
+```
+
+```csharp
+// AuditTarget.cs
+namespace HoneyDrunk.Audit.Abstractions;
+
+/// <summary>
+/// Resource, entity, workflow, integration, or system component targeted by an audit event.
+/// </summary>
+public sealed record AuditTarget(
+    string Type,
+    string Id,
+    string? DisplayName = null);
+```
+
+```csharp
+// AuditChange.cs
+namespace HoneyDrunk.Audit.Abstractions;
+
+/// <summary>
+/// Optional per-field data-change detail. Values must be redacted before append when the
+/// field contains secrets, credentials, tokens, regulated data, or sensitive PII.
+/// </summary>
+public sealed record AuditChange(
+    string Field,
+    string? Before = null,
+    string? After = null,
+    bool IsRedacted = false);
 ```
 
 ```csharp
@@ -194,29 +264,35 @@ namespace HoneyDrunk.Audit.Abstractions;
 using HoneyDrunk.Kernel.Abstractions.Identity;
 
 /// <summary>
-/// Canonical append-only audit record. Generalized Grid-wide from the original
+/// Canonical append-only audit record envelope. Generalized Grid-wide from the original
 /// Operator-scoped shape per ADR-0030 D5.
 /// </summary>
 /// <param name="Id">Unique identifier for the audit entry. Strong-typed <c>AuditEntryId</c> (ULID-shaped). Pass <see cref="AuditEntryId.Empty"/> at construction; the writer overwrites at append time.</param>
 /// <param name="OccurredAt">Wall-clock time the audited action occurred.</param>
-/// <param name="Actor">Identifier for who performed the action (user id, system id, etc.).</param>
-/// <param name="Action">Identifier for what action was performed (e.g. "auth.login.attempt").</param>
-/// <param name="Outcome">Outcome of the action (e.g. "granted", "denied", "succeeded", "failed").</param>
+/// <param name="Category">Broad event family: security, user activity, data change, system action, agent action, or integration.</param>
+/// <param name="EventName">Stable domain event name (e.g. <c>auth.login.attempt</c>, <c>entity.customer.updated</c>, <c>purchase.completed</c>).</param>
+/// <param name="Actor">Identifier for who performed or attempted the action (user id, system id, agent id, etc.).</param>
+/// <param name="Target">Resource/entity/workflow/integration target of the event.</param>
+/// <param name="Outcome">Outcome of the audited event.</param>
 /// <param name="CorrelationId">Correlation identifier tying this entry to a broader operation. Stays string at v0.1.0; promoted to <c>Kernel.Abstractions.Identity.CorrelationId</c> at v0.2.0 (follow-up packet).</param>
 /// <param name="TenantId">Tenant scope of the entry. Uses the Kernel strong type per ADR-0026; use <c>TenantId.Internal</c> for non-tenant-scoped Grid events.</param>
-/// <param name="Context">Free-form JSON-shaped context payload (action-specific detail).</param>
+/// <param name="Metadata">Structured string metadata for event-specific detail. Do not store secrets.</param>
+/// <param name="Changes">Optional data-change detail for create/update/delete audit. Redact sensitive fields before append.</param>
 public sealed record AuditEntry(
     AuditEntryId Id,
     DateTimeOffset OccurredAt,
+    AuditCategory Category,
+    string EventName,
     string Actor,
-    string Action,
-    string Outcome,
+    AuditTarget Target,
+    AuditOutcome Outcome,
     string CorrelationId,
     TenantId TenantId,
-    string? Context = null);
+    IReadOnlyDictionary<string, string>? Metadata = null,
+    IReadOnlyList<AuditChange>? Changes = null);
 ```
 
-**`AuditQueryFilter` is first-pass; refinement expected before v0.2.0.** The three names `IAuditLog`, `IAuditQuery`, `AuditEntry` are stable; only `AuditQueryFilter` members are negotiable.
+**`AuditQueryFilter` is first-pass; refinement expected before v0.2.0.** The names `IAuditLog`, `IAuditQuery`, `AuditEntry`, and their supporting category/outcome/target/change value types are stable; only additive filter refinements are expected before v0.2.0.
 
 **`Id` and `OccurredAt` assignment.** Writer assigns `Id` (`DataAuditLog.AppendAsync` overwrites caller-passed). Caller assigns `OccurredAt`; Audit never overwrites it.
 
@@ -234,6 +310,7 @@ public sealed record AuditEntry(
 - `Microsoft.Extensions.Options.ConfigurationExtensions` (bind options from `IConfigProvider`)
 
 **`DataAuditLog`** — implements `IAuditLog.AppendAsync(AuditEntry, CancellationToken)`:
+- Accepts both activity/security/system events and data-change events through the same `AuditEntry` envelope; validates that `AuditCategory.DataChange` entries include a target and at least one `AuditChange` when the action is update/delete.
 - Assigns the entry's `Id` (ULID) at write time, overwriting any caller-passed value.
 - Enriches the entry with the caller's `IGridContext.CorrelationId` and `TenantId` if the entry's fields are empty (defensive — callers should pass them, but Audit is the durable-record-of-last-resort; an unattributable audit entry is worse than a redundantly-attributed one).
 - Persists via `IRepository<AuditEntry>.AddAsync` + `IUnitOfWork.SaveChangesAsync`. No update path. No delete path. The contract has none; the implementation must have none either.
@@ -306,11 +383,11 @@ public sealed class DataAuditLog : IAuditLog
 Two `internal sealed` classes; not packaged at v0.1.0 (per D2 + ADR-0027 D3). Cut into `HoneyDrunk.Audit.Testing` as non-breaking change when a third consumer needs it.
 
 - `InMemoryAuditLog : IAuditLog` — `List<AuditEntry>` + `lock(_gate)`; `AppendAsync` stamps `Id` (via `entry with { Id = entry.Id.IsEmpty ? AuditEntryId.New() : entry.Id }`) and appends; exposes `internal IReadOnlyList<AuditEntry> Snapshot()` for assertions.
-- `InMemoryAuditQuery : IAuditQuery` — takes `InMemoryAuditLog` in ctor; `ReadAsync` filters snapshot by `Since/Until`/optional `Actor`/`Action`/`CorrelationId`/`TenantId`, `OrderBy(e => e.OccurredAt)`, applies `Limit` via `Take`.
+- `InMemoryAuditQuery : IAuditQuery` — takes `InMemoryAuditLog` in ctor; `ReadAsync` filters snapshot by `Since`/`Until`/optional `Actor`/`Category`/`EventName`/`TargetType`/`TargetId`/`CorrelationId`/`TenantId`, `OrderBy(e => e.OccurredAt)`, applies `Limit` via `Take`.
 
 ### Smoke test — `tests/HoneyDrunk.Audit.Data.Tests/SmokeTests.cs`
 
-`WriteThroughIAuditLog_ReadBackThroughIAuditQuery_RoundTrips`: instantiate `InMemoryAuditLog` + `InMemoryAuditQuery` over it; append one `AuditEntry` with `Id: AuditEntryId.Empty`, `Actor: "user:42"`, `Action: "auth.login.attempt"`, `Outcome: "granted"`, `TenantId: TenantId.Internal`; query a one-minute window around `OccurredAt`; assert single result with the expected Actor/Action/Outcome and `Id.IsEmpty == false` (writer-stamped). Satisfies ADR-0031 D11.
+`WriteThroughIAuditLog_ReadBackThroughIAuditQuery_RoundTrips`: instantiate `InMemoryAuditLog` + `InMemoryAuditQuery` over it; append one `AuditEntry` with `Id: AuditEntryId.Empty`, `Category: AuditCategory.Security`, `EventName: "auth.login.attempt"`, `Actor: "user:42"`, `Target: new AuditTarget("auth-session", "session:123")`, `Outcome: AuditOutcome.Succeeded`, `TenantId: TenantId.Internal`; query a one-minute window around `OccurredAt`; assert single result with the expected Actor/EventName/Outcome and `Id.IsEmpty == false` (writer-stamped). Add a second smoke/fixture test for `AuditCategory.DataChange` with target `customer:42`, one public changed field, and one redacted sensitive changed field. Satisfies ADR-0031 D11.
 
 ### Append-only-at-interface enforcement test
 
@@ -376,7 +453,7 @@ This pulls in the StyleCop ruleset, `.editorconfig`, and analyzer suite that eve
 ## Affected Files
 Entire repo is created from this packet. Notable new files:
 - `HoneyDrunk.Audit.slnx`, `Directory.Build.props`, `README.md`, `CHANGELOG.md`, `.editorconfig`
-- `src/HoneyDrunk.Audit.Abstractions/` — `.csproj`, `IAuditLog.cs`, `IAuditQuery.cs`, `AuditEntry.cs`, `AuditEntryId.cs` (record-struct, strong-typed id per Kernel template), `README.md`, `CHANGELOG.md`
+- `src/HoneyDrunk.Audit.Abstractions/` — `.csproj`, `IAuditLog.cs`, `IAuditQuery.cs`, `AuditEntry.cs`, `AuditEntryId.cs` (record-struct, strong-typed id per Kernel template), `AuditCategory.cs`, `AuditOutcome.cs`, `AuditTarget.cs`, `AuditChange.cs`, `README.md`, `CHANGELOG.md`
 - `src/HoneyDrunk.Audit.Data/` — `.csproj`, `ServiceCollectionExtensions.cs`, `DataAuditLog.cs`, `DataAuditQuery.cs`, `AuditRetentionPolicy.cs`, `AuditTelemetry.cs`, `README.md`, `CHANGELOG.md`
 - `tests/HoneyDrunk.Audit.Abstractions.Tests/` — `.csproj`, `ContractSurfaceTests.cs`, `AppendOnlyAtInterfaceTests.cs`
 - `tests/HoneyDrunk.Audit.Data.Tests/` — `.csproj`, `Fixtures/InMemoryAuditLog.cs`, `Fixtures/InMemoryAuditQuery.cs`, `DataAuditLogTests.cs`, `DataAuditQueryTests.cs`, `SmokeTests.cs`
@@ -420,7 +497,7 @@ Project reference: `HoneyDrunk.Audit.Abstractions`.
 - [x] `HoneyDrunk.Audit.Data` references `Abstractions` (project), `Kernel.Abstractions`, `Data.Abstractions`, `Vault`. No `HoneyDrunk.Pulse` (telemetry is one-way per D7).
 - [x] No secrets in code; retention value is non-secret config read via `IConfigProvider`.
 - [x] `IAuditLog` exposes exactly `AppendAsync` — no update/replace/delete. Enforces `{N-substrate}` at interface surface.
-- [x] Records drop `I` (`AuditEntry`, `AuditQueryFilter`); interfaces keep it (`IAuditLog`, `IAuditQuery`).
+- [x] Records/enums drop `I` (`AuditEntry`, `AuditQueryFilter`, `AuditTarget`, `AuditChange`, `AuditCategory`, `AuditOutcome`); interfaces keep it (`IAuditLog`, `IAuditQuery`).
 - [x] Fixtures `internal` to test project; not packaged.
 - [x] Scaffold does NOT include: hash-chain/WORM tamper-evidence (Phase-2), tenant-facing forensics Service (deferred), Auth emitter wiring (packet 04), Operator reconciliation (separate).
 - [x] Store is **not** documented as tamper-evident anywhere. README's `## Phase-1 honest limitation` section is explicit.
@@ -428,7 +505,7 @@ Project reference: `HoneyDrunk.Audit.Abstractions`.
 ## Acceptance Criteria
 
 - [ ] `HoneyDrunk.Audit.slnx` builds clean from a fresh clone via `dotnet build` with no warnings (warnings-as-errors).
-- [ ] All three D3 contracts present in `HoneyDrunk.Audit.Abstractions` with XML documentation per invariant 13. Records (`AuditEntry`, `AuditQueryFilter`) drop the `I` prefix; interfaces (`IAuditLog`, `IAuditQuery`) keep it. The strong-typed identifier `AuditEntryId` is also a record-struct without `I` (Grid-wide naming rule).
+- [ ] D3 public surface present in `HoneyDrunk.Audit.Abstractions` with XML documentation per invariant 13: `IAuditLog`, `IAuditQuery`, `AuditEntry`, `AuditEntryId`, `AuditQueryFilter`, `AuditCategory`, `AuditOutcome`, `AuditTarget`, and `AuditChange`. Records/enums drop the `I` prefix; interfaces keep it. The strong-typed identifier `AuditEntryId` is also a record-struct without `I` (Grid-wide naming rule).
 - [ ] `HoneyDrunk.Audit.Abstractions` has exactly ONE `HoneyDrunk.*` PackageReference: `HoneyDrunk.Kernel.Abstractions` (for `TenantId`). Per ADR-0031 D2's "zero runtime dependencies beyond `HoneyDrunk.Kernel` abstractions" allowance. No `HoneyDrunk.Kernel` runtime ref; no `HoneyDrunk.Data*` / `HoneyDrunk.Vault*` / `HoneyDrunk.Pulse*` refs. Constitutional invariants `{N-coupling}` and 1 (downstream Abstractions-only coupling; Abstractions stay near-minimal) are satisfied — the single Kernel-Abstractions reference is an intentional, ADR-permitted exception.
 - [ ] `IAuditLog` exposes exactly one method, `AppendAsync(AuditEntry, CancellationToken)`. No `UpdateAsync`, no `ReplaceAsync`, no `DeleteAsync`, no `RemoveAsync`. The reflection test `AppendOnlyAtInterfaceTests.cs` asserts this and passes.
 - [ ] `HoneyDrunk.Audit.Data` exposes `AddHoneyDrunkAuditData()` extension; `IAuditLog` and `IAuditQuery` resolve from DI after registration.
@@ -437,9 +514,11 @@ Project reference: `HoneyDrunk.Audit.Abstractions`.
 - [ ] `DataAuditLog` and `DataAuditQuery` resolve `IGridContext` via `IGridContextAccessor.GridContext` (ambient per-call), **not** via direct `IGridContext` ctor injection. The classes are Singleton; `IGridContext` is Scoped — direct injection would be a captive-dep.
 - [ ] `DataAuditLog` and `DataAuditQuery` resolve `IRepository<AuditEntry>` / `IReadOnlyRepository<AuditEntry>` / `IUnitOfWork` via `IServiceScopeFactory.CreateAsyncScope()` per call (the classes are Singleton; Data abstractions are typically Scoped — same captive-dep avoidance pattern).
 - [ ] `IAuditLog`, `IAuditQuery`, `AuditRetentionPolicy`, `AuditTelemetry`, `DataAuditLog`, `DataAuditQuery` are all registered as `Singleton` in `AddHoneyDrunkAuditData()`. Lifetime story is documented in the repo README and matches the Singleton-emitters-in-Auth lifetime (per packet 04).
-- [ ] `DataAuditQuery.ReadAsync` is implemented over `IReadOnlyRepository<AuditEntry>.FindAsync(predicate, ct)` (the actual public read method on the Data abstraction at v0.1.0; there is no `Query()` method). Time ordering and `Limit` are applied post-fetch, in memory. The class file carries a `// Phase-1: FindAsync + in-memory order/take. Phase-2: switch to a public order-by/take primitive when Data ships one.` comment near the read site.
+- [ ] `DataAuditQuery.ReadAsync` is implemented over `IReadOnlyRepository<AuditEntry>.FindAsync(predicate, ct)` (the actual public read method on the Data abstraction at v0.1.0; there is no `Query()` method). Time ordering and `Limit` are applied post-fetch, in memory. Filters cover `Since`/`Until`, `Actor`, `Category`, `EventName`, `TargetType`, `TargetId`, `CorrelationId`, and `TenantId`. The class file carries a `// Phase-1: FindAsync + in-memory order/take. Phase-2: switch to a public order-by/take primitive when Data ships one.` comment near the read site.
 - [ ] **`AuditEntryId` strong type lives at `src/HoneyDrunk.Audit.Abstractions/AuditEntryId.cs`** as a `readonly record struct` matching the Kernel template (`TenantId`, `CorrelationId`). Exposes `AuditEntryId.New()`, `AuditEntryId.Empty`, `IsEmpty` property, and `ToString()` returning the wrapped string. `AuditEntry.Id` is typed as `AuditEntryId`, not `string`.
 - [ ] `DataAuditLog` and `DataAuditQuery` emit operational telemetry via `ITelemetryActivityFactory` (activities `audit.log.append`, `audit.query.read`). No `HoneyDrunk.Pulse.*` reference anywhere in `HoneyDrunk.Audit.Data.csproj`.
+- [ ] Data-change audit is first-class: `AuditCategory.DataChange`, `AuditTarget`, and `AuditChange` exist; at least one unit test appends an entity update with a redacted sensitive field and reads it back through `IAuditQuery`.
+- [ ] README documents that before/after field values must be redacted before append; Audit stores the supplied record and must not become a secret/PII leak path.
 - [ ] `AuditRetentionPolicy.RetentionDays` is sourced from `IConfigProvider.GetValueAsync` (key `audit:retention:days`) **once at startup**; defaults to 365d with a `::warning::` log if unset. No hardcoded retention literal in code. **No subscription to change-events** — `IConfigProvider` does not expose a change-token / observable surface at v0.1.0 (see `HoneyDrunk.Vault.Abstractions/IConfigProvider.cs`). Configuration changes require a host restart; hot-reload is an out-of-scope follow-up.
 - [ ] The scaffold's `README.md` includes a "Phase-1 honest limitation" section that explicitly states the store is **append-only-by-interface and NOT tamper-evident**, hash-chain/WORM is deferred behind the boundary. No language describing the store as tamper-evident appears anywhere in the repo.
 - [ ] In-memory fixtures `InMemoryAuditLog` and `InMemoryAuditQuery` exist under `tests/HoneyDrunk.Audit.Data.Tests/Fixtures/` with `internal` visibility. **No `src/HoneyDrunk.Audit.Testing/` project exists** — the fixture is not packaged at v0.1.0.
@@ -505,13 +584,13 @@ Project reference: `HoneyDrunk.Audit.Abstractions`.
 
 > **Invariant `{N-coupling}` (this initiative, packet 01):** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Audit.Abstractions`. Composition against `HoneyDrunk.Audit.Data` is a host-time concern resolved at application startup from App Configuration. — `Abstractions` kept near-minimal (one Kernel.Abstractions ref).
 
-> **Invariant `{N-canary}` (this initiative, packet 01):** The HoneyDrunk.Audit Node CI must include a contract-shape canary for `IAuditLog`, `IAuditQuery`, and `AuditEntry`. Shape drift on any of the three is a build failure unless paired with an intentional version bump. — `api-compatibility.yml` covers this (whole-assembly diff over `Abstractions`).
+> **Invariant `{N-canary}` (this initiative, packet 01):** The HoneyDrunk.Audit Node CI must include a contract-shape canary for the `HoneyDrunk.Audit.Abstractions` public surface. Shape drift on `IAuditLog`, `IAuditQuery`, `AuditEntry`, or the supporting query/category/outcome/target/change value types is a build failure unless paired with an intentional version bump. — `api-compatibility.yml` covers this (whole-assembly diff over `Abstractions`).
 
 ## Referenced ADR Decisions
 
-- **ADR-0031 D1** — Audit is the Core sector's single Node for durable security-and-action record. Substrate only; no allow/deny logic, no aggregation.
+- **ADR-0031 D1** — Audit is the Core sector's single Node for durable security, action, and data-change records. Substrate only; no allow/deny logic, no aggregation.
 - **ADR-0031 D2** — Two packages (`Abstractions` + `Data`); runtime named for backing; fixtures `internal` per ADR-0027 D3.
-- **ADR-0031 D3** — Three contracts: `IAuditLog`, `IAuditQuery`, `AuditEntry`.
+- **ADR-0031 D3** — Primary surfaces: `IAuditLog`, `IAuditQuery`, `AuditEntry`; supporting value types: `AuditEntryId`, `AuditQueryFilter`, `AuditCategory`, `AuditOutcome`, `AuditTarget`, `AuditChange`.
 - **ADR-0031 D4** — Data-backed via `IRepository`/`IUnitOfWork`; append-only at interface (no update/delete method). Audit-class retention distinct from observability; sourced via App Config / `IConfigProvider`. Phase-1 is append-only-by-interface, NOT tamper-evident (D9).
 - **ADR-0031 D5** — Audit runs under its own managed identity. Both packages are libraries here; identity provisioning belongs with the first deploying packet.
 - **ADR-0031 D6** — Auth is first emitter (packet 04); Operator reconciliation lands with Operator scaffolding (separate initiative).
@@ -539,12 +618,12 @@ Project reference: `HoneyDrunk.Audit.Abstractions`.
 
 ## Agent Handoff
 
-**Objective:** Take the empty `HoneyDrunk.Audit` repo and ship version 0.1.0 with the three D3 contracts, Data-backed append-only `IAuditLog` writer + `IAuditQuery` reader, audit-class retention policy hook (App Config-sourced), in-memory fixture (internal to the test project), end-to-end smoke test proving round-trip, full CI, and the contract-shape canary scoped to `Abstractions`.
+**Objective:** Take the empty `HoneyDrunk.Audit` repo and ship version 0.1.0 with the D3 public surface, Data-backed append-only `IAuditLog` writer + `IAuditQuery` reader, audit-class retention policy hook (App Config-sourced), first-class activity/security and data-change event shapes, in-memory fixture (internal to the test project), end-to-end smoke tests proving round-trip, full CI, and the contract-shape canary scoped to `Abstractions`.
 
 **Target:** HoneyDrunk.Audit, branch from `main`. (Packet 02 ensures `main` exists with `.gitignore`/`LICENSE` already in place.)
 
 **Context:**
-- Goal: Unblock HoneyDrunk.Auth (packet 04 of this initiative — first emitter) and any future Node that needs to record durable, attributable security or privileged-action events. Establish the contract-shape canary baseline that protects the surface from drift.
+- Goal: Unblock HoneyDrunk.Auth (packet 04 of this initiative — first emitter), future data-change emitters, and any future Node that needs to record durable, attributable security, activity, system, integration, or privileged-action events. Establish the contract-shape canary baseline that protects the surface from drift.
 - Feature: ADR-0031 standup initiative — this is the substrate scaffold, the third packet of the initiative (after the two new Audit invariants `{N-coupling}` / `{N-canary}` in packet 01 and the repo creation in packet 02).
 - ADRs: ADR-0031 (sole governing standup ADR); ADR-0030 (the driving capability/decision ADR — Phase-1 honest limitation, contract relocation, retention regime, Operator reconciliation framing all come from there); ADR-0005 (App Config-via-Vault pattern that D4 builds on); ADR-0009 (no Dependabot config file).
 
@@ -554,7 +633,7 @@ Project reference: `HoneyDrunk.Audit.Abstractions`.
 
 **Constraints:**
 
-- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — `HoneyDrunk.Audit.Abstractions.csproj` must contain no `HoneyDrunk.*` PackageReference or ProjectReference. The `HoneyDrunk.Standards` reference uses `PrivateAssets="all"` so it does not propagate.
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are normally permitted. — `HoneyDrunk.Audit.Abstractions.csproj` carries exactly one intentional ADR-permitted `HoneyDrunk.*` reference: `HoneyDrunk.Kernel.Abstractions` for `TenantId`. The `HoneyDrunk.Standards` reference uses `PrivateAssets="all"` so it does not propagate.
 - **Invariant 4:** No circular dependencies. The dependency graph is a DAG. Kernel is always at the root. — Audit → Data → Kernel and Audit → Kernel are DAG-consistent. The rejected Kernel-hosted alternative (per ADR-0030) would have created a Kernel → Data → Kernel cycle; this Node placement specifically avoids that.
 - **Invariant 5/6:** GridContext + CorrelationId + TenantId must be present in every scoped operation. — `DataAuditLog.AppendAsync` enriches the entry from `IGridContext` defensively when caller-passed fields are empty.
 - **Invariant 9:** Vault is the only source of secrets. — The retention value is non-secret configuration, sourced via `IConfigProvider` from App Configuration per ADR-0005. No `ISecretStore` calls are needed in this scaffold.
@@ -562,9 +641,9 @@ Project reference: `HoneyDrunk.Audit.Abstractions`.
 - **Invariant 13:** All public APIs have XML documentation. — Every public type/member in `HoneyDrunk.Audit.Abstractions` carries `///` summaries. StyleCop rules from `HoneyDrunk.Standards` enforce this.
 - **Invariant 26:** Packets for .NET code work must include `## NuGet Dependencies`. `HoneyDrunk.Standards` must be on every new .NET project. — Confirmed in the NuGet Dependencies section above.
 - **Invariant 27:** All projects in a solution share one version. — Both `src/*.csproj` ship at `0.1.0`. Test projects do not bump.
-- **Invariant `{N-substrate}` (substrate-level audit-emission boundary, ADR-0030 packet 02):** Durable, attributable security and action events are emitted to the `HoneyDrunk.Audit` substrate via `IAuditLog`, on a durable channel separate from observability telemetry. Phase-1 audit integrity is append-only-by-interface (`IAuditLog` exposes no update and no delete method); it is explicitly **not** tamper-evident, and Phase 1 must not be documented or marketed as such. — `IAuditLog` exposes exactly `AppendAsync`. The reflection test `AppendOnlyAtInterfaceTests` makes accidental future addition of an update/delete method a build failure. The README's "Phase-1 honest limitation" section names the not-tamper-evident reality.
+- **Invariant `{N-substrate}` (substrate-level audit-emission boundary, ADR-0030 packet 02):** Durable, attributable security, action, and data-change events are emitted to the `HoneyDrunk.Audit` substrate via `IAuditLog`, on a durable channel separate from observability telemetry. Phase-1 audit integrity is append-only-by-interface (`IAuditLog` exposes no update and no delete method); it is explicitly **not** tamper-evident, and Phase 1 must not be documented or marketed as such. Data-change details that include sensitive fields must be redacted before append. — `IAuditLog` exposes exactly `AppendAsync`. The reflection test `AppendOnlyAtInterfaceTests` makes accidental future addition of an update/delete method a build failure. The README's "Phase-1 honest limitation" section names the not-tamper-evident reality.
 - **Invariant `{N-coupling}`:** Downstream Nodes take a runtime dependency only on `HoneyDrunk.Audit.Abstractions`. Composition against `HoneyDrunk.Audit.Data` is a host-time concern. — Reinforced by keeping `Abstractions` near-minimal (one `HoneyDrunk.Kernel.Abstractions` reference for `TenantId`).
-- **Invariant `{N-canary}`:** The HoneyDrunk.Audit Node CI must include a contract-shape canary for `IAuditLog`, `IAuditQuery`, and `AuditEntry`. Shape drift is a build failure unless paired with an intentional version bump. — `api-compatibility.yml` covers this by scoping to `HoneyDrunk.Audit.Abstractions`.
+- **Invariant `{N-canary}`:** The HoneyDrunk.Audit Node CI must include a contract-shape canary for the `HoneyDrunk.Audit.Abstractions` public surface. Shape drift on `IAuditLog`, `IAuditQuery`, `AuditEntry`, or the supporting query/category/outcome/target/change value types is a build failure unless paired with an intentional version bump. — `api-compatibility.yml` covers this by scoping to `HoneyDrunk.Audit.Abstractions`.
 - **Canary on the scaffolding PR reports `status: skipped`, not fail.** First PR against near-empty repo: `git worktree add` against the baseline ref fails → `::warning::` + exit 0. Not a misconfiguration. Scaffold merge establishes baseline; verify post-merge via a throwaway breaking-change PR (revert after).
 - **Abstractions stance — exactly ONE `HoneyDrunk.*` ref**, `HoneyDrunk.Kernel.Abstractions` (for `TenantId` per ADR-0026). No `Kernel`-runtime, no `Data*`, no `Vault*`, no `Pulse*`. `CorrelationId` stays `string` until v0.2.0.
 - **Records drop `I`; interfaces keep it.**
@@ -577,7 +656,7 @@ Project reference: `HoneyDrunk.Audit.Abstractions`.
 
 **Key Files:**
 - `HoneyDrunk.Audit.slnx`, `Directory.Build.props`
-- `src/HoneyDrunk.Audit.Abstractions/IAuditLog.cs`, `IAuditQuery.cs`, `AuditEntry.cs` (the record + the `AuditQueryFilter` record)
+- `src/HoneyDrunk.Audit.Abstractions/IAuditLog.cs`, `IAuditQuery.cs`, `AuditEntry.cs`, `AuditEntryId.cs`, `AuditQueryFilter.cs`, `AuditCategory.cs`, `AuditOutcome.cs`, `AuditTarget.cs`, `AuditChange.cs`
 - `src/HoneyDrunk.Audit.Data/ServiceCollectionExtensions.cs`, `DataAuditLog.cs`, `DataAuditQuery.cs`, `AuditRetentionPolicy.cs`, `AuditTelemetry.cs`
 - `tests/HoneyDrunk.Audit.Abstractions.Tests/ContractSurfaceTests.cs`, `AppendOnlyAtInterfaceTests.cs`
 - `tests/HoneyDrunk.Audit.Data.Tests/Fixtures/InMemoryAuditLog.cs`, `Fixtures/InMemoryAuditQuery.cs`, `DataAuditLogTests.cs`, `DataAuditQueryTests.cs`, `SmokeTests.cs`
@@ -585,5 +664,5 @@ Project reference: `HoneyDrunk.Audit.Abstractions`.
 - `README.md`, `CHANGELOG.md` (repo-level), per-package `README.md` and `CHANGELOG.md`
 
 **Contracts:**
-- All three D3 contracts (`IAuditLog`, `IAuditQuery`, `AuditEntry`) plus the supporting `AuditQueryFilter` record authored fresh in this packet inside `HoneyDrunk.Audit.Abstractions`.
+- D3 public surface (`IAuditLog`, `IAuditQuery`, `AuditEntry`) plus supporting value types (`AuditEntryId`, `AuditQueryFilter`, `AuditCategory`, `AuditOutcome`, `AuditTarget`, `AuditChange`) authored fresh in this packet inside `HoneyDrunk.Audit.Abstractions`.
 - The contract-shape canary establishes its baseline against this packet's commit. Future shape changes to any public type in `Abstractions` trigger the canary.

--- a/repos/HoneyDrunk.Audit/active-work.md
+++ b/repos/HoneyDrunk.Audit/active-work.md
@@ -11,11 +11,12 @@
 
 - Create the `HoneyDrunk.Audit` public GitHub repo
 - Scaffold `HoneyDrunk.Audit.slnx` with `HoneyDrunk.Audit.Abstractions` + `HoneyDrunk.Audit.Data` and matching `.Tests` projects
-- Author the three frozen contracts (`IAuditLog`, `IAuditQuery`, `AuditEntry`)
+- Author the D3 public surface (`IAuditLog`, `IAuditQuery`, `AuditEntry`) plus supporting category/outcome/target/change value types
 - Data-backed append-only store over `IRepository`/`IUnitOfWork`; audit-class retention hook (App Config-sourced)
+- First-class support for activity/security/system events and data-change events, including redaction guidance for changed fields
 - The Node's own managed identity (per-Node isolation)
 - In-memory `IAuditLog`/`IAuditQuery` fixture (internal to the test project)
-- Contract-shape canary on all three contracts in CI
+- Contract-shape canary on the full `HoneyDrunk.Audit.Abstractions` public surface in CI
 
 ## Deferred (behind the now-existing boundary — each gated on a stated trigger)
 

--- a/repos/HoneyDrunk.Audit/boundaries.md
+++ b/repos/HoneyDrunk.Audit/boundaries.md
@@ -2,16 +2,17 @@
 
 ## What Audit Owns
 
-- The durable write of a security or privileged-action event (`IAuditLog`)
+- The durable write of a security, activity, system, integration, privileged-action, or data-change event (`IAuditLog`)
 - The append-only guarantee, enforced at the interface surface — no update method, no delete method
 - The audit-class retention policy — long, lossless, policy-governed; distinct from observability retention
 - The forensic read surface (`IAuditQuery`) — time-ordered and filtered reads for incident reconstruction and a future tenant-facing forensics surface
-- The canonical `AuditEntry` shape — actor, action, context, outcome, correlation id, tenant
+- The canonical `AuditEntry` envelope — category, event name/action, actor, target/resource, outcome, correlation id, tenant, metadata, and optional data-change details
 
 ## What Audit Does NOT Own
 
 - **Deciding whether an action is allowed** — that is HoneyDrunk.Auth (authentication, authorization) and HoneyDrunk.Operator (gates, breakers, cost guards). Audit records the outcome; it does not produce it.
 - **Observability / health signal** — sampled, aggregate, retention-bounded telemetry belongs in Pulse. Audit records are not telemetry and never flow to Pulse.
+- **Secret/PII redaction decisions** — emitters must redact sensitive before/after values before append. Audit stores durable records; it is not responsible for deciding which domain fields are safe to persist in clear text.
 - **Tamper-evidence (Phase 1)** — hash-chain/WORM is deferred behind the boundary. Phase 1 is append-only-by-interface only.
 - **An external/tenant-facing read path (Phase 1)** — the deployable tenant-facing forensics Service is deferred behind the boundary. Phase-1 reads are internal via `IAuditQuery`.
 - **The store backing choice in production** — composition (which store backend, which retention policy) is a host-time concern. Downstream Nodes compile against `HoneyDrunk.Audit.Abstractions` only.
@@ -19,7 +20,8 @@
 ## Boundary Decision Tests
 
 - Is this **deciding allow/deny**? → Auth or Operator.
-- Is this **recording that a security/privileged event happened, durably and attributably**? → Audit.
+- Is this **recording that a security/privileged/activity/system/integration event happened, durably and attributably**? → Audit.
+- Is this **recording that an entity/resource was created, updated, or deleted, with actor/time/target/changed fields**? → Audit, with redaction before append.
 - Is this **aggregate health/observability signal**? → Pulse.
 - Is this **mutating or deleting an existing audit record**? → forbidden — the contract exposes no such method.
 - Is this **a cryptographic tamper-evidence guarantee**? → deferred behind the boundary; not a Phase-1 capability.

--- a/repos/HoneyDrunk.Audit/integration-points.md
+++ b/repos/HoneyDrunk.Audit/integration-points.md
@@ -5,7 +5,7 @@
 | Node | Contract | Usage |
 |------|----------|-------|
 | **HoneyDrunk.Kernel** | `IGridContext`, lifecycle hooks, health/readiness, `ITelemetryActivityFactory` (`HoneyDrunk.Kernel`) | Every audit write is context-aware; an audit entry without correlation and tenant is unattributable, which defeats the substrate's purpose. Audit emits its own operational telemetry via Kernel's telemetry factory. |
-| **HoneyDrunk.Data** | `IRepository`, `IUnitOfWork` (`HoneyDrunk.Data.Abstractions`) | The append-only write/read path and the audit-class retention both sit on Data's transactional surface — the same surface Operator's audit log already sat on before the relocation. |
+| **HoneyDrunk.Data** | `IRepository`, `IUnitOfWork` (`HoneyDrunk.Data.Abstractions`) | The append-only write/read path and the audit-class retention both sit on Data's transactional surface — the same surface Operator's audit log already sat on before the relocation. Data-layer emitters may later record create/update/delete audit events through `IAuditLog` when redaction policy is explicit. |
 
 ## Telemetry (no runtime dependency)
 
@@ -19,9 +19,11 @@
 |------|---------------|--------|
 | **HoneyDrunk.Auth** | `IAuditLog` (`HoneyDrunk.Audit.Abstractions`) | Planned first emitter — records durable attributable security events (login attempts, authz grants/denials) additively to its existing OTel traces, on a separate durable channel. Auth's identity-out-of-traces invariant is untouched. |
 | **HoneyDrunk.Operator** | `IAuditLog`, `IAuditQuery` (`HoneyDrunk.Audit.Abstractions`) | Reclassified from owner to consumer/emitter. Continues recording its AI-runtime decisions by emitting `AuditEntry` against the `IAuditLog` it now consumes. |
+| **Future Data-change emitters** | `IAuditLog` (`HoneyDrunk.Audit.Abstractions`) | Record entity/resource create/update/delete events with `AuditCategory.DataChange`, `AuditTarget`, and redacted `AuditChange` details. |
 
 ## Boundary Notes
 
 - Downstream Nodes consume `HoneyDrunk.Audit.Abstractions` only — never the `HoneyDrunk.Audit.Data` runtime, never the store directly. Composition (store backing, retention policy) is a host-time concern.
 - Audit runs under its **own dedicated managed identity**, distinct from Auth's and Operator's. The recorder authenticating as itself — not borrowing an emitter's identity — keeps the audit write path attributable and keeps the recorder/actor trust boundary intact at the infrastructure layer, not only at the contract layer.
 - Key Vault and App Configuration access for the audit-class retention configuration is scoped to Audit's own identity. The retention value is sourced from App Configuration, never hardcoded.
+- Before/after values in data-change events are redacted by the emitter before append; Audit persists what it is given and is not a secret store.

--- a/repos/HoneyDrunk.Audit/invariants.md
+++ b/repos/HoneyDrunk.Audit/invariants.md
@@ -2,8 +2,8 @@
 
 Audit-specific invariants (supplements `constitution/invariants.md`).
 
-1. **Audit.Abstractions has zero HoneyDrunk dependencies.**
-   Only `Microsoft.Extensions.*` abstractions are allowed. The Kernel/Data references live in the `HoneyDrunk.Audit.Data` runtime package, never in Abstractions.
+1. **Audit.Abstractions stays near-minimal and carries only the ADR-permitted Kernel abstraction dependency.**
+   `HoneyDrunk.Kernel.Abstractions` is allowed for `TenantId`; Data/Vault/Pulse/Kernel-runtime references live outside Abstractions.
 
 2. **`IAuditLog` is append-only at the interface surface.**
    The contract exposes no update method and no delete method. Append-only is enforced at the interface, not only at the storage layer. Consumers that need retention or archival work off `IAuditQuery`, never by mutating entries.
@@ -12,7 +12,7 @@ Audit-specific invariants (supplements `constitution/invariants.md`).
    Audit records; it never decides whether an action is allowed and never halts, gates, or trips breakers. Those are Auth and Operator concerns.
 
 4. **The durable audit channel and the observability channel are never merged.**
-   Auditable security events are emitted to the Audit substrate via `IAuditLog` on a durable channel separate from observability telemetry. Audit *records* are not telemetry and never flow to Pulse. Audit emits its own operational telemetry (write/query latency, throughput) which Pulse observes one-way — Audit has no runtime dependency on Pulse.
+   Auditable security, action, and data-change events are emitted to the Audit substrate via `IAuditLog` on a durable channel separate from observability telemetry. Audit *records* are not telemetry and never flow to Pulse. Audit emits its own operational telemetry (write/query latency, throughput) which Pulse observes one-way — Audit has no runtime dependency on Pulse.
 
 5. **Audit-class retention is distinct from observability retention.**
    Observability retention is short and sampling-tolerant; audit retention is long, lossless, and policy-governed. The two regimes are not shared and not interchangeable. The retention value is sourced from App Configuration via Vault's config provider, never hardcoded.
@@ -22,6 +22,9 @@ Audit-specific invariants (supplements `constitution/invariants.md`).
 
 7. **Downstream Nodes compile only against `HoneyDrunk.Audit.Abstractions`.**
    No runtime dependency on `HoneyDrunk.Audit.Data` in production composition. Composition is a host-time concern.
+
+8. **Sensitive data-change details are redacted before append.**
+   `AuditChange` may carry before/after values, but emitters must redact secrets, credentials, tokens, regulated data, and sensitive PII before calling `IAuditLog`. Audit is durable and queryable; it is not a secret store.
 
 _Constitutional invariant 44 (the audit-emission boundary invariant, in `constitution/invariants.md`) is the Grid-level rule this Node exists to enforce. The Audit-specific downstream-coupling and contract-shape-canary invariants are introduced by the standup ADR and assigned their final constitutional numbers when that standup initiative lands._
 

--- a/repos/HoneyDrunk.Audit/overview.md
+++ b/repos/HoneyDrunk.Audit/overview.md
@@ -8,7 +8,7 @@
 
 ## Purpose
 
-The Grid's single durable, attributable system of record for security and privileged-action events — login attempts, authorization grants and denials, privileged-action execution. It durably records "actor X attempted or executed action Y" and serves that record back for incident reconstruction and forensics.
+The Grid's single durable, attributable system of record for security, privileged-action, activity, system, integration, and data-change events — login attempts, authorization grants and denials, privileged-action execution, workflow starts, purchases, agent/operator decisions, integration callbacks, and entity create/update/delete records. It durably records "actor X attempted or executed action Y" and "actor X changed record Y" and serves that record back for incident reconstruction and forensics.
 
 It is a record substrate, not a control plane and not an observability pipeline. It does not decide whether an action is allowed (that is Auth and Operator). It does not sample, aggregate, or surface health signal (that is Pulse). It owns the durable write, the append-only guarantee enforced at the interface surface, the audit-class retention, and the forensic read surface.
 
@@ -16,16 +16,21 @@ It is a record substrate, not a control plane and not an observability pipeline.
 
 | Package | Type | Description |
 |---------|------|-------------|
-| `HoneyDrunk.Audit.Abstractions` | Abstractions | `IAuditLog`, `IAuditQuery`, `AuditEntry`. Zero HoneyDrunk dependencies; only `Microsoft.Extensions.*` abstractions permitted. |
+| `HoneyDrunk.Audit.Abstractions` | Abstractions | `IAuditLog`, `IAuditQuery`, `AuditEntry`, and supporting category/outcome/target/change value types. Near-minimal; only the ADR-permitted `HoneyDrunk.Kernel.Abstractions` dependency for `TenantId`. |
 | `HoneyDrunk.Audit.Data` | Runtime (backing slot) | Data-backed append-only `IAuditLog` writer and `IAuditQuery` reader over `HoneyDrunk.Data`'s `IRepository`/`IUnitOfWork`; audit-class retention wiring; DI composition. |
 
 ## Key Contracts
 
 - `IAuditLog` — append-only write of an `AuditEntry`. No update method, no delete method. Append-only is enforced at the interface surface.
 - `IAuditQuery` — time-ordered and filtered read/forensic retrieval over the durable record.
-- `AuditEntry` — canonical append-only record: actor, action, context, outcome, correlation id, tenant.
+- `AuditEntry` — canonical append-only record envelope: category, event name/action, actor, target/resource, outcome, correlation id, tenant, metadata, and optional data-change details.
+- `AuditCategory` / `AuditOutcome` — explicit event family and result values.
+- `AuditTarget` — resource/entity/workflow/integration target identity.
+- `AuditChange` — optional per-field data-change detail with redaction flag.
 
 ## Design Notes
+
+The event taxonomy is intentionally broad but bounded: activity/security/system events and data-change events share one ledger and one `AuditEntry` envelope, but they use explicit categories and target/change value types so row mutations do not get buried as opaque context strings. Sensitive before/after data must be redacted before append; Audit is not a secret store.
 
 The boundary rule is sharp: **the recorder is not the actor.** A control plane that can halt, gate, and trip breakers (Operator) must not also be the authoritative ledger that records whether it was right to. The durable audit channel and the observability channel (Pulse) are never merged — observability answers "is the system healthy in aggregate"; audit answers "who did what, when, against what, and was it allowed," durably and attributably.
 


### PR DESCRIPTION
## Summary
- amend ADR-0030/0031 so Audit explicitly covers both activity/security/system events and data-change audit
- update the Audit scaffold packet to include category/outcome/target/change value types in the v0.1.0 contract surface
- refresh Audit repo context docs and changelog with redaction guidance for before/after field values

## Validation
- git diff --check
- checked markdown code fences are balanced in touched ADR/packet files