### PR TITLE
docs(adr): reframe ADR-0044 around OpenClaw runner

### DIFF
--- a/adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md
+++ b/adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md
@@ -11,37 +11,39 @@ ADR-0011 (Proposed) established the Grid's code review pipeline with the Grid-aw
 
 Both decisions were correct in April 2026. Both are stale today:
 
-- **AI-authored PR volume has scaled.** Wave-style rollouts routinely produce 5–15 agent PRs in a window. The AI-sector standup wave (ADR-0016 through ADR-0025) adds nine Nodes' worth of scaffold packets. ADR-0043's Strategic and Tactical sources will mechanically generate agent PRs on cadence once running. "Human remembers to invoke the review agent" is no longer a viable discipline.
+- **AI-authored PR volume has scaled.** Wave-style rollouts routinely produce 5-15 agent PRs in a window. The AI-sector standup wave (ADR-0016 through ADR-0025) adds nine Nodes' worth of scaffold packets. ADR-0043's Strategic and Tactical sources will mechanically generate agent PRs on cadence once running. "Human remembers to invoke the review agent" is no longer a viable discipline.
 - **Copilot's automatic review has not earned its slot.** Its PR-time signal is generic (style nits, occasional null-check suggestions) and not Grid-aware. It does not load `constitution/invariants.md`, cannot read a packet via PR-body link, and has no knowledge of which ADRs govern a change. It fills a slot in name only.
 - **CodeRabbit was reconsidered** in the conversation that produced this ADR. Its rule system via `.coderabbit.yaml` is genuinely strong for prose-shaped rules, but its hard limit is that it cannot actively load Grid catalogs (`relationships.json`, `contracts.json`, `grid-health.json`) at review time, walk invariants, or reason against a linked packet's stated scope. The "make sense with the Grid and our ADRs" requirement is the one thing no third-party tool can do, because no third-party tool knows the Grid.
 
-The conclusion: **the slot that needs filling is not "automatic LLM reviewer" generically — it's "automatic Grid-aware LLM reviewer."** That slot is empty. Filling it means cloud-wiring the existing local `review` agent, not adopting an external service that fills the slot only by name.
+The conclusion: **the slot that needs filling is not "automatic LLM reviewer" generically - it's "automatic Grid-aware LLM reviewer."** That slot is empty. Filling it means automatic invocation of the existing local `review` agent, not adopting an external service that fills the slot only by name.
 
-The build is small. The prompt logic exists in `.claude/agents/review.md`. The context-loading contract is defined in ADR-0011 D4. The workflow host exists in HoneyDrunk.Actions. The Claude Agent SDK provides the runtime. The MVP is a 1–2 day engineering project — wire the existing agent into a GitHub Action, post the verdict as a PR comment. Polish (per-path config, learnings, output formatter) is bounded follow-up.
+The build is small, but the runtime placement matters. The prompt logic exists in `.claude/agents/review.md`. The context-loading contract is defined in ADR-0011 D4. The workflow host exists in HoneyDrunk.Actions, but GitHub Actions should be the cheap trigger/visibility rail, not the reasoning brain. The default v1 runtime is an OpenClaw-hosted Grid Review Runner using Codex through the Studio's existing subscription/session. GitHub Actions emits/validates review requests and exposes advisory status; OpenClaw performs the Grid-aware review and posts the verdict back to the PR.
 
-The cost calculus has also shifted. The April 2026 ADR-0011 D10 rejection was per-PR cloud LLM cost against a low PR volume; at today's volume (~20–50 agent PRs/month) and current Sonnet pricing, expected monthly cost is ~$40–100. Comparable to CodeRabbit private-tier; cheaper than running `/ultrareview` on every PR; smaller than the cost of a single late-caught production regression.
+The cost calculus has also shifted. The April 2026 ADR-0011 D10 rejection was per-PR cloud LLM cost against a low PR volume; at today's volume (~20-50 agent PRs/month), an Anthropic/API-backed GitHub Action makes AI review a recurring variable bill and sends private repo diffs to an external model API by default. The Studio already runs OpenClaw/Codex locally. The cheapest and most controllable v1 is therefore: use GitHub/webhooks/cron to request reviews automatically, run the review in OpenClaw/Codex, track the reviewed head SHA, and comment back only when the PR changed.
 
