### PR TITLE
Scope ADR-0036 — disaster recovery and backup policy

### DIFF
--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/00-architecture-adr-0036-acceptance.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/00-architecture-adr-0036-acceptance.md
@@ -1,0 +1,105 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "infrastructure", "docs", "adr-0036", "wave-1"]
+dependencies: []
+adrs: ["ADR-0036"]
+accepts: ["ADR-0036"]
+wave: 1
+initiative: adr-0036-disaster-recovery-and-backup-policy
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0036 — flip status, add the two DR invariants, register the initiative
+
+## Summary
+Flip ADR-0036 (Disaster Recovery and Backup Policy) from Proposed to Accepted: update the ADR header, update the ADR index row, add the two new DR invariants ADR-0036 commits in its Consequences section to `constitution/invariants.md`, and register the `adr-0036-disaster-recovery-and-backup-policy` initiative in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0036 sets the Grid-wide disaster-recovery and backup policy: three durability tiers (T0/T1/T2) with explicit RPO/RTO targets, geo posture, and restore-drill cadence (D1); concrete Azure backup mechanics per backing slot (D2); restore drills as proof (D3); manual cross-region failover with documented runbooks (D4); tenant-scoped restore for multi-tenant Nodes (D5); a Vault bootstrap-recovery procedure that must exist before any other T0 drill (D6); backup-vs-data-subject-deletion handling (D7); a cost ceiling that makes tier promotion an ADR amendment (D8); and the documentation surface — per-Node `dr-runbook.md`, a `dr_tier` field in `catalogs/grid-health.json`, and `generated/restore-drills/` (D9).
+
+Every other packet in this initiative references ADR-0036's D-decisions as live rules. The acceptance flip must land first so those references read against Accepted text.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0036-disaster-recovery-and-backup-policy.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0036 row Status column to Accepted.
+- `constitution/invariants.md` — add the two new DR invariants ADR-0036 commits (see Proposed Implementation for exact text) as invariants **60** and **61** (pre-reserved numbers — see Constraints).
+- `initiatives/active-initiatives.md` — register the `adr-0036-disaster-recovery-and-backup-policy` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0036 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update the ADR-0036 index row in `adrs/README.md` to Accepted.
+3. Add two new invariants to `constitution/invariants.md` as invariants **60** and **61**. The text, taken verbatim-in-substance from ADR-0036's "Invariants" Consequences subsection:
+   - **60. Every Node holding state has a `dr_tier` assignment in `catalogs/grid-health.json`.** A Node that holds durable state with no `dr_tier` field is drift; `hive-sync` (ADR-0014) reports it. Stateless Nodes are not tiered. See ADR-0036 D1.
+   - **61. A missed restore drill freezes Tier-affecting tenant onboarding for the affected Node.** No new tenants are onboarded against a Node whose last restore drill is overdue per its tier cadence. Recovery is "complete the drill," not "wave the requirement." See ADR-0036 D3.
+   The current highest invariant in `constitution/invariants.md` is 51 (verified at scope time); numbers 60–61 are pre-reserved for ADR-0036 as part of a 12-ADR batch. Add them under the existing `## Infrastructure & Configuration Invariants` section (they are infrastructure rules) or a new `## Disaster Recovery Invariants` section — match the file's current sectioning convention.
+4. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder.
+
+## Affected Files
+- `adrs/ADR-0036-disaster-recovery-and-backup-policy.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0036 header reads `**Status:** Accepted`
+- [ ] The ADR-0036 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariants.md` carries the two new DR invariants (`dr_tier` assignment is mandatory; missed drill freezes tier-affecting onboarding), numbered **60** and **61**, each citing ADR-0036
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0036-disaster-recovery-and-backup-policy` initiative with a packet checklist
+- [ ] No catalog schema change in this packet (`grid-health.json`'s `dr_tier` field is added in packet 01)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0036 D1 — Three durability tiers.** Every Node holding state is assigned T0/T1/T2; each tier fixes RPO/RTO, geo posture, and restore-drill cadence. Stateless Nodes are not tiered. The mapping is recorded in `catalogs/grid-health.json` under a new `dr_tier` field; `hive-sync` treats a stateful Node without `dr_tier` as drift.
+
+**ADR-0036 D3 — Restore drills are the proof.** A missed drill is an incident; it triggers a Tier-promotion freeze on the affected Node (no new tenants onboarded against a Node whose last drill is overdue).
+
+**ADR-0036 Consequences — Invariants.** ADR-0036 adds exactly two invariants: (1) every stateful Node has a `dr_tier`; missing assignment is drift; (2) a missed restore drill freezes tier-affecting tenant onboarding for the affected Node.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0036 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbers 60–61 are pre-reserved** as part of a 12-ADR batch; the verified current highest invariant is 51. If any invariant above 51 lands from outside this batch before merge, shift this block upward — never reuse a number. Do not renumber existing invariants; append.
+
+## Labels
+`chore`, `tier-3`, `infrastructure`, `docs`, `adr-0036`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0036 to Accepted, add the two DR invariants to `constitution/invariants.md`, and register the disaster-recovery initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0036 so the DR packets can reference its decisions as live rules.
+- Feature: ADR-0036 Disaster Recovery and Backup Policy rollout, Wave 1.
+- ADRs: ADR-0036 (primary), ADR-0008 (initiative/packet conventions), ADR-0014 (`hive-sync` drift reconciliation).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0036 stays Proposed until this PR merges.
+- Add the two new invariants as numbers **60** and **61** (verified current highest is 51; 60–61 pre-reserved for ADR-0036 in a 12-ADR batch). If an invariant above 51 lands from outside the batch before merge, shift this block upward — never reuse a number. Do not renumber existing invariants.
+
+**Key Files:**
+- `adrs/ADR-0036-disaster-recovery-and-backup-policy.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/01-architecture-dr-tier-catalog-field-and-backfill.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/01-architecture-dr-tier-catalog-field-and-backfill.md
@@ -1,0 +1,105 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "infrastructure", "docs", "adr-0036", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0036"]
+accepts: ["ADR-0036"]
+wave: 1
+initiative: adr-0036-disaster-recovery-and-backup-policy
+node: honeydrunk-architecture
+---
+
+# Add the dr_tier field to grid-health.json and backfill every stateful Node (ADR-0036 D1/D9)
+
+## Summary
+Add a `dr_tier` field to the `catalogs/grid-health.json` Node schema, document it in the catalog `_meta`, and backfill the tier assignment for every Node that holds durable state per ADR-0036 D1's tier-membership lists. Stateless Nodes get an explicit `dr_tier: null` (or are documented as exempt) so the absence of a tier is never ambiguous.
+
+**This is a new field on the catalog Node schema.** No Node object carries a `dr_tier` field today — this packet adds it. The catalog's `_meta.schema_version` is bumped accordingly. This is an additive schema change, not a value-only backfill of an existing field.
+
+## Context
+ADR-0036 D1 assigns every stateful Node to one of three durability tiers (T0/T1/T2) and states the mapping "is recorded in `catalogs/grid-health.json` under a new `dr_tier` field per Node." ADR-0036 D9 lists this field addition under the documentation surface. The new invariant added by packet 00 — "every Node holding state has a `dr_tier` assignment" — is enforced by `hive-sync` (ADR-0014) reading this field; this packet creates the field the invariant references.
+
+This is an Architecture-repo catalog change only. No code, no .NET project.
+
+## Scope
+- `catalogs/grid-health.json` — add a `dr_tier` field to every Node object; update `_meta` to document the field and the schema_version bump.
+
+## Proposed Implementation
+1. Add a `dr_tier` field to each Node object in `catalogs/grid-health.json`. This field does not exist on the schema today — it is a genuine schema addition, so `_meta.schema_version` must be bumped. Permitted values: `"T0"`, `"T1"`, `"T2"`, or `null` (stateless Node — explicitly not tiered).
+2. Backfill values per ADR-0036 D1's tier-membership lists and the Consequences "Affected Nodes" section:
+   - **T0:** `honeydrunk-vault` (loss of secrets cascades Grid-wide), `honeydrunk-audit` (regulatory/forensic completeness).
+   - **T1:** `honeydrunk-notify` (delivery state — in-flight messages, retry queues), `honeydrunk-memory` (when stood up), `honeydrunk-knowledge` (when stood up).
+   - **T2:** `honeydrunk-pulse` (historical signals; current values not durable per ADR-0028), `honeydrunk-flow` (non-customer-facing workflow state, when stood up), `honeydrunk-evals` (historical run data, when stood up).
+   - **`null` (stateless — not tiered):** `honeydrunk-kernel`, `honeydrunk-transport`, `honeydrunk-web-rest`, `honeydrunk-communications`, `honeydrunk-actions`, `honeydrunk-architecture`, `honeydrunk-standards`, `honeydrunk-studios`. Per ADR-0036 D1 their DR posture is "redeploy from source" via ADR-0033.
+   - **`honeydrunk-data` special case:** ADR-0036 Consequences states Data "doesn't have its own DR tier; its backings inherit from the consuming Node's tier." Set `honeydrunk-data` to `null` and add an inline note (e.g. a sibling `dr_tier_note` field, or a comment in `_meta`) recording the tier-inheritance rule: `Audit.Data → T0, Memory.Data → T1, Pulse.Data → T2`.
+   - **Seed Nodes whose DR tier is decided at standup** (`honeydrunk-vault-rotation`, `honeydrunk-observe`, `honeydrunk-ai`, `honeydrunk-agents`, `honeydrunk-capabilities`, `honeydrunk-operator`, `honeydrunk-sim`, `honeydrunk-lore`): ADR-0036 says Memory/Knowledge/Flow's tiers are "decided at standup, recorded in their standup ADR amendments." For a Seed Node that does not yet hold state, set `dr_tier: null` with a note that it is assigned at standup. For `honeydrunk-memory`, `honeydrunk-knowledge`, `honeydrunk-flow` — ADR-0036 D1 already names their intended tiers (T1/T1/T2), so set those values and note "provisional — confirmed at standup."
+3. Update `_meta`: bump `schema_version`, refresh `updated`, and document the `dr_tier` field (permitted values, the `null` = stateless/standup-deferred meaning, the Data tier-inheritance rule).
+
+## Affected Files
+- `catalogs/grid-health.json`
+
+## NuGet Dependencies
+None. This packet touches only a JSON catalog; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `catalogs/grid-health.json` lives in `HoneyDrunk.Architecture`. Routing rule "catalog → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency. This is a catalog metadata field, not a runtime contract — `catalogs/contracts.json` is untouched.
+
+## Acceptance Criteria
+- [ ] Every Node object in `catalogs/grid-health.json` has a `dr_tier` field with value `T0`, `T1`, `T2`, or `null`
+- [ ] Vault and Audit are `T0`; Notify is `T1`; Pulse is `T2` — matching ADR-0036 D1's tier-membership lists
+- [ ] Memory and Knowledge are `T1`, Flow and Evals are `T2`, each noted "provisional — confirmed at standup"
+- [ ] `honeydrunk-data` is `null` with a recorded tier-inheritance note (`Audit.Data → T0, Memory.Data → T1, Pulse.Data → T2`)
+- [ ] Stateless Nodes (Kernel, Transport, Web.Rest, Communications, Actions, Architecture, Standards, Studios) are explicitly `null`
+- [ ] `_meta` documents the `dr_tier` field, its permitted values, and the Data tier-inheritance rule; `schema_version` and `updated` are bumped
+- [ ] The JSON is valid and the file's existing `summary` block is preserved
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0036 D1 — Three durability tiers.** T0: RPO ≤ 5 min, RTO ≤ 1 hr, geo-redundant with read-access secondary, annual drill + semiannual partial spot-check; members Vault, Audit, Notify Cloud tenant identity & billing. T1: RPO ≤ 1 hr, RTO ≤ 8 hr, geo-redundant passive secondary, semiannual drill; members Notify delivery state, Notify Cloud operational data, Memory, Knowledge. T2: RPO ≤ 24 hr, RTO ≤ 72 hr, LRS, annual drill; members Pulse historical signals, Flow non-customer workflow state, Evals history, internal dev/staging. Stateless Nodes not tiered — "redeploy from source" via ADR-0033.
+
+**ADR-0036 Consequences — Affected Nodes.** Data has no own tier; backings inherit the consuming Node's tier (`Audit.Data → T0, Memory.Data → T1, Pulse.Data → T2`). Memory/Knowledge/Flow tiers are decided at standup, recorded in their standup ADR amendments.
+
+**ADR-0036 D9 — Documentation surface.** A new `dr_tier` field in `catalogs/grid-health.json` is part of the documentation surface.
+
+## Constraints
+> **Invariant (added by packet 00) — every Node holding state has a `dr_tier` assignment in `catalogs/grid-health.json`.** A stateful Node with no `dr_tier` is drift. This packet is what makes that invariant satisfiable — every Node object must carry the field after this packet, stateless ones explicitly `null`.
+
+- **Do not invent tiers.** Only `T0`, `T1`, `T2`, `null`. Tier promotion is an ADR amendment (ADR-0036 D8), not a catalog edit.
+- **Preserve the existing `grid-health.json` structure** — Node ids, the `summary` block, and all existing fields stay intact; `dr_tier` is purely additive.
+
+## Labels
+`feature`, `tier-2`, `infrastructure`, `docs`, `adr-0036`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Add the `dr_tier` field to `catalogs/grid-health.json` and backfill every Node per ADR-0036 D1.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the packet-00 `dr_tier` invariant satisfiable; give `hive-sync` a field to reconcile.
+- Feature: ADR-0036 Disaster Recovery rollout, Wave 1.
+- ADRs: ADR-0036 (D1/D9 primary), ADR-0014 (`hive-sync` reads the field), ADR-0028 (Pulse signals not durable — informs Pulse = T2), ADR-0033 (stateless = redeploy-from-source).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. The acceptance flip and the `dr_tier` invariant should land first so this catalog change reads against Accepted ADR text.
+
+**Constraints:**
+- Only `T0`/`T1`/`T2`/`null` values.
+- Data is `null` + tier-inheritance note.
+- Stateless Nodes explicitly `null`.
+- Purely additive — preserve all existing fields and the `summary` block.
+
+**Key Files:**
+- `catalogs/grid-health.json`
+
+**Contracts:** No runtime contract change — catalog metadata field only. `catalogs/contracts.json` untouched.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/02-architecture-dr-runbook-template-and-restore-drills-directory.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/02-architecture-dr-runbook-template-and-restore-drills-directory.md
@@ -1,0 +1,108 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "infrastructure", "docs", "adr-0036", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0036"]
+accepts: ["ADR-0036"]
+wave: 1
+initiative: adr-0036-disaster-recovery-and-backup-policy
+node: honeydrunk-architecture
+---
+
+# Create the dr-runbook.md template and the generated/restore-drills/ directory (ADR-0036 D3/D9)
+
+## Summary
+Author a reusable `generated/dr-runbook.template.md` template that every Node's `repos/{name}/` directory will adopt, and create the `generated/restore-drills/` directory with its README and drill-log schema. These are the two shared documentation artifacts ADR-0036 D9 mandates; every per-Node DR packet downstream copies the template and logs drill outcomes here.
+
+## Context
+ADR-0036 D9 says each Node's `repos/{name}/` directory gains a `dr-runbook.md` (restore procedure, failover procedure, tier rationale) and that `generated/restore-drills/` is the rolling log of drill outcomes, included by `hive-sync` in drift reconciliation. ADR-0036 D3 says each drill result is logged "with the date, tier, Node, outcome, and any deltas to the runbook."
+
+Authoring the template and the drill-log directory once — before any per-Node runbook packet runs — means every downstream runbook (Vault packet 03, Audit packet 06, Notify packet 08) starts from the same structure rather than inventing one. This packet ships the templates only; per-Node runbooks are filled in by their own packets.
+
+This is an Architecture-repo docs change only. No code, no .NET project.
+
+## Scope
+- `generated/dr-runbook.template.md` (new) — the reusable runbook skeleton. The repo has no `templates/` directory; per-Node docs live in `repos/{name}/` and drafts/generated artifacts live in `generated/`, so the shared template lands at `generated/dr-runbook.template.md`.
+- `generated/restore-drills/` (new directory) — with `README.md` describing the directory's purpose and a drill-log entry schema/example.
+- `generated/restore-drills/.gitkeep` if the directory would otherwise be empty after the README.
+
+## Proposed Implementation
+1. **Author `generated/dr-runbook.template.md`.** The template has these sections (an executing agent for a per-Node runbook packet fills the bracketed slots):
+   - **Node + Tier** — `{Node name}`, `dr_tier: {T0|T1|T2}`, the tier's RPO/RTO/geo posture/drill cadence pulled from ADR-0036 D1.
+   - **Tier rationale** — why this Node is at this tier (D1 references).
+   - **Backing inventory** — every durable Azure resource the Node owns (Key Vault / Azure SQL / Cosmos / Blob / Service Bus namespace) and its ADR-0036 D2 backup configuration.
+   - **Restore procedure** — step-by-step restore of the most recent backup into an **ephemeral** environment and validation of basic operations (D3).
+   - **Failover procedure** — for T0 Nodes, the manual cross-region failover steps (D4); for T1/T2, "not applicable — see tier posture."
+   - **Tenant-scoped restore** — for multi-tenant Nodes only (D5): the "restore to ephemeral, export one TenantId, replay into prod" path.
+   - **Cross-Node recovery ordering** — if recovery has ordering dependencies (e.g. Audit must come up after Data, Data after Vault), a pointer to `integration-points.md` (D9).
+   - **Drill cadence + last-drill record** — the tier's mandated cadence and a line for the most recent drill date/outcome (links into `generated/restore-drills/`).
+2. **Create `generated/restore-drills/`** with a `README.md` that states: this is the rolling log of restore-drill outcomes per ADR-0036 D3; `hive-sync` includes it in drift reconciliation; a missed drill past its cadence is an incident that freezes tier-affecting tenant onboarding (the packet-00 invariant).
+3. **Define the drill-log entry schema** in that README — each drill is one Markdown file (or one entry) recording: `date`, `tier`, `node`, `outcome` (pass/fail/partial), `runbook-deltas` (any procedure corrections found), and `operator`. Include one worked example so the format is unambiguous.
+
+## Affected Files
+- `generated/dr-runbook.template.md` (new)
+- `generated/restore-drills/README.md` (new)
+- `generated/restore-drills/.gitkeep` (new, if needed)
+
+## NuGet Dependencies
+None. This packet touches only Markdown docs; no .NET project is created or modified.
+
+## Boundary Check
+- [x] The template and the `generated/restore-drills/` directory live in `HoneyDrunk.Architecture` per ADR-0036 D9.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] `generated/dr-runbook.template.md` exists with the eight sections above (Node+Tier, rationale, backing inventory, restore procedure, failover procedure, tenant-scoped restore, cross-Node ordering, drill cadence + last-drill record)
+- [ ] The template's RPO/RTO/cadence values per tier are quoted accurately from ADR-0036 D1
+- [ ] `generated/restore-drills/` exists with a `README.md` stating its purpose, the `hive-sync` reconciliation role, and the missed-drill freeze rule
+- [ ] The drill-log entry schema is defined with all five fields (`date`, `tier`, `node`, `outcome`, `runbook-deltas`) plus `operator`, and one worked example
+- [ ] The template is generic — no Node-specific content; per-Node runbooks are produced by their own packets
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0036 D3 — Restore drills are the proof.** Each Node's release runbook gains a Restore Drill section with a step-by-step procedure to restore the most recent backup into an ephemeral environment and validate basic operations. Drill cadence per D1 is mandatory; results logged to `generated/restore-drills/` with date, tier, Node, outcome, and runbook deltas. A missed drill is an incident — Tier-promotion freeze on the affected Node.
+
+**ADR-0036 D9 — Documentation surface.** Each Node's `repos/{name}/` gains `dr-runbook.md` (restore procedure, failover procedure, tier rationale); `generated/restore-drills/` is the rolling drill-outcome log; a line in `integration-points.md` if recovery has cross-Node ordering.
+
+**ADR-0036 D4 — Cross-region failover is a documented runbook.** T0 Nodes have read-access secondary regions and the mechanism to fail over, but failover is manually triggered by the Studio operator per the runbook. Automated failover is not adopted at solo-developer scale.
+
+**ADR-0036 D5 — Tenant-data isolation.** Multi-tenant Nodes' restore drills must include a tenant-scoped restore path: restore one TenantId without affecting others, via "restore to ephemeral, export the tenant, replay into prod."
+
+## Constraints
+- **Template, not instance.** This packet ships the empty template + the directory + schema. It does not author any Node's actual runbook — those are packets 03, 06, 08 and the standup-amendment follow-ups.
+- **Quote ADR-0036 D1 tier values exactly** — the RPO/RTO/cadence numbers in the template must match the ADR so per-Node runbooks inherit correct figures.
+
+## Labels
+`feature`, `tier-2`, `infrastructure`, `docs`, `adr-0036`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Author the shared `dr-runbook.template.md` and create `generated/restore-drills/` with its README and drill-log schema.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Give every downstream per-Node DR runbook packet a common structure to fill in, and stand up the drill-outcome log directory.
+- Feature: ADR-0036 Disaster Recovery rollout, Wave 1.
+- ADRs: ADR-0036 (D3/D4/D5/D9 primary), ADR-0014 (`hive-sync` reconciles `restore-drills/`).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. Should land after the acceptance flip so the template references Accepted ADR text.
+
+**Constraints:**
+- Ship the template + directory + schema only — no Node-specific runbook content.
+- Quote ADR-0036 D1 tier RPO/RTO/cadence values exactly.
+
+**Key Files:**
+- `generated/dr-runbook.template.md` (new)
+- `generated/restore-drills/README.md` (new)
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/03-vault-dr-runbook-and-bootstrap-recovery-doc.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/03-vault-dr-runbook-and-bootstrap-recovery-doc.md
@@ -1,0 +1,125 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "infrastructure", "docs", "adr-0036", "wave-2"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0036", "ADR-0005", "ADR-0006"]
+accepts: ["ADR-0036"]
+wave: 2
+initiative: adr-0036-disaster-recovery-and-backup-policy
+node: honeydrunk-vault
+---
+
+# Author the Vault T0 dr-runbook and the bootstrap-recovery procedure (ADR-0036 D2/D4/D6)
+
+## Summary
+Author `repos/HoneyDrunk.Vault/dr-runbook.md` from the packet-02 template — Vault as a T0 Node — and author the Vault bootstrap-recovery procedure (ADR-0036 D6): the special-case recovery path that every other Node's DR depends on. The bootstrap-recovery *procedure document* lives in the repo; the *offline encrypted copy of the recovery material* is a separate physical-world artifact provisioned by the human packet 04.
+
+## Context
+ADR-0036 D6 makes Vault recovery the special case: "every other Node's DR depends on Vault being readable. The recovery procedure (separate runbook, encrypted offline copy) must exist before any other Tier 0 Node's first drill, because no other Tier 0 drill can succeed without it." Vault is T0 (D1) — RPO ≤ 5 min, RTO ≤ 1 hr, geo-redundant with read-access secondary, annual drill plus semiannual partial spot-check.
+
+ADR-0036 D2 specifies the Vault backup mechanics: Azure Key Vault soft-delete and purge protection both **on**, 90-day retention window; Vault contents exportable via the Vault Node's restore tooling (per ADR-0006); cross-region replication is the Key Vault feature itself.
+
+This packet authors the **documentation** — the runbook and the bootstrap-recovery procedure. It is tracked against the Vault Node but the files live in `HoneyDrunk.Vault/`'s context directory inside `HoneyDrunk.Architecture` (the `repos/{name}/` model directory), so the target repo is `HoneyDrunk.Architecture`. No code, no .NET project. The Azure portal configuration that the runbook *describes* (soft-delete, purge protection, geo posture) is verified/applied by the human packet 04; the offline encrypted recovery copy is also packet 04.
+
+## Scope
+- `repos/HoneyDrunk.Vault/dr-runbook.md` (new) — the Vault T0 runbook, from the packet-02 template.
+- `repos/HoneyDrunk.Vault/vault-bootstrap-recovery.md` (new) — the D6 bootstrap-recovery procedure.
+- `repos/HoneyDrunk.Vault/integration-points.md` — add the cross-Node recovery-ordering line (Vault recovers first; every other T0 Node's drill depends on it).
+
+## Proposed Implementation
+1. **Author `dr-runbook.md`** from the packet-02 template at `generated/dr-runbook.template.md`, filled for Vault:
+   - Tier: T0. RPO ≤ 5 min, RTO ≤ 1 hr, geo-redundant storage with read-access secondary region, annual restore drill + semiannual partial-restore spot-check.
+   - Tier rationale: loss of secrets cascades to every Node (ADR-0036 D1).
+   - Backing inventory: the per-environment Azure Key Vaults (`kv-hd-{service}-{env}` per ADR-0005 invariant 17). Backup config per ADR-0036 D2: soft-delete **on**, purge protection **on**, 90-day retention.
+   - Restore procedure: restore the most recent Key Vault backup / recover soft-deleted secrets into an ephemeral environment; validate `ISecretStore` resolves a known secret. Reference the Vault Node's own restore tooling (ADR-0006).
+   - Failover procedure: manual cross-region failover steps — Key Vault's own cross-region replication is the mechanism (D2); operator triggers per D4.
+   - Tenant-scoped restore: Vault uses the `tenant-{tenantId}-{secretName}` convention (invariant 9a); document restoring a single tenant's secrets without touching others.
+   - Cross-Node ordering: Vault recovers **first** — point to `integration-points.md`.
+   - Drill cadence + last-drill record: annual + semiannual spot-check; a line linking to `generated/restore-drills/`.
+2. **Author `vault-bootstrap-recovery.md`** — the D6 procedure:
+   - The recovery scenario: the GitHub-hosted Architecture repo is itself a recovery dependency, so this procedure must be runnable from an offline copy.
+   - What the offline encrypted artifact contains (the minimum material to re-bootstrap a Key Vault and re-establish RBAC/OIDC access) — described generically; the artifact itself is provisioned by packet 04.
+   - The step-by-step recovery: from the offline copy, re-create the Key Vault, restore secrets, re-establish access, and validate.
+   - A pointer to `business/context/` for the offline copy's physical location and rotation procedure (recorded there per ADR-0036's BDR record, **not** in the repo — the repo is a recovery dependency).
+3. **Update `integration-points.md`** with the recovery-ordering line: Vault recovers first; Audit and other T0 Nodes' drills cannot succeed until Vault is readable.
+
+## Affected Files
+- `repos/HoneyDrunk.Vault/dr-runbook.md` (new)
+- `repos/HoneyDrunk.Vault/vault-bootstrap-recovery.md` (new)
+- `repos/HoneyDrunk.Vault/integration-points.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown docs; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `repos/HoneyDrunk.Vault/` is the Vault Node's context directory inside `HoneyDrunk.Architecture` — correct location for architecture-side runbook docs per ADR-0036 D9.
+- [x] No code change in any repo — the Vault Node's restore tooling already exists per ADR-0006; this packet documents the recovery procedure that uses it.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] `repos/HoneyDrunk.Vault/dr-runbook.md` exists, follows the packet-02 template, and records Vault as T0 with the correct RPO/RTO/geo/cadence
+- [ ] The runbook's backing inventory names the per-environment `kv-hd-{service}-{env}` Key Vaults and the D2 backup config (soft-delete on, purge protection on, 90-day retention)
+- [ ] The runbook has a restore procedure, a manual failover procedure, and a tenant-scoped restore path (`tenant-{tenantId}-{secretName}`)
+- [ ] `repos/HoneyDrunk.Vault/vault-bootstrap-recovery.md` exists with the full D6 bootstrap-recovery procedure and a pointer to `business/context/` for the offline copy's location
+- [ ] `integration-points.md` records the recovery-ordering line — Vault recovers first
+- [ ] No secret values appear anywhere in the runbook or the bootstrap-recovery doc (invariant 8)
+- [ ] The bootstrap-recovery doc explicitly states the offline encrypted copy is NOT stored in the repo, and that its location lives in `business/context/`
+
+## Human Prerequisites
+- [ ] None for authoring the documentation. **Note for the operator:** the offline encrypted recovery artifact and the Azure portal backup-configuration verification this runbook *describes* are provisioned by packet 04 (`Actor=Human`). This packet writes the procedure; packet 04 makes the procedure executable. Packet 04 is hard-blocked on this packet.
+
+## Referenced ADR Decisions
+**ADR-0036 D2 — Backup mechanics, Azure Key Vault.** Soft-delete and purge protection both on. Retention window 90 days. Vault contents are exportable via the Vault Node's restore tooling (per ADR-0006); cross-region replication is the Key Vault feature itself.
+
+**ADR-0036 D4 — Cross-region failover is a documented runbook, not automated failover.** T0 Nodes have read-access secondary regions and the mechanism to fail over; failover is manually triggered by the Studio operator per `repos/{name}/dr-runbook.md`. Automated failover is not adopted at solo-developer scale — spurious failover is a worse failure mode.
+
+**ADR-0036 D6 — Vault has a bootstrap-recovery procedure.** Vault recovery is the special case because every other Node's DR depends on Vault being readable. The recovery procedure (separate runbook, encrypted offline copy) must exist before any other T0 Node's first drill. The offline encrypted recovery copy is the only DR artifact that lives outside the GitHub-hosted Architecture repo; its location is recorded in `business/context/`.
+
+**ADR-0005 — per-Node Key Vault.** One Key Vault per deployable Node per environment, `kv-hd-{service}-{env}`, Azure RBAC enabled.
+
+**ADR-0006 — secret rotation and lifecycle.** The Vault Node's restore tooling and the secret lifecycle this runbook's restore procedure invokes.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** No secret value is written into the runbook or bootstrap-recovery doc. Only secret names/identifiers and procedure steps.
+
+> **Invariant 17 — One Key Vault per deployable Node per environment, `kv-hd-{service}-{env}`, Azure RBAC enabled.** The runbook's backing inventory names the vaults by this convention.
+
+> **Invariant 9a — Tenant-scoped secrets use `tenant-{tenantId}-{secretName}`.** The tenant-scoped restore path documents restoring one tenant's secrets at this path prefix without touching others.
+
+- **The offline encrypted copy never lands in the repo.** ADR-0036 D6: the repo is itself a recovery dependency. The doc points to `business/context/`; it does not embed the recovery material.
+- **This packet is the hard prerequisite for packet 04 and for every other T0 drill** — ADR-0036 D6 says the Vault bootstrap-recovery procedure must exist before any other T0 Node's first drill.
+
+## Labels
+`feature`, `tier-2`, `infrastructure`, `docs`, `adr-0036`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author the Vault T0 `dr-runbook.md` and the `vault-bootstrap-recovery.md` D6 procedure; add the recovery-ordering line to `integration-points.md`.
+
+**Target:** `HoneyDrunk.Architecture` (the `repos/HoneyDrunk.Vault/` context directory), branch from `main`. Tracked against the Vault Node.
+
+**Context:**
+- Goal: Produce the Vault DR documentation — the runbook and the special-case bootstrap-recovery procedure that gates every other T0 drill.
+- Feature: ADR-0036 Disaster Recovery rollout, Wave 2.
+- ADRs: ADR-0036 (D2/D4/D6 primary), ADR-0005 (per-Node Key Vault), ADR-0006 (Vault restore tooling, secret lifecycle).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — soft. The `dr_tier` field should exist so the runbook's tier reference is consistent with the catalog.
+- `packet:02` — hard. The template at `generated/dr-runbook.template.md` must exist; this packet fills it in.
+
+**Constraints:**
+- No secret values in any doc (invariant 8).
+- The offline encrypted recovery copy is never stored in the repo (ADR-0036 D6) — point to `business/context/`.
+- This packet is the hard prerequisite for packet 04 and gates every other T0 drill.
+
+**Key Files:**
+- `repos/HoneyDrunk.Vault/dr-runbook.md` (new)
+- `repos/HoneyDrunk.Vault/vault-bootstrap-recovery.md` (new)
+- `repos/HoneyDrunk.Vault/integration-points.md`
+
+**Contracts:** None changed — documentation only. The Vault restore tooling (ADR-0006) already exists.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/04-vault-t0-backup-config-and-offline-recovery-artifact.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/04-vault-t0-backup-config-and-offline-recovery-artifact.md
@@ -1,0 +1,122 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Vault
+labels: ["chore", "tier-2", "infrastructure", "human-only", "adr-0036", "wave-3"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0036", "ADR-0005", "ADR-0006"]
+accepts: ["ADR-0036"]
+wave: 3
+initiative: adr-0036-disaster-recovery-and-backup-policy
+node: honeydrunk-vault
+---
+
+# Apply Vault T0 backup configuration and create the offline bootstrap-recovery artifact (ADR-0036 D2/D6)
+
+## Summary
+Verify and apply the ADR-0036 D2 backup configuration on every Vault Key Vault via the Azure Portal — soft-delete on, purge protection on, geo-redundant posture — and create the D6 offline encrypted bootstrap-recovery artifact (encrypted USB or printed shares), recording its physical location and rotation procedure in `business/context/`. This is the human/portal work that makes the packet-03 Vault runbook executable.
+
+## Context
+ADR-0036 D6 requires the Vault bootstrap-recovery artifact — the encrypted offline copy — to exist **before any other T0 Node's first drill**, because no other T0 drill can succeed without Vault being recoverable. ADR-0036 D2 requires Azure Key Vault soft-delete and purge protection both on with a 90-day retention window, and cross-region replication (the Key Vault feature itself) for T0.
+
+This is **`Actor=Human`**. The work is: Azure Portal configuration of Key Vault backup flags, and the creation of a physical-world encrypted artifact (USB or printed Shamir shares). Neither is delegable to an agent — there is no code artifact. The procedure document already exists (packet 03 authored `vault-bootstrap-recovery.md`); this packet executes it for the first time and provisions the artifact the procedure depends on. The `human-only` label is set.
+
+The user prefers Azure Portal UI walkthroughs over CLI — the steps below are written as portal clicks.
+
+## Scope
+- Each environment's Vault Key Vault (`kv-hd-{service}-{env}` per ADR-0005) — backup configuration verified/applied via the Azure Portal.
+- The offline encrypted bootstrap-recovery artifact — created (encrypted USB or printed Shamir shares).
+- `business/context/` — a BDR-style record of the offline artifact's physical location and rotation procedure (in `HoneyDrunk.Architecture`, **not** in `repos/`).
+- `repos/HoneyDrunk.Vault/integration-points.md` — confirm the backup posture is recorded (the runbook line landed in packet 03; this packet confirms the live config matches).
+
+## Proposed Work (human-executed, Azure Portal)
+1. **For each Vault Key Vault** (`kv-hd-vault-dev`, `-stg`, `-prod` or whatever the live names are):
+   - Portal → Key Vault → **Properties** (or the vault's overview blade). Confirm **Soft-delete** is enabled. Soft-delete is on by default for new vaults and cannot be disabled; verify it is present.
+   - Portal → Key Vault → **Properties** → enable **Purge protection** if not already on. Purge protection is irreversible once enabled — this is intended for a T0 vault.
+   - Confirm the soft-delete **retention period** is set to **90 days** (ADR-0036 D2). The retention window is set at vault creation; if an existing vault is on a shorter window, note it — the window cannot be changed after creation, which may mean recreating the vault on the next maintenance window. Record any deviation.
+2. **Geo-redundancy / cross-region:** Azure Key Vault contents are automatically replicated within the region and to the paired region by the service — no portal toggle. **First confirm the vault's region actually has an Azure-defined paired region** — not every Azure region has one (some newer single-region geographies do not). Check Portal → the region's metadata, or the Azure "Cross-region replication / region pairs" documentation, before relying on geo-replication. If the region **has** a pair: document the paired region in the packet-03 runbook's failover section; the read-access-from-secondary expectation (D1) is satisfied by Key Vault's built-in regional failover and no additional resource is provisioned. If the region **has no pair**: record this as a deviation — geo-replication cannot be relied on, and the runbook's failover section must note that recovery falls back to the offline bootstrap-recovery artifact + soft-deleted-secret recovery. Surface the no-pair case to the operator before treating Vault's T0 geo posture as satisfied.
+3. **Diagnostic settings:** confirm each Key Vault routes diagnostic settings to the shared Log Analytics workspace (invariant 22) — Portal → Key Vault → **Diagnostic settings**. If absent, add it (this also supports the rotation-SLA monitoring from ADR-0006).
+4. **Create the offline bootstrap-recovery artifact** per the packet-03 `vault-bootstrap-recovery.md` procedure: capture the minimum material to re-bootstrap a Key Vault and re-establish RBAC/OIDC access onto an encrypted USB drive, or as printed Shamir secret shares. Encrypt it. This is the artifact ADR-0036 D6 requires to exist before any other T0 drill.
+5. **Record the artifact's location in `business/context/`** — a short BDR-style record: what the artifact is, where it physically lives, who can access it, and the rotation procedure (re-create the artifact whenever the underlying recovery material changes). Do **not** record this in `repos/` — the repo is itself a recovery dependency (ADR-0036 D6).
+6. **Confirm** `repos/HoneyDrunk.Vault/integration-points.md` and the packet-03 runbook accurately reflect the live backup posture; note any deltas.
+
+## Affected Files
+- `business/context/` — one new BDR-style record (Markdown) for the offline recovery artifact.
+- `repos/HoneyDrunk.Vault/integration-points.md` — confirmation/delta note only (the substantive content landed in packet 03).
+
+## NuGet Dependencies
+None. This packet has no .NET project — it is Azure Portal configuration plus a physical-world artifact plus one Markdown record.
+
+## Boundary Check
+- [x] The Key Vault backup configuration belongs to the Vault Node's Azure resources — Vault is the only source of secrets (invariant 9). Correct ownership.
+- [x] No code change in any repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] Every Vault Key Vault has soft-delete confirmed enabled and purge protection enabled
+- [ ] Each vault's soft-delete retention is 90 days, or any deviation is recorded with a remediation note
+- [ ] Each vault's region was checked for an Azure-defined paired region; if a pair exists it is recorded in the packet-03 runbook's failover section; if no pair exists the deviation is recorded and the offline-artifact fallback is noted in the runbook
+- [ ] Every Vault Key Vault routes diagnostic settings to the shared Log Analytics workspace (invariant 22)
+- [ ] The offline encrypted bootstrap-recovery artifact is created (encrypted USB or printed Shamir shares) per the packet-03 procedure
+- [ ] A BDR-style record in `business/context/` documents the artifact's physical location, access, and rotation procedure
+- [ ] The offline artifact and its location record are NOT committed to any `repos/` directory or any code repo
+- [ ] `repos/HoneyDrunk.Vault/integration-points.md` confirms the live backup posture matches the runbook; deltas (if any) noted
+- [ ] No secret values appear in the `business/context/` record (invariant 8) — it records location and procedure, not material
+
+## Human Prerequisites
+This entire packet is `Actor=Human`. The human-executed steps are the Proposed Work list above. Specifically:
+- [ ] Azure Portal access to every Vault Key Vault.
+- [ ] A physical medium for the offline artifact (encrypted USB drive) or a means to print Shamir shares, and a secure physical storage location for it.
+- [ ] Purge protection enablement is irreversible — confirm intent before clicking.
+
+## Referenced ADR Decisions
+**ADR-0036 D2 — Backup mechanics, Azure Key Vault.** Soft-delete and purge protection both on. Retention window 90 days. Cross-region replication is the Key Vault feature itself.
+
+**ADR-0036 D6 — Vault has a bootstrap-recovery procedure.** The recovery procedure (separate runbook, encrypted offline copy) must exist before any other T0 Node's first drill. The Vault bootstrap-recovery offline copy is the only DR artifact that lives outside the GitHub-hosted Architecture repo — its location and rotation procedure are recorded in `business/context/` per the BDR record, not in the repo, because the repo is itself a recovery dependency.
+
+**ADR-0036 Follow-up Work.** "Author Vault bootstrap-recovery procedure (D6) before any other Tier 0 drill." "Schedule the first Vault and Audit drills within 90 days of this ADR's acceptance" — packet 05 runs the Vault drill; this packet provisions the artifact those drills depend on.
+
+**ADR-0006 / Invariant 22 — Every Key Vault must have diagnostic settings routed to the shared Log Analytics workspace.**
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The `business/context/` record names the artifact's location and rotation procedure — never its contents.
+
+> **Invariant 22 — Every Key Vault must have diagnostic settings routed to the shared Log Analytics workspace.** Confirm this for every Vault Key Vault as part of the backup-posture verification.
+
+> **Invariant 9 — Vault is the only source of secrets.** The recovery material stays in Vault / the offline encrypted artifact — never on a developer laptop unencrypted, never in the repo.
+
+- **The offline artifact and its location record never enter a code repo or `repos/`** — ADR-0036 D6: the repo is itself a recovery dependency. `business/context/` (Architecture repo, but the operator's BDR area) is the recorded home for the *location pointer*; the artifact itself is physical.
+- **This packet must complete before any other T0 drill** — ADR-0036 D6. Packet 05 (Vault drill) and packet 07b (Audit drill) are downstream of this one.
+- **Purge protection is irreversible** — once enabled it cannot be turned off for the life of the vault; this is intended for T0.
+
+## Labels
+`chore`, `tier-2`, `infrastructure`, `human-only`, `adr-0036`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Apply ADR-0036 D2 backup configuration to every Vault Key Vault and create the D6 offline encrypted bootstrap-recovery artifact, recording its location in `business/context/`.
+
+**Target:** Tracked against `HoneyDrunk.Vault`; the work is human-executed (Azure Portal + a physical artifact). `Actor=Human` — `human-only` label set.
+
+**Context:**
+- Goal: Make the packet-03 Vault runbook and bootstrap-recovery procedure executable; satisfy the ADR-0036 D6 precondition that gates every other T0 drill.
+- Feature: ADR-0036 Disaster Recovery rollout, Wave 3.
+- ADRs: ADR-0036 (D2/D6 primary), ADR-0005 (per-Node Key Vault), ADR-0006 (diagnostics + rotation).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — hard. The `vault-bootstrap-recovery.md` procedure must exist; this packet executes it and provisions the artifact it depends on.
+
+**Constraints:**
+- The offline artifact and its location record never enter a code repo or `repos/`.
+- Purge protection is irreversible — confirm intent.
+- This packet gates every other T0 drill (ADR-0036 D6).
+- No secret values in the `business/context/` record (invariant 8).
+
+**Key Files:**
+- `business/context/` — one new BDR-style record (the only repo artifact).
+- `repos/HoneyDrunk.Vault/integration-points.md` — confirmation/delta note.
+
+**Contracts:** None changed — Azure Portal configuration + a physical artifact, no code.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/05-vault-first-restore-drill.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/05-vault-first-restore-drill.md
@@ -1,0 +1,113 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Vault
+labels: ["chore", "tier-2", "infrastructure", "human-only", "adr-0036", "wave-4"]
+dependencies: ["packet:04"]
+adrs: ["ADR-0036"]
+accepts: ["ADR-0036"]
+wave: 4
+initiative: adr-0036-disaster-recovery-and-backup-policy
+node: honeydrunk-vault
+---
+
+# Execute the first Vault T0 restore drill and log the outcome (ADR-0036 D3)
+
+## Summary
+Execute the first Vault restore drill following `repos/HoneyDrunk.Vault/dr-runbook.md`: restore the most recent Key Vault backup into an ephemeral environment, validate basic operations, and log the outcome to `generated/restore-drills/` per the packet-02 schema. Any procedure correction discovered during the drill is fed back into the runbook.
+
+## Context
+ADR-0036 D3: "A backup not test-restored is a backup not known to work." ADR-0036 Follow-up Work mandates "Schedule the first Vault and Audit drills within 90 days of this ADR's acceptance." The Vault drill must run first — ADR-0036 D6 says no other T0 drill can succeed until the Vault bootstrap-recovery procedure exists and is proven. Packet 04 created the offline recovery artifact; this packet runs the drill that proves the Vault runbook works end-to-end.
+
+This is **`Actor=Human`**. Executing a restore drill is operator work — provisioning an ephemeral environment, running the restore, validating, and judging the outcome. ADR-0036's Operational Consequences budget an annual T0 drill at roughly half a working day. The `human-only` label is set. The user prefers Azure Portal walkthroughs; the drill steps are in the packet-03 runbook and should be portal-oriented.
+
+## Scope
+- An ephemeral environment — provisioned for the drill, torn down after.
+- `generated/restore-drills/` — one new drill-log entry per the packet-02 schema.
+- `repos/HoneyDrunk.Vault/dr-runbook.md` — updated with any procedure deltas the drill surfaced.
+
+## Proposed Work (human-executed)
+1. Confirm packet 04 is complete — the offline bootstrap-recovery artifact exists and the backup configuration is applied.
+2. Follow `repos/HoneyDrunk.Vault/dr-runbook.md` restore procedure: provision an ephemeral environment and restore the most recent Vault Key Vault backup (recover soft-deleted secrets / restore from the geo-replicated copy) into it.
+3. Validate basic operations: confirm `ISecretStore` resolves a known secret from the restored vault; confirm a tenant-scoped secret (`tenant-{tenantId}-{secretName}`) restores correctly per the runbook's tenant-scoped restore path.
+4. Optionally exercise the `vault-bootstrap-recovery.md` procedure as a partial-restore spot-check (the semiannual T0 spot-check from D1) — at minimum confirm the offline artifact is readable and the procedure's first steps are accurate.
+5. Tear down the ephemeral environment.
+6. Log the drill outcome to `generated/restore-drills/` per the packet-02 schema: `date`, `tier: T0`, `node: honeydrunk-vault`, `outcome` (pass/fail/partial), `runbook-deltas`, `operator`.
+7. Apply any procedure corrections discovered during the drill back into `repos/HoneyDrunk.Vault/dr-runbook.md` (and `vault-bootstrap-recovery.md` if the spot-check surfaced a delta).
+
+## Affected Files
+- `generated/restore-drills/` — one new drill-log entry (Markdown).
+- `repos/HoneyDrunk.Vault/dr-runbook.md` — delta corrections, if any.
+- `repos/HoneyDrunk.Vault/vault-bootstrap-recovery.md` — delta corrections, if the spot-check surfaced any.
+
+## NuGet Dependencies
+None. This packet has no .NET project — it is an operator-executed drill plus a Markdown log entry.
+
+## Boundary Check
+- [x] The drill log lives in `generated/restore-drills/` per ADR-0036 D9; the runbook lives in `repos/HoneyDrunk.Vault/`. Correct locations.
+- [x] No code change in any repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] The Vault restore drill was executed against an ephemeral environment following the packet-03 runbook
+- [ ] Basic operations were validated — `ISecretStore` resolved a known secret; a tenant-scoped secret restored correctly
+- [ ] A drill-log entry exists in `generated/restore-drills/` with all schema fields (`date`, `tier: T0`, `node: honeydrunk-vault`, `outcome`, `runbook-deltas`, `operator`)
+- [ ] Any procedure delta discovered during the drill is applied back into the Vault runbook (and bootstrap-recovery doc if relevant)
+- [ ] The ephemeral environment was torn down — no orphaned drill resources left running (cost discipline)
+- [ ] If the drill outcome is `fail` or `partial`, a remediation note is recorded — a missed/failed drill is an incident per ADR-0036 D3 and freezes tier-affecting tenant onboarding until resolved
+
+## Human Prerequisites
+This entire packet is `Actor=Human`. The human-executed steps are the Proposed Work list above. Specifically:
+- [ ] Azure Portal access to provision and tear down an ephemeral environment for the drill.
+- [ ] Packet 04 confirmed complete (the offline recovery artifact exists; backup config applied).
+- [ ] Roughly half a working day budgeted (ADR-0036 Operational Consequences).
+
+## Referenced ADR Decisions
+**ADR-0036 D3 — Restore drills are the proof.** Restore the most recent backup into an ephemeral environment and validate basic operations. Results logged to `generated/restore-drills/` with date, tier, Node, outcome, runbook deltas. A missed drill is an incident — Tier-promotion freeze on the affected Node.
+
+**ADR-0036 D1 — Tier 0 drill cadence.** Annual restore drill, semiannual partial-restore spot-check.
+
+**ADR-0036 D6.** No other T0 drill can succeed until the Vault bootstrap-recovery procedure exists and is proven — the Vault drill goes first.
+
+**ADR-0036 Follow-up Work.** "Schedule the first Vault and Audit drills within 90 days of this ADR's acceptance." "Add `generated/restore-drills/` and an initial drill log for Vault" — this packet produces that initial Vault log entry.
+
+**ADR-0036 Operational Consequences.** Annual T0 drill ≈ half a working day per Node; explicitly budgeted.
+
+## Constraints
+> **Invariant 61 (added by packet 00) — a missed restore drill freezes tier-affecting tenant onboarding for the affected Node.** A `fail`/`partial` outcome without remediation is treated as a missed drill — record the remediation note and the freeze status.
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The drill-log entry records outcome and procedure deltas — never any secret value resolved during validation.
+
+- **Tear down the ephemeral environment** — leaving drill infrastructure running is unbudgeted cost; ADR-0036 D8's cost discipline applies.
+- **The Vault drill goes first** — ADR-0036 D6. Packet 07b's Audit drill depends on this drill having proven the Vault recovery path.
+
+## Labels
+`chore`, `tier-2`, `infrastructure`, `human-only`, `adr-0036`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Execute the first Vault T0 restore drill per the packet-03 runbook and log the outcome to `generated/restore-drills/`.
+
+**Target:** Tracked against `HoneyDrunk.Vault`; the work is human-executed (operator runs the drill). `Actor=Human` — `human-only` label set.
+
+**Context:**
+- Goal: Prove the Vault restore runbook works end-to-end; produce the initial Vault drill log; satisfy the 90-day first-drill mandate.
+- Feature: ADR-0036 Disaster Recovery rollout, Wave 4.
+- ADRs: ADR-0036 (D3/D1/D6, Follow-up Work).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:04` — hard. The offline recovery artifact must exist and the backup config must be applied before a meaningful drill can run.
+
+**Constraints:**
+- Tear down the ephemeral environment after the drill (cost discipline).
+- The Vault drill goes first — it gates packet 07b's Audit drill.
+- A `fail`/`partial` outcome is an incident — record remediation and the onboarding-freeze status.
+
+**Key Files:**
+- `generated/restore-drills/` — one new drill-log entry.
+- `repos/HoneyDrunk.Vault/dr-runbook.md` — delta corrections, if any.
+
+**Contracts:** None changed — operator drill + a Markdown log entry.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/06-audit-dr-runbook.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/06-audit-dr-runbook.md
@@ -1,0 +1,118 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "infrastructure", "docs", "adr-0036", "wave-2"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0036", "ADR-0030", "ADR-0031"]
+accepts: ["ADR-0036"]
+wave: 2
+initiative: adr-0036-disaster-recovery-and-backup-policy
+node: honeydrunk-audit
+---
+
+# Author the Audit T0 dr-runbook with the Data tier-inheritance and recovery-ordering rules (ADR-0036 D1/D2)
+
+## Summary
+Author `repos/HoneyDrunk.Audit/dr-runbook.md` from the packet-02 template — Audit as a T0 Node — and record the Data-Node tier-inheritance rule (`Audit.Data → T0`) and the cross-Node recovery ordering (Audit recovers after Data, Data after Vault) in `repos/HoneyDrunk.Audit/integration-points.md`.
+
+## Context
+ADR-0036 D1 places Audit at T0: "regulatory/forensic value scales with completeness." ADR-0036 Consequences is explicit that Audit "gains restore drill at standup" and that "the 'ADR-0030 Phase 2 hash-chain/WORM' deferral is decoupled from this ADR; durability comes from this ADR even before tamper-evidence lands." Audit's durability story — undefined in ADR-0030 Phase 1, which scoped only "append-only-by-interface" — is the secondary forcing function for ADR-0036.
+
+Audit's backing is `HoneyDrunk.Audit.Data` (ADR-0031), which `HoneyDrunk.Audit`'s overview states is **Data-backed** — it persists "over `HoneyDrunk.Data`'s `IRepository`/`IUnitOfWork`" and is published at v0.1.0. `HoneyDrunk.Data` provides EF Core and SQL Server implementations (`HoneyDrunk.Data.EntityFramework`, `HoneyDrunk.Data.SqlServer`). The concrete durable backing for `Audit.Data` is therefore **Azure SQL** — there is no Cosmos branch to resolve. ADR-0036's Data tier-inheritance rule means `Audit.Data` inherits Audit's T0 tier, so the Audit SQL backing runs T0 Azure SQL backup mechanics (D2). Recovery has cross-Node ordering: Audit must come up after Data, Data after Vault (ADR-0036 D9 names exactly this example).
+
+This packet authors the **documentation**. It is tracked against the Audit Node but the files live in `repos/HoneyDrunk.Audit/` inside `HoneyDrunk.Architecture`, so the target repo is `HoneyDrunk.Architecture`. No code, no .NET project. The Azure portal backup configuration the runbook describes is applied by packet 07a.
+
+## Scope
+- `repos/HoneyDrunk.Audit/dr-runbook.md` (new) — the Audit T0 runbook, from the packet-02 template.
+- `repos/HoneyDrunk.Audit/integration-points.md` — add the Data tier-inheritance line and the cross-Node recovery-ordering line.
+
+## Proposed Implementation
+1. **Author `dr-runbook.md`** from the packet-02 template at `generated/dr-runbook.template.md`, filled for Audit:
+   - Tier: T0. RPO ≤ 5 min, RTO ≤ 1 hr, geo-redundant storage with read-access secondary region, annual restore drill + semiannual partial-restore spot-check.
+   - Tier rationale: a security/forensic audit log's regulatory value scales with completeness; an audit log with undefined durability carries an unjustified trust premium (ADR-0036 Context).
+   - Backing inventory: the `HoneyDrunk.Audit.Data` backing store. `Audit.Data` is Data-backed over `HoneyDrunk.Data`'s `IRepository`/`IUnitOfWork`; `HoneyDrunk.Data` ships EF Core + SQL Server providers, so the live durable backing is **Azure SQL**. Record the T0 Azure SQL D2 mechanics: geo-redundant backup storage on; Long-Term Retention T0 = weekly for 1 year; point-in-time-restore window 35 days. There is no Cosmos branch — Audit.Data is SQL-backed.
+   - Restore procedure: restore the most recent Audit.Data Azure SQL backup into an ephemeral environment; validate `IAuditQuery` returns known entries and that `IAuditLog` append still works on the restored store.
+   - Failover procedure: manual cross-region failover steps for the T0 backing (D4).
+   - Tenant-scoped restore: if Audit holds per-tenant audit records, document the tenant-scoped restore path (D5); if Audit is internal-only at this stage, state "not currently multi-tenant — revisit when tenant-scoped audit records materialize."
+   - Cross-Node ordering: Audit recovers **after Data, after Vault** — point to `integration-points.md`.
+   - Drill cadence + last-drill record: annual + semiannual spot-check; a line linking to `generated/restore-drills/`.
+2. **Update `integration-points.md`:**
+   - The Data tier-inheritance rule: `HoneyDrunk.Audit.Data` inherits Audit's T0 tier — the Audit backing runs T0 backup mechanics.
+   - The recovery-ordering line: Audit recovers after Data, Data after Vault. An Audit restore drill cannot succeed until Vault and Data are recoverable.
+
+## Affected Files
+- `repos/HoneyDrunk.Audit/dr-runbook.md` (new)
+- `repos/HoneyDrunk.Audit/integration-points.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown docs; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `repos/HoneyDrunk.Audit/` is the Audit Node's context directory inside `HoneyDrunk.Architecture` — correct location for architecture-side runbook docs per ADR-0036 D9.
+- [x] No code change in any repo.
+- [x] No new cross-Node runtime dependency — Audit→Data and Audit→Kernel edges already exist per ADR-0031.
+
+## Acceptance Criteria
+- [ ] `repos/HoneyDrunk.Audit/dr-runbook.md` exists, follows the packet-02 template, and records Audit as T0 with the correct RPO/RTO/geo/cadence
+- [ ] The runbook's backing inventory names `HoneyDrunk.Audit.Data`, states it is Azure SQL-backed (via `HoneyDrunk.Data`'s SQL Server provider), and records the T0 Azure SQL D2 mechanics (geo-redundant backup storage, weekly LTR for 1 year, 35-day PITR) — single-branch, no Cosmos fork
+- [ ] The runbook has a restore procedure validating `IAuditQuery` and `IAuditLog` against the restored store, and a manual failover procedure
+- [ ] The runbook addresses tenant-scoped restore — either the D5 path, or an explicit "not currently multi-tenant" note
+- [ ] `integration-points.md` records the `Audit.Data → T0` tier-inheritance rule and the `Vault → Data → Audit` recovery ordering
+- [ ] The runbook notes that durability comes from ADR-0036 independent of the deferred ADR-0030 Phase 2 hash-chain/WORM work — and does NOT claim tamper-evidence (ADR-0030 Phase 1 is append-only-by-interface only, invariant 47)
+
+## Human Prerequisites
+- [ ] None for authoring the documentation. **Note for the operator:** the Azure portal backup configuration this runbook describes is packet 07a, and the first Audit restore drill is packet 07b — both `Actor=Human`. This packet writes the procedure; 07a applies the config and 07b runs the drill.
+
+## Referenced ADR Decisions
+**ADR-0036 D1 — Tier 0.** RPO ≤ 5 min, RTO ≤ 1 hr, geo-redundant with read-access secondary, annual drill + semiannual partial-restore spot-check. Audit is a member: "regulatory/forensic value scales with completeness."
+
+**ADR-0036 D2 — Backup mechanics, Azure SQL.** Geo-redundant backup storage on; T0 LTR weekly for 1 year; PITR window 35 days. (Audit.Data is Azure SQL-backed; the Cosmos backup profile in ADR-0036 D2 does not apply to Audit.)
+
+**ADR-0036 Consequences — Affected Nodes.** Audit is T0; gains restore drill at standup. The "ADR-0030 Phase 2 hash-chain/WORM" deferral is decoupled from this ADR; durability comes from this ADR even before tamper-evidence lands. Data has no own tier; `Audit.Data` inherits Audit's T0.
+
+**ADR-0036 D9.** A line in `integration-points.md` if recovery has cross-Node ordering — "e.g., Audit must come up after Data, Data after Vault."
+
+**ADR-0030 / Invariant 47 — Phase-1 audit integrity is append-only-by-interface; it is explicitly not tamper-evident, and Phase 1 must not be documented or marketed as such.** The runbook documents durability, not tamper-evidence.
+
+**ADR-0031 — Audit standup.** `HoneyDrunk.Audit.Data` is the Data-backed implementation, persisting over `HoneyDrunk.Data`'s `IRepository`/`IUnitOfWork`. `HoneyDrunk.Data` ships EF Core + SQL Server providers — the durable backing is Azure SQL.
+
+## Constraints
+> **Invariant 47 — Phase-1 audit integrity is append-only-by-interface; it is explicitly not tamper-evident, and Phase 1 must not be documented or marketed as such.** The runbook describes durability and restore — it must not describe or imply tamper-evidence / WORM, which is deferred ADR-0030 Phase 2 work.
+
+> **Invariant 60 (added by packet 00) — every Node holding state has a `dr_tier` assignment in `catalogs/grid-health.json`.** Audit's `dr_tier` is T0 (set in packet 01); the runbook's tier must match the catalog.
+
+- **Audit recovery ordering is Vault → Data → Audit** — an Audit drill cannot succeed until Vault and Data are recoverable. The runbook and `integration-points.md` must state this.
+- **The backing is Azure SQL** — `Audit.Data` persists over `HoneyDrunk.Data`'s SQL Server provider. Record the Azure SQL D2 mechanics only; do not write a Cosmos branch or a "flag for operator" hedge.
+
+## Labels
+`feature`, `tier-2`, `infrastructure`, `docs`, `adr-0036`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author the Audit T0 `dr-runbook.md` and record the `Audit.Data → T0` tier-inheritance and the `Vault → Data → Audit` recovery ordering in `integration-points.md`.
+
+**Target:** `HoneyDrunk.Architecture` (the `repos/HoneyDrunk.Audit/` context directory), branch from `main`. Tracked against the Audit Node.
+
+**Context:**
+- Goal: Produce the Audit DR documentation; pin the Data tier-inheritance and the cross-Node recovery ordering.
+- Feature: ADR-0036 Disaster Recovery rollout, Wave 2.
+- ADRs: ADR-0036 (D1/D2/D9 primary), ADR-0030 (Audit substrate, Phase-1 integrity scope), ADR-0031 (Audit standup, the Data backing).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — soft. The `dr_tier` field should exist so the runbook's tier is consistent with the catalog.
+- `packet:02` — hard. The template at `generated/dr-runbook.template.md` must exist; this packet fills it in.
+
+**Constraints:**
+- Do not claim tamper-evidence — durability only (invariant 47).
+- Audit recovery ordering is Vault → Data → Audit.
+- The backing is Azure SQL (via `HoneyDrunk.Data`'s SQL Server provider) — single-branch runbook, no Cosmos fork, no operator hedge.
+
+**Key Files:**
+- `repos/HoneyDrunk.Audit/dr-runbook.md` (new)
+- `repos/HoneyDrunk.Audit/integration-points.md`
+
+**Contracts:** None changed — documentation only.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/07a-audit-data-t0-backup-config.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/07a-audit-data-t0-backup-config.md
@@ -1,0 +1,98 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Audit
+labels: ["chore", "tier-2", "infrastructure", "human-only", "adr-0036", "wave-3"]
+dependencies: ["packet:06"]
+adrs: ["ADR-0036", "ADR-0031"]
+accepts: ["ADR-0036"]
+wave: 3
+initiative: adr-0036-disaster-recovery-and-backup-policy
+node: honeydrunk-audit
+---
+
+# Apply Audit.Data T0 Azure SQL backup configuration (ADR-0036 D2)
+
+## Summary
+Apply the ADR-0036 D2 T0 Azure SQL backup configuration to the `HoneyDrunk.Audit.Data` backing via the Azure Portal — geo-redundant backup storage, weekly Long-Term Retention for 1 year, 35-day point-in-time-restore window. This is the human/portal work that puts Audit's T0 backup posture in place. It has no ordering dependency on the Vault drill — only the Audit runbook (packet 06) must exist so the configuration matches the documented procedure. The first Audit restore drill is the separate packet 07b.
+
+## Context
+ADR-0036 D2 sets the T0 backup mechanics for the Audit.Data backing. `HoneyDrunk.Audit.Data` is Data-backed — it persists over `HoneyDrunk.Data`'s `IRepository`/`IUnitOfWork`, and `HoneyDrunk.Data` ships EF Core + SQL Server providers — so the durable backing is **Azure SQL**. There is no Cosmos branch.
+
+Applying the backup configuration is pure portal work against the Audit SQL backing; it does not require the Vault recovery path to be proven first. Only the *drill* (packet 07b) is hard-sequenced after the Vault drill per the Vault → Data → Audit recovery ordering. This packet is therefore Wave 3, blocked only on packet 06 (the Audit runbook must exist so the live config can be checked against it).
+
+This is **`Actor=Human`**: Azure Portal configuration of database backup flags. Not delegable — there is no code artifact. The `human-only` label is set. The user prefers Azure Portal walkthroughs — the steps below are portal clicks.
+
+## Scope
+- The `HoneyDrunk.Audit.Data` Azure SQL backing resource — T0 backup configuration applied via the Azure Portal.
+- `repos/HoneyDrunk.Audit/dr-runbook.md` — confirmation/delta note only if the live config surfaces a correction to the packet-06 runbook's backing-inventory section.
+
+## Proposed Work (human-executed, Azure Portal)
+1. **Apply T0 Azure SQL backup configuration to the Audit.Data backing.**
+   - Portal → SQL database (the Audit.Data backing) → **Backups** / **Compute + storage** → set backup storage redundancy to **Geo-redundant**.
+   - Portal → **Backups** → **Retention policies** → set Long-Term Retention to **weekly for 1 year** (T0).
+   - Confirm the point-in-time-restore window is **35 days** (T0).
+2. **Confirm diagnostic settings** route to the shared Log Analytics workspace if applicable (Portal → SQL database → **Diagnostic settings**).
+3. **Confirm** the live configuration matches the packet-06 `repos/HoneyDrunk.Audit/dr-runbook.md` backing-inventory section; note any delta.
+
+## Affected Files
+- `repos/HoneyDrunk.Audit/dr-runbook.md` — confirmation/delta note only, if the live config surfaces a correction.
+
+## NuGet Dependencies
+None. This packet has no .NET project — it is Azure Portal configuration plus, at most, a one-line confirmation note in an existing Markdown file.
+
+## Boundary Check
+- [x] The Audit.Data backing's backup configuration belongs to the Audit Node's Azure resources. Correct ownership.
+- [x] No code change in any repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] The Audit.Data Azure SQL backing has geo-redundant backup storage enabled
+- [ ] Long-Term Retention is set to weekly for 1 year (T0); the point-in-time-restore window is confirmed at 35 days
+- [ ] Diagnostic settings route to the shared Log Analytics workspace, if applicable
+- [ ] The live configuration is confirmed to match the packet-06 Audit runbook's backing-inventory section; any delta is noted in `repos/HoneyDrunk.Audit/dr-runbook.md`
+
+## Human Prerequisites
+This entire packet is `Actor=Human`. The human-executed steps are the Proposed Work list above. Specifically:
+- [ ] Azure Portal access to the `HoneyDrunk.Audit.Data` Azure SQL backing resource.
+
+## Referenced ADR Decisions
+**ADR-0036 D2 — Backup mechanics, Azure SQL.** Geo-redundant backup storage on; T0 LTR weekly for 1 year; PITR window 35 days. (Audit.Data is Azure SQL-backed; the Cosmos profile does not apply.)
+
+**ADR-0031 — Audit standup.** `HoneyDrunk.Audit.Data` is the Data-backed implementation, persisting over `HoneyDrunk.Data`'s `IRepository`/`IUnitOfWork` — Azure SQL via the SQL Server provider.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** Any confirmation note records configuration state — never any secret or sensitive audit-record content.
+
+- **The backing is Azure SQL** — apply the Azure SQL D2 mechanics only; there is no Cosmos branch.
+- **No ordering dependency on the Vault drill** — this is the backup-configuration step; the drill (07b) carries the Vault → Data → Audit sequencing.
+
+## Labels
+`chore`, `tier-2`, `infrastructure`, `human-only`, `adr-0036`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Apply ADR-0036 D2 T0 Azure SQL backup configuration to the `HoneyDrunk.Audit.Data` backing via the Azure Portal.
+
+**Target:** Tracked against `HoneyDrunk.Audit`; the work is human-executed (Azure Portal). `Actor=Human` — `human-only` label set.
+
+**Context:**
+- Goal: Put Audit's T0 backup posture in place — geo-redundant storage, weekly LTR, 35-day PITR.
+- Feature: ADR-0036 Disaster Recovery rollout, Wave 3.
+- ADRs: ADR-0036 (D2), ADR-0031 (Audit.Data backing — Azure SQL).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:06` — hard. The Audit runbook must exist so the live config can be checked against its backing-inventory section. No dependency on the Vault drill — this is the config step, not the drill.
+
+**Constraints:**
+- The backing is Azure SQL — apply the Azure SQL D2 mechanics only.
+- No ordering dependency on the Vault drill.
+- No secret values in any confirmation note (invariant 8).
+
+**Key Files:**
+- `repos/HoneyDrunk.Audit/dr-runbook.md` — confirmation/delta note only.
+
+**Contracts:** None changed — Azure Portal configuration, no code.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/07b-audit-first-restore-drill.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/07b-audit-first-restore-drill.md
@@ -1,0 +1,116 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Audit
+labels: ["chore", "tier-2", "infrastructure", "human-only", "adr-0036", "wave-4"]
+dependencies: ["packet:05", "packet:07a"]
+adrs: ["ADR-0036", "ADR-0031"]
+accepts: ["ADR-0036"]
+wave: 4
+initiative: adr-0036-disaster-recovery-and-backup-policy
+node: honeydrunk-audit
+---
+
+# Execute the first Audit T0 restore drill and log the outcome (ADR-0036 D3)
+
+## Summary
+Execute the first Audit restore drill following `repos/HoneyDrunk.Audit/dr-runbook.md`: restore the most recent `HoneyDrunk.Audit.Data` Azure SQL backup into an ephemeral environment, validate basic operations, tear the environment down, and log the outcome to `generated/restore-drills/` per the packet-02 schema. Any drill-surfaced procedure correction is fed back into the runbook.
+
+## Context
+ADR-0036 Consequences: Audit "gains restore drill at standup." ADR-0036 Follow-up Work mandates the first Vault and Audit drills within 90 days of acceptance. The Audit drill depends on the Vault drill (packet 05) having proven the Vault recovery path — ADR-0036 D6 and the recovery ordering (Vault → Data → Audit) mean Audit cannot be meaningfully restored until Vault is known-recoverable. It also depends on packet 07a having applied the T0 Azure SQL backup configuration — a drill against an unconfigured backing is not a meaningful proof.
+
+This is **`Actor=Human`**: an operator-executed restore drill. Not delegable — provisioning an ephemeral environment, running the restore, validating, and judging the outcome are operator work. The `human-only` label is set. The user prefers Azure Portal walkthroughs; the drill steps are in the packet-06 runbook and should be portal-oriented.
+
+## Scope
+- An ephemeral environment — provisioned for the drill, torn down after.
+- `generated/restore-drills/` — one new Audit drill-log entry per the packet-02 schema.
+- `repos/HoneyDrunk.Audit/dr-runbook.md` — updated with any drill-surfaced procedure deltas.
+
+## Proposed Work (human-executed)
+1. Confirm packet 05 (Vault first drill) is complete with a `pass` outcome — the Vault recovery path must be proven before the Audit drill, per the Vault → Data → Audit ordering.
+2. Confirm packet 07a is complete — the Audit.Data T0 Azure SQL backup configuration is applied.
+3. Follow `repos/HoneyDrunk.Audit/dr-runbook.md` restore procedure: provision an ephemeral environment and restore the most recent `HoneyDrunk.Audit.Data` Azure SQL backup into it.
+4. Validate basic operations: confirm `IAuditQuery` returns known entries and `IAuditLog` append still works on the restored store. Confirm the recovery ordering held (Vault and Data recoverable first).
+5. Tear down the ephemeral environment.
+6. Log the drill outcome to `generated/restore-drills/` per the packet-02 schema: `date`, `tier: T0`, `node: honeydrunk-audit`, `outcome` (pass/fail/partial), `runbook-deltas`, `operator`.
+7. Apply any procedure deltas back into `repos/HoneyDrunk.Audit/dr-runbook.md`.
+
+## Affected Files
+- `generated/restore-drills/` — one new Audit drill-log entry (Markdown).
+- `repos/HoneyDrunk.Audit/dr-runbook.md` — delta corrections, if any.
+
+## NuGet Dependencies
+None. This packet has no .NET project — it is an operator-executed drill plus a Markdown log entry.
+
+## Boundary Check
+- [x] The drill log lives in `generated/restore-drills/` per ADR-0036 D9; the runbook lives in `repos/HoneyDrunk.Audit/`. Correct locations.
+- [x] No code change in any repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] The first Audit restore drill was executed against an ephemeral environment following the packet-06 runbook
+- [ ] Validation confirmed `IAuditQuery` returns known entries and `IAuditLog` append works on the restored store
+- [ ] A drill-log entry exists in `generated/restore-drills/` with all schema fields (`date`, `tier: T0`, `node: honeydrunk-audit`, `outcome`, `runbook-deltas`, `operator`)
+- [ ] Any drill-surfaced procedure delta is applied back into the Audit runbook
+- [ ] The ephemeral environment was torn down — no orphaned drill resources (cost discipline)
+- [ ] If the drill outcome is `fail`/`partial`, a remediation note is recorded and the tier-affecting onboarding freeze is noted (ADR-0036 D3)
+
+## Human Prerequisites
+This entire packet is `Actor=Human`. The human-executed steps are the Proposed Work list above. Specifically:
+- [ ] Azure Portal access to provision and tear down an ephemeral environment for the drill.
+- [ ] Packet 05 (Vault first drill) confirmed complete with a `pass` outcome — the Vault recovery path must be proven before the Audit drill.
+- [ ] Packet 07a confirmed complete — the Audit.Data T0 Azure SQL backup configuration is applied.
+- [ ] Roughly half a working day budgeted (ADR-0036 Operational Consequences, annual T0 drill).
+
+## Referenced ADR Decisions
+**ADR-0036 D3 — Restore drills are the proof.** Restore the most recent backup into an ephemeral environment, validate, log to `generated/restore-drills/` with date, tier, Node, outcome, runbook deltas. A missed/failed drill is an incident — Tier-promotion freeze on the affected Node.
+
+**ADR-0036 D1 — Tier 0 drill cadence.** Annual restore drill, semiannual partial-restore spot-check.
+
+**ADR-0036 D6 / recovery ordering.** No other T0 drill can succeed until the Vault recovery path is proven; Audit recovers after Data, after Vault.
+
+**ADR-0036 Follow-up Work.** "Schedule the first Vault and Audit drills within 90 days of this ADR's acceptance." This packet produces the initial Audit drill log entry.
+
+**ADR-0036 Operational Consequences.** Annual T0 drill ≈ half a working day per Node; explicitly budgeted.
+
+**ADR-0031 — Audit standup.** `HoneyDrunk.Audit.Data` is the Azure SQL-backed implementation; the drill restores its Azure SQL backup.
+
+## Constraints
+> **Invariant 61 (added by packet 00) — a missed restore drill freezes tier-affecting tenant onboarding for the affected Node.** A `fail`/`partial` Audit drill without remediation is treated as a missed drill — record the remediation note and the freeze status.
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The drill-log entry records outcome and procedure deltas — never any secret or sensitive audit-record content.
+
+- **Tear down the ephemeral environment** — leaving drill infrastructure running is unbudgeted cost; ADR-0036 D8's cost discipline applies.
+- **The Audit drill runs after the Vault drill** — ADR-0036 recovery ordering (Vault → Data → Audit). Packet 05 must be complete first.
+
+## Labels
+`chore`, `tier-2`, `infrastructure`, `human-only`, `adr-0036`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Execute the first Audit T0 restore drill per the packet-06 runbook and log the outcome to `generated/restore-drills/`.
+
+**Target:** Tracked against `HoneyDrunk.Audit`; the work is human-executed (operator runs the drill). `Actor=Human` — `human-only` label set.
+
+**Context:**
+- Goal: Prove the Audit restore runbook works end-to-end; produce the initial Audit drill log; satisfy the 90-day first-drill mandate.
+- Feature: ADR-0036 Disaster Recovery rollout, Wave 4.
+- ADRs: ADR-0036 (D3/D1/D6, Follow-up Work), ADR-0031 (Audit.Data backing — Azure SQL).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:05` — hard. The Vault first drill must be complete with a `pass` outcome — the Vault recovery path must be proven before the Audit drill (Vault → Data → Audit ordering).
+- `packet:07a` — hard. The Audit.Data T0 Azure SQL backup configuration must be applied before a meaningful drill can run.
+
+**Constraints:**
+- Tear down the ephemeral environment after the drill (cost discipline).
+- The Audit drill runs after the Vault drill.
+- A `fail`/`partial` outcome is an incident — record remediation and the onboarding-freeze status.
+
+**Key Files:**
+- `generated/restore-drills/` — one new Audit drill-log entry.
+- `repos/HoneyDrunk.Audit/dr-runbook.md` — delta corrections, if any.
+
+**Contracts:** None changed — operator drill + a Markdown log entry.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/08-notify-dr-runbook-t1.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/08-notify-dr-runbook-t1.md
@@ -1,0 +1,123 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0036", "wave-2"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0036", "ADR-0028"]
+accepts: ["ADR-0036"]
+wave: 2
+initiative: adr-0036-disaster-recovery-and-backup-policy
+node: honeydrunk-notify
+---
+
+# Author the Notify T1 dr-runbook for delivery state and Service Bus DR posture (ADR-0036 D1/D2)
+
+## Summary
+Author `repos/HoneyDrunk.Notify/dr-runbook.md` from the packet-02 template — Notify as a T1 Node — covering delivery state (in-flight messages, retry queues), the Service Bus DR posture per ADR-0036 D2, and the semiannual T1 restore-drill cadence.
+
+## Context
+ADR-0036 D1 places **Notify delivery state** (in-flight messages, retry queues) at T1: RPO ≤ 1 hr, RTO ≤ 8 hr, geo-redundant storage with a passive secondary region, semiannual restore drill. ADR-0036's Affected Nodes section: "HoneyDrunk.Notify and HoneyDrunk.Notify.Cloud — T1 and T0 respectively; gain runbooks and drill cadence as a Notify Cloud GA prerequisite."
+
+`HoneyDrunk.Notify.Cloud` is the T0 commercial Node (ADR-0027) and is **not yet scaffolded** — its T0 runbook, tenant identity/billing backup, and tenant-scoped restore (ADR-0036 D5) are deferred to the Notify Cloud standup and out of this initiative's scope (see the dispatch plan's out-of-scope section). **This packet covers `HoneyDrunk.Notify` itself** — the live Ops Node at v0.3.0 — at T1.
+
+ADR-0036 D2 specifies the Service Bus DR posture: T0/T1 namespaces use the standard geo-disaster-recovery alias pairing (cross-region passive pairing); in-flight messages are **not** guaranteed to survive a forced failover, so consumers must be idempotent (ADR-0042) and message-replay-tolerant.
+
+This packet authors **documentation**. It is tracked against the Notify Node but the file lives in `repos/HoneyDrunk.Notify/` inside `HoneyDrunk.Architecture`, so the target repo is `HoneyDrunk.Architecture`. No code, no .NET project.
+
+## Scope
+- `repos/HoneyDrunk.Notify/dr-runbook.md` (new) — the Notify T1 runbook, from the packet-02 template.
+- `repos/HoneyDrunk.Notify/integration-points.md` — add the Service Bus DR-posture line and the idempotency dependency (ADR-0042).
+
+## Proposed Implementation
+1. **Author `dr-runbook.md`** from the packet-02 template at `generated/dr-runbook.template.md`, filled for Notify:
+   - Tier: T1. RPO ≤ 1 hr, RTO ≤ 8 hr, geo-redundant storage with a **passive** secondary region (no read traffic), semiannual restore drill.
+   - Tier rationale: Notify delivery state is customer-impacting (in-flight messages, retry queues) but not regulated/T0 — ADR-0036 D1.
+   - Backing inventory:
+     - **Notify's durable delivery state.** Identify the live backing — likely a Storage Queue / Service Bus for in-flight + retry queues, and any durable delivery-state store. Record the D2 mechanics:
+       - **Service Bus (T1 namespace):** DR via the standard geo-disaster-recovery **alias pairing** — cross-region passive pairing. In-flight messages are NOT guaranteed across a forced failover.
+       - **Storage Queue / Storage Blob (if used):** GRS for T1; soft-delete on, 30-day retention; versioning on.
+   - Restore procedure: restore the most recent backing-state backup into an ephemeral environment; validate that pending/retry delivery state is recoverable and that `INotificationSender` operates against the restored state.
+   - Failover procedure: for the Service Bus namespace, the geo-DR alias failover steps — note this is a manual operator action (ADR-0036 D4) and that in-flight messages may be lost on a forced failover.
+   - Tenant-scoped restore: Notify itself is not the multi-tenant commercial surface (that is Notify Cloud); state "Notify is internal/Grid-facing — tenant-scoped restore is a Notify Cloud T0 concern, deferred to the Notify Cloud standup."
+   - Cross-Node ordering: note any ordering (Notify depends on Kernel; Service Bus is the ADR-0028 default broker).
+   - Drill cadence + last-drill record: semiannual T1 drill; a line linking to `generated/restore-drills/`.
+2. **Update `integration-points.md`:**
+   - The Service Bus DR posture: T1 namespace uses geo-DR alias pairing; in-flight messages are not failover-durable.
+   - The idempotency dependency: ADR-0036 D2 + Operational Consequences make the Service Bus message-loss posture "load-bearing" on the ADR-0042 idempotency contract — Notify's consumers must be idempotent and message-replay-tolerant.
+
+## Affected Files
+- `repos/HoneyDrunk.Notify/dr-runbook.md` (new)
+- `repos/HoneyDrunk.Notify/integration-points.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown docs; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `repos/HoneyDrunk.Notify/` is the Notify Node's context directory inside `HoneyDrunk.Architecture` — correct location for architecture-side runbook docs per ADR-0036 D9.
+- [x] No code change in any repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] `repos/HoneyDrunk.Notify/dr-runbook.md` exists, follows the packet-02 template, and records Notify as T1 with the correct RPO/RTO/geo/cadence (RPO ≤ 1 hr, RTO ≤ 8 hr, passive secondary, semiannual drill)
+- [ ] The runbook's backing inventory records the Service Bus geo-DR alias-pairing posture and notes in-flight messages are not failover-durable
+- [ ] The runbook has a restore procedure validating `INotificationSender` against restored delivery state, and a manual failover procedure
+- [ ] The runbook explicitly states tenant-scoped restore is a Notify Cloud T0 concern, deferred to the Notify Cloud standup — NOT in scope for the Notify T1 runbook
+- [ ] `integration-points.md` records the Service Bus DR posture and the ADR-0042 idempotency dependency
+- [ ] The runbook scopes itself to `HoneyDrunk.Notify` only and does not author Notify Cloud DR content
+
+## Human Prerequisites
+- [ ] None for authoring the documentation.
+- [ ] The executing agent must confirm Notify's live durable backing (Service Bus namespace and/or Storage Queue) from `repos/HoneyDrunk.Notify/` docs or `catalogs/`; if undeterminable, document the likely shape and flag for the operator to confirm.
+
+## Referenced ADR Decisions
+**ADR-0036 D1 — Tier 1.** RPO ≤ 1 hr, RTO ≤ 8 hr, geo-redundant storage with a passive secondary (no read traffic), semiannual restore drill. Notify delivery state (in-flight messages, retry queues) is a member.
+
+**ADR-0036 D2 — Backup mechanics, Azure Service Bus.** DR via the standard geo-disaster-recovery alias pairing for T0/T1 namespaces (cross-region passive pairing). In-flight messages are not guaranteed to survive a forced failover; consumers must be idempotent (ADR-0042) and message-replay-tolerant. Storage Blob/Queue: GRS for T1; soft-delete on, 30-day retention; versioning on.
+
+**ADR-0036 D4 — Manual failover.** Failover is manually triggered by the operator per the runbook.
+
+**ADR-0036 Affected Nodes.** "HoneyDrunk.Notify and HoneyDrunk.Notify.Cloud — T1 and T0 respectively; gain runbooks and drill cadence as a Notify Cloud GA prerequisite."
+
+**ADR-0036 Operational Consequences.** "T2 message loss on Service Bus forced failover is accepted policy and depends on the idempotency contract (ADR-0042). The two ADRs are mutually load-bearing." (The same dependency applies to T1 in-flight messages per D2.)
+
+**ADR-0028 — Event-Driven Architecture.** Service Bus is the Grid's default broker, one shared namespace per environment.
+
+## Constraints
+> **Invariant 60 (added by packet 00) — every Node holding state has a `dr_tier` assignment in `catalogs/grid-health.json`.** Notify's `dr_tier` is T1 (set in packet 01); the runbook's tier must match the catalog.
+
+- **Notify ≠ Notify Cloud.** This runbook is for `HoneyDrunk.Notify` (T1, the live Ops Node). Notify Cloud's T0 runbook, tenant identity/billing backup, and tenant-scoped restore are out of scope — deferred to the Notify Cloud standup. Do not author Notify Cloud DR content here.
+- **In-flight Service Bus messages are not failover-durable** — the runbook must state this plainly; recovery relies on consumer idempotency (ADR-0042), not on message preservation.
+- **Confirm the live backing** — do not guess the Service Bus / Storage Queue topology; if undeterminable, document the likely shape and flag.
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0036`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author the Notify T1 `dr-runbook.md` covering delivery state and the Service Bus geo-DR posture; record the Service Bus DR posture and the ADR-0042 idempotency dependency in `integration-points.md`.
+
+**Target:** `HoneyDrunk.Architecture` (the `repos/HoneyDrunk.Notify/` context directory), branch from `main`. Tracked against the Notify Node.
+
+**Context:**
+- Goal: Produce the Notify T1 DR documentation; pin the Service Bus failover posture and its idempotency dependency.
+- Feature: ADR-0036 Disaster Recovery rollout, Wave 2.
+- ADRs: ADR-0036 (D1/D2/D4 primary), ADR-0028 (Service Bus default broker), ADR-0042 (idempotency — load-bearing for the failover message-loss posture).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — soft. The `dr_tier` field should exist so the runbook's tier is consistent with the catalog.
+- `packet:02` — hard. The template at `generated/dr-runbook.template.md` must exist; this packet fills it in.
+
+**Constraints:**
+- This runbook is for `HoneyDrunk.Notify` only — Notify Cloud DR is deferred to the Notify Cloud standup.
+- In-flight Service Bus messages are not failover-durable — state plainly.
+- Confirm the live backing; flag if undeterminable.
+
+**Key Files:**
+- `repos/HoneyDrunk.Notify/dr-runbook.md` (new)
+- `repos/HoneyDrunk.Notify/integration-points.md`
+
+**Contracts:** None changed — documentation only.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/09-architecture-hive-sync-dr-drift-detection.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/09-architecture-hive-sync-dr-drift-detection.md
@@ -1,0 +1,116 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "docs", "adr-0036", "wave-3"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0036", "ADR-0014"]
+accepts: ["ADR-0036"]
+wave: 3
+initiative: adr-0036-disaster-recovery-and-backup-policy
+node: honeydrunk-architecture
+---
+
+# Extend hive-sync to reconcile dr_tier assignments and overdue restore drills (ADR-0036 D1/D3/D9)
+
+## Summary
+Extend the `hive-sync` agent's drift-reconciliation mandate to cover two ADR-0036 concerns: (1) a stateful Node missing a `dr_tier` in `catalogs/grid-health.json` is drift; (2) a Node whose most recent restore-drill log in `generated/restore-drills/` is overdue per its tier cadence is drift — and triggers the tier-affecting tenant-onboarding freeze.
+
+## Context
+ADR-0036 D1: "`hive-sync` (ADR-0014) treats a Node holding state without a `dr_tier` as drift." ADR-0036 D9: "`generated/restore-drills/` is the rolling log of drill outcomes; `hive-sync` includes it in drift reconciliation." ADR-0036 D3: "A missed drill is an incident: it triggers a Tier-promotion freeze on the affected Node." Packet 00 added the two DR invariants; packet 01 created the `dr_tier` field; packet 02 created `generated/restore-drills/` and its log schema. This packet wires the `hive-sync` agent so those artifacts are actually reconciled rather than passively present.
+
+`hive-sync` is an agent defined by `.claude/agents/hive-sync.md` in `HoneyDrunk.Architecture`; per ADR-0014 it runs through OpenClaw scheduled/manual execution. This packet updates the agent's instructions — its drift-detection contract — not a .NET project.
+
+## Scope
+- `.claude/agents/hive-sync.md` — extend the drift-reconciliation section with the two ADR-0036 checks.
+- `initiatives/board-items.md` — note that `dr_tier`-missing and overdue-drill findings are surfaced as board items (per ADR-0014 D3 / invariant 38, non-initiative drift findings land here).
+
+## Proposed Implementation
+1. **Extend `hive-sync.md`'s drift-detection contract** with two checks:
+   - **`dr_tier` completeness check.** For every Node in `catalogs/grid-health.json` that holds durable state (the operative test: it has a non-null backing, or it appears in any ADR-0036 D1 tier-membership list), confirm a non-null `dr_tier`. A stateful Node with `dr_tier: null` or no field is drift — surface it. Stateless Nodes with explicit `dr_tier: null` are not drift (that is the documented stateless marker from packet 01).
+   - **Restore-drill currency check.** For every T0/T1/T2 Node, find the most recent entry for it in `generated/restore-drills/` and compute whether the drill is overdue against the tier cadence:
+     - T0: annual drill (overdue if last drill > 12 months ago); semiannual partial spot-check.
+     - T1: semiannual drill (overdue if > 6 months).
+     - T2: annual drill (overdue if > 12 months).
+     A Node with no drill log at all is overdue by definition once the 90-day first-drill grace window has elapsed since ADR-0036's acceptance. **The grace-window anchor is not a hardcoded date** — `hive-sync` must read ADR-0036's accepted-date from the ADR header (`adrs/ADR-0036-disaster-recovery-and-backup-policy.md`, the `**Status:**`/accepted-date line) at runtime and compute `accepted-date + 90 days` as the grace boundary. Do not bake a literal date into `hive-sync.md`. An overdue drill is drift AND triggers the tenant-onboarding-freeze flag — `hive-sync` surfaces the affected Node and the freeze status.
+2. **Define how findings surface.** Per ADR-0014 D3 and invariant 38, drift findings that are not packet-originated are mirrored onto The Hive and tracked in `initiatives/board-items.md`. A `dr_tier`-missing finding and an overdue-drill finding each become a board item. Document this in `hive-sync.md` and add the note to `board-items.md`.
+3. **Keep it advisory.** Like the other `hive-sync` checks, this is detection + surfacing — `hive-sync` does not itself enforce the freeze (that is an operator decision per ADR-0036 D3). It reports; the human acts.
+
+## Affected Files
+- `.claude/agents/hive-sync.md`
+- `initiatives/board-items.md`
+
+## NuGet Dependencies
+None. This packet edits an agent definition and a Markdown tracking file; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `.claude/agents/hive-sync.md` and `initiatives/board-items.md` live in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/hive-sync.md`'s drift-reconciliation section includes a `dr_tier` completeness check — a stateful Node missing a non-null `dr_tier` is drift; stateless Nodes with explicit `dr_tier: null` are not drift
+- [ ] `hive-sync.md` includes a restore-drill currency check with the per-tier overdue windows (T0 annual, T1 semiannual, T2 annual) and the no-log-at-all rule against the 90-day first-drill grace window
+- [ ] The grace-window anchor is computed at runtime from ADR-0036's accepted-date read out of the ADR header — `hive-sync.md` does not hardcode a literal date
+- [ ] `hive-sync.md` states an overdue drill triggers the tenant-onboarding-freeze flag and surfaces the affected Node + freeze status
+- [ ] `hive-sync.md` states the checks are advisory — `hive-sync` detects and surfaces; it does not enforce the freeze
+- [ ] `initiatives/board-items.md` documents that `dr_tier`-missing and overdue-drill findings are surfaced as board items per ADR-0014 D3 / invariant 38
+- [ ] No change to the `hive-sync` packet-move contract (invariant 37) — this packet adds drift checks, it does not change which directories `hive-sync` moves packets between
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0036 D1.** "`hive-sync` (ADR-0014) treats a Node holding state without a `dr_tier` as drift."
+
+**ADR-0036 D3 — Restore drills are the proof.** A missed drill is an incident; it triggers a Tier-promotion freeze on the affected Node — no new tenants onboarded against a Node whose last drill is overdue. Drill cadences: T0 annual + semiannual spot-check, T1 semiannual, T2 annual.
+
+**ADR-0036 D9.** "`generated/restore-drills/` is the rolling log of drill outcomes; `hive-sync` includes it in drift reconciliation."
+
+**ADR-0036 Follow-up Work.** "Schedule the first Vault and Audit drills within 90 days of this ADR's acceptance" — the 90-day grace window for the no-log-at-all rule. The anchor is ADR-0036's accepted-date, read from the ADR header at runtime, not a hardcoded value.
+
+**ADR-0014 — Hive–Architecture Reconciliation Agent.** `hive-sync` (renamed from `initiatives-sync`) has a broad drift-reconciliation mandate and runs through OpenClaw scheduled/manual execution. D3 / invariant 38: non-initiative drift findings are tracked in `initiatives/board-items.md`.
+
+## Constraints
+> **Invariant 60 (added by packet 00) — every Node holding state has a `dr_tier` assignment in `catalogs/grid-health.json`.** This packet wires the `hive-sync` check that enforces detection of violations of that invariant.
+
+> **Invariant 61 (added by packet 00) — a missed restore drill freezes tier-affecting tenant onboarding for the affected Node.** This packet wires the `hive-sync` check that detects an overdue drill and surfaces the freeze.
+
+> **Invariant 38 — the Architecture repo tracks all Hive board items.** Every non-initiative drift finding is represented in `initiatives/board-items.md`.
+
+> **Invariant 37 — `hive-sync` packet-move contract.** `hive-sync` moves closed packets from `active/` to `completed/`. This packet does NOT alter that contract — it only adds drift-detection checks.
+
+- **Advisory, not enforcing.** `hive-sync` detects and surfaces; the operator decides on the freeze (ADR-0036 D3). Do not make `hive-sync` mutate onboarding state.
+- **Stateless `dr_tier: null` is not drift** — only stateful Nodes missing a tier are drift. The packet-01 `_meta` documentation defines the stateless marker.
+
+## Labels
+`feature`, `tier-2`, `meta`, `docs`, `adr-0036`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Extend the `hive-sync` agent to reconcile `dr_tier` completeness and restore-drill currency, surfacing both as board-item drift findings.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the two packet-00 DR invariants actively reconciled rather than passively documented.
+- Feature: ADR-0036 Disaster Recovery rollout, Wave 3.
+- ADRs: ADR-0036 (D1/D3/D9, Follow-up Work), ADR-0014 (`hive-sync` mandate, board-items tracking).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — hard. The `dr_tier` field must exist in `grid-health.json` for the completeness check to read.
+- `packet:02` — hard. `generated/restore-drills/` and its log schema must exist for the currency check to read.
+
+**Constraints:**
+- Advisory only — detect and surface; do not enforce the freeze.
+- Stateless `dr_tier: null` is not drift.
+- Do not alter the invariant-37 packet-move contract.
+
+**Key Files:**
+- `.claude/agents/hive-sync.md`
+- `initiatives/board-items.md`
+
+**Contracts:** No runtime contract change — an agent-definition update.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/dispatch-plan.md
@@ -1,0 +1,152 @@
+# Dispatch Plan: Disaster Recovery and Backup Policy (ADR-0036)
+
+**Date:** 2026-05-22 (initial scope — drafted ahead of ADR-0036 acceptance).
+**Trigger:** ADR-0036 (Disaster Recovery and Backup Policy) — Proposed 2026-05-21, part of the 2026-05-21 batch of cross-cutting Grid-gap ADRs. Scoped now so the packet set is ready when the ADR lands. The forcing function per ADR-0036's Context is PDR-0002 / ADR-0027 Notify Cloud GA ("what's your RPO?" is the first paying-tenant onboarding question) and ADR-0030 Audit (a security audit log with undefined durability carries an unjustified trust premium).
+**Type:** Multi-repo. Most work lands in `HoneyDrunk.Architecture` (the ADR flip, catalog field, runbook template, per-Node runbook docs, `hive-sync` extension) — the per-Node runbook docs live in the `repos/{name}/` context directories which are in the Architecture repo. The four `Actor=Human` Azure-portal/drill packets (04, 05, 07a, 07b) are tracked against `HoneyDrunk.Vault` and `HoneyDrunk.Audit`.
+**Sector:** Infrastructure / cross-cutting.
+**Site sync required:** No. DR policy, tier assignments, runbooks, and drill logs are operational artifacts, not public-facing content on the Studios marketing site. Re-evaluate only if a future "trust / security" page on the Studios site states an RPO commitment publicly — that would be a separate site-sync packet, and ADR-0036's tier table would be its source.
+
+**Rollback plan:**
+- Architecture-side packets (00, 01, 02, 09) revert cleanly via `git revert` — the ADR flip, the two invariants, the `dr_tier` catalog field, the runbook template, the `restore-drills/` directory, and the `hive-sync` extension are all docs/text/catalog edits with no runtime consumer. Reverting `dr_tier` from `grid-health.json` is safe; `hive-sync` is the only reader and packet 09 adds that reader — revert both together if rolling back.
+- The per-Node runbook packets (03, 06, 08) are pure documentation — `dr-runbook.md` files and `integration-points.md` edits. Reverting deletes the docs; no runtime impact.
+- The three `Actor=Human` config/artifact packets (04, 07a) and the drill packets (05, 07b): "reverting" the Azure portal backup configuration is not advisable (soft-delete / purge protection / geo-redundancy / geo-redundant SQL storage are strictly safer states and purge protection is irreversible by design). The offline recovery artifact (packet 04) — "reverting" means destroying the artifact, which is never wanted. Treat 04 and 07a as forward-only operational work; if they are not yet done, the steady state is simply "DR config not yet applied," which is the pre-ADR baseline.
+- Packet 05 (Vault drill) and packet 07b (Audit drill) leave only a drill-log entry in `generated/restore-drills/` — reverting deletes the log entry. The ephemeral environments are torn down by the packets themselves.
+
+## Summary
+
+ADR-0036 sets the Grid-wide DR and backup policy: three durability tiers (T0/T1/T2) with explicit RPO/RTO targets, geo posture, and restore-drill cadence (D1); concrete Azure backup mechanics per backing-slot type (D2); restore drills as the proof a backup works (D3); manual cross-region failover via documented runbooks — no automated failover at solo-developer scale (D4); tenant-scoped restore for multi-tenant Nodes (D5); a Vault bootstrap-recovery procedure that must exist before any other T0 drill (D6); backup-retention-vs-data-subject-deletion handling (D7); a cost ceiling that makes tier promotion an ADR amendment (D8); and the documentation surface — per-Node `dr-runbook.md`, the `dr_tier` field in `catalogs/grid-health.json`, and `generated/restore-drills/` (D9).
+
+This initiative ships **11 packets** (`00`–`06`, `07a`, `07b`, `08`, `09`) across **four waves**:
+
+- **Wave 1** — governance + foundational artifacts: ADR acceptance + the two DR invariants (00), the `dr_tier` catalog field + backfill (01), the `generated/dr-runbook.template.md` template + `generated/restore-drills/` directory (02).
+- **Wave 2** — the per-Node runbook documentation: Vault T0 runbook + bootstrap-recovery procedure (03), Audit T0 runbook (06), Notify T1 runbook (08). All three are documentation packets and run in parallel after Wave 1.
+- **Wave 3** — the Vault T0 Azure backup configuration + the offline bootstrap-recovery artifact (04, `Actor=Human`), the Audit.Data T0 Azure SQL backup configuration (07a, `Actor=Human`), and the `hive-sync` DR drift-detection extension (09). 04, 07a, and 09 are independent of each other and run in parallel; 07a depends only on the Audit runbook (06), not on any drill.
+- **Wave 4** — the restore drills: the first Vault drill (05) and the first Audit drill (07b). Both `Actor=Human`. The Audit drill is hard-sequenced after the Vault drill per the Vault → Data → Audit recovery ordering.
+
+## Important constraints (from ADR-0036 itself)
+
+- **Vault recovery is the special case and goes first.** ADR-0036 D6: every other Node's DR depends on Vault being readable; the Vault bootstrap-recovery procedure (procedure doc = packet 03; offline artifact = packet 04) must exist before any other T0 drill. The drill order is fixed: Vault drill (05) before Audit drill (07b).
+- **Tier promotion is an ADR amendment, not a config change.** ADR-0036 D8. Packet 01 records the tier assignments; moving a Node up a tier later is a new ADR, not a `grid-health.json` edit.
+- **Manual failover only.** ADR-0036 D4: no automated cross-region failover at this stage — spurious failover under solo-developer operations is a worse failure mode than degraded availability. Every runbook documents a manually-triggered failover.
+- **In-flight messages are not failover-durable.** ADR-0036 D2: Service Bus geo-DR forced failover does not preserve in-flight messages; the recovery posture relies on consumer idempotency (ADR-0042). ADR-0036 and ADR-0042 are mutually load-bearing.
+- **The offline recovery artifact never enters the repo.** ADR-0036 D6: the GitHub-hosted Architecture repo is itself a recovery dependency. The artifact is physical (encrypted USB / printed shares); its location is recorded in `business/context/`, not in `repos/`.
+- **Stateless Nodes are not tiered.** ADR-0036 D1: Kernel, Transport, Web.Rest, Communications, Actions, Architecture, Standards, Studios have DR posture "redeploy from source" via ADR-0033 — `dr_tier: null`, explicitly, so the absence is unambiguous.
+- **Data inherits its consumer's tier.** ADR-0036 Consequences: `HoneyDrunk.Data` has no own tier; `Audit.Data → T0, Memory.Data → T1, Pulse.Data → T2`. `HoneyDrunk.Audit.Data` is Data-backed over `HoneyDrunk.Data`'s `IRepository`/`IUnitOfWork`; `HoneyDrunk.Data` ships EF Core + SQL Server providers — so the Audit backing is concretely **Azure SQL**. The Audit runbook (06) and the Audit backup-config packet (07a) are single-branch Azure SQL, with no Cosmos fork.
+- **Audit durability ≠ tamper-evidence.** ADR-0036 gives Audit T0 durability; the ADR-0030 Phase 2 hash-chain/WORM tamper-evidence work is decoupled and still deferred. Per invariant 47, Phase 1 must not be documented or marketed as tamper-evident — the Audit runbook (packet 06) describes durability only.
+
+## Wave Diagram
+
+### Wave 1 — Governance + foundational artifacts
+
+Run packet 00 first (ADR acceptance + the two invariants). Packets 01 and 02 may run in parallel with each other after 00 — 01 is a catalog field, 02 is the runbook template + directory; neither depends on the other.
+
+- [ ] `HoneyDrunk.Architecture`: **Accept ADR-0036** — flip status, add the two DR invariants, register the initiative — [`00-architecture-adr-0036-acceptance.md`](00-architecture-adr-0036-acceptance.md)
+  - Blocked by: nothing.
+- [ ] `HoneyDrunk.Architecture`: Add the `dr_tier` field to `grid-health.json` and backfill every stateful Node — [`01-architecture-dr-tier-catalog-field-and-backfill.md`](01-architecture-dr-tier-catalog-field-and-backfill.md)
+  - Blocked by: Wave 1 — `00` (soft — references the packet-00 `dr_tier` invariant as a live rule).
+- [ ] `HoneyDrunk.Architecture`: Create the `generated/dr-runbook.template.md` template and the `generated/restore-drills/` directory — [`02-architecture-dr-runbook-template-and-restore-drills-directory.md`](02-architecture-dr-runbook-template-and-restore-drills-directory.md)
+  - Blocked by: Wave 1 — `00` (soft — references ADR-0036 D3/D9 as live rules).
+
+**Wave 1 exit criteria:**
+- ADR-0036 reads `**Status:** Accepted`; the two DR invariants (numbered 60 and 61) are in `constitution/invariants.md`; the initiative is registered.
+- `catalogs/grid-health.json` carries a new `dr_tier` field on every Node (a genuine schema addition — `_meta.schema_version` bumped); stateful Nodes have T0/T1/T2; stateless Nodes have explicit `null`; Data has `null` + the tier-inheritance note.
+- `generated/dr-runbook.template.md` exists with its eight sections; `generated/restore-drills/` exists with its README and drill-log schema.
+
+### Wave 2 — Per-Node runbook documentation (parallel)
+
+Packets 03, 06, 08 are independent documentation packets. They all consume the packet-02 template and the packet-01 `dr_tier` field. They may run fully in parallel.
+
+- [ ] `HoneyDrunk.Vault` (docs in `HoneyDrunk.Architecture`): Author the Vault T0 `dr-runbook.md` + the `vault-bootstrap-recovery.md` procedure — [`03-vault-dr-runbook-and-bootstrap-recovery-doc.md`](03-vault-dr-runbook-and-bootstrap-recovery-doc.md)
+  - Blocked by: Wave 1 — `01` (soft), `02` (hard — fills in the template).
+- [ ] `HoneyDrunk.Audit` (docs in `HoneyDrunk.Architecture`): Author the Audit T0 `dr-runbook.md` with the Data tier-inheritance and recovery-ordering rules — [`06-audit-dr-runbook.md`](06-audit-dr-runbook.md)
+  - Blocked by: Wave 1 — `01` (soft), `02` (hard — fills in the template).
+- [ ] `HoneyDrunk.Notify` (docs in `HoneyDrunk.Architecture`): Author the Notify T1 `dr-runbook.md` for delivery state + Service Bus DR posture — [`08-notify-dr-runbook-t1.md`](08-notify-dr-runbook-t1.md)
+  - Blocked by: Wave 1 — `01` (soft), `02` (hard — fills in the template).
+
+**Wave 2 exit criteria:**
+- `repos/HoneyDrunk.Vault/dr-runbook.md` and `vault-bootstrap-recovery.md` exist; the Vault recovery-ordering line is in `integration-points.md`.
+- `repos/HoneyDrunk.Audit/dr-runbook.md` exists; the `Audit.Data → T0` tier-inheritance and `Vault → Data → Audit` recovery ordering are in `integration-points.md`.
+- `repos/HoneyDrunk.Notify/dr-runbook.md` exists; the Service Bus DR posture + ADR-0042 idempotency dependency are in `integration-points.md`.
+
+### Wave 3 — Vault Azure backup config + Audit.Data backup config + the hive-sync extension (parallel)
+
+Packets 04, 07a, and 09 are independent of each other and may run in parallel. Packets 04 and 07a are `Actor=Human`; packet 09 is `Actor=Agent`.
+
+- [ ] `HoneyDrunk.Vault`: Apply Vault T0 Azure backup configuration + create the offline bootstrap-recovery artifact — [`04-vault-t0-backup-config-and-offline-recovery-artifact.md`](04-vault-t0-backup-config-and-offline-recovery-artifact.md)
+  - Blocked by: Wave 2 — `03` (hard — the bootstrap-recovery procedure doc must exist for packet 04 to execute it).
+  - **`Actor=Human` — `human-only` label set.** Azure Portal configuration of Key Vault backup flags and the creation of a physical encrypted offline artifact cannot be delegated.
+- [ ] `HoneyDrunk.Audit`: Apply Audit.Data T0 Azure SQL backup configuration — [`07a-audit-data-t0-backup-config.md`](07a-audit-data-t0-backup-config.md)
+  - Blocked by: Wave 2 — `06` (hard — the Audit runbook must exist so the live config can be checked against it). No dependency on the Vault drill — this is the config step, not the drill.
+  - **`Actor=Human` — `human-only` label set.** Azure Portal configuration of Azure SQL backup flags cannot be delegated.
+- [ ] `HoneyDrunk.Architecture`: Extend `hive-sync` to reconcile `dr_tier` assignments and overdue restore drills — [`09-architecture-hive-sync-dr-drift-detection.md`](09-architecture-hive-sync-dr-drift-detection.md)
+  - Blocked by: Wave 1 — `01` (hard — the `dr_tier` field must exist to reconcile), `02` (hard — `restore-drills/` must exist to reconcile).
+
+**Wave 3 exit criteria:**
+- Every Vault Key Vault has soft-delete + purge protection on, 90-day retention, diagnostics to Log Analytics; the offline encrypted bootstrap-recovery artifact exists with its location recorded in `business/context/`.
+- The Audit.Data Azure SQL backing has T0 backup configuration applied — geo-redundant storage, weekly LTR for 1 year, 35-day PITR.
+- `hive-sync` reconciles `dr_tier` completeness and restore-drill currency, surfacing both as board-item drift findings.
+
+### Wave 4 — Restore drills
+
+Packet 05 (Vault drill) goes first. Packet 07b (first Audit drill) is hard-sequenced after 05 per the Vault → Data → Audit recovery ordering.
+
+- [ ] `HoneyDrunk.Vault`: Execute the first Vault T0 restore drill and log the outcome — [`05-vault-first-restore-drill.md`](05-vault-first-restore-drill.md)
+  - Blocked by: Wave 3 — `04` (hard — the offline artifact and backup config must be in place for a meaningful drill).
+  - **`Actor=Human` — `human-only` label set.**
+- [ ] `HoneyDrunk.Audit`: Execute the first Audit T0 restore drill and log the outcome — [`07b-audit-first-restore-drill.md`](07b-audit-first-restore-drill.md)
+  - Blocked by: Wave 4 — `05` (hard — the Vault drill must prove the Vault recovery path first, per Vault → Data → Audit ordering); Wave 3 — `07a` (hard — the Audit.Data T0 backup config must be applied before a meaningful drill).
+  - **`Actor=Human` — `human-only` label set.**
+
+**Wave 4 exit criteria:**
+- The first Vault drill is executed; a T0 Vault entry exists in `generated/restore-drills/`.
+- The first Audit drill is executed; a T0 Audit entry exists in `generated/restore-drills/`.
+- Both drills were within ADR-0036's 90-day-from-acceptance first-drill mandate, or the slip is recorded.
+
+## Out-of-scope / deferred items
+
+- **HoneyDrunk.Notify.Cloud T0 DR.** ADR-0036's Affected Nodes names Notify Cloud as T0 (tenant identity & billing data) with tenant-scoped restore (D5) a hard requirement. But `HoneyDrunk.Notify.Cloud` is not yet scaffolded — ADR-0027 (its standup ADR) is itself Proposed and its repo does not exist. Notify Cloud's T0 runbook, tenant identity/billing backup configuration, and the D5 tenant-scoped restore path are deferred to the **Notify Cloud standup initiative**. ADR-0036's own text frames Notify Cloud DR as "a Notify Cloud GA prerequisite" — it belongs to that bring-up, not here. Packet 08 covers `HoneyDrunk.Notify` (T1) only and says so explicitly. Recorded here so the gap is not silently assumed closed. **The Notify Cloud standup initiative must inherit a hard checklist item: a T0 `dr-runbook.md` and the ADR-0036 D5 tenant-scoped restore path are GA-blocking deliverables for Notify Cloud — this deferral is tracked, not waived.**
+- **Memory / Knowledge / Flow / Evals runbooks.** ADR-0036 D1 names provisional tiers (Memory T1, Knowledge T1, Flow T2, Evals T2) and packet 01 records them provisionally. But these Nodes are Seed (not scaffolded). Their `dr-runbook.md` and drill cadence are authored at each Node's standup, recorded in the standup ADR amendment per ADR-0036 Consequences. Not packets here.
+- **Vault.Rotation / Observe / AI-sector Seed Node DR.** Seed Nodes that hold no state yet have `dr_tier: null` (packet 01) with a "assigned at standup" note. DR scoping happens at each standup. Not here.
+- **The DPA template / data-subject-deletion mechanics (ADR-0036 D7).** D7 says GDPR data-subject deletion must be honored across active stores and backups, and that "the Studio's DPA template (not yet authored; deferred to a future ADR) must state retention windows explicitly." Authoring the DPA template and the deletion-across-backups mechanics is explicitly deferred by ADR-0036 itself to a future ADR. Not a packet here. The runbooks (03/06/08) record the retention windows D2 sets, which is the input that future DPA work consumes.
+- **Pulse T2 runbook.** ADR-0036 Consequences: "HoneyDrunk.Pulse — T2; existing posture mostly matches." Pulse's T2 posture is low-criticality (RPO ≤ 24 hr, LRS, annual drill) and ADR-0036 explicitly notes its current posture already mostly satisfies it. A Pulse T2 runbook is worth authoring but is **deliberately not in this initiative's critical path** — it can be a follow-up tactical packet (node-audit) once the T0/T1 runbooks and drills, which are the actual forcing functions, are done. Flagged so it is not forgotten: Pulse should get a T2 `dr-runbook.md` as a low-priority follow-up.
+- **Cross-region standby capacity provisioning.** ADR-0036 D4 explicitly does not adopt automated cross-region failover or standing standby compute at this stage. No packet provisions a standby region. Reconsidered when the Grid has more than one paying tenant whose contract requires it (D4).
+
+## After filing — board fields and blocking relationships
+
+The `file-packets` pipeline sets Status, Wave, Node, Tier, Actor, Initiative, and ADR fields from frontmatter and wires `addBlockedBy` automatically from each packet's `dependencies:` array. For reference, the blocking graph:
+
+- `01` blocked-by `00` (soft)
+- `02` blocked-by `00` (soft)
+- `03` blocked-by `01` (soft), `02` (hard)
+- `06` blocked-by `01` (soft), `02` (hard)
+- `08` blocked-by `01` (soft), `02` (hard)
+- `04` blocked-by `03` (hard)
+- `07a` blocked-by `06` (hard)
+- `09` blocked-by `01` (hard), `02` (hard)
+- `05` blocked-by `04` (hard)
+- `07b` blocked-by `05` (hard), `07a` (hard)
+
+**Actor:** packets 00, 01, 02, 03, 06, 08, 09 are `Actor=Agent` (ADR flip, catalog field, templates, per-Node runbook docs, agent-definition extension — all delegable). **Packets 04, 05, 07a, 07b are `Actor=Human`** — they carry the `human-only` label because Azure Portal backup configuration, the creation of a physical offline encrypted artifact, and operator-executed restore drills are the *entire* work item, not a side prerequisite.
+
+Verify a wave landed by checking The Hive for the new items + their blocked-by chains, not by inspecting the workflow log.
+
+## Notes
+
+- **Acceptance precedes flip.** ADR-0036 stays Proposed until packet 00's PR merges.
+- **The two new invariants land in packet 00**, not in a separate `constitution/invariants.md` packet — (1) every stateful Node has a `dr_tier` (invariant 60); (2) a missed restore drill freezes tier-affecting tenant onboarding (invariant 61). The verified current highest invariant in `constitution/invariants.md` is 51; numbers 60–61 are pre-reserved for ADR-0036 as part of a 12-ADR batch. If any invariant above 51 lands from outside this batch before merge, shift this block upward — never reuse a number.
+- **The 90-day first-drill clock starts at acceptance.** ADR-0036 Follow-up Work mandates the first Vault and Audit drills within 90 days of acceptance. Packets 05 and 07b are the drills; they should be filed and executed inside that window. The `hive-sync` extension (packet 09) treats a Node with no drill log past the 90-day grace window as drift — and computes the grace boundary from ADR-0036's accepted-date read out of the ADR header at runtime, not from a hardcoded date.
+- **No new repo, no new ADR, no new runtime contract.** This initiative ships an ADR flip + two invariants, one new catalog schema field, one runbook template + a new directory, three per-Node runbook docs, one `hive-sync` extension, and four human Azure-portal/drill packets. `catalogs/contracts.json` is untouched — `dr_tier` is catalog metadata, not a runtime contract.
+- **No Azure resources are provisioned by an agent.** All Azure portal work (Key Vault backup flags, Audit.Data Azure SQL backup policy, ephemeral drill environments) is `Actor=Human` (packets 04, 05, 07a, 07b). The portal steps are written as UI walkthroughs per the developer's preference, not CLI.
+- **Cost.** ADR-0036 D8 / Operational Consequences: T0 geo-redundant storage is ~2–3× T2 LRS; Vault, Audit, and (future) Notify Cloud T0 stores carry this premium. Restore drills cost ~3–5 operator-days/year at full Grid maturity. The dollar cost is the recorded price of "answering RPO defensibly when a tenant asks." No new compute is stood up — there is no standing standby region (D4).
+- **The dispatch plan is the one exception to packet immutability** (ADR-0008 D7). It is updated at wave boundaries as a historical record; packet bodies are immutable post-filing (invariant 24).
+
+## Archival
+
+Per ADR-0008 D10, when every **filed and in-scope** packet in this initiative reaches `Done` on the org Project board and the wave exit criteria are met, the entire `active/adr-0036-disaster-recovery-and-backup-policy/` folder moves to `archive/adr-0036-disaster-recovery-and-backup-policy/` in a single commit. Partial archival is forbidden.
+
+The `Actor=Human` packets (04, 05, 07a, 07b) are in-scope and NOT exempt from the archival gate — they have a concrete completion path (ADR-0036's 90-day first-drill mandate). The initiative's archival waits for them to be `Done`.
+
+## Revision history
+
+- **2026-05-22 initial scope** — 10 packets across four waves. Drafted ahead of ADR-0036 acceptance; packets are pending-acceptance drafts, not yet filed as GitHub Issues. Notify Cloud T0 DR, the Memory/Knowledge/Flow/Evals runbooks, the DPA template (ADR-0036 D7), and the Pulse T2 runbook are recorded as out-of-scope / deferred follow-ups.
+- **2026-05-22 refinement** — pre-filing corrections from a refinement review. Invariants pinned to numbers 60–61 (verified current max 51; pre-reserved in a 12-ADR batch). `dr_tier` clarified as a genuine new catalog schema field. The runbook template path pinned to `generated/dr-runbook.template.md` (no `templates/` directory exists). Old packet 07 split into **07a** (Audit.Data Azure SQL backup config — Wave 3, blocked only on 06) and **07b** (first Audit restore drill — Wave 4, blocked on 05 + 07a). The Audit runbook (06) and 07a rewritten as single-branch Azure SQL — `Audit.Data` is Data-backed over `HoneyDrunk.Data`'s SQL Server provider; the dual-branch "SQL or Cosmos" fork and the operator-flag hedge removed. The `hive-sync` 90-day grace anchor changed to read ADR-0036's accepted-date at runtime. Packet 04 strengthened to confirm the vault's region has an Azure-defined paired region before relying on geo-replication. Initiative now ships **11 packets** across four waves.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/handoff-wave2-node-runbooks.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/handoff-wave2-node-runbooks.md
@@ -1,0 +1,45 @@
+# Handoff: Wave 1 → Wave 2 (foundational artifacts → per-Node runbook documentation)
+
+**Read once at the Wave 1 → Wave 2 transition.** This is an ephemeral baton pass, not a live tracker. Immutable per invariant 24.
+
+## What Wave 1 delivered (upstream artifacts Wave 2 builds on)
+
+- **ADR-0036 is Accepted** (packet 00). Its two new DR invariants are live in `constitution/invariants.md`, numbered **60** and **61**: (60) every Node holding state has a `dr_tier` assignment in `catalogs/grid-health.json` — missing assignment is drift; (61) a missed restore drill freezes tier-affecting tenant onboarding for the affected Node. ADR-0036's D1–D9 are now binding rules.
+- **`catalogs/grid-health.json` carries a `dr_tier` field on every Node** (packet 01). Vault and Audit = `T0`; Notify = `T1`; Pulse = `T2`. Memory/Knowledge = `T1`, Flow/Evals = `T2` (provisional, confirmed at standup). Stateless Nodes (Kernel, Transport, Web.Rest, Communications, Actions, Architecture, Standards, Studios) = explicit `null`. `honeydrunk-data` = `null` + a tier-inheritance note: `Audit.Data → T0, Memory.Data → T1, Pulse.Data → T2`.
+- **`generated/dr-runbook.template.md` exists** (packet 02) — the shared runbook skeleton with eight sections: Node+Tier, tier rationale, backing inventory, restore procedure, failover procedure, tenant-scoped restore, cross-Node recovery ordering, drill cadence + last-drill record. Its per-tier RPO/RTO/cadence values are quoted from ADR-0036 D1. (The repo has no `templates/` directory; the shared template lives in `generated/`.)
+- **`generated/restore-drills/` exists** (packet 02) — the rolling drill-outcome log directory, with a README and a drill-log entry schema: `date`, `tier`, `node`, `outcome` (pass/fail/partial), `runbook-deltas`, `operator`.
+
+## Artifacts Wave 2 consumes
+
+- **The packet-02 template at `generated/dr-runbook.template.md`** — packets 03, 06, 08 each copy it and fill in the bracketed slots for their Node. Do not invent a new structure; the template is the contract.
+- **The packet-01 `dr_tier` values** — each runbook's tier must match the catalog. Vault = T0, Audit = T0, Notify = T1.
+- **The ADR-0036 D1 tier definitions** — the template carries the RPO/RTO/geo/cadence per tier; confirm the runbook inherits them correctly.
+- **The ADR-0036 D2 backup-mechanics table** — per-backing-slot Azure configuration; each runbook's backing-inventory section records the D2 config for its Node's actual backing resource type.
+
+## Wave 2 objectives
+
+Three independent per-Node runbook documentation packets, fully parallel:
+
+1. **Vault T0 runbook + bootstrap-recovery procedure** (packet 03) — `repos/HoneyDrunk.Vault/dr-runbook.md` (T0) plus `vault-bootstrap-recovery.md`, the D6 special-case recovery procedure. Vault recovery is the special case: every other Node's DR depends on Vault being readable, so the bootstrap-recovery procedure must exist before any other T0 drill. The offline encrypted recovery *artifact* is provisioned later by packet 04 (`Actor=Human`); packet 03 writes the *procedure*. The recovery-ordering line (Vault recovers first) goes in `integration-points.md`.
+2. **Audit T0 runbook** (packet 06) — `repos/HoneyDrunk.Audit/dr-runbook.md` (T0). Records the `Audit.Data → T0` tier-inheritance rule and the `Vault → Data → Audit` cross-Node recovery ordering in `integration-points.md`. The backing is `HoneyDrunk.Audit.Data`, which is Data-backed over `HoneyDrunk.Data`'s `IRepository`/`IUnitOfWork`; `HoneyDrunk.Data` ships EF Core + SQL Server providers, so the durable backing is **Azure SQL**. Record the Azure SQL T0 D2 mechanics — single-branch, no Cosmos fork.
+3. **Notify T1 runbook** (packet 08) — `repos/HoneyDrunk.Notify/dr-runbook.md` (T1) covering delivery state (in-flight messages, retry queues) and the Service Bus geo-DR alias-pairing posture. Scoped to `HoneyDrunk.Notify` only — Notify Cloud T0 DR is deferred to the Notify Cloud standup.
+
+## Constraints carried into Wave 2
+
+> **Invariant 60 (packet 00) — every Node holding state has a `dr_tier` assignment in `catalogs/grid-health.json`.** Each runbook's stated tier must match the packet-01 catalog value exactly.
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** No secret value in any runbook or the Vault bootstrap-recovery doc — only names, identifiers, and procedure steps.
+
+> **Invariant 47 — Phase-1 audit integrity is append-only-by-interface; it is explicitly not tamper-evident, and Phase 1 must not be documented or marketed as such.** The Audit runbook (packet 06) describes durability and restore — never tamper-evidence / WORM, which is deferred ADR-0030 Phase 2 work.
+
+> **Invariant 17 — One Key Vault per deployable Node per environment, `kv-hd-{service}-{env}`.** The Vault runbook's backing inventory names the vaults by this convention.
+
+- **The Vault offline recovery artifact never enters the repo.** ADR-0036 D6 — the repo is itself a recovery dependency. The packet-03 `vault-bootstrap-recovery.md` points to `business/context/` for the artifact's location; it does not embed recovery material.
+- **Vault recovery goes first; Audit recovers after Data, after Vault.** The recovery-ordering lines in `integration-points.md` are load-bearing — packet 07b's Audit drill is hard-sequenced after packet 05's Vault drill because of this ordering.
+- **In-flight Service Bus messages are not failover-durable** (ADR-0036 D2). The Notify runbook states this plainly; recovery relies on consumer idempotency (ADR-0042), not message preservation.
+- **Notify ≠ Notify Cloud.** Packet 08 is the Notify T1 runbook. Notify Cloud's T0 runbook, tenant identity/billing backup, and tenant-scoped restore are out of scope — Notify Cloud is not yet scaffolded; that work belongs to the Notify Cloud standup, which inherits a hard checklist item for the T0 runbook + D5 tenant-scoped restore.
+- **Audit's backing is Azure SQL — single-branch, no fork.** `Audit.Data` is Data-backed over `HoneyDrunk.Data`'s SQL Server provider; the Audit runbook records the Azure SQL D2 mechanics only. **Notify:** confirm the live Service Bus / Storage Queue topology from `repos/HoneyDrunk.Notify/` docs or `catalogs/`; if undeterminable, document the likely shape and flag for the operator.
+
+## Acceptance signal for Wave 2 completion
+
+`repos/HoneyDrunk.Vault/dr-runbook.md` + `vault-bootstrap-recovery.md` exist with the Vault recovery-ordering line in `integration-points.md`; `repos/HoneyDrunk.Audit/dr-runbook.md` exists with the `Audit.Data → T0` and `Vault → Data → Audit` lines in `integration-points.md`; `repos/HoneyDrunk.Notify/dr-runbook.md` exists with the Service Bus DR posture + ADR-0042 idempotency dependency in `integration-points.md`. All three runbooks follow the packet-02 template and state the correct tier. Wave 3 (Vault Azure backup config + `hive-sync` extension) and Wave 4 (the drills) build directly on these documents.

--- a/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/handoff-wave4-restore-drills.md
+++ b/generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/handoff-wave4-restore-drills.md
@@ -1,0 +1,37 @@
+# Handoff: Wave 3 → Wave 4 (backup configuration in place → execute the restore drills)
+
+**Read once at the Wave 3 → Wave 4 transition.** This is an ephemeral baton pass, not a live tracker. Immutable per invariant 24. This handoff is addressed primarily to the **Studio operator** — Wave 4 is human-executed work.
+
+## What Waves 1–3 delivered (upstream state Wave 4 depends on)
+
+- **The DR policy is live** — ADR-0036 Accepted, the two DR invariants in force, `dr_tier` on every Node in `grid-health.json` (packet 00, 01).
+- **The runbooks exist** — `repos/HoneyDrunk.Vault/dr-runbook.md` + `vault-bootstrap-recovery.md` (packet 03), `repos/HoneyDrunk.Audit/dr-runbook.md` (packet 06). These are the step-by-step procedures Wave 4 executes. `generated/restore-drills/` and its drill-log schema exist (packet 02).
+- **Vault T0 backup configuration is applied and the offline recovery artifact exists** (packet 04, `Actor=Human`). Every Vault Key Vault has soft-delete + purge protection on, 90-day retention, diagnostics to Log Analytics. The offline encrypted bootstrap-recovery artifact (encrypted USB or printed Shamir shares) exists; its physical location and rotation procedure are recorded in `business/context/`.
+- **Audit.Data T0 Azure SQL backup configuration is applied** (packet 07a, `Actor=Human`, Wave 3). The `HoneyDrunk.Audit.Data` Azure SQL backing has geo-redundant backup storage, weekly LTR for 1 year, and a 35-day PITR window. `Audit.Data` is Data-backed over `HoneyDrunk.Data`'s SQL Server provider — the backing is Azure SQL, single-branch, no Cosmos fork.
+- **`hive-sync` reconciles DR state** (packet 09). It now flags a stateful Node missing a `dr_tier` and a Node whose most recent `generated/restore-drills/` entry is overdue per its tier cadence — surfacing both as board-item drift findings, and flagging the tenant-onboarding freeze for an overdue drill. The overdue grace window is anchored to ADR-0036's accepted-date read from the ADR header at runtime.
+
+## Wave 4 objectives — the two first restore drills
+
+ADR-0036 Follow-up Work mandates the first Vault and Audit drills **within 90 days of ADR-0036's acceptance**. Wave 4 is those two drills. Both are `Actor=Human`.
+
+1. **Packet 05 — First Vault T0 restore drill.** Follow `repos/HoneyDrunk.Vault/dr-runbook.md`: provision an ephemeral environment, restore the most recent Vault Key Vault backup into it (recover soft-deleted secrets / restore from the geo-replicated copy), validate `ISecretStore` resolves a known secret and a tenant-scoped secret restores correctly, optionally exercise the `vault-bootstrap-recovery.md` procedure as the semiannual partial-restore spot-check, tear down the ephemeral environment, and log the outcome to `generated/restore-drills/`. Budget ~half a working day (ADR-0036 Operational Consequences).
+2. **Packet 07b — first Audit T0 restore drill.** The Audit.Data T0 Azure SQL backup configuration was already applied in Wave 3 (packet 07a). Follow `repos/HoneyDrunk.Audit/dr-runbook.md`: provision an ephemeral environment, restore the most recent Audit.Data Azure SQL backup, validate `IAuditQuery` returns known entries and `IAuditLog` append works on the restored store, tear down, and log the outcome.
+
+## Hard sequencing — the Vault drill goes first
+
+**Packet 07b's Audit drill is hard-blocked on packet 05's Vault drill** (and on packet 07a's Audit backup config, completed in Wave 3). ADR-0036 D6 and the recovery ordering `Vault → Data → Audit` mean an Audit restore cannot be meaningfully validated until the Vault recovery path is proven. Run packet 05 to completion — with a `pass` outcome — before starting packet 07b's drill. The old single packet 07 (which bundled the backup config with the drill) was split: the config has no Vault-drill dependency and ran in Wave 3 (07a); the drill carries the ordering and runs in Wave 4 (07b).
+
+## Constraints carried into Wave 4
+
+> **Invariant 61 (packet 00) — a missed restore drill freezes tier-affecting tenant onboarding for the affected Node.** If a drill outcome is `fail` or `partial`, record a remediation note and treat it as a missed drill — the affected Node's tier-affecting tenant onboarding is frozen until the drill passes. `hive-sync` (packet 09) will surface this.
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The drill-log entries record outcome and procedure deltas — never any secret value or sensitive audit-record content resolved during validation.
+
+- **Tear down every ephemeral environment.** Leaving drill infrastructure running is unbudgeted cost — ADR-0036 D8's cost discipline applies. Each drill packet ends with teardown.
+- **Log every drill, pass or fail.** The drill-log entry in `generated/restore-drills/` (schema: `date`, `tier`, `node`, `outcome`, `runbook-deltas`, `operator`) is the proof the drill happened. `hive-sync` reads it; a Node with no log past the 90-day grace window is drift.
+- **Feed deltas back into the runbook.** Any procedure correction discovered during a drill is applied back into the relevant `dr-runbook.md` (and `vault-bootstrap-recovery.md` if the Vault spot-check surfaced one). A drill that improves the runbook is a successful drill.
+- **The Audit drill follows the Vault drill** — non-negotiable per the recovery ordering.
+
+## Acceptance signal for Wave 4 completion
+
+The first Vault drill is executed with a recorded outcome; a `tier: T0, node: honeydrunk-vault` entry exists in `generated/restore-drills/`. The first Audit drill is executed with a recorded outcome; a `tier: T0, node: honeydrunk-audit` entry exists in `generated/restore-drills/`. (The Audit.Data T0 Azure SQL backup configuration was completed in Wave 3, packet 07a.) Any drill-surfaced procedure deltas are applied back into the runbooks. Both drills landed within ADR-0036's 90-day-from-acceptance mandate, or the slip is recorded. Once both drill packets (05, 07b) are `Done` — and all Wave 1–3 packets including 07a — the initiative meets its archival gate (ADR-0008 D10) and the folder moves to `archive/`.


### PR DESCRIPTION
## Summary
Adds the issue packets for **ADR-0036 — Disaster recovery and backup policy** under `generated/issue-packets/active/adr-0036-disaster-recovery-and-backup-policy/`.

One of 12 per-ADR PRs from the 2026-05-21 ADR batch — split per ADR so `file-packets.yml` files incrementally per merge rather than firing all 92 packets at once (GraphQL rate limits).

## Test plan
- [ ] `file-packets.yml` files this ADR's packets on merge and adds them to The Hive
- [ ] No GraphQL rate-limit errors in the filing run

🤖 Generated with [Claude Code](https://claude.com/claude-code)