### PR TITLE
Scope ADR-0035 — abstractions versioning and deprecation policy

### DIFF
--- a/generated/issue-packets/active/adr-0035-abstractions-versioning/00-architecture-adr-0035-acceptance.md
+++ b/generated/issue-packets/active/adr-0035-abstractions-versioning/00-architecture-adr-0035-acceptance.md
@@ -1,0 +1,119 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "docs", "adr-0035", "wave-1"]
+dependencies: []
+adrs: ["ADR-0035", "ADR-0034"]
+accepts: ["ADR-0035"]
+wave: 1
+initiative: adr-0035-abstractions-versioning
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0035 — flip status, add the three versioning invariants, declare the Kernel.Abstractions 1.0.0 baseline, register the initiative
+
+## Summary
+Flip ADR-0035 (Abstractions Versioning and Deprecation Policy) from Proposed to Accepted: update the ADR header, update the ADR index row, add the three new versioning invariants ADR-0035 commits in its Consequences section to `constitution/invariants.md`, record the retroactive Kernel.Abstractions 1.0.0 baseline declaration, and register the `adr-0035-abstractions-versioning` initiative in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0035 is the policy that makes the Grid's Abstractions-first coupling rule (every stand-up ADR from ADR-0016 through ADR-0031 pins consumers to `*.Abstractions` packages) safe to rely on. It governs version-number semantics (strict SemVer per D1), what changes are allowed at each level, the binary-compatibility guarantee (D2), interface evolution (D3 — no default-interface-member additions), record/DTO evolution (D4 — `init` members not positional syntax), the pre-release channel (D5 — 14-day `-preview` floor), the deprecation window (D6 — 60-day floor for 1.0+ packages), the coordinated-cascade procedure (D7 — cascade ABI bumps are initiatives), the private-package carve-out (D8), and three CI enforcement gates (D9).
+
+Every other packet in this initiative references ADR-0035's D-decisions as live rules. The acceptance flip must land first so those references read against Accepted text.
+
+**ADR-0034 lands together — separate initiative.** ADR-0034 D7 and ADR-0035 D10 both state explicitly: ADR-0034 (Public Package Distribution) and ADR-0035 "must land together; neither is useful alone." ADR-0034 governs *distribution* (feeds, metadata, the publish workflow); ADR-0035 governs *version semantics* (SemVer rules, deprecation windows, the API-diff job). ADR-0034 is scoped under `adr-0034-public-package-distribution`; its acceptance packet is `00-architecture-adr-0034-acceptance.md`. This packet flips **ADR-0035 only**. Its PR and ADR-0034's acceptance PR must be merged in the same session so the two land together; this packet does not touch ADR-0034's file.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0035-abstractions-versioning-and-deprecation-policy.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0035 row Status column to Accepted.
+- `constitution/invariants.md` — add the three new versioning invariants ADR-0035 commits (see Proposed Implementation for exact text). They take the **pre-reserved numbers 57, 58, 59** (see Proposed Implementation step 3 for the reservation rule).
+- `initiatives/active-initiatives.md` — register the `adr-0035-abstractions-versioning` initiative with the packet checklist for this folder.
+- The Kernel.Abstractions 1.0.0 baseline is **recorded** in this packet (a note in the ADR's Consequences-implementing trail and/or `repos/HoneyDrunk.Kernel/`), but the **release tag** itself is not pushed here — agents never push tags (invariant 27). See Proposed Implementation step 5.
+
+## Proposed Implementation
+1. Edit the ADR-0035 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update the ADR-0035 index row in `adrs/README.md` to Accepted.
+3. Add three new invariants to `constitution/invariants.md`. Append to the existing `## Packaging Invariants` section (or a new `## Versioning & Compatibility Invariants` section — match the file's current sectioning). **The true current maximum invariant number in `constitution/invariants.md` is 51 (verified). ADR-0035's reserved block is invariants 57, 58, 59 — use those hard numbers.** The numbers 57-59 are pre-reserved as part of a 12-ADR batch; if any invariant above 51 lands from outside this batch before merge, shift this block upward, never reuse a number. Do not renumber existing invariants. The text, taken from ADR-0035's "Invariants" Consequences subsection:
+   - **Invariant 57 — Every public Abstractions package follows strict SemVer per ADR-0035 D1.** Major bumps on any frozen-contract break; minor is additive-only; patch is doc/metadata-only. Calendar versions, marketing versions, and Node-aligned versions are forbidden — the version number is a breaking-change signal, not a release date. See ADR-0035 D1.
+   - **Invariant 58 — No default-interface-member additions on shipped public interfaces.** New behavior on an existing surface lands on a new, intention-revealing successor interface (`IModelRouter` → `IModelRouter2` / `IModelRouterWithCostFloors`); consumers opt in by taking the new dependency. The original interface gets `[Obsolete]` only after the successor has shipped at the same major and the 60-day deprecation window has elapsed. See ADR-0035 D3.
+   - **Invariant 59 — A major-version cascade is an initiative, not a loose set of packets.** When a major bump on a Kernel-level Abstractions package cascades through dependent Nodes, the cascade is scoped as a named initiative under the ADR-0008 D10 slug convention, recording the bumping Node and version delta, every downstream Node, the topological upgrade order, the `main` freeze status, and the pre-release window dates. Ad-hoc cross-Node ABI changes are forbidden. See ADR-0035 D7.
+4. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder. Include a note in the registration that **ADR-0035 D2 (the per-Node binary-compatibility canary extension) is an explicit deferred follow-up** — extending each Node's contract-shape canary (invariants 43, 46, 49) to assert the binary-compat guarantee specifically is per-Node canary work not covered by this initiative. "ADR-0035 Accepted" must not be read as "D2 fully enforced": the `job-api-diff.yml` gate (packet 03) is the package-level mechanical enforcement, but the finer-grained per-Node canary extension remains outstanding.
+5. **Record the Kernel.Abstractions 1.0.0 baseline declaration.** ADR-0035's Affected Nodes section states: "Kernel.Abstractions — currently at the version that absorbed ADR-0026's `TenantId` strict-typing. That bump is retroactively declared the **1.0.0 baseline** for the policy; pre-baseline history is grandfathered." Add a short retroactive note recording this declaration. Place it where the repo records cross-cutting version facts — preferably a one-line entry in `repos/HoneyDrunk.Kernel/` (e.g. `overview.md` or `active-work.md`, matching the file convention there) and a mention in this initiative's `active-initiatives.md` entry. Do **not** push the `1.0.0` git tag — tagging the corresponding Kernel release is a Human Prerequisite (agents never push tags, invariant 27). The note simply records *which already-shipped version* is hereby designated 1.0.0.
+
+## Affected Files
+- `adrs/ADR-0035-abstractions-versioning-and-deprecation-policy.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+- `repos/HoneyDrunk.Kernel/` — the file that records the 1.0.0-baseline note (match existing convention; `overview.md` or `active-work.md`)
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0035 header reads `**Status:** Accepted`
+- [ ] The ADR-0035 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariants.md` carries the three new versioning invariants (strict SemVer per D1 = invariant 57, no default-interface-member additions per D3 = invariant 58, major-cascade-is-an-initiative per D7 = invariant 59), each citing ADR-0035
+- [ ] A retroactive note records the Kernel.Abstractions 1.0.0 baseline declaration in `repos/HoneyDrunk.Kernel/` and is referenced in the initiative's `active-initiatives.md` entry
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0035-abstractions-versioning` initiative with a packet checklist
+- [ ] No git tag is pushed by this packet (tagging the Kernel 1.0.0 release is a Human Prerequisite)
+- [ ] No change to ADR-0034's file in this packet
+
+## Human Prerequisites
+- [ ] Tag the corresponding `HoneyDrunk.Kernel` release as the `1.0.0` baseline for `Kernel.Abstractions`. ADR-0035 Follow-up Work: "Declare Kernel.Abstractions 1.0.0 baseline in a retroactive note; tag the corresponding release." The note is authored by this packet's agent; pushing the release tag is a manual step (agents never push tags — invariant 27).
+
+## Referenced ADR Decisions
+**ADR-0035 D10 — Relationship to ADR-0034.** "This ADR governs version semantics. ADR-0034 governs distribution. The two land together; neither is useful alone, and `catalogs/package-feeds.json` (ADR-0034 D8) is the authority for which feeds these rules apply to." This acceptance PR must merge in the same session as ADR-0034's acceptance PR.
+
+**ADR-0035 Consequences — Invariants.** ADR-0035 adds exactly three invariants: (1) every public Abstractions package follows strict SemVer per D1 — calendar/marketing/Node-aligned versions forbidden; (2) no default-interface-member additions on shipped public interfaces — successors land on new interfaces; (3) a major-version cascade is an initiative, not a loose set of packets — procedure D7 is mandatory.
+
+**ADR-0035 Affected Nodes — Kernel.Abstractions baseline.** The version that absorbed ADR-0026's `TenantId` strict-typing (`IGridContext.TenantId` promoted from `string?` to `TenantId?`) is retroactively declared the 1.0.0 baseline; pre-baseline history is grandfathered. Every other Node's Abstractions package stays pre-1.0 and operates outside the window guarantee until it deliberately reaches 1.0.0 — no bulk-bump (ADR-0035 Follow-up Work: "Move each Node's Abstractions package to 1.0.0 only on deliberate review; do not bulk-bump.").
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0035 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Land together with ADR-0034.** Per ADR-0035 D10 / ADR-0034 D7, coordinate the merge of this PR with ADR-0034's acceptance PR. This packet does not edit ADR-0034's file — that is ADR-0034's own acceptance packet's job.
+- **Use the pre-reserved invariant numbers 57, 58, 59.** The true current maximum invariant in `constitution/invariants.md` is 51 (verified). Numbers 57-59 are pre-reserved for ADR-0035 as part of a 12-ADR batch; ADR-0034's acceptance packet holds its own distinct reserved block. Do not renumber existing invariants; append at 57-59. If any invariant above 51 lands from outside this 12-ADR batch before merge, shift this block upward — never reuse a number.
+- **No bulk 1.0.0 bump.** This packet records *only* the Kernel.Abstractions baseline. It does not declare any other Node's Abstractions package 1.0.0 — that is a deliberate per-Node review (ADR-0035 Follow-up Work), out of scope here.
+- **No tag push.** Agents never push git tags (invariant 27). The 1.0.0 baseline note is authored; the tag is a Human Prerequisite.
+
+## Labels
+`chore`, `tier-3`, `meta`, `docs`, `adr-0035`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0035 to Accepted, add the three versioning invariants to `constitution/invariants.md`, record the Kernel.Abstractions 1.0.0 baseline declaration, and register the abstractions-versioning initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0035 so the versioning-policy packets can reference its decisions as live rules.
+- Feature: ADR-0035 Abstractions Versioning and Deprecation Policy rollout, Wave 1.
+- ADRs: ADR-0035 (primary), ADR-0034 (lands together — separate initiative), ADR-0026 (the `TenantId` strict-typing bump being declared the 1.0.0 baseline), ADR-0008 (initiative/packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0035 stays Proposed until this PR merges.
+- Coordinate the merge with ADR-0034's acceptance PR (ADR-0035 D10 / ADR-0034 D7 — they land together).
+- Append the three new invariants at the pre-reserved numbers 57, 58, 59 (true current max is 51; 57-59 are reserved for ADR-0035 in a 12-ADR batch). Do not renumber existing invariants. If any invariant above 51 lands from outside the batch before merge, shift the block upward — never reuse a number.
+- Record only the Kernel.Abstractions 1.0.0 baseline — no bulk 1.0.0 bump for other Nodes.
+- No git tag push — agents never push tags (invariant 27).
+
+**Key Files:**
+- `adrs/ADR-0035-abstractions-versioning-and-deprecation-policy.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+- `repos/HoneyDrunk.Kernel/` (the 1.0.0-baseline note)
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0035-abstractions-versioning/01-standards-public-api-analyzers-props-fragment.md
+++ b/generated/issue-packets/active/adr-0035-abstractions-versioning/01-standards-public-api-analyzers-props-fragment.md
@@ -1,0 +1,132 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Standards
+labels: ["feature", "tier-2", "ops", "adr-0035", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0035"]
+accepts: ["ADR-0035"]
+wave: 1
+initiative: adr-0035-abstractions-versioning
+node: honeydrunk-standards
+---
+
+# Author the public-API-analyzer + record-evolution Directory.Build.props fragment (ADR-0035 D3/D4/D9)
+
+## Summary
+Create a shared, importable `Directory.Build.props` fragment in `HoneyDrunk.Standards` that enables `Microsoft.CodeAnalysis.PublicApiAnalyzers` (`RS0016`/`RS0017` family) on every packable project, wires the `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` tracked-file convention, and turns on the analyzer rules that enforce ADR-0035 D3 (no default-interface-member additions on shipped interfaces) and D4 (records use `init` members, enums include a default switch arm) — so every public Node consumes one canonical surface-stability tooling definition instead of drifting per-repo.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Standards`
+
+## Motivation
+ADR-0035 D9 commits three CI gates; the first is: "`Microsoft.CodeAnalysis.PublicApiAnalyzers` is enabled on every public package. `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` are tracked in-repo; PRs that touch the public surface must update `Unshipped.txt`, and CI fails if the file is stale." That analyzer must be turned on identically across every public Node — exactly the kind of shared build-tooling default `HoneyDrunk.Standards` already owns (the Grid-wide StyleCop + EditorConfig analyzer set per invariant 26, the ADR-0047 test-stack fragment, the ADR-0034 packaging-metadata fragment).
+
+Centralizing it means each public Node's adoption (packet 04, the fan-out) is a thin "import the fragment, commit the baseline `PublicAPI.Shipped.txt`" change rather than per-repo analyzer hand-wiring. This packet authors the shared definition only; per-Node adoption — including the one-time `PublicAPI.Shipped.txt` baseline commit at each Node's current published surface — is packet 04.
+
+This packet sits in the same `HoneyDrunk.Standards` family as the ADR-0034 packaging-metadata fragment (`adr-0034-public-package-distribution/02`). The two are independent build-asset fragments; this one carries surface-stability tooling, that one carries packaging metadata. They do not conflict and do not share a fragment file. **ADR-0034 packet 02 is the sole `HoneyDrunk.Standards` solution-version bumper across this 12-ADR batch — this packet (ADR-0035 packet 01) MUST NOT bump the `HoneyDrunk.Standards` solution version.** This packet adds its fragment content and appends to the existing in-progress `CHANGELOG.md` entry only. See Constraints.
+
+## Proposed Implementation
+
+### Public API analyzer block (ADR-0035 D9 gate 1)
+The fragment, scoped to packable projects (`$(IsPackable)`):
+- References `Microsoft.CodeAnalysis.PublicApiAnalyzers` with `PrivateAssets="all"` (a build-time analyzer, never a runtime dependency).
+- Wires `<AdditionalFiles Include="PublicAPI.Shipped.txt" />` and `<AdditionalFiles Include="PublicAPI.Unshipped.txt" />` so the analyzer reads the tracked surface files. The fragment provides the *wiring*; the two `.txt` files themselves are per-project content the consuming Node supplies (packet 04 commits each Node's baseline).
+- Sets the relevant analyzer rules to `error` severity (via `.editorconfig` shipped alongside the fragment, or `<WarningsAsErrors>` for the `RS00xx` IDs) so a stale `Unshipped.txt` or an undeclared public-surface change fails the build, not just warns — D9: "CI fails if the file is stale."
+- Provides a documented way for a Node to opt a project out only when it is genuinely non-packable (test projects, samples) — keyed on `$(IsPackable)`, never an arbitrary per-project flag.
+
+### Record / enum evolution analyzer config (ADR-0035 D3/D4)
+ADR-0035 D3 forbids adding members to shipped public interfaces (new behavior lands on a new interface) and forbids default-interface-member additions. D4 requires public records use `init` named members not positional syntax, requires new record members be non-required, and requires exhaustive `switch` over a non-`<closed/>` enum to carry a default arm. The `PublicApiAnalyzers` set covers the surface-tracking half; the D3/D4 *shape* rules are partly analyzer-enforceable:
+- Enable the Roslyn switch-exhaustiveness rule (`IDE0010` / `CS8509` family) at `warning` or `error` for packable projects so a `switch` over an open enum without a default arm is flagged — D4: "an enum that is not extensible is annotated with an XML doc tag (`<closed/>`) and a Roslyn analyzer warning on switch exhaustiveness flips on."
+- ADR-0035 D4's "all public records use `init` members, not positional syntax" and D3's "no default-interface-member additions" are **not fully expressible as an out-of-the-box analyzer rule**. The fragment ships what is enforceable now (the `PublicApiAnalyzers` diff catches a positional-parameter add as a surface change; switch-exhaustiveness catches the enum case). For the parts no shipped analyzer covers, ship an `.editorconfig` documentation block and a `README.md` section stating the D3/D4 rules so they are reviewable; a future custom analyzer is recorded as out-of-scope follow-up. Record in the PR exactly which D3/D4 rules are analyzer-enforced vs review-enforced.
+
+### Mechanism
+Preferred: ship the fragment + the accompanying `.editorconfig` rule block as static MSBuild `build/` content inside the **existing** `HoneyDrunk.Standards` build-assets package, so no new `.csproj` is created — the same mechanism the ADR-0047 test-stack fragment and the ADR-0034 packaging-metadata fragment use. Only if the current packaging cannot carry an additional build asset should a new build-assets `.csproj` be added — and that project must then reference `HoneyDrunk.Standards` analyzers with `PrivateAssets: all` per invariant 26. Record the chosen mechanism in the PR.
+
+### Scoping
+The fragment must apply only to packable projects — never enable `PublicApiAnalyzers` or the `PublicAPI.*.txt` `AdditionalFiles` wiring on test projects (`*.Tests.*`) or non-packable internal projects. Key all conditions on `$(IsPackable)` (default-true for library projects, false on test projects per the ADR-0047 test-stack fragment).
+
+## Affected Packages
+- `HoneyDrunk.Standards` — gains the public-API-analyzer + record/enum-evolution props fragment and the accompanying `.editorconfig` rule block.
+
+## NuGet Dependencies
+This packet authors a props fragment that **declares** the following `PackageReference` for consuming packable projects (it does not add a runtime reference to `HoneyDrunk.Standards`'s own projects):
+
+- `Microsoft.CodeAnalysis.PublicApiAnalyzers` — current stable; `PrivateAssets="all"` (a build-time Roslyn analyzer, not a runtime dependency).
+
+If a new build-assets `.csproj` is created in `HoneyDrunk.Standards` to host the fragment, that project additionally references:
+- `HoneyDrunk.Standards` analyzers — `PrivateAssets: all` (invariant 26: every new .NET project explicitly references the `HoneyDrunk.Standards` StyleCop + EditorConfig analyzers with `PrivateAssets: all`).
+
+`HoneyDrunk.Standards` is modeled in `catalogs/nodes.json` (id `honeydrunk-standards`) as the Grid's shared analyzer / EditorConfig / build-tooling Meta Node — a library-only, no-vault repo whose packages are consumed at compile time. The public-API-analyzer fragment is the same class of artifact as the existing analyzer set and the ADR-0047 / ADR-0034 fragments: a packaged MSBuild build asset, not a runtime project.
+
+## Boundary Check
+- [x] Shared build-tooling defaults belong in `HoneyDrunk.Standards` — it already owns the Grid-wide analyzer + EditorConfig set (invariant 26), the ADR-0047 test-stack fragment, and the ADR-0034 packaging-metadata fragment.
+- [x] No Node behavior changes; this packet only publishes a definition. Per-Node adoption — including the `PublicAPI.Shipped.txt` baseline commit — is packet 04.
+- [x] Does not duplicate any other Node's responsibility — the API-diff *workflow* (D9 gate 2) is HoneyDrunk.Actions' (packet 03); this is build-time analyzer config only.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Standards` ships a `Directory.Build.props` fragment that references `Microsoft.CodeAnalysis.PublicApiAnalyzers` with `PrivateAssets="all"` on packable projects
+- [ ] The fragment wires `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` as `AdditionalFiles` so the analyzer reads them
+- [ ] The `RS00xx` public-API analyzer rules are set to `error` severity so a stale `Unshipped.txt` / an undeclared public-surface change fails the build (ADR-0035 D9: "CI fails if the file is stale")
+- [ ] The fragment enables the switch-exhaustiveness rule at warning-or-error on packable projects (ADR-0035 D4 enum rule)
+- [ ] The fragment applies only to packable projects — no `PublicApiAnalyzers` / `PublicAPI.*.txt` wiring leaks into `*.Tests.*` projects (keyed on `$(IsPackable)`)
+- [ ] An `.editorconfig` / `README.md` block documents the D3/D4 rules that are review-enforced rather than analyzer-enforced (no positional records on public surface; no default-interface-member additions); the PR records which D3/D4 rules are analyzer-enforced vs review-enforced
+- [ ] Repo `README.md` documents how a Node package consumes the fragment and the obligation to commit a baseline `PublicAPI.Shipped.txt` per packable project
+- [ ] Repo-level `CHANGELOG.md` updated by **appending to the existing in-progress entry** — this packet does NOT create a new version entry and does NOT bump the `HoneyDrunk.Standards` solution version (ADR-0034 packet 02 is the sole Standards version bumper across this batch); per-package `CHANGELOG.md` updated for the package that gained the fragment
+- [ ] Build green; existing `HoneyDrunk.Standards` consumers unaffected (analyzer / EditorConfig / test-stack / packaging-metadata fragment behavior unchanged)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0035 D9 — Enforcement.** Three CI gates land in HoneyDrunk.Actions. Gate 1 (this packet's Standards side): `Microsoft.CodeAnalysis.PublicApiAnalyzers` is enabled on every public package; `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` are tracked in-repo; PRs that touch the public surface must update `Unshipped.txt`, and CI fails if the file is stale. (Gate 2, the API-diff job, and gate 3, the `[Obsolete]` audit, are HoneyDrunk.Actions' — packet 03.)
+
+**ADR-0035 D3 — Interface evolution rule.** No default-interface-member additions (the TFM matrix includes targets where DIM is unsupported — `netstandard2.0`, AOT). New behavior on an existing surface lands on a new, intention-revealing interface; consumers opt in by taking the new dependency. The original interface gets `[Obsolete]` with a `DiagnosticId` only after the successor has shipped at the same major and the deprecation window has elapsed.
+
+**ADR-0035 D4 — Record and DTO evolution.** All public records use property initializers (`init`) with named members, not positional syntax — so adding a member is non-breaking at the call site. New members on a record are non-required. Enums are extensible by default; consumers `switch` exhaustively at their own risk and must include a default arm. An enum that is *not* extensible is annotated `<closed/>` and the switch-exhaustiveness analyzer warning flips on.
+
+## Constraints
+> **Invariant 26 — Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section.** "`HoneyDrunk.Standards` must be explicitly listed on every new .NET project (StyleCop + EditorConfig analyzers, `PrivateAssets: all`)." If this packet creates a new `.csproj` in `HoneyDrunk.Standards` to host the fragment as build assets, that project must reference `HoneyDrunk.Standards` analyzers with `PrivateAssets: all`.
+
+> **Invariant 16 — No test code in runtime packages.** The same spirit forbids leaking the `PublicApiAnalyzers` reference and the `PublicAPI.*.txt` `AdditionalFiles` wiring into test projects. Scope the fragment to `$(IsPackable)`.
+
+> **Invariant 12 — Semantic versioning with CHANGELOG and README.** Every package directory must contain a `README.md`; the repo-level and per-package CHANGELOGs are updated per invariant 27. This packet appends to the existing in-progress `CHANGELOG.md` entry — it does not open a new version entry.
+
+- **`Microsoft.CodeAnalysis.PublicApiAnalyzers` is `PrivateAssets="all"`** — a build-time analyzer. It must never appear as a runtime dependency on an `.Abstractions` package (invariant 1: Abstractions packages have zero runtime HoneyDrunk dependencies — and analyzers must not become transitive runtime deps).
+- **The fragment is analyzer/build-tooling only** — it does not run the API-diff check. The API-diff *workflow* is HoneyDrunk.Actions' job (packet 03). Do not add diff logic here.
+- **Scope to `$(IsPackable)`** — no analyzer or `PublicAPI.*.txt` wiring on test projects.
+- **This packet never bumps the `HoneyDrunk.Standards` solution version.** ADR-0034 packet 02 (`adr-0034-public-package-distribution/02`, the packaging-metadata fragment) is the **sole `HoneyDrunk.Standards` version bumper** across this 12-ADR batch. Regardless of merge order, this packet only adds its fragment content and appends a line to the existing in-progress `CHANGELOG.md` entry. If this packet lands before ADR-0034 packet 02, the in-progress entry already exists from prior work or is opened by ADR-0034 packet 02 — this packet does not open it and does not bump the version itself.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0035`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Author a shared `Directory.Build.props` fragment in `HoneyDrunk.Standards` that enables `Microsoft.CodeAnalysis.PublicApiAnalyzers` + the `PublicAPI.{Shipped,Unshipped}.txt` convention on every packable project and turns on the switch-exhaustiveness rule, for Grid-wide consumption.
+
+**Target:** HoneyDrunk.Standards, branch from `main`.
+
+**Context:**
+- Goal: One canonical public-API-surface-stability tooling definition; eliminate per-Node analyzer drift.
+- Feature: ADR-0035 Abstractions Versioning and Deprecation Policy initiative, Wave 1.
+- ADRs: ADR-0035 (D9 gate 1, D3, D4).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0035 acceptance (soft — references ADR-0035 D3/D4/D9 as live rules).
+
+**Constraints:**
+- See "Constraints" — inlined for agent consumption.
+- `Microsoft.CodeAnalysis.PublicApiAnalyzers` is `PrivateAssets="all"` — build-time analyzer, never a runtime dependency.
+- Analyzer/build-tooling only — no API-diff logic (that is packet 03).
+- Scope to `$(IsPackable)` — no analyzer wiring on test projects.
+- This packet never bumps the `HoneyDrunk.Standards` solution version — ADR-0034 packet 02 is the sole Standards version bumper across the batch. Append to the existing in-progress CHANGELOG entry only.
+
+**Key Files:**
+- New props fragment + `.editorconfig` block under `HoneyDrunk.Standards` (path per repo convention).
+- `README.md` — consumption documentation.
+- `CHANGELOG.md` (repo-level + per-package).
+
+**Contracts:** None — this is build tooling, not a runtime contract. No `catalogs/contracts.json` change.

--- a/generated/issue-packets/active/adr-0035-abstractions-versioning/02-architecture-abstractions-cascade-initiative-template.md
+++ b/generated/issue-packets/active/adr-0035-abstractions-versioning/02-architecture-abstractions-cascade-initiative-template.md
@@ -1,0 +1,121 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "docs", "adr-0035", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0035", "ADR-0008"]
+accepts: ["ADR-0035"]
+wave: 1
+initiative: adr-0035-abstractions-versioning
+node: honeydrunk-architecture
+---
+
+# Author the abstractions-cascade initiative template (ADR-0035 D7)
+
+## Summary
+Create `initiatives/templates/abstractions-cascade.md` — the reusable initiative template for a coordinated major-version cascade of a Kernel-level Abstractions package, so the next ABI cascade (the second instance of the Kernel Adoption Alignment pattern) is scoped with explicit shape rather than triaged ad hoc.
+
+## Context
+ADR-0035 D7 commits the Grid to a procedure: when a major-version bump on a Kernel-level Abstractions package will cascade through dependent Nodes, the cascade is scoped as a named **initiative** under the ADR-0008 D10 slug convention (`adr-NNNN-<kebab>`), not as ad-hoc packets. ADR-0035's Context records why: the first Kernel Adoption Alignment initiative (11/11 closed, in exit review) "was triaged ad-hoc as an 'alignment initiative' because there was no policy. The next one will be the same unless this is decided." ADR-0026's `IGridContext.TenantId` strict-typing break "shipped as part of a coordinated cascade with no recorded deprecation window."
+
+ADR-0035's Consequences (Affected Nodes) names the deliverable directly: "HoneyDrunk.Architecture — initiative slug convention (ADR-0008 D10) gains the cascade variant; an example template lives at `initiatives/templates/abstractions-cascade.md`." This packet authors that template.
+
+D7 also adds an invariant (landed by packet 00): "A major-version cascade is an initiative, not a loose set of packets." This template is the artifact that makes that invariant operable — the scope agent fills it out when an ABI cascade is triggered.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project. The `initiatives/templates/` directory does not exist yet — this packet creates it.
+
+## Scope
+- Create `initiatives/templates/` directory (new).
+- Create `initiatives/templates/abstractions-cascade.md` — the cascade-initiative template.
+- If `initiatives/` carries an index or `README.md` that lists its contents, add a row for the new `templates/` directory.
+
+## Proposed Implementation
+Author `initiatives/templates/abstractions-cascade.md` as a fill-in-the-blanks template that an agent (`scope`) instantiates when a major Abstractions bump triggers a cascade. ADR-0035 D7 enumerates exactly the fields the instantiated initiative file must record — the template provides a labeled slot for each:
+
+1. **Bumping Node and version delta** — e.g. `Kernel.Abstractions 1.x → 2.0.0`. The package, the from-version, the to-version.
+2. **Every downstream Node and the version it must move to** — a table of consumer Nodes, each with its target version. The template instructs the author to derive the consumer set from `catalogs/relationships.json` (the `consumed_by` / `consumes_detail` fields).
+3. **Upgrade order** — the topological order downstream Nodes upgrade in, derived from `catalogs/relationships.json`. The template references the canonical Core Node order (`Kernel → Transport → Vault → Auth → Web.Rest → Data`) as the default and instructs the author to extend it for AI-sector / Ops Nodes per the dependency graph.
+4. **`main` freeze status during the cascade** — a freeze/no-freeze decision with rationale, recorded per Node.
+5. **Pre-release window dates (ADR-0035 D5)** — the `-preview.N` start date, the 14-calendar-day minimum-in-market floor, the `-rc.N` label and its 7-day floor, and the planned stable date. The template includes the no-skip rule (`1.0.0 → 2.0.0-preview.1 → … → 2.0.0-rc.1 → 2.0.0`, never direct).
+6. **Deprecation-window record (ADR-0035 D6)** — for any member removed at the cascade's major, the minor release that first marked it `[Obsolete]`, the `DiagnosticId`, the `UrlFormat` migration-doc link, and confirmation the 60-day window (1.0+) has elapsed.
+
+The template also includes the standard initiative-file sections an instantiated cascade needs — wave diagram, packet checklist, rollback plan, site-sync flag — matching the shape of existing dispatch plans (e.g. `kernel-adoption-alignment/dispatch-plan.md`, `adr-0034-public-package-distribution/dispatch-plan.md`). Mark clearly which sections are D7-mandated (1–6 above) and which are general initiative boilerplate.
+
+Add a short header note: this template is for **major-version ABI cascades only**. A minor (additive) bump does not cascade — downstream Nodes pick it up on their own cadence (no consumer recompile is forced by an additive change, per ADR-0035 D2's binary-compatibility guarantee). The template is the D7 procedure made concrete; instantiating it is mandatory for a major cascade and not used otherwise.
+
+Cross-reference: the template should point to ADR-0035 D5/D6/D7 and ADR-0008 D10 (the `adr-NNNN-<kebab>` slug convention) as the governing decisions, and note `kernel-adoption-alignment` as the retroactive first instance of the pattern.
+
+## Affected Files
+- `initiatives/templates/` (new directory)
+- `initiatives/templates/abstractions-cascade.md` (new)
+- `initiatives/` index / `README.md` if one exists (add a row for `templates/`)
+
+## NuGet Dependencies
+None. This packet creates a Markdown template; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly. Initiative templates are an architecture-repo artifact.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] `initiatives/templates/abstractions-cascade.md` exists
+- [ ] The template has a labeled, fill-in slot for each of the six ADR-0035 D7 fields: bumping Node + version delta; downstream Nodes + target versions; topological upgrade order; `main` freeze status; pre-release window dates (D5); deprecation-window record (D6)
+- [ ] The template instructs the author to derive the downstream-Node set and upgrade order from `catalogs/relationships.json`
+- [ ] The template includes the D5 no-skip pre-release rule and the 14-day / 7-day floors, and the D6 60-day deprecation window
+- [ ] The template includes the general initiative sections (wave diagram, packet checklist, rollback plan, site-sync flag) and clearly distinguishes D7-mandated sections from boilerplate
+- [ ] The template header states it is for major-version ABI cascades only and references ADR-0035 D5/D6/D7 + ADR-0008 D10
+- [ ] `kernel-adoption-alignment` is referenced as the retroactive first instance of the pattern
+- [ ] If `initiatives/` has an index, it lists the new `templates/` directory
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0035 D7 — Coordinated cascade procedure.** When a major-version bump on a Kernel-level Abstractions package will cascade through dependent Nodes (the Kernel Adoption Alignment pattern), the cascade is scoped as a named initiative under the ADR-0008 D10 slug convention, not as ad-hoc packets. The initiative file records: the bumping Node and its version delta; every downstream Node and the version it must move to; the topological upgrade order per `catalogs/relationships.json`; the freeze/no-freeze status of `main` during the cascade; the pre-release window dates (D5). "This becomes the second instance of the Kernel Adoption Alignment pattern with explicit shape rather than retroactive triage."
+
+**ADR-0035 D5 — Pre-release channel.** New majors ship as `X.0.0-preview.N` first; a `-preview` release is in market a minimum of 14 calendar days with at least one internal Grid consumer pinned to it; `-rc.N` is the final pre-stable label, minimum 7 calendar days; no version skips.
+
+**ADR-0035 D6 — Deprecation window.** A removed member carries `[Obsolete(message, error: false)]` with a `DiagnosticId` and a `UrlFormat` pointing to a migration doc, for at least one minor release; the window is a minimum of 60 calendar days between the first obsoleting minor and the removing major (1.0+; pre-1.0 collapses to "next minor").
+
+**ADR-0035 Consequences — Affected Nodes.** "HoneyDrunk.Architecture — initiative slug convention (ADR-0008 D10) gains the cascade variant; an example template lives at `initiatives/templates/abstractions-cascade.md`."
+
+**ADR-0008 D10 — Initiative slug convention.** Generated artifacts live under `generated/issue-packets/active/` grouped by initiative; the initiative slug follows `adr-NNNN-<kebab>`. The cascade variant of this convention is what D7 invokes.
+
+## Constraints
+- **Template, not an instantiated initiative.** This packet authors the blank template only. It does not scope or trigger any actual cascade — there is no live ABI cascade in flight. Filling the template out is future scope-agent work when a major bump is decided.
+- **Major cascades only.** The template explicitly does not apply to minor/additive bumps — those do not force a consumer recompile (ADR-0035 D2 binary-compat guarantee) and need no cascade initiative.
+- **Derive, do not hardcode, the consumer set.** The template instructs the author to read `catalogs/relationships.json` at instantiation time; it must not bake in a static Node list that will go stale.
+
+## Labels
+`chore`, `tier-3`, `meta`, `docs`, `adr-0035`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Author `initiatives/templates/abstractions-cascade.md` — the reusable initiative template for a coordinated major-version Abstractions cascade, per ADR-0035 D7.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the ADR-0035 D7 "a major cascade is an initiative" invariant operable with a concrete fill-in template.
+- Feature: ADR-0035 Abstractions Versioning and Deprecation Policy rollout, Wave 1.
+- ADRs: ADR-0035 (D5/D6/D7 + Affected Nodes), ADR-0008 (D10 initiative slug convention).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0035 acceptance (soft — references ADR-0035 D7 as a live rule).
+
+**Constraints:**
+- See "Constraints" — inlined for agent consumption.
+- Template only — do not scope or trigger an actual cascade.
+- Major cascades only — the template does not apply to minor/additive bumps.
+- The template derives the consumer set from `catalogs/relationships.json` at instantiation time; do not hardcode a Node list.
+
+**Key Files:**
+- `initiatives/templates/abstractions-cascade.md` (new)
+- `initiatives/` index / `README.md` (if present)
+
+**Contracts:** None — this is a governance template, not a runtime contract.

--- a/generated/issue-packets/active/adr-0035-abstractions-versioning/03-actions-job-api-diff-and-obsolete-audit-workflows.md
+++ b/generated/issue-packets/active/adr-0035-abstractions-versioning/03-actions-job-api-diff-and-obsolete-audit-workflows.md
@@ -1,0 +1,151 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["ci", "tier-2", "ops", "adr-0035", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0035", "ADR-0034", "ADR-0012"]
+accepts: ["ADR-0035"]
+wave: 2
+initiative: adr-0035-abstractions-versioning
+node: honeydrunk-actions
+---
+
+# Author job-api-diff.yml and the [Obsolete]-audit job — the ADR-0035 D9 enforcement gates
+
+## Summary
+Author a new reusable workflow `HoneyDrunk.Actions/.github/workflows/job-api-diff.yml` that compares a built package's public surface against its previous published version and asserts the diff matches the declared SemVer bump (additive-only for minor, no change for patch), and add an `[Obsolete]`-audit job that fails CI when any `[Obsolete]` member lacks a `DiagnosticId` and a `UrlFormat` — so ADR-0035's version semantics are mechanically enforced in the CI control plane, not left to review judgment.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Actions`
+
+## Motivation
+ADR-0035 D9 commits three CI gates. Gate 1 (`Microsoft.CodeAnalysis.PublicApiAnalyzers` on every public package, `PublicAPI.{Shipped,Unshipped}.txt` tracked) is the `HoneyDrunk.Standards` fragment from packet 01. Gates 2 and 3 are HoneyDrunk.Actions' and are this packet:
+
+- **Gate 2 — API-diff job.** D9: "compares the post-build `Unshipped.txt` to the previous-version package on nuget.org and asserts the diff matches the declared bump (additive-only for minor, no changes for patch). Implemented as a new reusable workflow `job-api-diff.yml`."
+- **Gate 3 — `[Obsolete]` audit job.** D9: "any `[Obsolete]` member without a `DiagnosticId` and a `UrlFormat` fails CI."
+
+ADR-0035's Follow-up Work names the deliverable directly: "Author `job-api-diff.yml` in HoneyDrunk.Actions." HoneyDrunk.Actions is the Grid CI/CD control plane (ADR-0012) — these gates belong there as reusable workflows that consumer release pipelines call, exactly like ADR-0034's `job-publish-nuget.yml`.
+
+This packet builds the two workflows. Per-Node wiring (each Node's release workflow calling `job-api-diff.yml`, each Node's PR pipeline running the `[Obsolete]` audit) is packet 04.
+
+## Proposed Change
+
+### `job-api-diff.yml` (ADR-0035 D9 gate 2)
+New reusable workflow callable via `workflow_call`. Inputs:
+- `package-id` — the package whose surface is being diffed (e.g. `HoneyDrunk.Kernel.Abstractions`).
+- `version` — the version being built/published.
+- `declared-bump` — `major` | `minor` | `patch`. The caller declares the intended SemVer level; the job asserts the actual surface diff is consistent with it.
+- **Artifact handoff — decided shape (do not leave open).** The caller uploads the built package's `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` for each packable project as a GitHub Actions artifact named `public-api-surface` (one artifact per caller run, containing the `PublicAPI.*.txt` pair under a per-project subdirectory path). `job-api-diff.yml` takes an input `surface-artifact-name` (default `public-api-surface`) and downloads that artifact rather than re-building. This is the same upload-artifact / download-artifact handoff `job-publish-nuget.yml` (ADR-0034 packet 03) uses for the `.nupkg`; the API-diff reuses that pattern with its own artifact name. Pin this shape in `docs/consumer-usage.md` as the committed contract — packet 04 wires callers against exactly this artifact name and layout.
+
+Behaviour:
+- Resolves the **previous published version** of `package-id` from nuget.org (the primary public feed per ADR-0034 D1). For a package with no prior published version (pre-1.0 first publish), the job is a clean no-op pass and logs that it had no baseline to diff against.
+- Computes the public-surface diff between the previous version and the build under test. The diff source is the `PublicAPI.{Shipped,Unshipped}.txt` files (the packet-01 analyzer convention) and/or a package-level API extractor — pick the mechanism that is reliable against a nuget.org-published package and record it in the PR.
+- **Asserts the diff matches `declared-bump`:**
+  - `patch` — **no IL/surface change permitted.** Any public-surface delta fails the job (ADR-0035 D1: patch is "documentation, XML doc fixes, package metadata, no IL change").
+  - `minor` — **additive-only.** New interfaces/records/enum-values/extension methods are allowed; any removal, signature change, narrowed return, widened parameter, rename, reorder, or added-required-interface-member fails the job (ADR-0035 D1 major-change list).
+  - `major` — any change is allowed; the job passes the diff but **still asserts D5 was honored** to the extent it can see it: a stable `X.0.0` whose immediately-prior version on the feed was not an `X.0.0-rc.N` is flagged (ADR-0035 D5: "No version skips: `1.0.0 → 2.0.0-preview.1 → … → 2.0.0-rc.1 → 2.0.0`"). Whether this is a hard fail or a warning is a strictness call — record it in the PR; default to fail for stable majors.
+- **Pre-1.0 handling.** ADR-0035 D1: pre-1.0 (`0.Y.Z`) makes no compatibility promise, but the minor/patch *additive* rules still apply to `0.Y` cascades. The job runs the same additive check for a `0.Y` minor bump but downgrades a violation to a warning (not a hard fail) when the package is pre-1.0, since pre-1.0 explicitly allows breakage. Record the pre-1.0-vs-1.0+ strictness switch in `docs/consumer-usage.md`.
+- Fails loudly with a clear diff printout naming each offending surface element; never reports success on an inconsistent diff.
+
+### `[Obsolete]`-audit job (ADR-0035 D9 gate 3)
+A job that scans the public surface for `[Obsolete]` attributes and fails when any `[Obsolete]` member lacks **both** a `DiagnosticId` and a `UrlFormat`. ADR-0035 D6 requires every deprecated member carry `[Obsolete(message, error: false)]` with a `DiagnosticId` and a `UrlFormat` pointing to a migration doc.
+
+- Mechanism: implement as a self-contained CI job step here — a source-scan over the `PublicAPI.Shipped.txt`-tracked types or a reflection scan over the built assembly. Do not push a Roslyn analyzer for this into the packet-01 `HoneyDrunk.Standards` fragment — the gate ships in HoneyDrunk.Actions as a job so it is self-contained and centrally owned. Pick the more reliable of source-scan vs reflection-scan and record the choice in the PR.
+- **Decided: the `[Obsolete]`-audit ships as a job wired into `pr-core.yml`** — not as a separate opt-in reusable job. ADR-0035 D9 says a malformed `[Obsolete]` "fails CI"; wiring into the tier-1 `pr-core.yml` gate is the only reading that makes the gate Grid-wide and unconditional, so it is the committed choice. The gate is a **PR-time check** — a malformed `[Obsolete]` is caught before merge. It **must be a guaranteed clean no-op in any repo with zero `[Obsolete]` members** so it never blocks an unrelated PR (the same no-op-guard discipline as ADR-0047's `job-integration-tests.yml`). Because it lands in `pr-core.yml`, packet 04 does **not** wire it per-repo — it is already active everywhere; packet 04 only confirms and records.
+- Failure message names each offending member and states the fix: add a `DiagnosticId` and a `UrlFormat`.
+
+### Caller-permissions and consumer documentation
+Document in `HoneyDrunk.Actions` `docs/consumer-usage.md`: the `job-api-diff.yml` caller snippet, the `declared-bump` input contract, the `public-api-surface` artifact-handoff shape (artifact name + per-project layout), and the pre-1.0-vs-1.0+ strictness behavior. State that the `[Obsolete]`-audit is active Grid-wide via `pr-core.yml` and needs no per-Node opt-in. This mirrors the ADR-0012 / ADR-0034 caller-contract documentation pattern.
+
+## Consumer Impact
+- `job-api-diff.yml` affects no consumer repo until its release workflow is wired to call it — that is packet 04's fan-out. `job-api-diff.yml` is purely additive.
+- The `[Obsolete]`-audit job is wired into `pr-core.yml` in this packet, so it becomes active Grid-wide on every .NET repo immediately. It must be a guaranteed no-op in every repo with no `[Obsolete]` members so it does not block existing PRs (the same no-op-guard discipline as ADR-0047's `job-integration-tests.yml`). Packet 04 does not wire it per-repo — it only confirms it is active.
+
+## Breaking Change?
+- [ ] Yes
+- [x] No — new reusable workflow + a new audit job in `pr-core.yml`, additive. The `[Obsolete]`-audit's mandatory no-op guard keeps it non-breaking for repos with no `[Obsolete]` members.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/job-api-diff.yml` exists and is callable via `workflow_call` with inputs `package-id`, `version`, `declared-bump`, and `surface-artifact-name` (default `public-api-surface`)
+- [ ] `job-api-diff.yml` downloads the `public-api-surface` artifact (the `PublicAPI.{Shipped,Unshipped}.txt` pair per packable project) rather than re-building — the committed artifact-handoff contract
+- [ ] The job resolves the previous published version from nuget.org and is a clean no-op pass when there is no prior version
+- [ ] `declared-bump: patch` fails on any public-surface change; `declared-bump: minor` fails on any non-additive change; `declared-bump: major` allows any change but flags a stable major not preceded by an `-rc.N` per ADR-0035 D5
+- [ ] Pre-1.0 (`0.Y.Z`) packages get the additive check at warning severity, not hard fail (ADR-0035 D1: pre-1.0 makes no compatibility promise); the strictness switch is documented in `docs/consumer-usage.md`
+- [ ] The job fails loudly with a per-element diff printout and never reports success on an inconsistent diff
+- [ ] The `[Obsolete]`-audit ships as a job wired into `pr-core.yml` and fails CI when any `[Obsolete]` member lacks a `DiagnosticId` or a `UrlFormat`, naming each offending member
+- [ ] The `[Obsolete]`-audit is a guaranteed no-op in repos with no `[Obsolete]` members so it never blocks an unrelated PR
+- [ ] `docs/consumer-usage.md` documents the `job-api-diff.yml` caller snippet, the `declared-bump` contract, the `public-api-surface` artifact-handoff shape, the pre-1.0 strictness behavior, and that the `[Obsolete]`-audit is active Grid-wide via `pr-core.yml` (no per-repo opt-in)
+- [ ] `docs/CHANGELOG.md` updated with a new entry for `job-api-diff.yml` and the `[Obsolete]`-audit `pr-core.yml` job
+- [ ] `README.md` updated to list `job-api-diff.yml` among the reusable workflows and to note the `[Obsolete]`-audit as part of the `pr-core.yml` tier-1 gate
+
+## Human Prerequisites
+None for building the workflows. (Resolving the previous published version from nuget.org needs no credential — read access to a public package is anonymous. The `HoneyDrunkStudios` nuget.org account claim is ADR-0034 packet 03's prerequisite, not this packet's.)
+
+## Dependencies
+- `packet:00` — ADR-0035 acceptance (soft — references ADR-0035 D9 as a live rule).
+- `packet:01` — the `HoneyDrunk.Standards` public-API-analyzer fragment (**hard** — `job-api-diff.yml` diffs the `PublicAPI.{Shipped,Unshipped}.txt` files that fragment establishes; without the convention there is nothing to diff).
+
+## Referenced ADR Decisions
+**ADR-0035 D9 — Enforcement.** Three CI gates land in HoneyDrunk.Actions. Gate 1 (Standards, packet 01): `PublicApiAnalyzers` on every public package, `PublicAPI.{Shipped,Unshipped}.txt` tracked, CI fails if `Unshipped.txt` is stale. Gate 2 (this packet): API-diff job in the release workflow compares post-build `Unshipped.txt` to the previous-version package on nuget.org and asserts the diff matches the declared bump (additive-only for minor, no changes for patch) — "Implemented as a new reusable workflow `job-api-diff.yml`." Gate 3 (this packet): `[Obsolete]`-audit job — any `[Obsolete]` member without a `DiagnosticId` and a `UrlFormat` fails CI.
+
+**ADR-0035 D1 — Strict SemVer.** Major = any change to a frozen interface/record/enum a downstream compiled binary could observe as a break (member removal, signature change, narrowed return, widened parameter, rename, enum underlying-type change, reordered record positional parameters, added required interface member). Minor = additive only (new interface, new record, new enum value at the end, new extension method). Patch = documentation / XML doc / package metadata, no IL change. Pre-1.0 (`0.Y.Z`) is explicitly unstable — the minor/patch rules apply to `0.Y` cascades but no compatibility promise is made.
+
+**ADR-0035 D5 — Pre-release channel.** New majors ship as `X.0.0-preview.N` first (14-calendar-day minimum in market), then `-rc.N` (7-day minimum), then stable. No version skips: `1.0.0 → 2.0.0-preview.1 → 2.0.0-preview.2 → 2.0.0-rc.1 → 2.0.0`, never `1.0.0 → 2.0.0` direct.
+
+**ADR-0035 D6 — Deprecation window.** A removed member carries `[Obsolete(message, error: false)]` with a `DiagnosticId` and a `UrlFormat` pointing to a migration doc, for at least one minor release, with a 60-calendar-day minimum window (1.0+).
+
+**ADR-0034 D1 — Primary feed.** nuget.org under `HoneyDrunkStudios` is the primary public feed — the authority `job-api-diff.yml` resolves the previous published version from.
+
+**ADR-0012** — CI mechanics live in the HoneyDrunk.Actions control plane via reusable workflows; consumers call them.
+
+## Constraints
+> **Invariant — publish via reusable workflow** (added by ADR-0034's acceptance). Consumer release workflows do not run release mechanics inline; they call HoneyDrunk.Actions reusable workflows. `job-api-diff.yml` follows that pattern — it is a reusable `workflow_call` workflow, not inline logic copied per repo.
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** `job-api-diff.yml` needs no secret (public-package read is anonymous), but if any auth is added for a private feed it must resolve from Vault and never echo to logs.
+
+> **Invariant 31 — Every PR traverses the tier-1 gate before merge.** The `[Obsolete]`-audit is wired into `pr-core.yml`, so it joins the tier-1 gate Grid-wide and must be a guaranteed no-op in repos with no `[Obsolete]` members so it never blocks an unrelated PR.
+
+- **The API-diff is the mechanical SemVer check** — it is the gate that catches a minor bump that actually broke the surface. It must fail hard on a `minor`-declared non-additive change; a warning is not enough (D9: "asserts the diff matches the declared bump").
+- **Pre-1.0 is genuinely allowed to break** — do not hard-fail a `0.Y` package on a non-additive change; warn. The hard guarantee starts at 1.0.0 (D1).
+- **No-baseline is a pass, not a fail** — a first publish of a package has nothing to diff against; pass cleanly and log it.
+- **No-op guard is mandatory** — the `[Obsolete]`-audit is in `pr-core.yml` and must never block a PR in a repo that has zero `[Obsolete]` members.
+- **Artifact handoff is a committed contract** — `job-api-diff.yml` consumes the `public-api-surface` artifact (the `PublicAPI.{Shipped,Unshipped}.txt` pair); packet 04 wires callers against exactly this name and layout. Do not leave the handoff shape "to be decided in the PR".
+
+## Labels
+`ci`, `tier-2`, `ops`, `adr-0035`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Build `job-api-diff.yml` (the ADR-0035 D9 gate-2 reusable workflow that asserts a package's public-surface diff matches its declared SemVer bump) and the `[Obsolete]`-audit job wired into `pr-core.yml` (gate 3 — fails CI on an `[Obsolete]` member missing a `DiagnosticId` or `UrlFormat`).
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: ADR-0035's version semantics enforced mechanically in the CI control plane; consumer release/PR pipelines call these gates (packet 04 wires them).
+- Feature: ADR-0035 Abstractions Versioning and Deprecation Policy rollout, Wave 2.
+- ADRs: ADR-0035 (D9 primary, D1/D5/D6), ADR-0034 (D1 — nuget.org is the previous-version source), ADR-0012 (reusable-workflow factoring).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0035 acceptance (soft).
+- `packet:01` — the `HoneyDrunk.Standards` public-API-analyzer fragment (hard — `job-api-diff.yml` diffs the `PublicAPI.{Shipped,Unshipped}.txt` files it establishes).
+
+**Constraints:**
+- See "Constraints" — inlined for agent consumption.
+- The API-diff fails hard on a `minor`-declared non-additive change; a warning is not enough.
+- Pre-1.0 (`0.Y`) packages get the additive check at warning severity — pre-1.0 is genuinely allowed to break.
+- No prior published version is a clean pass, logged.
+- The `[Obsolete]`-audit is wired into `pr-core.yml` (decided — not an opt-in reusable job) and must be a guaranteed no-op in repos with no `[Obsolete]` members.
+- The artifact handoff is the `public-api-surface` artifact (`PublicAPI.{Shipped,Unshipped}.txt` pair, per-project layout) — a committed contract, not a PR-time decision.
+
+**Key Files:**
+- `.github/workflows/job-api-diff.yml` (new)
+- `.github/workflows/pr-core.yml` (amended — adds the `[Obsolete]`-audit job)
+- `docs/consumer-usage.md`
+- `docs/CHANGELOG.md`
+- `README.md`
+
+**Contracts:** Defines the `job-api-diff.yml` `workflow_call` input contract (`package-id` / `version` / `declared-bump` / `surface-artifact-name`) and the `public-api-surface` artifact handoff (`PublicAPI.{Shipped,Unshipped}.txt` pair, per-project layout). Consumes the `PublicAPI.{Shipped,Unshipped}.txt` convention from packet 01 and nuget.org as the previous-version source (ADR-0034 D1).

--- a/generated/issue-packets/active/adr-0035-abstractions-versioning/04-cross-repo-public-api-baseline-and-api-diff-wiring.md
+++ b/generated/issue-packets/active/adr-0035-abstractions-versioning/04-cross-repo-public-api-baseline-and-api-diff-wiring.md
@@ -1,0 +1,152 @@
+---
+name: Cross-Repo Change
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+target_repos: ["HoneyDrunk.Kernel", "HoneyDrunk.Transport", "HoneyDrunk.Vault", "HoneyDrunk.Vault.Rotation", "HoneyDrunk.Auth", "HoneyDrunk.Web.Rest", "HoneyDrunk.Data", "HoneyDrunk.Audit", "HoneyDrunk.Pulse", "HoneyDrunk.Notify", "HoneyDrunk.Communications", "HoneyDrunk.Observe"]
+labels: ["chore", "tier-2", "core", "ops", "coordination", "adr-0035", "wave-3"]
+dependencies: ["packet:01", "packet:03"]
+adrs: ["ADR-0035", "ADR-0034"]
+accepts: ["ADR-0035"]
+wave: 3
+initiative: adr-0035-abstractions-versioning
+node: honeydrunk-architecture
+---
+
+# Adopt the public-API-analyzer fragment, commit PublicAPI.Shipped.txt baselines, and wire job-api-diff.yml across all public Nodes (ADR-0035 D9)
+
+## Summary
+Roll the ADR-0035 enforcement out to every public package-producing Node: import the `HoneyDrunk.Standards` public-API-analyzer fragment (packet 01), commit the one-time baseline `PublicAPI.Shipped.txt` for every packable project at its current published surface, add an empty `PublicAPI.Unshipped.txt`, and amend each Node's release/PR pipeline to call `job-api-diff.yml` and run the `[Obsolete]`-audit (packet 03).
+
+## Repo-list reconciliation (read this before filing)
+ADR-0035's Affected Nodes section says "Every public Node — gains `PublicAPI.{Shipped,Unshipped}.txt`, the analyzer reference, and a one-time baseline commit at current published version." ADR-0035 governs **every public `*.Abstractions` package**, so the gating test for inclusion in this fan-out is concrete and per-node:
+
+> **Inclusion test: a Node is in this fan-out if its repo is scaffolded and it currently ships at least one public `.Abstractions` NuGet package** (per `catalogs/relationships.json` `exposes.packages`, cross-checked against the actual scaffolded repo). A Node whose Abstractions package is still only `packages_planned` adopts ADR-0035's tooling at its own standup, not here.
+
+Applying that test:
+
+- **`HoneyDrunk.Architecture`**, **`HoneyDrunk.Studios`**, **`HoneyDrunk.Actions`** are excluded — **these repos ship no NuGet packages at all** (Architecture is the governance/catalog repo, Studios is the marketing site, Actions is the CI workflow repo). There is no public API surface to baseline.
+- **`HoneyDrunk.Standards`** is excluded from *this* fan-out — it adopts its own analyzer fragment as part of authoring it (packet 01). Do not double-apply here.
+- **`HoneyDrunk.Audit`** *is* included — it ships `HoneyDrunk.Audit.Abstractions` (`catalogs/relationships.json` id `honeydrunk-audit`; ADR-0030/0031 standup). If at filing time Audit's repo is not yet package-publishing, the `file-packets` agent drops it from the fan-out and notes it.
+- **`HoneyDrunk.Vault.Rotation`** is included — it ships `HoneyDrunk.Vault.Rotation`.
+- **`HoneyDrunk.Observe`** *is* included — it is an **Ops-sector Node** (`catalogs/nodes.json` `sector: "Ops"`), its repo **is scaffolded** (`src/HoneyDrunk.Observe.Abstractions/`), and it currently ships the public `HoneyDrunk.Observe.Abstractions` package (v0.1.0; `catalogs/relationships.json` `exposes.packages: ["HoneyDrunk.Observe.Abstractions"]`). Since ADR-0035 governs every public `.Abstractions` package, `Observe.Abstractions` is in scope. Observe's other packages (`HoneyDrunk.Observe`, the connector packages) are still `packages_planned` — only the already-shipped `Observe.Abstractions` is baselined now; the planned packages adopt the fragment when they scaffold.
+
+That gives the **12 package-producing scaffolded .NET Node repos** enumerated in `target_repos`. **The 9 AI-sector Seed Nodes** (AI, Capabilities, Agents, Memory, Knowledge, Flow, Operator, Evals, Sim) are explicitly OUT — they fail the inclusion test: not yet scaffolded as live package-producing repos. They adopt ADR-0035's tooling as they scaffold, in each Node's own standup-ADR work. **Private revenue Nodes** (`HoneyDrunk.Notify.Cloud`, ADR-0027 — not yet scaffolded) are OUT: ADR-0035 D8 says private packages are not bound by D1–D6 (they may break consumers at minor versions). They adopt their own rule at standup. The 12-repo list is pinned — do not add Nodes at filing time; apply the inclusion test if in doubt.
+
+## Context
+ADR-0035 D9 commits three CI gates. Packet 01 authored the shared `HoneyDrunk.Standards` public-API-analyzer fragment (gate 1's analyzer + the `PublicAPI.{Shipped,Unshipped}.txt` convention). Packet 03 authored `job-api-diff.yml` (gate 2) and the `[Obsolete]`-audit (gate 3). This packet is the per-Node adoption — the work ADR-0035's Follow-up Work names as "Add `Microsoft.CodeAnalysis.PublicApiAnalyzers` to every public Node's `Directory.Build.props`; one-time baseline commit."
+
+The **baseline commit** is the load-bearing part. `Microsoft.CodeAnalysis.PublicApiAnalyzers` treats every public member not listed in `PublicAPI.Shipped.txt` as an undeclared addition and fails the build. So the moment a Node imports the fragment, the build breaks until `PublicAPI.Shipped.txt` is populated with the Node's *current* public surface. The fix is the one-time baseline: generate `PublicAPI.Shipped.txt` from the existing surface (the analyzer ships a "add to shipped API" code fix; or `dotnet format`-style generation) and commit it. From that point on, any new public member must be added to `PublicAPI.Unshipped.txt` in the same PR or CI fails — which is exactly ADR-0035 D9 gate 1.
+
+**This is a multi-repo packet** describing one repeated unit of work across the 12 repos in `target_repos`. The `file-packets` agent files it as a tracking issue in `HoneyDrunk.Architecture` with one child issue per Node, or as 12 sibling issues. The per-repo work is identical in shape and small-to-medium.
+
+## Per-repo work unit (repeated for each of the 12 Node repos)
+For each Node repo:
+1. **Import the analyzer fragment.** Wire the repo-root `Directory.Build.props` to import the `HoneyDrunk.Standards` public-API-analyzer fragment (packet 01). Match the repo's existing `HoneyDrunk.Standards` consumption mechanism (the same way it consumes the analyzer set and — if the ADR-0034 initiative has already landed in this repo — the packaging-metadata fragment).
+2. **Commit the baseline `PublicAPI.Shipped.txt`.** For every packable project (`*.Abstractions`, the default backing, providers, `.AspNetCore`, etc.), generate `PublicAPI.Shipped.txt` populated with the project's **current published public surface** and commit it next to the `.csproj`. Use the `PublicApiAnalyzers` "add to shipped public API" bulk code fix, or the analyzer's documented generation path. The baseline must reflect what is *already published* — do not editorialize the surface; this is a snapshot, not a cleanup.
+3. **Add an empty `PublicAPI.Unshipped.txt`.** Commit an empty (or header-only) `PublicAPI.Unshipped.txt` next to each packable `.csproj` so the analyzer's tracked-file pair is complete. Future public-surface additions land here.
+4. **Verify the analyzer passes.** After steps 1–3, `dotnet build` must be green — the analyzer sees every public member declared in `Shipped.txt` and raises nothing. A build failure here means the baseline is incomplete; regenerate it.
+5. **Audit existing `[Obsolete]` members.** Scan the repo's public surface for `[Obsolete]` attributes. ADR-0035 D6 requires each carry a `DiagnosticId` and a `UrlFormat`. Any existing `[Obsolete]` member missing either must be brought into compliance — add a `DiagnosticId` and a `UrlFormat` pointing to a migration doc in the repo (create the migration doc if absent: name the replacement, show a before/after snippet). If a repo has no `[Obsolete]` members, this step is a no-op — record that.
+6. **Wire the API-diff gate.** Amend the repo's release workflow to call `job-api-diff.yml` (packet 03) at a pinned ref before publish. The release workflow first uploads each packable project's `PublicAPI.{Shipped,Unshipped}.txt` pair as the `public-api-surface` GitHub Actions artifact (the decided handoff shape from packet 03), then calls `job-api-diff.yml` passing `package-id`, `version`, `declared-bump`, and `surface-artifact-name: public-api-surface` (the default). The `declared-bump` value is sourced from the release's intended SemVer level (the developer/release process declares it; this packet wires the call, it does not compute the bump).
+7. **Confirm the `[Obsolete]`-audit gate is active.** Packet 03 wired the `[Obsolete]`-audit as a job inside `pr-core.yml` Grid-wide — so it is **already active** on every .NET repo. This step is a no-code confirmation: verify the repo's PR pipeline runs the `pr-core.yml` tier-1 gate (it must, per invariant 31) and record that the `[Obsolete]`-audit is therefore in effect. No per-repo audit wiring is added.
+8. **Update `repos/{Node}/integration-points.md`** (in `HoneyDrunk.Architecture`) to record that the Node now enforces the ADR-0035 surface gates and which Abstractions package(s) it tracks with `PublicAPI.{Shipped,Unshipped}.txt`.
+
+## Affected Repos
+Exactly the 12 package-producing scaffolded .NET Node repos in `target_repos`: Kernel, Transport, Vault, Vault.Rotation, Auth, Web.Rest, Data, Audit, Pulse, Notify, Communications, Observe. **Architecture, Studios, Actions excluded** (these repos ship no NuGet packages); **Standards excluded** (it self-adopts in packet 01). **The 9 AI-sector Seed Nodes excluded** (not yet scaffolded — they fail the inclusion test; adopt at their own standup). **Private revenue Nodes excluded** (not bound by D1–D6 per D8). The list is pinned — do not add Nodes at filing time; the inclusion test is "scaffolded repo currently shipping a public `.Abstractions` package".
+
+## NuGet Dependencies
+Per repo, the only `PackageReference` change is transitive through the imported fragment:
+- `Microsoft.CodeAnalysis.PublicApiAnalyzers` — declared by the packet-01 fragment with `PrivateAssets="all"`; it becomes an analyzer reference on each packable project when the fragment is imported. The per-repo adoption does not add it by hand — importing the fragment is what brings it in.
+- No other package reference is added or removed. `HoneyDrunk.Standards` analyzers remain referenced as before (invariant 26).
+
+This packet adds no new .NET project. `PublicAPI.Shipped.txt`, `PublicAPI.Unshipped.txt`, and any created migration doc are **content** (text/Markdown files), not `PackageReference` entries.
+
+## Boundary Check
+- [x] Each repo's `Directory.Build.props`, `PublicAPI.*.txt` baselines, `[Obsolete]` fixes, migration docs, and release/PR workflow live in that repo — correct ownership.
+- [x] `repos/{Node}/integration-points.md` edits live in `HoneyDrunk.Architecture` — correct (it is the architecture-side model file).
+- [x] No new cross-Node runtime dependency — the fragment carries a build-time analyzer; `Microsoft.CodeAnalysis.PublicApiAnalyzers` is `PrivateAssets="all"`. Invariant 1 (Abstractions packages have zero runtime HoneyDrunk dependencies) is not touched.
+- [x] No contract change — committing `PublicAPI.Shipped.txt` is a *snapshot* of the existing surface, not a surface modification. Adding a missing `DiagnosticId`/`UrlFormat` to an existing `[Obsolete]` is an attribute-argument change, not a public-shape change.
+
+## Acceptance Criteria
+- [ ] Each of the 12 repos in `target_repos` imports the `HoneyDrunk.Standards` public-API-analyzer fragment in its repo-root `Directory.Build.props`
+- [ ] Every packable project in each repo has a `PublicAPI.Shipped.txt` committed next to its `.csproj`, populated with the project's current published public surface, and an empty `PublicAPI.Unshipped.txt`
+- [ ] `dotnet build` is green in every repo — the analyzer raises nothing against the committed baseline
+- [ ] Every existing `[Obsolete]` member in each repo carries a `DiagnosticId` and a `UrlFormat`; a migration doc exists for each (created where absent); repos with no `[Obsolete]` members record that as a no-op
+- [ ] Each repo's release workflow uploads the `public-api-surface` artifact (the `PublicAPI.{Shipped,Unshipped}.txt` pair per packable project) and calls `job-api-diff.yml` at a pinned ref before publish, passing `package-id` / `version` / `declared-bump` / `surface-artifact-name`
+- [ ] The `[Obsolete]`-audit gate is confirmed active for each repo via the central `pr-core.yml` tier-1 wiring (packet 03 wired it Grid-wide — no per-repo opt-in); each repo records the confirmation
+- [ ] `repos/{Node}/integration-points.md` in `HoneyDrunk.Architecture` records that each Node enforces the ADR-0035 surface gates and which Abstractions package(s) it tracks
+- [ ] Each repo's repo-level `CHANGELOG.md` carries an entry for the public-API-surface-tracking adoption; per-package `CHANGELOG.md` entries only for packages with an actual functional change — the analyzer adoption + baseline is a tooling change, a single repo-level entry suffices, no per-package noise (invariant 12/27)
+- [ ] The 9 AI-sector Seed Nodes, private revenue Nodes, Architecture, Studios, Actions, and Standards are NOT touched by this fan-out
+
+## Human Prerequisites
+- [ ] Confirm the pinned `job-api-diff.yml` ref for all 12 callers.
+- [ ] For each repo, confirm the `declared-bump` value the release process supplies — or confirm that the release process declares it at release time (this packet wires the call; it does not encode a fixed bump).
+- [ ] Review each Node's generated `PublicAPI.Shipped.txt` baseline before merge — the baseline is the contract of record for that Node's surface; a wrong baseline silently weakens the gate. This is a review step, not a manual authoring step (the agent generates the file).
+
+## Dependencies
+- `packet:01` — the `HoneyDrunk.Standards` public-API-analyzer fragment (**hard** — each repo imports it; it must exist).
+- `packet:03` — `job-api-diff.yml` + the `[Obsolete]`-audit (**hard** — each repo's release/PR pipeline is amended to call them; they must exist).
+
+## Referenced ADR Decisions
+**ADR-0035 D9 — Enforcement.** `Microsoft.CodeAnalysis.PublicApiAnalyzers` enabled on every public package; `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` tracked in-repo; PRs touching the public surface must update `Unshipped.txt`, CI fails if stale. The API-diff job compares the post-build surface to the previous nuget.org version and asserts the diff matches the declared bump. The `[Obsolete]`-audit fails CI on any `[Obsolete]` member without a `DiagnosticId` and `UrlFormat`.
+
+**ADR-0035 Consequences — Affected Nodes.** "Every public Node — gains `PublicAPI.{Shipped,Unshipped}.txt`, the analyzer reference, and a one-time baseline commit at current published version." **Follow-up Work:** "Add `Microsoft.CodeAnalysis.PublicApiAnalyzers` to every public Node's `Directory.Build.props`; one-time baseline commit." (This packet is that fan-out.)
+
+**ADR-0035 D6 — Deprecation window.** Every deprecated member carries `[Obsolete(message, error: false)]` with a `DiagnosticId` and a `UrlFormat` pointing to a migration doc in the Node's repo; the migration doc names the replacement and shows a before/after snippet.
+
+**ADR-0035 D8 — Private packages get a different rule.** `HoneyDrunk.Notify.Cloud.*` and future revenue Nodes are not bound by D1–D6 — they may break consumers at minor versions. They are excluded from this fan-out and adopt their own rule at standup. (Public Abstractions transitively consumed by a private package are still bound — but that is the public Node's own gate, already covered here.)
+
+**ADR-0035 D1 — Pre-1.0 packages.** Every Node except the post-baseline Kernel is currently pre-1.0. Pre-1.0 makes no compatibility promise; the API-diff gate (packet 03) runs the additive check at warning severity for `0.Y` packages. The baseline commit still happens — pre-1.0 status changes the *strictness* of the diff, not whether the surface is tracked.
+
+## Constraints
+> **Invariant 12 — Semantic versioning with CHANGELOG and README.** The repo-level `CHANGELOG.md` gets an entry for the surface-tracking adoption.
+
+> **Invariant 27 — All projects in a solution share one version and move together; per-package changelogs updated only for packages with actual changes.** The analyzer adoption + baseline is a tooling change — one repo-level `CHANGELOG.md` entry per repo; no per-package changelog noise for packages whose only change is the imported fragment + a committed `PublicAPI.*.txt` pair. This packet does not push tags / trigger a release (agents never push tags).
+
+> **Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.** `Microsoft.CodeAnalysis.PublicApiAnalyzers` is `PrivateAssets="all"` — a build-time Roslyn analyzer, not a runtime dependency — so importing the fragment into an `.Abstractions` project does not violate this.
+
+- **The baseline is a snapshot, not a cleanup.** `PublicAPI.Shipped.txt` must reflect the surface *as currently published*. Do not remove, rename, or "tidy" public members while baselining — that would itself be an undeclared breaking change. If a Node's surface genuinely needs cleanup, that is a separate, deliberate major-bump packet, not this one.
+- **Build must be green per repo before the per-repo unit is done.** An incomplete `PublicAPI.Shipped.txt` leaves the analyzer failing — the per-repo unit is not complete until `dotnet build` passes.
+- **Pinned 12-repo list** — do not add the 9 AI-sector Seed Nodes, private revenue Nodes, Architecture, Studios, Actions, or Standards. The inclusion test is "scaffolded repo currently shipping a public `.Abstractions` package".
+- **No version bump is required by this packet alone** — adopting the analyzer is a build-tooling change. If a repo's release cadence means the next publish carries the change, the CHANGELOG entry rides the existing in-progress version per invariant 27; this packet does not itself trigger a release.
+
+## Labels
+`chore`, `tier-2`, `core`, `ops`, `coordination`, `adr-0035`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Per-Node adoption of ADR-0035 D9 — import the `HoneyDrunk.Standards` public-API-analyzer fragment, commit the one-time `PublicAPI.Shipped.txt` baseline + empty `PublicAPI.Unshipped.txt` for every packable project, bring existing `[Obsolete]` members into D6 compliance, wire `job-api-diff.yml` into each release pipeline, and confirm the `pr-core.yml`-resident `[Obsolete]`-audit is active. One identical work unit across 12 repos.
+
+**Target:** Coordination/tracking issue in `HoneyDrunk.Architecture` with one child issue per Node repo; each child branches from `main` in its own repo. The `integration-points.md` edits land in `HoneyDrunk.Architecture`.
+
+**Context:**
+- Goal: Every public Node mechanically enforces ADR-0035's version semantics — surface drift fails CI, a SemVer-inconsistent bump fails the API-diff, a malformed `[Obsolete]` fails the audit.
+- Feature: ADR-0035 Abstractions Versioning and Deprecation Policy rollout, Wave 3.
+- ADRs: ADR-0035 (D9/D6/D8/D1, Follow-up Work), ADR-0034 (D1 — nuget.org is the API-diff's previous-version source).
+- In scope: the 12 package-producing scaffolded .NET Node repos in `target_repos` (Kernel, Transport, Vault, Vault.Rotation, Auth, Web.Rest, Data, Audit, Pulse, Notify, Communications, Observe). Out: the 9 AI-sector Seed Nodes, private revenue Nodes, Architecture, Studios, Actions, Standards.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` (hard — the analyzer fragment), `packet:03` (hard — the API-diff + `[Obsolete]`-audit workflows).
+
+**Constraints:**
+- See "Constraints" — inlined for agent consumption.
+- The `PublicAPI.Shipped.txt` baseline is a snapshot of the *currently published* surface — do not clean up / remove / rename members while baselining.
+- `dotnet build` must be green per repo before that repo's unit is done.
+- Pinned 12-repo list — no additions. Inclusion test: scaffolded repo shipping a public `.Abstractions` package.
+- The `[Obsolete]`-audit is already Grid-wide via `pr-core.yml` (packet 03) — confirm, do not re-wire per repo.
+- The API-diff caller uploads the `public-api-surface` artifact then calls `job-api-diff.yml` with `surface-artifact-name`.
+- This packet does not push tags / trigger a release.
+
+**Key Files (per repo):**
+- repo-root `Directory.Build.props`
+- `PublicAPI.Shipped.txt` + `PublicAPI.Unshipped.txt` next to each packable `.csproj` (created)
+- migration docs for any non-compliant `[Obsolete]` member (created where absent)
+- the repo's release workflow (uploads the `public-api-surface` artifact, calls `job-api-diff.yml`)
+- `CHANGELOG.md`
+- `repos/{Node}/integration-points.md` (in `HoneyDrunk.Architecture`)
+
+(The `[Obsolete]`-audit needs no per-repo file change — it is resident in `pr-core.yml` Grid-wide from packet 03.)
+
+**Contracts:** No runtime contract change — `PublicAPI.Shipped.txt` snapshots the existing surface; the `[Obsolete]` fixes are attribute-argument changes. Consumes the `HoneyDrunk.Standards` analyzer fragment (packet 01) and the `job-api-diff.yml` `workflow_call` contract + `public-api-surface` artifact handoff (packet 03).

--- a/generated/issue-packets/active/adr-0035-abstractions-versioning/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0035-abstractions-versioning/dispatch-plan.md
@@ -1,0 +1,131 @@
+# Dispatch Plan: Abstractions Versioning and Deprecation Policy (ADR-0035)
+
+**Date:** 2026-05-22 (initial scope — drafted ahead of ADR-0035 acceptance).
+**Trigger:** ADR-0035 (Abstractions Versioning and Deprecation Policy) — Proposed 2026-05-21, part of the 2026-05-21 batch of cross-cutting Grid-gap ADRs. Scoped now so the packet set is ready when the ADR lands. ADR-0035 D10 and ADR-0034 D7 both state the two ADRs "must land together; neither is useful alone."
+**Type:** Multi-repo (Architecture, Standards, Actions — plus a per-Node fan-out across 12 package-producing scaffolded Node repos).
+**Sector:** Meta + cross-cutting (every package-producing Node is touched by Wave 3's adoption fan-out).
+**Site sync required:** No. Versioning policy, analyzer config, and CI workflows are not public-facing artifacts on the Studios marketing site. Re-evaluate only if a future "developer / SDK" page surfaces a compatibility/versioning promise — that would be a separate site-sync packet.
+
+**Rollback plan:**
+- Architecture-side packets (00, 02) revert cleanly via `git revert` — the ADR flip + invariant additions + the cascade template are docs/text-only with no runtime consumer.
+- The `HoneyDrunk.Standards` packet (01) is additive build-tooling — the public-API-analyzer fragment has no consumer until a Node imports it (Wave 3), so reverting has zero consumer impact.
+- The `HoneyDrunk.Actions` packet (03) is two additive CI artifacts — `job-api-diff.yml` has no caller until Wave 3 wires it; the `[Obsolete]`-audit is a job inside `pr-core.yml`, a guaranteed no-op in repos with no `[Obsolete]` members, so reverting is safe.
+- The Wave 3 fan-out (04) reverts per-repo: restore the prior `Directory.Build.props`, delete the committed `PublicAPI.{Shipped,Unshipped}.txt` files, restore the prior release workflow. No runtime change, no contract change — analyzer config + a surface snapshot only. A partially-reverted state (some repos adopted, some not) is operationally fine; the repos are independent.
+
+## Summary
+
+ADR-0035 decides **version semantics** for the Grid's public `*.Abstractions` packages — the policy that makes the Abstractions-first coupling rule (every stand-up ADR from ADR-0016 through ADR-0031) safe to rely on. The decision: strict SemVer 2.0.0 with an explicit major/minor/patch interpretation (D1); a binary-compatibility guarantee at minor/patch (D2); no default-interface-member additions — new behavior lands on a new interface (D3); public records use `init` named members not positional syntax, enums are extensible-by-default (D4); a pre-release channel with a 14-day `-preview` floor and a 7-day `-rc` floor, no version skips (D5); a 60-day deprecation window for member removals at 1.0+ (D6); major-version cascades scoped as initiatives via a template, not ad-hoc packets (D7); a private-package carve-out — revenue Nodes are not bound by D1–D6 (D8); three CI enforcement gates (D9); and version semantics delegated here while ADR-0034 owns distribution (D10).
+
+This initiative ships **5 packets** (`00`–`04`) across **three waves**:
+
+- **Wave 1** — governance + the two foundational artifacts: ADR acceptance + the three versioning invariants + the Kernel.Abstractions 1.0.0-baseline note (00); the `HoneyDrunk.Standards` public-API-analyzer fragment (01); the abstractions-cascade initiative template (02).
+- **Wave 2** — the enforcement mechanism: `job-api-diff.yml` + the `[Obsolete]`-audit job in HoneyDrunk.Actions (03).
+- **Wave 3** — execution: the per-Node adoption fan-out (04) across 12 package-producing scaffolded Node repos — import the analyzer fragment, commit the `PublicAPI.Shipped.txt` baseline, bring `[Obsolete]` members into compliance, wire the API-diff gate, confirm the `pr-core.yml`-resident `[Obsolete]`-audit.
+
+**ADR-0034 lands together — separate initiative.** ADR-0035 D10 and ADR-0034 D7 are explicit: the two "must land together; neither is useful alone." ADR-0034 (Public Package Distribution) is scoped under `adr-0034-public-package-distribution`. ADR-0035 governs version *semantics*; ADR-0034 governs *distribution* (feeds, metadata, the publish workflow). Packet 00 here flips ADR-0035 only; its acceptance PR must be merged in the same session as ADR-0034's acceptance PR. The two initiatives are sequenced loosely-parallel and share a release moment.
+
+## Cross-dependency with the ADR-0034 initiative
+
+The two initiatives are deliberately kept as separate folders (no shared packets) but they have real coupling at three points — all noted in the packet bodies:
+
+1. **Acceptance co-landing (hard).** ADR-0035 packet `00` and ADR-0034 packet `00-architecture-adr-0034-acceptance.md` must merge in the same session. Each appends three invariants to `constitution/invariants.md` (six total). **Invariant numbering is pre-reserved, not rebase-coordinated:** the true current maximum in `constitution/invariants.md` is 51 (verified). ADR-0035's reserved block is invariants **57, 58, 59**; ADR-0034's acceptance packet holds its own distinct reserved block. Numbers 57-59 are pre-reserved as part of a 12-ADR batch; if any invariant above 51 lands from outside this batch before merge, shift this block upward, never reuse a number. Neither packet edits the other ADR's file. This is a **merge-time coordination**, not a `dependencies:` edge — the two packets are in different initiative folders and the `packet:NN` form only resolves within one folder, so it cannot be expressed as machine-readable frontmatter. It is called out in both packet 00 bodies and both dispatch plans instead.
+
+2. **Shared `HoneyDrunk.Standards` target (version-bump ownership).** ADR-0035 packet `01` (public-API-analyzer fragment) and ADR-0034 packet `02` (packaging-metadata fragment) both add a build-asset fragment to `HoneyDrunk.Standards`. They are independent fragments — different files, no conflict — but both touch the same solution. **ADR-0034 packet 02 is the sole `HoneyDrunk.Standards` solution-version bumper across this 12-ADR batch.** ADR-0035 packet 01 MUST NOT bump the Standards version — it adds its fragment content and appends to the in-progress `CHANGELOG.md` entry only, regardless of merge order. This is recorded unconditionally in ADR-0035 packet 01's Constraints. No `dependencies:` edge — the two are genuinely parallel and either order is fine.
+
+3. **`job-api-diff.yml` reads nuget.org (soft — ordering preference, not a blocker).** ADR-0035 packet `03`'s API-diff job resolves a package's *previous published version* from nuget.org. nuget.org as the primary public feed is ADR-0034 D1. The job needs no credential (public-package read is anonymous) and is correct against whatever is on nuget.org today, so it is **not hard-blocked** on the ADR-0034 fan-out. But the gate is only *meaningful* once Nodes are actually publishing to nuget.org under `HoneyDrunkStudios` (ADR-0034 packet 05). In practice ADR-0035 Wave 3 and ADR-0034 Wave 3 run in the same window; if ADR-0035 Wave 3 lands first, `job-api-diff.yml` simply has fewer baselines to diff against until ADR-0034's publish fan-out catches up — a clean no-op pass per packet 03's no-baseline handling, not a failure.
+
+There is **no shared artifact** between the two initiatives — ADR-0034's `catalogs/package-feeds.json` and packaging-metadata fragment, and ADR-0035's public-API-analyzer fragment and cascade template, are all distinct files. The coupling is entirely the co-landing moment (point 1), one version-bump etiquette point (point 2), and one ordering preference (point 3).
+
+## Important constraints (from ADR-0035 itself)
+
+- **Strict SemVer — the version number is a breaking-change signal, not a release date.** D1 + the Alternatives section reject CalVer and lockstep versioning. An Abstractions package may be at 1.4.2 while its default backing is at 0.6.0; versions are independent per package.
+- **Binary compatibility is the guarantee at minor/patch.** D2 — a binary compiled at the prior minor must continue to load and execute without `MissingMethodException` / `TypeLoadException`. Source compatibility is best-effort only.
+- **No default-interface-member additions — ever.** D3 + the Alternatives section. DIM is unsupported on AOT and `netstandard2.0` (TFMs the Grid still emits). New behavior lands on a new interface (`IModelRouter` → `IModelRouter2`). This is now an invariant (added by packet 00).
+- **Public records use `init` members, not positional syntax.** D4 — positional records make adding a parameter a binary break. Enums are extensible-by-default; an exhaustive `switch` needs a default arm unless the enum is `<closed/>`.
+- **Pre-release windows are calendar floors, not "prove it's safe" gates.** D5 — 14 days `-preview`, 7 days `-rc`, no skips. The Alternatives section: "in market for long enough to be observable" is the axis, not "obvious."
+- **The 60-day deprecation window is a 1.0+ guarantee.** D6 — pre-1.0 collapses to "next minor." Every Abstractions package except the post-baseline Kernel is currently pre-1.0.
+- **A major cascade is an initiative.** D7 — scoped via the `abstractions-cascade.md` template (packet 02), recording the bumping Node, downstream Nodes, topological order, freeze status, and pre-release dates. This is now an invariant (added by packet 00).
+- **Private revenue Nodes are not bound by D1–D6.** D8 — they buy velocity by giving up the public ABI promise. They are excluded from the Wave 3 fan-out. But public Abstractions transitively consumed by a private package are still bound.
+- **Kernel.Abstractions is the only 1.0.0 package.** The ADR-0026 `TenantId` strict-typing bump is retroactively declared 1.0.0. No bulk-bump — every other Node reaches 1.0.0 only on deliberate review (Follow-up Work).
+
+## Wave Diagram
+
+### Wave 1 — Governance + foundational artifacts (parallel after packet 00)
+
+Run packet 00 first (ADR acceptance). Packets 01 and 02 may run in parallel with each other after 00 — 01 is a `HoneyDrunk.Standards` build-tooling fragment, 02 is an Architecture template; neither depends on the other.
+
+- [ ] `HoneyDrunk.Architecture`: **Accept ADR-0035** — flip status, add the three versioning invariants, record the Kernel.Abstractions 1.0.0 baseline, register the initiative — [`00-architecture-adr-0035-acceptance.md`](00-architecture-adr-0035-acceptance.md)
+  - Blocked by: nothing.
+- [ ] `HoneyDrunk.Standards`: Author the public-API-analyzer + record/enum-evolution `Directory.Build.props` fragment — [`01-standards-public-api-analyzers-props-fragment.md`](01-standards-public-api-analyzers-props-fragment.md)
+  - Blocked by: Wave 1 — `00` (soft — references ADR-0035 D3/D4/D9 as live rules).
+- [ ] `HoneyDrunk.Architecture`: Author the abstractions-cascade initiative template — [`02-architecture-abstractions-cascade-initiative-template.md`](02-architecture-abstractions-cascade-initiative-template.md)
+  - Blocked by: Wave 1 — `00` (soft — references ADR-0035 D7 as a live rule).
+
+**Wave 1 exit criteria:**
+- ADR-0035 reads `**Status:** Accepted`; the three versioning invariants are in `constitution/invariants.md`; the Kernel.Abstractions 1.0.0-baseline note is recorded; the initiative is registered.
+- `HoneyDrunk.Standards` ships the public-API-analyzer fragment (`PublicApiAnalyzers` reference, `PublicAPI.{Shipped,Unshipped}.txt` wiring, switch-exhaustiveness rule), scoped to `$(IsPackable)`.
+- `initiatives/templates/abstractions-cascade.md` exists with the six D7 fields.
+
+### Wave 2 — The enforcement mechanism
+
+- [ ] `HoneyDrunk.Actions`: Author `job-api-diff.yml` + the `[Obsolete]`-audit job — [`03-actions-job-api-diff-and-obsolete-audit-workflows.md`](03-actions-job-api-diff-and-obsolete-audit-workflows.md)
+  - Blocked by: Wave 1 — `00` (soft — references ADR-0035 D9), `01` (**hard** — `job-api-diff.yml` diffs the `PublicAPI.{Shipped,Unshipped}.txt` files the packet-01 fragment establishes).
+
+**Wave 2 exit criteria:**
+- `job-api-diff.yml` exists, is callable via `workflow_call` with `package-id` / `version` / `declared-bump`, resolves the previous nuget.org version, asserts the surface diff matches the declared bump (no-change for patch, additive-only for minor, any-change for major), no-ops cleanly when there is no baseline, and treats pre-1.0 violations as warnings.
+- The `[Obsolete]`-audit fails CI on any `[Obsolete]` member missing a `DiagnosticId` or `UrlFormat`.
+
+### Wave 3 — Execution: per-Node adoption fan-out
+
+- [ ] **Per-Node fan-out**: Adopt the analyzer fragment, commit `PublicAPI.Shipped.txt` baselines, bring `[Obsolete]` members into compliance, wire the API-diff gate, confirm the `[Obsolete]`-audit — across all 12 package-producing scaffolded Nodes — [`04-cross-repo-public-api-baseline-and-api-diff-wiring.md`](04-cross-repo-public-api-baseline-and-api-diff-wiring.md)
+  - Blocked by: Wave 1 — `01` (**hard** — each repo imports the fragment); Wave 2 — `03` (**hard** — each repo's release/PR pipeline is wired to call the gates).
+
+**Wave 3 exit criteria:**
+- All 12 package-producing scaffolded Nodes import the analyzer fragment, have a committed `PublicAPI.Shipped.txt` baseline + empty `PublicAPI.Unshipped.txt` per packable project, build green, have all `[Obsolete]` members in D6 compliance, call `job-api-diff.yml` from their release pipelines, and have the `pr-core.yml`-resident `[Obsolete]`-audit confirmed active.
+- `repos/{Node}/integration-points.md` records each Node's surface-gate enforcement.
+
+## Out-of-scope / deferred items
+
+- **ADR-0034 (Public Package Distribution and NuGet Policy).** Lands together with ADR-0035 (D10 / ADR-0034 D7) but is a separate initiative — `adr-0034-public-package-distribution`. It owns feeds, package metadata, SourceLink, and `job-publish-nuget.yml`. Packet 00's acceptance PR coordinates its merge moment with ADR-0034's. See the "Cross-dependency" section above for the three coupling points.
+- **Moving each Node's Abstractions package to 1.0.0.** ADR-0035 Follow-up Work: "Move each Node's Abstractions package to 1.0.0 only on deliberate review; do not bulk-bump." This initiative records *only* the Kernel.Abstractions 1.0.0 baseline (packet 00). Every other Node's 1.0.0 declaration is a future, deliberate, per-Node decision — each is its own small packet when the owning Node is ready to make the GA-grade compatibility promise. Not a packet here.
+- **An actual major-version ABI cascade.** Packet 02 authors the *template*; it does not scope a live cascade. There is no major bump in flight. The next cascade (the second instance of the Kernel Adoption Alignment pattern) instantiates the template as its own initiative when triggered.
+- **A custom Roslyn analyzer for the D3/D4 rules no shipped analyzer covers.** `PublicApiAnalyzers` + switch-exhaustiveness cover most of D3/D4 mechanically; "no positional records on public surface" and "no default-interface-member additions" are partly review-enforced (packet 01 documents which). A purpose-built analyzer is a possible follow-up but is not in this initiative.
+- **Unscaffolded Seed Node adoption.** The 9 AI-sector Seed Nodes (AI, Capabilities, Agents, Memory, Knowledge, Flow, Operator, Evals, Sim) are not yet scaffolded as live package-producing repos — they fail packet 04's inclusion test ("scaffolded repo currently shipping a public `.Abstractions` package") and adopt ADR-0035's tooling as they scaffold, each in its own standup-ADR work. Note: `HoneyDrunk.Observe` is *not* in this deferred bucket — it is an Ops-sector Node whose repo is scaffolded and which already ships `HoneyDrunk.Observe.Abstractions` (v0.1.0), so it IS in the packet 04 fan-out. Packet 04 is pinned to the 12 currently-package-producing scaffolded Nodes.
+- **Private revenue Node versioning.** ADR-0035 D8 explicitly carves `HoneyDrunk.Notify.Cloud.*` and future revenue Nodes out of D1–D6. They adopt their own (weaker) rule at standup. ADR-0035's own Operational Consequences note "their internal canary and integration-test coverage must be correspondingly stronger; recorded as a follow-up for ADR-0027" — that follow-up belongs to ADR-0027, not here.
+- **Extending the ADR-0016 / ADR-0019 / ADR-0031 contract-shape canaries to cover the D2 binary-compat guarantee.** ADR-0035 D2 says "ADR-0016's contract-shape canary is the test surface; canaries are extended per Node to cover this guarantee." The existing per-Node canaries (invariants 46, 43, 49) already gate shape drift; extending each to assert binary-compat specifically is per-Node canary work. The `job-api-diff.yml` gate (packet 03) is the primary mechanical enforcement of D2 at the package level; per-Node canary extension is a finer-grained follow-up best done by each Node's own audit, not bundled here. Recorded so it is not silently assumed done.
+
+## After filing — board fields and blocking relationships
+
+Filing is **automated**. The `file-packets.yml` workflow in `HoneyDrunk.Architecture` triggers on push to `generated/issue-packets/active/**/*.md` and files every packet, adds it to The Hive, sets board fields from frontmatter, and wires `addBlockedBy` from the `dependencies:` arrays. Do not run `gh issue create` manually.
+
+**Fan-out packet:** packet 04 is a per-Node fan-out — the `file-packets` agent expands it into one issue per repo across the 12 repos in `target_repos` (Kernel, Transport, Vault, Vault.Rotation, Auth, Web.Rest, Data, Audit, Pulse, Notify, Communications, Observe), or files it as a tracking issue with 12 sub-tasks. If at filing time `HoneyDrunk.Audit` is not yet package-publishing, it is dropped from the fan-out and noted.
+
+The `file-packets` pipeline sets Status, Wave, Node, Tier, Actor, Initiative, and ADR fields from frontmatter and wires `addBlockedBy` automatically. For reference, the blocking graph (resolved from each packet's `dependencies:`):
+
+- `01` blocked-by `00` (soft)
+- `02` blocked-by `00` (soft)
+- `03` blocked-by `00` (soft), `01` (hard)
+- `04` blocked-by `01` (hard), `03` (hard) — wired on each per-Node fan-out issue
+
+The acceptance co-landing with ADR-0034 packet 00 is **not** in any `dependencies:` array — it cannot be (cross-initiative `packet:NN` does not resolve, and ADR-0034's packet 00 is not yet a filed issue with a `{Repo}#N` id at scope time). It is a merge-time human coordination, called out in packet 00's body and here.
+
+**Actor:** all 5 packets are `Actor=Agent`. 00 and 02 are docs/template; 01 is build tooling; 03 is CI workflows; 04 is per-repo analyzer config + a generated surface baseline + workflow wiring — all delegable. Packet 00 carries one Human Prerequisite (tagging the Kernel 1.0.0 release — agents never push tags); packet 04 carries Human Prerequisites that are review/confirm steps (review each generated baseline, confirm pinned refs). None makes the *entire* work item human — no `human-only` label on any packet.
+
+Verify a wave landed by checking The Hive for the new items + their blocked-by chains, not by inspecting the workflow log.
+
+## Notes
+
+- **Acceptance precedes flip.** ADR-0035 stays Proposed until packet 00's PR merges — and that PR is coordinated with ADR-0034's acceptance PR (ADR-0035 D10 / ADR-0034 D7, "land together").
+- **The three new invariants land in packet 00**, not in a separate `constitution/invariants.md` packet — strict SemVer per D1 (invariant 57), no default-interface-member additions per D3 (invariant 58), major-cascade-is-an-initiative per D7 (invariant 59). The true current maximum invariant in `constitution/invariants.md` is 51 (verified); 57-59 are pre-reserved for ADR-0035 as part of a 12-ADR batch. If any invariant above 51 lands from outside this batch before merge, shift the block upward — never reuse a number. ADR-0034's acceptance packet holds its own distinct reserved block.
+- **The Kernel.Abstractions 1.0.0 baseline is recorded, not bulk-applied.** Packet 00 writes the retroactive note; the release tag is a Human Prerequisite (agents never push tags). No other Node is moved to 1.0.0 — that is deliberate per-Node future work.
+- **No new repo created, no new ADR, no new runtime contract.** This initiative ships an ADR flip + invariants, one build-tooling fragment, one initiative template, two reusable CI artifacts, and a per-Node analyzer-adoption fan-out. `catalogs/contracts.json` is untouched — `PublicAPI.Shipped.txt` snapshots existing surfaces, it does not define new ones.
+- **The `PublicAPI.Shipped.txt` baseline is the load-bearing Wave 3 step.** It is a snapshot of each Node's *currently published* surface — not a cleanup. A wrong baseline silently weakens the gate, which is why packet 04 makes "review each generated baseline before merge" a Human Prerequisite.
+- **The dispatch plan is the one exception to packet immutability** (ADR-0008 D7). It is updated at wave boundaries as a historical record; packet bodies are immutable post-filing (invariant 24).
+
+## Archival
+
+Per ADR-0008 D10, when every **filed and in-scope** packet in this initiative reaches `Done` on the org Project board and the wave exit criteria are met, the entire `active/adr-0035-abstractions-versioning/` folder moves to `archive/adr-0035-abstractions-versioning/` in a single commit. Partial archival is forbidden.
+
+## Revision history
+
+- **2026-05-22 initial scope** — 5 packets across three waves. Drafted ahead of ADR-0035 acceptance per the developer's request; packets are pending-acceptance drafts, not yet filed as GitHub Issues. ADR-0034 noted as a separate, co-landing initiative per ADR-0035 D10 / ADR-0034 D7; the three cross-initiative coupling points are recorded in the "Cross-dependency" section.

--- a/generated/issue-packets/active/adr-0035-abstractions-versioning/handoff-wave3-node-adoption.md
+++ b/generated/issue-packets/active/adr-0035-abstractions-versioning/handoff-wave3-node-adoption.md
@@ -1,0 +1,56 @@
+# Handoff: Wave 2 → Wave 3 (enforcement mechanism → per-Node adoption)
+
+**Read once at the Wave 2 → Wave 3 transition.** This is an ephemeral baton pass, not a live tracker. Immutable per invariant 24.
+
+## What Waves 1–2 delivered (upstream changes Wave 3 builds on)
+
+- **ADR-0035 is Accepted** (packet 00). Its three new versioning invariants are live in `constitution/invariants.md`: (1) every public Abstractions package follows strict SemVer per D1 — calendar/marketing/Node-aligned versions forbidden; (2) no default-interface-member additions on shipped public interfaces — successors land on new interfaces; (3) a major-version cascade is an initiative, not a loose set of packets. D1–D9 are now binding rules. ADR-0035's acceptance PR was merged together with ADR-0034's (D10 / ADR-0034 D7 — they land together). The Kernel.Abstractions 1.0.0 baseline is recorded (the ADR-0026 `TenantId` strict-typing version is retroactively 1.0.0); every other Node's Abstractions package stays pre-1.0 until a deliberate future review.
+- **The `HoneyDrunk.Standards` public-API-analyzer fragment exists** (packet 01) — a `Directory.Build.props` fragment that references `Microsoft.CodeAnalysis.PublicApiAnalyzers` (`PrivateAssets="all"`) on every packable project, wires `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` as `AdditionalFiles`, sets the `RS00xx` rules to `error` severity, and turns on the switch-exhaustiveness rule. It is scoped to `$(IsPackable)` — it never touches test projects. The PR records which D3/D4 rules are analyzer-enforced vs review-enforced.
+- **`job-api-diff.yml` exists in HoneyDrunk.Actions** (packet 03) — a reusable `workflow_call` workflow taking `package-id` / `version` / `declared-bump` / `surface-artifact-name` (default `public-api-surface`), resolving a package's previous published version from nuget.org, and asserting the public-surface diff matches the declared bump: no-change for `patch`, additive-only for `minor`, any-change for `major` (with a stable-major-not-preceded-by-`-rc` flag per D5). It downloads the `public-api-surface` artifact (the `PublicAPI.{Shipped,Unshipped}.txt` pair per packable project) rather than re-building. No prior published version is a clean no-op pass. Pre-1.0 (`0.Y`) violations are warnings, not hard fails.
+- **The `[Obsolete]`-audit gate exists** (packet 03) — fails CI when any `[Obsolete]` member lacks a `DiagnosticId` or a `UrlFormat`. **It is a job wired into `pr-core.yml` Grid-wide** (decided in packet 03 — not a separate opt-in reusable job), so it is already active on every .NET repo and is a guaranteed no-op in any repo with no `[Obsolete]` members. **Wave 3 does not wire it per-repo** — packet 04 only confirms the repo runs `pr-core.yml` and records the audit as in effect.
+
+## Contracts Wave 3 consumes
+
+- **The `HoneyDrunk.Standards` public-API-analyzer fragment** — packet 04's per-Node adoption imports it into each repo-root `Directory.Build.props`. Confirm the consumption mechanism the repo already uses for the `HoneyDrunk.Standards` analyzer set (and, if the ADR-0034 initiative already landed in the repo, the packaging-metadata fragment) and match it.
+- **`job-api-diff.yml` `workflow_call` contract** — inputs `package-id`, `version`, `declared-bump` (`major` | `minor` | `patch`), and `surface-artifact-name` (default `public-api-surface`). The caller uploads each packable project's `PublicAPI.{Shipped,Unshipped}.txt` pair as the `public-api-surface` artifact, then calls `job-api-diff.yml` at a pinned ref. Confirm the pinned ref before filing packet 04.
+- **The `[Obsolete]`-audit** — already wired Grid-wide via `pr-core.yml` (packet 03's decided path). Wave 3 just confirms the repo runs `pr-core.yml`; no per-repo audit-wiring is needed.
+- **nuget.org** — `job-api-diff.yml` resolves the previous published version from nuget.org (ADR-0034 D1). If ADR-0034's publish fan-out has not yet landed for a given Node, the API-diff is a clean no-op pass for that Node until it has a published version to diff against — not a failure.
+
+## Wave 3 objectives
+
+**Per-Node adoption fan-out** (packet 04) — across the **12 package-producing scaffolded .NET Node repos**: Kernel, Transport, Vault, Vault.Rotation, Auth, Web.Rest, Data, Audit, Pulse, Notify, Communications, Observe. Per repo:
+
+1. Import the public-API-analyzer fragment in the repo-root `Directory.Build.props`.
+2. **Commit the one-time `PublicAPI.Shipped.txt` baseline** for every packable project, populated with the project's *current published public surface* — use the `PublicApiAnalyzers` "add to shipped public API" bulk code fix. Add an empty `PublicAPI.Unshipped.txt` alongside.
+3. Verify `dotnet build` is green — an incomplete baseline leaves the analyzer failing.
+4. Bring every existing `[Obsolete]` member into ADR-0035 D6 compliance — a `DiagnosticId` and a `UrlFormat` pointing to a migration doc (create the doc where absent: name the replacement, before/after snippet).
+5. Amend the release workflow to upload the `public-api-surface` artifact (each packable project's `PublicAPI.{Shipped,Unshipped}.txt` pair) and call `job-api-diff.yml` at a pinned ref, passing `package-id` / `version` / `declared-bump` / `surface-artifact-name`.
+6. Confirm the `[Obsolete]`-audit gate is active — it is resident in `pr-core.yml` Grid-wide (packet 03); verify the repo runs `pr-core.yml` and record the confirmation. No per-repo wiring.
+7. Update `repos/{Node}/integration-points.md` with the Node's surface-gate enforcement.
+
+**OUT of the fan-out:** `HoneyDrunk.Architecture`, `HoneyDrunk.Studios`, `HoneyDrunk.Actions` (these repos ship no NuGet packages); `HoneyDrunk.Standards` (self-adopts in packet 01); the 9 AI-sector Seed Nodes (AI, Capabilities, Agents, Memory, Knowledge, Flow, Operator, Evals, Sim — not yet scaffolded, adopt at their own standup); private revenue Nodes (ADR-0035 D8 — not bound by D1–D6, own standup). `HoneyDrunk.Observe` is IN the fan-out — it is a scaffolded Ops-sector Node already shipping `HoneyDrunk.Observe.Abstractions`. The 12-repo list is pinned — do not add repos at filing time. If `HoneyDrunk.Audit` is not yet package-publishing at filing time, drop it and note it.
+
+## Constraints carried into Wave 3
+
+> **Invariant 57 — strict SemVer** (added by packet 00). Every public Abstractions package follows strict SemVer per ADR-0035 D1. The `PublicAPI.Shipped.txt` baseline + `job-api-diff.yml` are what make this mechanically checkable.
+
+> **Invariant 58 — no default-interface-member additions** (added by packet 00). New behavior on a shipped public interface lands on a new interface. Wave 3's baseline does not change any interface — it snapshots what exists.
+
+> **Invariant 59 — a major cascade is an initiative** (added by packet 00). Not relevant to Wave 3's adoption work directly, but the gate Wave 3 wires is what *detects* an undeclared cascade-class break.
+
+> **Invariant 1 — Abstractions packages have zero runtime HoneyDrunk dependencies.** `Microsoft.CodeAnalysis.PublicApiAnalyzers` is `PrivateAssets="all"` — a build-time Roslyn analyzer, not a runtime dependency — so importing the fragment into an `.Abstractions` project does not violate this.
+
+> **Invariant 12 / 27 — CHANGELOG.** One repo-level `CHANGELOG.md` entry per repo for the surface-tracking adoption; no per-package changelog noise for packages whose only change is the imported fragment + a `PublicAPI.*.txt` pair. Packet 04 does not push tags / trigger a release (agents never push tags).
+
+> **ADR-0035 D6 — Deprecation window.** Every `[Obsolete]` member carries a `DiagnosticId` and a `UrlFormat` pointing to a migration doc that names the replacement and shows a before/after snippet.
+
+> **ADR-0035 D1 — Pre-1.0.** Every Node except the post-baseline Kernel is currently pre-1.0. Pre-1.0 makes no compatibility promise; `job-api-diff.yml` runs the additive check at warning severity for `0.Y` packages. The baseline commit still happens — pre-1.0 changes the diff *strictness*, not whether the surface is tracked.
+
+- **The baseline is a snapshot, not a cleanup.** `PublicAPI.Shipped.txt` must reflect the surface *as currently published*. Do not remove, rename, or tidy public members while baselining — that would itself be an undeclared breaking change. Genuine surface cleanup is a separate deliberate major-bump packet.
+- **Build green per repo before the per-repo unit is done.** An incomplete `PublicAPI.Shipped.txt` leaves the analyzer failing.
+- **Review each generated baseline before merge** (a Human Prerequisite on packet 04). The baseline is the contract of record for a Node's surface; a wrong baseline silently weakens the gate. The agent generates the file; the human reviews it.
+- **Pinned 12-repo list** — do not add the 9 AI-sector Seed Nodes, private revenue Nodes, Architecture, Studios, Actions, or Standards. The inclusion test is "scaffolded repo currently shipping a public `.Abstractions` package".
+
+## Acceptance signal for Wave 3 completion
+
+All 12 package-producing scaffolded Nodes import the analyzer fragment, have a committed `PublicAPI.Shipped.txt` baseline + empty `PublicAPI.Unshipped.txt` per packable project, build green, have every `[Obsolete]` member in D6 compliance, call `job-api-diff.yml` from their release pipelines, and have the `pr-core.yml`-resident `[Obsolete]`-audit confirmed active; `repos/{Node}/integration-points.md` records each Node's surface-gate enforcement. The initiative archives when every filed and in-scope packet is `Done`.


### PR DESCRIPTION
## Summary
Adds the issue packets for **ADR-0035 — Abstractions versioning and deprecation policy** under `generated/issue-packets/active/adr-0035-abstractions-versioning/`.

One of 12 per-ADR PRs from the 2026-05-21 ADR batch — split per ADR so `file-packets.yml` files incrementally per merge rather than firing all 92 packets at once (GraphQL rate limits).

## Merge-order note
**Must co-land with ADR-0034** (PR #196) — ADR-0034 D7 requires the pair to merge in the same session; neither is useful alone.

## Test plan
- [ ] `file-packets.yml` files this ADR's packets on merge and adds them to The Hive
- [ ] No GraphQL rate-limit errors in the filing run

🤖 Generated with [Claude Code](https://claude.com/claude-code)