-This ADR amends ADR-0011 to **reverse the local-only stance**, **reverse the CodeRabbit rejection as moot** (we're not adopting an alternative), and add **AI-authored PR discipline** that the cloud-wired reviewer makes practical to enforce.
+This ADR amends ADR-0011 to **reverse the human-invoked-only stance**, **reverse the CodeRabbit rejection as moot** (we're not adopting an alternative), and add **AI-authored PR discipline** that the automatic Grid Review Runner makes practical to enforce.
 
 ## Decision
 
-The decision has two intertwined halves: the **build** (D1–D5) makes the **discipline** (D6–D9) practical. Neither half stands alone.
+The decision has two intertwined halves: the **build** (D1-D5) makes the **discipline** (D6-D9) practical. Neither half stands alone.
 
-### D1 — Build the cloud-wired reviewer as `job-review-agent.yml` in HoneyDrunk.Actions
+### D1 - Build the automatic Grid Review Runner with GitHub Actions as the trigger rail
 
-The Grid builds, owns, and operates its own cloud-wired Grid-aware code reviewer. Implementation:
+The Grid builds, owns, and operates its own automatic Grid-aware code reviewer. Implementation:
 
-- A new reusable workflow, `HoneyDrunk.Actions/.github/workflows/job-review-agent.yml`, follows the existing `pr-core.yml` factoring (per ADR-0012).
+- A new reusable workflow, `HoneyDrunk.Actions/.github/workflows/job-review-request.yml`, follows the existing `pr-core.yml` factoring (per ADR-0012) and validates whether a PR should request review.
 - Triggered on `pull_request` events: `opened`, `synchronize`, `ready_for_review`. Not on `draft` PRs (cost discipline; draft is by definition WIP).
-- Invokes the Claude Agent SDK against the `.claude/agents/review.md` definition (per ADR-0007's source-of-truth rule).
-- Posts the verdict as a PR comment using the format already defined in `.claude/agents/review.md`.
-- Sets a **non-required** check run (advisory, per ADR-0011 D5's posture — preserved by this ADR).
+- Emits a review request payload containing the repo, PR number, head SHA, author class, changed-file summary, packet link, and `.honeydrunk-review.yaml` settings.
+- Delivers the request to OpenClaw through the configured webhook path, or leaves a machine-readable artifact/comment for an OpenClaw cron job to pick up when webhooks are unavailable.
+- OpenClaw runs the Grid Review Runner using Codex and `.claude/agents/review.md` as the canonical prompt source (per ADR-0007's source-of-truth rule).
+- The runner posts the verdict as a PR comment using the format already defined in `.claude/agents/review.md` and records the reviewed head SHA to avoid re-reviewing unchanged diffs.
+- The workflow/check surface remains **non-required** and advisory, per ADR-0011 D5's posture - preserved by this ADR.
 
-The agent definition itself does not change. The same prompt that runs locally via Claude Code runs in the cloud workflow. Drift between the two execution surfaces is forbidden — both consume `.claude/agents/review.md` directly.
+The agent definition itself does not change. The same prompt that runs locally runs through the automatic runner. Drift between execution surfaces is forbidden - all surfaces consume `.claude/agents/review.md` directly.
 
-### D2 — Context loading is identical to the local invocation
+### D2 - Context loading is identical to the local invocation
 
-The cloud-wired reviewer loads exactly the context ADR-0011 D4 already mandates:
+The Grid Review Runner loads exactly the context ADR-0011 D4 already mandates:
 
 1. `constitution/invariants.md`
 2. Governing ADRs referenced in the packet frontmatter
@@ -52,15 +54,15 @@ The cloud-wired reviewer loads exactly the context ADR-0011 D4 already mandates:
 7. The packet file (via PR-body link)
 8. The PR diff
 
-The workflow checks out both the target repo and `HoneyDrunkStudios/HoneyDrunk.Architecture` (using a GitHub App token scoped to read on the architecture repo) so the context above is locally readable by the agent. This mirrors the local Claude Code workspace layout exactly.
+The runner checks out/updates both the target repo and `HoneyDrunkStudios/HoneyDrunk.Architecture` using local `gh` authentication or a narrowly scoped GitHub App token, so the context above is locally readable by the agent. This mirrors the local OpenClaw workspace layout exactly.
 
-ADR-0011 D4's coupling rule (review-agent context-loading must mirror scope-agent context-loading) is preserved. Updates land in `.claude/agents/review.md`, the workflow re-runs without code change.
+ADR-0011 D4's coupling rule (review-agent context-loading must mirror scope-agent context-loading) is preserved. Updates land in `.claude/agents/review.md`; the next runner invocation picks them up without workflow changes.
 
-### D3 — Review goals and rubric
+### D3 - Review goals and rubric
 
-The reviewer evaluates every PR against **twenty named categories**. The rubric is not the reviewer's private checklist — it is the **Grid's shared standard for any code change**, applied symmetrically by authors at authoring time and by the reviewer at evaluation time (see "Upstream awareness" below).
+The reviewer evaluates every PR against **twenty named categories**. The rubric is not the reviewer's private checklist - it is the **Grid's shared standard for any code change**, applied symmetrically by authors at authoring time and by the reviewer at evaluation time (see "Upstream awareness" below).
 
-This ADR binds the **categories and the questions within them**. The detailed per-category execution detail — exactly what to look for, what counts as a finding at each severity — lives in `.claude/agents/review.md` per ADR-0007's source-of-truth rule. Updates to the categories or their questions are amendments to this D3; updates to the answers/checklists are edits to the agent file.
+This ADR binds the **categories and the questions within them**. The detailed per-category execution detail - exactly what to look for, what counts as a finding at each severity - lives in `.claude/agents/review.md` per ADR-0007's source-of-truth rule. Updates to the categories or their questions are amendments to this D3; updates to the answers/checklists are edits to the agent file.
 
 #### 1. Correctness and functional integrity
 
@@ -91,7 +93,7 @@ This ADR binds the **categories and the questions within them**. The detailed pe
 #### 5. SOLID and design principles
 
 - **SRP.** Does the class or module have one responsibility?
-- **OCP.** Can behavior be extended without modification (where the cost is justified — not for hypothetical futures)?
+- **OCP.** Can behavior be extended without modification (where the cost is justified - not for hypothetical futures)?
 - **LSP.** Are abstractions substitutable in practice?
 - **ISP.** Are interfaces appropriately scoped, not too broad?
 - **DIP.** Are high-level policies isolated from implementation details?
@@ -156,7 +158,7 @@ This ADR binds the **categories and the questions within them**. The detailed pe
 
 - **Messaging.** Duplicate delivery handled (per ADR-0042)? Ordering assumptions explicit? Poison message handling defined?
 - **Event architecture.** Event versioning planned? Contract evolution path clear? Outbox pattern where it belongs?
-- **Consistency models.** Strong vs eventual consistency awareness — is the chosen model right for the use case and communicated to consumers?
+- **Consistency models.** Strong vs eventual consistency awareness - is the chosen model right for the use case and communicated to consumers?
 
 #### 15. CI/CD and delivery
 
@@ -183,14 +185,14 @@ This category is load-bearing as the Grid leans further into agent-authored code
 - **Agent safety.** Prompt injection resistance at trust boundaries? Tool permission scoping (per ADR-0017 capabilities)? Output validation before it leaves the agent's surface?
 - **Memory integrity.** Is agent memory scoped correctly (per ADR-0022's scope hierarchy)? Is context leakage possible across agents or tenants?
 - **Human override.** Can operators intervene (per ADR-0018 `IApprovalGate`)? Is the agent's behavior auditable (per ADR-0030)?
-- **Agent observability.** Decision tracing — can we reconstruct why the agent did what it did? Tool usage tracing? Token and cost tracking (per ADR-0011 D6 and ADR-0041 cost profile)?
+- **Agent observability.** Decision tracing - can we reconstruct why the agent did what it did? Tool usage tracing? Token and cost tracking (per ADR-0011 D6 and ADR-0041 cost profile)?
 
 #### 19. Anti-entropy and long-term system health
 
 This is the category most organizations never formalize, and the one that determines whether the system is still legible in three years. Load-bearing for the Grid's long-term cohesion.
 
 - **Entropy detection.** Is this increasing fragmentation? Is naming diverging across Nodes? Is inconsistency creeping in where consistency used to hold?
-- **Pattern erosion.** Are teams (including AI agents) bypassing standards? Is this "one-off syndrome" — a single justified exception that will be cited as precedent for ten unjustified ones?
+- **Pattern erosion.** Are teams (including AI agents) bypassing standards? Is this "one-off syndrome" - a single justified exception that will be cited as precedent for ten unjustified ones?
 - **Ecosystem sustainability.** Will this still make sense in 3 years? Does this increase architectural gravity (load-bearing dependencies) in a way that constrains future moves?
 
 #### 20. Human factors
@@ -199,21 +201,21 @@ This is the category most organizations never formalize, and the one that determ
 - **Bus factor.** Is knowledge being concentrated where only one person (or one agent run) holds it? Is the change reversible by someone who didn't make it?
 - **Communication quality.** Is intent documented (PR body, packet adherence, ADR if scope warrants)? Are trade-offs explained, not just decisions stated?
 
-#### Upstream awareness — the rubric is shared across authoring and review
+#### Upstream awareness - the rubric is shared across authoring and review
 
-**The categories above are not the reviewer's checklist alone.** They are the Grid's standard for what makes a change defensible, and they apply symmetrically to every agent that **authors** code or scoped work — not only to the reviewer that evaluates the result. An author who applies the rubric upstream prevents the problem; a reviewer who applies it downstream catches what slipped through. Both layers exist; the upstream layer is the load-bearing one for long-term system health, because catching a problem at review costs a review cycle, while catching it at authoring time costs nothing.
+**The categories above are not the reviewer's checklist alone.** They are the Grid's standard for what makes a change defensible, and they apply symmetrically to every agent that **authors** code or scoped work - not only to the reviewer that evaluates the result. An author who applies the rubric upstream prevents the problem; a reviewer who applies it downstream catches what slipped through. Both layers exist; the upstream layer is the load-bearing one for long-term system health, because catching a problem at review costs a review cycle, while catching it at authoring time costs nothing.
 
 The rubric therefore binds the following authoring surfaces, each via a section in its agent definition file referencing this D3:
 
-- **`scope`** — when decomposing a packet, evaluates which categories apply to the work and ensures the packet captures their implications. What's the failure mode (Reliability)? What observability is required (Observability)? What's the security blast radius (Security)? What's the testing strategy (Testing)? What anti-entropy risk does this carry (Anti-Entropy)? Packets that omit relevant categories produce changes that miss them at execution time.
-- **`adr-composer`** — when proposing an ADR, reasons about the decision against the categories that apply. Does this introduce architectural drift (Architectural Integrity)? Cost implications (Performance / Cost / Product alignment)? Long-term entropy (Anti-Entropy)? Security or compliance implications (Security / Enterprise Readiness)? AI/agent implications where relevant (Category 18)?
-- **`pdr-composer`** — same as `adr-composer`, with extra weight on Category 17 (Product / Business Alignment) and Category 19 (Anti-Entropy and Long-Term Health). PDRs that pass the rubric are likelier to age well.
-- **`refine`** — when challenging scoped work, evaluates whether the packet has accounted for the categories the work touches. A packet that ignores Reliability or Observability or Anti-Entropy on a change where those clearly apply surfaces as a `refine` finding.
-- **Execution agents** (Codex via packet, Copilot in-IDE, Claude Code in authoring mode) — write code mindful of the categories. Each execution surface's prompt or system instructions references this D3 as the **authoring discipline** the agent must consider before producing a diff. The categories most load-bearing at code-writing time (Correctness, Code Quality, SOLID, Reuse, Security, Performance, Testing, AI/Agent-Specific, Human Factors) are surfaced as a brief authoring checklist; the rest are by reference.
-- **`review`** (this reviewer) — applies the full rubric as the evaluation gate.
-- **`node-audit`** — when auditing a Node's health (per ADR-0043's Tactical source), walks the rubric to identify systemic gaps that span PRs rather than living in any single one. Findings flow to packets per ADR-0043.
+- **`scope`** - when decomposing a packet, evaluates which categories apply to the work and ensures the packet captures their implications. What's the failure mode (Reliability)? What observability is required (Observability)? What's the security blast radius (Security)? What's the testing strategy (Testing)? What anti-entropy risk does this carry (Anti-Entropy)? Packets that omit relevant categories produce changes that miss them at execution time.
+- **`adr-composer`** - when proposing an ADR, reasons about the decision against the categories that apply. Does this introduce architectural drift (Architectural Integrity)? Cost implications (Performance / Cost / Product alignment)? Long-term entropy (Anti-Entropy)? Security or compliance implications (Security / Enterprise Readiness)? AI/agent implications where relevant (Category 18)?
+- **`pdr-composer`** - same as `adr-composer`, with extra weight on Category 17 (Product / Business Alignment) and Category 19 (Anti-Entropy and Long-Term Health). PDRs that pass the rubric are likelier to age well.
+- **`refine`** - when challenging scoped work, evaluates whether the packet has accounted for the categories the work touches. A packet that ignores Reliability or Observability or Anti-Entropy on a change where those clearly apply surfaces as a `refine` finding.
+- **Execution agents** (Codex via packet, Copilot in-IDE, Claude Code in authoring mode) - write code mindful of the categories. Each execution surface's prompt or system instructions references this D3 as the **authoring discipline** the agent must consider before producing a diff. The categories most load-bearing at code-writing time (Correctness, Code Quality, SOLID, Reuse, Security, Performance, Testing, AI/Agent-Specific, Human Factors) are surfaced as a brief authoring checklist; the rest are by reference.
+- **`review`** (this reviewer) - applies the full rubric as the evaluation gate.
+- **`node-audit`** - when auditing a Node's health (per ADR-0043's Tactical source), walks the rubric to identify systemic gaps that span PRs rather than living in any single one. Findings flow to packets per ADR-0043.
 
-The shared rubric is the **single most important structural decision** in this ADR. A reviewer that catches only what authors missed is useful but expensive. A whole ecosystem of agents reasoning against the same rubric — at scope, at decision, at authoring, at refinement, at review, at audit — is what keeps a 13-Node Grid coherent under solo-developer-plus-AI throughput.
+The shared rubric is the **single most important structural decision** in this ADR. A reviewer that catches only what authors missed is useful but expensive. A whole ecosystem of agents reasoning against the same rubric - at scope, at decision, at authoring, at refinement, at review, at audit - is what keeps a 13-Node Grid coherent under solo-developer-plus-AI throughput.
 
 The mechanical change: each agent definition file (`scope.md`, `adr-composer.md`, `pdr-composer.md`, `refine.md`, `review.md`, `node-audit.md`, and the execution-surface prompts) gains a section referencing this D3 and the relevant subset of categories with severity expectations. Updates to the rubric are amendments to this D3 and propagate via agent-file updates per ADR-0007's source-of-truth rule. Drift between this D3 and any agent file is an anti-pattern; `hive-sync` (per ADR-0014) reconciles.
 
@@ -221,7 +223,7 @@ The mechanical change: each agent definition file (`scope.md`, `adr-composer.md`
 
 The reviewer's verdict comments findings against these categories using the severity taxonomy in `copilot/pr-review-rules.md` (`Block` / `Request Changes` / `Suggest`). The taxonomy, the per-category execution detail, and the per-agent authoring discipline all live in their respective agent files. This D3 binds the **categories, their questions, and the shared-upstream principle**; everything downstream of those bindings evolves in agent files without ADR ceremony.
 
-### D4 — Per-repo configuration via `.honeydrunk-review.yaml`
+### D4 - Per-repo configuration via `.honeydrunk-review.yaml`
 
 Each repo carries an optional `.honeydrunk-review.yaml` at the repo root. The v1 schema is deliberately minimal; the file's primary purpose is the **enabled/disabled gate** during phased rollout. Additional knobs land as later amendments.
 
@@ -234,74 +236,75 @@ skip_paths:                  # globs excluded from review
   - "**/*.Designer.cs"
   - "**/*.g.cs"
   - "**/generated/**"
-model: sonnet                # sonnet | opus; default sonnet, opus for high-risk-Node touches per D8
-cost_cap_per_pr_usd: 5.00    # hard ceiling; agent aborts if exceeded mid-review and posts a partial-review comment
+runner: openclaw-codex       # openclaw-codex | api-ci; default OpenClaw/Codex runner
+cost_cap_per_pr_usd: 0.00    # v1 subscription-backed default; API-backed fallback must set an explicit cap
 ```
 
 Per-path review-instruction overrides (the `path_instructions`-style surface CodeRabbit offers) are **explicitly deferred to a polish phase** (D11). v1 relies on the agent's built-in context loading and the prompt definition in `.claude/agents/review.md`. If per-path overrides earn their keep based on observed v1 gaps, they land in v2 with a documented schema; until then the configuration surface stays small.
 
 Repos without a `.honeydrunk-review.yaml` are treated as `enabled: false` during v1 phased rollout. This is the opt-in gate.
 
-### D5 — Cost guardrails are part of the build
+### D5 - Cost guardrails are part of the build
 
-The workflow ships with the following cost guardrails as default behavior (not configurable):
+The runner ships with the following cost guardrails as default behavior (not configurable):
 
-- **Hard per-PR ceiling** (`cost_cap_per_pr_usd` from D4, default $5). The agent's runtime tracks accumulated token cost; on cap exceedance, the agent posts a partial-review comment naming what was reviewed and what was skipped, and the workflow exits cleanly. Never silently fails.
+- **Subscription-backed default.** v1 uses OpenClaw/Codex through the Studio's existing subscription/session, avoiding a new per-token Anthropic/OpenAI API bill for routine PR review.
+- **API fallback is explicit.** Any future `api-ci` fallback must set a non-zero `cost_cap_per_pr_usd`, name the provider/model, and preserve the advisory posture. It is not the v1 default.
 - **Skip on draft PRs.** Already noted in D1.
 - **Skip on PRs labeled `skip-review`.** Manual escape hatch for the rare case (label-as-config, no schema change).
+- **Skip on unchanged head SHAs.** If the runner already reviewed the current PR head SHA, it does not re-run.
 - **Skip on PR-size limits when extreme.** If the diff exceeds 2000 lines (after `skip_paths` exclusions), the agent reviews only the highest-risk files (Node `.Abstractions/**`, `*.csproj` changes, anything touching `boundaries.md` or `invariants.md`) and posts a comment indicating coverage was capped.
-- **Sonnet by default.** Opus only when D8's high-risk-Node trigger fires. Model selection is the largest cost lever; defaulting to the cheaper model is non-negotiable.
-- **Cache context loads per workflow run.** Catalogs and invariants don't change within a single PR run; loaded once and reused across files in the diff.
+- **Cache context loads per runner invocation.** Catalogs and invariants don't change within a single review run; loaded once and reused across files in the diff.
 
-Expected monthly cost: $40–100 at current AI-PR cadence. Tracked in `business/context/` under review-tooling cost. Breaching $200/month for two consecutive months triggers an ADR amendment (revisit model selection, sampling rate, or cap).
+Expected incremental monthly model cost for v1 is approximately $0 beyond the existing Codex subscription/session. If API-backed fallback becomes necessary, review-tooling spend is tracked in `business/context/`; breaching $200/month for two consecutive months triggers an ADR amendment (revisit provider selection, sampling rate, or cap).
 
-### D6 — Authorship classification
+### D6 - Authorship classification
 
 Every PR declares its authorship class in the PR body, in a single line: `Authorship: <class>`. Classes:
 
-- **`human`** — written by the solo developer by hand. Default for any PR that doesn't declare otherwise.
-- **`agent-codex`** — written by Codex against a packet spec.
-- **`agent-copilot`** — written via GitHub Copilot in-IDE, accepted by the human.
-- **`agent-claude-code`** — written by Claude Code (this surface).
-- **`mixed`** — substantial contribution from both human and agent.
+- **`human`** - written by the solo developer by hand. Default for any PR that doesn't declare otherwise.
+- **`agent-codex`** - written by Codex against a packet spec.
+- **`agent-copilot`** - written via GitHub Copilot in-IDE, accepted by the human.
+- **`agent-claude-code`** - written by Claude Code (this surface).
+- **`mixed`** - substantial contribution from both human and agent.
 
 A CI check (added to `pr-core.yml`) verifies the line is present and parseable; absence fails the check as required. Codex/Copilot/Claude-Code execution surfaces are amended in follow-up packets to emit the line automatically (a small change to each surface's commit/PR-creation template).
 
 Authorship class drives D7, D8, and D9.
 
-### D7 — PR-size discipline for AI-authored changes
+### D7 - PR-size discipline for AI-authored changes
 
 Non-`human` PRs carry a soft size cap, enforced via a new `pr-size-check` job in `pr-core.yml`:
 
-- **≤ 400 changed lines** (excluding `skip_paths` from D4 and excluding test code) — normal review path.
-- **> 400, ≤ 800 changed lines** — PR body must include a `Size justification:` block. A `large-pr` label is auto-applied. The cloud reviewer's verdict must explicitly address whether the size is justified given the packet.
-- **> 800 changed lines** — CI auto-comments requesting a split or a `refine` pass. The PR can still merge if the human overrides; the override is logged.
+- **≤ 400 changed lines** (excluding `skip_paths` from D4 and excluding test code) - normal review path.
+- **> 400, ≤ 800 changed lines** — PR body must include a `Size justification:` block. A `large-pr` label is auto-applied. The Grid Review Runner's verdict must explicitly address whether the size is justified given the packet.
+- **> 800 changed lines** - CI auto-comments requesting a split or a `refine` pass. The PR can still merge if the human overrides; the override is logged.
 
-This catches PR sprawl — the most common AI-authorship failure mode — before review effort is spent on it.
+This catches PR sprawl - the most common AI-authorship failure mode - before review effort is spent on it.
 
-### D8 — Multi-perspective review for high-risk-Node PRs
+### D8 - Multi-perspective review for high-risk-Node PRs
 
 A non-`human` PR that touches a high-risk Node requires **two independent LLM-review perspectives** before merge. High-risk Nodes:
 
-- **HoneyDrunk.Kernel** — any change to `*.Abstractions` (per ADR-0035 ABI cascade rules).
-- **HoneyDrunk.Vault** — any change to secret handling, bootstrap, or rotation.
-- **HoneyDrunk.Auth** — any change to token validation, principal resolution, or the Audit emit boundary (ADR-0031).
-- **HoneyDrunk.Audit** — any change to the append-only-by-interface guarantee (ADR-0030 Phase 1).
-- **HoneyDrunk.Billing** (when standup lands per ADR-0037) — any change.
-- **Any `.Cloud` revenue Node** (per ADR-0027 D2) — any change.
+- **HoneyDrunk.Kernel** - any change to `*.Abstractions` (per ADR-0035 ABI cascade rules).
+- **HoneyDrunk.Vault** - any change to secret handling, bootstrap, or rotation.
+- **HoneyDrunk.Auth** - any change to token validation, principal resolution, or the Audit emit boundary (ADR-0031).
+- **HoneyDrunk.Audit** - any change to the append-only-by-interface guarantee (ADR-0030 Phase 1).
+- **HoneyDrunk.Billing** (when standup lands per ADR-0037) - any change.
+- **Any `.Cloud` revenue Node** (per ADR-0027 D2) - any change.
 
-The catalog of high-risk Nodes lives in `catalogs/grid-health.json` under a new field, `review_risk_class`, so the list evolves with the Grid without amending this ADR. The cloud workflow auto-detects high-risk touches and:
+The catalog of high-risk Nodes lives in `catalogs/grid-health.json` under a new field, `review_risk_class`, so the list evolves with the Grid without amending this ADR. The Grid Review Runner auto-detects high-risk touches and:
 
-- Switches the model to Opus for the first pass.
+- Switches to the highest-quality locally available Codex review profile for the first pass.
 - Triggers a second pass automatically using a deliberately contrarian prompt ("identify ways the first reviewer was wrong"). The two passes are independent sessions, posted as separate comments.
 
 Alternative escalation paths the human may invoke instead:
-- `/ultrareview` — multi-agent cloud review (billed separately).
+- `/ultrareview` - multi-agent cloud review (billed separately).
 - `refine` agent against the PR's packet + diff (skeptical-senior-dev archetype).
 
-The PR body records which path was used. Two same-agent passes is the default because it's cheapest and automatic; the alternatives exist for cases the human judges warrant deeper scrutiny.
+The PR body records which path was used. Two same-runner passes is the default because it is cheapest and automatic under the OpenClaw/Codex setup; the alternatives exist for cases the human judges warrant deeper scrutiny.
 
-### D9 — Post-merge sampling audit
+### D9 - Post-merge sampling audit
 
 Every Nth agent-authored merged PR (starting N=10, tunable via the weekly briefing per ADR-0043) is selected for a deeper post-merge audit:
 
@@ -312,76 +315,77 @@ Every Nth agent-authored merged PR (starting N=10, tunable via the weekly briefi
 
 The audit measures **the review process's own quality**, not individual bugs (the code already shipped). Findings feed back into `.claude/agents/review.md` and this ADR. Without this loop, review-process drift would surface only as production incidents.
 
-### D10 — Relationship to ADR-0011
+### D10 - Relationship to ADR-0011
 
 This ADR **amends ADR-0011** at three points:
 
-- **ADR-0011 D5 (review agent is advisory)** — preserved. The cloud-wired reviewer is also advisory; it posts a comment and a non-required check, never a blocking gate. ADR-0011's advisory rationale (agent outages don't halt merges, cost discipline on trivial PRs, symmetry with `refine`) all still apply.
-- **ADR-0011 D10 (local-only, human-invoked)** — **reversed.** The Grid-aware `review` agent now runs automatically in the cloud on every non-draft, non-`skip-review`-labeled, `enabled: true`-config'd PR. The local invocation path via Claude Code remains available (and is the right tool for offline review, ad-hoc deep dives, and pre-PR feedback), but is no longer the only invocation path.
-- **ADR-0011 D11 (rejected CodeRabbit)** — **rendered moot.** The original rationale (Copilot fills the automatic slot; the local agent fills the deeper slot) is superseded by the recognition that "automatic Grid-aware reviewer" is a distinct slot that neither Copilot nor CodeRabbit can fill. This ADR fills that slot by building, not by buying.
+- **ADR-0011 D5 (review agent is advisory)** - preserved. The automatic Grid Review Runner is also advisory; it posts a comment/status and never becomes a blocking gate. ADR-0011's advisory rationale (agent outages don't halt merges, cost discipline on trivial PRs, symmetry with `refine`) all still apply.
+- **ADR-0011 D10 (local-only, human-invoked)** - **reversed.** The Grid-aware `review` agent now runs automatically via the OpenClaw/Codex Grid Review Runner on every non-draft, non-`skip-review`-labeled, `enabled: true`-config'd PR. The local/manual invocation path remains available (and is the right tool for offline review, ad-hoc deep dives, and pre-PR feedback), but is no longer the only invocation path.
+- **ADR-0011 D11 (rejected CodeRabbit)** - **rendered moot.** The original rationale (Copilot fills the automatic slot; the local agent fills the deeper slot) is superseded by the recognition that "automatic Grid-aware reviewer" is a distinct slot that neither Copilot nor CodeRabbit can fill. This ADR fills that slot by building, not by buying.
 
 GitHub Copilot review remains enabled at the org level; its role is reduced to "generic LLM second opinion" with no specific responsibility in the pipeline. It costs nothing additional (existing subscription) and its occasional useful comment is upside, not a contract.
 
-ADR-0011's invariants 31–33 are preserved. This ADR adds two more (Consequences section).
+ADR-0011's invariants 31-33 are preserved. This ADR adds two more (Consequences section).
 
-### D11 — Phased rollout
+### D11 - Phased rollout
 
 Phased to minimize blast radius and let v1 earn its keep before polish:
 
-- **Phase 1 (Week 1–2) — MVP on one pilot repo.** Build `job-review-agent.yml`. Enable on `HoneyDrunk.Architecture` only (lowest blast radius — architecture PRs are predominantly docs/catalogs). Verify cost model and output quality. No discipline changes yet.
-- **Phase 2 (Week 3–6) — Rollout to all 12 live Nodes.** Each repo opts in via `.honeydrunk-review.yaml` with `enabled: true`. Authorship classification (D6) becomes mandatory. PR-size discipline (D7) activates with warnings only.
-- **Phase 3 (Month 2) — Discipline tightening.** High-risk-Node multi-perspective (D8) activates once `review_risk_class` lands in `catalogs/grid-health.json`. PR-size discipline moves from warnings to auto-comments at the > 800 threshold.
-- **Phase 4 (Month 3+) — Sampling audit.** D9 activates. Polish features (per-path config overrides, learnings from prior reviews, output formatter improvements) land based on observed v1–v3 gaps. Each polish feature is its own follow-up packet, not part of this ADR.
+- **Phase 1 (Week 1-2) - MVP on one pilot repo.** Build `job-review-request.yml` and the OpenClaw/Codex Grid Review Runner. Enable on `HoneyDrunk.Architecture` only (lowest blast radius - architecture PRs are predominantly docs/catalogs). Verify trigger reliability, reviewed-head-SHA tracking, output quality, and cost model. No discipline changes yet.
+- **Phase 2 (Week 3-6) - Rollout to all 12 live Nodes.** Each repo opts in via `.honeydrunk-review.yaml` with `enabled: true`. Authorship classification (D6) becomes mandatory. PR-size discipline (D7) activates with warnings only.
+- **Phase 3 (Month 2) - Discipline tightening.** High-risk-Node multi-perspective (D8) activates once `review_risk_class` lands in `catalogs/grid-health.json`. PR-size discipline moves from warnings to auto-comments at the > 800 threshold.
+- **Phase 4 (Month 3+) - Sampling audit.** D9 activates. Polish features (per-path config overrides, learnings from prior reviews, output formatter improvements) land based on observed v1-v3 gaps. Each polish feature is its own follow-up packet, not part of this ADR.
 
-Each phase is a discrete go/no-go. Phase 1's exit criterion is "the cloud-wired agent's verdicts are at least as useful as the local agent's, at acceptable cost." If that bar is missed, Phase 2 doesn't start.
+Each phase is a discrete go/no-go. Phase 1's exit criterion is "the automatic runner's verdicts are at least as useful as the local/manual agent's, the trigger path is reliable, and incremental model cost stays near zero under the subscription-backed default." If that bar is missed, Phase 2 doesn't start.
 
 ## Consequences
 
 ### Affected Nodes
 
-- **HoneyDrunk.Actions** — primary affected Node; new reusable workflow `job-review-agent.yml`; new jobs `pr-size-check` and `authorship-check` added to `pr-core.yml`; post-merge `audit-sample` labeling job added.
-- **HoneyDrunk.Architecture** (this repo) — pilot for Phase 1; new directory `generated/post-merge-audits/`; new field `review_risk_class` in `catalogs/grid-health.json`; `.honeydrunk-review.yaml` authored as the v1 reference.
-- **HoneyDrunk.Vault** — stores the Anthropic API key used by `job-review-agent.yml` (per ADR-0005); GitHub App credentials for the architecture-repo checkout token (also per ADR-0005).
-- **Every Grid repo (eventually)** — adds `.honeydrunk-review.yaml`, `large-pr` and `audit-sample` labels via the existing label-setup pattern, and the `Authorship:` line convention to PR templates.
-- **Codex execution surface** — amended in a follow-up packet to emit `Authorship: agent-codex` and the corresponding commit trailer (`Authorship:` and `Co-authored-by:`).
-- **Claude Code commit-template behavior** — amended to emit `Authorship: agent-claude-code`.
-- **`.claude/agents/review.md`** — gains the per-category execution detail implementing D3's twenty categories.
-- **`.claude/agents/scope.md`, `adr-composer.md`, `pdr-composer.md`, `refine.md`, `node-audit.md`** — each gains a section referencing D3 and the subset of categories relevant to its authoring surface, per D3's upstream-awareness clause. Updates land per ADR-0007's source-of-truth rule.
-- **Execution-surface prompts** (Codex packet-execution prompt, Copilot in-IDE custom instructions, Claude Code authoring-mode system instructions) — each surfaces the load-bearing authoring categories (Correctness, Code Quality, SOLID, Reuse, Security, Performance, Testing, AI-specific, Human Factors) per D3's upstream-awareness clause.
+- **HoneyDrunk.Actions** - primary affected Node; new reusable workflow `job-review-request.yml`; new jobs `pr-size-check` and `authorship-check` added to `pr-core.yml`; post-merge `audit-sample` labeling job added.
+- **HoneyDrunk.Architecture** (this repo) - pilot for Phase 1; OpenClaw runner configuration/runbook; new directory `generated/post-merge-audits/`; new field `review_risk_class` in `catalogs/grid-health.json`; `.honeydrunk-review.yaml` authored as the v1 reference.
+- **OpenClaw workspace/runtime** - hosts the Grid Review Runner, tracks reviewed PR head SHAs, loads local target/Architecture repos, runs Codex, and posts review comments via `gh`.
+- **HoneyDrunk.Vault** - no Anthropic API key is required for v1. It may store future GitHub App/webhook credentials if the webhook path is used; local `gh` auth is acceptable for the OpenClaw-hosted runner.
+- **Every Grid repo (eventually)** - adds `.honeydrunk-review.yaml`, `large-pr` and `audit-sample` labels via the existing label-setup pattern, and the `Authorship:` line convention to PR templates.
+- **Codex execution surface** - amended in a follow-up packet to emit `Authorship: agent-codex` and the corresponding commit trailer (`Authorship:` and `Co-authored-by:`).
+- **Claude Code commit-template behavior** - amended to emit `Authorship: agent-claude-code`.
+- **`.claude/agents/review.md`** - gains the per-category execution detail implementing D3's twenty categories.
+- **`.claude/agents/scope.md`, `adr-composer.md`, `pdr-composer.md`, `refine.md`, `node-audit.md`** - each gains a section referencing D3 and the subset of categories relevant to its authoring surface, per D3's upstream-awareness clause. Updates land per ADR-0007's source-of-truth rule.
+- **Execution-surface prompts** (Codex packet-execution prompt, Copilot in-IDE custom instructions, Claude Code authoring-mode system instructions) - each surfaces the load-bearing authoring categories (Correctness, Code Quality, SOLID, Reuse, Security, Performance, Testing, AI-specific, Human Factors) per D3's upstream-awareness clause.
 
 ### Invariants
 
 Adds two:
 
-- **Invariant: every non-draft PR on an `enabled` repo runs the cloud-wired `review` agent.** Skip is via the `skip-review` label or `enabled: false` config — both explicit, both visible.
+- **Invariant: every non-draft PR on an `enabled` repo requests an automatic Grid Review Runner pass.** Skip is via the `skip-review` label or `enabled: false` config - both explicit, both visible. Runner unavailability is surfaced as advisory/pending, not hidden.
 - **Invariant: agent-authored PRs touching a high-risk Node receive two independent LLM-review perspectives before merge.** The catalog of high-risk Nodes lives in `catalogs/grid-health.json`.
 
-ADR-0011's invariants 31–33 are preserved. Final invariant numbers for the two new invariants are assigned when the implementing work updates `constitution/invariants.md`; this ADR deliberately does not reserve specific numbers because the existing 34+ range is already contested between ADR-0012's CI/CD invariants (34–38) and ADR-0015's hosting invariants (34–36). `hive-sync` reconciles the final assignments at landing time.
+ADR-0011's invariants 31-33 are preserved. Final invariant numbers for the two new invariants are assigned when the implementing work updates `constitution/invariants.md`; this ADR deliberately does not reserve specific numbers because the existing 34+ range is already contested between ADR-0012's CI/CD invariants (34-38) and ADR-0015's hosting invariants (34-36). `hive-sync` reconciles the final assignments at landing time.
 
 ### Operational Consequences
 
-- **Per-PR cloud LLM cost is now non-zero by design.** Tracked monthly; ceiling is $200/month for two consecutive months before reconsideration. The build saves money relative to running `/ultrareview` per PR or paying CodeRabbit private-tier, but it is not free.
-- **Anthropic API key becomes load-bearing CI infrastructure.** Outage halts the cloud reviewer (workflow fails gracefully and posts a comment; PR can still merge — advisory posture). Rotation per ADR-0006.
-- **GitHub App for cross-repo checkout** — a new GitHub App scoped to read `HoneyDrunk.Architecture` is created; its installation token is fetched per workflow run. Credentials in Vault.
-- **PR diffs are sent to the Anthropic API.** Code is not customer data in any sense relevant to ADR-0036 (no tenant data is in repo diffs); the egress is acceptable and is documented here so it isn't relitigated. Private revenue Nodes (per ADR-0027 D2) are explicitly **excluded from the default v1 rollout** and require an explicit opt-in via `.honeydrunk-review.yaml`.
-- **The local Claude Code review invocation remains available** and is the right tool for offline review or pre-PR feedback. The cloud workflow does not replace it; it makes the routine case automatic.
+- **Per-PR cloud LLM API cost is avoided in v1 by design.** The default runner uses the existing OpenClaw/Codex subscription/session. API-backed execution remains a future fallback only, with explicit caps and provider choice.
+- **OpenClaw availability becomes part of the advisory review surface.** If the local runner is offline, the workflow/request path marks the review pending or unavailable and posts/records that state; PRs remain mergeable because the reviewer is advisory.
+- **GitHub App/webhook credentials are optional v1 infrastructure.** The webhook path may use a narrowly scoped GitHub App or secret; the cron/artifact path can rely on local `gh` authentication. Do not provision Anthropic API credentials for v1.
+- **PR diffs stay in the local OpenClaw/Codex path by default.** They are not sent to Anthropic API as part of v1. Any future external API fallback must be documented and explicitly enabled. Private revenue Nodes (per ADR-0027 D2) are explicitly **excluded from the default v1 rollout** and require an explicit opt-in via `.honeydrunk-review.yaml`.
+- **The manual review invocation remains available** and is the right tool for offline review or pre-PR feedback. The automatic runner does not replace it; it makes the routine case automatic.
 - **Copilot's role diminishes.** It remains enabled (zero marginal cost from the existing subscription) but no longer carries a specific responsibility in the pipeline.
 - **The `Authorship:` declaration adds friction.** For agent surfaces, one-time template change. For humans, one line per PR.
-- **Phase 1's pilot repo (Architecture)** will generate the first real cost data and the first review-quality signal. Phases 2+ are gated on that signal.
+- **Phase 1's pilot repo (Architecture)** will generate the first reliability signal, reviewed-SHA behavior, and review-quality signal. Phases 2+ are gated on that signal.
 
 ### Follow-up Work
 
-- Author `job-review-agent.yml` in HoneyDrunk.Actions (Phase 1 MVP).
+- Author `job-review-request.yml` in HoneyDrunk.Actions (Phase 1 trigger rail).
+- Author the OpenClaw/Codex Grid Review Runner runbook/config in Architecture.
 - Author `authorship-check` and `pr-size-check` jobs in `pr-core.yml`.
 - Author the `audit-sample` post-merge labeling job.
-- Create the GitHub App for cross-repo checkout; store credentials in Vault.
-- Provision the Anthropic API key in Vault; configure rotation per ADR-0006.
+- If using webhook delivery, create the narrowly scoped GitHub App/webhook credential and store it per ADR-0005/0006. Do not provision an Anthropic API key for v1.
 - Author `.honeydrunk-review.yaml` v1 schema doc in this repo (`copilot/review-config-schema.md` or similar).
 - Enable on the Architecture repo (Phase 1).
 - Add `review_risk_class` field to `catalogs/grid-health.json` schema; populate for current Nodes (deferred until Phase 3 activates).
 - Create `generated/post-merge-audits/` directory with a README.
 - Amend Codex execution surface to emit `Authorship:` + commit trailer.
-- Update `.claude/agents/review.md` with: (a) per-category execution detail implementing D3's twenty categories; (b) any clarifications needed for cloud-context execution (e.g., explicit handling of "context loaded from the architecture repo checkout").
+- Update `.claude/agents/review.md` with: (a) per-category execution detail implementing D3's twenty categories; (b) any clarifications needed for OpenClaw runner execution (e.g., explicit handling of "context loaded from the architecture repo checkout").
 - Update `.claude/agents/scope.md` with a section referencing D3 and the categories relevant to scoping (Correctness scope adherence, Reliability, Observability requirements, Security blast radius, Testing strategy, Anti-Entropy risk, AI/agent implications).
 - Update `.claude/agents/adr-composer.md` and `.claude/agents/pdr-composer.md` with sections referencing D3 and the categories relevant to architectural and product decisions (Architectural Integrity, Cost, Anti-Entropy, Security/Compliance, AI/agent implications; PDR adds extra weight on Product / Business Alignment).
 - Update `.claude/agents/refine.md` with a section referencing D3 and the rubric-completeness check it must perform on packets and dispatch plans.
@@ -397,9 +401,9 @@ ADR-0011's invariants 31–33 are preserved. Final invariant numbers for the two
 
 Considered seriously. CodeRabbit's `.coderabbit.yaml` rule system is genuinely strong for prose-shaped rules and `path_instructions` (per-glob review guidance). Free for public repos; paid for private. Zero engineering to adopt.
 
-Rejected because the requirement is **Grid awareness in the active sense** — reading `catalogs/contracts.json` at review time, walking `relationships.json` to assess downstream impact, resolving the packet via PR-body link, checking the diff against the packet's stated scope. CodeRabbit cannot do any of these; its rules are text-bound. Inlining the Grid context into `.coderabbit.yaml` is possible up to a point but degrades as the Grid grows and produces a maintenance surface (drift between the YAML inline copy and the canonical catalog files).
+Rejected because the requirement is **Grid awareness in the active sense** - reading `catalogs/contracts.json` at review time, walking `relationships.json` to assess downstream impact, resolving the packet via PR-body link, checking the diff against the packet's stated scope. CodeRabbit cannot do any of these; its rules are text-bound. Inlining the Grid context into `.coderabbit.yaml` is possible up to a point but degrades as the Grid grows and produces a maintenance surface (drift between the YAML inline copy and the canonical catalog files).
 
-The build path costs 1–2 days of engineering and $40–100/month in API spend, in exchange for a reviewer that is structurally capable of doing the job. The buy path costs $0 in engineering and $0–30/month, in exchange for a reviewer that is structurally incapable of the most important slot. The build wins on capability.
+The build path costs 1-2 days of engineering and near-zero incremental model cost under the existing OpenClaw/Codex subscription/session, in exchange for a reviewer that is structurally capable of doing the job. The buy path costs $0 in engineering and $0-30/month, in exchange for a reviewer that is structurally incapable of the most important slot. The build wins on capability.
 
 ### Continue ADR-0011 D10's local-only posture
 
@@ -413,19 +417,19 @@ Rejected. Polish before observation is over-engineering. v1's job is to prove th
 
 Considered. The argument: CodeRabbit's free public tier covers security/conventions/bugs/performance; our build covers Grid fit; total cost roughly the same; two perspectives.
 
-Rejected on the cumulative-vendor-surface argument and on the recognition that **our review agent's prompt already covers security/conventions/bugs/performance** — Grid fit is the addition, not the substitute. Building two reviewers when one with the right prompt does both is duplication. If gaps appear in v1 against the non-Grid surfaces, adding CodeRabbit later as a complementary signal is a small follow-up amendment; presuming the gap up front is decision-under-uncertainty.
+Rejected on the cumulative-vendor-surface argument and on the recognition that **our review agent's prompt already covers security/conventions/bugs/performance** - Grid fit is the addition, not the substitute. Building two reviewers when one with the right prompt does both is duplication. If gaps appear in v1 against the non-Grid surfaces, adding CodeRabbit later as a complementary signal is a small follow-up amendment; presuming the gap up front is decision-under-uncertainty.
 
-### Cloud-wire only for high-risk repos; keep local-only elsewhere
+### Automate only for high-risk repos; keep manual-only elsewhere
 
-Rejected. The discipline failure mode ("human forgets to invoke") applies equally to non-high-risk repos. The cost difference between "cloud-wire all 12 Nodes" and "cloud-wire 4 Nodes" is small ($40 vs $100/month order of magnitude); the simplicity benefit of one consistent policy is large. Phased rollout (D11) gets the same blast-radius safety without the permanent split-policy.
+Rejected. The discipline failure mode ("human forgets to invoke") applies equally to non-high-risk repos. The incremental model cost difference between "request reviews for all enabled Nodes" and "request reviews for only high-risk Nodes" is near-zero under the subscription-backed OpenClaw/Codex runner, and the simplicity benefit of one consistent policy is large. Phased rollout (D11) gets the same blast-radius safety without the permanent split-policy.
 
-### Make the cloud reviewer a required blocking check
+### Make the automatic reviewer a required blocking check
 
-Rejected. Preserves ADR-0011 D5's advisory posture. Required check on a third-party-runtime service (Anthropic API) bakes a single vendor into branch protection and strands merges on every API outage. Advisory plus weekly-briefing visibility (per ADR-0043 D5 of the briefing surfacing skipped reviews — though with auto-invocation, "skipped" is now near-zero) achieves observability without the lockout risk.
+Rejected. Preserves ADR-0011 D5's advisory posture. Required check on any AI runtime — local OpenClaw or third-party API — strands merges on runner outage, auth expiry, webhook failure, or provider outage. Advisory plus weekly-briefing visibility (per ADR-0043 D5 of the briefing surfacing skipped reviews - though with auto-invocation, "skipped" should be near-zero) achieves observability without the lockout risk.
 
-### Use only Opus to maximize review quality
+### Use only API-hosted frontier review to maximize review quality
 
-Rejected on cost. Opus is ~5× the cost of Sonnet per token at current pricing. The marginal quality gain on routine PRs does not justify the cost; Opus belongs on high-risk-Node PRs (D8) where the failure cost is high enough to warrant the spend. Default-Sonnet, escalate-to-Opus is the standard cost-quality factoring for tiered LLM use.
+Rejected on cost and operational coupling. The marginal quality gain on routine PRs does not justify turning every PR into external API spend and provider dependency. High-risk-Node PRs get a second independent pass under D8; routine PRs use the OpenClaw/Codex subscription-backed runner by default.
 
 ### Defer until first AI-authored production regression
 

--- a/generated/issue-packets/active/adr-0044-cloud-code-review/02b-architecture-openclaw-grid-review-runner.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/02b-architecture-openclaw-grid-review-runner.md
@@ -1,0 +1,69 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-2", "meta", "openclaw", "adr-0044", "wave-1"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0044"]
+accepts: ["ADR-0044"]
+wave: 1
+initiative: adr-0044-cloud-code-review
+node: honeydrunk-architecture
+supersedes: ["packet:02"]
+---
+
+# Define the OpenClaw/Codex Grid Review Runner runtime
+
+## Summary
+Replace the originally scoped Anthropic/GitHub-App credential packet with an Architecture-owned OpenClaw/Codex runner definition and runbook. The runner is the v1 reasoning brain for ADR-0044: GitHub Actions requests reviews; OpenClaw runs Codex against `.claude/agents/review.md`; the runner comments back on the PR and records the reviewed head SHA.
+
+## Context
+ADR-0044 now chooses a subscription-backed OpenClaw/Codex runtime for v1 instead of an Anthropic API-backed GitHub Action. This avoids a new per-token review bill and keeps PR diff review in the Studio's local OpenClaw/Codex path by default. The previously filed packet 02 (GitHub App + Anthropic key) is superseded by this packet.
+
+## Scope
+- Add Architecture documentation/config for the Grid Review Runner, e.g. `infrastructure/openclaw/grid-review-runner.md`.
+- Define the review request payload consumed by the runner: repo, PR number, head SHA, authorship class, changed-file summary, packet link, and `.honeydrunk-review.yaml` settings.
+- Define reviewed-head-SHA state storage under the OpenClaw workspace or Architecture-managed state file.
+- Document both trigger modes:
+  - webhook/request delivery from `job-review-request.yml`;
+  - cron/poll fallback for open PRs when webhook delivery is unavailable.
+- Document local auth expectations: `gh` auth is acceptable for v1; a narrowly scoped GitHub App/webhook credential is optional.
+
+## NuGet Dependencies
+None. Markdown/config only.
+
+## Acceptance Criteria
+- [ ] OpenClaw/Codex runner runtime is documented/configured in Architecture
+- [ ] The runner consumes `.claude/agents/review.md` as the canonical prompt source
+- [ ] The review request payload schema is documented
+- [ ] Reviewed head SHA tracking is specified so unchanged PRs are not re-reviewed
+- [ ] Webhook and cron/poll trigger modes are both documented
+- [ ] The doc explicitly says no Anthropic API key is required for v1
+- [ ] The doc names the advisory failure behavior when OpenClaw is offline
+
+## Human Prerequisites
+- [ ] Confirm whether Phase 1 uses webhook delivery first or cron/poll fallback first.
+
+## Dependencies
+- `packet:01` — ADR-0044 acceptance/amendment (soft).
+
+## Referenced ADR Decisions
+- ADR-0044 D1 — GitHub Actions as trigger rail; OpenClaw/Codex as runner.
+- ADR-0044 D2 — runner context loading mirrors local invocation.
+- ADR-0044 D5 — subscription-backed cost guardrails.
+
+## Constraints
+- Do not provision or require an Anthropic API key for v1.
+- Do not make review a required blocking check.
+- Keep runtime behavior provider-neutral enough that a future API-backed fallback can be added deliberately.
+
+## Agent Handoff
+
+**Objective:** Add the Architecture-side OpenClaw/Codex Grid Review Runner runtime doc/config that supersedes the old Anthropic credential packet.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Key Files:**
+- `infrastructure/openclaw/grid-review-runner.md` (new; exact path may be adjusted if an existing OpenClaw infrastructure directory exists)
+- `.claude/agents/review.md` (reference only; do not change unless packet 04 is in scope)

--- a/generated/issue-packets/active/adr-0044-cloud-code-review/03b-actions-job-review-request-workflow.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/03b-actions-job-review-request-workflow.md
@@ -1,0 +1,80 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["ci", "tier-2", "ops", "openclaw", "adr-0044", "wave-1"]
+dependencies: ["packet:01", "packet:02b"]
+adrs: ["ADR-0044"]
+accepts: ["ADR-0044"]
+wave: 1
+initiative: adr-0044-cloud-code-review
+node: honeydrunk-actions
+supersedes: ["packet:03"]
+---
+
+# Build job-review-request.yml — the GitHub trigger rail for the OpenClaw reviewer
+
+## Summary
+Replace the originally scoped `job-review-agent.yml` Anthropic/Claude runtime with a lightweight reusable workflow, `job-review-request.yml`, that decides whether a PR should request Grid review and emits/delivers a request for the OpenClaw/Codex Grid Review Runner.
+
+## Target Workflow
+**File:** `.github/workflows/job-review-request.yml`
+**Family:** pr-core / advisory review trigger
+
+## Motivation
+ADR-0044 now keeps reasoning-heavy review in OpenClaw/Codex and uses GitHub Actions as the cheap rail. The workflow should not invoke Anthropic, Claude Agent SDK, or any model API directly. It should collect PR metadata, apply skip/enable rules, and deliver a request to OpenClaw or leave a durable artifact for OpenClaw cron/poll pickup.
+
+## Proposed Change
+1. Add reusable workflow `job-review-request.yml`.
+2. Trigger from caller workflows on `pull_request` opened/synchronize/ready_for_review.
+3. Skip when:
+   - PR is draft;
+   - PR has `skip-review`;
+   - `.honeydrunk-review.yaml` is absent or `enabled: false`;
+   - current head SHA was already marked reviewed if that state is available to the workflow.
+4. Produce a request payload with repo, PR number, head SHA, author class, changed-file summary, packet link, config, and callback/comment target.
+5. Delivery:
+   - preferred: POST to an OpenClaw webhook URL if configured;
+   - fallback: upload artifact and/or post a machine-readable advisory comment that OpenClaw cron can discover.
+6. Set/report advisory status only. Do not fail branch protection if OpenClaw is offline.
+
+## NuGet Dependencies
+None. GitHub Actions workflow only.
+
+## Acceptance Criteria
+- [ ] `job-review-request.yml` exists in HoneyDrunk.Actions
+- [ ] It contains no Anthropic, Claude Agent SDK, or model API invocation
+- [ ] It applies draft, `skip-review`, and `.honeydrunk-review.yaml enabled` skip rules
+- [ ] It emits the documented review request payload
+- [ ] It supports webhook delivery and durable fallback artifact/comment delivery
+- [ ] It reports advisory pending/unavailable state when OpenClaw is offline
+- [ ] `docs/consumer-usage.md` documents how repos call the workflow
+- [ ] `docs/CHANGELOG.md` records the new workflow
+
+## Human Prerequisites
+- [ ] Choose webhook-first vs artifact/comment-first delivery for Phase 1.
+- [ ] If webhook-first, provide the OpenClaw webhook URL/secret through GitHub Actions secrets.
+
+## Dependencies
+- `packet:02b` — runner payload/schema and runtime behavior (hard).
+
+## Referenced ADR Decisions
+- ADR-0044 D1 — `job-review-request.yml` is the trigger rail, not the reasoning brain.
+- ADR-0044 D5 — subscription-backed default; no per-token API bill for v1.
+
+## Constraints
+- Do not call Anthropic/OpenAI APIs from GitHub Actions in v1.
+- Do not make review a required blocking check.
+- Preserve reusable-workflow factoring per ADR-0012.
+
+## Agent Handoff
+
+**Objective:** Build the reusable GitHub Actions trigger rail for the OpenClaw/Codex Grid Review Runner.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Key Files:**
+- `.github/workflows/job-review-request.yml` (new)
+- `docs/consumer-usage.md`
+- `docs/CHANGELOG.md`

--- a/generated/issue-packets/active/adr-0044-cloud-code-review/05b-architecture-review-config-schema-openclaw.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/05b-architecture-review-config-schema-openclaw.md
@@ -1,0 +1,60 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-1", "meta", "openclaw", "adr-0044", "wave-1"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0044"]
+accepts: ["ADR-0044"]
+wave: 1
+initiative: adr-0044-cloud-code-review
+node: honeydrunk-architecture
+supersedes: ["packet:05"]
+---
+
+# Author the OpenClaw-aware .honeydrunk-review.yaml v1 schema doc
+
+## Summary
+Author `copilot/review-config-schema.md` for the revised ADR-0044 v1 schema. The schema keeps the enabled gate, severity floor, and skip paths, but replaces Anthropic/Sonnet/Opus model selection with `runner: openclaw-codex` and keeps API-backed execution as an explicit future fallback only.
+
+## Context
+The originally filed packet 05 documented `model: sonnet|opus` and `cost_cap_per_pr_usd: 5.00`. ADR-0044 now uses OpenClaw/Codex as the v1 runner to avoid a new per-token Anthropic bill. This packet supersedes packet 05 for schema work.
+
+## Proposed v1 Schema
+
+```yaml
+enabled: true
+runner: openclaw-codex       # openclaw-codex | api-ci; v1 default is openclaw-codex
+severity_floor: Suggest      # Suggest | Request Changes | Block
+skip_paths:
+  - "**/*.Designer.cs"
+  - "**/*.g.cs"
+  - "**/generated/**"
+cost_cap_per_pr_usd: 0.00    # v1 subscription-backed default; API fallback must set explicit non-zero cap
+```
+
+## Acceptance Criteria
+- [ ] `copilot/review-config-schema.md` documents the revised v1 schema
+- [ ] The schema includes `enabled`, `runner`, `severity_floor`, `skip_paths`, and `cost_cap_per_pr_usd`
+- [ ] The doc says `openclaw-codex` is the default v1 runner
+- [ ] The doc says `api-ci` is a future explicit fallback, not default behavior
+- [ ] The doc removes Sonnet/Opus as per-repo config knobs for v1
+- [ ] The doc explains reviewed-head-SHA behavior and `skip-review`
+- [ ] Cross-links to ADR-0044 D1/D4/D5 and packet 02b runner docs
+
+## Dependencies
+- `packet:01` — ADR-0044 acceptance/amendment (soft).
+
+## Constraints
+- Do not document Anthropic API as a required v1 dependency.
+- Do not make review a blocking required check.
+
+## Agent Handoff
+
+**Objective:** Write the revised OpenClaw-aware `.honeydrunk-review.yaml` schema doc.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Key Files:**
+- `copilot/review-config-schema.md`

--- a/generated/issue-packets/active/adr-0044-cloud-code-review/06b-architecture-enable-openclaw-review-phase-1-pilot.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/06b-architecture-enable-openclaw-review-phase-1-pilot.md
@@ -1,0 +1,68 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["ci", "tier-2", "meta", "openclaw", "adr-0044", "wave-1"]
+dependencies: ["packet:02b", "packet:03b", "packet:04", "packet:05b"]
+adrs: ["ADR-0044", "ADR-0011"]
+accepts: ["ADR-0044"]
+wave: 1
+initiative: adr-0044-cloud-code-review
+node: honeydrunk-architecture
+supersedes: ["packet:06"]
+---
+
+# Enable the OpenClaw/Codex reviewer on HoneyDrunk.Architecture (Phase 1 pilot)
+
+## Summary
+Enable ADR-0044 Phase 1 on the Architecture repo using the OpenClaw/Codex Grid Review Runner and `job-review-request.yml` trigger rail. This supersedes the originally filed packet 06 that assumed a cloud model runtime in GitHub Actions.
+
+## Scope
+- Add `.honeydrunk-review.yaml` to `HoneyDrunk.Architecture` with `enabled: true`, `runner: openclaw-codex`, `severity_floor: Suggest`, and appropriate `skip_paths`.
+- Add/extend the Architecture PR review caller workflow to invoke `job-review-request.yml` on pull_request opened/synchronize/ready_for_review.
+- Confirm the OpenClaw runner can receive/pick up review requests for Architecture PRs.
+- Verify the runner comments a review verdict and records the reviewed head SHA.
+- Document Phase 1 go/no-go evidence in the PR body or a small Architecture note.
+
+## NuGet Dependencies
+None. YAML/docs only.
+
+## Acceptance Criteria
+- [ ] `.honeydrunk-review.yaml` exists with `enabled: true` and `runner: openclaw-codex`
+- [ ] Architecture PR workflow invokes `job-review-request.yml`
+- [ ] Draft PRs and `skip-review` PRs do not request review
+- [ ] A real/test Architecture PR receives a Grid Review Runner comment
+- [ ] Re-running on the same head SHA does not duplicate review work
+- [ ] OpenClaw-offline behavior is advisory/pending, not a hard failure
+- [ ] Phase 1 go/no-go evidence is recorded
+
+## Human Prerequisites
+- [ ] Confirm OpenClaw runner is available for the pilot window.
+- [ ] Confirm whether the pilot uses webhook or cron/poll pickup.
+
+## Dependencies
+- `packet:02b` — OpenClaw runner runtime definition (hard)
+- `packet:03b` — `job-review-request.yml` trigger rail (hard)
+- `packet:04` — review rubric in `review.md` (hard)
+- `packet:05b` — OpenClaw-aware review config schema doc (soft)
+
+## Referenced ADR Decisions
+- ADR-0044 D1/D2/D5/D11 Phase 1.
+- ADR-0011 D5 advisory posture.
+
+## Constraints
+- Do not use Anthropic API for the Phase 1 pilot.
+- Do not make the review check required.
+- Do not fan out to other repos until the Phase 1 go/no-go is documented.
+
+## Agent Handoff
+
+**Objective:** Enable ADR-0044 Phase 1 on `HoneyDrunk.Architecture` using the OpenClaw/Codex runner and validate automatic PR review without per-token API spend.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Key Files:**
+- `.honeydrunk-review.yaml` (new)
+- `.github/workflows/pr-review.yml` or existing PR workflow caller
+- Phase 1 evidence note, if needed

--- a/generated/issue-packets/active/adr-0044-cloud-code-review/11-cross-repo-enable-review-ten-nodes.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/11-cross-repo-enable-review-ten-nodes.md
@@ -2,9 +2,10 @@
 name: Cross-Repo Change
 type: cross-repo-change
 tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
 target_repos: ["HoneyDrunk.Kernel", "HoneyDrunk.Transport", "HoneyDrunk.Vault", "HoneyDrunk.Auth", "HoneyDrunk.Web.Rest", "HoneyDrunk.Data", "HoneyDrunk.Notify", "HoneyDrunk.Communications", "HoneyDrunk.Pulse", "HoneyDrunk.Actions"]
 labels: ["ci", "tier-2", "core", "ops", "coordination", "adr-0044", "wave-2"]
-dependencies: ["packet:06", "packet:07", "packet:08", "packet:09", "packet:10"]
+dependencies: ["packet:06b", "packet:07", "packet:08", "packet:09", "packet:10"]
 adrs: ["ADR-0044"]
 accepts: ["ADR-0044"]
 wave: 2
@@ -12,83 +13,83 @@ initiative: adr-0044-cloud-code-review
 node: honeydrunk-architecture
 ---
 
-# Enable the cloud reviewer on the 10 remaining live Nodes (Phase 2 rollout)
+# Enable the OpenClaw/Codex reviewer on the 10 remaining live Nodes (Phase 2 rollout)
 
 ## Summary
-Roll the cloud reviewer out to the **10 remaining live .NET Nodes** — Kernel, Transport, Vault, Auth, Web.Rest, Data (Core); Notify, Communications, Pulse, Actions (Ops) — by authoring a `.honeydrunk-review.yaml` (`enabled: true`) and a `pr-review.yml` caller in each. This is the Phase-2 fan-out, gated on a successful Phase-1 go/no-go. It is filed as a coordination/tracking issue in `HoneyDrunk.Architecture` with one child issue per Node repo.
+Roll the OpenClaw/Codex Grid Review Runner out to the **10 remaining live .NET Nodes** - Kernel, Transport, Vault, Auth, Web.Rest, Data (Core); Notify, Communications, Pulse, Actions (Ops) - by authoring a `.honeydrunk-review.yaml` (`enabled: true`) and a `pr-review.yml` caller in each. This is the Phase-2 fan-out, gated on a successful Phase-1 go/no-go. It is filed as a coordination/tracking issue in `HoneyDrunk.Architecture` with one child issue per Node repo.
 
 ## Repo-list reconciliation (read this before filing)
 ADR-0044 D11 Phase 2 says "rollout to all 12 live Nodes." The Grid has exactly **12 live Nodes** per `catalogs/grid-health.json` (`signal: "Live"`): Kernel, Transport, Vault, Data, Web.Rest, Auth (Core); Notify, Communications, Pulse, Actions (Ops); Architecture, Studios (Meta). This packet's fan-out is those 12 **minus two**:
 
-- **`HoneyDrunk.Architecture`** — already enabled in Phase 1 (packet 06). Not re-enabled here.
-- **`HoneyDrunk.Studios`** — a TypeScript repo, not a .NET Node; its onboarding is evaluated separately (see the dispatch plan's out-of-scope list). Not part of this .NET-shaped fan-out.
+- **`HoneyDrunk.Architecture`** - already enabled in Phase 1 (packet 06). Not re-enabled here.
+- **`HoneyDrunk.Studios`** - a TypeScript repo, not a .NET Node; its onboarding is evaluated separately (see the dispatch plan's out-of-scope list). Not part of this .NET-shaped fan-out.
 
-That leaves **exactly 10 .NET Node repos** in scope, enumerated in `target_repos` above. **`HoneyDrunk.Observe` is explicitly OUT** — it carries `signal: "Seed"` in `catalogs/grid-health.json` (it is scaffolded but not a live Node) and is not among the 12 live Nodes per the Grid state in CLAUDE.md. Do not add Observe to this fan-out; if Observe reaches `Live` status later, its enablement is a separate follow-up packet, not a silent addition here.
+That leaves **exactly 10 .NET Node repos** in scope, enumerated in `target_repos` above. **`HoneyDrunk.Observe` is explicitly OUT** - it carries `signal: "Seed"` in `catalogs/grid-health.json` (it is scaffolded but not a live Node) and is not among the 12 live Nodes per the Grid state in CLAUDE.md. Do not add Observe to this fan-out; if Observe reaches `Live` status later, its enablement is a separate follow-up packet, not a silent addition here.
 
 ## Context
-ADR-0044 D11 Phase 2 rolls the reviewer out to the live Nodes after Phase 1 (the Architecture-repo pilot, packet 06) proves the cloud reviewer's verdicts are at least as useful as the local agent's at acceptable cost. Each repo opts in via `.honeydrunk-review.yaml` with `enabled: true`. Authorship classification (D6) becomes mandatory and PR-size discipline (D7, warnings-only) activates Grid-wide — both come for free via the `pr-core.yml` jobs (packet 07); this packet only adds the per-repo reviewer config and caller.
+ADR-0044 D11 Phase 2 rolls the reviewer out to the live Nodes after Phase 1 (the Architecture-repo pilot, packet 06b) proves the OpenClaw/Codex runner's verdicts are at least as useful as the manual agent's, the trigger path is reliable, and reviewed-head-SHA tracking works. Each repo opts in via `.honeydrunk-review.yaml` with `enabled: true`. Authorship classification (D6) becomes mandatory and PR-size discipline (D7, warnings-only) activates Grid-wide - both come for free via the `pr-core.yml` jobs (packet 07); this packet only adds the per-repo reviewer config and caller.
 
-**This is a multi-repo packet** describing one repeated unit of work across the 10 repos in `target_repos`. The `file-issues` agent files it as a tracking issue in `HoneyDrunk.Architecture` with 10 child issues (one per Node), or as 10 sibling issues — the human/dispatch decides the filing shape. The work per repo is identical and small.
+**This is a multi-repo packet** describing one repeated unit of work across the 10 repos in `target_repos`. The `file-issues` agent files it as a tracking issue in `HoneyDrunk.Architecture` with 10 child issues (one per Node), or as 10 sibling issues - the human/dispatch decides the filing shape. The work per repo is identical and small.
 
 ## Per-repo work unit (repeated for each of the 10 Node repos)
 For each Node repo:
-1. Author `.honeydrunk-review.yaml` at the repo root with `enabled: true`, `severity_floor: Suggest`, `model: sonnet`, `cost_cap_per_pr_usd: 5.00`, and `skip_paths` tuned for that repo (generated code, designer files — per the packet-05 schema doc).
-2. Author/extend `.github/workflows/pr-review.yml` to call `job-review-agent.yml` on `pull_request` opened/synchronize/ready_for_review.
+1. Author `.honeydrunk-review.yaml` at the repo root with `enabled: true`, `runner: openclaw-codex`, `severity_floor: Suggest`, and `skip_paths` tuned for that repo (generated code, designer files - per the packet-05b schema doc).
+2. Author/extend `.github/workflows/pr-review.yml` to call `job-review-request.yml` on `pull_request` opened/synchronize/ready_for_review.
 3. Verify the repo's PR template carries the `Authorship:` line (or add it) so `authorship-check` (now Grid-wide via `pr-core.yml`) passes.
-4. **Private revenue Nodes are excluded from the default rollout** — per ADR-0044 Operational Consequences, any `.Cloud` revenue Node (per ADR-0027 D2) is excluded from the default v1 rollout and requires an explicit opt-in. If a Node in the list is a private revenue Node, leave it `enabled: false` (or omit the file) and note it; do not enable it as part of the default fan-out.
+4. **Private revenue Nodes are excluded from the default rollout** - per ADR-0044 Operational Consequences, any `.Cloud` revenue Node (per ADR-0027 D2) is excluded from the default v1 rollout and requires an explicit opt-in. If a Node in the list is a private revenue Node, leave it `enabled: false` (or omit the file) and note it; do not enable it as part of the default fan-out.
 
 ## Affected Repos
-Exactly these 10 .NET Node repos: HoneyDrunk.Kernel, HoneyDrunk.Transport, HoneyDrunk.Vault, HoneyDrunk.Auth, HoneyDrunk.Web.Rest, HoneyDrunk.Data, HoneyDrunk.Notify, HoneyDrunk.Communications, HoneyDrunk.Pulse, HoneyDrunk.Actions. **`HoneyDrunk.Architecture` is excluded** (already enabled in Phase 1, packet 06). **`HoneyDrunk.Studios` is excluded** (TypeScript repo, evaluated separately). **`HoneyDrunk.Observe` is excluded** (`signal: "Seed"` in `catalogs/grid-health.json` — not a live Node). Do not add repos to this list; it is pinned, not "any live Node at filing time."
+Exactly these 10 .NET Node repos: HoneyDrunk.Kernel, HoneyDrunk.Transport, HoneyDrunk.Vault, HoneyDrunk.Auth, HoneyDrunk.Web.Rest, HoneyDrunk.Data, HoneyDrunk.Notify, HoneyDrunk.Communications, HoneyDrunk.Pulse, HoneyDrunk.Actions. **`HoneyDrunk.Architecture` is excluded** (already enabled in Phase 1, packet 06). **`HoneyDrunk.Studios` is excluded** (TypeScript repo, evaluated separately). **`HoneyDrunk.Observe` is excluded** (`signal: "Seed"` in `catalogs/grid-health.json` - not a live Node). Do not add repos to this list; it is pinned, not "any live Node at filing time."
 
 ## NuGet Dependencies
 None. This packet adds YAML config and a caller workflow per repo; no .NET project or package reference changes.
 
 ## Boundary Check
-- [x] Each `.honeydrunk-review.yaml` and `pr-review.yml` lives in its own Node repo — correct ownership.
+- [x] Each `.honeydrunk-review.yaml` and `pr-review.yml` lives in its own Node repo - correct ownership.
 - [x] No cross-Node runtime dependency introduced; the reviewer is CI tooling.
 - [x] Private revenue Nodes excluded from the default rollout per ADR-0044 Operational Consequences.
 
 ## Acceptance Criteria
 - [ ] Each of the 10 .NET Node repos in `target_repos` (private revenue Nodes excluded) has a `.honeydrunk-review.yaml` with `enabled: true` at its repo root
-- [ ] Each has a `pr-review.yml` caller invoking `job-review-agent.yml` at a pinned ref on `pull_request` opened/synchronize/ready_for_review
+- [ ] Each has a `pr-review.yml` caller invoking `job-review-request.yml` at a pinned ref on `pull_request` opened/synchronize/ready_for_review
 - [ ] Each repo's PR template carries the `Authorship:` line
-- [ ] The cloud reviewer posts an advisory comment on a real or test PR in each enabled repo
+- [ ] The OpenClaw/Codex Grid Review Runner posts an advisory comment on a real or test PR in each enabled repo
 - [ ] `HoneyDrunk.Observe`, `HoneyDrunk.Architecture`, and `HoneyDrunk.Studios` are NOT touched by this fan-out (Observe is Seed; Architecture is Phase-1; Studios is TypeScript)
 - [ ] Any private revenue Node touched by the list is documented as excluded and left `enabled: false` / no file
 - [ ] Each repo's `CHANGELOG.md` carries an entry noting cloud-review enablement (CI tooling change)
 
 ## Human Prerequisites
 - [ ] The Phase-1 → Phase-2 go/no-go decision (from packet 06) must be a documented "go" before this packet is filed
-- [ ] Confirm the pinned `job-review-agent.yml` ref for all 10 callers
+- [ ] Confirm the pinned `job-review-request.yml` ref for all 10 callers
 - [ ] Confirm the list of private revenue Nodes to exclude (per ADR-0027 D2 / `catalogs/nodes.json`)
-- [ ] Verify the Anthropic/GitHub-App secrets are available to each Node's CI surface (org-level secrets cover this if configured org-wide in packet 02)
+- [ ] Confirm OpenClaw runner delivery mode (webhook or cron/poll) and any webhook secret, if used
 
 ## Dependencies
-- `packet:06` — Phase-1 pilot + go/no-go (**hard** — Phase 2 does not start until Phase 1's exit criterion is met).
-- `packet:07` — authorship/pr-size checks in `pr-core.yml` (**hard** — Phase 2 makes authorship classification mandatory; the checks must exist).
-- `packet:08` — Grid-wide labels (**hard** — `large-pr` etc. must exist before `pr-size-check` runs in these repos).
-- `packet:09` — D3 rubric in the upstream authoring agents (soft — agent PRs raised in these repos should be authored against the same rubric the reviewer evaluates; the upstream-authoring discipline, not only the `Authorship:` line, should be live as the fan-out lands).
-- `packet:10` — execution-surface authorship emitters (soft — agent PRs in these repos should declare `Authorship:` automatically once the emitters land).
+- `packet:06b` - OpenClaw/Codex Phase-1 pilot + go/no-go (**hard** - Phase 2 does not start until Phase 1's exit criterion is met).
+- `packet:07` - authorship/pr-size checks in `pr-core.yml` (**hard** - Phase 2 makes authorship classification mandatory; the checks must exist).
+- `packet:08` - Grid-wide labels (**hard** - `large-pr` etc. must exist before `pr-size-check` runs in these repos).
+- `packet:09` - D3 rubric in the upstream authoring agents (soft - agent PRs raised in these repos should be authored against the same rubric the reviewer evaluates; the upstream-authoring discipline, not only the `Authorship:` line, should be live as the fan-out lands).
+- `packet:10` - execution-surface authorship emitters (soft - agent PRs in these repos should declare `Authorship:` automatically once the emitters land).
 
 ## Referenced ADR Decisions
 
-**ADR-0044 D11 Phase 2** — Rollout to the live Nodes; each opts in via `.honeydrunk-review.yaml` with `enabled: true`; authorship classification becomes mandatory; PR-size discipline activates with warnings only. (D11 says "all 12 live Nodes"; this packet covers the 10 not already enabled in Phase 1 — Architecture is the Phase-1 pilot, Studios is TypeScript and onboarded separately.)
-**ADR-0044 D4** — `.honeydrunk-review.yaml` v1 schema and the enabled gate.
-**ADR-0044 Operational Consequences** — Private revenue Nodes (per ADR-0027 D2) are excluded from the default v1 rollout and require explicit opt-in.
+**ADR-0044 D11 Phase 2** - Rollout to the live Nodes; each opts in via `.honeydrunk-review.yaml` with `enabled: true`; authorship classification becomes mandatory; PR-size discipline activates with warnings only. (D11 says "all 12 live Nodes"; this packet covers the 10 not already enabled in Phase 1 - Architecture is the Phase-1 pilot, Studios is TypeScript and onboarded separately.)
+**ADR-0044 D4** - `.honeydrunk-review.yaml` v1 schema and the enabled gate.
+**ADR-0044 Operational Consequences** - Private revenue Nodes (per ADR-0027 D2) are excluded from the default v1 rollout and require explicit opt-in.
 
 ## Constraints
 - **Phase 2 is gated on a documented Phase-1 "go".** Do not file this packet before the Phase-1 outcome is recorded.
 - **Private revenue Nodes excluded by default.** Do not enable a `.Cloud` revenue Node as part of the default fan-out.
 - **Advisory only.** Never make the review check required on any Node.
 - **Pinned 10-repo list.** Do not add `HoneyDrunk.Observe` (Seed), `HoneyDrunk.Architecture` (Phase-1), or `HoneyDrunk.Studios` (TypeScript) to the fan-out.
-- One small, identical work unit per repo — file as 10 issues or a tracking issue with 10 sub-tasks.
+- One small, identical work unit per repo - file as 10 issues or a tracking issue with 10 sub-tasks.
 
 ## Labels
 `ci`, `tier-2`, `core`, `ops`, `coordination`, `adr-0044`, `wave-2`
 
 ## Agent Handoff
 
-**Objective:** Enable the cloud reviewer on the 10 remaining live .NET Nodes — `.honeydrunk-review.yaml` (`enabled: true`) + `pr-review.yml` caller per repo. Exclude private revenue Nodes.
+**Objective:** Enable the OpenClaw/Codex Grid Review Runner on the 10 remaining live .NET Nodes - `.honeydrunk-review.yaml` (`enabled: true`) + `pr-review.yml` caller per repo. Exclude private revenue Nodes.
 
 **Target:** Coordination/tracking issue in `HoneyDrunk.Architecture`, with one child issue per Node repo; each child branches from `main` in its own repo.
 
@@ -101,12 +102,12 @@ None. This packet adds YAML config and a caller workflow per repo; no .NET proje
 **Acceptance Criteria:** As listed above.
 
 **Dependencies:**
-- `packet:06` (hard), `packet:07` (hard), `packet:08` (hard), `packet:09` (soft), `packet:10` (soft).
+- `packet:06b` (hard), `packet:07` (hard), `packet:08` (hard), `packet:09` (soft), `packet:10` (soft).
 
 **Constraints:**
 - Gated on a documented Phase-1 "go".
 - Private revenue Nodes excluded; advisory only.
-- Pinned 10-repo list — do not add Observe, Architecture, or Studios.
+- Pinned 10-repo list - do not add Observe, Architecture, or Studios.
 
 **Key Files (per repo):**
 - `.honeydrunk-review.yaml` (new, repo root)
@@ -114,4 +115,4 @@ None. This packet adds YAML config and a caller workflow per repo; no .NET proje
 - the repo PR template
 - `CHANGELOG.md`
 
-**Contracts:** Consumes `job-review-agent.yml` (`workflow_call`) and the `.honeydrunk-review.yaml` v1 schema.
+**Contracts:** Consumes `job-review-request.yml` (`workflow_call`) and the `.honeydrunk-review.yaml` v1 schema.

--- a/generated/issue-packets/active/adr-0044-cloud-code-review/13-architecture-review-risk-class-catalog-field.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/13-architecture-review-risk-class-catalog-field.md
@@ -15,10 +15,10 @@ node: honeydrunk-architecture
 # Add the review_risk_class field to catalogs/grid-health.json
 
 ## Summary
-Add a new `review_risk_class` field to the per-Node entries in `catalogs/grid-health.json` and populate it, so the cloud reviewer can auto-detect high-risk-Node touches and trigger D8's multi-perspective review without amending the ADR each time the high-risk list changes.
+Add a new `review_risk_class` field to the per-Node entries in `catalogs/grid-health.json` and populate it, so the Grid Review Runner can auto-detect high-risk-Node touches and trigger D8's multi-perspective review without amending the ADR each time the high-risk list changes.
 
 ## Context
-ADR-0044 D8 requires a non-`human` PR touching a high-risk Node to receive two independent LLM-review perspectives before merge. The ADR deliberately keeps the catalog of high-risk Nodes in `catalogs/grid-health.json` under a new `review_risk_class` field "so the list evolves with the Grid without amending this ADR." This is the data dependency Phase 3 (D8 activation, packet 14) is gated on — `job-review-agent.yml` reads this field to decide whether to escalate to Opus + a contrarian second pass. This packet adds and populates the field; packet 14 wires the workflow to consume it.
+ADR-0044 D8 requires a non-`human` PR touching a high-risk Node to receive two independent LLM-review perspectives before merge. The ADR deliberately keeps the catalog of high-risk Nodes in `catalogs/grid-health.json` under a new `review_risk_class` field "so the list evolves with the Grid without amending this ADR." This is the data dependency Phase 3 (D8 activation, packet 14) is gated on — the Grid Review Runner reads this field to decide whether to run a higher-attention first pass plus a contrarian second pass. This packet adds and populates the field; packet 14 wires the workflow to consume it.
 
 ## Scope
 - `catalogs/grid-health.json` — add `review_risk_class` to every Node entry and populate.
@@ -80,7 +80,7 @@ None. Pure Architecture-repo catalog edit.
 
 ## Referenced ADR Decisions
 
-**ADR-0044 D8** — High-risk Nodes (Kernel `*.Abstractions`, Vault secret handling, Auth token/principal/Audit-boundary, Audit append-only guarantee, Billing any change, any `.Cloud` revenue Node any change). The catalog of high-risk Nodes lives in `catalogs/grid-health.json` under `review_risk_class` so the list evolves without amending the ADR. The workflow auto-detects high-risk touches and escalates to Opus + a contrarian second pass.
+**ADR-0044 D8** — High-risk Nodes (Kernel `*.Abstractions`, Vault secret handling, Auth token/principal/Audit-boundary, Audit append-only guarantee, Billing any change, any `.Cloud` revenue Node any change). The catalog of high-risk Nodes lives in `catalogs/grid-health.json` under `review_risk_class` so the list evolves without amending the ADR. The runner auto-detects high-risk touches and escalates to a higher-attention first pass plus a contrarian second pass.
 **ADR-0030** — Audit append-only-by-interface guarantee (Phase 1).
 **ADR-0031** — Auth/Audit emit boundary.
 **ADR-0035** — `*.Abstractions` ABI cascade rules.
@@ -101,7 +101,7 @@ None. Pure Architecture-repo catalog edit.
 **Target:** `HoneyDrunk.Architecture`, branch from `main`.
 
 **Context:**
-- Goal: Provide the data the cloud reviewer reads to decide D8 multi-perspective escalation. Phase 3 (packet 14) is gated on this field.
+- Goal: Provide the data the Grid Review Runner reads to decide D8 multi-perspective escalation. Phase 3 (packet 14) is gated on this field.
 - Feature: ADR-0044 Cloud Code Review rollout, Phase 3.
 - ADRs: ADR-0044 (D8), ADR-0030, ADR-0031, ADR-0035, ADR-0037.
 
@@ -116,4 +116,4 @@ None. Pure Architecture-repo catalog edit.
 **Key Files:**
 - `catalogs/grid-health.json`
 
-**Contracts:** Defines the `review_risk_class` field consumed by `job-review-agent.yml` (packet 14).
+**Contracts:** Defines the `review_risk_class` field consumed by the Grid Review Runner / `job-review-request.yml` path (packet 14).

--- a/generated/issue-packets/active/adr-0044-cloud-code-review/14-actions-d8-multi-perspective-review.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/14-actions-d8-multi-perspective-review.md
@@ -4,7 +4,7 @@ type: ci-change
 tier: 2
 target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
 labels: ["ci", "tier-2", "ops", "adr-0044", "wave-3"]
-dependencies: ["packet:03", "packet:13"]
+dependencies: ["packet:03b", "packet:13"]
 adrs: ["ADR-0044"]
 accepts: ["ADR-0044"]
 wave: 3
@@ -15,14 +15,14 @@ node: honeydrunk-actions
 # Activate D8 multi-perspective review for high-risk-Node PRs
 
 ## Summary
-Extend `job-review-agent.yml` so that a non-`human` PR touching a high-risk Node — detected via the `review_risk_class` field in `catalogs/grid-health.json` — switches the first pass to Opus and automatically runs a second, contrarian-prompt pass as an independent session, posted as a separate comment.
+Extend the `job-review-request.yml` / OpenClaw runner path so that a non-`human` PR touching a high-risk Node - detected via the `review_risk_class` field in `catalogs/grid-health.json` - switches the first pass to the highest-quality locally available review profile and automatically runs a second, contrarian-prompt pass as an independent session, posted as a separate comment.
 
 ## Target Workflow
-**File:** `.github/workflows/job-review-agent.yml`
+**Files:** `.github/workflows/job-review-request.yml` and the Architecture-owned OpenClaw runner config/runbook
 **Family:** pr-core
 
 ## Motivation
-ADR-0044 D8 requires a non-`human` PR touching a high-risk Node to receive two independent LLM-review perspectives before merge. Phase 3 (D11) activates D8 "once `review_risk_class` lands in `catalogs/grid-health.json`" — that field is delivered by packet 13. This packet wires `job-review-agent.yml` to consume the field and escalate. Two same-agent passes is the default because it is cheapest and automatic; `/ultrareview` and a `refine` pass are alternative escalation paths the human may invoke instead.
+ADR-0044 D8 requires a non-`human` PR touching a high-risk Node to receive two independent LLM-review perspectives before merge. Phase 3 (D11) activates D8 "once `review_risk_class` lands in `catalogs/grid-health.json`" - that field is delivered by packet 13. This packet wires the request/runner path to consume the field and escalate. Two same-runner passes is the default because it is cheapest and automatic under OpenClaw/Codex; `/ultrareview` and a `refine` pass are alternative escalation paths the human may invoke instead.
 
 ## Proposed Change
 
@@ -34,48 +34,48 @@ ADR-0044 D8 requires a non-`human` PR touching a high-risk Node to receive two i
 
 ### Escalation behavior (per D8)
 When a high-risk touch is detected on a non-`human` PR:
-- **First pass switches to Opus** — overrides the `model` default for this PR.
+- **First pass switches to the highest-quality locally available review profile** - overrides the `model` default for this PR.
 - **A second pass runs automatically** using a deliberately contrarian prompt ("identify ways the first reviewer was wrong"). The two passes are **independent sessions**, posted as **separate comments**.
 - The PR body's recorded escalation path notes "two same-agent passes (default)". If the human invoked `/ultrareview` or a `refine` pass instead, the workflow respects that and does not double-run.
 
 ### PR-size discipline tightening (D11 Phase 3)
-ADR-0044 D11 Phase 3 also moves PR-size discipline "from warnings to auto-comments at the > 800 threshold." Packet 07 shipped `pr-size-check` with the `> 800` path warnings-only and a documented single-point toggle. **This packet flips that toggle** — at `> 800`, `pr-size-check` now auto-comments requesting a split or `refine` pass as the standard behavior (still not a hard merge block — the PR can merge on a logged human override per D7). Make the `pr-core.yml` change here so the Phase-3 discipline tightening lands atomically with D8 activation.
+ADR-0044 D11 Phase 3 also moves PR-size discipline "from warnings to auto-comments at the > 800 threshold." Packet 07 shipped `pr-size-check` with the `> 800` path warnings-only and a documented single-point toggle. **This packet flips that toggle** - at `> 800`, `pr-size-check` now auto-comments requesting a split or `refine` pass as the standard behavior (still not a hard merge block - the PR can merge on a logged human override per D7). Make the `pr-core.yml` change here so the Phase-3 discipline tightening lands atomically with D8 activation.
 
 ## Consumer Impact
-- High-risk-Node PRs now cost more (Opus + a second pass) — this is the intended D8 cost-for-safety trade. Standard-Node PRs are unaffected.
+- High-risk-Node PRs now spend more review budget/latency (higher-attention pass + a second pass) - this is the intended D8 cost-for-safety trade. Standard-Node PRs are unaffected.
 - The `> 800` PR-size auto-comment now posts as standard Phase-3 behavior across every `pr-core.yml` consumer.
 
 ## Breaking Change?
 - [ ] Yes
-- [x] No — escalation is additive and advisory; the `> 800` change is a posture shift within an existing job, still non-blocking.
+- [x] No - escalation is additive and advisory; the `> 800` change is a posture shift within an existing job, still non-blocking.
 
 ## Acceptance Criteria
-- [ ] `job-review-agent.yml` reads `review_risk_class` from `catalogs/grid-health.json` and resolves the target repo's class
+- [ ] the request/runner path reads `review_risk_class` from `catalogs/grid-health.json` and resolves the target repo's class
 - [ ] `"trigger": "any"` and `"trigger": "path"` (diff-glob match) detection both work; `human` PRs never trigger D8
-- [ ] On a high-risk non-`human` PR: the first pass uses Opus; a second contrarian-prompt pass runs as an independent session posted as a separate comment
+- [ ] On a high-risk non-`human` PR: the first pass uses the highest-quality locally available review profile; a second contrarian-prompt pass runs as an independent session posted as a separate comment
 - [ ] The PR records which escalation path was used; `/ultrareview` or `refine` invoked by the human suppresses the auto double-run
 - [ ] `pr-size-check`'s `> 800` path is flipped from warnings-only to auto-comment (Phase-3 tightening); still non-blocking with a logged-override path
 - [ ] `docs/CHANGELOG.md` updated; `docs/consumer-usage.md` notes the Phase-3 behavior changes
 
 ## Human Prerequisites
 - [ ] The Phase-2 → Phase-3 go decision must be made; D8 activation should follow observed Phase-2 review quality
-- [ ] Confirm the Anthropic workspace can absorb Opus-rate spend on high-risk PRs within the D5 cost ceiling
+- [ ] Confirm OpenClaw/Codex can run two independent passes for high-risk PRs within acceptable latency
 
 ## Dependencies
-- `packet:03` — `job-review-agent.yml` (**hard** — this packet extends it).
-- `packet:13` — `review_risk_class` catalog field (**hard** — D8 activation is explicitly gated on this field landing).
+- `packet:03b` - `job-review-request.yml` / OpenClaw runner trigger path (**hard** - this packet extends it).
+- `packet:13` - `review_risk_class` catalog field (**hard** - D8 activation is explicitly gated on this field landing).
 
 ## Referenced ADR Decisions
 
-**ADR-0044 D8** — Non-`human` PRs touching a high-risk Node get two independent LLM-review perspectives; the workflow switches to Opus for the first pass and auto-runs a contrarian second pass as a separate session/comment. High-risk catalog lives in `catalogs/grid-health.json` `review_risk_class`. `/ultrareview` and `refine` are alternative human-invoked escalation paths.
-**ADR-0044 D11 Phase 3** — D8 activates once `review_risk_class` lands; PR-size discipline moves from warnings to auto-comments at the `> 800` threshold.
-**ADR-0044 D7** — `> 800` lines: CI auto-comments requesting a split or `refine`; the PR can still merge on a logged human override.
+**ADR-0044 D8** - Non-`human` PRs touching a high-risk Node get two independent LLM-review perspectives; the runner uses the highest-quality locally available review profile for the first pass and auto-runs a contrarian second pass as a separate session/comment. High-risk catalog lives in `catalogs/grid-health.json` `review_risk_class`. `/ultrareview` and `refine` are alternative human-invoked escalation paths.
+**ADR-0044 D11 Phase 3** - D8 activates once `review_risk_class` lands; PR-size discipline moves from warnings to auto-comments at the `> 800` threshold.
+**ADR-0044 D7** - `> 800` lines: CI auto-comments requesting a split or `refine`; the PR can still merge on a logged human override.
 
 ## Constraints
-> **Invariant 31:** Every PR traverses the tier-1 gate before merge. D8's second pass and the `> 800` auto-comment are advisory — neither becomes a required check.
+> **Invariant 31:** Every PR traverses the tier-1 gate before merge. D8's second pass and the `> 800` auto-comment are advisory - neither becomes a required check.
 
-- **Two same-agent passes is the default.** Do not implement `/ultrareview` or `refine` as the automatic path — they are human-invoked alternatives.
-- **Independent sessions.** The contrarian pass must be a fresh session, not a continuation of the first — independence is the point.
+- **Two same-agent passes is the default.** Do not implement `/ultrareview` or `refine` as the automatic path - they are human-invoked alternatives.
+- **Independent sessions.** The contrarian pass must be a fresh session, not a continuation of the first - independence is the point.
 - **`> 800` stays non-blocking.** Phase 3 tightens it to an auto-comment, not a hard gate; the logged-override merge path is preserved per D7.
 
 ## Labels
@@ -83,26 +83,26 @@ ADR-0044 D11 Phase 3 also moves PR-size discipline "from warnings to auto-commen
 
 ## Agent Handoff
 
-**Objective:** Activate D8 multi-perspective review in `job-review-agent.yml` (Opus first pass + contrarian second pass on high-risk-Node non-`human` PRs) and flip `pr-size-check`'s `> 800` path to auto-comment (Phase-3 tightening).
+**Objective:** Activate D8 multi-perspective review in the OpenClaw runner path (higher-attention first pass + contrarian second pass on high-risk-Node non-`human` PRs) and flip `pr-size-check`'s `> 800` path to auto-comment (Phase-3 tightening).
 
 **Target:** `HoneyDrunk.Actions`, branch from `main`.
 
 **Context:**
-- Goal: Phase-3 discipline tightening — multi-perspective review for high-risk Nodes, harder PR-size posture.
+- Goal: Phase-3 discipline tightening - multi-perspective review for high-risk Nodes, harder PR-size posture.
 - Feature: ADR-0044 Cloud Code Review rollout, Phase 3.
 - ADRs: ADR-0044 (D8, D7, D11 Phase 3).
 
 **Acceptance Criteria:** As listed above.
 
 **Dependencies:**
-- `packet:03` — `job-review-agent.yml` (hard).
-- `packet:13` — `review_risk_class` field (hard).
+- `packet:03b` - `job-review-request.yml` / OpenClaw runner trigger path (hard).
+- `packet:13` - `review_risk_class` field (hard).
 
 **Constraints:**
 - Two same-agent passes is the default; independent sessions; `> 800` stays non-blocking.
 
 **Key Files:**
-- `.github/workflows/job-review-agent.yml`
+- `.github/workflows/job-review-request.yml`
 - `.github/workflows/pr-core.yml` (the `pr-size-check` `> 800` toggle)
 - `docs/CHANGELOG.md`, `docs/consumer-usage.md`
 

--- a/generated/issue-packets/active/adr-0044-cloud-code-review/16-actions-audit-sample-post-merge-job.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/16-actions-audit-sample-post-merge-job.md
@@ -4,7 +4,7 @@ type: ci-change
 tier: 2
 target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
 labels: ["ci", "tier-2", "ops", "adr-0044", "wave-4"]
-dependencies: ["packet:02", "packet:03", "packet:08", "packet:15"]
+dependencies: ["packet:02b", "packet:03b", "packet:08", "packet:15"]
 adrs: ["ADR-0044", "ADR-0043"]
 accepts: ["ADR-0044"]
 wave: 4
@@ -15,38 +15,38 @@ node: honeydrunk-actions
 # Build the D9 audit-sample post-merge labeling and audit job
 
 ## Summary
-Build the post-merge job that selects every Nth agent-authored merged PR, labels it `audit-sample`, runs `/ultrareview` against the merged diff, and commits the audit report to `generated/post-merge-audits/` in `HoneyDrunk.Architecture` — activating ADR-0044 D9's sampling audit (Phase 4).
+Build the post-merge job that selects every Nth agent-authored merged PR, labels it `audit-sample`, runs `/ultrareview` against the merged diff, and commits the audit report to `generated/post-merge-audits/` in `HoneyDrunk.Architecture` - activating ADR-0044 D9's sampling audit (Phase 4).
 
 ## Target Workflow
 **File:** a new post-merge workflow (e.g. `.github/workflows/job-audit-sample.yml`) and its caller wiring
 **Family:** post-merge / manual
 
 ## Motivation
-ADR-0044 D9 establishes a post-merge sampling audit that measures the review process's own quality — without this loop, review-process drift would surface only as production incidents. D11 Phase 4 activates D9. The job: select every Nth agent-authored merged PR (N=10 to start, tunable via the weekly briefing per ADR-0043), label it `audit-sample`, run `/ultrareview` against the merged diff, commit the report, and convert `Block`/`Request Changes` findings into Reactive packets.
+ADR-0044 D9 establishes a post-merge sampling audit that measures the review process's own quality - without this loop, review-process drift would surface only as production incidents. D11 Phase 4 activates D9. The job: select every Nth agent-authored merged PR (N=10 to start, tunable via the weekly briefing per ADR-0043), label it `audit-sample`, run `/ultrareview` against the merged diff, commit the report, and convert `Block`/`Request Changes` findings into Reactive packets.
 
 ## Proposed Change
 
 ### Selection + labeling
 - Triggered on PR `closed` with `merged == true`.
-- The job determines the PR's authorship class (from the `Authorship:` line — only `agent-*` and `mixed` PRs are eligible; `human` PRs are not sampled, per D9 "every Nth agent-authored merged PR").
-- It maintains a counter of agent-authored merges; every Nth (N=10 default, read from a single configurable constant — the weekly briefing tunes it per ADR-0043) the PR is selected.
+- The job determines the PR's authorship class (from the `Authorship:` line - only `agent-*` and `mixed` PRs are eligible; `human` PRs are not sampled, per D9 "every Nth agent-authored merged PR").
+- It maintains a counter of agent-authored merges; every Nth (N=10 default, read from a single configurable constant - the weekly briefing tunes it per ADR-0043) the PR is selected.
 - The selected PR is labeled `audit-sample` (the label exists Grid-wide via packet 08).
 
 ### Audit run
 - For a selected PR, the job runs `/ultrareview` against the merged PR's diff (deeper multi-agent cloud review, billed separately per D8's `/ultrareview` reference).
-- The audit job reuses the **Claude Agent SDK** runtime. It must pin the SDK to the **exact same version recorded by packet 03** — read the pin from the "Claude Agent SDK version pin" heading in `docs/consumer-usage.md` (this repo, where packet 03 records it) and use that exact version in `job-audit-sample.yml`. Do not pick a different or floating version; review and audit must run on the same SDK so their behavior is comparable. If packet 03's pin is later bumped, this job's pin moves with it.
-- The output is committed to `HoneyDrunkStudios/HoneyDrunk.Architecture` at `generated/post-merge-audits/{YYYY-MM-DD}-{repo}-{pr-number}.md` (directory created by packet 15). The commit uses the GitHub App token from packet 02. **Packet 02 provisions that App with `Contents: Write` on `HoneyDrunk.Architecture` up front** (a developer decision recorded in packet 02) precisely so this audit-commit step has the scope it needs — no permission widening is required at this packet's execution time. The token is resolved from the same CI-surface Vault secrets (`review-agent-github-app-id` / `-private-key` / `-installation-id`).
+- The audit job reuses the same OpenClaw/Codex Grid Review Runner prompt/runtime contract as the PR reviewer. It must consume `.claude/agents/review.md` rather than copying prompt text, and any local runner version/profile pin should be read from the Architecture runner config introduced by packet 02b.
+- The output is committed to `HoneyDrunkStudios/HoneyDrunk.Architecture` at `generated/post-merge-audits/{YYYY-MM-DD}-{repo}-{pr-number}.md` (directory created by packet 15). The commit uses the GitHub App token from packet 02. **Packet 02 provisions that App with `Contents: Write` on `HoneyDrunk.Architecture` up front** (a developer decision recorded in packet 02) precisely so this audit-commit step has the scope it needs - no permission widening is required at this packet's execution time. The token is resolved from the same CI-surface Vault secrets (`review-agent-github-app-id` / `-private-key` / `-installation-id`).
 
 ### Reactive-packet conversion
 - Findings at `Block` or `Request Changes` severity become Reactive packets per ADR-0043's Reactive source taxonomy. If ADR-0043's Reactive pipeline is live, emit into it; if not, the job opens a tracking issue tagged for Reactive-packet scoping and the dispatch plan notes the dependency.
 
 ## Consumer Impact
-- Every repo's merged agent PRs are eligible for sampling — but only 1-in-N is audited, so per-repo cost impact is small.
+- Every repo's merged agent PRs are eligible for sampling - but only 1-in-N is audited, so per-repo cost impact is small.
 - Audit reports accumulate in `HoneyDrunk.Architecture/generated/post-merge-audits/`.
 
 ## Breaking Change?
 - [ ] Yes
-- [x] No — post-merge, additive; does not affect the PR pipeline or merges.
+- [x] No - post-merge, additive; does not affect the PR pipeline or merges.
 
 ## Acceptance Criteria
 - [ ] A post-merge job triggers on PR `closed` + `merged`, eligible only for `agent-*`/`mixed` authorship
@@ -54,42 +54,42 @@ ADR-0044 D9 establishes a post-merge sampling audit that measures the review pro
 - [ ] The job runs `/ultrareview` against the selected merged PR's diff
 - [ ] The audit report commits to `HoneyDrunk.Architecture/generated/post-merge-audits/{YYYY-MM-DD}-{repo}-{pr-number}.md`
 - [ ] `Block`/`Request Changes` findings convert to Reactive packets (via ADR-0043's pipeline if live, else a tracking issue)
-- [ ] `job-audit-sample.yml` pins the Claude Agent SDK to the exact version recorded by packet 03 in `docs/consumer-usage.md` — no separate or floating version
+- [ ] `job-audit-sample.yml` uses the same OpenClaw/Codex runner config/prompt contract as packet 02b/03b - no copied prompt or separate provider choice
 - [ ] `docs/CHANGELOG.md` updated; `docs/consumer-usage.md` notes the post-merge audit job
 - [ ] N is documented as tunable via the weekly briefing per ADR-0043
 
 ## Human Prerequisites
-- [ ] Confirm packet 02 provisioned the GitHub App with `Contents: Write` on `HoneyDrunk.Architecture` (it does so by design — this is a hard dependency). If for any reason the App was provisioned `Read`-only, widen it before this job runs and update `infrastructure/review-agent-credentials-setup.md`.
+- [ ] Confirm packet 02 provisioned the GitHub App with `Contents: Write` on `HoneyDrunk.Architecture` (it does so by design - this is a hard dependency). If for any reason the App was provisioned `Read`-only, widen it before this job runs and update `infrastructure/review-agent-credentials-setup.md`.
 - [ ] Confirm `/ultrareview` is available as an invocable surface from CI and confirm its separate billing is acceptable within the D5 cost ceiling
 - [ ] Decide the initial N (D9 says 10) and where the constant lives
 
 ## Dependencies
-- `packet:02` — review-agent GitHub App (**hard** — the audit-commit step writes into `HoneyDrunk.Architecture`; it needs the App provisioned with `Contents: Write` and its credentials in Vault).
-- `packet:03` — `job-review-agent.yml` (soft — shares the Claude Agent SDK runtime and credential plumbing).
-- `packet:08` — Grid-wide labels (**hard** — `audit-sample` must exist before the job applies it).
-- `packet:15` — `generated/post-merge-audits/` directory (**hard** — the audit report has nowhere to commit without it).
+- `packet:02b` - OpenClaw runner config and write-back/auth approach (**hard** - the audit step writes reports into `HoneyDrunk.Architecture` using the documented local `gh` auth or optional GitHub App path).
+- `packet:03b` - `job-review-request.yml` / runner trigger path (soft - shares the review request and runner contract).
+- `packet:08` - Grid-wide labels (**hard** - `audit-sample` must exist before the job applies it).
+- `packet:15` - `generated/post-merge-audits/` directory (**hard** - the audit report has nowhere to commit without it).
 
 ## Referenced ADR Decisions
 
-**ADR-0044 D9** — Every Nth agent-authored merged PR (N=10, tunable via the weekly briefing) is `audit-sample`-labeled at merge; the audit runs `/ultrareview`; output commits to `generated/post-merge-audits/{YYYY-MM-DD}-{repo}-{pr-number}.md`; `Block`/`Request Changes` findings become Reactive packets per ADR-0043; the audit measures review-process quality, feeding back into `review.md` and the ADR.
-**ADR-0044 D11 Phase 4** — D9 activates in Phase 4.
-**ADR-0043** — Reactive source taxonomy; the weekly briefing tunes N.
+**ADR-0044 D9** - Every Nth agent-authored merged PR (N=10, tunable via the weekly briefing) is `audit-sample`-labeled at merge; the audit runs `/ultrareview`; output commits to `generated/post-merge-audits/{YYYY-MM-DD}-{repo}-{pr-number}.md`; `Block`/`Request Changes` findings become Reactive packets per ADR-0043; the audit measures review-process quality, feeding back into `review.md` and the ADR.
+**ADR-0044 D11 Phase 4** - D9 activates in Phase 4.
+**ADR-0043** - Reactive source taxonomy; the weekly briefing tunes N.
 
 ## Constraints
-> **Invariant 8:** Secret values never appear in logs. The GitHub App credentials and Anthropic key used by the audit job must never be echoed.
+> **Invariant 8:** Secret values never appear in logs. Any GitHub App/webhook credentials used by the audit job must never be echoed. No Anthropic key is required for v1.
 
 > **Invariant 9:** Vault is the only source of secrets. The audit-commit credential is resolved from Vault via the CI secrets surface.
 
 - **Only agent-authored PRs are sampled.** `human` PRs are not part of the D9 population.
 - **N is a single configurable constant.** The weekly briefing tunes it; do not hardcode it in multiple places.
-- The cross-repo audit-commit uses packet 02's GitHub App, which is provisioned with `Contents: Write` on `HoneyDrunk.Architecture` — resolve its token from the CI-surface Vault secrets, never hardcode.
+- The cross-repo audit-commit uses packet 02's GitHub App, which is provisioned with `Contents: Write` on `HoneyDrunk.Architecture` - resolve its token from the CI-surface Vault secrets, never hardcode.
 
 ## Labels
 `ci`, `tier-2`, `ops`, `adr-0044`, `wave-4`
 
 ## Agent Handoff
 
-**Objective:** Build the D9 post-merge `audit-sample` job — select every Nth agent-authored merged PR, label it, run `/ultrareview`, commit the report to `generated/post-merge-audits/`, and convert serious findings to Reactive packets.
+**Objective:** Build the D9 post-merge `audit-sample` job - select every Nth agent-authored merged PR, label it, run `/ultrareview`, commit the report to `generated/post-merge-audits/`, and convert serious findings to Reactive packets.
 
 **Target:** `HoneyDrunk.Actions`, branch from `main`.
 
@@ -101,7 +101,7 @@ ADR-0044 D9 establishes a post-merge sampling audit that measures the review pro
 **Acceptance Criteria:** As listed above.
 
 **Dependencies:**
-- `packet:02` (hard — App with `Contents: Write`), `packet:03` (soft), `packet:08` (hard), `packet:15` (hard).
+- `packet:02b` (hard - runner write-back/auth approach), `packet:03b` (soft), `packet:08` (hard), `packet:15` (hard).
 
 **Constraints:**
 - Only agent PRs sampled; N is one configurable constant; the cross-repo audit-commit uses packet 02's `Contents: Write` App.

--- a/generated/issue-packets/active/adr-0044-cloud-code-review/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/dispatch-plan.md
@@ -1,134 +1,138 @@
-# Dispatch Plan: Cloud Code Review (ADR-0044)
+# Dispatch Plan: Automatic Grid Review Runner (ADR-0044)
 
 **Date:** 2026-05-22 (initial scope).
-**Trigger:** ADR-0044 (Grid-Aware Cloud Code Review and AI-Authored PR Discipline) — Proposed 2026-05-21; scoped 2026-05-22 ahead of formal acceptance (priority #3 on `current-focus.md`).
+**Trigger:** ADR-0044 (Grid-Aware Cloud Code Review and AI-Authored PR Discipline) - Proposed 2026-05-21; scoped 2026-05-22 ahead of formal acceptance (priority #3 on `current-focus.md`).
 **Type:** Multi-repo (HoneyDrunk.Architecture + HoneyDrunk.Actions + the 10 remaining live .NET Nodes via packet 11's fan-out).
 **Sector:** Meta (governance + agent definitions) + Ops (CI workflows in HoneyDrunk.Actions).
-**Status:** **Draft — pending ADR-0044 acceptance.** These packets are NOT to be filed as GitHub Issues until ADR-0044 is Accepted (packet 01 is the mechanically-coupled acceptance flip). Filing is the `file-issues` agent's job, post-acceptance.
+**Status:** **Draft - pending ADR-0044 acceptance.** These packets are NOT to be filed as GitHub Issues until ADR-0044 is Accepted (packet 01 is the mechanically-coupled acceptance flip). Filing is the `file-issues` agent's job, post-acceptance.
 **Site sync required:** No. ADR-0044 produces CI tooling and governance docs; nothing public-facing on the Studios site today.
-**Rollback plan:** Every Architecture-repo packet (01, 02, 04, 05, 06, 09, 10, 12, 13, 15, 17) is docs/catalog/YAML and reverts cleanly via `git revert`. The Actions-repo workflow packets (03, 07, 08, 14, 16) are additive — `job-review-agent.yml`, `job-audit-sample.yml`, and the new `pr-core.yml` jobs are reverted by removing them. Packet 11 (the 10-Node cross-repo fan-out) reverts per repo: setting a Node's `.honeydrunk-review.yaml` to `enabled: false` (or removing it) makes the reviewer go silent on that repo immediately — the enabled gate is the per-repo kill switch. The phased rollout (D11) is itself the blast-radius control — each phase is a discrete go/no-go.
+**Rollback plan:** Every Architecture-repo packet (01, 02b, 04, 05b, 06b, 09, 10, 12, 13, 15, 17) is docs/catalog/YAML and reverts cleanly via `git revert`. The Actions-repo workflow packets (03, 07, 08, 14, 16) are additive - `job-review-request.yml`, `job-audit-sample.yml`, and the new `pr-core.yml` jobs are reverted by removing them. Packet 11 (the 10-Node cross-repo fan-out) reverts per repo: setting a Node's `.honeydrunk-review.yaml` to `enabled: false` (or removing it) makes the reviewer go silent on that repo immediately - the enabled gate is the per-repo kill switch. The phased rollout (D11) is itself the blast-radius control - each phase is a discrete go/no-go.
 
 ## Summary
 
-ADR-0044 fills an empty slot: "automatic Grid-aware LLM reviewer." It cloud-wires the existing local `review` agent (`.claude/agents/review.md`) into a GitHub Action, adds AI-authored PR discipline (authorship classification, PR-size caps, multi-perspective review for high-risk Nodes, post-merge sampling audit), and binds a twenty-category review rubric as the Grid's shared authoring + review standard. It amends ADR-0011 (reverses the local-only posture, renders the CodeRabbit rejection moot).
+ADR-0044 fills an empty slot: "automatic Grid-aware LLM reviewer." It wires GitHub Actions as the request rail for an OpenClaw/Codex Grid Review Runner that consumes `.claude/agents/review.md`, adds AI-authored PR discipline (authorship classification, PR-size caps, multi-perspective review for high-risk Nodes, post-merge sampling audit), and binds a twenty-category review rubric as the Grid's shared authoring + review standard. It amends ADR-0011 (reverses the local-only posture, renders the CodeRabbit rejection moot).
 
-This initiative ships **seventeen packets across four waves** mapped 1:1 to ADR-0044 D11's four phases. Packets 01 and 02 were authored in a prior scope pass; packets 03-17 are added here.
+This initiative ships **twenty-one packets across four waves (including 02b/03b/05b/06b supersession packets)** mapped 1:1 to ADR-0044 D11's four phases. Packets 01 and 02 were authored in a prior scope pass; packets 03-17 are added here.
 
 ## Phase ↔ Wave mapping
 
-ADR-0044 D11's four phases map directly to the four waves. Each phase is a **discrete go/no-go** — Phase 1's exit criterion ("cloud verdicts at least as useful as the local agent's, at acceptable cost") gates Phase 2; missing it stops the rollout.
+ADR-0044 D11's four phases map directly to the four waves. Each phase is a **discrete go/no-go** - Phase 1's exit criterion ("cloud verdicts at least as useful as the local agent's, at acceptable cost") gates Phase 2; missing it stops the rollout.
 
 ## Wave Diagram
 
-### Wave 1 — Phase 1: MVP on the Architecture pilot repo
+### Wave 1 - Phase 1: MVP on the Architecture pilot repo
 
 Packet 01 first (the acceptance flip). Then 02-05 in parallel; 06 after 03/04/05.
 
-- [ ] `HoneyDrunk.Architecture`: **Accept ADR-0044** — flip status, finalize the two new invariants, ADR-0011 amendment note, register the initiative — [`01-architecture-adr-0044-acceptance.md`](01-architecture-adr-0044-acceptance.md)
-- [ ] `HoneyDrunk.Architecture`: **[Actor=Human]** Create the cross-repo-checkout GitHub App + provision the Anthropic API key in Vault — [`02-architecture-create-review-agent-github-app.md`](02-architecture-create-review-agent-github-app.md)
+- [ ] `HoneyDrunk.Architecture`: **Accept ADR-0044** - flip status, finalize the two new invariants, ADR-0011 amendment note, register the initiative - [`01-architecture-adr-0044-acceptance.md`](01-architecture-adr-0044-acceptance.md)
+- [x] **Superseded:** `packet:02` originally provisioned a GitHub App + Anthropic key. Replaced by `packet:02b`; do not execute the old filed issue.
+- [ ] `HoneyDrunk.Architecture`: Define the OpenClaw/Codex Grid Review Runner runtime - [`02b-architecture-openclaw-grid-review-runner.md`](02b-architecture-openclaw-grid-review-runner.md)
   - Blocked by: `packet:01` (soft).
-- [ ] `HoneyDrunk.Actions`: Build `job-review-agent.yml` — the cloud-wired Grid-aware reviewer (D1/D2/D4/D5) — [`03-actions-job-review-agent-workflow.md`](03-actions-job-review-agent-workflow.md)
-  - Blocked by: `packet:01` (soft), `packet:02` (**hard** — credentials).
-- [ ] `HoneyDrunk.Architecture`: Update `review.md` with the D3 twenty-category rubric execution detail — [`04-architecture-review-md-twenty-category-rubric.md`](04-architecture-review-md-twenty-category-rubric.md) — **`current-focus.md` priority #7 (review.md half)**
+- [x] **Superseded:** `packet:03` originally built an Anthropic/Claude `job-review-agent.yml`. Replaced by `packet:03b`; do not execute the old filed issue.
+- [ ] `HoneyDrunk.Actions`: Build `job-review-request.yml` - the GitHub trigger rail for the OpenClaw reviewer - [`03b-actions-job-review-request-workflow.md`](03b-actions-job-review-request-workflow.md)
+  - Blocked by: `packet:01` (soft), `packet:02b` (**hard** - runner payload/schema).
+- [ ] `HoneyDrunk.Architecture`: Update `review.md` with the D3 twenty-category rubric execution detail - [`04-architecture-review-md-twenty-category-rubric.md`](04-architecture-review-md-twenty-category-rubric.md) - **`current-focus.md` priority #7 (review.md half)**
   - Blocked by: `packet:01` (soft).
-- [ ] `HoneyDrunk.Architecture`: Author the `.honeydrunk-review.yaml` v1 schema doc — [`05-architecture-review-config-schema-doc.md`](05-architecture-review-config-schema-doc.md)
+- [x] **Superseded:** `packet:05` documented the old Sonnet/Opus/API schema. Replaced by `packet:05b`; do not execute the old filed issue.
+- [ ] `HoneyDrunk.Architecture`: Author the OpenClaw-aware `.honeydrunk-review.yaml` v1 schema doc - [`05b-architecture-review-config-schema-openclaw.md`](05b-architecture-review-config-schema-openclaw.md)
   - Blocked by: `packet:01` (soft).
-- [ ] `HoneyDrunk.Architecture`: Enable the cloud reviewer on the Architecture repo (Phase 1 pilot) — [`06-architecture-enable-review-phase-1-pilot.md`](06-architecture-enable-review-phase-1-pilot.md)
-  - Blocked by: `packet:03` (hard), `packet:04` (hard), `packet:05` (soft).
+- [x] **Superseded:** `packet:06` enabled the old cloud/API reviewer. Replaced by `packet:06b`; do not execute the old filed issue.
+- [ ] `HoneyDrunk.Architecture`: Enable the OpenClaw/Codex reviewer on the Architecture repo (Phase 1 pilot) - [`06b-architecture-enable-openclaw-review-phase-1-pilot.md`](06b-architecture-enable-openclaw-review-phase-1-pilot.md)
+  - Blocked by: `packet:02b` (hard), `packet:03b` (hard), `packet:04` (hard), `packet:05b` (soft).
 
-**Wave 1 exit criterion (Phase 1 go/no-go):** the cloud-wired reviewer's verdicts on real Architecture-repo PRs are at least as useful as the local `review` agent's, at acceptable cost ($40-100/month Grid-wide projection holding). **If this bar is missed, Wave 2 does not start.**
+**Wave 1 exit criterion (Phase 1 go/no-go):** the OpenClaw/Codex runner verdicts on real Architecture-repo PRs are at least as useful as the manual `review` agent, the trigger path is reliable, reviewed-head-SHA tracking works, and incremental model cost stays near zero. **If this bar is missed, Wave 2 does not start.**
 
-### Wave 2 — Phase 2: Rollout to the 10 remaining live .NET Nodes + discipline foundations
+### Wave 2 - Phase 2: Rollout to the 10 remaining live .NET Nodes + discipline foundations
 
 Runs after the Phase-1 go decision. Packets 07-12.
 
-- [ ] `HoneyDrunk.Actions`: Add `authorship-check` + `pr-size-check` jobs to `pr-core.yml` (D6/D7, warnings-only) — [`07-actions-authorship-and-pr-size-checks.md`](07-actions-authorship-and-pr-size-checks.md)
+- [ ] `HoneyDrunk.Actions`: Add `authorship-check` + `pr-size-check` jobs to `pr-core.yml` (D6/D7, warnings-only) - [`07-actions-authorship-and-pr-size-checks.md`](07-actions-authorship-and-pr-size-checks.md)
   - Blocked by: `packet:01` (soft).
-- [ ] `HoneyDrunk.Actions`: Seed `large-pr`, `audit-sample`, `skip-review` labels Grid-wide — [`08-actions-seed-review-labels-grid-wide.md`](08-actions-seed-review-labels-grid-wide.md)
+- [ ] `HoneyDrunk.Actions`: Seed `large-pr`, `audit-sample`, `skip-review` labels Grid-wide - [`08-actions-seed-review-labels-grid-wide.md`](08-actions-seed-review-labels-grid-wide.md)
   - Blocked by: `packet:07` (soft).
-- [ ] `HoneyDrunk.Architecture`: Roll the D3 rubric into the upstream authoring agents (`scope`/`adr-composer`/`pdr-composer`/`refine`/`node-audit`) — [`09-architecture-d3-rubric-upstream-agent-rollout.md`](09-architecture-d3-rubric-upstream-agent-rollout.md) — **`current-focus.md` priority #7 (upstream half)**
-  - Blocked by: `packet:04` (**hard** — same category names/numbering).
-- [ ] `HoneyDrunk.Architecture`: Amend execution-surface prompts — emit `Authorship:` line + surface the D3 authoring checklist — [`10-architecture-execution-surface-authorship-and-rubric.md`](10-architecture-execution-surface-authorship-and-rubric.md)
+- [ ] `HoneyDrunk.Architecture`: Roll the D3 rubric into the upstream authoring agents (`scope`/`adr-composer`/`pdr-composer`/`refine`/`node-audit`) - [`09-architecture-d3-rubric-upstream-agent-rollout.md`](09-architecture-d3-rubric-upstream-agent-rollout.md) - **`current-focus.md` priority #7 (upstream half)**
+  - Blocked by: `packet:04` (**hard** - same category names/numbering).
+- [ ] `HoneyDrunk.Architecture`: Amend execution-surface prompts - emit `Authorship:` line + surface the D3 authoring checklist - [`10-architecture-execution-surface-authorship-and-rubric.md`](10-architecture-execution-surface-authorship-and-rubric.md)
   - Blocked by: `packet:04` (hard), `packet:07` (soft).
-- [ ] 10 live .NET Nodes (cross-repo, tracked from `HoneyDrunk.Architecture`): Enable the cloud reviewer on the 10 remaining live .NET Nodes — [`11-cross-repo-enable-review-ten-nodes.md`](11-cross-repo-enable-review-ten-nodes.md)
-  - Blocked by: `packet:06` (**hard** — Phase-1 go), `packet:07` (hard), `packet:08` (hard), `packet:09` (soft), `packet:10` (soft).
-- [ ] `HoneyDrunk.Architecture`: Verify `pr-review-rules.md` severity coverage across all twenty D3 categories — [`12-architecture-pr-review-rules-severity-coverage.md`](12-architecture-pr-review-rules-severity-coverage.md)
+- [ ] 10 live .NET Nodes (cross-repo, tracked from `HoneyDrunk.Architecture`): Enable the OpenClaw/Codex reviewer on the 10 remaining live .NET Nodes - [`11-cross-repo-enable-review-ten-nodes.md`](11-cross-repo-enable-review-ten-nodes.md)
+  - Blocked by: `packet:06b` (**hard** - Phase-1 go), `packet:07` (hard), `packet:08` (hard), `packet:09` (soft), `packet:10` (soft).
+- [ ] `HoneyDrunk.Architecture`: Verify `pr-review-rules.md` severity coverage across all twenty D3 categories - [`12-architecture-pr-review-rules-severity-coverage.md`](12-architecture-pr-review-rules-severity-coverage.md)
   - Blocked by: `packet:04` (hard).
 
 **Wave 2 exit criterion (Phase 2 go/no-go):** all 10 fan-out Nodes enabled (Architecture already piloted; Studios and Observe excluded; private revenue Nodes excluded); authorship classification mandatory and passing across the Grid; PR-size discipline visible (warnings-only); the D3 rubric present in all seven agent files; Phase-2 review quality reviewed before Phase 3.
 
-### Wave 3 — Phase 3: Discipline tightening
+### Wave 3 - Phase 3: Discipline tightening
 
 Runs after the Phase-2 go decision. Packets 13-14. **D8 is data-gated on packet 13.**
 
-- [ ] `HoneyDrunk.Architecture`: Add the `review_risk_class` field to `catalogs/grid-health.json` — [`13-architecture-review-risk-class-catalog-field.md`](13-architecture-review-risk-class-catalog-field.md)
+- [ ] `HoneyDrunk.Architecture`: Add the `review_risk_class` field to `catalogs/grid-health.json` - [`13-architecture-review-risk-class-catalog-field.md`](13-architecture-review-risk-class-catalog-field.md)
   - Blocked by: `packet:01` (soft).
-- [ ] `HoneyDrunk.Actions`: Activate D8 multi-perspective review for high-risk-Node PRs + flip `pr-size-check` `> 800` to auto-comment — [`14-actions-d8-multi-perspective-review.md`](14-actions-d8-multi-perspective-review.md)
-  - Blocked by: `packet:03` (hard), `packet:13` (**hard — D8 activation is explicitly gated on `review_risk_class` landing**).
+- [ ] `HoneyDrunk.Actions`: Activate D8 multi-perspective review for high-risk-Node PRs + flip `pr-size-check` `> 800` to auto-comment - [`14-actions-d8-multi-perspective-review.md`](14-actions-d8-multi-perspective-review.md)
+  - Blocked by: `packet:03b` (hard), `packet:13` (**hard - D8 activation is explicitly gated on `review_risk_class` landing**).
 
 **Wave 3 exit criterion (Phase 3 go/no-go):** `review_risk_class` populated; D8 escalation firing correctly on high-risk-Node PRs; `> 800` PR-size auto-comment live.
 
-### Wave 4 — Phase 4: Sampling audit + polish
+### Wave 4 - Phase 4: Sampling audit + polish
 
 Runs after the Phase-3 go decision. Packets 15-17.
 
-- [ ] `HoneyDrunk.Architecture`: Create `generated/post-merge-audits/` with a README — [`15-architecture-post-merge-audits-directory.md`](15-architecture-post-merge-audits-directory.md)
+- [ ] `HoneyDrunk.Architecture`: Create `generated/post-merge-audits/` with a README - [`15-architecture-post-merge-audits-directory.md`](15-architecture-post-merge-audits-directory.md)
   - Blocked by: `packet:01` (soft).
-- [ ] `HoneyDrunk.Actions`: Build the D9 `audit-sample` post-merge labeling + audit job — [`16-actions-audit-sample-post-merge-job.md`](16-actions-audit-sample-post-merge-job.md)
-  - Blocked by: `packet:03` (soft), `packet:08` (hard), `packet:15` (hard).
-- [ ] `HoneyDrunk.Architecture`: Wire `hive-sync` to detect D3↔agent-file drift — [`17-architecture-hive-sync-d3-drift-detection.md`](17-architecture-hive-sync-d3-drift-detection.md)
+- [ ] `HoneyDrunk.Actions`: Build the D9 `audit-sample` post-merge labeling + audit job - [`16-actions-audit-sample-post-merge-job.md`](16-actions-audit-sample-post-merge-job.md)
+  - Blocked by: `packet:03b` (soft), `packet:08` (hard), `packet:15` (hard).
+- [ ] `HoneyDrunk.Architecture`: Wire `hive-sync` to detect D3↔agent-file drift - [`17-architecture-hive-sync-d3-drift-detection.md`](17-architecture-hive-sync-d3-drift-detection.md)
   - Blocked by: `packet:04` (hard), `packet:09` (hard).
 
-**Wave 4 exit criterion (Phase 4 go/no-go):** D9 sampling audit running; audit reports landing in `generated/post-merge-audits/`; `hive-sync` drift detection live. ADR-0044's polish features (per-path config overrides, learnings, output-formatter improvements per D11) are **explicitly not scoped here** — each is its own follow-up packet against observed v1-v3 gaps.
+**Wave 4 exit criterion (Phase 4 go/no-go):** D9 sampling audit running; audit reports landing in `generated/post-merge-audits/`; `hive-sync` drift detection live. ADR-0044's polish features (per-path config overrides, learnings, output-formatter improvements per D11) are **explicitly not scoped here** - each is its own follow-up packet against observed v1-v3 gaps.
 
 ## Out-of-scope items from ADR-0044
 
-- **Per-path `path_instructions`-style config overrides** — D4/D11 explicitly defer to a v2 polish phase. No packet here.
-- **Learnings-from-prior-reviews and output-formatter polish** — D11 Phase 4 polish; each its own follow-up packet against observed gaps.
-- **The ADR-0011 amendment record / supersession note** — partially handled by packet 01's ADR-0011 amendment note; a fuller supersession record is a small follow-up if the human wants one.
-- **HoneyDrunk.Studios (TypeScript) onboarding** — evaluated separately from the .NET-shaped fan-out (packet 11).
-- **Private revenue (`.Cloud`) Node enablement** — excluded from the default v1 rollout per ADR-0044 Operational Consequences; explicit opt-in only.
+- **Per-path `path_instructions`-style config overrides** - D4/D11 explicitly defer to a v2 polish phase. No packet here.
+- **Learnings-from-prior-reviews and output-formatter polish** - D11 Phase 4 polish; each its own follow-up packet against observed gaps.
+- **The ADR-0011 amendment record / supersession note** - partially handled by packet 01's ADR-0011 amendment note; a fuller supersession record is a small follow-up if the human wants one.
+- **HoneyDrunk.Studios (TypeScript) onboarding** - evaluated separately from the .NET-shaped fan-out (packet 11).
+- **Private revenue (`.Cloud`) Node enablement** - excluded from the default v1 rollout per ADR-0044 Operational Consequences; explicit opt-in only.
 
 ## `current-focus.md` priority #7 correspondence
 
 `current-focus.md` priority #7 ("ADR-0044 D3 rubric rollout", gated on #3 = ADR-0044 landing) maps to **packet 04** (the `review.md` twenty-category rubric) **and packet 09** (the upstream `scope`/`adr-composer`/`pdr-composer`/`refine`/`node-audit` D3 sections). Packet 10 (execution-surface prompts) is the third leg of D3's upstream-awareness clause and belongs to the same priority-#7 family. These three packets together discharge priority #7.
 
-## `gh` CLI Commands — file post-acceptance only
+## `gh` CLI Commands - file post-acceptance only
 
 **Do not run these until ADR-0044 is Accepted (packet 01 merged).** The `file-issues` agent files them.
 
 ```bash
 PACKETS="generated/issue-packets/active/adr-0044-cloud-code-review"
 
-# Wave 1 — Phase 1
-gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Accept ADR-0044 — cloud code review, finalize new invariants, register initiative" --body-file $PACKETS/01-architecture-adr-0044-acceptance.md --label "chore,tier-3,meta,docs,adr-0044,wave-1"
-gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Create review-agent GitHub App and provision Anthropic key in Vault" --body-file $PACKETS/02-architecture-create-review-agent-github-app.md --label "chore,tier-2,meta,docs,infrastructure,human-only,adr-0044,wave-1"
-gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Actions --title "Build job-review-agent.yml — cloud-wired Grid-aware reviewer" --body-file $PACKETS/03-actions-job-review-agent-workflow.md --label "ci,tier-3,ops,adr-0044,wave-1"
+# Wave 1 - Phase 1
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Accept ADR-0044 - cloud code review, finalize new invariants, register initiative" --body-file $PACKETS/01-architecture-adr-0044-acceptance.md --label "chore,tier-3,meta,docs,adr-0044,wave-1"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Define OpenClaw/Codex Grid Review Runner runtime" --body-file $PACKETS/02b-architecture-openclaw-grid-review-runner.md --label "chore,tier-2,meta,docs,infrastructure,human-only,adr-0044,wave-1"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Actions --title "Build job-review-request.yml - GitHub trigger rail for OpenClaw reviewer" --body-file $PACKETS/03b-actions-job-review-request-workflow.md --label "ci,tier-2,ops,openclaw,adr-0044,wave-1"
 gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Update review.md with the D3 twenty-category rubric" --body-file $PACKETS/04-architecture-review-md-twenty-category-rubric.md --label "docs,tier-2,meta,adr-0044,wave-1"
-gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Author the .honeydrunk-review.yaml v1 schema doc" --body-file $PACKETS/05-architecture-review-config-schema-doc.md --label "docs,tier-1,meta,adr-0044,wave-1"
-gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Enable the cloud reviewer on HoneyDrunk.Architecture (Phase 1 pilot)" --body-file $PACKETS/06-architecture-enable-review-phase-1-pilot.md --label "ci,tier-2,meta,adr-0044,wave-1"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Author the OpenClaw-aware .honeydrunk-review.yaml v1 schema doc" --body-file $PACKETS/05b-architecture-review-config-schema-openclaw.md --label "docs,tier-1,meta,adr-0044,wave-1"
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Enable the OpenClaw/Codex reviewer on HoneyDrunk.Architecture (Phase 1 pilot)" --body-file $PACKETS/06b-architecture-enable-openclaw-review-phase-1-pilot.md --label "ci,tier-2,meta,adr-0044,wave-1"
 
-# Wave 2 — Phase 2
+# Wave 2 - Phase 2
 gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Actions --title "Add authorship-check and pr-size-check jobs to pr-core.yml" --body-file $PACKETS/07-actions-authorship-and-pr-size-checks.md --label "ci,tier-2,ops,adr-0044,wave-2"
 gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Actions --title "Seed large-pr, audit-sample, skip-review labels Grid-wide" --body-file $PACKETS/08-actions-seed-review-labels-grid-wide.md --label "chore,tier-1,ops,adr-0044,wave-2"
 gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Roll the D3 rubric into the upstream authoring agents" --body-file $PACKETS/09-architecture-d3-rubric-upstream-agent-rollout.md --label "docs,tier-2,meta,adr-0044,wave-2"
-gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Amend execution-surface prompts — Authorship line + D3 authoring checklist" --body-file $PACKETS/10-architecture-execution-surface-authorship-and-rubric.md --label "docs,tier-2,meta,adr-0044,wave-2"
-# Packet 11 is a multi-repo unit — file as a tracking issue in HoneyDrunk.Architecture with 10 child issues (one per .NET Node in its target_repos), or as 10 sibling issues (dispatch decides). Observe/Architecture/Studios are NOT in the fan-out.
+gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Amend execution-surface prompts - Authorship line + D3 authoring checklist" --body-file $PACKETS/10-architecture-execution-surface-authorship-and-rubric.md --label "docs,tier-2,meta,adr-0044,wave-2"
+# Packet 11 is a multi-repo unit - file as a tracking issue in HoneyDrunk.Architecture with 10 child issues (one per .NET Node in its target_repos), or as 10 sibling issues (dispatch decides). Observe/Architecture/Studios are NOT in the fan-out.
 gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Verify pr-review-rules.md severity coverage across all twenty D3 categories" --body-file $PACKETS/12-architecture-pr-review-rules-severity-coverage.md --label "docs,tier-1,meta,adr-0044,wave-2"
 
-# Wave 3 — Phase 3
+# Wave 3 - Phase 3
 gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Add the review_risk_class field to catalogs/grid-health.json" --body-file $PACKETS/13-architecture-review-risk-class-catalog-field.md --label "docs,tier-2,meta,adr-0044,wave-3"
 gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Actions --title "Activate D8 multi-perspective review for high-risk-Node PRs" --body-file $PACKETS/14-actions-d8-multi-perspective-review.md --label "ci,tier-2,ops,adr-0044,wave-3"
 
-# Wave 4 — Phase 4
+# Wave 4 - Phase 4
 gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Create generated/post-merge-audits/ directory with a README" --body-file $PACKETS/15-architecture-post-merge-audits-directory.md --label "docs,tier-1,meta,adr-0044,wave-4"
 gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Actions --title "Build the D9 audit-sample post-merge labeling and audit job" --body-file $PACKETS/16-actions-audit-sample-post-merge-job.md --label "ci,tier-2,ops,adr-0044,wave-4"
 gh issue create --repo HoneyDrunkStudios/HoneyDrunk.Architecture --title "Wire hive-sync to detect D3 / agent-file drift" --body-file $PACKETS/17-architecture-hive-sync-d3-drift-detection.md --label "docs,tier-1,meta,adr-0044,wave-4"
 ```
 
-## After filing — board fields and blocking relationships
+## After filing - board fields and blocking relationships
 
-For each issue: `gh project item-add 4 --owner HoneyDrunkStudios --url <ISSUE_URL>`, then set Status, Wave (1-4), Initiative=`adr-0044-cloud-code-review`, Node, Tier, Actor. **Actor=Human** for packet 02 only (it carries the `human-only` label); every other packet is `Actor=Agent` (packets with substantial Human Prerequisites — 03, 06, 11, 16 — keep `Actor=Agent` because the code/doc critical path is delegable).
+For each issue: `gh project item-add 4 --owner HoneyDrunkStudios --url <ISSUE_URL>`, then set Status, Wave (1-4), Initiative=`adr-0044-cloud-code-review`, Node, Tier, Actor. **Actor=Human** for packet 02 only (it carries the `human-only` label); every other packet is `Actor=Agent` (packets with substantial Human Prerequisites - 03, 06, 11, 16 - keep `Actor=Agent` because the code/doc critical path is delegable).
 
 Blocking relationships to wire via `addBlockedBy` (30 edges across packets 02-17; packet 11's five blockers are wired on its tracking issue, and each of its 10 child issues inherits them):
 
@@ -141,24 +145,24 @@ Blocking relationships to wire via `addBlockedBy` (30 edges across packets 02-17
 - `08` ← `07` (soft)
 - `09` ← `04` (hard)
 - `10` ← `04` (hard), `10` ← `07` (soft)
-- `11` ← `06` (hard), `11` ← `07` (hard), `11` ← `08` (hard), `11` ← `09` (soft), `11` ← `10` (soft)
+- `11` ← `06b` (hard), `11` ← `07` (hard), `11` ← `08` (hard), `11` ← `09` (soft), `11` ← `10` (soft)
 - `12` ← `04` (hard)
 - `13` ← `01` (soft)
-- `14` ← `03` (hard), `14` ← `13` (hard)
+- `14` ← `03b` (hard), `14` ← `13` (hard)
 - `15` ← `01` (soft)
-- `16` ← `02` (hard), `16` ← `03` (soft), `16` ← `08` (hard), `16` ← `15` (hard)
+- `16` ← `02b` (hard), `16` ← `03b` (soft), `16` ← `08` (hard), `16` ← `15` (hard)
 - `17` ← `04` (hard), `17` ← `09` (hard)
 
 ## Notes
 
-- **Acceptance precedes flip.** ADR-0044 stays Proposed until packet 01's PR merges. These packets are draft/pending-acceptance — not filed as Issues until then.
-- **Phases are go/no-go gates.** Per ADR-0044 D11, each wave's exit criterion gates the next. Phase 1's miss stops the rollout — packet 06 carries the Phase-1 decision.
+- **Acceptance precedes flip.** ADR-0044 stays Proposed until packet 01's PR merges. These packets are draft/pending-acceptance - not filed as Issues until then.
+- **Phases are go/no-go gates.** Per ADR-0044 D11, each wave's exit criterion gates the next. Phase 1's miss stops the rollout - packet 06 carries the Phase-1 decision.
 - **D8 is data-gated.** D8 multi-perspective review (packet 14) cannot activate until `review_risk_class` lands (packet 13). The dispatch order reflects this hard dependency.
 - **Packet 11 is a 10-repo unit.** It is the one multi-repo packet, filed as a coordination/tracking issue in `HoneyDrunk.Architecture` with 10 child issues (or 10 sibling issues). In scope: the 10 .NET Node repos in its `target_repos` frontmatter. Explicitly OUT: `HoneyDrunk.Observe` (Seed, not a live Node), `HoneyDrunk.Architecture` (already enabled in Phase 1), `HoneyDrunk.Studios` (TypeScript, onboarded separately). The Grid has 12 live Nodes; this fan-out is those 12 minus the two already-handled/excluded. Each per-Node work unit is small and identical.
-- **GitHub App permission.** Packet 02 provisions the review-agent GitHub App with **Contents: Write** on `HoneyDrunk.Architecture` from the start (a developer decision, recorded in packet 02). The write scope serves packet 16's post-merge audit-commit step; provisioning it up front avoids a second mid-rollout portal pass. Packet 16 therefore takes a hard `packet:02` dependency. The scope is confined to the single architecture repo.
-- **`current-focus.md` priorities #3 and #7** are discharged by this initiative (see the priority-#7 correspondence section above and packet 01's `current-focus.md` bookkeeping note). When all 17 packets reach `Done` and all four phase exit criteria are met, both priorities should be marked complete and dropped from the ranked list at the next ADR-0043 weekly briefing.
+- **OpenClaw/Codex runner.** Packet 02b replaces the old GitHub-App/Anthropic credential packet. v1 uses local OpenClaw/Codex plus `gh` auth or an optional narrowly scoped webhook/GitHub App path. No Anthropic API key is required for v1. Packet 16 depends on the runner write-back/auth approach from 02b.
+- **`current-focus.md` priorities #3 and #7** are discharged by this initiative (see the priority-#7 correspondence section above and packet 01's `current-focus.md` bookkeeping note). When all active/superseding packets reach `Done` and all four phase exit criteria are met, both priorities should be marked complete and dropped from the ranked list at the next ADR-0043 weekly briefing.
 - **The dispatch plan is the one exception to packet immutability** (ADR-0008 D7). It is updated at wave boundaries (especially after each phase's go/no-go) as the historical record.
 
 ## Archival
 
-Per ADR-0008 D10, when every packet reaches `Done` on The Hive and all four phase exit criteria are met, the entire `active/adr-0044-cloud-code-review/` folder moves to `archive/adr-0044-cloud-code-review/` in a single commit. Polish-phase follow-up packets, when scoped, live in a new initiative folder — not appended here.
+Per ADR-0008 D10, when every packet reaches `Done` on The Hive and all four phase exit criteria are met, the entire `active/adr-0044-cloud-code-review/` folder moves to `archive/adr-0044-cloud-code-review/` in a single commit. Polish-phase follow-up packets, when scoped, live in a new initiative folder - not appended here.

--- a/generated/issue-packets/active/adr-0044-cloud-code-review/handoff-wave2-node-rollout.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/handoff-wave2-node-rollout.md
@@ -4,25 +4,25 @@
 
 ## Precondition — the Phase-1 go/no-go decision
 
-Wave 2 does **not** start until packet 06's Phase-1 exit criterion is met and documented:
+Wave 2 does **not** start until packet 06b's Phase-1 exit criterion is met and documented:
 
-> The cloud-wired `review` agent's verdicts on real `HoneyDrunk.Architecture` PRs are at least as useful as the local `review` agent's, at acceptable cost (the $40-100/month Grid-wide projection holding pro-rata for one repo).
+> The OpenClaw/Codex Grid Review Runner's verdicts on real `HoneyDrunk.Architecture` PRs are at least as useful as the manual `review` agent's; the request path is reliable; reviewed-head-SHA tracking prevents duplicate work; incremental model cost stays near zero.
 
-If that bar is missed, **stop** — do not file Wave 2. Re-scope `job-review-agent.yml` (packet 03) or the rubric (packet 04) and re-run Phase 1.
+If that bar is missed, **stop** — do not file Wave 2. Re-scope the OpenClaw runner (packet 02b), `job-review-request.yml` (packet 03b), or the rubric (packet 04) and re-run Phase 1.
 
 ## What Wave 1 delivered (upstream changes Wave 2 builds on)
 
 - **ADR-0044 is Accepted** (packet 01). Its two new invariants are live in `constitution/invariants.md`; the ADR-0011 amendment note is recorded. D1-D11 are now binding rules, not proposals.
-- **The cross-repo-checkout GitHub App and the Anthropic API key exist in Vault** (packet 02). Secret names: `review-agent-github-app-id`, `review-agent-github-app-private-key`, `review-agent-github-app-installation-id`, `review-agent-anthropic-api-key`. The App has **Contents: Write** on `HoneyDrunk.Architecture` only (write scope provisioned up front for packet 16's post-merge audit-commit; scoped to the single architecture repo). For Wave 2's read-only context checkout, the same App's token is used read-only.
-- **`job-review-agent.yml` exists in HoneyDrunk.Actions** (packet 03) — a reusable `workflow_call` workflow that checks out the target repo + `HoneyDrunk.Architecture`, runs `.claude/agents/review.md` via the Claude Agent SDK, posts an advisory PR comment, and honors the D5 cost guardrails. It exits without API spend when a repo has no `.honeydrunk-review.yaml` or `enabled: false`.
+- **The OpenClaw/Codex Grid Review Runner runtime is documented/configured** (packet 02b). v1 does not require an Anthropic API key. Local `gh` auth is acceptable; webhook/GitHub App credentials are optional and narrowly scoped if used.
+- **`job-review-request.yml` exists in HoneyDrunk.Actions** (packet 03b) — a reusable trigger rail that validates skip/enable rules, emits a review request payload, and delivers it to OpenClaw or leaves durable pickup state. It never invokes a model API directly.
 - **`.claude/agents/review.md` carries the full D3 twenty-category rubric** (packet 04) with per-category execution detail and severity mappings.
-- **The `.honeydrunk-review.yaml` v1 schema doc exists** at `copilot/review-config-schema.md` (packet 05).
-- **The Architecture repo is enabled and piloted** (packet 06) — `.honeydrunk-review.yaml` (`enabled: true`) + a `pr-review.yml` caller. The Phase-1 cost and quality data is recorded in packet 06's PR body.
+- **The `.honeydrunk-review.yaml` v1 schema doc exists** at `copilot/review-config-schema.md` (packet 05b), with `runner: openclaw-codex` as the default.
+- **The Architecture repo is enabled and piloted** (packet 06b) — `.honeydrunk-review.yaml` (`enabled: true`, `runner: openclaw-codex`) + a `pr-review.yml` caller. The Phase-1 quality, reliability, and near-zero incremental-cost evidence is recorded in packet 06b's PR body.
 
 ## Contracts Wave 2 consumes
 
-- **`job-review-agent.yml`** — callable via `workflow_call` at a pinned ref. Wave 2's per-Node `pr-review.yml` callers invoke it. Confirm the pinned ref before filing packet 11.
-- **`.honeydrunk-review.yaml` v1 schema** — `enabled` (required), `severity_floor`, `skip_paths`, `model`, `cost_cap_per_pr_usd`. Documented in `copilot/review-config-schema.md`. Each of the 10 fan-out Nodes authors one in packet 11.
+- **`job-review-request.yml`** — callable via `workflow_call` at a pinned ref. Wave 2's per-Node `pr-review.yml` callers invoke it. Confirm the pinned ref before filing packet 11.
+- **`.honeydrunk-review.yaml` v1 schema** — `enabled` (required), `runner`, `severity_floor`, `skip_paths`, `cost_cap_per_pr_usd`. Documented in `copilot/review-config-schema.md`. Each of the 10 fan-out Nodes authors one in packet 11.
 - **The five D6 authorship classes** — `human`, `agent-codex`, `agent-copilot`, `agent-claude-code`, `mixed`. `authorship-check` (packet 07) validates the `Authorship:` line against exactly these.
 - **The twenty D3 category names/numbering** as authored in `review.md` — packets 09, 10, 12 must reuse them verbatim. Divergence is the anti-pattern D3 warns against.
 
@@ -32,16 +32,16 @@ If that bar is missed, **stop** — do not file Wave 2. Re-scope `job-review-age
 2. **Seed `large-pr`, `audit-sample`, `skip-review` labels Grid-wide** (packet 08) via the existing labels-as-code fan-out.
 3. **Roll the D3 rubric into the upstream authoring agents** (packet 09) — `scope`, `adr-composer`, `pdr-composer`, `refine`, `node-audit`. With packet 04, this discharges `current-focus.md` priority #7.
 4. **Amend the execution-surface prompts** (packet 10) — Codex/Copilot/Claude Code emit the `Authorship:` line + commit trailer and surface the brief D3 authoring checklist.
-5. **Enable the cloud reviewer on the 10 remaining live .NET Nodes** (packet 11) — `.honeydrunk-review.yaml` (`enabled: true`) + `pr-review.yml` caller per repo. The fan-out is exactly the 10 .NET Node repos in packet 11's `target_repos`: Kernel, Transport, Vault, Auth, Web.Rest, Data, Notify, Communications, Pulse, Actions. **`HoneyDrunk.Observe` is OUT** (Seed, not a live Node); `HoneyDrunk.Architecture` is OUT (already enabled in Phase 1); `HoneyDrunk.Studios` is OUT (TypeScript, onboarded separately). **Private revenue (`.Cloud`) Nodes are excluded from the default rollout** — confirm the exclusion list against `catalogs/nodes.json` / ADR-0027 D2.
+5. **Enable the OpenClaw/Codex reviewer on the 10 remaining live .NET Nodes** (packet 11) — `.honeydrunk-review.yaml` (`enabled: true`, `runner: openclaw-codex`) + `pr-review.yml` caller per repo. The fan-out is exactly the 10 .NET Node repos in packet 11's `target_repos`: Kernel, Transport, Vault, Auth, Web.Rest, Data, Notify, Communications, Pulse, Actions. **`HoneyDrunk.Observe` is OUT** (Seed, not a live Node); `HoneyDrunk.Architecture` is OUT (already enabled in Phase 1); `HoneyDrunk.Studios` is OUT (TypeScript, onboarded separately). **Private revenue (`.Cloud`) Nodes are excluded from the default rollout** — confirm the exclusion list against `catalogs/nodes.json` / ADR-0027 D2.
 6. **Verify `pr-review-rules.md` severity coverage** across all twenty D3 categories (packet 12).
 
 ## Constraints carried into Wave 2
 
-> **Invariant 31:** Every PR traverses the tier-1 gate before merge. `authorship-check` joins that gate; `pr-size-check` is warnings-only in Phase 2 and does not gate; the review agent itself stays advisory and non-required.
+> **Invariant 31:** Every PR traverses the tier-1 gate before merge. `authorship-check` joins that gate; `pr-size-check` is warnings-only in Phase 2 and does not gate; the Grid Review Runner itself stays advisory and non-required.
 
 > **Invariant 33:** Review-agent and scope-agent context-loading contracts are coupled — `review.md`'s context-loading list must remain a superset of `scope.md`'s. Packet 09 edits `scope.md`'s D3 section; do not touch its context-loading list.
 
-> **Invariant 8 / 9:** The Anthropic key and GitHub App credentials live in Vault; never echoed in logs, never committed.
+> **Invariant 8 / 9:** No Anthropic API key is required for v1. If webhook/GitHub App credentials are used, they live in Vault/secret storage; never echoed in logs, never committed.
 
 - **Phase 2 is gated on a documented Phase-1 "go".** No Wave 2 filing before that decision is recorded.
 - **Private revenue Nodes excluded by default** (ADR-0044 Operational Consequences).
@@ -50,4 +50,4 @@ If that bar is missed, **stop** — do not file Wave 2. Re-scope `job-review-age
 
 ## Acceptance signal for Wave 2 → Wave 3
 
-All 10 fan-out Nodes enabled (Observe/Architecture/Studios excluded; private revenue Nodes excluded); authorship classification mandatory and green Grid-wide; PR-size discipline visible; the D3 rubric present in all seven agent files (`review.md` + the six upstream); `pr-review-rules.md` covers all twenty categories. Then make the Phase-2 → Phase-3 go decision before filing Wave 3 (packets 13-14). Note: Wave 3's packet 14 (D8 activation) is hard-gated on packet 13 (`review_risk_class`) — that data dependency cannot be short-circuited.
+All 10 fan-out Nodes enabled with `runner: openclaw-codex` (Observe/Architecture/Studios excluded; private revenue Nodes excluded); authorship classification mandatory and green Grid-wide; PR-size discipline visible; the D3 rubric present in all seven agent files (`review.md` + the six upstream); `pr-review-rules.md` covers all twenty categories. Then make the Phase-2 → Phase-3 go decision before filing Wave 3 (packets 13-14). Note: Wave 3's packet 14 (D8 activation) is hard-gated on packet 13 (`review_risk_class`) — that data dependency cannot be short-circuited.

--- a/generated/issue-packets/active/adr-0047-testing-patterns-and-tooling/04-cross-repo-fluentassertions-to-awesomeassertions-migration.md
+++ b/generated/issue-packets/active/adr-0047-testing-patterns-and-tooling/04-cross-repo-fluentassertions-to-awesomeassertions-migration.md
@@ -2,6 +2,7 @@
 name: Cross-Repo Change
 type: cross-repo-change
 tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
 target_repos: []
 labels: ["chore", "tier-2", "coordination", "adr-0047", "wave-1"]
 dependencies: ["packet:01"]

--- a/generated/issue-packets/active/adr-0047-testing-patterns-and-tooling/05-cross-repo-moq-to-nsubstitute-migration.md
+++ b/generated/issue-packets/active/adr-0047-testing-patterns-and-tooling/05-cross-repo-moq-to-nsubstitute-migration.md
@@ -2,6 +2,7 @@
 name: Cross-Repo Change
 type: cross-repo-change
 tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
 target_repos: []
 labels: ["chore", "tier-2", "coordination", "adr-0047", "wave-1"]
 dependencies: ["packet:01"]


### PR DESCRIPTION
## Summary
- Reframes ADR-0044 around an automatic OpenClaw/Codex Grid Review Runner instead of an Anthropic/Claude GitHub Action runtime.
- Adds superseding packets 02b/03b/05b/06b for the runner runtime, request workflow, config schema, and Phase 1 pilot while preserving already-filed packets as immutable.
- Updates later unfiled/active packet surfaces and Wave 2 handoff to consume the OpenClaw/Codex runner path.
- Folds in missing `target_repo` routing metadata for cross-repo packets, including ADR-0047 migration packets.

## Validation
- `git diff --cached --check`
- frontmatter scan confirmed no active issue packets are missing `target_repo`

## Filed packet handling
Packets/issues already filed from ADR-0044 should not be rewritten. The old filed packet semantics are superseded by new 02b/03b/05b/06b packets and should be commented/closed/superseded after this PR is linked.
