### PR TITLE
Scope ADR-0034 — public package distribution and NuGet policy

### DIFF
--- a/generated/issue-packets/active/adr-0034-public-package-distribution/00-architecture-adr-0034-acceptance.md
+++ b/generated/issue-packets/active/adr-0034-public-package-distribution/00-architecture-adr-0034-acceptance.md
@@ -1,0 +1,108 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "docs", "adr-0034", "wave-1"]
+dependencies: []
+adrs: ["ADR-0034", "ADR-0035"]
+accepts: ["ADR-0034"]
+wave: 1
+initiative: adr-0034-public-package-distribution
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0034 — flip status, add the three packaging invariants, register the distribution initiative
+
+## Summary
+Flip ADR-0034 (Public Package Distribution and NuGet Policy) from Proposed to Accepted: update the ADR header, update the ADR index row, add the three new packaging invariants ADR-0034 commits in its Consequences section to `constitution/invariants.md`, and register the `adr-0034-public-package-distribution` initiative in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0034 decides where and how the Grid's public packages are distributed — nuget.org under the `HoneyDrunkStudios` owner as the primary feed, GitHub Packages for private revenue Nodes, Azure Artifacts retained as pre-release staging, mandatory package metadata, SourceLink + symbols, deterministic builds, author signing, and a single `job-publish-nuget.yml` reusable workflow. Every other packet in this initiative references ADR-0034's D-decisions as live rules. The acceptance flip must land first so those references read against Accepted text.
+
+ADR-0034 D7 states explicitly that ADR-0034 and ADR-0035 (Abstractions Versioning and Deprecation Policy) "must land together; neither is useful alone." ADR-0035 is being scoped under its own initiative folder (`adr-0035-abstractions-versioning`). This packet flips **ADR-0034 only**. Its PR and ADR-0035's acceptance PR should be merged in the same session so the two land together; this packet does not touch ADR-0035's file.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0034-public-package-distribution-and-nuget-policy.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0034 row Status column to Accepted.
+- `constitution/invariants.md` — add the three new packaging invariants ADR-0034 commits (see Proposed Implementation for exact text). They are **invariants 54, 55, 56** — pre-reserved numbers (see the coordination note below).
+- `initiatives/active-initiatives.md` — register the `adr-0034-public-package-distribution` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0034 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update the ADR-0034 index row in `adrs/README.md` to Accepted.
+3. Add three new invariants to `constitution/invariants.md` under a new `## Distribution & Packaging Invariants` section (or appended to the existing `## Packaging Invariants` section — match the file's current sectioning), as **invariants 54, 55, 56** in this exact order. The text, taken from ADR-0034's "Invariants" Consequences subsection:
+   - **54 — Every public package is owned by `HoneyDrunkStudios` on nuget.org.** No fork-owned, no individual-developer-owned public packages. See ADR-0034 D1.
+   - **55 — Every public package ships SourceLink + symbols.** The build fails if SourceLink is not produced. See ADR-0034 D4.
+   - **56 — Package publish runs through the HoneyDrunk.Actions reusable workflow.** Consumer release workflows do not call `dotnet nuget push` directly. (Parallels ADR-0012's deploy-mechanics rule.) See ADR-0034 D6.
+
+**Invariant-numbering coordination note.** The current highest invariant in `constitution/invariants.md` is **51** (1–51 all present). Invariant numbers **54–56** are pre-reserved for ADR-0034 as part of a 12-ADR batch that reserves blocks of invariant numbers across ADRs 0034–0042/0045 (ADR-0034's block is 54–56; numbers 52–53 belong to a sibling ADR in the batch). Do **not** scan for the current max or compute "next free number" — use the hard numbers 54, 55, 56. If any invariant above 51 lands from **outside** this batch before this PR merges, shift this block upward to the next free triple and never reuse a number.
+4. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder.
+
+## Affected Files
+- `adrs/ADR-0034-public-package-distribution-and-nuget-policy.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0034 header reads `**Status:** Accepted`
+- [ ] The ADR-0034 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariants.md` carries the three new packaging invariants (nuget.org ownership, SourceLink + symbols, publish-via-reusable-workflow) as invariants **54, 55, 56** in that order, each citing ADR-0034
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0034-public-package-distribution` initiative with a packet checklist
+- [ ] No catalog schema change in this packet (`catalogs/package-feeds.json` is created in packet 01)
+- [ ] No change to ADR-0035's file in this packet
+
+## Human Prerequisites
+None. (The nuget.org owner-account claim and the BDR-0001 signing-certificate procurement are operational prerequisites surfaced in packets 01 and 04 respectively — they are not blockers for the acceptance flip itself.)
+
+## Referenced ADR Decisions
+**ADR-0034 D7 — Versioning is governed by ADR-0035.** ADR-0034 decides *where and how* packages publish; ADR-0035 decides version semantics, deprecation rules, and ABI-stability. "The two ADRs must land together; neither is useful alone." This acceptance PR should merge in the same session as ADR-0035's acceptance PR.
+
+**ADR-0034 Consequences — Invariants.** ADR-0034 adds exactly three invariants: (1) public-package nuget.org ownership by `HoneyDrunkStudios`; (2) every public package ships SourceLink + symbols, build fails otherwise; (3) publish runs through the HoneyDrunk.Actions reusable workflow, not inline `dotnet nuget push`.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0034 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Land together with ADR-0035.** Per ADR-0034 D7, coordinate the merge of this PR with ADR-0035's acceptance PR. This packet does not edit ADR-0035's file — that is ADR-0035's own acceptance packet's job.
+- **Use the pre-reserved invariant numbers 54, 55, 56.** Do not renumber existing invariants and do not scan for the current max — 54–56 are reserved for ADR-0034 by the 12-ADR batch. Only shift the block upward if an out-of-batch invariant above 51 lands first (see the coordination note in Proposed Implementation).
+
+## Labels
+`chore`, `tier-3`, `meta`, `docs`, `adr-0034`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0034 to Accepted, add the three packaging invariants to `constitution/invariants.md`, and register the public-package-distribution initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0034 so the distribution packets can reference its decisions as live rules.
+- Feature: ADR-0034 Public Package Distribution rollout, Wave 1.
+- ADRs: ADR-0034 (primary), ADR-0035 (lands together — separate initiative), ADR-0008 (initiative/packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0034 stays Proposed until this PR merges.
+- Coordinate the merge with ADR-0035's acceptance PR (ADR-0034 D7 — they land together).
+- Add the three new invariants as the pre-reserved numbers 54, 55, 56; do not renumber existing invariants and do not scan for the current max (see the coordination note in Proposed Implementation).
+
+**Key Files:**
+- `adrs/ADR-0034-public-package-distribution-and-nuget-policy.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0034-public-package-distribution/01-architecture-package-feeds-catalog.md
+++ b/generated/issue-packets/active/adr-0034-public-package-distribution/01-architecture-package-feeds-catalog.md
@@ -1,0 +1,144 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "docs", "adr-0034", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0034", "ADR-0032"]
+accepts: ["ADR-0034"]
+wave: 1
+initiative: adr-0034-public-package-distribution
+node: honeydrunk-architecture
+---
+
+# Create catalogs/package-feeds.json — the approved-feeds allowlist (ADR-0034 D8)
+
+## Summary
+Create the new `catalogs/package-feeds.json` catalog — the single source of truth for the Grid's approved package feeds — keyed by `feed-id` with `url`, `owner`, `visibility`, and `consumers` fields per ADR-0034 D8, and index it so the catalog is discoverable and so ADR-0032's NuGet-leak PR check can read it as the allowlist.
+
+## Context
+ADR-0034 D8 commits the approved-feeds list to catalog form: `catalogs/package-feeds.json`, "keyed by `feed-id`, with fields `url`, `owner`, `visibility (public|private|prerelease-staging)`, and `consumers (node-ids)`." This artifact does not exist today — the Grid's feed configuration is fragmented (some Nodes on GitHub Packages, some on an internal Azure Artifacts feed). ADR-0032 (PR validation policy) flags NuGet leaks and, per ADR-0034's Context section, "presupposes a defined approved-feeds list that does not exist as a single artifact." This packet creates that artifact.
+
+ADR-0034 D8 also states the catalog "is the single source of truth; readme tables and ADR text reference it but do not redefine it." So no feed list is duplicated into ADR text or README tables — they point at this file.
+
+This is a docs/catalog-only packet. No code, no workflow, no .NET project. The ADR-0032 NuGet-leak check that *reads* this catalog as its allowlist is ADR-0032's own scope — not a packet in this initiative (see the dispatch plan's Out-of-scope section).
+
+## Scope
+- `catalogs/package-feeds.json` — new file.
+- The catalog index — ADR-0034 D8 says the new catalog is "indexed in `catalogs/README.md`." Check whether `catalogs/README.md` exists. If it does **not** exist, this packet **unconditionally creates it** — this initiative owns the new catalog index. Author it as a short index of every file in `catalogs/` (a one-line description per catalog), with the `package-feeds.json` row included. If `catalogs/README.md` already exists, add the `package-feeds.json` row to it. Do not defer the create/add decision to discretion — the existence check is the deterministic switch.
+- `initiatives/drift-report.md` / `hive-sync` note — ADR-0034's Operational Consequences says `package-feeds.json` "is a new artifact `hive-sync` (ADR-0014) must include in drift reconciliation." No code change is required for that; `hive-sync` reconciles the `catalogs/` directory generically. If `hive-sync` maintains an explicit per-catalog list, add `package-feeds.json` to it; otherwise no action.
+
+## Proposed Implementation
+Author `catalogs/package-feeds.json` with this shape (one object per approved feed):
+
+```json
+{
+  "feeds": [
+    {
+      "feed-id": "nuget-org-public",
+      "url": "https://api.nuget.org/v3/index.json",
+      "owner": "HoneyDrunkStudios",
+      "visibility": "public",
+      "consumers": ["honeydrunk-kernel", "honeydrunk-transport", "..."]
+    },
+    {
+      "feed-id": "github-packages-private",
+      "url": "https://nuget.pkg.github.com/HoneyDrunkStudios/index.json",
+      "owner": "HoneyDrunkStudios",
+      "visibility": "private",
+      "consumers": []
+    },
+    {
+      "feed-id": "azure-artifacts-prerelease",
+      "url": "<the existing internal Azure Artifacts feed URL — see Human Prerequisites>",
+      "owner": "HoneyDrunkStudios",
+      "visibility": "prerelease-staging",
+      "consumers": ["..."]
+    }
+  ]
+}
+```
+
+Field rules per ADR-0034 D8:
+- `feed-id` — stable string key, unique per feed.
+- `url` — the v3 feed index URL.
+- `owner` — `HoneyDrunkStudios` for all three (ADR-0034 D1/D2).
+- `visibility` — exactly one of `public`, `private`, `prerelease-staging`.
+- `consumers` — array of Node ids from `catalogs/nodes.json` (e.g. `honeydrunk-kernel`). For `nuget-org-public`, list the 12 live public Nodes that produce packages. For `github-packages-private`, leave empty until the first private revenue Node (`HoneyDrunk.Notify.Cloud`, ADR-0027) is scaffolded. For `azure-artifacts-prerelease`, list the Nodes that currently SHA-pin pre-release builds.
+
+The exact Azure Artifacts feed URL is not in the ADR — it is the existing internal feed used for SHA-pinned Kernel-adoption builds. See Human Prerequisites: the human supplies the URL, or the implementing agent uses a documented placeholder and flags it in the PR for the human to fill before merge. The URL is an org-internal endpoint, not a secret — committing it is acceptable (it is not credentials; see CLAUDE.md "repos public by default — never commit secrets or env-specific IDs": the feed *URL* is not a secret, but if it embeds an org/project GUID, prefer the org-name form `https://pkgs.dev.azure.com/{org}/_packaging/{feed}/nuget/v3/index.json`).
+
+Match the JSON style of the existing catalogs (`catalogs/nodes.json`, `catalogs/relationships.json`) — two-space indent, top-level object with a single array property.
+
+## Affected Files
+- `catalogs/package-feeds.json` (new)
+- `catalogs/README.md` (created if absent — this initiative owns the new catalog index; otherwise the `package-feeds.json` row is appended, per Scope)
+
+## NuGet Dependencies
+None. This packet creates a JSON catalog and a Markdown index; no .NET project is created or modified.
+
+## Boundary Check
+- [x] Catalogs live in `HoneyDrunk.Architecture`. Routing rule "catalog → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] `catalogs/package-feeds.json` exists with at least the three ADR-0034 feeds: `nuget-org-public` (public), `github-packages-private` (private), `azure-artifacts-prerelease` (prerelease-staging)
+- [ ] Each feed object has `feed-id`, `url`, `owner`, `visibility`, and `consumers`; `owner` is `HoneyDrunkStudios` on all; `visibility` is exactly one of `public` / `private` / `prerelease-staging`
+- [ ] `consumers` arrays use Node ids from `catalogs/nodes.json` (e.g. `honeydrunk-kernel`); `github-packages-private` consumers may be empty (no private Node scaffolded yet)
+- [ ] The JSON is well-formed and matches the style of the existing catalog files
+- [ ] The catalog is indexed — if `catalogs/README.md` did not exist it is created (this packet owns the new index) with a one-line description per catalog file including `package-feeds.json`; if it already existed the `package-feeds.json` row is appended to it
+- [ ] The Azure Artifacts feed URL is either the real internal feed URL or a clearly-flagged placeholder for the human to fill before merge
+- [ ] No feed list is duplicated into ADR text or other README tables — they reference this catalog (ADR-0034 D8 single-source-of-truth rule)
+
+## Human Prerequisites
+- [ ] Provide the existing internal Azure Artifacts feed URL (the feed currently used for SHA-pinned pre-release builds during Kernel adoption cascades). If not provided before the packet runs, the agent uses a flagged placeholder and the human fills it before merge.
+- [ ] Confirm the set of Nodes that currently consume the Azure Artifacts pre-release feed, so the `azure-artifacts-prerelease` `consumers` array is accurate.
+
+## Referenced ADR Decisions
+**ADR-0034 D8 — Approved feeds list lives in catalog form.** "The list of approved feeds is recorded in `catalogs/package-feeds.json` (new), keyed by `feed-id`, with fields `url`, `owner`, `visibility (public|private|prerelease-staging)`, and `consumers (node-ids)`. ADR-0032's NuGet-flag check reads this catalog as the allowlist. The catalog is the single source of truth; readme tables and ADR text reference it but do not redefine it."
+
+**ADR-0034 D1 — Primary feed.** nuget.org under the `HoneyDrunkStudios` owner is the primary public feed. Azure Artifacts is retained as a pre-release-only staging surface — pre-release versions flow there first; stable versions land on nuget.org and are never republished back.
+
+**ADR-0034 D2 — Private packages.** `HoneyDrunk.Notify.Cloud.*` and future private Nodes publish to GitHub Packages scoped to `HoneyDrunkStudios`.
+
+**ADR-0034 Operational Consequences.** `catalogs/package-feeds.json` is a new artifact `hive-sync` (ADR-0014) must include in drift reconciliation.
+
+## Constraints
+- **The catalog is the single source of truth.** Do not duplicate the feed list into ADR text or README tables — those reference the catalog.
+- **`visibility` is a closed enum** — exactly `public`, `private`, or `prerelease-staging`. No other value.
+- **`consumers` uses canonical Node ids** from `catalogs/nodes.json`, not display names.
+- The Azure Artifacts URL is an internal endpoint, not a credential — committing it is fine. Never commit a feed *token* or PAT.
+
+## Labels
+`chore`, `tier-3`, `meta`, `docs`, `adr-0034`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Create `catalogs/package-feeds.json` — the approved-feeds allowlist per ADR-0034 D8 — and index it.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Establish the single-source-of-truth feed catalog that ADR-0032's NuGet-leak check will read as its allowlist (that check is ADR-0032's own scope, not a packet here).
+- Feature: ADR-0034 Public Package Distribution rollout, Wave 1.
+- ADRs: ADR-0034 (D8, D1, D2), ADR-0032 (the future consumer of this catalog), ADR-0014 (`hive-sync` drift reconciliation).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0034 acceptance (soft — references ADR-0034 D8 as a live rule).
+
+**Constraints:**
+- The catalog is the single source of truth; do not duplicate the feed list elsewhere.
+- `visibility` is a closed enum: `public` / `private` / `prerelease-staging`.
+- `consumers` uses canonical Node ids from `catalogs/nodes.json`.
+- The Azure Artifacts URL is an internal endpoint, not a secret — but never commit a token/PAT.
+
+**Key Files:**
+- `catalogs/package-feeds.json` (new)
+- `catalogs/README.md` (created if absent; otherwise appended to)
+- `catalogs/nodes.json` (read-only — source of `consumers` Node ids)
+
+**Contracts:** Introduces the `package-feeds.json` schema (`feed-id` / `url` / `owner` / `visibility` / `consumers`). Future consumer: ADR-0032's NuGet-leak check (built under ADR-0032's own scope).

