### PR TITLE
Scope ADR-0043 — continuous backlog generation strategy

### DIFF
--- a/generated/issue-packets/active/adr-0043-continuous-backlog-generation/01-architecture-adr-0043-acceptance.md
+++ b/generated/issue-packets/active/adr-0043-continuous-backlog-generation/01-architecture-adr-0043-acceptance.md
@@ -1,0 +1,123 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "docs", "adr-0043", "wave-1"]
+dependencies: []
+adrs: ["ADR-0043", "ADR-0008", "ADR-0014"]
+accepts: ["ADR-0043"]
+wave: 1
+initiative: adr-0043-continuous-backlog-generation
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0043 — flip status, finalize the two new invariants, register the backlog-generation initiative
+
+## Summary
+Flip ADR-0043 (Continuous Backlog Generation Strategy) from Proposed to Accepted: update the ADR header, update the ADR index, record the two new backlog-generation invariants in `constitution/invariants.md`, and register the `adr-0043-continuous-backlog-generation` initiative in the tracking files.
+
+## Context
+ADR-0043 is `initiatives/current-focus.md` priority #5 ("Land ADR-0043 — Backlog Generation"). It commits the Grid to four named backlog-source streams (Strategic, Tactical, Opportunistic, Reactive) plus a weekly triage briefing, a three-state packet lifecycle (`proposed/` → `active/` → `completed/`), and a packet-handoff contract. Every other packet in this initiative references ADR-0043's decisions as live rules, so the flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project. It is `Actor=Agent`. The two new invariants take the **pre-reserved numbers 78 and 79** (see Proposed Implementation) — they are not scanned for at landing time.
+
+## Scope
+- `adrs/ADR-0043-continuous-backlog-generation-strategy.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- The ADR index (`adrs/README.md` or equivalent index file) — update the ADR-0043 row to Accepted.
+- `constitution/invariants.md` — append the two new invariants ADR-0043 introduces (see below).
+- `initiatives/active-initiatives.md` — register the `adr-0043-continuous-backlog-generation` initiative with a packet checklist.
+- `initiatives/proposed-adrs.md` — ADR-0043 moves from "Awaiting" to "In Progress" once packets are filed; the `hive-sync` agent maintains this surface, so this packet only needs to ensure the initiative is registered in `active-initiatives.md`.
+
+**`current-focus.md` priority bookkeeping.** ADR-0043 is `current-focus.md` priority #5. This acceptance packet flipping ADR-0043 to Accepted satisfies the "ADR-0043 Accepted" half of priority #5's exit signal; the "`generated/issue-packets/proposed/` directory + Strategic source live" half is satisfied by packets 02 (directory) and 05 (the `hive-sync` Strategic trigger) plus packet 08 (first Strategic run). When the initiative reaches completion (all 8 packets `Done`), priority #5 should be marked complete and dropped from the ranked list at the next ADR-0043 weekly briefing. This packet does not edit `current-focus.md` priority status itself (the briefing owns that surface); it is noted here and in the dispatch plan so the bookkeeping is not lost.
+
+## Proposed Implementation
+
+### The two new invariants
+ADR-0043's Consequences/Invariants section adds exactly two. They are assigned the **hard-reserved numbers 78 and 79**.
+
+**Invariant numbers are pre-reserved — use 78 and 79, do not scan.** `constitution/invariants.md` is topic-grouped and NOT contiguously numbered; its true highest invariant number is **51** (verified). ADR-0043 sits in a 12-ADR batch and its invariant block is **pre-reserved as numbers 78 and 79** to avoid a collision with sibling ADRs (notably ADR-0044) racing for 52/53. The execution agent must assign **invariant 78** and **invariant 79** literally — do not scan for "next free" and do not reuse 52/53.
+
+> **Invariant numbers 78-79 are pre-reserved as part of a 12-ADR batch; if any invariant above 51 lands from outside this batch before merge, shift this block upward, never reuse a number.**
+
+Invariant text to add (verbatim intent from ADR-0043 Consequences) — the wording itself is **forward-only / non-retroactive**; existing already-filed packets are not rewritten:
+
+> **78. Every agent-generated packet authored after ADR-0043 acceptance lands in `generated/issue-packets/proposed/`, never directly in `active/`.** Agents do not self-promote work; a human is the only authority for the `proposed/` → `active/` transition. The `active/` directory holds only packets a human has explicitly elected to file. This invariant is forward-only: packets authored before ADR-0043 acceptance are not retroactively moved or rewritten. See ADR-0043 D3.
+
+> **79. Every issue packet authored after ADR-0043 acceptance carries `source` and `generator` frontmatter fields.** `source` is one of `strategic` | `tactical` | `opportunistic` | `reactive` and names which backlog stream produced the packet. `generator` names the agent that authored it (or `human` for human-authored packets). Auditability of agent-generated work is non-negotiable. This invariant is forward-only: the ~25 sibling initiative folders already filed without these fields are valid as-authored and are not retroactively rewritten — invariant 24 (filed packets are immutable) governs them. See ADR-0043 D2.
+
+A new "Backlog Generation Invariants" topic group is the natural home, or append to an existing Work Tracking group — the execution agent chooses placement consistent with the file's topic-grouped structure and records the choice in the PR body.
+
+## Affected Files
+- `adrs/ADR-0043-continuous-backlog-generation-strategy.md`
+- `adrs/README.md` (or the ADR index file in use)
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0043 header reads `**Status:** Accepted`
+- [ ] ADR index row for ADR-0043 reflects Accepted
+- [ ] `constitution/invariants.md` carries the two new invariants as numbers **78 and 79**, with no "(Proposed)" qualifier, and each invariant's text carries the forward-only / non-retroactive carve-out verbatim
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0043-continuous-backlog-generation` initiative with a packet checklist (8 packets)
+- [ ] The PR body confirms invariants 78/79 were used and notes the `hive-sync` reconciliation expectation
+- [ ] No directory creation, agent edit, or `issue-authoring-rules.md` change in this packet (those land in packets 02, 03, 05, 06, 07)
+
+## Human Prerequisites
+- [ ] Confirm before merge that no invariant above 51 has landed from **outside** the 12-ADR batch (which would force this block to shift upward from 78/79). If only batch ADRs have landed, 78/79 stand as reserved. Never reuse a number.
+
+## Dependencies
+None. This is the first packet in the initiative.
+
+## Referenced ADR Decisions
+
+**ADR-0043 D1** — Four backlog-source streams (Strategic, Tactical, Opportunistic, Reactive) plus one weekly-briefing triage surface owned by `netrunner`.
+**ADR-0043 D2** — The issue packet is the canonical output of every source; new `source` and `generator` frontmatter fields are mandatory.
+**ADR-0043 D3** — Three-state packet lifecycle: `proposed/` (agent-generated, awaiting triage) → `active/` (human-promoted, filed) → `completed/`. The `proposed/` → `active/` transition is the only human-decision gate.
+**ADR-0043 D8** — No code-Node changes; entirely a Meta-sector decision. `hive-sync` gains two new responsibilities (Strategic acceptance trigger, Reactive drift-to-packet conversion), permitted under ADR-0014's existing mandate.
+**ADR-0008** — Defines the packet → issue → board → PR pipeline this ADR fills the upstream slot of.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0043 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Use the pre-reserved invariant numbers 78 and 79.** They are part of a 12-ADR batch reservation. Do not scan for "next free" and do not take 52/53 — that range is being raced for by sibling ADRs. If any invariant above 51 lands from outside this batch before merge, shift this block upward; never reuse a number.
+- **The two new invariants are forward-only.** Their text must explicitly carve out existing already-filed packets — the ~25 sibling initiative folders authored before ADR-0043 are not retroactively rewritten (invariant 24 governs them). The carve-out lives in the invariant wording itself, not only here.
+- **Do not create directories or amend agents in this packet.** Those are scoped to packets 02–07; this packet is the governance flip only.
+
+## Labels
+`chore`, `tier-3`, `meta`, `docs`, `adr-0043`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0043 to Accepted, record its two new invariants in `constitution/invariants.md`, and register the initiative in the trackers.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0043 so the backlog-generation build packets can reference its decisions as live rules.
+- Feature: ADR-0043 Continuous Backlog Generation rollout, Phase 1.
+- ADRs: ADR-0043 (primary), ADR-0008 (packet/initiative conventions), ADR-0014 (hive-sync mandate).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0043 stays Proposed until this PR merges.
+- Use the pre-reserved invariant numbers 78 and 79; do not scan for next-free, do not take 52/53.
+- Both new invariants must carry the forward-only / non-retroactive carve-out in their own text.
+- No directory creation or agent edits in this packet.
+
+**Key Files:**
+- `adrs/ADR-0043-continuous-backlog-generation-strategy.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0043-continuous-backlog-generation/02-architecture-create-backlog-generation-directories.md
+++ b/generated/issue-packets/active/adr-0043-continuous-backlog-generation/02-architecture-create-backlog-generation-directories.md
@@ -1,0 +1,117 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "docs", "adr-0043", "wave-1"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0043", "ADR-0008"]
+accepts: ["ADR-0043"]
+wave: 1
+initiative: adr-0043-continuous-backlog-generation
+node: honeydrunk-architecture
+---
+
+# Create the four new backlog-generation directories with READMEs
+
+## Summary
+Create the four new generated directories ADR-0043 calls for — `generated/issue-packets/proposed/`, `generated/audits/`, `generated/scout-reports/`, `generated/briefings/` — each seeded with a `README.md` describing its purpose, contents, and lifecycle.
+
+## Context
+ADR-0043 D3 formalizes a three-state packet lifecycle. The `active/` and `completed/` packet directories already exist; the new `proposed/` directory is the agent-generated triage queue. Three other generated directories hold the audit-trail outputs of the Tactical and Opportunistic sources and the weekly-briefing triage surface. ADR-0043's Follow-up Work section lists "Create the new directories" as the first concrete task. Directories cannot be committed empty to git, so each gets a README that doubles as its documentation.
+
+This is a docs/scaffolding-only packet. No code, no workflow, no .NET project.
+
+## Scope
+Create these four directories, each with a `README.md`:
+
+- `generated/issue-packets/proposed/` — agent-generated packets awaiting human triage. Not yet GitHub issues. May be edited or deleted without ceremony. The human's queue. Per ADR-0043 D3.
+- `generated/audits/` — `node-audit` reports from the Tactical source, named `{node}-{YYYY-MM-DD}.md`. Committed for the audit trail even when no packets graduate. Per ADR-0043 D4 Tactical.
+- `generated/scout-reports/` — `product-strategist` Scout-mode reports from the Opportunistic source, named `{YYYY-MM-DD}.md`. Holds lower-ranked opportunities filed for future re-evaluation. Per ADR-0043 D4 Opportunistic.
+- `generated/briefings/` — `netrunner` weekly triage briefings, named `{YYYY-MM-DD}.md`, plus the rolling out-of-band file `urgent.md` for `priority: urgent` reactive packets. Per ADR-0043 D5, D6.
+
+## Proposed Implementation
+Each `README.md` states: the directory's purpose, what files land there and their naming convention, which agent writes to it, the lifecycle rules, and a cross-reference to ADR-0043's governing decision.
+
+**`generated/issue-packets/proposed/README.md`** must additionally state the load-bearing discipline: agents write here, never to `active/`; the `proposed/` → `active/` transition is a human-only decision (invariant 78 from packet 01); `proposed/` is allowed to accumulate; stale packets older than 30 days are surfaced in the weekly briefing for "promote, refine, or drop" triage and are never auto-archived.
+
+The README must also state explicitly: **`generated/issue-packets/proposed/` is deliberately OUTSIDE the `file-packets.yml` path filter.** That workflow triggers only on `generated/issue-packets/active/**/*.md`. Packets sitting in `proposed/` are therefore *structurally incapable* of auto-filing — they cannot become GitHub issues until a human moves them into `active/`. This is the backward-compatibility and human-gate guarantee made concrete: the directory boundary, not agent discipline alone, enforces it.
+
+**`generated/briefings/README.md`** must document both the dated weekly briefing files and the rolling `urgent.md` file, and note that `urgent.md` is the out-of-band surface for `priority: urgent` reactive packets per ADR-0043 D6.
+
+Naming conventions to record verbatim in the relevant READMEs:
+- `proposed/` packets: `{YYYY-MM-DD}-{repo}-{description}.md` per ADR-0008 D10.
+- `audits/`: `{node}-{YYYY-MM-DD}.md`.
+- `scout-reports/`: `{YYYY-MM-DD}.md`.
+- `briefings/`: `{YYYY-MM-DD}.md` plus the fixed-name `urgent.md`.
+
+## Affected Files
+- `generated/issue-packets/proposed/README.md` (new)
+- `generated/audits/README.md` (new)
+- `generated/scout-reports/README.md` (new)
+- `generated/briefings/README.md` (new)
+
+## NuGet Dependencies
+None. This packet creates Markdown documentation files only; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All directories under `HoneyDrunk.Architecture/generated/`. Correct repo per routing.
+- [x] No code change in any repo.
+- [x] No catalog or invariant change (those are in packet 01).
+
+## Acceptance Criteria
+- [ ] `generated/issue-packets/proposed/` exists with a `README.md` documenting purpose, naming, lifecycle, and the human-only-promotion discipline
+- [ ] The `proposed/README.md` explicitly states that `proposed/` is outside the `file-packets.yml` path filter (`active/**` only), so packets there cannot auto-file
+- [ ] `generated/audits/` exists with a `README.md` documenting purpose and the `{node}-{YYYY-MM-DD}.md` naming
+- [ ] `generated/scout-reports/` exists with a `README.md` documenting purpose and the `{YYYY-MM-DD}.md` naming
+- [ ] `generated/briefings/` exists with a `README.md` documenting the dated weekly briefing files and the rolling `urgent.md` file
+- [ ] Each README cross-references the relevant ADR-0043 decision (D3 / D4 / D5 / D6)
+- [ ] No packet files are placed in `proposed/` in this packet — the directory ships with only its README (packet 08 seeds the first packets)
+
+## Human Prerequisites
+None. Pure Architecture-repo scaffolding.
+
+## Dependencies
+- `packet:01` — ADR-0043 must be Accepted so these directories are created against live decisions, not a Proposed ADR.
+
+## Referenced ADR Decisions
+
+**ADR-0043 D3** — Three-state lifecycle: `proposed/` (agent-generated, awaiting triage) → `active/` (human-promoted) → `completed/`. `proposed/` accumulates; stale entries surface in the weekly briefing; never auto-archived.
+**ADR-0043 D4** — Tactical audit reports go to `generated/audits/{node}-{YYYY-MM-DD}.md` even when no packets graduate; Opportunistic lower-ranked items go to `generated/scout-reports/{YYYY-MM-DD}.md`.
+**ADR-0043 D5/D6** — The weekly briefing is committed to `generated/briefings/{YYYY-MM-DD}.md`; `priority: urgent` reactive packets are additionally surfaced in the rolling `generated/briefings/urgent.md`.
+**ADR-0043 Follow-up Work** — "Create the new directories: `generated/issue-packets/proposed/`, `generated/audits/`, `generated/scout-reports/`, `generated/briefings/`."
+
+## Constraints
+- Directories must contain a `README.md` so git tracks them — never commit a bare `.gitkeep` where a documented README belongs.
+- Do not place any packet files in `proposed/` in this packet; it ships with only its README.
+
+## Labels
+`chore`, `tier-1`, `meta`, `docs`, `adr-0043`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Create the four ADR-0043 generated directories, each with a documenting README.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Provide the on-disk surfaces the four backlog sources and the briefing write to.
+- Feature: ADR-0043 Continuous Backlog Generation rollout, Phase 1.
+- ADRs: ADR-0043 (D3/D4/D5/D6), ADR-0008 (packet naming).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — ADR-0043 Accepted.
+
+**Constraints:**
+- README per directory; no bare `.gitkeep`.
+- No packet files placed in `proposed/`.
+
+**Key Files:**
+- `generated/issue-packets/proposed/README.md`
+- `generated/audits/README.md`
+- `generated/scout-reports/README.md`
+- `generated/briefings/README.md`
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0043-continuous-backlog-generation/03-architecture-issue-authoring-rules-source-generator-fields.md
+++ b/generated/issue-packets/active/adr-0043-continuous-backlog-generation/03-architecture-issue-authoring-rules-source-generator-fields.md
@@ -1,0 +1,122 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-2", "meta", "adr-0043", "wave-1"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0043", "ADR-0008"]
+accepts: ["ADR-0043"]
+wave: 1
+initiative: adr-0043-continuous-backlog-generation
+node: honeydrunk-architecture
+---
+
+# Amend issue-authoring-rules.md for the source/generator/priority frontmatter and the three-state lifecycle
+
+## Summary
+Amend `copilot/issue-authoring-rules.md` to require the new `source` and `generator` frontmatter fields on every packet, document the optional `priority` field, and document the three-state `proposed/` → `active/` → `completed/` packet lifecycle and naming conventions ADR-0043 D2/D3 introduce.
+
+## Context
+ADR-0043 D2 makes the issue packet the canonical output of every backlog source and adds two mandatory frontmatter fields: `source` (which backlog stream produced the packet) and `generator` (which agent authored it). D3 formalizes the three-state lifecycle with a new `proposed/` directory. D6 introduces a `priority: urgent` flag on reactive packets. `copilot/issue-authoring-rules.md` is the quality contract every packet-authoring agent (`scope`, and via this rollout the other sources) loads — it must carry these new requirements or the new fields will be inconsistently applied. ADR-0043's Follow-up Work explicitly lists "Amend `copilot/issue-authoring-rules.md` to require the `source` and `generator` frontmatter fields."
+
+This is a docs-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `copilot/issue-authoring-rules.md` — add the new frontmatter fields and lifecycle documentation.
+
+## Proposed Implementation
+Amend `copilot/issue-authoring-rules.md` as follows.
+
+**New mandatory frontmatter fields — FORWARD-ONLY.** Add `source` and `generator` to the frontmatter requirements (the file's "Quality Checks" list currently calls for `wave`, `initiative`, `node`, `adrs`, `tier`). The rule text must state explicitly that the requirement is **forward-only / non-retroactive**: it applies to packets authored *after ADR-0043 acceptance*. The ~25 sibling initiative folders already filed under `active/` were authored without these fields, are valid as-authored, and are **not** retroactively rewritten — invariant 24 (filed packets are immutable) governs them. The rule, like invariant 79, carries this carve-out in its own wording, not only as a note.
+
+- `source` — one of `strategic` | `tactical` | `opportunistic` | `reactive`. Names which ADR-0043 backlog stream produced the packet. Required on every packet authored after ADR-0043 acceptance.
+- `generator` — names who authored the packet. Required on every packet authored after ADR-0043 acceptance. Auditability of "who said this should be done."
+
+**`generator` value convention — pinned, do not improvise.** Document this decisively in the file:
+- **Human-authored packets** use the stable literal `generator: human`. Never use a GitHub handle — handles can change; the literal is stable and machine-comparable.
+- **Agent-authored packets** use the agent's name: `generator: scope`, `generator: node-audit`, `generator: product-strategist`, `generator: hive-sync`, etc.
+- For human-authored packets, `source` reflects the closest matching stream (typically `strategic` for ADR-driven work).
+
+**Optional `priority` field — `urgent`-only.** Document `priority: urgent` as an optional frontmatter field carried by Reactive-source packets for high+ CVEs and production incidents (ADR-0043 D6). The field's **only valid value is `urgent`**; **absence of the field means normal priority**. Do not introduce `priority: normal` or `priority: high` — those values do not exist in the schema. State this explicitly so an execution agent does not invent them. `priority: urgent` packets are surfaced out-of-band in `generated/briefings/urgent.md`.
+
+**Three-state lifecycle.** Add a short section documenting the `proposed/` → `active/` → `completed/` lifecycle from ADR-0043 D3:
+- `proposed/` — agent-generated, awaiting human triage; not yet a GitHub issue; may be edited or deleted freely.
+- `active/` — human-promoted, filed as a GitHub issue, in flight.
+- `completed/` — closed in GitHub, moved here by `hive-sync`.
+- State the load-bearing rule: agents never self-promote; the `proposed/` → `active/` transition is the only human-decision gate (invariant 78 from packet 01).
+- State the structural enforcement: **`generated/issue-packets/proposed/` is deliberately outside the `file-packets.yml` path filter**, which watches only `generated/issue-packets/active/**`. Agent-generated packets in `proposed/` are therefore structurally incapable of auto-filing — they cannot become GitHub issues until a human moves them to `active/`. This makes the human gate a directory boundary, not merely an agent-discipline convention.
+
+**Naming convention scope.** Note that the `{YYYY-MM-DD}-{repo}-{description}.md` packet-naming convention (already in the file) applies to `proposed/` packets too; the two-digit-prefix initiative-folder form applies once a multi-repo set is promoted to `active/`.
+
+## Affected Files
+- `copilot/issue-authoring-rules.md`
+
+## NuGet Dependencies
+None. This packet edits a Markdown rules file; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `copilot/issue-authoring-rules.md` lives in `HoneyDrunk.Architecture`. Correct repo per routing.
+- [x] No code change in any repo.
+- [x] No agent-definition edit in this packet (agent amendments are packets 05–07).
+
+## Acceptance Criteria
+- [ ] `copilot/issue-authoring-rules.md` requires `source` (one of `strategic`/`tactical`/`opportunistic`/`reactive`) on every packet authored after ADR-0043 acceptance
+- [ ] The file requires `generator` on every packet authored after ADR-0043 acceptance
+- [ ] The `source`/`generator` rule text is explicitly forward-only — it states that existing already-filed packets are not retroactively rewritten (invariant 24)
+- [ ] The file pins the `generator` convention: `generator: human` (stable literal, never a GitHub handle) for human-authored packets; the agent name for agent-authored packets
+- [ ] The file documents `priority` as `urgent`-only, states that absence means normal priority, and states that `priority: normal`/`priority: high` are not valid values
+- [ ] The file documents the optional `priority: urgent` field and its tie to `generated/briefings/urgent.md`
+- [ ] The file documents the three-state `proposed/` → `active/` → `completed/` lifecycle and the human-only-promotion rule
+- [ ] The file states that `proposed/` is outside the `file-packets.yml` `active/**` path filter, so `proposed/` packets cannot auto-file
+- [ ] The Quality Checks frontmatter checklist line is updated to include `source` and `generator`
+- [ ] The amendment cross-references ADR-0043 D2, D3, and D6
+
+## Human Prerequisites
+None. Pure Architecture-repo docs edit.
+
+## Dependencies
+- `packet:01` — ADR-0043 must be Accepted; this packet documents its D2/D3/D6 decisions as live rules. The human-only-promotion rule references invariant 78 added in packet 01.
+
+## Referenced ADR Decisions
+
+**ADR-0043 D2** — The packet is the canonical output of every source. New `source` field (`strategic`/`tactical`/`opportunistic`/`reactive`) and `generator` field (authoring agent) are mandatory frontmatter.
+**ADR-0043 D3** — Three-state lifecycle `proposed/` → `active/` → `completed/`; agents never self-promote.
+**ADR-0043 D6** — `priority: urgent` reactive packets (high+ CVE, production incident) are surfaced out-of-band in `generated/briefings/urgent.md`.
+**ADR-0043 Follow-up Work** — "Amend `copilot/issue-authoring-rules.md` to require the `source` and `generator` frontmatter fields."
+
+## Constraints
+- Document, do not redesign. The packet body structure and existing frontmatter fields are unchanged; this adds three fields and one lifecycle section.
+- **The `source`/`generator` requirement is forward-only.** The rule text itself must say it applies to packets authored after ADR-0043 acceptance. The ~25 sibling initiative folders already in `active/` were authored without these fields, are valid as-authored, and are never retroactively rewritten — invariant 24 (filed packets are immutable) governs them. Do not write a rule that is retroactively false the moment it lands.
+- **`priority` is `urgent`-only.** The only valid value is `urgent`; absence means normal. Do not document or imply `priority: normal` or `priority: high`.
+- **`generator` is a fixed convention.** `human` for human-authored packets (the stable literal, never a GitHub handle); the agent name for agent-authored packets. Do not leave this open for the execution agent to choose.
+
+## Labels
+`docs`, `tier-2`, `meta`, `adr-0043`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Add the `source`/`generator`/`priority` frontmatter fields and the three-state lifecycle to `copilot/issue-authoring-rules.md`.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the new ADR-0043 packet contract a live quality rule every authoring agent loads.
+- Feature: ADR-0043 Continuous Backlog Generation rollout, Phase 1.
+- ADRs: ADR-0043 (D2/D3/D6), ADR-0008 (packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — ADR-0043 Accepted.
+
+**Constraints:**
+- Document, do not redesign; fields are additive.
+- The `source`/`generator` rule is forward-only — its text must carve out existing already-filed packets (invariant 24); do not write a retroactively-false rule.
+- `priority` is `urgent`-only; absence means normal; no `normal`/`high` values.
+- `generator` convention is pinned: `human` literal for humans, agent name for agents.
+
+**Key Files:**
+- `copilot/issue-authoring-rules.md`
+
+**Contracts:** Packet frontmatter schema — adds `source` (required), `generator` (required), `priority` (optional).

--- a/generated/issue-packets/active/adr-0043-continuous-backlog-generation/04-architecture-author-audit-rotation-file.md
+++ b/generated/issue-packets/active/adr-0043-continuous-backlog-generation/04-architecture-author-audit-rotation-file.md
@@ -1,0 +1,106 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-1", "meta", "adr-0043", "wave-1"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0043"]
+accepts: ["ADR-0043"]
+wave: 1
+initiative: adr-0043-continuous-backlog-generation
+node: honeydrunk-architecture
+---
+
+# Author initiatives/audit-rotation.md with the 12-Node quarterly rotation order
+
+## Summary
+Author the new `initiatives/audit-rotation.md` file recording the rotation order for the ADR-0043 Tactical source — the 12 live Nodes covered one-per-week over a quarter, then the cycle repeats — with the rule for how Seed Nodes enter the rotation as they scaffold.
+
+## Context
+ADR-0043 D4 Tactical specifies a rotating Node-of-the-week audit: `node-audit` runs against one Node per week, 12 live Nodes covered per quarter, then the cycle repeats. The rotation order is recorded in `initiatives/audit-rotation.md` — a new file. ADR-0043's Follow-up Work lists "Author `initiatives/audit-rotation.md` with the initial 12-Node rotation order." Without this file, the Tactical source has no schedule and Phase 2 cannot begin.
+
+This is a docs-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `initiatives/audit-rotation.md` (new) — the rotation order and the rotation rules.
+
+## Proposed Implementation
+Author `initiatives/audit-rotation.md` containing:
+
+**The rotation list.** An ordered list of the 12 live Nodes, week 1 through week 12. The execution agent must read `catalogs/nodes.json` to enumerate the current 12 live Nodes (Nodes whose status is live, not Seed) and order them. A defensible default order is the canonical Core Node order first (Kernel → Transport → Vault → Auth → Web.Rest → Data) followed by the remaining live Nodes (Pulse, Notify, Communications, and the rest) — but the execution agent must reconcile against `catalogs/nodes.json` ground truth and record any deviation. If `nodes.json` shows a count other than 12 live Nodes at execution time, list exactly the live Nodes present and note the actual count in the file and the PR body.
+
+**Per-Node row contents.** For each rotation slot: week number, Node name, repo, and a "last audited" date column (initially blank — `hive-sync` or the briefing fills it as audits run).
+
+**Rotation rules**, stated verbatim from ADR-0043 D4 Tactical:
+- One Node per week; 12 live Nodes → one quarterly cycle; then the cycle repeats.
+- Seed Nodes enter the rotation as they scaffold (i.e. when a Seed Node becomes live, it is appended to the rotation and the cycle lengthens).
+- Each audit's output is committed to `generated/audits/{node}-{YYYY-MM-DD}.md` regardless of whether any packets graduate.
+- `node-audit` output is always triaged to `proposed/`; the human picks which findings become `active/`.
+
+**Phase note.** Record that per ADR-0043 D9, the Tactical rotation begins in Phase 2 (Week 3), weekly thereafter. The first audit Node is rotation slot 1.
+
+**Cross-reference** ADR-0043 D4 Tactical and D9.
+
+## Affected Files
+- `initiatives/audit-rotation.md` (new)
+
+## NuGet Dependencies
+None. This packet creates a Markdown tracking file; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `initiatives/` is the Architecture repo's tracking surface. Correct repo per routing.
+- [x] No code change in any repo.
+
+## Acceptance Criteria
+- [ ] `initiatives/audit-rotation.md` exists with an ordered 12-slot rotation (or the actual live-Node count, reconciled against `catalogs/nodes.json`)
+- [ ] Each rotation row carries week number, Node name, repo, and a "last audited" date column
+- [ ] The file states the one-per-week / quarterly-cycle / cycle-repeats rule verbatim
+- [ ] The file states the Seed-Node-enters-on-scaffold rule
+- [ ] The file states that audit output is committed to `generated/audits/{node}-{YYYY-MM-DD}.md` and always triaged to `proposed/`
+- [ ] The file records that the rotation begins Phase 2 / Week 3 per ADR-0043 D9
+- [ ] The PR body notes the actual live-Node count if it differs from 12
+
+## Human Prerequisites
+- [ ] Confirm the rotation order — the agent proposes a defensible order from `catalogs/nodes.json`, but the operator may want a specific Node first (e.g. the Node most overdue for an audit). Adjust before merge if desired.
+
+## Dependencies
+- `packet:01` — ADR-0043 must be Accepted so the file is authored against a live decision.
+
+## Referenced ADR Decisions
+
+**ADR-0043 D4 Tactical** — Rotating Node-of-the-week; 12 live Nodes covered per quarter, then repeat; Seed Nodes enter as they scaffold. `node-audit` output always triaged to `proposed/`; the audit report is committed to `generated/audits/{node}-{YYYY-MM-DD}.md` even if no packets graduate.
+**ADR-0043 D9** — Staged rollout: the Tactical rotation begins in Phase 2 (Week 3), weekly cadence thereafter; the weekly briefing also begins Week 3.
+
+## Constraints
+- Reconcile the Node list against `catalogs/nodes.json` ground truth — do not hardcode a count of 12 if the catalog disagrees.
+- The "last audited" column ships blank; it is filled as audits run, not pre-populated.
+
+## Labels
+`docs`, `tier-1`, `meta`, `adr-0043`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Author `initiatives/audit-rotation.md` with the 12-Node quarterly rotation and the rotation rules.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Give the ADR-0043 Tactical source a documented schedule so Phase 2 can begin.
+- Feature: ADR-0043 Continuous Backlog Generation rollout, Phase 1 (file authored now; rotation runs in Phase 2).
+- ADRs: ADR-0043 (D4 Tactical, D9).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — ADR-0043 Accepted.
+
+**Constraints:**
+- Reconcile the Node list against `catalogs/nodes.json`.
+- "Last audited" column ships blank.
+
+**Key Files:**
+- `initiatives/audit-rotation.md` (new)
+- `catalogs/nodes.json` (read-only, to enumerate live Nodes)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0043-continuous-backlog-generation/05-architecture-hive-sync-strategic-and-reactive-triggers.md
+++ b/generated/issue-packets/active/adr-0043-continuous-backlog-generation/05-architecture-hive-sync-strategic-and-reactive-triggers.md
@@ -1,0 +1,117 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-2", "meta", "adr-0043", "wave-2"]
+dependencies: ["packet:02", "packet:03"]
+adrs: ["ADR-0043", "ADR-0014", "ADR-0009"]
+accepts: ["ADR-0043"]
+wave: 2
+initiative: adr-0043-continuous-backlog-generation
+node: honeydrunk-architecture
+---
+
+# Amend the hive-sync agent with the Strategic acceptance trigger and the Reactive drift-to-packet conversion
+
+## Summary
+Amend the `hive-sync` agent definition with two new responsibilities ADR-0043 D4/D8 assign it: (1) the Strategic-source trigger — when `hive-sync` flips an ADR/PDR to Accepted, it records that a `scope` pass is owed for that decision; (2) the Reactive-source drift-to-packet conversion — drift items at severity ≥ medium become packets in `generated/issue-packets/proposed/`, with deduplication against existing `proposed/`/`active/` packets.
+
+## Context
+ADR-0043 D8 states: "ADR-0014 (hive-sync) already runs on a schedule. It gains two new responsibilities: detecting ADR/PDR acceptance to trigger Strategic scope (D4); generating Reactive packets from drift/incidents/scans (D4)." Both are amendments to the existing `hive-sync` run loop, permitted under ADR-0014's mandate without an agent re-design. `hive-sync` already does Step 9 (ADR/PDR acceptance reconciliation, including auto-flips) and Step 12 (drift detection → `initiatives/drift-report.md`) — this packet wires the output of those steps into the ADR-0043 backlog pipeline.
+
+ADR-0043's Follow-up Work lists "Amend `hive-sync` for the ADR-acceptance trigger and drift-to-packet conversion (per D8)."
+
+This is an agent-definition (Markdown) packet. No code, no workflow, no .NET project. The `.claude/agents/` directory is the agent source of truth per ADR-0007.
+
+## Scope
+- `.claude/agents/hive-sync.md` — add the Strategic-trigger responsibility and the Reactive drift-to-packet responsibility.
+
+## Proposed Implementation
+
+### Strategic-source trigger (ADR-0043 D4 Strategic)
+`hive-sync` Step 9 already auto-flips eligible Proposed ADRs/PDRs to Accepted (capped at `MAX_FLIPS_PER_RUN=3`). Amend the agent definition so that for every ADR/PDR `hive-sync` flips to Accepted in a run — and for any ADR/PDR flipped to Accepted by a human since the last run, detected by comparing current status against the prior-run frontmatter — `hive-sync` records a **Strategic scope owed** entry. Implementation guidance for the agent definition:
+- Surface the owed `scope` pass in the PR summary comment and in `initiatives/proposed-adrs.md` (the "Flipped This Run" section is the natural place) as an explicit "→ Strategic source: `scope` pass owed for ADR-XXXX" line.
+- State that `hive-sync` does **not** itself run `scope` — it detects and records the trigger; the actual `scope` invocation is a separate agent run (manual on the documented cadence until ADR-0043 D7's execution-surface ADR lands).
+- Add the secondary 14-day age-out: a Proposed ADR/PDR whose `**Date:**` is more than 14 days old is surfaced in `proposed-adrs.md` as "stale — accept or kill," distinct from the acceptance trigger (this surfaces stale decisions, it does not scope unaccepted work).
+
+### Reactive-source drift-to-packet conversion (ADR-0043 D4 Reactive)
+`hive-sync` Step 12 already produces `initiatives/drift-report.md`. Amend the agent definition so that drift findings at **severity ≥ medium** additionally become packets written to `generated/issue-packets/proposed/`. Implementation guidance:
+- Each generated packet uses the `{YYYY-MM-DD}-{repo}-{description}.md` naming and carries the mandatory `source: reactive` and `generator: hive-sync` frontmatter (per packet 03's amended `issue-authoring-rules.md`).
+- **Deduplication is mandatory** — before creating a packet, `hive-sync` checks `generated/issue-packets/proposed/` and `generated/issue-packets/active/` for an existing packet covering the same finding. ADR-0043 D4 calls deduplication "the single most important quality control" for reactive sources. State the dedupe key explicitly: the (drift category, item identity) pair, the same identity `hive-sync` already uses for First Surfaced date stickiness.
+- Low-severity drift remains in `initiatives/drift-report.md` only — no packet.
+- Note for future expansion (ADR-0043 D9 Phase 3): the same mechanism extends to security-CVE findings (ADR-0009 nightly scan, high+ CVE → `priority: urgent` packet) and `generated/incidents/` entries. This packet wires **drift only** — the lowest-cost reactive sub-source, "already 80% built into hive-sync" per ADR-0043 D9 Phase 1. The CVE and incident sub-sources are explicitly out of scope here and are a Phase-3 follow-up.
+
+### Constraint to preserve
+`hive-sync` writing packets to `proposed/` is new authority. State clearly that this authority is bounded to `proposed/` — `hive-sync` never writes to `active/`, never self-promotes, and never files GitHub issues (the human triages `proposed/` → `active/`; `file-issues` files). This is consistent with `hive-sync`'s existing constraint "Never create GitHub issues — that's `scope` and `file-issues`."
+
+## Affected Files
+- `.claude/agents/hive-sync.md`
+
+## NuGet Dependencies
+None. This packet edits a Markdown agent-definition file; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `.claude/agents/` is the single source of truth for agent definitions (ADR-0007); lives in `HoneyDrunk.Architecture`. Correct repo.
+- [x] No code change in any repo.
+- [x] New authority (`hive-sync` writes to `proposed/`) is explicitly bounded; no `active/` write, no issue creation.
+
+## Acceptance Criteria
+- [ ] `hive-sync.md` documents the Strategic trigger: every ADR/PDR flipped to Accepted records a "`scope` pass owed" entry surfaced in the PR summary and `proposed-adrs.md`
+- [ ] `hive-sync.md` states `hive-sync` detects/records the Strategic trigger but does not itself run `scope`
+- [ ] `hive-sync.md` documents the 14-day age-out for stale Proposed decisions as a distinct "accept or kill" surface
+- [ ] `hive-sync.md` documents the Reactive drift-to-packet conversion: drift at severity ≥ medium becomes a `source: reactive`, `generator: hive-sync` packet in `proposed/`
+- [ ] The dedupe rule is documented with the explicit (drift category, item identity) key, citing ADR-0043 D4's "single most important quality control"
+- [ ] Low-severity drift is documented as report-only, no packet
+- [ ] The CVE and incident reactive sub-sources are documented as Phase-3 out-of-scope follow-ups
+- [ ] The new `proposed/`-write authority is documented as bounded — no `active/` write, no self-promotion, no GitHub issue creation
+- [ ] The amendment cross-references ADR-0043 D4/D8, ADR-0014, and ADR-0009
+
+## Human Prerequisites
+None. Pure Architecture-repo agent-definition edit.
+
+## Dependencies
+- `packet:02` — the `generated/issue-packets/proposed/` directory must exist before `hive-sync` is told to write packets into it.
+- `packet:03` — the `source`/`generator` frontmatter contract must be documented in `issue-authoring-rules.md` before `hive-sync` is told to emit those fields.
+
+## Referenced ADR Decisions
+
+**ADR-0043 D4 Strategic** — Trigger: `hive-sync` detects an ADR/PDR status change to Accepted; `scope` runs once per acceptance. 14-day age-out on Proposed decisions is a secondary "accept or kill" trigger.
+**ADR-0043 D4 Reactive** — Drift items at severity ≥ medium become packets in `proposed/`; low-severity drift stays in the report. Deduplication is "the single most important quality control."
+**ADR-0043 D8** — `hive-sync` gains the acceptance trigger and the drift-to-packet conversion; both are amendments to its existing run loop permitted under ADR-0014.
+**ADR-0043 D9 Phase 1/Phase 3** — Reactive-for-drift is Phase 1 ("already 80% built into hive-sync"); CVE and incident sub-sources expand in Phase 3.
+**ADR-0014** — `hive-sync`'s reconciliation mandate and existing Step 9 (acceptance) / Step 12 (drift) responsibilities.
+**ADR-0009** — Nightly security scan; high+ CVE feeds the Reactive source in the Phase-3 expansion.
+
+## Constraints
+- **Amend, do not re-architect.** `hive-sync`'s Steps 9 and 12 already produce the inputs; this packet wires their outputs into the backlog pipeline. Do not restructure the run loop.
+- **`proposed/` only.** `hive-sync`'s new write authority stops at `proposed/`. No `active/` write, no self-promotion, no GitHub issue creation.
+- **Drift only in this packet.** CVE and incident reactive sub-sources are a Phase-3 follow-up, explicitly out of scope.
+
+## Labels
+`docs`, `tier-2`, `meta`, `adr-0043`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Amend `hive-sync` with the Strategic acceptance trigger and the Reactive drift-to-packet conversion.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Wire the outputs of `hive-sync`'s existing acceptance-reconciliation and drift-detection steps into the ADR-0043 backlog pipeline.
+- Feature: ADR-0043 Continuous Backlog Generation rollout, Phase 1 (Strategic + Reactive-for-drift).
+- ADRs: ADR-0043 (D4/D8/D9), ADR-0014 (hive-sync mandate), ADR-0009 (CVE source, Phase-3).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — `proposed/` directory exists.
+- `packet:03` — `source`/`generator` frontmatter contract documented.
+
+**Constraints:**
+- Amend, do not re-architect; `proposed/` only; drift only (no CVE/incident in this packet).
+
+**Key Files:**
+- `.claude/agents/hive-sync.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0043-continuous-backlog-generation/06-architecture-source-agents-proposed-output-contract.md
+++ b/generated/issue-packets/active/adr-0043-continuous-backlog-generation/06-architecture-source-agents-proposed-output-contract.md
@@ -1,0 +1,144 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-2", "meta", "adr-0043", "wave-2"]
+dependencies: ["packet:02", "packet:03", "packet:04"]
+adrs: ["ADR-0043", "ADR-0007"]
+accepts: ["ADR-0043"]
+wave: 2
+initiative: adr-0043-continuous-backlog-generation
+node: honeydrunk-architecture
+---
+
+# Amend the scope, node-audit, and product-strategist agents for the proposed/ output contract
+
+## Summary
+Amend three backlog-source agent definitions — `scope`, `node-audit`, `product-strategist` — so each produces packets into `generated/issue-packets/proposed/` with the mandatory `source` and `generator` frontmatter, and follows its per-source cadence and quality-control rules from ADR-0043 D4.
+
+## Context
+ADR-0043 D1 names four backlog sources; D8 states "each gains a documented scheduled invocation per D4. No prompt changes required at this ADR's acceptance" — but the agent *definitions* must document the new output contract so each source produces ADR-0043-compliant packets. `hive-sync` is handled in packet 05. This packet handles the other three source-owning agents:
+
+- `scope` — owns the **Strategic** source. Currently writes packets into `generated/issue-packets/active/`. Must learn that source-triggered (agent-cadence) scope passes write to `proposed/`.
+- `node-audit` — feeds the **Tactical** source. Currently a read-only agent that recommends handoffs. Must learn to commit its audit report to `generated/audits/` and route findings to `scope` for `proposed/` packets.
+- `product-strategist` — owns the **Opportunistic** source. Scout mode must learn to write to `generated/scout-reports/` and route product-level findings to `pdr-composer` and in-scope findings to `proposed/` packets.
+
+`netrunner`'s weekly-briefing role is packet 07; this packet covers the three packet-*producing* source agents.
+
+This is an agent-definition (Markdown) packet. No code, no workflow, no .NET project. `.claude/agents/` is the agent source of truth per ADR-0007.
+
+## Scope
+- `.claude/agents/scope.md`
+- `.claude/agents/node-audit.md`
+- `.claude/agents/product-strategist.md`
+
+## Proposed Implementation
+
+### `scope.md` — Strategic source
+- **`active/` is the default; `proposed/` requires an explicit Strategic-source signal.** The agent definition must state the routing rule unambiguously: `scope` writes to `generated/issue-packets/active/` **by default and whenever the invocation mode is ambiguous**. Writing to `generated/issue-packets/proposed/` happens **only** when `scope` is invoked with an explicit agent-cadence Strategic-source signal (e.g. downstream of a `hive-sync`-detected ADR/PDR acceptance trigger, on the ADR-0043 cadence). If `scope` cannot positively confirm it is running as the Strategic source, it writes to `active/`.
+- Rationale to state in the definition: the 11 concurrent sibling ADR initiatives are scoped by operator-directed `scope` runs and **must** land in `active/` so `file-packets.yml` files them. A `proposed/` default would silently strand them (`file-packets.yml` does not scan `proposed/`). Defaulting to `active/` makes misrouting fail safe.
+- The distinction the agent definition must make explicit: **operator-directed runs and ambiguous-mode runs → `active/` (default); agent-cadence Strategic-source runs, only when explicitly signalled → `proposed/`.**
+- Every Strategic-source packet carries `source: strategic` and `generator: scope` frontmatter (per packet 03's `issue-authoring-rules.md`).
+- For operator-directed (human-initiated) scope passes, packets carry `generator: human` (the stable literal — never a GitHub handle) if the human is authoring directly, or `generator: scope` if `scope` itself authors them on the operator's instruction. Pin this in the definition; do not leave it open.
+- Document the D4 Strategic quality control: when a decision implies more than 3 packets, `scope` produces a dispatch plan and a `refine` pass runs against the dispatch plan before packets land in `proposed/`.
+
+### `node-audit.md` — Tactical source
+- `node-audit` stays read-only with respect to code, but document that its audit report is now **committed** to `generated/audits/{node}-{YYYY-MM-DD}.md` as the audit trail — even when no packets graduate (ADR-0043 D4 Tactical: "we looked at this Node and chose not to act" is information).
+- Document the handoff: `node-audit` findings the operator elects to act on are handed to `scope`, which writes them into `proposed/` as `source: tactical`, `generator: node-audit` — `generator` names the originating source agent (`node-audit`), since it is the agent that found the work. This is pinned, not left to the execution agent.
+- Reference `initiatives/audit-rotation.md` (packet 04) as the schedule that selects which Node `node-audit` runs against each week.
+- Preserve the existing read-only constraint — `node-audit` does not itself write packets; it writes its report to `generated/audits/` and hands findings to `scope`.
+
+### `product-strategist.md` — Opportunistic source
+- Document the monthly Scout-mode cadence as the Opportunistic backlog source.
+- Scout output: ranked opportunities. High-ranked items become PDR drafts via `pdr-composer` (feeding back into the Strategic source on acceptance). Lower-ranked in-scope items become `source: opportunistic`, `generator: product-strategist` packets in `proposed/`. The remainder are filed in `generated/scout-reports/{YYYY-MM-DD}.md` for future re-evaluation.
+- Document the D4 Opportunistic quality control: Scout output explicitly includes a "kill" / "build nothing right now" recommendation when warranted — the agent already carries this stance; the amendment makes the surfacing of it an ADR-0043 requirement.
+
+### Common
+- Each agent definition states the load-bearing discipline: agent-cadence-generated packets land in `proposed/`, never `active/`; the human is the only `proposed/` → `active/` authority (invariant 78 from packet 01). The one exception, stated above for `scope`: operator-directed and ambiguous-mode runs default to `active/` — `proposed/` requires an explicit Strategic-source signal.
+- **`generator` convention (pinned across all three agents):** `generator: human` (the stable literal, never a GitHub handle) for human-authored packets; the agent name (`generator: scope`, `generator: node-audit`, `generator: product-strategist`) for agent-authored packets.
+
+## Affected Files
+- `.claude/agents/scope.md`
+- `.claude/agents/node-audit.md`
+- `.claude/agents/product-strategist.md`
+
+## NuGet Dependencies
+None. This packet edits Markdown agent-definition files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `.claude/agents/` is the single source of truth for agent definitions (ADR-0007); lives in `HoneyDrunk.Architecture`. Correct repo.
+- [x] No code change in any repo.
+- [x] `scope`'s existing operator-directed `active/` behaviour is preserved; only agent-cadence runs change to `proposed/`.
+
+## Acceptance Criteria
+- [ ] `scope.md` states unambiguously that `active/` is the default — operator-directed runs AND ambiguous-mode runs write to `active/`; only an explicit agent-cadence Strategic-source signal routes to `proposed/`
+- [ ] `scope.md` records the rationale: a `proposed/` default would silently strand the concurrent sibling ADR initiatives, which `file-packets.yml` does not scan in `proposed/`
+- [ ] `scope.md` documents the `source: strategic` / `generator: scope` frontmatter and the >3-packet → dispatch-plan + `refine` quality control
+- [ ] All three agent definitions pin the `generator` convention: `human` literal for human-authored, agent name for agent-authored
+- [ ] `node-audit.md` documents that the audit report is committed to `generated/audits/{node}-{YYYY-MM-DD}.md` even when no packets graduate
+- [ ] `node-audit.md` documents the handoff to `scope` for `proposed/` packets and references `initiatives/audit-rotation.md` as its schedule
+- [ ] `product-strategist.md` documents the monthly Scout cadence, the PDR-vs-packet-vs-scout-report routing, and the `source: opportunistic` / `generator: product-strategist` frontmatter
+- [ ] `product-strategist.md` documents the "kill / build nothing" recommendation as an ADR-0043 D4 quality control
+- [ ] All three agent definitions state the human-only `proposed/` → `active/` promotion rule
+- [ ] Each amendment cross-references the relevant ADR-0043 D4 source section
+- [ ] Invariant 33 honored: if any context-loading section in `scope.md` changes, the mirror in `review.md` is updated in the same PR (see Constraints)
+
+## Human Prerequisites
+None. Pure Architecture-repo agent-definition edits.
+
+## Dependencies
+- `packet:02` — the `generated/issue-packets/proposed/`, `generated/audits/`, and `generated/scout-reports/` directories must exist before agents are told to write into them.
+- `packet:03` — the `source`/`generator` frontmatter contract must be documented in `issue-authoring-rules.md` first.
+- `packet:04` — `node-audit.md` references `initiatives/audit-rotation.md`, which packet 04 authors.
+
+## Referenced ADR Decisions
+
+**ADR-0043 D1** — Four sources: Strategic (`scope`), Tactical (`node-audit` → `scope`), Opportunistic (`product-strategist` → `pdr-composer`), Reactive (`hive-sync`/`scope`).
+**ADR-0043 D4 Strategic** — `scope` produces a dispatch plan when >3 packets are implied; `refine` runs against it before packets land in `proposed/`.
+**ADR-0043 D4 Tactical** — `node-audit` output always triaged to `proposed/`; audit report committed to `generated/audits/{node}-{YYYY-MM-DD}.md` even when no packets graduate.
+**ADR-0043 D4 Opportunistic** — Monthly Scout pass; ranked output; high → PDR draft, low in-scope → `proposed/` packet, remainder → `generated/scout-reports/`; explicit "kill" recommendation when warranted.
+**ADR-0043 D8** — Each agent gains a documented scheduled invocation; "no prompt changes required at acceptance" — this packet documents the output contract, which is the minimal compliant amendment.
+**ADR-0007** — `.claude/agents/` is the agent source of truth.
+
+## Constraints
+- **`active/` is the fail-safe default.** `scope` writes to `active/` for operator-directed runs and whenever the invocation mode is ambiguous. Routing to `proposed/` requires an explicit, positively-confirmed agent-cadence Strategic-source signal. This protects the 11 concurrent sibling ADR initiatives from being silently stranded in `proposed/`, which `file-packets.yml` does not scan.
+- **Preserve `scope`'s operator-directed behaviour.** A human directly invoking `scope` to file an initiative still uses `active/` exactly as today.
+- **`node-audit` stays read-only with respect to code.** It writes its report to `generated/audits/` and hands findings to `scope`; it does not author packets itself.
+- **Invariant 33 — review/scope context coupling.** "The set of files loaded by the review agent must be a superset of the set loaded by the scope agent. Updates to either agent's context-loading section must be mirrored in the other." If this packet's `scope.md` edit does not touch the context-loading list, no `review.md` change is needed; if it does, mirror it in `review.md` in the same PR.
+
+## Labels
+`docs`, `tier-2`, `meta`, `adr-0043`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Amend `scope`, `node-audit`, and `product-strategist` to produce ADR-0043-compliant `proposed/` output with `source`/`generator` frontmatter and per-source quality controls.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the three packet-producing source agents emit packets per the ADR-0043 contract.
+- Feature: ADR-0043 Continuous Backlog Generation rollout, Phase 1/2.
+- ADRs: ADR-0043 (D1/D4/D8), ADR-0007 (agent source of truth).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — directories exist.
+- `packet:03` — frontmatter contract documented.
+- `packet:04` — `audit-rotation.md` exists.
+
+**Constraints:**
+- `active/` is the fail-safe default for `scope`; `proposed/` requires an explicit Strategic-source signal. Ambiguous mode → `active/`.
+- Preserve `scope`'s operator-directed `active/` behaviour.
+- `node-audit` stays code-read-only.
+- `generator` pinned: `human` literal for humans, agent name for agents.
+- Honor invariant 33 — mirror any `scope.md` context-loading change into `review.md`.
+
+**Key Files:**
+- `.claude/agents/scope.md`
+- `.claude/agents/node-audit.md`
+- `.claude/agents/product-strategist.md`
+- `.claude/agents/review.md` (only if `scope.md`'s context-loading list changes)
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0043-continuous-backlog-generation/07-architecture-netrunner-weekly-briefing-mode.md
+++ b/generated/issue-packets/active/adr-0043-continuous-backlog-generation/07-architecture-netrunner-weekly-briefing-mode.md
@@ -1,0 +1,117 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-2", "meta", "adr-0043", "wave-2"]
+dependencies: ["packet:02", "packet:03"]
+adrs: ["ADR-0043", "ADR-0007"]
+accepts: ["ADR-0043"]
+wave: 2
+initiative: adr-0043-continuous-backlog-generation
+node: honeydrunk-architecture
+---
+
+# Add the weekly-briefing triage mode to the netrunner agent
+
+## Summary
+Amend the `netrunner` agent definition with a Weekly Briefing mode: a scheduled (weekly) triage report committed to `generated/briefings/{YYYY-MM-DD}.md` that summarizes new `proposed/` packets, closed and stale `active/` work, stale proposals, the top-3 recommended next actions, and any `priority: urgent` reactive packets — the single human-AI sync surface ADR-0043 D5 defines.
+
+## Context
+ADR-0043 D1 names one triage surface — the weekly briefing — and assigns it to `netrunner`. D5 makes it "the single review surface": the standing human-AI sync where the human reads, makes `proposed/` → `active/` triage decisions, and the week's work flows from the resulting `active/` queue. There is no other standing review (daily briefings were considered and rejected in D9).
+
+`netrunner` today produces an on-demand tactical "what's next?" briefing. The Weekly Briefing mode is a related but distinct output: it is scheduled, it is committed as a dated artifact, and its contents are fixed by ADR-0043 D5. This packet adds that mode to the agent definition without removing the existing on-demand briefing.
+
+This is an agent-definition (Markdown) packet. No code, no workflow, no .NET project. `.claude/agents/` is the agent source of truth per ADR-0007.
+
+## Scope
+- `.claude/agents/netrunner.md` — add the Weekly Briefing mode.
+
+## Proposed Implementation
+Add a "Weekly Briefing" mode section to `netrunner.md`. The mode produces one Markdown file at `generated/briefings/{YYYY-MM-DD}.md`. Its contents are fixed by ADR-0043 D5 — document each section:
+
+1. **New `proposed/` packets since the last briefing**, grouped by `source` (`strategic` / `tactical` / `opportunistic` / `reactive`). `netrunner` determines "since the last briefing" by reading the most recent prior file in `generated/briefings/`.
+2. **`active/` packets that closed since the last briefing.**
+3. **`active/` packets open more than 14 days with no status change** — the stale-work surface.
+4. **`proposed/` packets older than 30 days** — the stale-proposal surface, flagged for "promote, refine, or drop" triage.
+5. **The top-3 recommended next actions for the week ahead.**
+6. **Any `priority: urgent` reactive packets**, cross-referenced to `generated/briefings/urgent.md`.
+
+Document the framing rules from ADR-0043:
+- The briefing is **not** a backlog source — it is the human-facing triage trigger. Sources fill the queue; the briefing surfaces the head of it.
+- Cadence is weekly (Monday-of-each-week). Document that daily was rejected (D9) and bi-weekly is the fallback if weekly proves heavier than budgeted (D5 Operational Consequences) — the cadence is the lever before reducing sources.
+- The briefing is read-only with respect to packets — `netrunner` does not promote, edit, or delete packets. It summarizes; the human triages.
+- `priority: urgent` reactive packets do not wait for the Monday briefing — they are surfaced out-of-band in `generated/briefings/urgent.md` per D6. The weekly briefing still lists them (section 6) so they are not lost, but the urgent file is their primary surface.
+
+Document that the existing on-demand "what's next?" briefing modes (full briefing, "what shipped?", single-Node deep dive, etc.) are unchanged — the Weekly Briefing is an additional, scheduled, file-committed mode.
+
+## Affected Files
+- `.claude/agents/netrunner.md`
+
+## NuGet Dependencies
+None. This packet edits a Markdown agent-definition file; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `.claude/agents/` is the single source of truth for agent definitions (ADR-0007); lives in `HoneyDrunk.Architecture`. Correct repo.
+- [x] No code change in any repo.
+- [x] `netrunner`'s read-only / non-mutating posture is preserved — the Weekly Briefing summarizes, it does not triage.
+
+## Acceptance Criteria
+- [ ] `netrunner.md` has a Weekly Briefing mode section producing `generated/briefings/{YYYY-MM-DD}.md`
+- [ ] The six fixed sections (new proposed by source, closed active, stale active >14d, stale proposed >30d, top-3, urgent packets) are documented
+- [ ] The mode documents "since the last briefing" as derived from the most recent prior file in `generated/briefings/`
+- [ ] The weekly cadence is documented, with daily rejected and bi-weekly noted as the fallback lever
+- [ ] The briefing is documented as read-only with respect to packets — `netrunner` summarizes, the human triages
+- [ ] The `priority: urgent` out-of-band path via `generated/briefings/urgent.md` is documented
+- [ ] The existing on-demand briefing modes are documented as unchanged
+- [ ] The amendment cross-references ADR-0043 D1, D5, D6, D9
+
+## Human Prerequisites
+None. Pure Architecture-repo agent-definition edit.
+
+## Dependencies
+- `packet:02` — the `generated/briefings/` directory (and `urgent.md`) must exist before `netrunner` is told to write the weekly briefing into it.
+- `packet:03` — the briefing reads packet `source` and `priority` frontmatter; that contract must be documented in `issue-authoring-rules.md` first.
+
+## Referenced ADR Decisions
+
+**ADR-0043 D1** — The weekly briefing is the one named triage surface, owned by `netrunner`, committed to `generated/briefings/{YYYY-MM-DD}.md`.
+**ADR-0043 D5** — The weekly briefing is the single review surface; its six fixed sections; the human triages `proposed/` → `active/` from it. Bi-weekly is the fallback cadence lever.
+**ADR-0043 D6** — `priority: urgent` reactive packets are surfaced out-of-band in `generated/briefings/urgent.md` and do not wait for the Monday briefing.
+**ADR-0043 D9** — Daily briefings considered and rejected for a solo + agents shop; the weekly briefing begins Phase 2 / Week 3.
+**ADR-0007** — `.claude/agents/` is the agent source of truth.
+
+## Constraints
+- **Additive mode.** The Weekly Briefing is a new mode; the existing on-demand `netrunner` briefing behaviour is unchanged.
+- **Read-only with respect to packets.** `netrunner` summarizes the `proposed/` queue; it never promotes, edits, or deletes packets. Triage is the human's act at the briefing.
+- The briefing's six sections are fixed by ADR-0043 D5 — do not add or drop sections.
+
+## Labels
+`docs`, `tier-2`, `meta`, `adr-0043`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add a scheduled Weekly Briefing mode to `netrunner` that commits the ADR-0043 D5 triage report to `generated/briefings/`.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Give the human a single weekly triage surface that drains the `proposed/` queue.
+- Feature: ADR-0043 Continuous Backlog Generation rollout, Phase 2 (briefing begins Week 3).
+- ADRs: ADR-0043 (D1/D5/D6/D9), ADR-0007 (agent source of truth).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — `generated/briefings/` exists.
+- `packet:03` — `source`/`priority` frontmatter contract documented.
+
+**Constraints:**
+- Additive mode; existing on-demand briefing unchanged.
+- Read-only with respect to packets.
+- Six fixed sections per D5.
+
+**Key Files:**
+- `.claude/agents/netrunner.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0043-continuous-backlog-generation/08-architecture-phase-1-strategic-source-kickoff.md
+++ b/generated/issue-packets/active/adr-0043-continuous-backlog-generation/08-architecture-phase-1-strategic-source-kickoff.md
@@ -1,0 +1,114 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "meta", "adr-0043", "wave-3"]
+dependencies: ["packet:02", "packet:03", "packet:05", "packet:06"]
+adrs: ["ADR-0043"]
+accepts: ["ADR-0043"]
+wave: 3
+initiative: adr-0043-continuous-backlog-generation
+node: honeydrunk-architecture
+---
+
+# Phase 1 kickoff — validate the Strategic-source machinery end-to-end
+
+## Summary
+Run the first Strategic-source pass to **validate the machinery end-to-end**: invoke the `scope` agent against the Proposed ADRs in the ADR-0034 through ADR-0042 range and confirm the Strategic source produces correctly-routed, correctly-frontmattered output. This is a validation exercise, not a backlog-generation exercise. Because ADR-0034–0042 already have `active/` initiative folders, the expected and **acceptable PASS outcome is zero new packets plus a kickoff report** confirming the path works. Do not expect — or frame this as — a packet-producing run.
+
+## Context
+ADR-0043 D9 Phase 1 brings the Strategic source live. ADR-0043's Follow-up Work names the concrete kickoff: "Phase 1 kickoff: invoke `scope` against ADR-0034 through ADR-0042 to populate the first round of `proposed/` packets. This is also the first real-world test of the Strategic source."
+
+These nine ADRs (the commercial/substrate batch — public package distribution, abstractions versioning, disaster recovery, payment/billing, sender deliverability, OSS license, telemetry retention, AI model registry, async idempotency) are tracked in `initiatives/current-focus.md` Future/Watch as "all Proposed; each gated on a forcing function." The Strategic source's job here is **not** to accept those ADRs — it is to demonstrate that when an ADR moves to Accepted, the Strategic source produces well-formed implementation packets into `proposed/` for human triage.
+
+**What this packet actually validates — read honestly.** ADR-0043 D4 Strategic says the Strategic source triggers *on acceptance*. The nine ADRs in the 0034–0042 range are still Proposed and **already have scoped `active/` initiative folders**. This packet therefore very likely produces **zero new `proposed/` packets** — and that is the expected, acceptable PASS. Its real deliverable is proof that the Strategic-source machinery (the `scope` agent's `proposed/`-routing, the `source`/`generator` frontmatter, the directory plumbing) operates correctly end-to-end, and a kickoff report recording that. This packet does not generate backlog; it validates a path. Do not reframe it as a backlog-producing run, and do not treat a zero-packet result as a failure.
+
+This is a process/validation packet. No code, no workflow, no .NET project — its deliverable is a kickoff report, plus `proposed/` packet files only in the unlikely event an in-range ADR has no `active/` folder.
+
+## Scope
+- For each Proposed ADR in the ADR-0034 to ADR-0042 range that does **not** already have a scoped initiative folder under `generated/issue-packets/active/`, run a `scope` pass and write the resulting packets to `generated/issue-packets/proposed/`.
+- **Exclude** ADRs that already have an `active/` initiative folder: as of scoping, `active/` contains `adr-0034-public-package-distribution`, `adr-0035-abstractions-versioning`, `adr-0036-disaster-recovery-and-backup-policy`, `adr-0037-payment-and-billing-integration`, `adr-0038-outbound-sender-identity-and-deliverability`, `adr-0039-grid-open-source-license-policy`, `adr-0040-telemetry-backend-and-retention`, `adr-0041-ai-model-registry-and-approval-workflow`, and `adr-0042-idempotency-contract-for-async-boundaries`. The execution agent must re-check `active/` at execution time — **only ADRs in the 0034–0042 range with no existing folder get a Strategic pass.** If every ADR in the range already has a folder (likely, given the list above), this packet's deliverable shrinks to the kickoff report alone (see below) — that is an acceptable and expected outcome; record it.
+- `generated/briefings/` — write a short Phase-1 kickoff report `generated/briefings/{YYYY-MM-DD}-phase-1-kickoff.md` (or fold into the first weekly briefing if one has run) recording: which ADRs were scoped, how many `proposed/` packets were produced, which ADRs were skipped because they already have a folder, and an assessment of whether the Strategic source produced useful output (the Phase-1 go/no-go signal per ADR-0043 D9).
+
+## Proposed Implementation
+1. Enumerate `adrs/ADR-00{34..42}-*.md`; read each `**Status:**`.
+2. Cross-reference `generated/issue-packets/active/` for an existing `adr-00NN-*` initiative folder.
+3. For each ADR with **Proposed status and no existing folder**: run a `scope` pass producing packets with `source: strategic`, `generator: scope` frontmatter into `generated/issue-packets/proposed/`, named `{YYYY-MM-DD}-{repo}-{description}.md` per ADR-0008 D10. These are dry-run packets — they reference a Proposed (not Accepted) ADR and stay in `proposed/` until the parent ADR is accepted.
+4. Write the kickoff report to `generated/briefings/`.
+5. If all nine ADRs already have folders, step 3 produces nothing — this is the expected PASS. The kickoff report records that the Strategic-source machinery is validated (directory routing, `source`/`generator` frontmatter, the `scope` `proposed/` path all confirmed working by packets 05/06 and this run), states that zero new packets is a correct and acceptable outcome here, and recommends the next genuine Strategic trigger (the next real ADR acceptance) as the first true backlog-producing run.
+
+## Affected Files
+- `generated/issue-packets/proposed/*.md` (new — zero or more, depending on how many ADRs in range lack a folder)
+- `generated/briefings/{YYYY-MM-DD}-phase-1-kickoff.md` (new)
+
+## NuGet Dependencies
+None. This packet produces Markdown packet files and a report; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All output under `HoneyDrunk.Architecture/generated/`. Correct repo per routing.
+- [x] No code change in any repo. The `proposed/` packets *describe* future cross-repo work but are not themselves filed as issues — they await human triage.
+- [x] No ADR is accepted or modified by this packet.
+
+## Acceptance Criteria
+- [ ] Every Proposed ADR in the ADR-0034–0042 range has been checked for an existing `active/` initiative folder
+- [ ] For each in-range Proposed ADR without a folder, a `scope` pass has produced `proposed/` packets with `source: strategic` and `generator: scope` frontmatter
+- [ ] All produced packets are in `generated/issue-packets/proposed/`, none in `active/`
+- [ ] A Phase-1 kickoff report exists in `generated/briefings/` recording ADRs scoped, packet counts, ADRs skipped, and the Strategic-source go/no-go assessment
+- [ ] If all in-range ADRs already have folders, the kickoff report explicitly records that zero new packets is the expected, acceptable PASS and states the machinery is validated
+- [ ] The kickoff report frames this run as a machinery validation, not a backlog-generation exercise
+- [ ] No ADR status is changed by this packet
+
+## Human Prerequisites
+- [ ] Review the Phase-1 kickoff report and make the Phase-1 go/no-go call (ADR-0043 D9: "If Phase 1 generates more noise than value, Phases 2–4 don't auto-start"). The dry-run `proposed/` packets remain parked until their parent ADRs are accepted; the human decides at a weekly briefing whether to keep, refine, or drop them.
+
+## Dependencies
+- `packet:02` — the `generated/issue-packets/proposed/` and `generated/briefings/` directories must exist.
+- `packet:03` — the `source`/`generator` frontmatter contract must be documented before packets are produced with those fields.
+- `packet:05` — the `hive-sync` Strategic trigger documents how Strategic passes are triggered in steady state; this kickoff is the first manual exercise of that path.
+- `packet:06` — `scope.md` must document the agent-cadence-Strategic-runs-write-to-`proposed/` behaviour before `scope` is run as the Strategic source.
+
+## Referenced ADR Decisions
+
+**ADR-0043 D4 Strategic** — The Strategic source triggers on ADR/PDR acceptance; `scope` produces one packet per implementation step, a dispatch plan when >3 packets are implied, with a `refine` pass before packets land.
+**ADR-0043 D9 Phase 1** — Strategic source live; this kickoff is "the first real-world test of the Strategic source"; each phase is an independent go/no-go.
+**ADR-0043 Follow-up Work** — "Phase 1 kickoff: invoke `scope` against ADR-0034 through ADR-0042 to populate the first round of `proposed/` packets."
+
+## Constraints
+- **Dry run — no acceptance.** The ADR-0034–0042 batch is Proposed and gated on forcing functions. This packet does not accept any of them. Its packets stay in `proposed/` until the parent ADR is genuinely accepted.
+- **`proposed/` only.** No packet produced here goes to `active/`; the human triages.
+- **Skip already-scoped ADRs.** Any ADR with an existing `active/adr-00NN-*` folder is excluded — re-scoping it would duplicate filed work.
+- **Honor the >3-packet quality control.** If a scoped ADR implies more than 3 packets, produce a dispatch plan and note that a `refine` pass is owed before the packets would be promoted.
+
+## Labels
+`chore`, `tier-2`, `meta`, `adr-0043`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Run the first Strategic-source pass against the Proposed ADR-0034–0042 batch, seeding `generated/issue-packets/proposed/` and writing a Phase-1 kickoff report.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Validate the Strategic source end-to-end and produce the first round of `proposed/` packets.
+- Feature: ADR-0043 Continuous Backlog Generation rollout, Phase 1 kickoff.
+- ADRs: ADR-0043 (D4 Strategic, D9 Phase 1).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — directories exist.
+- `packet:03` — frontmatter contract documented.
+- `packet:05` — `hive-sync` Strategic trigger documented.
+- `packet:06` — `scope.md` `proposed/` behaviour documented.
+
+**Constraints:**
+- Dry run — accept no ADR; `proposed/` only; skip already-scoped ADRs; honor the >3-packet dispatch-plan rule.
+
+**Key Files:**
+- `adrs/ADR-0034-*.md` through `adrs/ADR-0042-*.md` (read-only, to scope)
+- `generated/issue-packets/active/` (read-only, to detect already-scoped ADRs)
+- `generated/issue-packets/proposed/*.md` (new output)
+- `generated/briefings/{YYYY-MM-DD}-phase-1-kickoff.md` (new report)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0043-continuous-backlog-generation/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0043-continuous-backlog-generation/dispatch-plan.md
@@ -1,0 +1,105 @@
+# Dispatch Plan: Continuous Backlog Generation (ADR-0043)
+
+**Date:** 2026-05-22 (initial scope).
+**Trigger:** ADR-0043 (Continuous Backlog Generation Strategy) — Proposed 2026-05-21; scoped 2026-05-22 (priority #5 on `current-focus.md`).
+**Type:** Single-repo. Every packet targets `HoneyDrunk.Architecture`. ADR-0043 D8 is explicit: "No code-Node changes. This is entirely a Meta-sector decision about how work flows into the existing pipeline." The four backlog *sources* eventually produce packets for all Nodes, but the *machinery* this initiative builds — directories, agent-definition amendments, the rotation file, the briefing mode, the rules amendment — lives entirely in the Architecture repo.
+**Sector:** Meta (governance + agent definitions + tracking files).
+**Status:** Draft — pending ADR-0043 acceptance. Packet 01 is the mechanically-coupled acceptance flip. Filing is automated on push to `main` via `file-packets.yml`.
+**Site sync required:** No. ADR-0043 produces governance docs and agent definitions; nothing public-facing on the Studios site.
+**Rollback plan:** Every packet is Markdown — governance docs, agent definitions, tracking files, directory READMEs. All revert cleanly via `git revert`. The four new directories revert by deletion (each holds only a README until packet 08 runs). The agent-definition amendments (packets 05/06/07) revert to the prior agent behaviour by reverting the file. Packet 08's `proposed/` output is dry-run packet files that are never filed as issues until a human triages them — reverting packet 08 simply removes those files from the queue. The phased rollout (D9) is itself the blast-radius control: each phase is a discrete go/no-go and Phases 2–4 do not auto-start if Phase 1 underperforms.
+
+## Summary
+
+ADR-0043 fills the empty slot **upstream** of the packet pipeline. Downstream of a packet is industrialized (file → issue → board → PR per ADR-0008); upstream — *finding* and *queuing* the work — was artisanal. ADR-0043 commits to four named backlog sources (Strategic, Tactical, Opportunistic, Reactive), a weekly triage briefing, a three-state packet lifecycle (`proposed/` → `active/` → `completed/`), and a packet-handoff contract.
+
+This initiative ships **eight packets across three waves**. It explicitly defers (per ADR-0043 D7) the *execution surface* — whether the source cadences run via OpenClaw cron, GitHub Actions cron, a `/loop` slash command, or manual invocation. That choice is a separate follow-up ADR due within 90 days of acceptance. Until then, the *shape* this initiative builds is honored by the human invoking the appropriate agent on the documented cadence.
+
+## Phase ↔ Wave mapping
+
+ADR-0043 D9 stages the rollout. This initiative's three waves build the *machinery*; the ADR's four *phases* are operational milestones that run on the machinery once it exists.
+
+- **Wave 1** = the Phase-1 foundation (acceptance, directories, the rules contract, the rotation schedule).
+- **Wave 2** = the agent amendments that make the sources and the briefing real (`hive-sync`, `scope`/`node-audit`/`product-strategist`, `netrunner`).
+- **Wave 3** = the Phase-1 kickoff dry run that validates the Strategic source.
+
+ADR-0043 D9's Phase 2 (Tactical rotation begins Week 3), Phase 3 (Opportunistic Scout; Reactive expands to CVE/incidents), and Phase 4 (execution-surface follow-up ADR) are operational milestones *after* this initiative's eight packets land — they are not packets here. Phase 3's CVE/incident reactive sub-sources and Phase 4's execution-surface ADR are out-of-scope follow-ups (see below).
+
+## Wave Diagram
+
+### Wave 1 — Foundation (Phase 1)
+
+Packet 01 first (the acceptance flip). Then 02, 03, 04 in parallel — all depend only on 01.
+
+- [ ] `HoneyDrunk.Architecture`: **Accept ADR-0043** — flip status, finalize the two new invariants, register the initiative — [`01-architecture-adr-0043-acceptance.md`](01-architecture-adr-0043-acceptance.md)
+- [ ] `HoneyDrunk.Architecture`: Create the four backlog-generation directories with READMEs — [`02-architecture-create-backlog-generation-directories.md`](02-architecture-create-backlog-generation-directories.md)
+  - Blocked by: `packet:01`.
+- [ ] `HoneyDrunk.Architecture`: Amend `issue-authoring-rules.md` for `source`/`generator`/`priority` + the three-state lifecycle — [`03-architecture-issue-authoring-rules-source-generator-fields.md`](03-architecture-issue-authoring-rules-source-generator-fields.md)
+  - Blocked by: `packet:01`.
+- [ ] `HoneyDrunk.Architecture`: Author `initiatives/audit-rotation.md` with the 12-Node rotation — [`04-architecture-author-audit-rotation-file.md`](04-architecture-author-audit-rotation-file.md)
+  - Blocked by: `packet:01`.
+
+### Wave 2 — Source and briefing agents (Phase 1/2)
+
+Runs after Wave 1. Packets 05, 06, 07 — each depends on the directories (02) and the frontmatter contract (03); 06 also needs the rotation file (04).
+
+- [ ] `HoneyDrunk.Architecture`: Amend `hive-sync` — Strategic acceptance trigger + Reactive drift-to-packet conversion — [`05-architecture-hive-sync-strategic-and-reactive-triggers.md`](05-architecture-hive-sync-strategic-and-reactive-triggers.md)
+  - Blocked by: `packet:02`, `packet:03`.
+- [ ] `HoneyDrunk.Architecture`: Amend `scope`/`node-audit`/`product-strategist` for the `proposed/` output contract — [`06-architecture-source-agents-proposed-output-contract.md`](06-architecture-source-agents-proposed-output-contract.md)
+  - Blocked by: `packet:02`, `packet:03`, `packet:04`.
+- [ ] `HoneyDrunk.Architecture`: Add the Weekly Briefing mode to `netrunner` — [`07-architecture-netrunner-weekly-briefing-mode.md`](07-architecture-netrunner-weekly-briefing-mode.md)
+  - Blocked by: `packet:02`, `packet:03`.
+
+### Wave 3 — Phase-1 kickoff dry run
+
+Runs after Wave 2. Packet 08 — the first real exercise of the Strategic source.
+
+- [ ] `HoneyDrunk.Architecture`: Phase 1 kickoff — run the Strategic source against the Proposed ADR-0034–0042 batch — [`08-architecture-phase-1-strategic-source-kickoff.md`](08-architecture-phase-1-strategic-source-kickoff.md)
+  - Blocked by: `packet:02`, `packet:03`, `packet:05`, `packet:06`.
+
+## Blocking relationships
+
+The filing pipeline wires `addBlockedBy` from each packet's `dependencies:` frontmatter. For reference:
+
+- `02` ← `01`
+- `03` ← `01`
+- `04` ← `01`
+- `05` ← `02`, `03`
+- `06` ← `02`, `03`, `04`
+- `07` ← `02`, `03`
+- `08` ← `02`, `03`, `05`, `06`
+
+## Actor classification
+
+Every packet is **`Actor=Agent`** — all eight are Markdown governance/agent/tracking edits within delegable reach. No packet carries the `human-only` label. Three packets carry Human Prerequisites that are *confirmation* steps, not blockers on the agent's critical path:
+
+- **Packet 01** — the human confirms before merge that no invariant above 51 has landed from outside the 12-ADR batch (which would force the reserved 78/79 block to shift upward).
+- **Packet 04** — the human confirms the audit-rotation order (the agent proposes a defensible default from `nodes.json`).
+- **Packet 08** — the human makes the Phase-1 go/no-go call on the kickoff report (ADR-0043 D9: Phases 2–4 do not auto-start if Phase 1 is more noise than value).
+
+## Out-of-scope items from ADR-0043
+
+- **The execution-surface follow-up ADR (D7).** ADR-0043 explicitly defers whether the source cadences run via OpenClaw cron, GitHub Actions cron, a `/loop` slash command, or manual invocation. A follow-up ADR decides this within 90 days of acceptance, after the first `node-audit` rotation quarter and the first Scout pass. **Not a packet here** — it is a new ADR, routed to `adr-composer` when the 90-day window or the informing data arrives.
+- **Reactive CVE and incident sub-sources (D9 Phase 3).** Packet 05 wires Reactive-for-*drift* only — the lowest-cost sub-source, "already 80% built into `hive-sync`." The security-CVE sub-source (ADR-0009 nightly scan → `priority: urgent` packet) and the incident sub-source (`generated/incidents/` → corrective-action packet) expand in Phase 3. Each is its own follow-up packet against the then-current `hive-sync`.
+- **Canary-failure Reactive sub-source (D4 Reactive).** ADR-0043 D4 lists "canary failing past its grace window" as a Reactive trigger. Like the CVE/incident sub-sources, this is a Phase-3 expansion; not scoped here.
+- **The Opportunistic Scout cadence going live (D9 Phase 3).** Packet 06 documents `product-strategist`'s output contract; the monthly Scout pass actually beginning is a Phase-3 operational milestone, not a packet.
+
+## current-focus.md priority correspondence
+
+`current-focus.md` priority #5 ("Land ADR-0043 — Backlog Generation") is discharged by this initiative. Its exit signal — "ADR-0043 Accepted; `generated/issue-packets/proposed/` directory + Strategic source live" — is satisfied by packet 01 (Accepted), packet 02 (`proposed/` directory), and packets 05/06/08 (Strategic source live and exercised). When all eight packets reach `Done` on The Hive, priority #5 should be marked complete and dropped from the ranked list at the next ADR-0043 weekly briefing. (Pleasingly recursive: ADR-0043's own completion is triaged by the briefing surface ADR-0043 creates.)
+
+## Agents intentionally NOT amended
+
+ADR-0043 D4's Strategic path invokes the `refine` agent (a `refine` pass runs against the dispatch plan when a decision implies more than 3 packets). **`refine.md` is deliberately left unchanged** by this initiative: `refine` already reviews dispatch plans as its existing function and needs no new behaviour to play its ADR-0043 role. The gap is intentional and explained here, not silent — there is no missing packet.
+
+## Notes
+
+- **Invariant numbers are pre-reserved at 78-79.** ADR-0043's two new invariants take the hard-reserved numbers 78 and 79 (packet 01). The true current max in `constitution/invariants.md` is 51 (verified). 78-79 are pre-reserved as part of a 12-ADR batch to avoid colliding with ADR-0044 over 52/53. **If any invariant above 51 lands from outside this batch before merge, shift this block upward, never reuse a number.** Packet 01 must not scan for "next free."
+- **Acceptance precedes flip.** ADR-0043 stays Proposed until packet 01's PR merges. Packet 01 is the mechanically-coupled acceptance flip.
+- **Single-repo initiative.** Unlike most multi-repo ADR rollouts, every packet here targets `HoneyDrunk.Architecture`. The dispatch plan exists because the eight packets have a real dependency chain across three waves, not because the work spans repos.
+- **Packet 08 is a machinery validation, not a backlog run.** Packet 08 runs the Strategic source against the ADR-0034–0042 batch purely to validate the machinery end-to-end (`proposed/` routing, `source`/`generator` frontmatter, the `scope` path). Those ADRs already have `active/` folders, so the expected and **acceptable PASS outcome is zero new packets plus a kickoff report** confirming the path works. Packet 08 does not oversell itself as generating backlog; a zero-packet result is success, not failure.
+- **Invariant 33 coupling.** Packet 06 amends `scope.md`. If that edit touches `scope.md`'s context-loading section, the mirror in `review.md` must be updated in the same PR (invariant 33: review-agent context must be a superset of scope-agent context). Packet 06's acceptance criteria carry this check.
+- **The dispatch plan is the one exception to packet immutability** (ADR-0008 D7). It is updated at wave boundaries as the historical record.
+
+## Archival
+
+Per ADR-0008 D10 and ADR-0043 D3, when every packet reaches `Done` on The Hive and ADR-0043's Phase-1 go decision is recorded, the `active/adr-0043-continuous-backlog-generation/` folder moves to `completed/` in a single commit. ADR-0043 D3 formalizes the lifecycle as `proposed/` → `active/` → `completed/`; there is no `archive/` state, and invariant 37 confirms completed packets move to `completed/`. The Phase-2/3/4 operational milestones and the execution-surface follow-up ADR are tracked separately — they are not appended to this initiative folder.


### PR DESCRIPTION
## Summary
Adds the issue packets for **ADR-0043 — Continuous backlog generation strategy** under `generated/issue-packets/active/adr-0043-continuous-backlog-generation/`.

One of 12 per-ADR PRs from the 2026-05-21 ADR batch — split per ADR so `file-packets.yml` files incrementally per merge rather than firing all 92 packets at once (GraphQL rate limits).

## Test plan
- [ ] `file-packets.yml` files this ADR's packets on merge and adds them to The Hive
- [ ] No GraphQL rate-limit errors in the filing run

🤖 Generated with [Claude Code](https://claude.com/claude-code)