### PR TITLE
fix(packets): add routing targets for cross-repo packets

### DIFF
--- a/generated/issue-packets/active/adr-0044-cloud-code-review/11-cross-repo-enable-review-ten-nodes.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/11-cross-repo-enable-review-ten-nodes.md
@@ -2,6 +2,7 @@
 name: Cross-Repo Change
 type: cross-repo-change
 tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
 target_repos: ["HoneyDrunk.Kernel", "HoneyDrunk.Transport", "HoneyDrunk.Vault", "HoneyDrunk.Auth", "HoneyDrunk.Web.Rest", "HoneyDrunk.Data", "HoneyDrunk.Notify", "HoneyDrunk.Communications", "HoneyDrunk.Pulse", "HoneyDrunk.Actions"]
 labels: ["ci", "tier-2", "core", "ops", "coordination", "adr-0044", "wave-2"]
 dependencies: ["packet:06", "packet:07", "packet:08", "packet:09", "packet:10"]

--- a/generated/issue-packets/active/adr-0047-testing-patterns-and-tooling/04-cross-repo-fluentassertions-to-awesomeassertions-migration.md
+++ b/generated/issue-packets/active/adr-0047-testing-patterns-and-tooling/04-cross-repo-fluentassertions-to-awesomeassertions-migration.md
@@ -2,6 +2,7 @@
 name: Cross-Repo Change
 type: cross-repo-change
 tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
 target_repos: []
 labels: ["chore", "tier-2", "coordination", "adr-0047", "wave-1"]
 dependencies: ["packet:01"]

--- a/generated/issue-packets/active/adr-0047-testing-patterns-and-tooling/05-cross-repo-moq-to-nsubstitute-migration.md
+++ b/generated/issue-packets/active/adr-0047-testing-patterns-and-tooling/05-cross-repo-moq-to-nsubstitute-migration.md
@@ -2,6 +2,7 @@
 name: Cross-Repo Change
 type: cross-repo-change
 tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
 target_repos: []
 labels: ["chore", "tier-2", "coordination", "adr-0047", "wave-1"]
 dependencies: ["packet:01"]


### PR DESCRIPTION
## Summary
- Add 	arget_repo: HoneyDrunkStudios/HoneyDrunk.Architecture to cross-repo coordination packets that the file-packets workflow cannot route without a primary repo.
- Covers the failed ADR-0044 packet 11 and the next two ADR-0047 cross-repo migration packets that would fail the same validation.

## Validation
- Parsed all unfiled active packet frontmatter and confirmed every packet has 	arget_repo.
- git diff --check passed.

## Notes
- The failed run already filed ADR-0044 packets 01-10 and committed the manifest update on main.
- Do not merge until we decide whether to pause/reframe ADR-0044 filing around OpenClaw/Codex instead of Anthropic API.