--- a/generated/issue-packets/active/adr-0034-public-package-distribution/02-standards-packaging-metadata-props-fragment.md
+++ b/generated/issue-packets/active/adr-0034-public-package-distribution/02-standards-packaging-metadata-props-fragment.md
@@ -1,0 +1,151 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Standards
+labels: ["feature", "tier-2", "ops", "adr-0034", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0034", "ADR-0039"]
+accepts: ["ADR-0034"]
+wave: 1
+initiative: adr-0034-public-package-distribution
+node: honeydrunk-standards
+---
+
+# Author the shared package-metadata + SourceLink Directory.Build.props fragment (ADR-0034 D3/D4)
+
+## Summary
+Create a shared, importable `Directory.Build.props` fragment in `HoneyDrunk.Standards` that establishes the ADR-0034 D3 required package-metadata block and the ADR-0034 D4 SourceLink + deterministic-build block as one canonical definition, plus a CI-enforceable check that fails the build when a packable project is missing a required metadata field — so every public Node consumes one fragment instead of drifting per-repo.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Standards`
+
+## Motivation
+ADR-0034 D3 lists thirteen metadata fields "required in each project file or `Directory.Build.props` and CI-enforced (build fails if missing)." D4 lists six SourceLink / determinism properties that are "non-negotiable for any public package." ADR-0034's Context section records the current state as fragmented: package metadata (`Authors`, `Company`, `RepositoryUrl`, `PackageLicenseExpression`, icons) is inconsistent across Nodes and signing is unset.
+
+`HoneyDrunk.Standards` is the existing Grid-wide home for shared analyzers and EditorConfig consumed by every .NET repo (invariant 26 mandates `HoneyDrunk.Standards` on every new .NET project). It is the correct owner for a shared packaging-metadata props fragment — exactly as it owns the unit-test-stack fragment authored under the ADR-0047 initiative. Centralizing it means each public Node's adoption (packet 05, the fan-out) is a thin "import the fragment, set the three per-project overrides" change rather than thirteen-field hand-authoring per repo.
+
+This packet does **not** adopt the fragment into any Node — it only authors the shared definition and the enforcement check. Per-Node adoption is packet 05.
+
+## Proposed Implementation
+
+### Metadata block (ADR-0034 D3)
+The fragment sets these thirteen fields. The first ten are fixed Grid-wide values; the last three are per-project overrides D3 explicitly permits (`PackageId`, `Description`, `PackageTags`):
+
+- `<Authors>HoneyDrunk Studios</Authors>`
+- `<Company>HoneyDrunk Studios</Company>`
+- `<Product>HoneyDrunk Grid</Product>`
+- `<RepositoryUrl>` — the canonical GitHub repo URL. Set this from a Node-supplied property (e.g. `$(HoneyDrunkRepositoryUrl)`) or derive it; the fragment provides the slot, the consuming repo supplies the value.
+- `<RepositoryType>git</RepositoryType>`
+- `<PackageProjectUrl>` — Studios product page or repo readme; Node-supplied slot.
+- `<PackageLicenseExpression>` — an SPDX expression. ADR-0034 D3 says this is "set by ADR-0039 (license policy); never `<PackageLicenseFile>` for public packages, to avoid stale embedded text." ADR-0039 (Proposed) sets MIT as the Grid default. The fragment defaults `<PackageLicenseExpression>` to `MIT` and leaves it overridable per repo (a revenue Node on FSL overrides it). Never emit `<PackageLicenseFile>` for a packable project.
+- `<PackageReadmeFile>` — points to a per-package `README.md` packed into the nupkg. The fragment wires the `<None Include="README.md" Pack="true" PackagePath="\" />` item; the consuming package supplies the README content.
+- `<PackageIcon>` — the Studios mark, a single shared asset packed per-project. Ship the icon asset inside `HoneyDrunk.Standards` and have the fragment reference + pack it so no Node copies the binary.
+- `<PackageTags>` — per-project override; D3 minimum content is `honeydrunk`, the sector tag, and the slot kind (`abstractions` / `backing` / `sdk`).
+- `<Description>` — per-project override, one paragraph.
+- `<RepositoryCommit>` — set by CI from `$GITHUB_SHA`. The fragment reads an MSBuild property fed from the `GITHUB_SHA` environment variable when `$(CI)` is true.
+
+ADR-0034 D3: "`Directory.Build.props` at the repo root is the enforcement point; per-project overrides are limited to `<PackageId>`, `<Description>`, and `<PackageTags>`."
+
+### SourceLink + determinism block (ADR-0034 D4)
+The fragment sets, for all packable projects:
+- `<PublishRepositoryUrl>true</PublishRepositoryUrl>`
+- `<EmbedUntrackedSources>true</EmbedUntrackedSources>`
+- `<IncludeSymbols>true</IncludeSymbols>`
+- `<SymbolPackageFormat>snupkg</SymbolPackageFormat>`
+- `<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>` — conditioned on `$(CI) == 'true'`.
+- `<Deterministic>true</Deterministic>`
+- A `<PackageReference Include="Microsoft.SourceLink.GitHub" />` with `PrivateAssets="all"` — D4: "`Microsoft.SourceLink.GitHub` is referenced from `Directory.Build.props`."
+
+### CI metadata-enforcement check (ADR-0034 D3 "build fails if missing")
+Add an MSBuild target (in the fragment, or as a `.targets` companion shipped alongside it) that runs before pack/publish and fails the build with a clear diagnostic if any of the thirteen required fields is empty on a packable project (`IsPackable != false`). The target keys off `IsPackable` so it never fires on test projects or non-packable internal projects.
+
+### Scoping
+The fragment must apply only to packable projects — never inject `PackageReadmeFile`, `PackageIcon`, or the SourceLink reference into test projects (`*.Tests.*`) or non-packable runtime helpers. Key the conditions on `$(IsPackable)` (default-true for library projects, false on test projects per the ADR-0047 test-stack fragment).
+
+### Mechanism
+Preferred: ship the fragment + the Studios icon asset + the enforcement `.targets` as static MSBuild `build/` content inside the **existing** `HoneyDrunk.Standards` build-assets package, so no new `.csproj` is created. Only if the current packaging cannot carry an additional build asset should a new build-assets `.csproj` be added — and that project must then reference `HoneyDrunk.Standards` analyzers with `PrivateAssets: all` per invariant 26. Record the chosen mechanism in the PR.
+
+## Affected Packages
+- `HoneyDrunk.Standards` — gains the packaging-metadata props fragment, the SourceLink block, the enforcement target, and the packed Studios icon asset.
+
+## NuGet Dependencies
+This packet authors a props fragment that **declares** the following `PackageReference` for consuming packable projects (it does not add a runtime reference to `HoneyDrunk.Standards`'s own projects):
+
+- `Microsoft.SourceLink.GitHub` — current stable; `PrivateAssets="all"` (it is a build-time-only source-indexer, not a runtime dependency).
+
+If a new build-assets `.csproj` is created in `HoneyDrunk.Standards` to host the fragment, that project additionally references:
+- `HoneyDrunk.Standards` analyzers — `PrivateAssets: all` (invariant 26: every new .NET project explicitly references the `HoneyDrunk.Standards` StyleCop + EditorConfig analyzers with `PrivateAssets: all`).
+
+`HoneyDrunk.Standards` is modeled in `catalogs/nodes.json` (id `honeydrunk-standards`) as the Grid's shared analyzer / EditorConfig / build-tooling Meta Node — a library-only, no-vault repo whose packages are consumed at compile time. The packaging-metadata fragment is the same class of artifact as the existing analyzer set and the ADR-0047 test-stack fragment: a packaged MSBuild build asset, not a runtime project.
+
+## Boundary Check
+- [x] Shared build-tooling defaults belong in `HoneyDrunk.Standards` — it already owns the Grid-wide analyzer + EditorConfig set (invariant 26) and the ADR-0047 test-stack fragment.
+- [x] No Node behavior changes; this packet only publishes a definition. Per-Node adoption is packet 05.
+- [x] Does not duplicate any other Node's responsibility — the publish *workflow* (D6) is HoneyDrunk.Actions' (packet 03); this is build-time metadata only.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Standards` ships a `Directory.Build.props` fragment setting the thirteen ADR-0034 D3 metadata fields, with `PackageId` / `Description` / `PackageTags` as per-project overrides and the other ten as Grid-wide / Node-supplied-slot values
+- [ ] `<PackageLicenseExpression>` defaults to `MIT` (ADR-0039) and is overridable; `<PackageLicenseFile>` is never emitted for a packable project
+- [ ] The fragment sets the six ADR-0034 D4 properties (`PublishRepositoryUrl`, `EmbedUntrackedSources`, `IncludeSymbols`, `SymbolPackageFormat=snupkg`, `ContinuousIntegrationBuild` gated on `$(CI)`, `Deterministic`) and references `Microsoft.SourceLink.GitHub` with `PrivateAssets="all"`
+- [ ] The Studios icon asset is packed inside `HoneyDrunk.Standards` and referenced by the fragment via `<PackageIcon>` — no Node copies the binary
+- [ ] An MSBuild enforcement target fails the build with a clear diagnostic when any required D3 field is empty on a packable project; it never fires on `IsPackable=false` projects
+- [ ] The fragment applies only to packable projects — no `PackageReadmeFile` / `PackageIcon` / SourceLink leakage into `*.Tests.*` projects
+- [ ] Repo `README.md` documents how a Node package consumes the fragment and which three fields the Node overrides
+- [ ] Repo-level `CHANGELOG.md` updated — new version entry (this is the bumping packet for `HoneyDrunk.Standards` in this initiative); per-package `CHANGELOG.md` updated for the package that gained the fragment
+- [ ] Build green; existing `HoneyDrunk.Standards` consumers unaffected (analyzer / EditorConfig / test-stack-fragment behavior unchanged)
+
+## Human Prerequisites
+- [ ] Provide the Studios mark icon asset (PNG, the size nuget.org expects — 128x128 recommended) if one is not already in the repo. The agent packs whatever asset the human supplies; it does not create artwork.
+
+## Referenced ADR Decisions
+**ADR-0034 D3 — Package identity.** Thirteen metadata fields required in each project file or `Directory.Build.props`, CI-enforced (build fails if missing): `Authors`, `Company`, `Product`, `RepositoryUrl`, `RepositoryType`, `PackageProjectUrl`, `PackageLicenseExpression` (SPDX, never `PackageLicenseFile`), `PackageReadmeFile`, `PackageIcon`, `PackageTags`, `Description`, `RepositoryCommit`. `Directory.Build.props` at the repo root is the enforcement point; per-project overrides limited to `PackageId`, `Description`, `PackageTags`.
+
+**ADR-0034 D4 — SourceLink and deterministic builds.** All public packages enable `PublishRepositoryUrl`, `EmbedUntrackedSources`, `IncludeSymbols`, `SymbolPackageFormat=snupkg`, `ContinuousIntegrationBuild` (when `$CI=true`), `Deterministic`. `Microsoft.SourceLink.GitHub` referenced from `Directory.Build.props`. `.snupkg` symbol packages publish alongside the main package. "Non-negotiable for any public package."
+
+**ADR-0039 — license policy.** MIT is the Grid default; the SPDX expression for `PackageLicenseExpression` comes from ADR-0039. Revenue Nodes use FSL and override.
+
+## Constraints
+> **Invariant 26 — Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section.** "`HoneyDrunk.Standards` must be explicitly listed on every new .NET project (StyleCop + EditorConfig analyzers, `PrivateAssets: all`)." If this packet creates a new `.csproj` in `HoneyDrunk.Standards` to host the fragment as build assets, that project must reference `HoneyDrunk.Standards` analyzers with `PrivateAssets: all`.
+
+> **Invariant 16 — No test code in runtime packages.** The same spirit forbids leaking packaging metadata (`PackageReadmeFile`, `PackageIcon`, SourceLink) into test projects. Scope the fragment to `$(IsPackable)`.
+
+> **Invariant 12 — Semantic versioning with CHANGELOG and README.** Every package directory must contain a `README.md`. The fragment's `PackageReadmeFile` wiring depends on each consuming package having a README — packet 05's per-Node adoption ensures it.
+
+- **Never `<PackageLicenseFile>` for public packages** — ADR-0034 D3 explicitly forbids it to avoid stale embedded license text. Always the SPDX `<PackageLicenseExpression>`.
+- **The fragment is build-metadata only** — it does not push packages. The publish workflow is HoneyDrunk.Actions' job (packet 03). Do not add `dotnet nuget push` logic here.
+- **One shared icon asset** — packed from `HoneyDrunk.Standards`, never copied per-Node.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0034`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Author a shared `Directory.Build.props` fragment in `HoneyDrunk.Standards` for the ADR-0034 D3 package-metadata block + D4 SourceLink/determinism block, plus a build-failing enforcement target for the required D3 fields, for Grid-wide consumption by packable Node projects.
+
+**Target:** HoneyDrunk.Standards, branch from `main`.
+
+**Context:**
+- Goal: One canonical packaging-metadata + SourceLink definition; eliminate per-Node metadata drift.
+- Feature: ADR-0034 Public Package Distribution initiative, Wave 1.
+- ADRs: ADR-0034 (D3, D4), ADR-0039 (license SPDX expression).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0034 acceptance (soft — references ADR-0034 D3/D4 as live rules).
+
+**Constraints:**
+- See "Constraints" — inlined for agent consumption.
+- Never `<PackageLicenseFile>` for public packages; always SPDX `<PackageLicenseExpression>`.
+- Build-metadata only — no `dotnet nuget push` logic.
+- One shared icon asset, packed from `HoneyDrunk.Standards`.
+- Scope to `$(IsPackable)` — no metadata leakage into test projects.
+
+**Key Files:**
+- New props fragment + `.targets` under `HoneyDrunk.Standards` (path per repo convention).
+- The packed Studios icon asset.
+- `README.md` — consumption documentation.
+- `CHANGELOG.md` (repo-level + per-package).
+
+**Contracts:** None — this is build tooling, not a runtime contract. No `catalogs/contracts.json` change.

--- a/generated/issue-packets/active/adr-0034-public-package-distribution/03-actions-job-publish-nuget-workflow.md
+++ b/generated/issue-packets/active/adr-0034-public-package-distribution/03-actions-job-publish-nuget-workflow.md
@@ -1,0 +1,149 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["ci", "tier-2", "ops", "adr-0034", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0034", "ADR-0012", "ADR-0005"]
+accepts: ["ADR-0034"]
+wave: 2
+initiative: adr-0034-public-package-distribution
+node: honeydrunk-actions
+---
+
+# Author job-publish-nuget.yml — the single reusable package-publish workflow (ADR-0034 D6)
+
+## Summary
+Author a new reusable workflow `HoneyDrunk.Actions/.github/workflows/job-publish-nuget.yml` that handles package authentication, signing, push, and post-publish verification for any Node's release pipeline, parameterised by `package-id`, `version`, and `feed` — so package publish lives in the CI control plane and consumer release workflows never call `dotnet nuget push` directly.
+
+## Target Workflow
+**File:** `.github/workflows/job-publish-nuget.yml`
+**Family:** release (reusable `workflow_call`, follows the ADR-0012 reusable-workflow factoring)
+
+## Motivation
+ADR-0034 D6 commits package publish to "a single reusable workflow (`job-publish-nuget.yml`), called by every Node's release workflow. This preserves the ADR-0012 invariant that CI mechanics live in the control plane." ADR-0034 adds an invariant (created in packet 00): "Package publish runs through the HoneyDrunk.Actions reusable workflow. Consumer release workflows do not call `dotnet nuget push` directly." Today some Nodes publish to GitHub Packages, some to an internal Azure Artifacts feed, with inline push logic that has drifted per-repo. This packet builds the one workflow that replaces all of it. Per-Node release workflows are amended to call it in packet 05.
+
+## Proposed Change
+
+### Workflow shape (ADR-0034 D6)
+New reusable workflow callable via `workflow_call`. Inputs:
+- `package-id` — the package being published (e.g. `HoneyDrunk.Kernel.Abstractions`).
+- `version` — the package version (the Node's release workflow supplies it; ADR-0034 D7 / ADR-0035 govern the version *semantics* — this workflow does not compute or validate SemVer beyond what `feed` selection requires).
+- `feed` — a feed-id from `catalogs/package-feeds.json`: one of `nuget-org-public` | `github-packages-private` | `azure-artifacts-prerelease`. **The `feed` input values are the catalog `feed-id` keys verbatim** — not the short names `nuget.org` / `github` / `azure-artifacts`. The workflow validates the supplied `feed` against the catalog by exact `feed-id` match, so the input enum and the catalog keys must be identical strings. (ADR-0034 D6 describes the feeds informally as "nuget.org | github | azure-artifacts"; this packet binds the actual workflow input to the catalog's `feed-id` keys so validation is a direct lookup.)
+
+The caller passes the path to the built `.nupkg` (and `.snupkg`) artifact, or the workflow builds + packs from a checked-out repo — match the existing `HoneyDrunk.Actions` release-workflow pattern (e.g. how the Container Apps deploy workflow takes its inputs). Record the chosen artifact-handoff shape in `docs/consumer-usage.md`.
+
+The workflow handles four stages per D6: **auth → sign → push → post-publish verification**.
+
+### Feed selection and auth
+Each `feed` value below is the exact `feed-id` key from `catalogs/package-feeds.json`:
+- `feed: nuget-org-public` — push to `https://api.nuget.org/v3/index.json`. Auth via the nuget.org API key resolved from the CI-surface Key Vault (per ADR-0005; never a hardcoded secret, never echoed to logs). This is the stable-release path.
+- `feed: azure-artifacts-prerelease` — push to the internal Azure Artifacts feed (URL from `catalogs/package-feeds.json`, `feed-id: azure-artifacts-prerelease`). This is the pre-release-only staging path per ADR-0034 D1 — pre-release versions (`-preview.N`, `-rc.N`) flow here first.
+- `feed: github-packages-private` — push to GitHub Packages scoped to `HoneyDrunkStudios`. Per ADR-0034 D2, auth uses a **federated GitHub Actions token** — no long-lived PAT. This is the private-revenue-Node path.
+
+The workflow validates `feed` against `catalogs/package-feeds.json` (the allowlist from packet 01) by exact `feed-id` match: an unknown feed-id is a hard failure. It also enforces the ADR-0034 D1 staging rule — a stable (non-pre-release) version targeting `azure-artifacts-prerelease` is a failure (stable lands on nuget.org, never on the staging feed), and a pre-release version targeting `nuget-org-public` is a failure or a warning per the ADR-0035 pre-release flow (default: fail; the caller opts into nuget.org pre-release explicitly if ADR-0035 allows it — record the chosen strictness in the PR).
+
+### Signing (ADR-0034 D5)
+- The workflow has a **sign** stage that author-signs the package with the code-signing certificate when one is available, resolved from the Studios Key Vault via **federated OIDC** (per ADR-0005 / ADR-0006 — never a stored secret, never a key on a developer laptop, no long-lived signing PAT).
+- Per ADR-0034 D5, the signing certificate is **gated on the BDR-0001 Sunbiz amendment landing** so the certificate subject matches the legal entity name. Until then, packages publish **unsigned**. The workflow must therefore make the sign stage **conditional**: if the signing certificate secret is present in Vault, sign; if absent, skip the sign stage cleanly and publish unsigned. This is not a silent skip — the workflow logs `Publishing UNSIGNED — code-signing certificate not yet provisioned (BDR-0001 pending)` so the unsigned state is visible in every run.
+- Repository signing (nuget.org server-side) is unconditionally enabled — ADR-0034 D5: "Repository signing (nuget.org server-side) is unconditionally enabled in parallel." Nothing in this workflow blocks it; it is a nuget.org account/feed setting (see Human Prerequisites).
+
+### Post-publish verification (ADR-0034 D6)
+After push, the workflow **pulls the package back by name + version** and asserts the ADR-0034 D3 metadata fields are populated (`Authors`, `Company`, `Product`, `RepositoryUrl`, `PackageLicenseExpression`, `PackageReadmeFile`, `PackageIcon`, `Description`, etc.). A package that publishes with empty required metadata fails the verification stage and the workflow run, so a metadata regression is caught at publish time, not by a consumer.
+
+### Caller-permissions contract (ADR-0034 Consequences)
+ADR-0034's Affected Nodes section: HoneyDrunk.Actions gains "a new caller-permissions contract requiring `id-token: write` for federated OIDC to the signing cert." The workflow documents in `docs/consumer-usage.md` that callers must grant `id-token: write` (for the OIDC signing-cert fetch and the `feed: github-packages-private` federated token) and `packages: write` when `feed: github-packages-private`. This mirrors the existing ADR-0012 caller-permissions contract pattern.
+
+### Graceful behaviour
+- Feed unreachable / push rejected → the workflow fails loudly with the feed's error; it never reports success on a failed push.
+- `.snupkg` symbol package is pushed alongside the main package to the feed's symbol server (nuget.org's symbol server for `feed: nuget-org-public`) — ADR-0034 D4.
+
+## Consumer Impact
+- No consumer repo is affected until its release workflow is amended to call `job-publish-nuget.yml` — that is packet 05's fan-out. This workflow is purely additive.
+- Existing `HoneyDrunk.Actions` reusable workflows are untouched.
+
+## Breaking Change?
+- [ ] Yes
+- [x] No — new reusable workflow, additive. No consumer calls it until packet 05.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/job-publish-nuget.yml` exists and is callable via `workflow_call` with inputs `package-id`, `version`, `feed`
+- [ ] `feed` accepts exactly the `catalogs/package-feeds.json` feed-id keys — `nuget-org-public` / `github-packages-private` / `azure-artifacts-prerelease`; the value is validated against the catalog by exact `feed-id` match and an unknown feed is a hard failure
+- [ ] nuget.org auth uses the API key from the CI-surface Key Vault; GitHub Packages auth uses a federated GitHub Actions token (no long-lived PAT) per ADR-0034 D2
+- [ ] The ADR-0034 D1 staging rule is enforced: a stable version targeting `azure-artifacts` fails; pre-release-vs-nuget.org strictness is implemented and the chosen strictness recorded in the PR
+- [ ] The sign stage is conditional: signs when the code-signing certificate is present in Vault (via federated OIDC), skips cleanly and logs an explicit `Publishing UNSIGNED` message when absent (BDR-0001 pending)
+- [ ] The `.snupkg` symbol package is pushed alongside the main package to the feed's symbol server
+- [ ] Post-publish verification pulls the package back by name+version and fails the run if any required ADR-0034 D3 metadata field is empty
+- [ ] `docs/consumer-usage.md` documents the caller snippet, the `id-token: write` / `packages: write` permissions contract, and the artifact-handoff shape
+- [ ] `docs/CHANGELOG.md` updated with a new entry for the `job-publish-nuget.yml` reusable workflow
+- [ ] `README.md` updated to list `job-publish-nuget.yml` among the reusable workflows
+
+## Human Prerequisites
+- [ ] Claim the `HoneyDrunkStudios` owner account on nuget.org, bind it to the studio's primary email (BDR-0001 mail-of-record), and enable org-level 2FA — ADR-0034 Operational Consequences. Cross-link the infrastructure walkthrough doc if one exists.
+- [ ] Generate a nuget.org API key scoped to push for `HoneyDrunk.*` packages and seed it into the CI-surface Key Vault (per ADR-0005). The workflow resolves it by name; it is never committed.
+- [ ] Enable nuget.org server-side repository signing on the `HoneyDrunkStudios` account/feed — ADR-0034 D5 (unconditional, independent of the author-signing cert).
+- [ ] Configure the federated OIDC trust between GitHub Actions and the Studios Key Vault for the signing-cert fetch (subscription / RBAC / federated credential — portal steps).
+- [ ] The code-signing certificate itself is **not** a prerequisite for this packet — D5 explicitly publishes unsigned until the BDR-0001 Sunbiz amendment lands. Certificate procurement + Vault seeding is packet 04.
+
+## Dependencies
+- `packet:00` — ADR-0034 acceptance (soft — references ADR-0034 D6 as a live rule).
+- `packet:01` — `catalogs/package-feeds.json` (**hard** — the workflow validates the `feed` input against this catalog's allowlist).
+
+## Referenced ADR Decisions
+**ADR-0034 D6 — Release workflow factoring.** Package publish lives in HoneyDrunk.Actions as a single reusable workflow `job-publish-nuget.yml`, called by every Node's release workflow. Inputs: `package-id`, `version`, `feed`. ADR-0034 D6 names the feeds informally as "nuget.org | github | azure-artifacts"; this packet binds the actual `feed` input to the `catalogs/package-feeds.json` feed-id keys (`nuget-org-public` | `github-packages-private` | `azure-artifacts-prerelease`) so validation is a direct catalog lookup. The workflow handles auth, sign, push, and post-publish verification (pulls the package by name+version and asserts metadata fields are populated). Existing Node release workflows are amended in a discrete follow-up rollout to call this workflow rather than running `dotnet nuget push` inline.
+
+**ADR-0034 D5 — Package signing.** All published packages are author-signed with a code-signing certificate issued to "HoneyDrunk Studios". Per BDR-0001 the entity is mid-Sunbiz-amendment; signing-cert procurement waits on that amendment so the subject matches the legal entity name. Until then, packages publish **unsigned**. Repository signing (nuget.org server-side) is unconditionally enabled in parallel. The signing cert's private key lives in the Studios Key Vault; CI accesses it via federated OIDC, never as a stored secret. No long-lived signing PAT.
+
+**ADR-0034 D1 — Primary feed.** nuget.org under `HoneyDrunkStudios` is the primary public feed; stable versions land on nuget.org and are never republished back. Azure Artifacts is the pre-release-only staging surface — `-preview.N` / `-rc.N` flow there first.
+
+**ADR-0034 D2 — Private packages.** GitHub Packages under the org for private revenue Nodes; auth uses a federated GitHub Actions token, no long-lived PAT.
+
+**ADR-0012** — CI mechanics live in the HoneyDrunk.Actions control plane via reusable workflows; consumers call them.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The nuget.org API key, the federated tokens, and the signing-certificate material must never be echoed into workflow logs. Only secret names/identifiers may be traced.
+
+> **Invariant 9 — Vault is the only source of secrets.** The nuget.org API key resolves through the CI-surface Key Vault; the signing certificate resolves from the Studios Key Vault via federated OIDC. No hardcoded keys, no env-file secrets, no key on a developer laptop.
+
+> **Invariant 31 — Every PR traverses the tier-1 gate before merge.** This is a release-family reusable workflow, not a PR check; it does not alter the tier-1 gate.
+
+- **No `dotnet nuget push` in consumer repos.** The whole point of D6 — and the new invariant packet 00 adds — is that publish runs through this workflow. The workflow is the only place push happens.
+- **Sign stage is conditional, not silently skipped.** When the cert is absent, log an explicit `Publishing UNSIGNED` line so the unsigned state is visible in every run until BDR-0001 lands.
+- **`feed` is validated against the catalog.** An unknown or mistyped feed-id is a hard failure, never a default-to-something fallback.
+- **No long-lived PAT** anywhere — nuget.org via Vault-stored API key, GitHub Packages and signing-cert via federated OIDC tokens.
+
+## Labels
+`ci`, `tier-2`, `ops`, `adr-0034`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Build `job-publish-nuget.yml` — the single reusable package-publish workflow. Parameterise on `package-id` / `version` / `feed`; handle auth, conditional signing, push, and post-publish metadata verification; validate `feed` against `catalogs/package-feeds.json`.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: One control-plane workflow for all package publishing; consumer release workflows stop calling `dotnet nuget push` directly (packet 05 amends them).
+- Feature: ADR-0034 Public Package Distribution rollout, Wave 2.
+- ADRs: ADR-0034 (D6 primary, D1/D2/D5), ADR-0012 (reusable-workflow factoring), ADR-0005 (Key Vault / federated OIDC), ADR-0006 (cert rotation lifecycle).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0034 acceptance (soft).
+- `packet:01` — `catalogs/package-feeds.json` (hard — the `feed` input is validated against it).
+
+**Constraints:**
+- See "Constraints" — inlined for agent consumption.
+- No `dotnet nuget push` in consumer repos; this workflow is the only place push happens.
+- The sign stage is conditional but never silently skipped — log `Publishing UNSIGNED` when the cert is absent.
+- `feed` is validated against the catalog; unknown feed-id is a hard failure.
+- No long-lived PAT anywhere.
+
+**Key Files:**
+- `.github/workflows/job-publish-nuget.yml` (new)
+- `docs/consumer-usage.md`
+- `docs/CHANGELOG.md`
+- `README.md`
+
+**Contracts:** Consumes `catalogs/package-feeds.json` (read-only, from the architecture-repo checkout — ADR-0008 D8 checks out both repos) — the `feed` input is validated by exact `feed-id` match against this catalog. Defines the `job-publish-nuget.yml` `workflow_call` input contract (`package-id` / `version` / `feed`, where `feed` is one of `nuget-org-public` / `github-packages-private` / `azure-artifacts-prerelease`) and the caller-permissions contract (`id-token: write`, `packages: write` on `feed: github-packages-private`).

--- a/generated/issue-packets/active/adr-0034-public-package-distribution/04-vault-signing-certificate-procurement.md
+++ b/generated/issue-packets/active/adr-0034-public-package-distribution/04-vault-signing-certificate-procurement.md
@@ -1,0 +1,118 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Vault
+labels: ["chore", "tier-2", "infrastructure", "human-only", "adr-0034", "wave-3"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0034", "ADR-0005", "ADR-0006"]
+accepts: ["ADR-0034"]
+wave: 3
+initiative: adr-0034-public-package-distribution
+node: honeydrunk-vault
+---
+
+# Procure and seed the code-signing certificate, enable author-signing (ADR-0034 D5)
+
+## Summary
+After the BDR-0001 Sunbiz amendment lands, procure a code-signing certificate issued to the finalized "HoneyDrunk Studios" legal entity, store its private key in the Studios Key Vault, confirm the federated-OIDC access path from CI, and verify `job-publish-nuget.yml`'s conditional sign stage activates — flipping public packages from unsigned to author-signed.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Vault` — the Vault node owns the secret/certificate substrate. The certificate *material* lives in the Studios Key Vault; this packet is tracked against Vault as the responsible Node.
+
+## Context
+ADR-0034 D5 commits all published packages to author-signing with a code-signing certificate issued to "HoneyDrunk Studios" (the LLC). Per BDR-0001 the entity is mid-Sunbiz-amendment; ADR-0034 D5 holds certificate procurement until the amendment lands "so the certificate subject matches the legal entity name." Until then, `job-publish-nuget.yml` (packet 03) publishes unsigned with an explicit `Publishing UNSIGNED` log line.
+
+ADR-0034's Operational Consequences are explicit that the unsigned state "blocks the 'remove Proposed status' gate" — except ADR-0034 is accepted (packet 00) with this as a known, recorded follow-up. This packet is that follow-up: it is the work that takes the Grid from unsigned to signed once BDR-0001 clears.
+
+This is **`Actor=Human`** — procuring a certificate from a CA, validating the legal entity, and the portal-only Key Vault certificate import cannot be delegated to an agent. There is no code artifact for an agent to author; `job-publish-nuget.yml` (packet 03) already handles the signed path conditionally. The `human-only` label is set.
+
+## HARD PRECONDITION — do not file or start until BDR-0001 lands
+The BDR-0001 Sunbiz amendment must be **complete and the legal entity name final** before this packet runs. ADR-0034 D5: signing-cert procurement "waits on that amendment landing so the certificate subject matches the legal entity name." If the amendment has not landed, this packet stays in `active/` as a held draft and is not filed as a GitHub Issue. The `file-packets` pipeline holds it until the human confirms BDR-0001 is done.
+
+## Scope
+- Code-signing certificate — procured from a CA, subject = the finalized HoneyDrunk Studios legal entity name.
+- Studios Key Vault — the certificate private key imported/stored per ADR-0005.
+- Federated OIDC trust — confirmed working for the CI signing-cert fetch (the trust itself is configured as a Human Prerequisite of packet 03; this packet confirms it resolves the now-present certificate).
+- Rotation — the certificate enrolled in the ADR-0006 secret/certificate lifecycle (auto-renew 30 days before expiry).
+- `repos/HoneyDrunk.Vault/integration-points.md` — record the signing certificate as a Vault-managed secret.
+
+## Proposed Work (human-executed)
+1. Confirm BDR-0001 has landed and the legal entity name is final.
+2. Procure a code-signing (Authenticode) certificate from a CA, with subject matching the finalized "HoneyDrunk Studios" entity name. (CA validation has a 1–3 week lead time per ADR-0034's Alternatives section.)
+3. Import the certificate (with private key) into the Studios Key Vault as a certificate object, per ADR-0005's per-Node Key Vault model. The private key never leaves Vault and never lands on a developer laptop (ADR-0034 D5).
+4. Verify the federated-OIDC path from `job-publish-nuget.yml` (packet 03) can fetch the certificate — run a publish of a test/canary package and confirm the workflow's sign stage activates (the `Publishing UNSIGNED` log line no longer appears; the package is author-signed).
+5. Enroll the certificate in the ADR-0006 lifecycle: certificates auto-renew 30 days before expiry; route the Key Vault's diagnostic settings to the shared Log Analytics workspace (invariant 22) if not already.
+6. Update `repos/HoneyDrunk.Vault/integration-points.md` to record the signing certificate as a Vault-managed secret with its rotation posture.
+
+## NuGet Dependencies
+None. This packet has no .NET project — `job-publish-nuget.yml` (packet 03) already implements the signed path conditionally. This packet provisions the certificate that activates that path.
+
+## Boundary Check
+- [x] The certificate material belongs in the Studios Key Vault — Vault is the only source of secrets (invariant 9). Correct ownership.
+- [x] No code change in any repo — the signed code path already exists (packet 03).
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] BDR-0001 confirmed landed; the legal entity name is final
+- [ ] A code-signing certificate with subject = the finalized HoneyDrunk Studios entity name is procured
+- [ ] The certificate (with private key) is stored in the Studios Key Vault; the private key never left Vault and is not on any developer laptop
+- [ ] A test/canary package publish through `job-publish-nuget.yml` produces an **author-signed** package — the `Publishing UNSIGNED` log line no longer appears
+- [ ] The certificate is enrolled in the ADR-0006 lifecycle (auto-renew 30 days before expiry); the Key Vault diagnostics route to the shared Log Analytics workspace
+- [ ] `repos/HoneyDrunk.Vault/integration-points.md` records the signing certificate as a Vault-managed secret
+- [ ] The ADR-0034 "remove Proposed status" gate note (Operational Consequences) is satisfiable — the unsigned-publish window is closed
+
+## Human Prerequisites
+This entire packet is `Actor=Human`. The human-executed steps are the Proposed Work list above. Specifically:
+- [ ] BDR-0001 Sunbiz amendment must be complete (this is the packet's HARD PRECONDITION).
+- [ ] Code-signing certificate procured from a CA — note the 1–3 week CA validation lead time (ADR-0034 Alternatives: "Skip signing until external customers actually exist — Rejected").
+- [ ] Certificate imported into the Studios Key Vault via the Azure portal.
+- [ ] The federated-OIDC trust between GitHub Actions and the Studios Key Vault (configured as a packet 03 prerequisite) confirmed to resolve the certificate.
+
+## Referenced ADR Decisions
+**ADR-0034 D5 — Package signing.** All published packages are author-signed with a code-signing certificate issued to "HoneyDrunk Studios" (the LLC). Per BDR-0001 the entity is mid-Sunbiz-amendment; signing-cert procurement waits on that amendment landing so the certificate subject matches the legal entity name. Until then, packages publish unsigned. Repository signing (nuget.org server-side) is unconditionally enabled in parallel. The signing certificate's private key lives in the Studios Key Vault (per ADR-0005); CI accesses it via federated OIDC, never as a stored secret. Rotation follows ADR-0006's secret lifecycle. No long-lived signing PAT, no key on a developer laptop.
+
+**ADR-0034 Operational Consequences.** "Until D5 signing lands, unsigned packages will produce a yellow warning in `dotnet restore` for security-conscious consumers. This is acceptable for the Proposed → Accepted window but blocks the 'remove Proposed status' gate." Procuring the certificate is named explicitly under Follow-up Work: "Procure the code-signing certificate after Sunbiz amendment lands (BDR-0001)."
+
+**ADR-0006 — Secret rotation and lifecycle.** Certificates are auto-renewed 30 days before expiry.
+
+## Constraints
+> **Invariant 9 — Vault is the only source of secrets.** The signing certificate's private key lives in the Studios Key Vault. No Node reads it from environment variables, config files, or a laptop.
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The certificate private key is never echoed; only its name/identifier may be traced.
+
+> **Invariant 20 — No secret may exceed its tier's rotation SLA.** Certificates are auto-renewed 30 days before expiry; enroll the signing certificate accordingly.
+
+> **Invariant 22 — Every Key Vault must have diagnostic settings routed to the shared Log Analytics workspace.** Confirm the Studios Key Vault holding the certificate satisfies this.
+
+- **Do not start before BDR-0001 lands** — the certificate subject must match the final legal entity name. A cert issued to a soon-to-be-renamed entity is wasted procurement spend and lead time.
+- **The private key never leaves Vault** — no export to a laptop, no long-lived signing PAT.
+
+## Labels
+`chore`, `tier-2`, `infrastructure`, `human-only`, `adr-0034`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Procure the code-signing certificate (subject = finalized HoneyDrunk Studios entity), store it in the Studios Key Vault, and verify `job-publish-nuget.yml`'s sign stage flips public packages from unsigned to author-signed.
+
+**Target:** Tracked against `HoneyDrunk.Vault`; the work is human-executed (portal + CA procurement). `Actor=Human` — `human-only` label set.
+
+**Context:**
+- Goal: Close the unsigned-publish window ADR-0034 D5 opens; satisfy the "remove Proposed status" gate.
+- Feature: ADR-0034 Public Package Distribution rollout, Wave 3 (signing).
+- ADRs: ADR-0034 (D5 primary), ADR-0005 (Key Vault model), ADR-0006 (certificate auto-renewal), BDR-0001 (entity finalization — the hard precondition).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — `job-publish-nuget.yml` (hard — the workflow with the conditional sign stage must exist; this packet provisions the certificate that activates it).
+
+**Constraints:**
+- HARD PRECONDITION — do not file or start until BDR-0001 lands.
+- The private key never leaves Vault; no long-lived signing PAT.
+- The certificate subject must match the final legal entity name.
+
+**Key Files:**
+- `repos/HoneyDrunk.Vault/integration-points.md` (the only file artifact — records the certificate as a Vault-managed secret).
+
+**Contracts:** None changed — no code, no runtime contract. This packet provisions the certificate the existing packet-03 sign stage consumes.

--- a/generated/issue-packets/active/adr-0034-public-package-distribution/05-cross-repo-adopt-packaging-metadata-and-publish-workflow.md
+++ b/generated/issue-packets/active/adr-0034-public-package-distribution/05-cross-repo-adopt-packaging-metadata-and-publish-workflow.md
@@ -1,0 +1,143 @@
+---
+name: Cross-Repo Change
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+target_repos: ["HoneyDrunk.Kernel", "HoneyDrunk.Transport", "HoneyDrunk.Vault", "HoneyDrunk.Vault.Rotation", "HoneyDrunk.Auth", "HoneyDrunk.Web.Rest", "HoneyDrunk.Data", "HoneyDrunk.Audit", "HoneyDrunk.Pulse", "HoneyDrunk.Notify", "HoneyDrunk.Communications"]
+labels: ["chore", "tier-2", "core", "ops", "coordination", "adr-0034", "wave-3"]
+dependencies: ["packet:02", "packet:03"]
+adrs: ["ADR-0034"]
+accepts: ["ADR-0034"]
+wave: 3
+initiative: adr-0034-public-package-distribution
+node: honeydrunk-architecture
+---
+
+# Adopt the packaging-metadata fragment + the job-publish-nuget.yml workflow across all public Nodes (ADR-0034 D3/D4/D6)
+
+## Summary
+Roll the ADR-0034 packaging conventions out to every public package-producing Node: import the shared `Directory.Build.props` packaging-metadata + SourceLink fragment from `HoneyDrunk.Standards` (packet 02), supply the three per-project metadata overrides and the Node-level metadata slots, ensure every package directory has a `README.md` packed into the nupkg, and amend each Node's release workflow to call `job-publish-nuget.yml` (packet 03) instead of any inline `dotnet nuget push`.
+
+## Repo-list reconciliation (read this before filing)
+ADR-0034's Affected Nodes section says "All public Nodes." This packet's fan-out is the **package-producing** subset. The membership test for the fan-out is concrete: a repo is in if it is **scaffolded** (a real repo with buildable .NET projects) **and package-producing** (it ships at least one `.nupkg`). It is *not* gated on a `Live` signal in `catalogs/nodes.json`.
+
+- **`HoneyDrunk.Architecture`**, **`HoneyDrunk.Studios`**, and **`HoneyDrunk.Actions`** are excluded — none of the three ships any NuGet package. This is a known fact about what each repo produces: Architecture is docs/catalogs, Studios is a Next.js site, Actions ships reusable GitHub workflows. (There is no `packages` field in `catalogs/nodes.json` to cite — exclusion is by what the repo actually produces, confirmed against `catalogs/relationships.json` `exposes` and `catalogs/contracts.json`, neither of which lists a package for these three.)
+- **`HoneyDrunk.Standards`** is excluded from *this* fan-out — it adopts its own fragment as part of authoring it (packet 02 ships the fragment and `HoneyDrunk.Standards`'s own packable analyzer/build-asset packages adopt it in that packet). Do not double-apply here.
+- **`HoneyDrunk.Audit`** *is* included. Audit carries `signal: "Seed"` in `catalogs/nodes.json` (id `honeydrunk-audit`) — it is **not** a Live Node. But it **is** scaffolded and package-producing: the ADR-0030/0031 standup stood up the repo with buildable `HoneyDrunk.Audit.Abstractions` + `HoneyDrunk.Audit.Data` projects. Fan-out membership is the scaffolded-and-package-producing test, not the Live signal — Audit passes it, so it is in. No "drop at filing time" escape hatch applies: Audit is a fixed member of the pinned list.
+- **`HoneyDrunk.Vault.Rotation`** is included — it ships `HoneyDrunk.Vault.Rotation`.
+
+That leaves the **11 package-producing .NET Node repos** enumerated in `target_repos`. **Seed Nodes** (AI, Capabilities, Operator, Agents, Memory, Knowledge, Flow, Evals, Sim, Observe) are explicitly OUT — they are not yet scaffolded as package-producing repos; per ADR-0034 they adopt the conventions "as they scaffold," which is each Seed Node's own standup-ADR work, not a silent addition here. **Private revenue Nodes** (`HoneyDrunk.Notify.Cloud`, ADR-0027 — not yet scaffolded) are OUT: they publish to GitHub Packages (`feed: github-packages-private`) per ADR-0034 D2 and adopt the conventions in their own standup.
+
+## Context
+ADR-0034 D3/D4 commit every public package to a fixed metadata block + SourceLink + deterministic builds; D6 commits publish to the `job-publish-nuget.yml` reusable workflow. Packet 02 authored the shared `HoneyDrunk.Standards` fragment that carries the D3/D4 block and the build-failing metadata-enforcement target; packet 03 authored `job-publish-nuget.yml`. This packet is the per-Node adoption — the work ADR-0034 Follow-up Work names as "Roll out `Directory.Build.props` updates to all 12 live Nodes (one packet per repo; scope agent)" plus the D6 release-workflow amendment ("Existing Node release workflows are amended in a discrete follow-up rollout to call this reusable workflow").
+
+**This is a multi-repo packet** describing one repeated unit of work across the 11 repos in `target_repos`. The `file-packets` agent files it as a tracking issue in `HoneyDrunk.Architecture` with one child issue per Node, or as 11 sibling issues. The per-repo work is identical in shape and small-to-medium.
+
+## Per-repo work unit (repeated for each of the 11 Node repos)
+For each Node repo:
+1. **Import the metadata fragment.** Wire the repo-root `Directory.Build.props` to import the `HoneyDrunk.Standards` packaging-metadata + SourceLink fragment (packet 02). Match the repo's existing `HoneyDrunk.Standards` consumption mechanism (the same way it consumes the analyzer set).
+2. **Supply the Node-level metadata slots.** Set the per-repo values the fragment leaves as slots: `RepositoryUrl` (the canonical GitHub URL for this repo), `PackageProjectUrl`, and — if the Node is on a non-default license — `PackageLicenseExpression` (default is `MIT` per ADR-0039; only override for a revenue/FSL Node, which none in this fan-out are).
+3. **Per-project overrides.** For each packable project (`*.Abstractions`, the default backing, providers, `.AspNetCore`, etc.), set the three D3-permitted overrides: `PackageId`, `Description` (one paragraph), `PackageTags` (minimum: `honeydrunk`, the sector tag, the slot kind — `abstractions` / `backing` / `sdk`).
+4. **Per-package README.** Ensure every packable package directory has a `README.md` (invariant 12 already requires this) and that `PackageReadmeFile` resolves to it so it is packed into the nupkg. Create the README if a package directory is missing one — describe purpose, installation (`dotnet add package <id>`), and public API surface.
+5. **Verify the metadata-enforcement target passes.** The packet-02 build-failing target fails the build if any required D3 field is empty. After steps 1–4, `dotnet build` / `dotnet pack` must be green.
+6. **Amend the release workflow.** Replace any inline `dotnet nuget push` in the repo's release workflow with a call to `job-publish-nuget.yml` (packet 03) at a pinned ref, passing `package-id`, `version`, and `feed`. `feed` is a `catalogs/package-feeds.json` feed-id — `nuget-org-public` for stable releases and `azure-artifacts-prerelease` for pre-release (`-preview.N` / `-rc.N`) per ADR-0034 D1. After this, no `dotnet nuget push` remains anywhere in the repo.
+7. **Update `repos/{Node}/integration-points.md`** (in `HoneyDrunk.Architecture`) to record the Node's published feed — ADR-0034 Follow-up Work: "Update `repos/{name}/integration-points.md` for each Node with its published feed."
+
+## Affected Repos
+Exactly the 11 package-producing .NET Node repos in `target_repos`: Kernel, Transport, Vault, Vault.Rotation, Auth, Web.Rest, Data, Audit, Pulse, Notify, Communications. **Architecture, Studios, Actions, Standards excluded** — Architecture/Studios/Actions ship no NuGet package at all (Architecture is docs/catalogs, Studios is a Next.js site, Actions ships reusable workflows); Standards self-adopts in packet 02. **Seed Nodes and private revenue Nodes excluded** (adopt at their own standup). The list is pinned and fixed — do not add or drop Nodes at filing time (Audit is `signal: Seed` but scaffolded and package-producing, so it is a permanent member, not a filing-time conditional).
+
+## NuGet Dependencies
+Per repo, the only `PackageReference` change is transitive through the imported fragment:
+- `Microsoft.SourceLink.GitHub` — declared by the packet-02 fragment with `PrivateAssets="all"`; it becomes a reference on each packable project in the repo when the fragment is imported. The per-repo adoption does not add it by hand — importing the fragment is what brings it in.
+- No other package reference is added or removed. `HoneyDrunk.Standards` analyzers remain referenced as before (invariant 26).
+
+This packet adds no new .NET project. If a packable project in any repo lacks a `README.md`, one is **created** (a Markdown file, not a project) so `PackageReadmeFile` resolves — that is content, not a `PackageReference`.
+
+## Boundary Check
+- [x] Each repo's `Directory.Build.props`, per-project overrides, package READMEs, and release workflow live in that repo — correct ownership.
+- [x] `repos/{Node}/integration-points.md` edits live in `HoneyDrunk.Architecture` — correct (it is the architecture-side model file).
+- [x] No new cross-Node runtime dependency — the fragment is build tooling; `Microsoft.SourceLink.GitHub` is `PrivateAssets="all"` (build-time only, not a runtime dependency, so invariant 1 — Abstractions packages have zero runtime HoneyDrunk dependencies — is not touched).
+- [x] No contract change — packaging metadata, not interface shape.
+
+## Acceptance Criteria
+- [ ] Each of the 11 repos in `target_repos` imports the `HoneyDrunk.Standards` packaging-metadata + SourceLink fragment in its repo-root `Directory.Build.props`
+- [ ] Each repo supplies its Node-level metadata slots (`RepositoryUrl`, `PackageProjectUrl`); `PackageLicenseExpression` is `MIT` (none in this fan-out is a revenue/FSL Node)
+- [ ] Every packable project in each repo sets `PackageId`, `Description`, and `PackageTags` (minimum `honeydrunk` + sector tag + slot kind)
+- [ ] Every packable package directory has a `README.md` and `PackageReadmeFile` resolves to it — the README is packed into the nupkg
+- [ ] The packet-02 metadata-enforcement target passes — `dotnet build` / `dotnet pack` green in every repo with no empty required D3 field
+- [ ] SourceLink + `.snupkg` symbol packages are produced for every packable project (ADR-0034 D4 — verifiable in the pack output)
+- [ ] Each repo's release workflow calls `job-publish-nuget.yml` at a pinned ref; **no `dotnet nuget push` remains** in any of the 11 repos
+- [ ] `repos/{Node}/integration-points.md` in `HoneyDrunk.Architecture` records each Node's published feed (`nuget-org-public`, with pre-release via `azure-artifacts-prerelease`)
+- [ ] Each repo's repo-level `CHANGELOG.md` carries an entry for the packaging-metadata/SourceLink adoption; per-package `CHANGELOG.md` entries only for packages with an actual functional change (the metadata adoption alone is a tooling change — a single repo-level entry suffices, no per-package noise per invariant 12/27)
+- [ ] Seed Nodes, private revenue Nodes, Architecture, Studios, Actions, and Standards are NOT touched by this fan-out
+
+## Human Prerequisites
+- [ ] Packet 03's Human Prerequisites must be complete — the `HoneyDrunkStudios` nuget.org account claimed, the API key seeded in Vault, and the federated-OIDC trust configured — before any repo's amended release workflow can actually publish. (The workflow can be wired before that, but a publish run needs the credentials.)
+- [ ] Confirm the pinned `job-publish-nuget.yml` ref for all 11 callers.
+- [ ] Confirm the canonical `RepositoryUrl` / `PackageProjectUrl` for each of the 11 repos if not derivable.
+
+## Dependencies
+- `packet:02` — the `HoneyDrunk.Standards` packaging-metadata + SourceLink fragment (**hard** — each repo imports it; it must exist).
+- `packet:03` — `job-publish-nuget.yml` (**hard** — each repo's release workflow is amended to call it; it must exist).
+
+## Referenced ADR Decisions
+**ADR-0034 D3 — Package identity.** Thirteen required metadata fields, CI-enforced; `Directory.Build.props` at the repo root is the enforcement point; per-project overrides limited to `PackageId`, `Description`, `PackageTags`. Public package naming: `HoneyDrunk.<Node>[.<Slot>]`. `PackageTags` minimum: `honeydrunk`, the sector tag, the slot kind.
+
+**ADR-0034 D4 — SourceLink and deterministic builds.** Every public package enables SourceLink + symbols + deterministic builds; `.snupkg` symbol packages publish alongside. Non-negotiable.
+
+**ADR-0034 D6 — Release workflow factoring.** Existing Node release workflows are amended in a discrete follow-up rollout to call `job-publish-nuget.yml` rather than running `dotnet nuget push` inline. (This packet is that rollout.)
+
+**ADR-0034 D1 — Primary feed.** Stable versions publish to nuget.org; pre-release (`-preview.N` / `-rc.N`) transit Azure Artifacts first.
+
+**ADR-0034 Follow-up Work.** "Roll out `Directory.Build.props` updates to all 12 live Nodes (one packet per repo; scope agent)." "Update `repos/{name}/integration-points.md` for each Node with its published feed."
+
+**ADR-0034 — alternative rejected: "One package per repo."** Rejected — per-slot package identity is non-negotiable so external consumers can take `HoneyDrunk.<Node>.Abstractions` without dragging in a default backing. So every packable project — Abstractions, backing, providers — gets its own `PackageId`, not one per repo.
+
+## Constraints
+> **Invariant 12 — Semantic versioning with CHANGELOG and README.** Every package directory must contain a `README.md`. This packet ensures `PackageReadmeFile` resolves to it and packs it into the nupkg. Create the README where one is missing.
+
+> **Invariant 27 — All projects in a solution share one version and move together; per-package changelogs updated only for packages with actual changes.** The metadata adoption is a tooling change — record it as one repo-level `CHANGELOG.md` entry per repo; do not add per-package changelog noise for packages whose only change is the imported fragment.
+
+> **Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.** `Microsoft.SourceLink.GitHub` is `PrivateAssets="all"` — a build-time source-indexer, not a runtime dependency — so importing the fragment into an `.Abstractions` project does not violate this.
+
+- **No `dotnet nuget push` may remain** in any of the 11 repos after the fan-out — that is the ADR-0034 D6 invariant (added by packet 00).
+- **Per-slot package identity** — every packable project gets its own `PackageId`; do not collapse a repo to one package.
+- **Pinned 11-repo list** — do not add Seed Nodes, private revenue Nodes, Architecture, Studios, Actions, or Standards.
+- **No version bump is required by this packet alone** — adopting the metadata fragment is a build-tooling change. If a repo's release cadence means the next publish carries the change, the CHANGELOG entry rides the existing in-progress version per invariant 27; this packet does not itself trigger a release (agents never push tags — invariant 27).
+
+## Labels
+`chore`, `tier-2`, `core`, `ops`, `coordination`, `adr-0034`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Per-Node adoption of ADR-0034 D3/D4/D6 — import the `HoneyDrunk.Standards` packaging-metadata + SourceLink fragment, set the per-project + Node-level metadata, ensure per-package READMEs are packed, and amend each release workflow to call `job-publish-nuget.yml`. One identical work unit across 11 repos.
+
+**Target:** Coordination/tracking issue in `HoneyDrunk.Architecture` with one child issue per Node repo; each child branches from `main` in its own repo. The `integration-points.md` edits land in `HoneyDrunk.Architecture`.
+
+**Context:**
+- Goal: Every public package ships consistent metadata + SourceLink + symbols and publishes through the one control-plane workflow.
+- Feature: ADR-0034 Public Package Distribution rollout, Wave 3.
+- ADRs: ADR-0034 (D3/D4/D6/D1, Follow-up Work), ADR-0039 (MIT default license).
+- In scope: the 11 package-producing .NET Node repos in `target_repos`. Out: Seed Nodes, private revenue Nodes, Architecture, Studios, Actions, Standards.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` (hard — the fragment), `packet:03` (hard — the publish workflow).
+
+**Constraints:**
+- See "Constraints" — inlined for agent consumption.
+- No `dotnet nuget push` may remain in any of the 11 repos.
+- Per-slot package identity — every packable project gets its own `PackageId`.
+- Pinned 11-repo list — no additions.
+- This packet does not push tags / trigger a release.
+
+**Key Files (per repo):**
+- repo-root `Directory.Build.props`
+- per-project `.csproj` files (the three metadata overrides)
+- per-package `README.md` (created where missing)
+- the repo's release workflow
+- `CHANGELOG.md`
+- `repos/{Node}/integration-points.md` (in `HoneyDrunk.Architecture`)
+
+**Contracts:** No runtime contract change — packaging metadata only. Consumes the `HoneyDrunk.Standards` packaging fragment (packet 02) and the `job-publish-nuget.yml` `workflow_call` contract (packet 03).

--- a/generated/issue-packets/active/adr-0034-public-package-distribution/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0034-public-package-distribution/dispatch-plan.md
@@ -1,0 +1,130 @@
+# Dispatch Plan: Public Package Distribution and NuGet Policy (ADR-0034)
+
+**Date:** 2026-05-22 (initial scope — drafted ahead of ADR-0034 acceptance).
+**Trigger:** ADR-0034 (Public Package Distribution and NuGet Policy) — Proposed 2026-05-21, part of the 2026-05-21 batch of cross-cutting Grid-gap ADRs. Scoped now so the packet set is ready when the ADR lands. ADR-0034 sits in `current-focus.md`'s "Future / Watch — Commercial / substrate ADRs (0034–0042, 0045)" group, gated on the "first external NuGet consumer" forcing function — which ADR-0034's own Context says has effectively arrived (Notify Cloud SDK per PDR-0002/ADR-0027).
+**Type:** Multi-repo (Architecture, Standards, Actions, Vault — plus a per-Node fan-out across 11 package-producing Node repos).
+**Sector:** Meta + cross-cutting (every package-producing Node is touched by Wave 3's adoption fan-out).
+**Site sync required:** No. Package-distribution policy, feed configuration, and CI workflows are not public-facing artifacts on the Studios marketing site. Re-evaluate only if a future "developer / SDK" page on the Studios site surfaces install instructions — that would be a separate site-sync packet.
+
+**Rollback plan:**
+- Architecture-side packets (00, 01) revert cleanly via `git revert` — the ADR flip + invariant additions are docs/text-only; `catalogs/package-feeds.json` is a new file with no consumer until ADR-0032's leak check reads it (out of this initiative's scope), so deleting it has no consumer impact.
+- The `HoneyDrunk.Standards` packet (02) is additive build-tooling — the packaging-metadata fragment has no consumer until a Node imports it (Wave 3), so reverting has zero consumer impact.
+- The `HoneyDrunk.Actions` packet (03) is an additive reusable workflow — no consumer calls `job-publish-nuget.yml` until Wave 3's fan-out amends release workflows; reverting is safe.
+- The signing-certificate packet (04) is human/portal work — "reverting" means not procuring the cert; `job-publish-nuget.yml` already publishes unsigned conditionally, so the absence of a cert is the pre-packet-04 steady state, not a broken state.
+- The Wave 3 fan-out (05) reverts per-repo: restore the prior `Directory.Build.props`, the prior per-project metadata, and the inline `dotnet nuget push` in the release workflow. No runtime change, no contract change — packaging metadata only. A partially-reverted state (some repos adopted, some not) is operationally fine; the repos are independent and each publishes through its own release workflow.
+
+## Summary
+
+ADR-0034 decides **where and how** the Grid's public packages are distributed. The decision: nuget.org under a single `HoneyDrunkStudios` owner account as the primary public feed (D1); GitHub Packages for private revenue Nodes (D2); Azure Artifacts retained only as a pre-release staging surface (D1); thirteen required, CI-enforced package-metadata fields (D3); SourceLink + symbols + deterministic builds, non-negotiable (D4); author-signing gated on the BDR-0001 entity finalization, with repository signing unconditional (D5); a single `job-publish-nuget.yml` reusable workflow in HoneyDrunk.Actions that every Node's release workflow calls (D6); version *semantics* delegated to ADR-0035 (D7); and the approved-feeds list recorded as `catalogs/package-feeds.json` (D8).
+
+This initiative ships **6 packets** (`00`–`05`) across **three waves**:
+
+- **Wave 1** — governance + the two foundational artifacts: ADR acceptance (00), the feeds catalog (01), the shared packaging-metadata fragment (02).
+- **Wave 2** — the publish mechanism: `job-publish-nuget.yml` in HoneyDrunk.Actions (03).
+- **Wave 3** — execution: the per-Node adoption fan-out (05) across 11 package-producing Node repos, and the signing-certificate procurement (04).
+
+**ADR-0035 lands together — separate initiative.** ADR-0034 D7 is explicit: ADR-0034 and ADR-0035 "must land together; neither is useful alone." ADR-0035 (Abstractions Versioning and Deprecation Policy) is scoped under its own initiative folder. Packet 00 here flips ADR-0034 only; its acceptance PR must be merged in the same session as ADR-0035's acceptance PR. The two initiatives are sequenced loosely-parallel: ADR-0035 governs version *semantics* (SemVer rules, deprecation windows, the API-diff job) while ADR-0034 governs *distribution* (feeds, metadata, the publish workflow). They share no packet but they share a release moment.
+
+## Important constraints (from ADR-0034 itself)
+
+- **nuget.org is the primary public feed — not GitHub Packages, not Azure Artifacts.** D1 + the Alternatives section. GitHub Packages requires authenticated pulls (breaks "install without an account"); Azure Artifacts is tenant-locked. Both rejected as the primary surface.
+- **Per-slot package identity is non-negotiable.** The Alternatives section rejects "one package per repo" — external consumers must take `HoneyDrunk.<Node>.Abstractions` without dragging in a default backing. Every packable project gets its own `PackageId`.
+- **Author-signing is gated on BDR-0001.** D5 — the code-signing certificate's subject must match the finalized legal entity name. Until the Sunbiz amendment lands, packages publish **unsigned**, and `job-publish-nuget.yml` logs an explicit `Publishing UNSIGNED` line. Repository signing (nuget.org server-side) is unconditional and independent.
+- **Publish runs through the one reusable workflow.** D6 + the new invariant — no consumer repo calls `dotnet nuget push` directly. The whole point of D6 is the ADR-0012 control-plane rule.
+- **`catalogs/package-feeds.json` is the single source of truth.** D8 — feed lists are not duplicated into ADR text or README tables; those reference the catalog.
+- **No long-lived PATs.** D2/D5 — nuget.org via a Vault-stored API key, GitHub Packages and the signing-cert fetch via federated OIDC tokens.
+- **Private packages are scoped separately.** ADR-0034 governs only the *public* surface; `HoneyDrunk.Notify.Cloud.*` and future revenue Nodes (ADR-0027 D2) use the GitHub Packages private path and adopt the conventions in their own standup — out of this initiative.
+
+## Wave Diagram
+
+### Wave 1 — Governance + foundational artifacts (parallel after packet 00)
+
+Run packet 00 first (ADR acceptance). Packets 01 and 02 may run in parallel with each other after 00 — 01 is an Architecture catalog, 02 is `HoneyDrunk.Standards` build tooling; neither depends on the other.
+
+- [ ] `HoneyDrunk.Architecture`: **Accept ADR-0034** — flip status, add the three packaging invariants, register the initiative — [`00-architecture-adr-0034-acceptance.md`](00-architecture-adr-0034-acceptance.md)
+  - Blocked by: nothing.
+- [ ] `HoneyDrunk.Architecture`: Create `catalogs/package-feeds.json` — the approved-feeds allowlist — [`01-architecture-package-feeds-catalog.md`](01-architecture-package-feeds-catalog.md)
+  - Blocked by: Wave 1 — `00` (soft — references ADR-0034 D8 as a live rule).
+- [ ] `HoneyDrunk.Standards`: Author the shared packaging-metadata + SourceLink `Directory.Build.props` fragment — [`02-standards-packaging-metadata-props-fragment.md`](02-standards-packaging-metadata-props-fragment.md)
+  - Blocked by: Wave 1 — `00` (soft — references ADR-0034 D3/D4 as live rules).
+
+**Wave 1 exit criteria:**
+- ADR-0034 reads `**Status:** Accepted`; the three packaging invariants are in `constitution/invariants.md`; the initiative is registered.
+- `catalogs/package-feeds.json` exists with the three feeds (`nuget-org-public`, `github-packages-private`, `azure-artifacts-prerelease`) and is indexed.
+- `HoneyDrunk.Standards` ships the packaging-metadata + SourceLink fragment and the build-failing metadata-enforcement target.
+
+### Wave 2 — The publish mechanism
+
+- [ ] `HoneyDrunk.Actions`: Author `job-publish-nuget.yml` — the single reusable package-publish workflow — [`03-actions-job-publish-nuget-workflow.md`](03-actions-job-publish-nuget-workflow.md)
+  - Blocked by: Wave 1 — `00` (soft — references ADR-0034 D6), `01` (**hard** — the workflow validates the `feed` input against `catalogs/package-feeds.json`).
+
+**Wave 2 exit criteria:**
+- `job-publish-nuget.yml` exists, is callable via `workflow_call` with `package-id` / `version` / `feed`, validates `feed` against the catalog, handles auth + conditional signing + push + post-publish metadata verification, and pushes `.snupkg` alongside.
+
+### Wave 3 — Execution: adoption fan-out + signing
+
+Packets 04 and 05 are independent of each other and may run in parallel. Packet 04 is hard-gated on BDR-0001; packet 05 is not.
+
+- [ ] **Per-Node fan-out**: Adopt the packaging-metadata fragment + `job-publish-nuget.yml` across all 11 package-producing Nodes — [`05-cross-repo-adopt-packaging-metadata-and-publish-workflow.md`](05-cross-repo-adopt-packaging-metadata-and-publish-workflow.md)
+  - Blocked by: Wave 1 — `02` (**hard** — each repo imports the fragment); Wave 2 — `03` (**hard** — each repo's release workflow is amended to call the workflow).
+- [ ] `HoneyDrunk.Vault`: Procure + seed the code-signing certificate, enable author-signing — [`04-vault-signing-certificate-procurement.md`](04-vault-signing-certificate-procurement.md)
+  - Blocked by: Wave 2 — `03` (**hard** — the workflow with the conditional sign stage must exist; this packet provisions the cert that activates it).
+  - **`Actor=Human` — `human-only` label set.** Procuring a CA certificate and the portal-only Key Vault import cannot be delegated.
+  - **HARD PRECONDITION — do not file until BDR-0001 lands.** ADR-0034 D5 holds cert procurement until the Sunbiz amendment finalizes the legal entity name. The `file-packets` agent holds this packet until the human confirms BDR-0001 is complete. Until then it stays in `active/` as a held draft. This does not block the rest of the initiative — packets 00–03 and 05 publish unsigned in the interim, exactly as ADR-0034 D5 specifies.
+
+**Wave 3 exit criteria:**
+- All 11 package-producing Nodes import the metadata fragment, set per-project + Node-level metadata, pack per-package READMEs, produce SourceLink + `.snupkg`, and call `job-publish-nuget.yml` from their release workflows — no `dotnet nuget push` remains anywhere.
+- `repos/{Node}/integration-points.md` records each Node's published feed.
+- **Wave 3 fan-out completion means the publish workflow is WIRED into every repo's release workflow — not that any package has actually published to nuget.org.** Actual publishing requires the human prerequisites from packet 03 (the `HoneyDrunkStudios` nuget.org account claimed, the API key seeded into Vault, the federated-OIDC trust configured). The fan-out's exit criterion is "calls `job-publish-nuget.yml` and the build/pack is green," not "a `.nupkg` is live on nuget.org." First real publish happens on each repo's next release run once the nuget.org credentials exist.
+- *Conditional:* if BDR-0001 lands within the wave, the code-signing certificate is procured + seeded and published packages flip from unsigned to author-signed (packet 04). If BDR-0001 has not landed, Wave 3 exits on packet 05 alone; packet 04 is filed later when BDR-0001 clears, without re-opening the wave.
+
+## Out-of-scope / deferred items
+
+- **ADR-0035 (Abstractions Versioning and Deprecation Policy).** Lands together with ADR-0034 (D7) but is a separate initiative — `adr-0035-abstractions-versioning`. ADR-0035 owns version semantics, the `-preview.N`/deprecation windows, `Microsoft.CodeAnalysis.PublicApiAnalyzers`, and the API-diff job. This initiative owns distribution only. Packet 00's acceptance PR coordinates its merge moment with ADR-0035's.
+- **The ADR-0032 NuGet-leak PR check that *reads* `package-feeds.json`.** ADR-0034 D8 says ADR-0032's leak check "reads this catalog as the allowlist," and ADR-0034's Context names ADR-0032 as a forcing function. But ADR-0032 is itself Proposed and its current text carries no feed/allowlist check. Building the leak check is ADR-0032's own scope, not ADR-0034's. This initiative produces the *catalog* (packet 01, the artifact ADR-0034 owns); ADR-0032's check consuming it is correctly deferred to ADR-0032's scope/initiative. Recorded here so it is not silently assumed done.
+- **Private revenue Node distribution (`HoneyDrunk.Notify.Cloud.*`, ADR-0027).** ADR-0034 governs only the public surface (its Context is explicit). The GitHub Packages private path (D2) is built into `job-publish-nuget.yml` (`feed: github-packages-private`), but no private Node is scaffolded yet — Notify Cloud adopts the `feed: github-packages-private` path in its own ADR-0027 standup initiative. Not a packet here.
+- **Seed Node adoption.** The 10 AI-sector + Observe Seed Nodes adopt the ADR-0034 conventions "as they scaffold" (ADR-0034 Affected Nodes). That is each Seed Node's standup-ADR work — the standup ADRs already exist (0017–0025, 0031). Not a fan-out here; packet 05 is pinned to the 11 currently-package-producing live Nodes.
+- **`HoneyDrunk.Actions` / `HoneyDrunk.Architecture` / `HoneyDrunk.Studios` package metadata.** None of the three ships a NuGet package — this is a known fact about what each repo produces (Actions ships reusable GitHub workflows, Architecture is docs/catalogs, Studios is a Next.js site), confirmed against `catalogs/relationships.json` `exposes` and `catalogs/contracts.json`, neither of which lists a package for these three. (`catalogs/nodes.json` has no `packages` field — exclusion is by repo type / what the repo actually produces, not a catalog flag.) Excluded from the packet-05 fan-out. If any later starts producing a package, its adoption is a follow-up.
+- **Migrating existing GitHub-Packages-published Nodes off GitHub Packages.** ADR-0034 D1 makes nuget.org the public feed; ADR-0034's Context notes "some Nodes publish to GitHub Packages." Packet 05's release-workflow amendment switches each Node's `feed` to `nuget.org` for stable — the de-facto migration. No separate "decommission the old GitHub Packages feed" packet is filed; the old feed simply stops receiving new versions. If an explicit deprecation/cleanup of stale GitHub Packages versions is wanted, that is a follow-up housekeeping packet.
+
+## `gh` CLI Commands — file Wave 1–3 issues
+
+Filing is **automated**. The `file-packets.yml` workflow in `HoneyDrunk.Architecture` triggers on push to `generated/issue-packets/active/**/*.md` and files every packet, adds it to The Hive, sets board fields from frontmatter, and wires `addBlockedBy` from the `dependencies:` arrays. Do not run `gh issue create` manually.
+
+**Held packet:** packet 04 (signing-certificate procurement) is **hard-preconditioned on BDR-0001** — the `file-packets` agent holds it until the human confirms the Sunbiz amendment has landed. Packets 00–03 and 05 file on the normal push trigger.
+
+**Fan-out packet:** packet 05 is a per-Node fan-out — the `file-packets` agent expands it into one issue per repo across the 11 repos in `target_repos` (Kernel, Transport, Vault, Vault.Rotation, Auth, Web.Rest, Data, Audit, Pulse, Notify, Communications), or files it as a tracking issue with 11 sub-tasks. The 11-repo list is pinned and fixed — no repo is added or dropped at filing time. `HoneyDrunk.Audit` carries `signal: "Seed"` in `catalogs/nodes.json` (it is not a Live Node) but it is scaffolded and package-producing — the ADR-0030/0031 standup stood up buildable `HoneyDrunk.Audit.Abstractions` + `HoneyDrunk.Audit.Data` projects. Fan-out membership is the scaffolded-and-package-producing test, not the Live signal, so Audit is a permanent member.
+
+## After filing — board fields and blocking relationships
+
+The `file-packets` pipeline sets Status, Wave, Node, Tier, Actor, Initiative, and ADR fields from frontmatter and wires `addBlockedBy` automatically. For reference, the blocking graph (resolved from each packet's `dependencies:`):
+
+- `01` blocked-by `00` (soft)
+- `02` blocked-by `00` (soft)
+- `03` blocked-by `00` (soft), `01` (hard)
+- `04` blocked-by `03` (hard) — wired only when packet 04 is un-held (BDR-0001 landed) and filed
+- `05` blocked-by `02` (hard), `03` (hard) — wired on each per-Node fan-out issue
+
+**Actor:** packets 00, 01, 02, 03, 05 are `Actor=Agent` (00/01 are docs/catalog; 02 is build tooling; 03 is a workflow; 05 is per-repo metadata + workflow edits — all delegable, though 03 and 05 carry Human Prerequisites for the nuget.org account/credentials). **Packet 04 is `Actor=Human`** — it carries the `human-only` label because CA procurement and portal-only Key Vault import are the *entire* work item, not a side prerequisite.
+
+Verify a wave landed by checking The Hive for the new items + their blocked-by chains, not by inspecting the workflow log.
+
+## Notes
+
+- **Acceptance precedes flip.** ADR-0034 stays Proposed until packet 00's PR merges — and that PR is coordinated with ADR-0035's acceptance PR (ADR-0034 D7, "land together").
+- **The three new invariants land in packet 00**, not in a separate `constitution/invariants.md` packet — nuget.org ownership, SourceLink + symbols, publish-via-reusable-workflow. They are **invariants 54, 55, 56** (in that order). The current highest invariant in `constitution/invariants.md` is 51 (1–51 all present). Numbers 54–56 are **pre-reserved for ADR-0034 as part of a 12-ADR batch** that reserves blocks of invariant numbers across ADRs 0034–0042/0045; numbers 52–53 belong to a sibling ADR in the batch. Packet 00 uses the hard numbers 54–56 — it does not scan for "next free." If any invariant above 51 lands from **outside** this batch before packet 00's PR merges, shift the block upward to the next free triple and never reuse a number.
+- **The unsigned-publish window is expected and acceptable.** ADR-0034 D5 explicitly publishes unsigned until BDR-0001 lands. `job-publish-nuget.yml` (packet 03) implements the conditional sign stage from day one; packet 04 provisions the certificate that activates it. The initiative does not wait on BDR-0001 — only packet 04 does.
+- **No new repo created, no new ADR, no new runtime contract.** This initiative ships an ADR flip + invariants, one catalog, one build-tooling fragment, one reusable workflow, and a per-Node packaging/release-workflow fan-out. The one new catalog (`package-feeds.json`) introduces a new JSON schema but no runtime contract — `catalogs/contracts.json` is untouched.
+- **No Azure resources are provisioned by an agent.** The nuget.org account, the nuget.org API key, the federated-OIDC trust, and the code-signing certificate are all Human Prerequisites / `Actor=Human` work. The Studios Key Vault already exists per ADR-0005; this initiative seeds two secrets into it (the nuget.org API key, the signing certificate).
+- **Cost.** nuget.org hosting is free. The code-signing certificate is a recurring CA cost (typically $200–600/year). Azure Artifacts pre-release staging uses the existing internal feed — no new spend.
+- **The dispatch plan is the one exception to packet immutability** (ADR-0008 D7). It is updated at wave boundaries as a historical record; packet bodies are immutable post-filing (invariant 24).
+
+## Archival
+
+Per ADR-0008 D10, when every **filed and in-scope** packet in this initiative reaches `Done` on the org Project board and the wave exit criteria are met, the entire `active/adr-0034-public-package-distribution/` folder moves to `archive/adr-0034-public-package-distribution/` in a single commit. Partial archival is forbidden.
+
+**Archival-gate decision for packet 04 (signing-certificate procurement):** packet 04 is **in-scope and NOT exempt** from the archival gate. Unlike a packet gated on a thing that may never exist, BDR-0001 is a near-term, committed entity-finalization step with a concrete completion path. The initiative's archival waits for packet 04 to be filed-and-`Done` once BDR-0001 lands. If BDR-0001 is materially deferred such that the unsigned-publish window stretches indefinitely, a future dispatch-plan revision records that and re-classifies packet 04 — but the default expectation is that packet 04 completes within this initiative.
+
+## Revision history
+
+- **2026-05-22 initial scope** — 6 packets across three waves. Drafted ahead of ADR-0034 acceptance per the developer's request; packets are pending-acceptance drafts, not yet filed as GitHub Issues. ADR-0035 noted as a separate, co-landing initiative per ADR-0034 D7.

--- a/generated/issue-packets/active/adr-0034-public-package-distribution/handoff-wave3-node-adoption.md
+++ b/generated/issue-packets/active/adr-0034-public-package-distribution/handoff-wave3-node-adoption.md
@@ -1,0 +1,47 @@
+# Handoff: Wave 2 → Wave 3 (publish mechanism → per-Node adoption + signing)
+
+**Read once at the Wave 2 → Wave 3 transition.** This is an ephemeral baton pass, not a live tracker. Immutable per invariant 24.
+
+## What Waves 1–2 delivered (upstream changes Wave 3 builds on)
+
+- **ADR-0034 is Accepted** (packet 00). Its three new packaging invariants are live in `constitution/invariants.md`: (1) every public package is owned by `HoneyDrunkStudios` on nuget.org; (2) every public package ships SourceLink + symbols, build fails otherwise; (3) package publish runs through the HoneyDrunk.Actions reusable workflow, not inline `dotnet nuget push`. D1–D8 are now binding rules. ADR-0034's acceptance PR was merged together with ADR-0035's (D7 — they land together).
+- **`catalogs/package-feeds.json` exists** (packet 01) — the approved-feeds allowlist. Three feeds: `nuget-org-public` (public), `github-packages-private` (private), `azure-artifacts-prerelease` (prerelease-staging). It is the single source of truth; `job-publish-nuget.yml` validates its `feed` input against it.
+- **The `HoneyDrunk.Standards` packaging-metadata + SourceLink fragment exists** (packet 02) — a `Directory.Build.props` fragment carrying the thirteen ADR-0034 D3 metadata fields, the six D4 SourceLink/determinism properties, the `Microsoft.SourceLink.GitHub` reference (`PrivateAssets="all"`), the packed Studios icon asset, and a build-failing MSBuild target that fails the build when any required D3 field is empty on a packable project. It is scoped to `$(IsPackable)` — it never touches test projects.
+- **`job-publish-nuget.yml` exists in HoneyDrunk.Actions** (packet 03) — a reusable `workflow_call` workflow taking `package-id` / `version` / `feed`, handling auth → conditional sign → push → post-publish metadata verification, pushing `.snupkg` alongside the main package, and validating `feed` against `catalogs/package-feeds.json`. The sign stage is conditional: it author-signs when the code-signing certificate is present in the Studios Key Vault and logs an explicit `Publishing UNSIGNED` line when it is absent (BDR-0001 pending).
+
+## Contracts Wave 3 consumes
+
+- **The `HoneyDrunk.Standards` packaging-metadata fragment** — packet 05's per-Node adoption imports it into each repo-root `Directory.Build.props`. Confirm the consumption mechanism the repo already uses for the `HoneyDrunk.Standards` analyzer set and match it. The fragment leaves `RepositoryUrl`, `PackageProjectUrl`, and `PackageLicenseExpression` as slots the Node supplies, and `PackageId` / `Description` / `PackageTags` as per-project overrides.
+- **`job-publish-nuget.yml` `workflow_call` contract** — inputs `package-id`, `version`, `feed`. The `feed` input takes a `catalogs/package-feeds.json` feed-id key: `nuget-org-public` | `github-packages-private` | `azure-artifacts-prerelease` (the workflow validates `feed` by exact `feed-id` match against the catalog). Packet 05's per-Node release-workflow amendments call it at a pinned ref. Confirm the pinned ref before filing packet 05.
+- **The caller-permissions contract** — callers of `job-publish-nuget.yml` must grant `id-token: write` (federated OIDC for the signing-cert fetch and the `feed: github-packages-private` token) and `packages: write` when `feed: github-packages-private`. Documented in HoneyDrunk.Actions `docs/consumer-usage.md`.
+- **`catalogs/package-feeds.json`** — the feed-id values packet 05's release workflows pass as `feed`: `nuget-org-public` for stable, `azure-artifacts-prerelease` for pre-release (`-preview.N` / `-rc.N`) per ADR-0034 D1.
+
+## Wave 3 objectives
+
+1. **Per-Node adoption fan-out** (packet 05) — across the **11 package-producing .NET Node repos**: Kernel, Transport, Vault, Vault.Rotation, Auth, Web.Rest, Data, Audit, Pulse, Notify, Communications. Per repo: import the metadata fragment, supply the Node-level metadata slots, set the three per-project overrides on every packable project, ensure every package directory has a packed `README.md`, verify the build-failing metadata-enforcement target passes, and amend the release workflow to call `job-publish-nuget.yml` — removing every inline `dotnet nuget push`. Update `repos/{Node}/integration-points.md` with each Node's published feed.
+   - **OUT of the fan-out:** `HoneyDrunk.Architecture`, `HoneyDrunk.Studios`, `HoneyDrunk.Actions` — none ships any NuGet package (Architecture is docs/catalogs, Studios is a Next.js site, Actions ships reusable workflows; exclusion is by what the repo produces, not a catalog flag — `catalogs/nodes.json` has no `packages` field); `HoneyDrunk.Standards` (self-adopts in packet 02); the 10 Seed Nodes (adopt at their own standup); private revenue Nodes (GitHub Packages path, own standup). The 11-repo list is pinned and fixed — no repo is added or dropped at filing time. `HoneyDrunk.Audit` is `signal: "Seed"` (not Live) but it is scaffolded and package-producing — buildable `HoneyDrunk.Audit.Abstractions` + `HoneyDrunk.Audit.Data` from the ADR-0030/0031 standup. Fan-out membership is the scaffolded-and-package-producing test, not the Live signal, so Audit is a permanent member.
+2. **Signing-certificate procurement** (packet 04) — `Actor=Human`, `human-only`. After BDR-0001 lands, procure a code-signing certificate with subject = the finalized HoneyDrunk Studios legal entity, import it into the Studios Key Vault, confirm the federated-OIDC fetch path, and verify `job-publish-nuget.yml`'s sign stage flips packages from unsigned to signed.
+
+## Constraints carried into Wave 3
+
+> **Invariant — public package nuget.org ownership** (added by packet 00). Every public package is owned by `HoneyDrunkStudios` on nuget.org. No fork-owned, no individual-developer-owned public packages.
+
+> **Invariant — SourceLink + symbols** (added by packet 00). Every public package ships SourceLink + symbols; the build fails if SourceLink is not produced. Packet 05's adoption brings this in via the imported fragment — verify the `.snupkg` is produced for every packable project.
+
+> **Invariant — publish via reusable workflow** (added by packet 00). Consumer release workflows do not call `dotnet nuget push` directly. Packet 05 must leave **zero** `dotnet nuget push` in any of the 11 repos.
+
+> **Invariant 12 — Semantic versioning with CHANGELOG and README.** Every package directory must contain a `README.md`. Packet 05 ensures `PackageReadmeFile` resolves to it and packs it; create the README where one is missing.
+
+> **Invariant 27 — per-package changelogs only for packages with actual changes.** The metadata adoption is a tooling change — one repo-level `CHANGELOG.md` entry per repo; no per-package changelog noise for packages whose only change is the imported fragment. Packet 05 does not push tags / trigger a release (agents never push tags).
+
+> **Invariant 1 — Abstractions packages have zero runtime HoneyDrunk dependencies.** `Microsoft.SourceLink.GitHub` is `PrivateAssets="all"` — a build-time source-indexer, not a runtime dependency — so importing the fragment into an `.Abstractions` project does not violate this.
+
+> **Invariant 9 — Vault is the only source of secrets.** Packet 04's code-signing certificate private key lives in the Studios Key Vault, accessed via federated OIDC — never a stored secret, never a key on a laptop, no long-lived signing PAT.
+
+- **Per-slot package identity.** Every packable project — Abstractions, default backing, providers, `.AspNetCore` — gets its own `PackageId`. Do not collapse a repo to one package (ADR-0034 Alternatives explicitly rejects "one package per repo").
+- **Packet 04 is hard-gated on BDR-0001.** Do not file or start it until the human confirms the Sunbiz amendment has landed. Packets 00–03 and 05 publish unsigned in the interim — that is the ADR-0034 D5 design, not a defect.
+- **Packets 04 and 05 are independent.** They may run in parallel. Packet 05's fan-out does not wait on the signing certificate; the publish workflow handles unsigned and signed identically (sign stage is conditional).
+
+## Acceptance signal for Wave 3 completion
+
+All 11 package-producing Nodes import the metadata fragment, set per-project + Node-level metadata, pack per-package READMEs, produce SourceLink + `.snupkg`, and call `job-publish-nuget.yml` from their release workflows with no `dotnet nuget push` remaining; `repos/{Node}/integration-points.md` records each Node's published feed. *Conditional:* if BDR-0001 has landed, the code-signing certificate is procured + seeded and published packages are author-signed (packet 04); if not, Wave 3 exits on packet 05 alone and packet 04 is filed later when BDR-0001 clears. The initiative archives when every filed and in-scope packet — including packet 04 — is `Done`.


### PR DESCRIPTION
## Summary
Adds the issue packets for **ADR-0034 — Public package distribution and NuGet policy**: 6 packets (00–05), dispatch plan, and one wave handoff under `generated/issue-packets/active/adr-0034-public-package-distribution/`.

Merging this PR triggers `file-packets.yml` to file **only this ADR's packets**. This is one of 12 per-ADR PRs from the 2026-05-21 ADR batch — split per ADR so filing runs incrementally rather than firing all 92 packets at once (GraphQL rate limits).

## Merge-order note
ADR-0034 and **ADR-0035** must land in the same session — ADR-0034 D7 requires the pair to co-land (neither is useful alone).

## Test plan
- [ ] `file-packets.yml` files 6 issues on merge and adds them to The Hive
- [ ] No GraphQL rate-limit errors in the filing run

🤖 Generated with [Claude Code](https://claude.com/claude-code)