### PR TITLE
Scope ADR-0045 — grid-wide error tracking

### DIFF
--- a/adrs/ADR-0045-grid-wide-error-tracking.md
+++ b/adrs/ADR-0045-grid-wide-error-tracking.md
@@ -5,9 +5,11 @@
 **Deciders:** HoneyDrunk Studios
 **Sector:** Ops / cross-cutting
 
+> **Amendment — 2026-05-22.** The original draft placed the error-reporting abstraction and the App Insights error backing in `HoneyDrunk.Observe`. That assignment was a boundary error: `repos/HoneyDrunk.Observe/boundaries.md` explicitly states outbound telemetry to external sinks belongs to **`HoneyDrunk.Pulse`** — Observe is the *inbound* external-system observation layer. `HoneyDrunk.Pulse` is the LIVE (v0.3.0) telemetry-export Node and already owns `ITraceSink`/`ILogSink`/`IMetricsSink`/`IAnalyticsSink`/**`IErrorSink`** plus the `HoneyDrunk.Telemetry.Sink.*` provider family (including `HoneyDrunk.Telemetry.Sink.AzureMonitor` and `HoneyDrunk.Telemetry.Sink.Sentry`). This ADR is corrected throughout to target **Pulse** for the error path, matching the same correction already applied to the companion ADR-0040. The error-reporting facade lives in `HoneyDrunk.Telemetry.Abstractions`; the App Insights error backing **extends the existing `HoneyDrunk.Telemetry.Sink.AzureMonitor` package** — it does not create a new package and does not live in Observe. See D3 for the `IErrorReporter`/`IErrorSink` reconciliation.
+
 ## Context
 
-ADR-0040 (Proposed) selects Azure Monitor + Application Insights as the unified backend for **traces, metrics, and logs**, with `HoneyDrunk.Observe` as the OTLP-only boundary. That decision scopes itself to those three signal types; this ADR addresses **errors** as a distinct signal with first-class error-tracking semantics.
+ADR-0040 (Proposed) selects Azure Monitor + Application Insights as the unified backend for **traces, metrics, and logs**, with `HoneyDrunk.Pulse` as the telemetry-export boundary. That decision scopes itself to those three signal types; this ADR addresses **errors** as a distinct signal with first-class error-tracking semantics.
 
 Today the error story is uneven:
 
@@ -23,7 +25,7 @@ The forcing functions for deciding this now:
 - **Notify Cloud GA** (PDR-0002 / ADR-0027) carries an implicit "we know when errors happen on tenant traffic" expectation.
 - **The existing Notify-Sentry setup needs governance.** Without an ADR, the Notify configuration drifts: account ownership, DSN rotation, sample-rate decisions, PII scrubbing rules all live in unrecorded form.
 
-This ADR decides errors as a fourth Grid signal type, the v1 backend (**Application Insights' Failures + exception tracking**), the **Observe-mediated** integration pattern (preserving ADR-0010's provider-slot reversibility), the cross-link semantics, the per-Node opt-in mechanics, and the explicit **escalation path to Sentry** if v1 doesn't earn its keep.
+This ADR decides errors as a fourth Grid signal type, the v1 backend (**Application Insights' Failures + exception tracking**), the **Pulse-mediated** integration pattern (preserving the sink-provider reversibility Pulse already implements), the cross-link semantics, the per-Node opt-in mechanics, and the explicit **escalation path to Sentry** if v1 doesn't earn its keep.
 
 ## Decision
 
@@ -48,13 +50,18 @@ App Insights' Failures is acknowledged as **"Sentry-lite"** — the model and wo
 
 The architectural property that matters is preserved: **one backend, one unified-view surface, native cross-signal navigation** (D4). The error workflow is good enough for v1 Grid volume; the abstraction (D3) makes future migration cheap.
 
-### D3 — Errors flow through Observe via `IErrorReporter`
+### D3 — Errors flow through Pulse; `IErrorReporter` is a thin facade over the existing `IErrorSink`
 
-The principle from ADR-0010 (Observe is the provider-slot connector layer) and ADR-0040 D2 (Observe is the OTLP-only boundary) extends to errors with a small carve-out: **errors flow through Observe**, but the App Insights connector for errors uses the **App Insights .NET SDK** wrapped behind an `IErrorReporter` interface in `HoneyDrunk.Observe.Abstractions`, not raw OTLP.
+Errors flow through **`HoneyDrunk.Pulse`** — the Grid's telemetry-export Node — exactly as traces/metrics/logs do per ADR-0040. The App Insights connector for errors uses the **App Insights .NET SDK** (not raw OTLP) because App Insights' error model carries fields that are not OTLP primitives — `problem_id`, `application_Version`, custom dimensions for user/tenant scoping that participate in the Failures-blade grouping. The SDK is wrapped behind a sink so the substrate can survive a future backend swap (Sentry per D11, GlitchTip, Bugsnag, etc.).
 
-The carve-out exists because App Insights' error model carries fields that are not OTLP primitives — `problem_id`, `application_Version`, custom dimensions for user/tenant scoping that participate in the Failures-blade grouping. Routing errors as OTLP-generic would strip those features. Better to use the SDK behind an abstraction so the abstraction can survive a future backend swap (Sentry per D11, GlitchTip, Bugsnag, etc.).
+**Reconciliation with Pulse's existing `IErrorSink`.** `HoneyDrunk.Pulse` (v0.3.0, LIVE) **already ships `IErrorSink`** in `HoneyDrunk.Telemetry.Abstractions` — a structured error-capture contract (`CaptureAsync(ErrorEvent)`, `CaptureExceptionAsync`, `CaptureMessageAsync`, `FlushAsync`) with an `ErrorEvent` model carrying exception, message, severity, `CorrelationId`/`OperationId`, `NodeId`, `UserId`, `Environment`, `Release`, and a tag/extra dictionary. The error *capture and fan-out* contract therefore **already exists** — this ADR does **not** create a parallel one.
 
-The `IErrorReporter` shape (added to `HoneyDrunk.Observe.Abstractions`):
+`IErrorReporter` is kept as a **thin, Grid-facing convenience facade layered over `IErrorSink`** — it is explicitly **not** a duplicate of `IErrorSink`. The division of labour:
+
+- **`IErrorSink`** (existing, unchanged) — the sink/fan-out contract. One of five Pulse sinks the Collector fans telemetry out to. It takes a fully-populated `ErrorEvent` and routes it to a backend. It has no notion of ambient request context, no breadcrumb/scope stack — those are caller-side concerns.
+- **`IErrorReporter`** (new, the facade) — the application-facing ergonomic contract a Node consumes. It captures ambient context (the current `Activity`/`trace_id`, the Grid `TenantId`/`PrincipalId`, the deployable `Release`), maintains the breadcrumb/scope stack, builds an `ErrorEvent` from that context, and hands it to `IErrorSink`. It adds no new capture mechanism — it adds ambient-context capture and Sentry-style breadcrumb/scope ergonomics on top of the existing sink.
+
+The `IErrorReporter` facade shape (added to `HoneyDrunk.Telemetry.Abstractions`, alongside `IErrorSink`):
 
 ```
 ValueTask CaptureException(Exception ex, ErrorContext? context = null);
@@ -63,9 +70,9 @@ IDisposable AddBreadcrumb(Breadcrumb crumb);
 IDisposable PushScope(ErrorScope scope);
 ```
 
-`ErrorContext` carries `trace_id` (linking automatically to App Insights traces), `tenant_id` (linking to ADR-0026's primitives), `user_id`, `release` (= application version), and arbitrary tag dictionary. `Breadcrumb` and `ErrorScope` are modeled on Sentry's semantics — they're backend-portable concepts that App Insights can express via custom events on the same `operation_id`, and that Sentry would consume natively if D11 ever fires.
+`ErrorContext` carries `trace_id` (linking automatically to App Insights traces), `tenant_id` (linking to ADR-0026's primitives — the dimension `IErrorSink`'s `ErrorEvent` does **not** carry, and the load-bearing reason the facade exists), `user_id`, `release` (= application version), and an arbitrary tag dictionary. The facade maps `ErrorContext` onto `ErrorEvent` fields (`OperationId`/`CorrelationId` ← `trace_id`; `UserId`; `Release`; tenant id and breadcrumbs ride on `ErrorEvent.Tags`/`ErrorEvent.Extra`). `Breadcrumb` and `ErrorScope` are modeled on Sentry's semantics — backend-portable concepts that App Insights expresses via custom events on the same `operation_id` and that Sentry consumes natively if D11 fires.
 
-The v1 default backing is `HoneyDrunk.Observe.AzureMonitor` (the same backing per ADR-0040 — errors share the App Insights resource with traces/metrics/logs). A Sentry backing (`HoneyDrunk.Observe.Sentry`) is sketched as the D11 escalation path; not implemented at v1.
+The v1 default error backing **extends the existing `HoneyDrunk.Telemetry.Sink.AzureMonitor` package** — the same Pulse sink that ADR-0040 uses for traces/metrics/logs. Errors share the App Insights resource. **No new package is created.** A Sentry error backing already exists as `HoneyDrunk.Telemetry.Sink.Sentry`; it is the D11 escalation path — present in the repo, not the v1 default.
 
 ### D4 — Cross-link is native via `operation_id`
 
@@ -79,11 +86,11 @@ This is the **load-bearing piece** for the unified-view claim. ADR-0040 D4 (cros
 
 If D11 ever fires (move to Sentry), cross-linking re-emerges as a configured integration via `trace_id` — same shape as the original draft of this ADR contemplated. The configuration cost is the trade-off accepted at escalation.
 
-### D5 — Per-Node opt-in via Observe configuration
+### D5 — Per-Node opt-in via Pulse configuration
 
-Each Node enables error capture by configuring its consumption of `IErrorReporter` (which is part of the standard Observe registration). All Nodes consuming Observe get error reporting automatically once the Observe backing is wired; opt-out is per Node via the Observe configuration if a Node has reason to suppress errors (rare; e.g., `HoneyDrunk.Architecture` itself, which does not run user-facing code).
+Each Node enables error capture by configuring its consumption of `IErrorReporter` (which is part of the standard Pulse telemetry registration). All Nodes consuming Pulse get error reporting automatically once the error sink backing is wired; opt-out is per Node via the Pulse configuration if a Node has reason to suppress errors (rare; e.g., `HoneyDrunk.Architecture` itself, which does not run user-facing code).
 
-`HoneyDrunk.Notify`'s existing Sentry configuration is **migrated** into this pattern. Notify drops its direct `SentrySdk.Init(dsn)` call; depends on `HoneyDrunk.Observe` (already does, via the broader Observe relationship); replaces every `SentrySdk.CaptureException(...)` call with `_errorReporter.CaptureException(...)`. Errors flow to App Insights instead of Sentry. The Notify-specific Sentry account is archived after a parallel-run window.
+`HoneyDrunk.Notify`'s existing Sentry configuration is **migrated** into this pattern. A source scan found **no Sentry SDK code in Notify** — only account/DSN configuration. So the migration is config-only: Notify audits its D8 error-capture sites, wires them to `IErrorReporter` via its Pulse telemetry dependency, and the Notify-specific Sentry account is archived. Errors flow to App Insights instead of Sentry. Because nothing in Notify emits to Sentry from code, there is **no parallel-output window** — the cutover is the moment `IErrorReporter` is wired. (If an execution-time scan unexpectedly finds SDK code, the SDK-replacement path with a parallel-run window is the fallback.)
 
 This is the explicit reversal of the first draft of this ADR, which proposed adopting Sentry Grid-wide. The current decision adopts App Insights Grid-wide; Notify's existing Sentry usage is **removed**, not extended.
 
@@ -91,9 +98,9 @@ This is the explicit reversal of the first draft of this ADR, which proposed ado
 
 App Insights' release-tracking feature uses the `application_Version` property on captured telemetry. Wiring to the Grid's release flows:
 
-- **Container Apps deployable Nodes** (Notify.Functions, Notify.Worker, Pulse.Collector, future Notify Cloud) — the `HoneyDrunk.Actions` reusable deploy workflows (per ADR-0015) are amended to set `application_Version` to the deployable's SemVer tag (per ADR-0033's tag→environment mapping) via the App Insights resource's release annotations API. Captured exceptions automatically carry this version.
+- **Container Apps deployable Nodes** (Notify.Functions, Notify.Worker, Pulse.Collector, future Notify Cloud) — the `HoneyDrunk.Actions` reusable deploy workflows (per ADR-0015) are amended to set `application_Version` to the deployable's SemVer tag (per ADR-0033's tag→environment mapping) and to mark the deploy via the current supported release-annotation mechanism. Captured exceptions automatically carry this version.
 - **Library / Abstractions packages** — not deployable, do not set a version. Errors caught in code consuming a library record the consuming application's version, not the library's package version.
-- **Release annotations** — App Insights' release annotations API (`https://aigs1.aisvc.visualstudio.com/applicationinsights/release/v2.0/api`) is called from the deploy workflow with the new version. The Failures blade surfaces these as annotations on the trend graph, making "this error first appeared in v0.4.2" visible.
+- **Release annotations** — the deploy workflow marks the deploy moment on the App Insights Failures trend graph using the **current supported release-annotation mechanism** (`az monitor app-insights` / ARM). The legacy `aisvc.visualstudio.com` annotations endpoint is a fallback only if no supported equivalent applies. The Failures blade surfaces these annotations, making "this error first appeared in v0.4.2" visible.
 
 The workflow quality is **lower than Sentry's** release surface (Sentry has a richer Issues/Releases UX with regression detection, suspect commits, suspect releases). Acceptable for v1 Grid volume; named as one of the D11 escalation triggers if error-triage volume grows.
 
@@ -104,7 +111,7 @@ Errors can leak PII, tenant data, and model content. The mechanism is `ITelemetr
 - **`tenant_id` is allowed** as a custom dimension on exceptions; low cardinality bounded by tenant count. Load-bearing for multi-tenant triage. Not considered PII.
 - **`user_id` is allowed but pseudonymous** — the Grid's internal opaque `PrincipalId` per ADR-0026, never an email or external identifier.
 - **Prompt/completion text from AI Nodes** follows ADR-0040 D9: **forbidden by default**, allowed only behind the `evals.sensitive=true` carve-out. Exceptions thrown from agent execution paths must scrub the prompt/completion content before capture; the breadcrumb (capability invoked, model, cost) is allowed.
-- **Common PII patterns** (emails, phone numbers, credit card patterns, API keys, JWT shapes) are stripped from exception messages and custom dimensions by a regex-based processor in `HoneyDrunk.Observe.AzureMonitor`.
+- **Common PII patterns** (emails, phone numbers, credit card patterns, API keys, JWT shapes) are stripped from exception messages and custom dimensions by the shared, mechanism-agnostic PII scrubber that ADR-0040 builds as a shared component; the error path in `HoneyDrunk.Telemetry.Sink.AzureMonitor` consumes that shared scrubber rather than re-implementing the regex set.
 - **`HoneyDrunk.Audit`-emitted errors** are PII-bearing by design (recipient address on a notification failure, for instance). These flow to the dedicated Audit-tagged Log Analytics table with `sensitive=audit` and 730-day retention per ADR-0040 D3.
 
 ### D8 — When to capture an error vs. log a line
@@ -137,8 +144,8 @@ Free Sentry-tier (5K errors/month, 1 user, 30-day retention) is what the Notify-
 
 ### D10 — Phased rollout
 
-- **Phase 1 (Week 1–2) — `IErrorReporter` abstraction + Notify migration.** Add `IErrorReporter` and related types to `HoneyDrunk.Observe.Abstractions`. Implement the App Insights backing in `HoneyDrunk.Observe.AzureMonitor`. Migrate `HoneyDrunk.Notify` from direct Sentry SDK to `IErrorReporter`; run in parallel-output mode for one week (errors go to both Sentry and App Insights for parity verification); cut over; archive the Notify-Sentry account.
-- **Phase 2 (Week 3–6) — Rollout to deployable Nodes.** Notify.Functions, Notify.Worker, Pulse.Collector wire `IErrorReporter` via their existing Observe dependency. Release tracking (D6) lands in the deploy workflows.
+- **Phase 1 (Week 1–2) — `IErrorReporter` facade + Notify migration.** Add the `IErrorReporter` facade and related types to `HoneyDrunk.Telemetry.Abstractions` (alongside the existing `IErrorSink`). Extend the App Insights error backing in `HoneyDrunk.Telemetry.Sink.AzureMonitor`. Migrate `HoneyDrunk.Notify` onto `IErrorReporter` — config-only (Notify has no Sentry SDK code); wire the D8 capture sites and archive the Notify-Sentry account. No parallel-output window is needed because nothing in Notify emits to Sentry from code.
+- **Phase 2 (Week 3–6) — Rollout to deployable Nodes.** Notify.Functions, Notify.Worker, Pulse.Collector wire `IErrorReporter` via their existing Pulse telemetry dependency. Release tracking (D6) lands in the deploy workflows.
 - **Phase 3 (Month 2–3) — AI-sector standup wave consumes the pattern.** Every Seed-sector AI Node, on standup, wires `IErrorReporter` from day one. The agent execution loop's breadcrumb usage (tool dispatched, model invoked, cost incurred) is the high-value error-tracking surface area for AI Nodes.
 - **Phase 4 (Month 3+) — Escalation evaluation.** Review observed error volume, triage workflow pain points, and Notify Cloud GA error surfaces. Decide whether any D11 trigger has fired. If yes, the relevant escalation amendment lands. If no, hold on App Insights.
 
@@ -155,7 +162,7 @@ Application Insights' Failures + exception tracking is the v1 default chosen for
 | Tenant-scoped error views needed (Notify Cloud) | Multi-tenant error triage at scale needs Sentry's tag-and-environment filtering polish. | Move errors to Sentry; preserve tenant-scoped App Insights traces for context. |
 | AI-sector tool-call breadcrumb depth | Agent-execution failures need the rich breadcrumb chain Sentry handles natively but App Insights expresses awkwardly via custom events. | Move errors to Sentry; preserve App Insights for traces/metrics/logs of the same execution. |
 
-The escalation preserves the substrate: `IErrorReporter` abstraction stays, `HoneyDrunk.Observe.Sentry` backing comes online, the Observe-level configuration swap moves errors to Sentry while traces/metrics/logs stay on App Insights. The result is the two-backend posture the first draft of this ADR committed to, **arrived at with evidence rather than speculation.**
+The escalation preserves the substrate: the `IErrorReporter` facade and `IErrorSink` contract stay, the existing `HoneyDrunk.Telemetry.Sink.Sentry` backing is activated as the error sink, the Pulse-level configuration swap moves errors to Sentry while traces/metrics/logs stay on App Insights. The result is the two-backend posture the first draft of this ADR committed to, **arrived at with evidence rather than speculation.**
 
 Combined cost at escalation: App Insights (~$30–100/month for traces/metrics/logs) + Sentry (free or Team $26/month) = within ADR-0040's $100/month ceiling at low volume, growing to ~$150/month at meaningful Notify Cloud volume.
 
@@ -167,20 +174,20 @@ Recorded explicitly so the boundary doesn't blur: Pulse → metrics/logs; applic
 
 ### D13 — Relationship to ADR-0010, ADR-0040, and the existing Notify-Sentry setup
 
-- **ADR-0010** — preserved. `HoneyDrunk.Observe` is the provider-slot connector layer. This ADR adds `IErrorReporter` to its abstractions surface alongside the existing OTLP-shaped surfaces.
-- **ADR-0040** — extended. ADR-0040 covers traces/metrics/logs in App Insights; this ADR covers errors in the same App Insights resource. The two are complementary; ADR-0040's "unified view" claim is completed by D4's native cross-link.
-- **Existing Notify-Sentry setup** — **removed, not extended.** The first draft of this ADR proposed adopting Sentry Grid-wide; this revised decision instead migrates Notify off Sentry onto App Insights. The Notify-Sentry account is archived after the parallel-run window (D5/Phase 1). Sentry returns only if D11 fires.
+- **ADR-0010** — preserved. `HoneyDrunk.Observe` remains the inbound external-system observation layer; this ADR does **not** touch Observe. Outbound error telemetry is a Pulse concern per Observe's and Pulse's boundary docs.
+- **ADR-0040** — extended. ADR-0040 covers traces/metrics/logs through Pulse into App Insights; this ADR covers errors through the same Pulse sink family into the same App Insights resource. The two are complementary; ADR-0040's "unified view" claim is completed by D4's native cross-link. ADR-0040 was likewise corrected to target Pulse — this ADR's correction is the matching companion change.
+- **Existing Notify-Sentry setup** — **removed, not extended.** The first draft of this ADR proposed adopting Sentry Grid-wide; this revised decision instead migrates Notify off Sentry onto App Insights. The Notify-Sentry account is archived once `IErrorReporter` is wired (D5/Phase 1) — config-only, no parallel-run window, since Notify has no Sentry SDK code. Sentry returns only if D11 fires, via the existing `HoneyDrunk.Telemetry.Sink.Sentry` package.
 
 ## Consequences
 
 ### Affected Nodes
 
-- **HoneyDrunk.Observe** — primary affected Node. `HoneyDrunk.Observe.Abstractions` gains `IErrorReporter`, `ErrorContext`, `ErrorScope`, `Breadcrumb`, `ErrorLevel`. `HoneyDrunk.Observe.AzureMonitor` (the ADR-0040 backing) extends to handle error capture via the App Insights SDK.
-- **HoneyDrunk.Notify** — direct-Sentry usage migrates to `IErrorReporter`; Notify-Sentry account archived after parallel-run cutover.
-- **HoneyDrunk.Notify.Functions, HoneyDrunk.Notify.Worker, HoneyDrunk.Pulse.Collector** — consume `IErrorReporter` via their existing Observe dependency in Phase 2.
-- **HoneyDrunk.Actions** — reusable deploy workflows amended to call the App Insights release annotations API as a post-deploy step (D6).
-- **HoneyDrunk.Vault** — App Insights instrumentation keys (from ADR-0040) are reused; no new secrets for the error path in v1. If D11 fires, Sentry DSNs join Vault.
-- **HoneyDrunk.Architecture** — `catalogs/contracts.json` gains `IErrorReporter` under the Observe Node's published contracts.
+- **HoneyDrunk.Pulse** — primary affected Node. `HoneyDrunk.Telemetry.Abstractions` gains the `IErrorReporter` facade plus `ErrorContext`, `ErrorScope`, `Breadcrumb`, `ErrorLevel` — layered over the existing `IErrorSink`/`ErrorEvent`, not duplicating them. `HoneyDrunk.Telemetry.Sink.AzureMonitor` (the existing ADR-0040 sink) extends to handle error capture via the App Insights SDK. No new package.
+- **HoneyDrunk.Notify** — Sentry config (no SDK code) migrates to `IErrorReporter`; Notify-Sentry account archived once wired.
+- **HoneyDrunk.Notify.Functions, HoneyDrunk.Notify.Worker, HoneyDrunk.Pulse.Collector** — consume `IErrorReporter` via their existing Pulse telemetry dependency in Phase 2.
+- **HoneyDrunk.Actions** — reusable deploy workflows amended to mark the deploy via the current supported App Insights release-annotation mechanism as a post-deploy step (D6).
+- **HoneyDrunk.Vault** — App Insights connection string (from ADR-0040) is reused; no new secrets for the error path in v1. If D11 fires, Sentry DSNs join Vault.
+- **HoneyDrunk.Architecture** — `catalogs/contracts.json` gains the `IErrorReporter` facade under the Pulse Node's published contracts.
 - **AI-sector Seed Nodes (ADR-0016 through ADR-0025)** — each consumes `IErrorReporter` at standup; error capture is part of the standup canary.
 - **HoneyDrunk.Audit** — emits errors with `sensitive=audit` tag and longer-retention requirements per ADR-0040 D3.
 - **HoneyDrunk.Notify.Cloud** (future, ADR-0027) — multi-tenant error capture with `tenant_id` dimensions from day one.
@@ -189,14 +196,14 @@ Recorded explicitly so the boundary doesn't blur: Pulse → metrics/logs; applic
 
 Adds one:
 
-- **Invariant: errors captured for Sentry-eligible cases (D8) flow through `IErrorReporter`, never via direct backend SDK calls.** This preserves backend reversibility (D11 escalation) and the centralized PII-scrubbing surface.
+- **Invariant: errors captured for the capture-eligible cases (D8) flow through `IErrorReporter`, never via a direct backend SDK call.** This preserves backend reversibility (D11 escalation) and the centralized PII-scrubbing surface. Secret values must never survive scrubbing into a captured exception — this invariant references, rather than restates, invariant 8 (secret values never appear in logs, traces, exceptions, or telemetry).
 
-(Final invariant number assigned when the implementing work updates `constitution/invariants.md`; `hive-sync` reconciles per the ADR-0044 pattern.)
+The reserved number for this invariant is **80** — pre-allocated as part of a 12-ADR batch. The implementing packet (packet 00) appends it to `constitution/invariants.md`; if any invariant above the file's verified current maximum (51) lands from outside this batch before merge, shift this one upward, never reuse a number.
 
 ### Operational Consequences
 
 - **No new vendor relationship at v1.** Errors share the App Insights resource that ADR-0040 already provisioned. No new account ownership, no new billing line.
-- **The Notify-Sentry migration is the highest-friction step.** Phase 1 includes a parallel-output window where errors go to both Sentry and App Insights for verification; cut over after parity is confirmed; archive the Sentry account. ~1 week of operator attention.
+- **The Notify-Sentry migration is config-only.** A source scan found no Sentry SDK code in Notify — only account/DSN configuration. Phase 1 wires Notify's D8 capture sites to `IErrorReporter` and archives the Sentry account; there is no parallel-output window because nothing emits to Sentry from code. Low-friction; the SDK-replacement path with a parallel window is the fallback only if an execution-time scan unexpectedly finds SDK code.
 - **App Insights' Failures-blade workflow is the v1 acceptance.** It is real but rougher than Sentry. The escalation triggers (D11) name the conditions under which it stops being acceptable.
 - **Release tracking quality is "good enough" not "best."** Sentry's Releases UX with regression detection and suspect commits is recognized as superior; D11 names that as one of the escalation triggers.
 - **PII-scrubbing rules apply equally** to errors as to traces/logs; the same `ITelemetryProcessor` mechanism (ADR-0040 D9) handles both. Reduces the surface area where a misconfigured scrubber could leak.
@@ -204,10 +211,10 @@ Adds one:
 
 ### Follow-up Work
 
-- Add `IErrorReporter`, `ErrorContext`, `ErrorScope`, `Breadcrumb`, `ErrorLevel` to `HoneyDrunk.Observe.Abstractions`.
-- Extend `HoneyDrunk.Observe.AzureMonitor` with App-Insights-SDK-based error capture.
-- Migrate Notify's direct-Sentry usage to `IErrorReporter`; parallel-output window; cutover; archive Sentry account.
-- Amend HoneyDrunk.Actions deploy workflows to call App Insights release annotations API.
+- Add the `IErrorReporter` facade, `ErrorContext`, `ErrorScope`, `Breadcrumb`, `ErrorLevel` to `HoneyDrunk.Telemetry.Abstractions`, layered over the existing `IErrorSink`.
+- Extend `HoneyDrunk.Telemetry.Sink.AzureMonitor` with App-Insights-SDK-based error capture.
+- Migrate Notify's Sentry config to `IErrorReporter` (config-only — no SDK code, no parallel-output window); archive the Sentry account.
+- Amend HoneyDrunk.Actions deploy workflows to mark the deploy via the current supported App Insights release-annotation mechanism.
 - Implement the PII-scrubbing canary for the error path (similar to ADR-0040 D9 canary for traces/logs).
 - Wire `IErrorReporter` into each AI-sector standup ADR (0016–0025) as the standup canary surface.
 - Update `.claude/agents/review.md` D3 Observability category with the D8 capture-vs-log mapping.
@@ -241,9 +248,13 @@ Considered. Strong on high-cardinality trace-driven error analysis. Rejected bec
 
 Rejected on operational burden. Same conclusion as ADR-0040's self-hosting rejection.
 
-### Direct backend SDK usage without an Observe abstraction
+### Direct backend SDK usage without a Pulse abstraction
 
-Rejected. The `IErrorReporter` abstraction costs little (≤200 lines of code in the Observe.AzureMonitor backing) and buys backend reversibility (D11 escalation), centralized PII scrubbing, consistent `trace_id`/`tenant_id` tagging, and uniform semantics. The direct-SDK pattern is what Notify has today, and the Phase 1 migration is the explicit cost of fixing that.
+Rejected. The `IErrorReporter` facade costs little (it builds an `ErrorEvent` and hands it to the existing `IErrorSink`) and buys backend reversibility (D11 escalation), centralized PII scrubbing, consistent `trace_id`/`tenant_id` tagging, and uniform semantics. The direct-SDK pattern is what Notify has today, and the Phase 1 migration is the explicit cost of fixing that.
+
+### A parallel new error contract instead of reusing `IErrorSink`
+
+Considered and rejected. `HoneyDrunk.Pulse` already ships `IErrorSink` and the `ErrorEvent` model for structured error capture and fan-out. Introducing a second, parallel error-capture contract would silently reinvent that surface and create two error models to keep in sync. `IErrorReporter` is instead a thin Grid-facing facade *over* `IErrorSink` — it adds ambient-context capture (`trace_id`, `tenant_id`, `release`) and Sentry-style breadcrumb/scope ergonomics, and maps onto the existing `ErrorEvent`. It does not duplicate the sink contract.
 
 ### Keep Notify on Sentry as a special case; adopt App Insights elsewhere
 

--- a/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/00-architecture-adr-0045-acceptance.md
+++ b/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/00-architecture-adr-0045-acceptance.md
@@ -1,0 +1,130 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "docs", "adr-0045", "wave-1"]
+dependencies: ["Architecture#ADR0040-PACKET00"]
+adrs: ["ADR-0045", "ADR-0040"]
+accepts: ["ADR-0045"]
+wave: 1
+initiative: adr-0045-grid-wide-error-tracking
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0045 — flip status, add the error-flow invariant, register the initiative
+
+## Summary
+Flip ADR-0045 (Grid-Wide Error Tracking) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, add the one new error-flow invariant ADR-0045 commits in its Consequences/Invariants section to `constitution/invariants.md`, and register the `adr-0045-grid-wide-error-tracking` initiative in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0045 makes **errors** a fourth Grid signal type alongside traces, metrics, and logs from ADR-0040, and was revised in PR #164 to pivot to **Application Insights' Failures + exception tracking** as the v1 backend (Sentry becomes the documented D11 escalation path). The ADR decides:
+
+- **D1** — errors are a fourth Grid signal type with first-class error-tracking semantics (problem grouping, release tracking, fingerprinting). Errors are not logs.
+- **D2** — backend v1 is Application Insights' Failures + exception tracking, captured into the **same App Insights resource** ADR-0040 provisions. No new vendor, no new billing line.
+- **D3** — errors flow through `HoneyDrunk.Pulse` via a new `IErrorReporter` **facade** in `HoneyDrunk.Telemetry.Abstractions`, layered over Pulse's **existing `IErrorSink`** (it does not duplicate it). The error connector uses the App Insights .NET SDK (a carve-out from ADR-0040's OTLP-only path, because the App Insights error model carries non-OTLP fields — `problem_id`, `application_Version`, custom dimensions for Failures-blade grouping).
+- **D4** — cross-link between errors, traces, and logs is native via the shared `operation_id`; no configured integration needed on the App Insights path.
+- **D5** — per-Node opt-in via Pulse telemetry configuration; `HoneyDrunk.Notify`'s existing Sentry usage is **migrated** onto `IErrorReporter` (removed, not extended).
+- **D6** — release tracking via the `application_Version` property; the Actions deploy workflows call the App Insights release annotations API.
+- **D7** — PII / tenant-scoping carve-outs: `tenant_id` allowed, `user_id` pseudonymous (`PrincipalId`), prompt/completion text forbidden by default per ADR-0040 D9's carve-out, common PII patterns scrubbed by a regex processor.
+- **D8** — the capture-an-error-vs-log-a-line policy.
+- **D9** — cost: near-zero v1 contribution; within ADR-0040's $100/month ceiling.
+- **D10** — four-phase rollout: abstraction + Notify migration → deployable Nodes → AI-sector standup → escalation evaluation.
+- **D11** — documented escalation path to Sentry (via the existing `HoneyDrunk.Telemetry.Sink.Sentry` package) with four explicit triggers.
+- **D12** — Pulse synthetic monitoring is not an error source (a synthetic probe failure → metric/log, not an exception; errors come from application code paths).
+- **D13** — relationship to ADR-0010 (preserved — Observe untouched), ADR-0040 (extended), and the Notify-Sentry setup (removed).
+
+ADR-0045 is a **policy / decision** ADR. The concrete code — the `IErrorReporter` facade and its types in `HoneyDrunk.Telemetry.Abstractions`, the App Insights error-capture backing in `HoneyDrunk.Telemetry.Sink.AzureMonitor`, the Notify migration, the Actions release-annotation step — lands in the implementing packets (02–06). Catalog updates land as packet 01.
+
+Every other packet in this initiative references ADR-0045's D-decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Cross-Initiative Dependency — ADR-0040
+ADR-0045 is a sibling observability ADR built on the same Azure Monitor backend, pivoted in the same PR (#164). Its `dependencies:` frontmatter references **ADR-0040's acceptance packet** (packet 00 of `adr-0040-telemetry-backend-and-retention`). That cross-initiative reference must be expressed as a `{Repo}#N` qualified edge once ADR-0040's packets are filed and their issue numbers are known. **Until ADR-0040 packet 00 has a GitHub issue number, leave the placeholder `Architecture#ADR0040-PACKET00` in this packet's `dependencies:` and replace it with the real `Architecture#<n>` before this folder is pushed to `main`** — `packet:NN` edges only resolve *within the same initiative folder*, so a same-folder ordinal cannot point at ADR-0040. The ADR-0040 dependency is for invariant-numbering hygiene only — see the invariant-numbering note below.
+
+## Invariant Numbering
+The verified current maximum invariant number in `constitution/invariants.md` is **51**. ADR-0045 adds exactly **one** invariant; its **pre-reserved number is 80** — pre-allocated as part of a 12-ADR batch (ADR-0045 is one ADR in that batch; numbers 52–80+ are reserved across the batch even though the file currently tops out at 51). Append invariant 80 to `constitution/invariants.md`. Do **not** assume any `## Telemetry Invariants` section exists — ADR-0040's packets may not have landed yet. Append the invariant in an appropriate section (an existing observability/Ops-flavoured section, or create a new section if none fits). Add this batch note in or beside the invariant: *"Invariant 80 is pre-reserved as part of a 12-ADR batch; if any invariant above 51 lands from outside this batch before merge, shift upward, never reuse."*
+
+## Scope
+- `adrs/ADR-0045-grid-wide-error-tracking.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0045 row Status column to Accepted.
+- `constitution/invariants.md` — add the one new error-flow invariant ADR-0045 commits (see Proposed Implementation for exact text) as **invariant 80** (pre-reserved — see Invariant Numbering above).
+- `initiatives/active-initiatives.md` — register the `adr-0045-grid-wide-error-tracking` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0045 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update the ADR-0045 index row in `adrs/README.md` to Accepted.
+3. Add one new invariant to `constitution/invariants.md` as **invariant 80**. The text, taken verbatim-in-substance from ADR-0045's Consequences "Invariants" subsection:
+   - **Errors captured for the capture-eligible cases (ADR-0045 D8) flow through `IErrorReporter`, never via a direct backend SDK call.** This preserves backend reversibility (the D11 Sentry escalation) and the centralized PII-scrubbing surface. Secret values must never survive scrubbing into a captured exception — this invariant **references** invariant 8 ("Secret values never appear in logs, traces, exceptions, or telemetry") rather than restating it.
+   - Number it **80** (pre-reserved — see Invariant Numbering). Append it; do not renumber any existing invariant. Do not assume a `## Telemetry Invariants` section exists — append under an appropriate existing section, or create one. Include the batch note: *"Invariant 80 is pre-reserved as part of a 12-ADR batch; if any invariant above 51 lands from outside this batch before merge, shift upward, never reuse."*
+4. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder.
+
+## Affected Files
+- `adrs/ADR-0045-grid-wide-error-tracking.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0045 header reads `**Status:** Accepted`
+- [ ] The ADR-0045 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariants.md` carries the one new error-flow invariant (errors flow through `IErrorReporter`, never a direct backend SDK call) as **invariant 80**, citing ADR-0045, referencing (not restating) invariant 8, and carrying the pre-reservation batch note
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0045-grid-wide-error-tracking` initiative with a packet checklist
+- [ ] No catalog schema change in this packet (catalog updates land in packet 01)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0045 D3 — Errors flow through Pulse; `IErrorReporter` is a facade over `IErrorSink`.** A new `IErrorReporter` facade in `HoneyDrunk.Telemetry.Abstractions`, layered over Pulse's existing `IErrorSink` — it adds ambient-context capture and breadcrumb/scope ergonomics, it does not duplicate the sink contract. The App Insights connector for errors uses the App Insights .NET SDK and extends the existing `HoneyDrunk.Telemetry.Sink.AzureMonitor` package (a carve-out from ADR-0040's OTLP-only path). A future backend swap (Sentry per D11, via the existing `HoneyDrunk.Telemetry.Sink.Sentry`) is a configuration change.
+
+**ADR-0045 Consequences — Invariants.** ADR-0045 adds exactly one invariant: errors captured for the D8 capture-eligible cases flow through `IErrorReporter`, never via a direct backend SDK call. Reserved number 80.
+
+**Invariant 8 (referenced) — Secret values never appear in logs, traces, exceptions, or telemetry.** The error-flow invariant references invariant 8: scrubbing must never let a secret survive into a captured exception.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0045 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant number 80.** Append the one new invariant as number 80 (pre-reserved). Do not renumber existing invariants. Do not assume a `## Telemetry Invariants` section exists; append under an appropriate section or create one. Include the batch note.
+- **Reference, do not restate, invariant 8.** The error-flow invariant references invariant 8 (secrets never in telemetry) — write them as complementary.
+- **Replace the placeholder dependency.** `Architecture#ADR0040-PACKET00` is a placeholder; substitute the real `Architecture#<issue-number>` once ADR-0040's packets are filed and before this folder is pushed.
+
+## Labels
+`chore`, `tier-3`, `ops`, `docs`, `adr-0045`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0045 to Accepted, add the error-flow invariant to `constitution/invariants.md`, and register the error-tracking initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0045 so the remaining packets in this initiative can reference its decisions as live rules.
+- Feature: ADR-0045 Grid-Wide Error Tracking rollout, Wave 1.
+- ADRs: ADR-0045 (primary), ADR-0040 (the telemetry backend ADR-0045 extends), ADR-0008 (initiative/packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- ADR-0040 packet 00 (cross-initiative) — sibling observability ADR; the edge exists for invariant-numbering hygiene within the 12-ADR batch. Express as `Architecture#<issue-number>` once filed.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0045 stays Proposed until this PR merges.
+- Append the one new invariant as **number 80** (pre-reserved); do not renumber existing invariants; do not assume a `## Telemetry Invariants` section exists; include the batch note.
+- The error-flow invariant references invariant 8 (secrets never in telemetry) — it does not restate it.
+
+**Key Files:**
+- `adrs/ADR-0045-grid-wide-error-tracking.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/01-architecture-error-tracking-catalog-and-contracts.md
+++ b/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/01-architecture-error-tracking-catalog-and-contracts.md
@@ -1,0 +1,114 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0045", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0045", "ADR-0040"]
+accepts: ["ADR-0045"]
+wave: 1
+initiative: adr-0045-grid-wide-error-tracking
+node: honeydrunk-architecture
+---
+
+# Record the IErrorReporter contract and the D8 capture policy in the Grid catalogs
+
+## Summary
+Record ADR-0045's decisions as catalog data: register the `IErrorReporter` facade contract in `catalogs/contracts.json` under the **Pulse** Node (alongside the existing `IErrorSink`), and document the D8 capture-vs-log policy where the Grid keeps cross-cutting policy notes.
+
+## Context
+ADR-0045 D1 adds **errors** to the canonical Grid signal taxonomy and D3 adds the `IErrorReporter` facade — layered over Pulse's **existing `IErrorSink`** in `HoneyDrunk.Telemetry.Abstractions`. Pulse (v0.3.0, LIVE) already ships `IErrorSink`/`ErrorEvent`; this packet registers the new facade contract alongside it.
+
+ADR-0045's Affected Nodes: "`HoneyDrunk.Architecture` — `catalogs/contracts.json` gains the `IErrorReporter` facade under the Pulse Node's published contracts."
+
+**Catalog schema ground truth — read before editing.**
+- `catalogs/contracts.json` has the shape `{_meta, contracts:[{node, node_name, package, status, interfaces:[...]}]}`. The `honeydrunk-pulse` entry already exists (package `HoneyDrunk.Pulse.Contracts`, status `seed`, listing `ITraceSink`/`ILogSink`/`IMetricsSink` and the `TelemetryTagKeys` type). The `IErrorReporter` facade is added to that Pulse entry's `interfaces` list (or, if the catalog convention separates packages, a `HoneyDrunk.Telemetry.Abstractions` Pulse entry — match the existing convention).
+- `catalogs/grid-health.json` node entries carry **only** `signal`/`version`/`canary_status`/`last_release`/`active_blockers`/`notes` (plus a top-level `_meta` and `summary`). There is **no** observability/telemetry/error-tracking readout in `grid-health.json`, and **no place** for a Notify-Sentry decommission item. **Do not edit `grid-health.json` in this packet** — there is no observability section there to extend (an earlier draft of this packet referenced one created by "ADR-0040 packet 01"; that section does not exist — it was a phantom).
+- `catalogs/nodes.json` has no `exposes` field; node exposure lives in `relationships.json`. This packet does not touch either.
+
+**No new App Insights resource.** ADR-0045 D2 captures errors into the *same* App Insights resource ADR-0040 provisions — no resource entry is added anywhere.
+
+**Notify-Sentry decommission tracking.** The Notify-Sentry account decommission is *not* tracked in `grid-health.json` (no schema slot for it). It is tracked in the dispatch plan's "Notify-Sentry account decommission" deferred note and surfaces as packet 05's Human Prerequisite. This packet adds no catalog field for it.
+
+This is a catalog/docs packet. No code, no .NET project.
+
+## Scope
+- `catalogs/contracts.json` — register the `IErrorReporter` facade under the `honeydrunk-pulse` Node's contracts, alongside the existing `IErrorSink`/`ITraceSink`/`ILogSink`/`IMetricsSink` surface.
+- A cross-cutting policy note for the D8 capture-vs-log boundary — placed where the Grid keeps such notes (match the existing convention for cross-cutting policy notes).
+
+## Proposed Implementation
+1. **`catalogs/contracts.json`** — add the `IErrorReporter` facade to the `honeydrunk-pulse` Node's `interfaces` list. The contract lives in `HoneyDrunk.Telemetry.Abstractions` (packet 02 creates it). Mark its kind `interface`; describe it as the Grid-facing error-reporting facade layered over the existing `IErrorSink` — it captures ambient context (`trace_id`, `tenant_id`, `release`) and breadcrumb/scope state and routes to `IErrorSink`. Do not invent member names beyond what ADR-0045 D3 specifies (`CaptureException`, `CaptureMessage`, `AddBreadcrumb`, `PushScope`). If the catalog tracks per-interface status, mark it `planned` until packet 02 lands. Note in the description that it does **not** duplicate `IErrorSink`.
+2. **No `grid-health.json` edit.** That file's node entries have no observability/error-tracking readout — see the schema note. Skip it entirely.
+3. **D8 capture-vs-log policy note** — record the D8 boundary (when to `CaptureException` vs when to log an ERROR line vs when to do both) as a cross-cutting policy note in the Grid's established location for such notes. This note is the human-readable companion to the per-case mapping that packet 06 adds to `.claude/agents/review.md`.
+
+## Affected Files
+- `catalogs/contracts.json`
+- A capture-vs-log policy note in the established cross-cutting-notes location.
+
+## NuGet Dependencies
+None. This packet touches only catalog JSON and Markdown; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] Catalog data only — the `IErrorReporter` code lands in packet 02.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` registers the `IErrorReporter` facade under the `honeydrunk-pulse` Node, alongside the existing `IErrorSink`/`ITraceSink`/`ILogSink`/`IMetricsSink`, with the four-member shape summary (`CaptureException`, `CaptureMessage`, `AddBreadcrumb`, `PushScope`) and a description stating it is a facade over `IErrorSink`, not a duplicate; marked `planned` if the catalog tracks per-interface status
+- [ ] `catalogs/grid-health.json` is **not** edited — its node-entry schema (`signal`/`version`/`canary_status`/`last_release`/`active_blockers`/`notes`) has no observability/error-tracking readout to extend
+- [ ] The Notify-Sentry decommission is **not** added as a `grid-health.json` field (no schema slot) — it is tracked in the dispatch plan's deferred note and packet 05's Human Prerequisites
+- [ ] The D8 capture-vs-log policy is recorded as a cross-cutting policy note in the Grid's established location for such notes
+- [ ] No invariant change in this packet (the error-flow invariant lands in packet 00)
+- [ ] No new App Insights resource — errors reuse the ADR-0040-provisioned resources
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0045 D1 — Errors are a fourth Grid signal type.** Errors join traces/metrics/logs in the Grid signal taxonomy. Backend v1 App Insights Failures; 90-day retention in the same workspace.
+
+**ADR-0045 D2 — Backend v1: App Insights Failures + exception tracking.** Errors capture into the *same* App Insights resource that holds traces/metrics/logs per ADR-0040, via the existing `HoneyDrunk.Telemetry.Sink.AzureMonitor` package. No separate vendor, no separate billing line, no new package.
+
+**ADR-0045 D3 — `IErrorReporter` facade.** A new facade added to `HoneyDrunk.Telemetry.Abstractions`, layered over Pulse's existing `IErrorSink` — it does not duplicate `IErrorSink`. Shape: `CaptureException(Exception, ErrorContext?)`, `CaptureMessage(string, ErrorLevel, ErrorContext?)`, `AddBreadcrumb(Breadcrumb)`, `PushScope(ErrorScope)`.
+
+**ADR-0045 D8 — Capture-vs-log policy.** Capture-as-error: uncaught/programmatic exceptions, unrecoverable failed dependency calls, failed agent tool dispatch, failed Stripe meter-event push, Audit write failures. Log-only at ERROR: retries that succeeded, inbound-validation failures, expected 4xx, poison-message deserialization. Both: anything in the capture list also produces an ERROR log line carrying the same `operation_id`.
+
+**ADR-0045 D5 — Notify-Sentry migration.** Notify's Sentry config is migrated to `IErrorReporter`; the Notify-Sentry account is archived once wired (config-only — no parallel-run window).
+
+## Constraints
+- **No new App Insights resource.** Errors share the ADR-0040-provisioned resource (D2).
+- **No invented contract members.** The `IErrorReporter` shape is fixed by ADR-0045 D3 — four members. Do not add or rename.
+- **`IErrorReporter` is a facade, not a duplicate.** The catalog description must state it layers over the existing `IErrorSink` and adds ambient-context + breadcrumb/scope ergonomics — it does not reinvent error capture.
+- **Do not edit `grid-health.json`.** Its node-entry schema has no observability/error-tracking readout. Editing it to add a signal type or a decommission item would invent a field that does not exist.
+- **Match existing catalog shape.** The `IErrorReporter` entry mirrors the existing `interfaces[]` entries on the `honeydrunk-pulse` `contracts.json` record.
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0045`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Register the `IErrorReporter` facade in `catalogs/contracts.json` under the Pulse Node, and record the D8 capture policy as a cross-cutting note.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Register `IErrorReporter` as a published Pulse contract and record the D8 policy.
+- Feature: ADR-0045 Grid-Wide Error Tracking rollout, Wave 1.
+- ADRs: ADR-0045 D1/D2/D3/D5/D8 (primary).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0045 should be Accepted before its decisions are recorded as catalog data.
+
+**Constraints:**
+- Register `IErrorReporter` under `honeydrunk-pulse` in `contracts.json`, alongside the existing `IErrorSink` — describe it as a facade over `IErrorSink`, not a duplicate.
+- No invented contract members — `IErrorReporter` is the four-member shape from D3.
+- Do **not** edit `grid-health.json` — its node-entry schema has no observability/error-tracking readout (no phantom field).
+- The Notify-Sentry decommission is tracked in the dispatch plan / packet 05 Human Prerequisites, not in any catalog.
+
+**Key Files:**
+- `catalogs/contracts.json`
+
+**Contracts:** `IErrorReporter` facade registered as catalog metadata under the Pulse Node (the code is packet 02).

--- a/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/02-pulse-ierror-reporter-abstraction.md
+++ b/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/02-pulse-ierror-reporter-abstraction.md
@@ -1,0 +1,172 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Pulse
+labels: ["feature", "tier-2", "ops", "adr-0045", "wave-2"]
+dependencies: ["packet:00", "Architecture#ADR0040-PACKET03"]
+adrs: ["ADR-0045", "ADR-0040", "ADR-0026"]
+accepts: ["ADR-0045"]
+wave: 2
+initiative: adr-0045-grid-wide-error-tracking
+node: honeydrunk-pulse
+---
+
+# Add the IErrorReporter facade and its types to HoneyDrunk.Telemetry.Abstractions
+
+## Summary
+Add the `IErrorReporter` facade interface and the error-model types (`ErrorContext`, `ErrorScope`, `Breadcrumb`, `ErrorLevel`) to `HoneyDrunk.Telemetry.Abstractions` per ADR-0045 D3 — the Grid-facing error-reporting facade layered over Pulse's **existing `IErrorSink`**. This is the contract-only packet; no backend code lands here.
+
+## Context
+ADR-0045 D3 makes errors flow through `HoneyDrunk.Pulse`, the Grid's telemetry-export Node, via a new `IErrorReporter` **facade**. The facade is the Grid-facing convenience layer: it captures ambient request context, maintains breadcrumb/scope state, builds an `ErrorEvent`, and hands it to `IErrorSink`. The breadcrumb/scope shape is deliberately modeled on Sentry's semantics because those are backend-portable concepts — App Insights expresses them via custom events on the same `operation_id`, and Sentry would consume them natively if D11 ever fires.
+
+**Reconcile with Pulse's existing `IErrorSink` — read first.** `HoneyDrunk.Pulse` (v0.3.0, LIVE) **already ships `IErrorSink`** in `HoneyDrunk.Telemetry.Abstractions` (`HoneyDrunk.Telemetry.Abstractions/Abstractions/IErrorSink.cs`) — a structured error-capture contract: `CaptureAsync(ErrorEvent)`, `CaptureExceptionAsync(Exception, IDictionary<string,string>?)`, `CaptureMessageAsync(string, TelemetryEventSeverity)`, `FlushAsync()`. It is backed by the `ErrorEvent` model (`Models/ErrorEvent.cs`), which carries `Exception`, `Message`, `Severity`, `Timestamp`, `CorrelationId`, `OperationId`, `NodeId`, `UserId`, `Environment`, `Release`, `Tags`, `Extra`.
+
+ADR-0045 D3 names a new `IErrorReporter`. **`IErrorReporter` does not duplicate `IErrorSink`.** The reconciliation, fixed by ADR-0045 D3:
+- **`IErrorSink`** (existing, unchanged) — the sink/fan-out contract. Takes a fully-populated `ErrorEvent` and routes it to a backend. No ambient context, no breadcrumb/scope stack.
+- **`IErrorReporter`** (new — this packet) — the application-facing **facade**. It captures ambient context (the current `Activity`/`trace_id`, the Grid `TenantId`/`PrincipalId`, the deployable `Release`), maintains the breadcrumb/scope stack, builds an `ErrorEvent`, and routes it to `IErrorSink`. It adds **no new capture mechanism** — only ambient-context capture and breadcrumb/scope ergonomics.
+
+This packet adds the facade interface and its three model types — `ErrorContext`, `Breadcrumb`, `ErrorScope` — plus the `ErrorLevel` enum, alongside the existing `IErrorSink`/`ErrorEvent`. **Do not modify `IErrorSink` or `ErrorEvent`.** `ErrorContext` is the facade's per-call input; the facade implementation (packet 03) maps it onto `ErrorEvent`.
+
+ADR-0045 D3 specifies the `IErrorReporter` shape exactly:
+
+```
+ValueTask CaptureException(Exception ex, ErrorContext? context = null);
+ValueTask CaptureMessage(string message, ErrorLevel level, ErrorContext? context = null);
+IDisposable AddBreadcrumb(Breadcrumb crumb);
+IDisposable PushScope(ErrorScope scope);
+```
+
+`ErrorContext` carries `trace_id` (links automatically to App Insights traces, maps to `ErrorEvent.OperationId`/`CorrelationId`), `tenant_id` (links to ADR-0026's primitives — the dimension `ErrorEvent` does **not** carry, and the load-bearing reason the facade exists; the facade carries it onto `ErrorEvent.Tags`), `user_id`, `release` (= application version), and an arbitrary tag dictionary. `Breadcrumb` and `ErrorScope` are modeled on Sentry's semantics.
+
+**Cross-initiative dependency — read first.** This packet's `dependencies:` references ADR-0040 packet 03 (`Architecture#<issue-number>` once filed — replace the `Architecture#ADR0040-PACKET03` placeholder before this folder is pushed). ADR-0040's Pulse work touches the `HoneyDrunk.Pulse` solution; ADR-0045's Pulse work is sequenced after it so version-bump ownership is unambiguous. Per invariant 27, check the `HoneyDrunk.Pulse` solution's in-progress version state at edit time:
+- If ADR-0040's Pulse packets have all merged and the solution is at a released version, **this packet bumps** (minor — new public types in `HoneyDrunk.Telemetry.Abstractions`).
+- If an ADR-0040 Pulse version bump is still in-progress (unreleased), **this packet appends** to that in-progress version entry and does not bump again.
+Record which case applied in the PR.
+
+**Repo-state note.** `HoneyDrunk.Pulse` is a LIVE Node (v0.3.0). `HoneyDrunk.Telemetry.Abstractions` already exists and ships `IErrorSink`/`ErrorEvent`. This packet adds new types to an existing package — no scaffolding concern.
+
+This packet adds only public abstraction types. No App Insights SDK, no backend code — that is packet 03.
+
+## Scope
+- `HoneyDrunk.Telemetry.Abstractions` — add `IErrorReporter`, `ErrorContext`, `ErrorScope`, `Breadcrumb`, `ErrorLevel`, alongside the existing `IErrorSink`/`ErrorEvent` (which are not modified).
+- The `HoneyDrunk.Telemetry.Abstractions` unit-test project (or the existing Pulse abstractions test project) — record-equality / construction tests for the new model types.
+
+## Proposed Implementation
+1. **`ErrorLevel`** — an enum for `CaptureMessage` severity. Model on Sentry's levels: `Debug`, `Info`, `Warning`, `Error`, `Fatal` (or the subset the Grid needs — pick and document). Plain enum, no behavior. If the existing `TelemetryEventSeverity` enum already covers these levels, the facade may reuse it instead — check at edit time and document the choice (do not create a redundant enum if `TelemetryEventSeverity` already serves).
+2. **`ErrorContext`** — the per-capture context record. Per the Grid naming rule (records drop the `I` prefix and are records, not interfaces), this is a `record` named `ErrorContext`, not `IErrorContext`. Fields per ADR-0045 D3:
+   - `TraceId` — links to the App Insights trace (`operation_id`); the facade maps it onto `ErrorEvent.OperationId`/`CorrelationId`.
+   - `TenantId` — the multi-tenant scoping dimension `ErrorEvent` does not carry; ADR-0026's tenant primitive type if one exists, otherwise a string. Reconcile against `HoneyDrunk.Kernel.Abstractions` — if Kernel exposes a `TenantId` type the Grid already uses, use it (invariant 1 allows the Kernel.Abstractions contract reference).
+   - `UserId` — the opaque `PrincipalId` per ADR-0026, never an email or external identifier. Use the Kernel/Auth `PrincipalId` type if one exists; otherwise a string with an XML-doc note that it must be the opaque id.
+   - `Release` — the application version string (set by the deployable per packet 04).
+   - `Tags` — an arbitrary `IReadOnlyDictionary<string, string>`.
+   All fields optional/nullable where D3 shows `ErrorContext?` is itself optional.
+3. **`Breadcrumb`** — a `record` capturing a navigational/diagnostic crumb (timestamp, category, message, level, optional data dictionary). Modeled on Sentry's breadcrumb; backend-portable.
+4. **`ErrorScope`** — a `record` carrying scoped tags/context pushed onto a stack via `PushScope` and popped when the returned `IDisposable` is disposed.
+5. **`IErrorReporter`** — the facade interface, exactly the four-member D3 shape. `IErrorReporter` keeps the `I` prefix (it is an interface, per the Grid naming rule). `AddBreadcrumb` and `PushScope` return `IDisposable` (the breadcrumb/scope is active until disposed). The XML docs must state that it is a facade over `IErrorSink` — it builds an `ErrorEvent` from ambient context and routes to the sink; it does not duplicate `IErrorSink`.
+6. **Do not modify `IErrorSink` or `ErrorEvent`.** They are existing, LIVE contracts. The facade is purely additive.
+7. **XML documentation** on every public member (invariant 13 — enforced by `HoneyDrunk.Standards`). The XML docs must state the backend-portability intent: these types are modeled to survive a backend swap (App Insights → Sentry per D11).
+8. **No new dependencies.** Per invariant 1, `HoneyDrunk.Telemetry.Abstractions` takes only `Microsoft.Extensions.*` abstractions plus whatever HoneyDrunk abstraction package it already references. No App Insights SDK, no Sentry SDK, no Azure type in this package.
+9. **Version.** See the cross-initiative version-state check in Context. Either this packet bumps the `HoneyDrunk.Pulse` solution (minor — new public types) or appends to an in-progress ADR-0040 version entry. Record which.
+10. **CHANGELOG.** Repo-level `CHANGELOG.md` entry (new version entry if bumping, append if not). Per-package `HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md` entry — this package has an actual change. Update `HoneyDrunk.Telemetry.Abstractions/README.md` if it documents the public contract surface.
+
+## Affected Files
+- `HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/Abstractions/IErrorReporter.cs` (new — alongside the existing `IErrorSink.cs`)
+- `HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/Models/ErrorContext.cs` (new)
+- `HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/Models/ErrorScope.cs` (new)
+- `HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/Models/Breadcrumb.cs` (new)
+- `HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/Models/ErrorLevel.cs` (new — only if `TelemetryEventSeverity` is not reused)
+- The `HoneyDrunk.Telemetry.Abstractions` unit-test project — model-type tests.
+- Repo-level `CHANGELOG.md`; `HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md`; possibly every non-test `.csproj` (if this packet bumps the solution version).
+
+## NuGet Dependencies
+`HoneyDrunk.Telemetry.Abstractions` takes **no new `PackageReference`** — invariant 1: Abstractions packages take only `Microsoft.Extensions.*` abstractions plus whatever HoneyDrunk abstraction package it already references. No App Insights SDK, no Sentry SDK, no Azure type in this package.
+
+The `HoneyDrunk.Telemetry.Abstractions` unit-test project (if a new project is needed):
+- The Grid's standard test stack — match the other `HoneyDrunk.Pulse` test projects.
+- `HoneyDrunk.Standards` — analyzers, `PrivateAssets: all` (invariant 26).
+- Project reference to `HoneyDrunk.Telemetry.Abstractions`.
+
+## Boundary Check
+- [x] `HoneyDrunk.Pulse` is the correct repo — outbound error telemetry belongs to Pulse per `repos/HoneyDrunk.Observe/boundaries.md` and `repos/HoneyDrunk.Pulse/boundaries.md`; Pulse already owns `IErrorSink`. ADR-0045 (amended 2026-05-22) places `IErrorReporter` in `HoneyDrunk.Telemetry.Abstractions`.
+- [x] Abstraction-only — no backend SDK in `Telemetry.Abstractions` (invariant 1). The App Insights implementation is packet 03.
+- [x] `IErrorReporter` is a facade over the existing `IErrorSink` — it does not duplicate it; it is purely additive to the package.
+- [x] `IErrorReporter` is a published Pulse contract — provider packages and consuming Nodes depend on it, not on internals (invariant 3).
+
+## Acceptance Criteria
+- [ ] `IErrorReporter` exists in `HoneyDrunk.Telemetry.Abstractions` with exactly the four-member D3 shape: `CaptureException`, `CaptureMessage`, `AddBreadcrumb`, `PushScope`
+- [ ] `IErrorReporter`'s XML docs state it is a facade over the existing `IErrorSink` — it builds an `ErrorEvent` from ambient context and routes to the sink; it does not duplicate `IErrorSink`
+- [ ] The existing `IErrorSink` and `ErrorEvent` are **not** modified — the facade is purely additive
+- [ ] `ErrorContext`, `ErrorScope`, `Breadcrumb` are records (not interfaces) per the Grid naming rule; `ErrorLevel` is an enum (or the existing `TelemetryEventSeverity` is reused — decision recorded)
+- [ ] `ErrorContext` carries `TraceId`, `TenantId`, `UserId` (the opaque `PrincipalId`), `Release`, and a `Tags` dictionary; the Kernel `TenantId`/`PrincipalId` types are reused if they exist
+- [ ] `HoneyDrunk.Telemetry.Abstractions` takes no new HoneyDrunk runtime dependency and no Azure/Sentry SDK (invariant 1)
+- [ ] Every new public member has XML documentation stating the backend-portability intent (invariant 13)
+- [ ] Model-type tests cover record equality and construction; tests use no external services (invariant 15), no `Thread.Sleep` (invariant 51)
+- [ ] The version-state check is performed: the `HoneyDrunk.Pulse` solution either bumps or appends to an in-progress ADR-0040 version entry — the decision recorded in the PR (invariant 27)
+- [ ] `HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md` has an entry; repo-level `CHANGELOG.md` updated
+- [ ] The solution builds; existing unit tests pass
+
+## Human Prerequisites
+None. This packet is pure abstraction code — no Azure resource, no portal step.
+
+## Referenced ADR Decisions
+**ADR-0045 D3 — Errors flow through Pulse; `IErrorReporter` is a facade over `IErrorSink`.** The facade interface and its types (`ErrorContext`, `ErrorScope`, `Breadcrumb`, `ErrorLevel`) are added to `HoneyDrunk.Telemetry.Abstractions`, alongside the existing `IErrorSink`/`ErrorEvent`. The four-member shape is fixed. `IErrorReporter` does **not** duplicate `IErrorSink` — it captures ambient context (`trace_id`, `tenant_id`, `release`) and breadcrumb/scope state, builds an `ErrorEvent`, and routes to `IErrorSink`. `ErrorContext` carries `trace_id`, `tenant_id`, `user_id`, `release`, and a tag dictionary. `Breadcrumb`/`ErrorScope` are modeled on Sentry's semantics — backend-portable.
+
+**ADR-0045 — amendment 2026-05-22.** The error path targets `HoneyDrunk.Pulse`, not `HoneyDrunk.Observe`. Observe's `boundaries.md` states outbound telemetry to external sinks belongs to Pulse; Pulse already owns `IErrorSink` and the `HoneyDrunk.Telemetry.Sink.*` provider family.
+
+**ADR-0026 — Tenant/principal primitives.** `tenant_id` links to ADR-0026's tenant primitive; `user_id` is the opaque `PrincipalId`, never an email or external identifier.
+
+**ADR-0040 — Pulse is the telemetry-export boundary.** ADR-0045 D3 is a small carve-out from ADR-0040's OTLP path: errors flow through Pulse but the *backing* uses the App Insights SDK (packet 03), not OTLP. The *abstraction* this packet adds is SDK-free.
+
+## Constraints
+> **Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.** `HoneyDrunk.Telemetry.Abstractions` takes only `Microsoft.Extensions.*` abstractions plus whatever HoneyDrunk abstraction package it already references. No App Insights SDK, no Sentry SDK, no Azure type in `IErrorReporter` or its model types.
+
+> **Invariant 3 — Provider packages depend on their parent Node's contracts, not internals.** `IErrorReporter` is a published Pulse contract; the App Insights backing (packet 03) and every consuming Node depend on this abstraction, never on Pulse internals.
+
+> **Invariant 13 — All public APIs have XML documentation.** Enforced by `HoneyDrunk.Standards`.
+
+> **Invariant 15 — Unit tests never depend on external services.** Model-type tests run in-process.
+
+> **Invariant 26 — Issue packets for .NET code work include a `## NuGet Dependencies` section; `HoneyDrunk.Standards` is on every new .NET project** (analyzers, `PrivateAssets: all`).
+
+> **Invariant 27 — All projects in a solution share one version and move together.** Perform the in-progress version-state check (see Context): either this packet bumps the `HoneyDrunk.Pulse` solution or appends to an unreleased ADR-0040 version entry. Record the decision.
+
+- **Grid naming rule.** `ErrorContext`, `ErrorScope`, `Breadcrumb` are records and drop the `I` prefix. `IErrorReporter` is an interface and keeps it.
+- **No invented members.** `IErrorReporter` is the four-member D3 shape — do not add or rename.
+- **Facade, not duplicate.** `IErrorReporter` layers over the existing `IErrorSink` — do not modify `IErrorSink` or `ErrorEvent`, and do not create a parallel error model.
+- **Abstraction-only.** No App Insights SDK reference in this packet — packet 03 owns the backend code.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0045`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add the `IErrorReporter` facade and the error-model types (`ErrorContext`, `ErrorScope`, `Breadcrumb`, `ErrorLevel`) to `HoneyDrunk.Telemetry.Abstractions`, layered over the existing `IErrorSink`.
+
+**Target:** `HoneyDrunk.Pulse`, branch from `main`.
+
+**Context:**
+- Goal: Establish the Grid-facing error-reporting facade every Node consumes — built over Pulse's existing `IErrorSink` (App Insights now, Sentry under D11, both behind the same sink).
+- Feature: ADR-0045 Grid-Wide Error Tracking rollout, Wave 2.
+- ADRs: ADR-0045 D3 (primary), ADR-0026 (tenant/principal primitives), ADR-0040 (the OTLP carve-out and the version-bump coordination).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0045 should be Accepted before its contracts land.
+- ADR-0040 packet 03 (cross-initiative) — ADR-0045's Pulse work sequences after ADR-0040's Pulse work so version-bump ownership is unambiguous. Express as `Architecture#<issue-number>` once filed.
+
+**Constraints:**
+- Abstraction-only — no App Insights/Sentry SDK in `Telemetry.Abstractions` (invariant 1).
+- `IErrorReporter` is the fixed four-member D3 shape — no invented members.
+- `IErrorReporter` is a facade over the existing `IErrorSink` — do not modify `IErrorSink`/`ErrorEvent`, do not create a parallel error model.
+- `ErrorContext`/`ErrorScope`/`Breadcrumb` are records (drop `I`); `IErrorReporter` is an interface (keeps `I`).
+- Perform the invariant-27 version-state check on the `HoneyDrunk.Pulse` solution — bump or append; record the decision.
+
+**Key Files:**
+- `HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/Abstractions/IErrorReporter.cs` (new, alongside `IErrorSink.cs`)
+- `HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/Models/ErrorContext.cs`, `ErrorScope.cs`, `Breadcrumb.cs`, `ErrorLevel.cs` (new)
+- `HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md`; repo-level `CHANGELOG.md`
+
+**Contracts:**
+- `IErrorReporter` — the new error-reporting facade. Feed the confirmed final shape back to packet 01's `contracts.json` entry.

--- a/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/03-pulse-app-insights-error-backing.md
+++ b/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/03-pulse-app-insights-error-backing.md
@@ -1,0 +1,186 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Pulse
+labels: ["feature", "tier-2", "ops", "adr-0045", "wave-3"]
+dependencies: ["packet:02", "Architecture#ADR0040-PACKET05"]
+adrs: ["ADR-0045", "ADR-0040", "ADR-0005", "ADR-0023", "ADR-0026"]
+accepts: ["ADR-0045"]
+wave: 3
+initiative: adr-0045-grid-wide-error-tracking
+node: honeydrunk-pulse
+---
+
+# Implement the App Insights error-capture backing and the error PII processor in HoneyDrunk.Telemetry.Sink.AzureMonitor
+
+## Summary
+Extend the **existing** `HoneyDrunk.Telemetry.Sink.AzureMonitor` package with the App-Insights-SDK-based error-capture backing and the `IErrorReporter` facade implementation per ADR-0045 D3, the `operation_id` cross-link wiring (D4), the `application_Version` release tagging hook (D6), and the error-path PII scrubbing per D7 — consuming the shared PII scrubber ADR-0040 builds. This is the core implementation packet of the initiative.
+
+## Context
+ADR-0045 D3 routes errors through `HoneyDrunk.Pulse` but, unlike traces/metrics/logs (which use OTLP per ADR-0040 D2), the error backing uses the **App Insights .NET SDK** (`Microsoft.ApplicationInsights`). The carve-out exists because App Insights' error model carries fields that are not OTLP primitives — `problem_id`, `application_Version`, custom dimensions for user/tenant scoping that drive Failures-blade grouping. Routing errors as OTLP-generic would strip those features.
+
+This packet adds the error backing to the **existing `HoneyDrunk.Telemetry.Sink.AzureMonitor` package** — the same Pulse sink ADR-0040 uses for traces/metrics/logs. It does **not** create a new package and does **not** live in `HoneyDrunk.Observe`. The App Insights connection string (seeded into Vault by ADR-0040 packet 02) is reused; ADR-0045 D2 is explicit that errors capture into the same App Insights resource as traces/metrics/logs. No new resource, no new secret.
+
+**Facade over the existing `IErrorSink`.** Packet 02 added the `IErrorReporter` facade to `HoneyDrunk.Telemetry.Abstractions`. This packet has two parts: (1) extend `HoneyDrunk.Telemetry.Sink.AzureMonitor`'s error-capture path — the `IErrorSink` backing that routes an `ErrorEvent` to App Insights via the SDK; and (2) implement the `IErrorReporter` facade — the class that captures ambient context, maintains breadcrumb/scope state, builds an `ErrorEvent`, and routes it to `IErrorSink`. The facade implementation belongs in `HoneyDrunk.Telemetry.Sink.AzureMonitor` (or a Pulse runtime/shared project — match the Pulse solution's existing structure for where sink-backed services compose). It must **not** reinvent `IErrorSink`; it builds an `ErrorEvent` and hands it over.
+
+**Cross-initiative dependency — read first.** This packet's `dependencies:` references **ADR-0040 packet 05** (`Architecture#<issue-number>` once filed — replace the `Architecture#ADR0040-PACKET05` placeholder before this folder is pushed). ADR-0040 packet 05 builds the PII redaction processors **and the shared, mechanism-agnostic PII scrubber as a shared component from the start** (ADR-0040 packet 05 was corrected to do so). This is a plain hard cross-initiative dependency: this packet **consumes** that shared scrubber — no refactor needed. It also means all of ADR-0040's Pulse waves have landed, so the `HoneyDrunk.Pulse` solution version state is settled.
+
+**Version.** Per invariant 27, this packet appends to the `HoneyDrunk.Pulse` solution's in-progress version entry if packet 02 of *this* initiative bumped it, or bumps if packet 02 only appended to an ADR-0040 entry that has since released. Check the in-progress state at edit time and record the decision. The two ADR-0045 Pulse packets (02 and 03) and ADR-0040's Pulse packets all share one solution version — only the first un-released packet bumps.
+
+## PII processor — `ITelemetryProcessor` is correct; consume the shared scrubber
+ADR-0045 D7 says error PII scrubbing uses `ITelemetryProcessor` — the classic App Insights SDK filter pipeline. ADR-0040 D9 is OTel-native (`SpanProcessor`/`LogRecordProcessor`). The two are not contradictory once the mechanism is understood: errors use the App Insights SDK directly (D3's carve-out), and the App Insights SDK's *only* filter hook is `ITelemetryProcessor` — OTel processors do not sit in the App Insights SDK's pipeline. So the error path **must** use `ITelemetryProcessor`; it is the correct and only mechanism for SDK-captured exception telemetry. ADR-0040 D9's mechanism choice applies to the *OTLP* path, not the *SDK* path.
+
+The **regex scrubbing rules** (emails, phone numbers, credit-card patterns, API keys, JWT shapes — the D7 list, identical to ADR-0040 D9's set) are **not** re-implemented here. ADR-0040 packet 05 builds the PII scrubber as a **shared, mechanism-agnostic component** (a plain, framework-free `PiiScrubber` — string in → redacted string out, plus an attribute/dimension allowlist). This packet's error `ITelemetryProcessor` simply **consumes** that shared scrubber. No refactor of ADR-0040 packet 05's code is needed — it is already shared by construction. Do not duplicate the regex set; reference the shared component.
+
+## Scope
+- `HoneyDrunk.Telemetry.Sink.AzureMonitor` — add the App-Insights-SDK-based error-capture path (exceptions → `TrackException`), the error `ITelemetryProcessor` for PII scrubbing (consuming the shared `PiiScrubber` from ADR-0040 packet 05), the `operation_id` cross-link wiring, the `application_Version` release-tag hook, the `IErrorReporter` facade implementation, and the DI registration so `IErrorReporter` is part of the standard Pulse telemetry registration (D5).
+- The `HoneyDrunk.Telemetry.Sink.AzureMonitor` unit-test project — unit tests for error capture, PII scrubbing, breadcrumb/scope behavior, and the `evals.sensitive` / Audit pass-through.
+
+## Proposed Implementation
+1. **App Insights error backing + `IErrorReporter` facade.** Extend `HoneyDrunk.Telemetry.Sink.AzureMonitor` so its error path captures exceptions into App Insights via `Microsoft.ApplicationInsights`'s `TelemetryClient`, and implement the `IErrorReporter` facade (packet 02's contract) — the class that captures ambient context, maintains breadcrumb/scope state, builds an `ErrorEvent`, and routes it through `IErrorSink`. The facade does not reinvent `IErrorSink`.
+   - `CaptureException` → builds an `ErrorEvent` from the exception + `ErrorContext`, routed via `IErrorSink` to `TelemetryClient.TrackException`, mapping `ErrorContext.TraceId` to the telemetry's `operation_Id` (D4 cross-link), `TenantId`/`UserId`/`Release` to custom dimensions / `Context.Component.Version`, and `Tags` to custom properties.
+   - `CaptureMessage` → `TelemetryClient.TrackTrace` with the mapped `ErrorLevel` → `SeverityLevel`.
+   - `AddBreadcrumb` → a scoped breadcrumb buffer; on the next capture, breadcrumbs are emitted as `customEvents` on the same `operation_Id` (D3 — App Insights expresses Sentry-style breadcrumbs via custom events).
+   - `PushScope` → an `AsyncLocal`-backed scope stack; scoped tags merge into subsequent captures until the returned `IDisposable` disposes.
+2. **`application_Version` release tag (D6)** — the implementation reads `ErrorContext.Release` and sets it as the telemetry's `application_Version`. Where `ErrorContext.Release` is not supplied, fall back to the host's assembly/informational version. The deploy-time release-annotation API call is packet 04's concern — this packet only ensures captured exceptions carry the version.
+3. **Connection string from Vault.** Reuse the App Insights connection string ADR-0040 packet 02 seeded into the relevant `kv-hd-{service}-{env}` Key Vault, resolved via `ISecretStore` — invariant 9, Vault is the only source of secrets; ADR-0045 D2 reuses the ADR-0040 connection string, no new secret. Never read it from an env var holding the raw value or an Azure SDK default credential path. The `TelemetryClient`'s `TelemetryConfiguration.ConnectionString` is set from the Vault-resolved value.
+4. **Error PII `ITelemetryProcessor` (D7)** — an `ITelemetryProcessor` registered into the App Insights SDK's processing pipeline (the SDK's only filter hook):
+   - Scrubs `ExceptionTelemetry` messages, stack-frame data, and custom dimensions of the D7 default-deny set: prompt text, completion text, recipient email addresses, message bodies, plus the common PII patterns (emails, phone numbers, credit-card patterns, API keys, JWT shapes).
+   - **Allowed through:** `tenant_id` (low-cardinality, load-bearing for triage, not PII); `user_id` as the opaque `PrincipalId` (ADR-0026); `service.name`; release version.
+   - **`evals.sensitive=true` carve-out** — exceptions thrown from AI-Node agent-execution paths carrying the `evals.sensitive=true` dimension are *not* scrubbed of prompt/completion content (ADR-0023 / ADR-0040 D9 carve-out). Without that dimension, prompt/completion content is redacted. The breadcrumb (capability invoked, model, cost) is always allowed.
+   - **`HoneyDrunk.Audit`-emitted errors** carry PII by design (recipient address on a notification failure). These are recognized by the Audit `service.name` / `source=hd-audit` dimension and pass through unredacted to the Audit-tagged Log Analytics table (`sensitive=audit`, 730-day retention per ADR-0040 D3).
+5. **Consume the shared `PiiScrubber`.** ADR-0040 packet 05 builds the regex PII scrubber as a shared, mechanism-agnostic component (a plain, framework-free `PiiScrubber` — string in → redacted string out, plus the attribute allowlist). This packet's error `ITelemetryProcessor` references that shared component — it does **not** re-implement the regex set and does **not** refactor packet 05's code (the component is already shared by construction). One regex surface, no duplication, no drift.
+6. **DI registration (D5)** — a registration extension so `IErrorReporter` is part of the standard Pulse telemetry registration. All Nodes consuming Pulse get error reporting once the backing is wired; opt-out is per Node via configuration. The error `ITelemetryProcessor` is added to the `TelemetryConfiguration` pipeline in the same extension.
+7. **XML documentation** on every public member (invariant 13).
+8. **Version.** See Context — append or bump per the invariant-27 in-progress state check; record the decision.
+9. **CHANGELOG / README.** `HoneyDrunk.Telemetry.Sink.AzureMonitor/CHANGELOG.md` gets an entry (actual change). Repo-level `CHANGELOG.md` updated. Update `HoneyDrunk.Telemetry.Sink.AzureMonitor/README.md` if the error-capture registration is part of the documented public surface.
+
+## Affected Files
+- `HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/` — the App Insights error-capture path (`IErrorSink` backing), the `IErrorReporter` facade implementation, error `ITelemetryProcessor`, breadcrumb/scope handling, DI registration.
+- The `HoneyDrunk.Telemetry.Sink.AzureMonitor` unit-test project — error-capture and scrubbing tests.
+- Repo-level `CHANGELOG.md`; `HoneyDrunk.Telemetry.Sink.AzureMonitor/CHANGELOG.md`; `HoneyDrunk.Telemetry.Sink.AzureMonitor/README.md` (if API-surface relevant).
+- Possibly every non-test `.csproj` (if this packet bumps the solution version).
+
+## NuGet Dependencies
+`HoneyDrunk.Telemetry.Sink.AzureMonitor` — confirm `Microsoft.ApplicationInsights` is present (the App Insights .NET SDK — `TelemetryClient`, `ExceptionTelemetry`, `ITelemetryProcessor`); the existing AzureMonitor sink most likely already references it. Add it only if absent. ADR-0045 D3's carve-out: the error path uses the SDK directly, not OTLP. If a hosting integration is needed, `Microsoft.ApplicationInsights.AspNetCore` — pick per the Pulse runtime's host model and document.
+
+Already present in `HoneyDrunk.Telemetry.Sink.AzureMonitor` (confirm; add none of these new):
+- `HoneyDrunk.Telemetry.Abstractions` — the project reference carrying `IErrorReporter` and `IErrorSink`/`ErrorEvent` (packet 02 added the facade).
+- The shared `PiiScrubber` component from ADR-0040 packet 05 — reference the project/package it lives in; do not duplicate the regex set.
+- The Vault `ISecretStore` reference for the connection string.
+- `HoneyDrunk.Kernel.Abstractions` — Grid context for `TenantId`/`PrincipalId`.
+- `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Options`, `Microsoft.Extensions.Logging.Abstractions`.
+- `HoneyDrunk.Standards` — analyzers, `PrivateAssets: all` (invariant 26).
+
+The `HoneyDrunk.Telemetry.Sink.AzureMonitor` unit-test project — no new packages beyond the existing test stack; project reference to `HoneyDrunk.Telemetry.Sink.AzureMonitor`.
+
+## Boundary Check
+- [x] `HoneyDrunk.Pulse` is the correct repo — outbound error telemetry export belongs to Pulse per `repos/HoneyDrunk.Observe/boundaries.md` and `repos/HoneyDrunk.Pulse/boundaries.md`; the error backing extends the existing `HoneyDrunk.Telemetry.Sink.AzureMonitor` package. ADR-0045 (amended 2026-05-22) confirms it.
+- [x] The App Insights error SDK lives inside the Pulse sink package, never in a consuming Node — D3/D5 reversibility property.
+- [x] The error backing consumes the published `IErrorReporter`/`IErrorSink` contracts from `HoneyDrunk.Telemetry.Abstractions`, not internals (invariant 3); the `IErrorReporter` facade does not reinvent `IErrorSink`.
+- [x] No consuming Node changes in this packet — Nodes wire `IErrorReporter` via the standard Pulse telemetry registration (packet 05 / the wiring playbook do the per-Node wiring).
+- [x] No new package — the error backing extends the existing `HoneyDrunk.Telemetry.Sink.AzureMonitor`.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Telemetry.Sink.AzureMonitor` captures exceptions into App Insights via the .NET SDK (`TelemetryClient.TrackException`/`TrackTrace`); the `IErrorReporter` facade is implemented over the existing `IErrorSink` and does not reinvent it
+- [ ] `ErrorContext.TraceId` maps to the telemetry's `operation_Id` so the App Insights Failures→Transactions cross-link works natively (D4)
+- [ ] `application_Version` is set from `ErrorContext.Release` (fallback: host assembly version) so captured exceptions carry release info (D6)
+- [ ] `AddBreadcrumb` and `PushScope` work as scoped `IDisposable`s; breadcrumbs emit as `customEvents` on the same `operation_Id`
+- [ ] The App Insights connection string is resolved via `ISecretStore` (Vault) — the same secret ADR-0040 packet 02 seeded, no new secret; never from an env var holding the raw value, never hardcoded (invariants 8, 9)
+- [ ] An error PII `ITelemetryProcessor` is registered into the App Insights SDK pipeline and scrubs prompt/completion text, recipient emails, message bodies, and common PII patterns (emails, phones, credit cards, API keys, JWT shapes) from exception messages and custom dimensions
+- [ ] `tenant_id`, the opaque `user_id`, `service.name`, and release version pass through (not PII per D7)
+- [ ] Telemetry carrying `evals.sensitive=true` is NOT scrubbed of prompt/completion content (the ADR-0023/ADR-0040 D9 carve-out); `HoneyDrunk.Audit`-attributed errors pass through unredacted to the Audit-tagged table
+- [ ] The error `ITelemetryProcessor` **consumes the shared `PiiScrubber`** from ADR-0040 packet 05 — single regex surface, no duplication, no re-implementation of the regex set
+- [ ] `IErrorReporter` is registered as part of the standard Pulse telemetry registration so consuming Nodes get error reporting automatically; per-Node opt-out is configurable (D5)
+- [ ] The `HoneyDrunk.Telemetry.Sink.AzureMonitor` unit-test project covers error capture, the `operation_id` mapping, breadcrumb/scope behavior, PII scrubbing, and the `evals.sensitive`/Audit pass-through; tests use no external services (invariant 15), no `Thread.Sleep` (invariant 51)
+- [ ] Every new public member has XML documentation (invariant 13)
+- [ ] The invariant-27 version-state check is performed — bump or append — and recorded in the PR
+- [ ] `HoneyDrunk.Telemetry.Sink.AzureMonitor/CHANGELOG.md` updated; repo-level `CHANGELOG.md` updated
+- [ ] The solution builds; existing unit and canary tests pass
+
+## Human Prerequisites
+- [ ] The `dev` App Insights resource and its Vault-stored connection string must exist — provisioned by **ADR-0040 packet 02** (`infrastructure/walkthroughs/application-insights-provisioning.md`). ADR-0045 introduces **no new Azure resource**: errors capture into the same App Insights resource as traces/metrics/logs (D2). This is a cross-initiative prerequisite, not a `dependencies:` edge — the filing pipeline does not resolve cross-initiative `packet:NN` references, so it is listed here. Unit tests for this packet must not require a live resource (invariant 15 — use in-memory doubles); the end-to-end smoke check (an exception appears in the `dev` App Insights Failures blade) is the realistic verification and is deferred until ADR-0040 packet 02 has run.
+
+## Referenced ADR Decisions
+**ADR-0045 D3 — Errors flow through Pulse; `IErrorReporter` is a facade over `IErrorSink`; the App Insights backing uses the .NET SDK.** A carve-out from ADR-0040's OTLP path: the App Insights error model carries `problem_id`, `application_Version`, and Failures-blade grouping dimensions that are not OTLP primitives. The SDK is wrapped behind Pulse's `IErrorSink`; `IErrorReporter` is the facade over it. A backend swap (Sentry, D11 — via the existing `HoneyDrunk.Telemetry.Sink.Sentry`) stays a config change.
+
+**ADR-0045 — amendment 2026-05-22.** The error backing extends the existing `HoneyDrunk.Telemetry.Sink.AzureMonitor` package in `HoneyDrunk.Pulse` — it does not create a new package and does not live in `HoneyDrunk.Observe`.
+
+**ADR-0045 D4 — Cross-link via `operation_id`.** App Insights' Failures and Transactions blades share `operation_id` (≈ `trace_id`). Mapping `ErrorContext.TraceId` to `operation_Id` makes the errors↔traces↔logs navigation native — no configured integration.
+
+**ADR-0045 D5 — Per-Node opt-in via Pulse configuration.** `IErrorReporter` is part of the standard Pulse telemetry registration; all Nodes consuming Pulse get error reporting once the backing is wired; opt-out is per Node via configuration.
+
+**ADR-0045 D6 — Release tracking via `application_Version`.** Captured exceptions carry the deployable's SemVer; the Failures-blade release annotations make "this error first appeared in v0.4.2" visible. The deploy-time annotation call is packet 04.
+
+**ADR-0045 D7 — PII, tenant scoping, sensitive-content carve-outs.** Mechanism is `ITelemetryProcessor` (the App Insights SDK's filter hook — the correct mechanism for SDK-captured telemetry; ADR-0040 D9's mechanism choice applies only to the OTLP path). `tenant_id` allowed (not PII); `user_id` allowed as the opaque `PrincipalId`; prompt/completion text forbidden by default, allowed only behind `evals.sensitive=true`; common PII patterns regex-scrubbed via the shared scrubber; Audit-emitted errors are PII-bearing by design and route to the Audit-tagged table.
+
+**ADR-0040 D9 — PII carve-outs.** ADR-0040 builds the PII scrubber as a shared, mechanism-agnostic component; this packet's error `ITelemetryProcessor` consumes that shared component.
+
+**ADR-0040 D2 — Pulse is the telemetry-export boundary.** The error path is the explicit carve-out — SDK, not OTLP — but the backend still lives inside the Pulse sink family, never in a consuming Node.
+
+**ADR-0023 — Evals carve-out.** `HoneyDrunk.Evals` signals (and prompt/completion content) are the deliberate exception to the content default-deny.
+
+**ADR-0005 — Vault.** The App Insights connection string is resolved via `ISecretStore`. One Key Vault per deployable Node per environment.
+
+## Constraints
+> **Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.** Does not apply to `HoneyDrunk.Telemetry.Sink.AzureMonitor` (a provider/sink package) — but the App Insights SDK reference goes in the sink package, never in `HoneyDrunk.Telemetry.Abstractions` (packet 02 kept the abstraction SDK-free).
+
+> **Invariant 3 — Provider packages depend on their parent Node's contracts, not internals.** `HoneyDrunk.Telemetry.Sink.AzureMonitor` implements the published `IErrorSink`; the `IErrorReporter` facade builds on it. Neither reinvents the other.
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The App Insights connection string is a secret. Additionally — load-bearing for an *error-tracking* packet — the PII processor must ensure scrubbing never lets a secret value (API key, JWT) survive into a captured exception.
+
+> **Invariant 9 — Vault is the only source of secrets.** The connection string is resolved via `ISecretStore` — the same secret ADR-0040 packet 02 seeded. No new secret for the error path in v1 (ADR-0045 D2).
+
+> **Invariant 13 — All public APIs have XML documentation.**
+
+> **Invariant 15 — Unit tests never depend on external services.** Error-capture and scrubbing tests run in-process against constructed `ExceptionTelemetry` — no live App Insights resource.
+
+> **Invariant 26 — `## NuGet Dependencies` section required; `HoneyDrunk.Standards` on every new .NET project.**
+
+> **Invariant 27 — All projects in a solution share one version and move together.** Perform the in-progress version-state check; bump or append; record the decision.
+
+> **Invariant 51 — Test code contains no `Thread.Sleep`.**
+
+> **Error-flow invariant (invariant 80, added by packet 00) — errors captured for the D8 capture-eligible cases flow through `IErrorReporter`, never via a direct backend SDK call.** This packet is the *only* place the App Insights SDK is touched for errors — it is the backing behind `IErrorSink`/`IErrorReporter`. Consuming Nodes never call `TelemetryClient` directly.
+
+- **`ITelemetryProcessor` is correct here.** The error path uses the App Insights SDK directly (D3's carve-out); `ITelemetryProcessor` is the SDK's only filter hook. ADR-0040 D9's mechanism choice applies to the OTLP path, not the SDK path. Do not try to use an OTel `SpanProcessor` for SDK-captured exceptions.
+- **Consume the shared `PiiScrubber`.** ADR-0040 packet 05 builds the PII scrubber as a shared, mechanism-agnostic component from the start. This packet consumes it — do not re-implement the regex set, do not refactor packet 05's code.
+- **No new App Insights resource, no new secret, no new package.** Errors reuse the ADR-0040 resource and connection string (D2) and extend the existing `HoneyDrunk.Telemetry.Sink.AzureMonitor`.
+- **`IErrorReporter` is a facade over `IErrorSink`.** Do not reinvent error capture — build an `ErrorEvent` and route it through the existing sink.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0045`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Extend `HoneyDrunk.Telemetry.Sink.AzureMonitor` with the App-Insights-SDK-based error backing, the `IErrorReporter` facade implementation, the `operation_id` cross-link, the `application_Version` release tag, and the error PII `ITelemetryProcessor`.
+
+**Target:** `HoneyDrunk.Pulse`, branch from `main`.
+
+**Context:**
+- Goal: Give the Grid a real error-capture path — `IErrorReporter` (facade) over `IErrorSink` backed by App Insights Failures, with native trace cross-link and PII scrubbing.
+- Feature: ADR-0045 Grid-Wide Error Tracking rollout, Wave 3.
+- ADRs: ADR-0045 D3/D4/D5/D6/D7 (primary), ADR-0040 D2/D9 (the OTLP carve-out and the shared PII-scrubbing surface), ADR-0023 (Evals carve-out), ADR-0005 (Vault), ADR-0026 (tenant/principal primitives).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — hard. This packet implements the `IErrorReporter` facade packet 02 added.
+- ADR-0040 packet 05 (cross-initiative) — hard. Packet 05 builds the shared PII scrubber this packet consumes. Express as `Architecture#<issue-number>` once filed.
+
+**Constraints:**
+- The App Insights error SDK lives in the Pulse sink package, never in a consuming Node.
+- `ITelemetryProcessor` is the correct mechanism for the SDK error path — not an OTel `SpanProcessor`.
+- Consume the shared `PiiScrubber` from ADR-0040 packet 05 — do not re-implement or refactor.
+- `IErrorReporter` is a facade over the existing `IErrorSink` — do not reinvent error capture.
+- Connection string from Vault — the same secret as ADR-0040 packet 02, no new secret (invariants 8, 9).
+- Perform the invariant-27 version-state check on the `HoneyDrunk.Pulse` solution — bump or append; record the decision.
+
+**Key Files:**
+- `HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/` — error backing, `IErrorReporter` facade impl, error `ITelemetryProcessor`, DI registration
+- The `HoneyDrunk.Telemetry.Sink.AzureMonitor` unit-test project
+- `HoneyDrunk.Telemetry.Sink.AzureMonitor/CHANGELOG.md`; repo-level `CHANGELOG.md`
+
+**Contracts:**
+- Implements `IErrorSink` (existing) and the `IErrorReporter` facade (from packet 02). No contract change — this is the backing.

--- a/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/04-actions-app-insights-release-annotation.md
+++ b/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/04-actions-app-insights-release-annotation.md
@@ -1,0 +1,131 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "adr-0045", "wave-3"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0045", "ADR-0015", "ADR-0033", "ADR-0012"]
+accepts: ["ADR-0045"]
+wave: 3
+initiative: adr-0045-grid-wide-error-tracking
+node: honeydrunk-actions
+---
+
+# Amend the Actions deploy workflows to call the App Insights release annotations API
+
+## Summary
+Amend the reusable deploy workflows in `HoneyDrunk.Actions` (`job-deploy-container-app.yml`, `job-deploy-function.yml`) with a post-deploy step that calls the Application Insights release annotations API per ADR-0045 D6 — so the deployable's SemVer tag lands as a release annotation on the App Insights Failures-blade trend graph, making "this error first appeared in v0.4.2" visible.
+
+## Context
+ADR-0045 D6 wires release tracking to the Grid's deploy flows. App Insights' release-tracking feature uses the `application_Version` property on captured telemetry (packet 03 sets that on each captured exception) **and** the release annotations API, which marks the deploy moment on the Failures trend graph.
+
+ADR-0045 D6 is explicit: "the `HoneyDrunk.Actions` reusable deploy workflows (per ADR-0015) are amended to set `application_Version` to the deployable's SemVer tag (per ADR-0033's tag→environment mapping) and to mark the deploy via the current supported release-annotation mechanism. Captured exceptions automatically carry this version."
+
+**Release-annotation mechanism — use the current supported one.** The deploy step marks the deploy moment on the App Insights Failures trend graph using the **current supported release-annotation mechanism — `az monitor app-insights` / ARM**. The legacy `aisvc.visualstudio.com` annotations endpoint (`https://aigs1.aisvc.visualstudio.com/applicationinsights/release/v2.0/api`) is a **fallback only** if no supported equivalent applies. Research the current surface at execution time and prefer the supported path.
+
+`HoneyDrunk.Actions` already owns the reusable CI/CD workflows (per ADR-0012, Actions is the Grid's CI/CD control plane). The relevant deploy workflows in `.github/workflows/`:
+- `job-deploy-container-app.yml` — Azure Container Apps deploy (per ADR-0015 — Notify.Functions/Worker, Pulse.Collector, future Notify Cloud).
+- `job-deploy-function.yml` — Azure Function App deploy.
+
+This packet adds a post-deploy release-annotation step to those reusable workflows, gated so it is a no-op when the App Insights resource is not configured (graceful for environments that have not provisioned telemetry yet — staging/prod are still in flight per ADR-0033).
+
+**This is a workflow/YAML packet. No .NET project.** `HoneyDrunk.Actions` is not a versioned .NET solution — no version bump, no `## NuGet Dependencies`-driven project change. The repo's `CHANGELOG.md` (if it keeps one for the workflow surface) is updated per the repo convention.
+
+## Scope
+- `.github/workflows/job-deploy-container-app.yml` — add the post-deploy release-annotation step.
+- `.github/workflows/job-deploy-function.yml` — add the same step.
+- `docs/consumer-usage.md` (or the equivalent docs the deploy workflows reference) — document the new optional inputs.
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface.
+
+## Proposed Implementation
+1. **New optional workflow inputs** on both deploy workflows:
+   - `app-insights-release-annotation` (boolean, default `false`) — gate the step. When `false`, the step is a clean no-op (environments without provisioned telemetry — staging/prod per ADR-0033).
+   - `app-insights-resource-id` — the App Insights ARM resource id the annotation targets. Supplied by the consuming repo's release workflow.
+   - The deployable's SemVer version — reuse whatever input the workflows already carry for the version/tag (per ADR-0033's tag→environment mapping). Do not add a duplicate version input if one exists.
+2. **Post-deploy release-annotation step** — runs after the deploy + health-probe succeeds (an annotation for a failed deploy is misleading; only annotate a successful revision/slot). The step:
+   - Authenticates with Azure via the existing OIDC federation the workflows already use (no new credential — the deploy job is already OIDC-authenticated; reuse that token / `az` session).
+   - Marks the deploy via the **current supported release-annotation mechanism — `az monitor app-insights` / ARM** (the primary, default path). The legacy raw `aisvc.visualstudio.com` endpoint is a **fallback only** if the supported mechanism does not apply. **Research the current supported surface at execution time and document the choice.** The annotation payload carries the deployable's name, the SemVer version, and the deploy timestamp.
+   - Is gated on `app-insights-release-annotation == true` and a non-empty `app-insights-resource-id`.
+3. **Graceful no-op.** If the gate input is `false` or the resource id is empty, the step logs a single skipped-annotation line and exits 0. A deploy must never fail because release annotation was not configured — annotation is observability sugar, not a deploy gate.
+4. **No secret in the workflow.** The annotation API call authenticates via the existing OIDC federation. No DSN, no instrumentation key, no connection string is needed for the annotation API — it is ARM/AAD-authenticated. If any token is required, it is acquired at runtime via OIDC; nothing is stored in the workflow or repo (invariant 8).
+5. **Docs.** Update the consumer-usage docs so a consuming repo's release workflow knows to set the two new inputs. Cross-reference: the consuming repo also needs packet 03's `HoneyDrunk.Telemetry.Sink.AzureMonitor` error backing wired for the `application_Version` on captured exceptions to be meaningful — note that the annotation and the per-exception version are two halves of D6.
+
+## Affected Files
+- `.github/workflows/job-deploy-container-app.yml`
+- `.github/workflows/job-deploy-function.yml`
+- `docs/consumer-usage.md` (or the equivalent referenced docs)
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface.
+
+## NuGet Dependencies
+None. `HoneyDrunk.Actions` deploy workflows are GitHub Actions YAML — no .NET project is created or modified by this packet.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo — ADR-0045 D6 names "the `HoneyDrunk.Actions` reusable deploy workflows"; ADR-0012 makes Actions the CI/CD control plane.
+- [x] The reusable deploy workflows are the right surface — consuming repos call them; the release annotation is a deploy-time concern.
+- [x] No code change in any Node — the per-exception `application_Version` is packet 03's concern in Observe; this packet only adds the deploy-moment annotation.
+
+## Acceptance Criteria
+- [ ] `job-deploy-container-app.yml` and `job-deploy-function.yml` each have a post-deploy step that marks the deploy on App Insights via the **current supported release-annotation mechanism (`az monitor app-insights` / ARM)** with the deployable name, SemVer version, and deploy timestamp; the legacy `aisvc.visualstudio.com` endpoint is used only as a documented fallback if no supported equivalent applies
+- [ ] The step runs only after a successful deploy + health probe — a failed deploy produces no annotation
+- [ ] New optional inputs `app-insights-release-annotation` (boolean, default `false`) and `app-insights-resource-id` gate the step; the deployable version reuses an existing version/tag input
+- [ ] When the gate is `false` or the resource id is empty, the step is a clean no-op (logs one skipped line, exits 0) — a deploy never fails for lack of annotation config
+- [ ] The annotation call authenticates via the existing OIDC federation — no DSN, instrumentation key, connection string, or any secret in the workflow or repo (invariant 8)
+- [ ] `docs/consumer-usage.md` documents the two new inputs and notes the annotation pairs with packet 03's per-exception `application_Version`
+- [ ] The current supported annotation mechanism is researched and the choice documented; `az monitor app-insights` / ARM is the default, the raw `aisvc` endpoint a fallback only
+- [ ] The repo `CHANGELOG.md` is updated if the repo keeps one for the workflow surface
+- [ ] Existing consumers of the deploy workflows are unaffected — the new inputs are optional with safe defaults
+
+## Human Prerequisites
+- [ ] For the release annotation to land on a real resource, a consuming repo's release workflow must supply the `app-insights-resource-id` of an App Insights resource provisioned by **ADR-0040 packet 02**. Until that resource exists (and staging/prod environments stand up per ADR-0033), the annotation step is left gated `false` — the workflow change is inert and safe. This is a cross-initiative prerequisite, not a `dependencies:` edge.
+- [ ] No portal step is required to land this packet itself — it is a workflow edit. The first *use* of the annotation happens when a consuming repo opts in.
+
+## Referenced ADR Decisions
+**ADR-0045 D6 — Release tracking via `application_Version`.** Container Apps deployable Nodes — the `HoneyDrunk.Actions` reusable deploy workflows are amended to set the deployable's SemVer tag (per ADR-0033's tag→environment mapping) and mark the deploy via the **current supported release-annotation mechanism (`az monitor app-insights` / ARM)**; the legacy `aisvc.visualstudio.com` endpoint is a fallback only. The Failures blade surfaces these as annotations on the trend graph. Library/Abstractions packages do not set a version. Workflow quality is lower than Sentry's release surface — acceptable for v1, named as a D11 escalation trigger.
+
+**ADR-0015 — Container hosting.** Azure Container Apps for containerized Nodes; the Actions reusable deploy workflows are the deploy surface.
+
+**ADR-0033 — Tag→environment mapping.** The SemVer tag drives the environment; staging/prod environments are still in flight — the annotation step is gated off until they stand up.
+
+**ADR-0012 — Actions is the CI/CD control plane.** Reusable workflows in `HoneyDrunk.Actions` are the Grid's CI/CD surface.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry — or in workflow files.** The release annotation API call is OIDC/AAD-authenticated. No DSN, instrumentation key, or connection string is committed to a workflow or the repo.
+
+- **Annotation is never a deploy gate.** A failed or unconfigured annotation must not fail the deploy. Gate the step; no-op cleanly.
+- **Reuse the existing OIDC auth.** The deploy job is already OIDC-authenticated — do not add a new credential or service principal for the annotation call.
+- **Optional, backward-compatible inputs.** Existing consumers of the deploy workflows must be unaffected — new inputs default to off.
+- **Use the current supported API surface.** `az monitor app-insights` / ARM is the default, supported mechanism. The raw `aisvc.visualstudio.com` endpoint is a legacy surface — fallback only if no supported equivalent applies. Research and document the choice.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `adr-0045`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Add a post-deploy App Insights release-annotation step to the `HoneyDrunk.Actions` reusable container-app and function deploy workflows.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Make "this error first appeared in v0.4.2" visible on the App Insights Failures trend graph by annotating each successful deploy with the deployable's SemVer.
+- Feature: ADR-0045 Grid-Wide Error Tracking rollout, Wave 3.
+- ADRs: ADR-0045 D6 (primary), ADR-0015 (Container Apps deploy surface), ADR-0033 (tag→environment mapping), ADR-0012 (Actions as CI/CD control plane).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0045 should be Accepted before its deploy-flow changes land. No code dependency on the Observe packets — this packet is independent of packets 02/03 and can run in parallel.
+
+**Constraints:**
+- The annotation step is never a deploy gate — gate it, no-op cleanly.
+- Reuse the existing OIDC auth; no new credential.
+- New inputs are optional, default-off, backward-compatible.
+- No secret in the workflow (invariant 8).
+- Use the current supported annotation mechanism (`az monitor app-insights` / ARM) as the default; legacy `aisvc` endpoint fallback only; document the choice.
+
+**Key Files:**
+- `.github/workflows/job-deploy-container-app.yml`
+- `.github/workflows/job-deploy-function.yml`
+- `docs/consumer-usage.md`
+
+**Contracts:** None — workflow inputs only.

--- a/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/05-notify-migrate-sentry-to-ierror-reporter.md
+++ b/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/05-notify-migrate-sentry-to-ierror-reporter.md
@@ -1,0 +1,159 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["feature", "tier-2", "ops", "adr-0045", "wave-4"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0045", "ADR-0040"]
+accepts: ["ADR-0045"]
+wave: 4
+initiative: adr-0045-grid-wide-error-tracking
+node: honeydrunk-notify
+---
+
+# Migrate HoneyDrunk.Notify from Sentry config to IErrorReporter
+
+## Summary
+Migrate `HoneyDrunk.Notify` off its one-off Sentry integration onto the Grid's `IErrorReporter` (ADR-0045 D5). A source scan found **no Sentry SDK code in Notify — only account/DSN configuration**, so the primary case is a **config-only migration**: audit Notify's D8 error-capture sites, wire them to `IErrorReporter` via Notify's Pulse telemetry dependency, and archive the config-only Sentry account. The parallel-output window is skipped — nothing in Notify emits to Sentry from code, so there is nothing to run in parallel. The SDK-replacement path is kept only as a fallback if the execution-time scan unexpectedly finds SDK code.
+
+## Context
+ADR-0045 D5 makes `HoneyDrunk.Notify` the migration case. Notify has Sentry provisioned as a one-off that predates the ADR family — but **only at the account / DSN / config level**. D5/D13: this is **removed, not extended** — Notify migrates onto App Insights via `IErrorReporter`; the Notify-Sentry account is archived.
+
+**Repo-state — the primary case is config-only.** A scan of `HoneyDrunk.Notify` found **no `Sentry` / `SentrySdk` references in the `.cs` source** and Sentry in **no `.csproj`**. Notify has a `Diagnostics/NotifyActivitySource.cs` (OTel `ActivitySource`) and a `HoneyDrunk.Notify.slnx` with ~17 projects. The Sentry integration the ADR describes lives only at the account / DSN / config level — a Sentry project + DSN provisioned but with no SDK wiring in code. So the **primary scope** of this packet is:
+1. Audit Notify's D8 error-capture sites.
+2. Wire those sites to `IErrorReporter`.
+3. Remove any Sentry DSN/config references (`appsettings*.json` keys, Vault DSN secret references in config).
+4. Archive the config-only Sentry account (human step).
+
+**No parallel-output window.** The ADR's D10 Phase 1 parallel-run window exists to de-risk an SDK cutover. Because nothing in Notify emits to Sentry from code, there is nothing to run in parallel — the cutover *is* the moment `IErrorReporter` is wired. Skip the parallel window; record in the PR that it was skipped because no SDK code exists.
+
+**Fallback — SDK migration.** *Only if* the execution-time scan unexpectedly finds Sentry SDK code (a host-bootstrap project, a config file the scan missed): fall back to the SDK-replacement path — replace `SentrySdk.CaptureException(...)` with `_errorReporter.CaptureException(...)`, remove `SentrySdk.Init(dsn)`, drop the `Sentry` `PackageReference`, and run a parallel-output window for parity verification. This is the fallback, not the expected path.
+
+**Cross-package dependency.** This packet depends on `packet:03` — `HoneyDrunk.Telemetry.Sink.AzureMonitor` must implement the `IErrorReporter` facade and register it before Notify can consume it. Confirm Notify depends on `HoneyDrunk.Pulse`'s telemetry packages (Notify already consumes Pulse telemetry) and add the reference if a project that needs `IErrorReporter` lacks it.
+
+**Notify is a live, deployable Node.** Notify is at the version its `CHANGELOG.md` records; this packet bumps the `HoneyDrunk.Notify` solution (the only ADR-0045 packet on that solution — minor bump for the error-reporting integration).
+
+## Scope
+- `HoneyDrunk.Notify` solution — wire `IErrorReporter` through Notify's Pulse telemetry dependency; route Notify's error-capture call sites (per D8) through it.
+- Notify's error-capture sites — audit against ADR-0045 D8 (capture-as-error vs log-only) and route the capture-eligible ones through `IErrorReporter`.
+- Sentry config references — remove DSN / config keys from `appsettings*.json` and any Vault DSN config reference (the code does not read a Sentry SDK; this is config cleanup).
+- Notify test projects — update/extend tests for the new error path.
+- The Notify-Sentry account and DSN — archival is a human step (see Human Prerequisites).
+- **Fallback only** — if SDK code is found: replace `SentrySdk.*` calls, drop the `Sentry` `PackageReference`, run a parallel-output window.
+
+## Proposed Implementation
+1. **Scan to confirm the config-only case.** Grep the whole `HoneyDrunk.Notify.slnx` tree for `Sentry`; check `HoneyDrunk.Notify.HostBootstrap`, `HoneyDrunk.Notify.Functions`, `HoneyDrunk.Notify.Worker`, and `appsettings*.json`. The expected finding: config/DSN only, no SDK code. Record the finding in the PR. Steps 2–4 are the primary path; step 6 is the fallback.
+2. **Wire `IErrorReporter`.** Confirm `HoneyDrunk.Notify` (the core project, and the deployable hosts) depend on Pulse's telemetry packages and consume the standard Pulse telemetry registration. Inject `IErrorReporter` where errors are captured. The DI registration from packet 03 makes `IErrorReporter` available once the AzureMonitor sink backing is registered in Notify's host composition.
+3. **Audit error-capture sites against D8.** Route Notify's capture-eligible failures through `IErrorReporter`: failed provider sends after retries exhausted (Resend/SMTP/Twilio 5xx with no retry path), unrecoverable dispatch failures, idempotency-store write failures. Recoverable-retry successes and inbound-validation failures stay log-only (D8). The per-case mapping is the D8 list — packet 06 also lands this in `.claude/agents/review.md`. Populate `ErrorContext` with `TraceId` (from the current `Activity` / `NotifyActivitySource`), `TenantId`, `UserId` (opaque `PrincipalId`), `Release` (the Notify deployable version).
+4. **Remove Sentry config.** Remove Sentry DSN / config keys from `appsettings*.json` and any config-level Vault DSN reference. The Sentry DSN *secret* in the Key Vault is not deleted by this PR (the human archival step handles decommission so a rollback window exists) — but the config stops pointing at it.
+5. **Vault.** No new secret. The App Insights connection string is resolved by the Pulse AzureMonitor backing (packet 03), not by Notify directly — Notify never touches a telemetry secret (invariant 9; invariant 80).
+6. **Fallback — only if SDK code is found.** Replace `SentrySdk.CaptureException(ex)` → `IErrorReporter.CaptureException(ex, errorContext)`, `SentrySdk.CaptureMessage(...)` → `IErrorReporter.CaptureMessage(...)`, Sentry breadcrumb/scope → `AddBreadcrumb`/`PushScope`; remove `SentrySdk.Init(dsn)`; drop the `Sentry` `PackageReference` from every `.csproj` that has it; run a parallel-output window (transitional config flag `errors.parallel-output-to-sentry`, default off after cutover) for parity verification, then remove the flag. Skip this entire step in the expected config-only case.
+7. **XML documentation** on any new public member (invariant 13).
+8. **Version bump.** Per invariant 27, this is the only ADR-0045 packet on the `HoneyDrunk.Notify` solution — it bumps the version (minor — the error-reporting integration). Every non-test `.csproj` moves to the same new version in one commit.
+9. **CHANGELOG / README.** Repo-level `CHANGELOG.md` new-version entry. Per-package `CHANGELOG.md` entries only for packages with actual changes (no noise entries for alignment-only bumps — invariant 27). Update Notify's `README.md` if the error-reporting setup is part of the documented public/operational surface.
+
+## Affected Files
+- `HoneyDrunk.Notify/HoneyDrunk.Notify/` (core) — `IErrorReporter` injection, error-capture call sites.
+- `HoneyDrunk.Notify.HostBootstrap`, `HoneyDrunk.Notify.Functions`, `HoneyDrunk.Notify.Worker` — Pulse telemetry registration; `appsettings*.json` Sentry config removal.
+- Any `.csproj` carrying a `Sentry` `PackageReference` — reference removed (**fallback only — not expected**).
+- Notify test projects — error-path tests.
+- Repo-level `CHANGELOG.md`; per-package `CHANGELOG.md` for changed packages; every non-test `.csproj` (version bump).
+
+## NuGet Dependencies
+- **Removed:** `Sentry` (and any `Sentry.*` package) — **fallback only, not expected.** The scan found no `Sentry` `PackageReference`; remove one only if the execution-time scan unexpectedly finds it.
+- **Added:** none directly — `IErrorReporter` comes from `HoneyDrunk.Telemetry.Abstractions`, which Notify reaches through its existing Pulse telemetry dependency. Confirm the Pulse telemetry project/package reference is present on the projects that need `IErrorReporter`; add the reference only if a project that needs it does not already have it.
+- The AzureMonitor sink backing (`HoneyDrunk.Telemetry.Sink.AzureMonitor`) is registered in Notify's deployable **host** composition (HostBootstrap/Functions/Worker) — confirm the host references it; the App Insights SDK stays inside the Pulse sink backing, never in Notify code (invariant 80).
+- `HoneyDrunk.Standards` is already on Notify's projects — no change.
+
+## Boundary Check
+- [x] `HoneyDrunk.Notify` is the correct repo — ADR-0045 D5 names Notify as the migration case explicitly.
+- [x] Notify consumes `IErrorReporter` (a published Pulse contract) — it does not reference the App Insights SDK or Pulse internals (invariant 3; invariant 80).
+- [x] The App Insights sink backing is composed in Notify's deployable host, not in Notify's library code — D3/D5 reversibility.
+- [x] No contract change — Notify is a consumer of `IErrorReporter`, not its owner.
+
+## Acceptance Criteria
+- [ ] The Sentry footprint in `HoneyDrunk.Notify` is confirmed by a whole-solution scan; the expected finding (config/DSN only, no SDK code) is recorded in the PR
+- [ ] `IErrorReporter` is injected and consumed at Notify's error-capture sites; Notify's deployable hosts register the Pulse AzureMonitor sink backing
+- [ ] Notify's error-capture sites are audited against ADR-0045 D8 — capture-eligible failures (exhausted-retry provider sends, unrecoverable dispatch failures, idempotency-store write failures) route through `IErrorReporter`; recoverable retries and inbound-validation failures stay log-only
+- [ ] Sentry DSN / config keys are removed from `appsettings*.json` and any config-level Vault DSN reference
+- [ ] The parallel-output window is **skipped** (config-only case — nothing emits to Sentry from code) and that is recorded in the PR; the SDK-replacement fallback is applied only if the scan unexpectedly finds SDK code
+- [ ] After the migration, errors flow to App Insights via `IErrorReporter`; no `SentrySdk` call exists (and none did)
+- [ ] Notify reads no telemetry secret directly — the App Insights connection string is resolved by the Pulse sink backing (invariant 9; invariant 80)
+- [ ] Notify test projects cover the new error path; tests use no external services (invariant 15), no `Thread.Sleep` (invariant 51)
+- [ ] Every new public member has XML documentation (invariant 13)
+- [ ] The `HoneyDrunk.Notify` solution version is bumped (minor); every non-test `.csproj` moves to the same version (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new-version entry; per-package `CHANGELOG.md` entries only for packages with actual changes (invariant 27)
+- [ ] The solution builds; existing unit and integration tests pass
+
+## Human Prerequisites
+- [ ] **Archive the config-only Notify-Sentry account/project** after the migration PR merges and errors are confirmed flowing to App Insights (ADR-0045 D5/D13). This is a Sentry-portal action — the developer logs into the Sentry account, archives/deletes the Notify project, and decommissions the DSN. Because the migration is config-only (no SDK code emits to Sentry), no parallel-run window is needed — archive once `IErrorReporter` is wired and verified. The dispatch plan's deferred "Notify-Sentry account decommission" note tracks this.
+- [ ] If a Sentry DSN secret exists in Notify's Key Vault, remove it from the vault *after* the account is archived (this packet's PR stops the config pointing at it; the secret cleanup is a separate portal step so a rollback window exists).
+- [ ] The `dev` App Insights resource (ADR-0040 packet 02) must exist for the end-to-end smoke check — confirm a Notify-thrown exception lands in the App Insights Failures blade. Cross-initiative prerequisite.
+
+## Referenced ADR Decisions
+**ADR-0045 D5 — Per-Node opt-in; Notify migration.** Notify's Sentry config (no SDK code) is migrated onto `IErrorReporter` via Notify's Pulse telemetry dependency. Errors flow to App Insights instead of Sentry. The Notify-Sentry account is archived once `IErrorReporter` is wired — config-only, no parallel-run window.
+
+**ADR-0045 D8 — Capture-vs-log policy.** Capture-as-error: unrecoverable failed dependency calls (provider 5xx with no retry path), failed dispatch with no retry remaining, write failures. Log-only at ERROR: recoverable retries that succeeded, inbound-validation failures, expected 4xx. Both: capture-eligible cases also produce an ERROR log line with the same `operation_id`.
+
+**ADR-0045 D10 Phase 1 — Notify migration.** Config-only migration: wire the D8 capture sites to `IErrorReporter`, archive the Sentry account. No parallel-output window because nothing in Notify emits to Sentry from code. The SDK-replacement path with a parallel window is the fallback only if SDK code is found.
+
+**ADR-0045 D13 — the Notify-Sentry setup is removed, not extended.** The account is archived once `IErrorReporter` is wired.
+
+**ADR-0040 — Pulse is the telemetry-export boundary.** Notify consumes `IErrorReporter`; the App Insights sink backing is composed in Notify's host, never in Notify's library code.
+
+## Constraints
+> **Invariant 3 — Provider/consumer packages depend on a Node's contracts, not internals.** Notify consumes the published `IErrorReporter` contract — never the App Insights SDK, never Pulse internals.
+
+> **Invariant 9 — Vault is the only source of secrets.** Notify reads no telemetry secret directly. The App Insights connection string is resolved by the Pulse sink backing.
+
+> **Invariant 13 — All public APIs have XML documentation.**
+
+> **Invariant 15 — Unit tests never depend on external services.**
+
+> **Invariant 26 — `## NuGet Dependencies` section required; `HoneyDrunk.Standards` on every .NET project.**
+
+> **Invariant 27 — All projects in a solution share one version and move together.** This is the only ADR-0045 packet on the `HoneyDrunk.Notify` solution — it bumps the version (minor); every non-test `.csproj` moves together. Per-package CHANGELOG entries only for packages with actual changes.
+
+> **Invariant 51 — Test code contains no `Thread.Sleep`.**
+
+> **Invariant 80 (error-flow, added by packet 00) — errors captured for the D8 capture-eligible cases flow through `IErrorReporter`, never via a direct backend SDK call.** This packet is the enforcement point for Notify — after it, Notify's D8 sites route through `IErrorReporter` and Notify never calls `TelemetryClient` directly.
+
+- **Config-only is the primary case.** The scan found no Sentry SDK code — the migration is wiring `IErrorReporter` to D8 sites + config cleanup. The SDK-replacement path is a fallback only if the execution-time scan unexpectedly finds SDK code.
+- **No parallel-output window.** Nothing in Notify emits to Sentry from code — there is nothing to run in parallel. Skip it; record that in the PR.
+- **The account archival is human and post-merge.** Do not delete the Sentry account or DSN in this PR — archival is a portal step done after the migration is verified.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0045`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Migrate `HoneyDrunk.Notify` off its config-only Sentry integration onto the Grid's `IErrorReporter` — wire the D8 capture sites, clean up Sentry config, archive the Sentry account.
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: End Notify's ungoverned Sentry drift — bring its error tracking under the Grid-wide `IErrorReporter` pattern, errors to App Insights.
+- Feature: ADR-0045 Grid-Wide Error Tracking rollout, Wave 4.
+- ADRs: ADR-0045 D5/D8/D10/D13 (primary), ADR-0040 (Pulse as the telemetry-export boundary).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — hard. `HoneyDrunk.Telemetry.Sink.AzureMonitor` must implement and register the `IErrorReporter` facade before Notify can consume it.
+
+**Constraints:**
+- Config-only is the primary case — the scan found no Sentry SDK code. Wire `IErrorReporter` to D8 sites + clean up Sentry config.
+- No parallel-output window — nothing in Notify emits to Sentry from code. The SDK-replacement path with a parallel window is the fallback only if the scan unexpectedly finds SDK code.
+- Notify consumes `IErrorReporter` only — no App Insights SDK in Notify code.
+- The Sentry account archival is a human, post-merge step — not in this PR.
+- First and only ADR-0045 packet on the Notify solution — bump the version (minor); all non-test `.csproj` move together.
+
+**Key Files:**
+- `HoneyDrunk.Notify/HoneyDrunk.Notify/` (core), `HoneyDrunk.Notify.HostBootstrap`, `HoneyDrunk.Notify.Functions`, `HoneyDrunk.Notify.Worker`
+- `HoneyDrunk.Notify/HoneyDrunk.Notify/Diagnostics/NotifyActivitySource.cs` (for `TraceId` correlation)
+- `appsettings*.json` (Sentry config removal)
+- Repo-level `CHANGELOG.md`
+
+**Contracts:**
+- Consumes the `IErrorReporter` facade (from `HoneyDrunk.Telemetry.Abstractions`, packet 02). No contract owned or changed.

--- a/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/06-architecture-review-d8-mapping-and-escalation-doc.md
+++ b/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/06-architecture-review-d8-mapping-and-escalation-doc.md
@@ -1,0 +1,115 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "docs", "adr-0045", "wave-4"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0045", "ADR-0044", "ADR-0040"]
+accepts: ["ADR-0045"]
+wave: 4
+initiative: adr-0045-grid-wide-error-tracking
+node: honeydrunk-architecture
+---
+
+# Add the D8 capture-vs-log mapping to review.md and document the D11 escalation triggers
+
+## Summary
+Two governance documentation tasks from ADR-0045's Follow-up Work: (1) extend the Observability category of `.claude/agents/review.md` with the ADR-0045 D8 capture-an-error-vs-log-a-line mapping so the review agent enforces it per Node, and (2) document the four D11 Sentry-escalation triggers in `business/context/` so the operator can recognize when v1 App Insights stops earning its keep.
+
+## Context
+ADR-0045's Follow-up Work names two doc tasks:
+- "Update `.claude/agents/review.md` D3 Observability category with the D8 capture-vs-log mapping." ADR-0045 D8 says: "The detailed checklist per Node lives in `.claude/agents/review.md` per ADR-0044 D3's Observability category. This ADR binds the principle; the agent file binds the per-case mapping."
+- "Document the D11 escalation triggers in `business/context/` so the operator can recognize them."
+
+`.claude/agents/review.md` is the review-agent rubric established by ADR-0044 (the cloud-code-review initiative — see sibling folder `adr-0044-cloud-code-review/`, packets 04 and 09 which built and rolled out the D3 rubric). ADR-0044's D3 rubric has an Observability category; this packet adds the error-capture sub-rubric to it.
+
+`business/context/` is where the Grid keeps operator-facing context notes (the ADR-0040 cost-ceiling tracking lives there per ADR-0040 packet 08). The D11 escalation triggers are operator-facing — the operator must recognize the symptom and know the response is "amend the ADR, move errors to Sentry."
+
+**This is a docs/governance packet. No code, no .NET project.** It depends only on packet 00 (ADR-0045 Accepted) — independent of the Pulse/Notify/Actions implementation packets, so it can run in parallel with them in Wave 4.
+
+## Scope
+- `.claude/agents/review.md` — extend the Observability category with the D8 capture-vs-log error sub-rubric.
+- A note in `business/context/` documenting the four D11 escalation triggers.
+
+## Proposed Implementation
+1. **`.claude/agents/review.md` — D8 error-capture sub-rubric.** Locate the Observability category in the D3 rubric (established by ADR-0044 packet 04, rolled out by packet 09). Add a sub-rubric the review agent applies to PRs touching error-handling code. The checklist, from ADR-0045 D8 verbatim-in-substance:
+   - **Capture as an error (via `IErrorReporter`):** uncaught or programmatic exceptions in business logic; failed dependency calls (LLM provider 5xx, downstream Node call failures) the caller cannot recover from in-line; failed agent tool dispatch with no retry path remaining; failed billing meter-event push to Stripe after retries (ADR-0037); Audit write failures (ADR-0030 — also incidents).
+   - **Log to Log Analytics at ERROR level only (do NOT capture as error):** recoverable errors retries handled successfully; inbound-request validation failures (the caller's problem); expected 4xx outcomes from external APIs; deserialization failures on poison messages (a dead-letter-queue concern per ADR-0028 — capture the DLQ event, not the deserialization).
+   - **Both (capture as error AND log an ERROR line):** anything in the capture list also produces an ERROR log line — the log for the forensic timeline, the error capture for triage and trend; both carry the same `operation_id`.
+   - The sub-rubric also checks: error capture goes through `IErrorReporter`, never a direct backend SDK call (the ADR-0045 error-flow invariant); prompt/completion content is not in a captured exception unless `evals.sensitive=true` (ADR-0045 D7 / ADR-0040 D9).
+   - Match the existing rubric's format and severity-tagging convention — do not invent a parallel structure.
+2. **`business/context/` — D11 escalation-trigger note.** Add (or extend, if a telemetry/observability operator note already exists from ADR-0040 packet 08) a note documenting the four D11 triggers, each with its symptom and the action:
+   - **Error-triage workflow pain** — App Insights' Failures blade insufficient for the volume (estimated threshold: > 50 distinct problem IDs in any 7-day window) → move errors to Sentry; configure `trace_id` cross-link to App Insights traces.
+   - **Release-triage workflow pain** — "this regressed in v0.4.2" is a regular need and App Insights' release-annotation UX is the bottleneck → move errors to Sentry; use Sentry's Releases/Suspect-Commits surface.
+   - **Tenant-scoped error views needed (Notify Cloud)** — multi-tenant error triage at scale needs Sentry's tag-and-environment filtering → move errors to Sentry; preserve tenant-scoped App Insights traces for context.
+   - **AI-sector tool-call breadcrumb depth** — agent-execution failures need the rich breadcrumb chain Sentry handles natively → move errors to Sentry; preserve App Insights for traces/metrics/logs.
+   - State the escalation mechanics: `IErrorReporter` and `IErrorSink` stay, the existing `HoneyDrunk.Telemetry.Sink.Sentry` backing is activated as the error sink, the Pulse-level config swap moves errors to Sentry while traces/metrics/logs stay on App Insights. Combined cost at escalation: App Insights (~$30–100/month) + Sentry (free or Team $26/month), within ADR-0040's $100/month ceiling at low volume.
+   - Note that D11 is reviewed at D10 Phase 4 (Month 3+) as a go/no-go.
+
+## Affected Files
+- `.claude/agents/review.md`
+- A D11-escalation note in `business/context/` (new, or an extension of the ADR-0040 telemetry operator note).
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance/agent files; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture` — `.claude/agents/review.md` and `business/context/` both live here. Routing rule "architecture, ADR, agent, sector → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] The review-agent rubric is the ADR-0044-established surface; this packet extends it, consistent with ADR-0045 D8's explicit instruction.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/review.md` Observability category carries the D8 error-capture sub-rubric: the capture-as-error list, the log-only list, the both list, plus the `IErrorReporter`-not-direct-SDK and the `evals.sensitive` content checks
+- [ ] The sub-rubric matches the existing rubric's format and severity-tagging convention (ADR-0044 D3)
+- [ ] `business/context/` documents the four D11 escalation triggers, each with symptom + action, the escalation mechanics, the combined cost, and the D10 Phase 4 review point
+- [ ] If an ADR-0040 telemetry operator note already exists in `business/context/`, the D11 triggers extend it rather than creating a parallel note
+- [ ] No invariant change (the error-flow invariant lands in packet 00); no catalog change (catalogs land in packet 01)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0045 D8 — When to capture an error vs. log a line.** Capture-as-error, log-only, and both categories as listed in Proposed Implementation. The principle is ADR-bound; the per-case mapping lives in `.claude/agents/review.md`.
+
+**ADR-0045 D11 — Escalation path: Sentry.** Four documented triggers (error-triage pain > 50 distinct problem IDs/7-day window; release-triage pain; tenant-scoped views for Notify Cloud; AI-sector breadcrumb depth). On any trigger, the next ADR amendment moves errors to Sentry; `IErrorReporter`/`IErrorSink` stay, the existing `HoneyDrunk.Telemetry.Sink.Sentry` backing is activated as the error sink, the swap is a Pulse-level config change. Reviewed at D10 Phase 4.
+
+**ADR-0044 D3 — the review-agent rubric.** `.claude/agents/review.md` carries the multi-category review rubric, including an Observability category. ADR-0045 D8's mapping extends that category.
+
+**ADR-0040 — cost ceiling and operator context.** `business/context/` holds the telemetry cost-ceiling tracking; the D11 cost figures sit within ADR-0040's $100/month ceiling.
+
+## Constraints
+- **Extend, do not fork, the review rubric.** The D8 sub-rubric joins the existing Observability category in `.claude/agents/review.md` — match the established format and severity tags (ADR-0044 D3).
+- **Operator-facing language for the D11 note.** `business/context/` is read by the operator; the D11 note must let the operator recognize a trigger symptom and know the response.
+- **No invariant or catalog change here.** Those land in packets 00 and 01.
+- **Coordinate with `hive-sync`.** ADR-0045's invariant note says `hive-sync` reconciles the rubric drift per the ADR-0044 pattern — keep the rubric edit consistent with that mechanism (ADR-0044 packet 17 built the D3 drift detection).
+
+## Labels
+`chore`, `tier-3`, `ops`, `docs`, `adr-0045`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Add the ADR-0045 D8 capture-vs-log mapping to the review-agent rubric and document the four D11 Sentry-escalation triggers for the operator.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the D8 capture-vs-log policy enforceable by the review agent per Node, and make the D11 escalation triggers recognizable by the operator.
+- Feature: ADR-0045 Grid-Wide Error Tracking rollout, Wave 4.
+- ADRs: ADR-0045 D8/D11 (primary), ADR-0044 (the review-agent rubric this extends), ADR-0040 (operator-context location).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0045 should be Accepted before its policy is bound into the review rubric. Independent of packets 02–05 — can run in parallel.
+
+**Constraints:**
+- Extend the existing Observability category — do not fork the rubric.
+- Operator-facing language for the D11 note.
+- No invariant or catalog change here.
+
+**Key Files:**
+- `.claude/agents/review.md`
+- `business/context/` (the D11-escalation note)
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/07-architecture-deployable-node-error-wiring-playbook.md
+++ b/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/07-architecture-deployable-node-error-wiring-playbook.md
@@ -1,0 +1,112 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "docs", "adr-0045", "wave-4"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0045", "ADR-0015"]
+accepts: ["ADR-0045"]
+wave: 4
+initiative: adr-0045-grid-wide-error-tracking
+node: honeydrunk-architecture
+---
+
+# Author the deployable-Node error-wiring playbook for Phase 2/3 rollout
+
+## Summary
+Author a short, reusable playbook (in `infrastructure/` or the Grid's established standup-doc location) that tells any deployable Node — Notify.Functions, Notify.Worker, Pulse.Collector now (D10 Phase 2), and every AI-sector Seed Node at standup (D10 Phase 3) — exactly how to wire `IErrorReporter` via its existing Pulse telemetry dependency. This packet does not modify any Node; it produces the canonical wiring instructions so Phase 2/3 rollout does not need a separate scope pass per Node.
+
+## Context
+ADR-0045 D10 stages the rollout:
+- **Phase 2** — Notify.Functions, Notify.Worker, Pulse.Collector wire `IErrorReporter` via their existing Pulse telemetry dependency.
+- **Phase 3** — every AI-sector Seed Node (ADR-0016 through ADR-0025) wires `IErrorReporter` from day one at standup; error capture is part of the standup canary.
+
+The per-Node wiring is mechanically identical: depend on Pulse's telemetry packages, register the AzureMonitor sink backing in the host composition, inject `IErrorReporter`, route capture-eligible failures (per D8) through it. Writing a separate scoped packet for each of Notify.Functions / Notify.Worker / Pulse.Collector — and pre-writing packets for nine AI Nodes that are not yet stood up — would be premature decomposition (the AI-sector Nodes get their own standup ADRs/initiatives per the Grid's New-Node-scaffold convention; bundling error-wiring into a not-yet-existing repo is wrong).
+
+Instead, this packet produces **one canonical playbook**. Phase 2's three deployable wirings are then small, near-mechanical changes a future packet (or the operator directly) applies by following the playbook; each AI-Node standup ADR references the playbook as a standup-canary step. This keeps the ADR-0045 initiative focused on the substrate (the facade, the backing, the Notify migration, the deploy-flow change, the governance docs) and defers the repetitive per-Node application to where it belongs — the Node's own work.
+
+**Why not wire Notify.Functions/Worker and Pulse.Collector in this initiative directly?** Notify.Functions and Notify.Worker are part of the `HoneyDrunk.Notify` solution — packet 05 already migrates Notify and bumps that solution; a separate later packet touching the same solution would collide on the version-bump rule (invariant 27). The cleanest path is: packet 05 wires the Notify *core* error path, and the playbook covers any host-composition follow-up so it lands in the same Notify solution version or a clearly-sequenced later one. Pulse.Collector is part of the `HoneyDrunk.Pulse` solution — packets 02 and 03 already bump that solution; Pulse.Collector's own host-composition wiring follows the playbook as a near-mechanical change.
+
+**This is a docs packet. No code, no .NET project.**
+
+## Scope
+- A deployable-Node error-wiring playbook doc, in the Grid's established location for cross-Node standup/wiring guidance (check `infrastructure/`, a `standards/`-style doc, or wherever the Pulse-telemetry-consumption guidance lives — match the existing convention; do not invent a location).
+
+## Proposed Implementation
+Author the playbook covering, concisely:
+1. **Dependency** — the Node depends on Pulse's telemetry packages; `IErrorReporter` comes from `HoneyDrunk.Telemetry.Abstractions` transitively.
+2. **Host registration** — the deployable's host composition registers the `HoneyDrunk.Telemetry.Sink.AzureMonitor` backing (the same registration that wires traces/metrics/logs per ADR-0040 also wires `IErrorReporter` per ADR-0045 D5 — one Pulse telemetry registration covers all four signal types). The App Insights connection string is Vault-resolved by the backing; the Node itself touches no telemetry secret.
+3. **Injection** — inject `IErrorReporter` where errors are captured.
+4. **The D8 capture decision** — route only capture-eligible failures (per the D8 mapping — cross-reference packet 06's `review.md` sub-rubric) through `IErrorReporter`; recoverable retries and inbound-validation failures stay log-only.
+5. **`ErrorContext` population** — `TraceId` from the ambient `Activity`, `TenantId`/`UserId` (opaque `PrincipalId`) from the Grid context, `Release` from the deployable version.
+6. **Release annotation** — the deployable's release workflow opts into the App Insights release-annotation step (packet 04's new workflow inputs) so captured exceptions' `application_Version` lines up with a trend-graph annotation.
+7. **Standup canary (Phase 3)** — for an AI-sector Node, error capture is part of the standup canary: the canary throws a controlled exception and asserts it lands in App Insights Failures. Reference this as a standup-ADR checklist item.
+8. **Per-Node opt-out** — the rare case (D5): a Node configures Pulse telemetry to suppress error reporting (e.g. `HoneyDrunk.Architecture` itself runs no user-facing code). Document the opt-out config.
+
+The playbook explicitly lists the Phase 2 deployables (Notify.Functions, Notify.Worker, Pulse.Collector).
+
+## Affected Files
+- A deployable-Node error-wiring playbook doc in the established cross-Node-guidance location.
+
+## NuGet Dependencies
+None. This packet is a documentation deliverable; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture` — cross-Node standup/wiring guidance lives here.
+- [x] No code change in any Node — the playbook is instructions; the application is each Node's own work.
+- [x] Deliberately does not pre-scope per-Node packets — AI-sector Nodes get error-wiring as a standup-ADR checklist item, not a pre-written packet against a non-existent repo.
+
+## Acceptance Criteria
+- [ ] A deployable-Node error-wiring playbook exists in the Grid's established cross-Node-guidance location, covering: the Pulse telemetry dependency, host registration, `IErrorReporter` injection, the D8 capture decision, `ErrorContext` population, the release-annotation opt-in, the Phase 3 standup canary, and per-Node opt-out
+- [ ] The playbook lists the Phase 2 deployables (Notify.Functions, Notify.Worker, Pulse.Collector)
+- [ ] The playbook cross-references packet 06's D8 `review.md` sub-rubric and packet 04's release-annotation workflow inputs
+- [ ] The playbook is concise — it is a wiring checklist, not a tutorial
+- [ ] No code change, no per-Node packet pre-written for not-yet-stood-up AI Nodes
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0045 D10 Phase 2 — Rollout to deployable Nodes.** Notify.Functions, Notify.Worker, Pulse.Collector wire `IErrorReporter` via their existing Pulse telemetry dependency.
+
+**ADR-0045 D10 Phase 3 — AI-sector standup wave.** Every Seed-sector AI Node wires `IErrorReporter` from day one at standup; error capture is part of the standup canary; the agent-execution-loop breadcrumb usage is the high-value error-tracking surface.
+
+**ADR-0045 D5 — Per-Node opt-in via Pulse configuration.** All Nodes consuming Pulse get error reporting once the backing is wired; opt-out is per Node via configuration (rare — e.g. `HoneyDrunk.Architecture`).
+
+**ADR-0045 D6 — Release tracking.** Captured exceptions carry `application_Version`; the deploy workflow's release-annotation step (packet 04) marks the trend graph.
+
+**ADR-0015 — Container hosting.** The Phase 2 deployables run on Azure Container Apps.
+
+## Constraints
+- **Playbook, not per-Node packets.** Do not pre-write error-wiring packets for AI-sector Nodes that are not yet scaffolded — a New-Node scaffold is its own ADR/initiative. The playbook is referenced by each Node's standup ADR.
+- **Concise.** A wiring checklist, not a tutorial — match the length and tone of the Grid's existing standup/wiring docs.
+- **One Pulse telemetry registration, four signal types.** The playbook makes clear that the ADR-0040 Pulse telemetry registration and the ADR-0045 `IErrorReporter` registration are the same registration call — traces/metrics/logs/errors all wired together.
+
+## Labels
+`chore`, `tier-3`, `ops`, `docs`, `adr-0045`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Author the canonical deployable-Node error-wiring playbook so Phase 2/3 `IErrorReporter` rollout is a mechanical per-Node application, not a fresh scope pass.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Capture the mechanically-identical `IErrorReporter` wiring once, so Phase 2 deployables and Phase 3 AI-Node standups apply it from a checklist.
+- Feature: ADR-0045 Grid-Wide Error Tracking rollout, Wave 4.
+- ADRs: ADR-0045 D5/D6/D10 (primary), ADR-0015 (Container Apps deployables).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0045 should be Accepted before its rollout playbook lands. Independent of packets 02–06 — can run in parallel.
+
+**Constraints:**
+- Playbook only — no per-Node packets pre-written for non-existent AI repos.
+- Concise wiring checklist; one Pulse telemetry registration covers all four signal types.
+
+**Key Files:**
+- A deployable-Node error-wiring playbook in the established cross-Node-guidance location.
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/dispatch-plan.md
@@ -1,0 +1,122 @@
+# Dispatch Plan — ADR-0045: Grid-Wide Error Tracking
+
+**Initiative:** `adr-0045-grid-wide-error-tracking`
+**ADR:** ADR-0045 (Proposed → Accepted via packet 00)
+**Sector:** Ops / cross-cutting
+**Created:** 2026-05-22
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+> **Amendment — 2026-05-22.** This dispatch plan and its packets were corrected: the error path targets **`HoneyDrunk.Pulse`**, not `HoneyDrunk.Observe`. Observe's `boundaries.md` states outbound telemetry to external sinks belongs to Pulse; Pulse (v0.3.0, LIVE) already owns `IErrorSink` and the `HoneyDrunk.Telemetry.Sink.*` provider family. ADR-0045 was amended to match (the same correction applied to companion ADR-0040). Packets 02/03 retargeted Observe → Pulse; the `IErrorReporter`/`IErrorSink` reconciliation, the invariant-80 numbering, the contracts.json catalog placement, the config-only Notify migration, and the shared-scrubber consumption were all corrected.
+
+## Summary
+
+ADR-0045 makes **errors** a fourth Grid signal type alongside the traces/metrics/logs of ADR-0040, and selects **Application Insights' Failures + exception tracking** as the v1 backend (revised in PR #164 to pivot off the original Sentry-Grid-wide framing; Sentry becomes the documented D11 escalation path). Errors flow through `HoneyDrunk.Pulse` via a new `IErrorReporter` **facade** — layered over Pulse's existing `IErrorSink` — whose App Insights backing uses the App Insights .NET SDK directly, a deliberate carve-out from ADR-0040's OTLP path because the App Insights error model carries non-OTLP fields (`problem_id`, `application_Version`, Failures-blade grouping dimensions).
+
+This initiative delivers: the `IErrorReporter` facade + error-model types in `HoneyDrunk.Telemetry.Abstractions`, the App-Insights-SDK error-capture backing + error PII processor extended into the existing `HoneyDrunk.Telemetry.Sink.AzureMonitor`, the Actions deploy-workflow release-annotation step, the config-only `HoneyDrunk.Notify` migration off its Sentry account, the `IErrorReporter` contract registration in `catalogs/contracts.json`, the error-flow invariant (number 80), the D8 review-rubric mapping, the D11 escalation-trigger operator doc, and the Phase 2/3 deployable-Node wiring playbook.
+
+**8 packets across 4 waves**, targeting **4 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Pulse`, `HoneyDrunk.Actions`, `HoneyDrunk.Notify`). 8 `Actor=Agent`, 0 `Actor=Human`. (No `human-only` packet — but several packets carry Human Prerequisites: the Sentry-account archival, and the cross-initiative dependency on ADR-0040's Azure provisioning.)
+
+## Trigger
+
+ADR-0045 is Proposed with no scope. Forcing functions (from the ADR's Context): ADR-0040 just landed claiming unified observability, and the error gap makes the claim partially false; the AI-sector standup wave (ADR-0016–0025) is about to emit error volume that needs problem-grouping triage; Notify Cloud GA carries an implicit "we know when errors happen" expectation; and the existing ungoverned Notify-Sentry one-off needs governance.
+
+## Scope Detection
+
+**Multi-repo.** ADR-0045 touches `HoneyDrunk.Pulse` (the new `IErrorReporter` facade + the App Insights error backing extending `HoneyDrunk.Telemetry.Sink.AzureMonitor`), `HoneyDrunk.Actions` (the deploy-workflow release-annotation step), `HoneyDrunk.Notify` (the config-only Sentry→`IErrorReporter` migration), and `HoneyDrunk.Architecture` (acceptance, the `contracts.json` registration, the error-flow invariant, the review-rubric mapping, the escalation doc, the wiring playbook). The new `IErrorReporter` facade is consumed by every deployable Node — but the per-Node wiring is mechanically identical and deliberately deferred to a playbook (packet 07) rather than fanned out into premature per-Node packets.
+
+## Wave Diagram
+
+### Wave 1 (governance + catalog — depends only on the cross-initiative ADR-0040 acceptance)
+- [ ] **00** — Architecture: Accept ADR-0045, add the error-flow invariant (number 80), register the initiative. `Actor=Agent`. Blocked by: ADR-0040 packet 00 (cross-initiative).
+- [ ] **01** — Architecture: register the `IErrorReporter` facade in `catalogs/contracts.json` under the Pulse Node and record the D8 policy. `Actor=Agent`. Blocked by: 00.
+
+### Wave 2 (the error-reporting facade)
+- [ ] **02** — Pulse: add the `IErrorReporter` facade + `ErrorContext`/`ErrorScope`/`Breadcrumb`/`ErrorLevel` to `HoneyDrunk.Telemetry.Abstractions`. `Actor=Agent`. Blocked by: 00, ADR-0040 packet 03 (cross-initiative — Pulse-solution version-bump sequencing).
+
+### Wave 3 (the App Insights backing + the deploy-flow change — parallel)
+- [ ] **03** — Pulse: implement the App-Insights-SDK error backing + the error PII `ITelemetryProcessor` in `HoneyDrunk.Telemetry.Sink.AzureMonitor`. `Actor=Agent`. Blocked by: 02, ADR-0040 packet 05 (cross-initiative — consumes the shared PII scrubber).
+- [ ] **04** — Actions: amend the reusable deploy workflows with the App Insights release-annotation step. `Actor=Agent`. Blocked by: 00. (Independent of the Pulse packets — parallel with 03.)
+
+### Wave 4 (the Notify migration + the governance/rollout docs — parallel)
+- [ ] **05** — Notify: migrate `HoneyDrunk.Notify` off its config-only Sentry account onto `IErrorReporter`. `Actor=Agent`. Blocked by: 03.
+- [ ] **06** — Architecture: add the D8 mapping to `review.md` and document the D11 escalation triggers. `Actor=Agent`. Blocked by: 00. (Independent of 02–05 — parallel.)
+- [ ] **07** — Architecture: author the deployable-Node error-wiring playbook for Phase 2/3 rollout. `Actor=Agent`. Blocked by: 00. (Independent of 02–05 — parallel.)
+
+Packets within a wave run in parallel. Note Wave 4 is not strictly gated as a wave — only packet 05 depends on a Wave 3 packet; packets 06 and 07 depend only on packet 00 and could run as early as Wave 2. They are grouped into Wave 4 for tidy filing, but the `dependencies:` frontmatter is the real ordering signal — 06 and 07 will unblock as soon as 00 lands.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0045](./00-architecture-adr-0045-acceptance.md) | Architecture | Agent | 1 | ADR-0040 #00 (X-init) |
+| 01 | [IErrorReporter contract + D8 policy catalog](./01-architecture-error-tracking-catalog-and-contracts.md) | Architecture | Agent | 1 | 00 |
+| 02 | [IErrorReporter facade](./02-pulse-ierror-reporter-abstraction.md) | Pulse | Agent | 2 | 00, ADR-0040 #03 (X-init) |
+| 03 | [App Insights error backing + PII processor](./03-pulse-app-insights-error-backing.md) | Pulse | Agent | 3 | 02, ADR-0040 #05 (X-init) |
+| 04 | [Actions release-annotation step](./04-actions-app-insights-release-annotation.md) | Actions | Agent | 3 | 00 |
+| 05 | [Notify Sentry→IErrorReporter migration](./05-notify-migrate-sentry-to-ierror-reporter.md) | Notify | Agent | 4 | 03 |
+| 06 | [review.md D8 mapping + D11 escalation doc](./06-architecture-review-d8-mapping-and-escalation-doc.md) | Architecture | Agent | 4 | 00 |
+| 07 | [Deployable-Node error-wiring playbook](./07-architecture-deployable-node-error-wiring-playbook.md) | Architecture | Agent | 4 | 00 |
+
+## Cross-Initiative Dependency Wiring — ADR-0040
+
+ADR-0045 is built on the same Azure Monitor backend as ADR-0040 (`adr-0040-telemetry-backend-and-retention`), pivoted in the same PR (#164). The two initiatives share infrastructure. **The filing pipeline does not resolve `packet:NN` references across initiative folders** — a `packet:NN` edge only resolves within the same folder. So every ADR-0045→ADR-0040 dependency is expressed as a qualified `{Repo}#N` issue edge, *or* — where it is a human/portal prerequisite rather than a packet ordering — as a Human Prerequisites note. The wiring:
+
+| ADR-0045 packet | Depends on (ADR-0040) | Form | Why |
+|---|---|---|---|
+| 00 (acceptance) | ADR-0040 packet 00 (acceptance) | `dependencies:` edge — `Architecture#<n>` | Sibling observability ADR; the edge exists for invariant-numbering hygiene within the 12-ADR batch. ADR-0045 packet 00 appends invariant **80** (pre-reserved). |
+| 02 (`IErrorReporter` facade) | ADR-0040 packet 03 (Pulse telemetry work) | `dependencies:` edge — `Architecture#<n>` | ADR-0040's Pulse work bumps the `HoneyDrunk.Pulse` solution version (invariant 27). ADR-0045's Pulse work sequences after ADR-0040's Pulse waves so version-bump ownership is unambiguous. |
+| 03 (App Insights error backing) | ADR-0040 packet 05 (PII processors) | `dependencies:` edge — `Architecture#<n>` | ADR-0040 packet 05 builds the PII scrubber as a shared, mechanism-agnostic component from the start; ADR-0045 packet 03 **consumes** it (a plain hard dependency — no refactor needed). |
+| 03, 05 (App Insights resource) | ADR-0040 packet 02 (App Insights provisioning) | **Human Prerequisites note**, not an edge | ADR-0045 D2 captures errors into the *same* App Insights resource ADR-0040 provisions — **ADR-0045 provisions no new resource**. The dependency is on a provisioned Azure resource, a human/portal artifact — recorded as a Human Prerequisite, not a `dependencies:` edge. |
+
+**Action before this folder is pushed to `main`:** the `dependencies:` arrays of packets 00, 02, and 03 currently carry the placeholders `Architecture#ADR0040-PACKET00`, `Architecture#ADR0040-PACKET03`, `Architecture#ADR0040-PACKET05`. These must be replaced with the real `Architecture#<issue-number>` once ADR-0040's packets are filed and their GitHub issue numbers are known. A placeholder left in place will produce a `::warning::` and an unwired edge. The safe sequence: file the ADR-0040 folder first, read the issue numbers off The Hive, substitute them here, then push this folder.
+
+**Co-landing recommendation:** land ADR-0040 fully — at minimum Waves 1–3 (packets 00, 02, 03, 05) — before ADR-0045's Pulse packets (02, 03). ADR-0045 packets 00, 01, 04, 06, 07 have no hard ADR-0040 code dependency and can land earlier (00 still wants ADR-0040 #00 first for invariant numbering).
+
+## PII Processor — `ITelemetryProcessor` is correct; the scrubber is shared
+
+ADR-0040 D9 is OTel-native (`SpanProcessor`/`LogRecordProcessor`). ADR-0045 D7 names `ITelemetryProcessor`. **This is not a contradiction once the mechanism is understood:**
+
+- ADR-0045 D3 routes errors through the **App Insights .NET SDK directly** (the carve-out — the error model needs non-OTLP fields). The App Insights SDK's *only* filter hook is `ITelemetryProcessor`; OTel `SpanProcessor`s do not sit in the SDK's pipeline. So the error path **must** use `ITelemetryProcessor` — the correct and only mechanism for SDK-captured exception telemetry. ADR-0040 D9's mechanism choice applies to the **OTLP path**, not the SDK path.
+
+The **regex scrubbing rules** (emails, phones, credit cards, API keys, JWT shapes) are **shared, not duplicated**. ADR-0040 packet 05 builds the PII scrubber as a **shared, mechanism-agnostic `PiiScrubber`** (string in → redacted string out + an attribute allowlist) from the start. ADR-0045 packet 03's error `ITelemetryProcessor` simply **consumes** it. No refactor is needed — the component is shared by construction. This is a plain hard cross-initiative dependency (packet 03 → ADR-0040 packet 05), not a soft/recommendation edge.
+
+## Observe-vs-Pulse Boundary — RESOLVED
+
+The error path targets **`HoneyDrunk.Pulse`**, not `HoneyDrunk.Observe`. `repos/HoneyDrunk.Observe/boundaries.md` explicitly states outbound telemetry to external sinks belongs to Pulse — Observe is the *inbound* external-system observation layer. `HoneyDrunk.Pulse` (v0.3.0, LIVE) already owns `ITraceSink`/`ILogSink`/`IMetricsSink`/`IAnalyticsSink`/**`IErrorSink`** and the `HoneyDrunk.Telemetry.Sink.*` provider family (including `HoneyDrunk.Telemetry.Sink.AzureMonitor` and `HoneyDrunk.Telemetry.Sink.Sentry`). ADR-0045 was amended 2026-05-22 to match, the same correction applied to companion ADR-0040. Packets 02 and 03 target `HoneyDrunk.Pulse`. The `IErrorReporter` facade is added to `HoneyDrunk.Telemetry.Abstractions` alongside the existing `IErrorSink`; the App Insights error backing extends the existing `HoneyDrunk.Telemetry.Sink.AzureMonitor` package — no new package. Pulse.Collector's error-wiring is no longer gated — packet 07's playbook covers it as a near-mechanical change.
+
+## Version Bumps
+
+- **`HoneyDrunk.Pulse`** — packets 02 and 03 land on the solution. The version-bump rule (invariant 27) interacts with ADR-0040's Pulse packets. The packets are written to **check the in-progress version state at edit time**: whichever of {ADR-0040's Pulse packets, ADR-0045 #02/03} is the first un-released packet bumps the solution; the rest append. Because ADR-0045's Pulse packets are sequenced *after* ADR-0040's Pulse waves (via the cross-initiative `dependencies:` edges), the expected outcome is ADR-0040 bumped the solution and by the time ADR-0045 #02 lands the solution may be at a released version — in which case #02 bumps (minor, new public types) and #03 appends. Each packet records which case applied.
+- **`HoneyDrunk.Notify`** — packet 05 is the only ADR-0045 packet on the solution; it bumps the version (minor — the error-reporting integration). Per-package CHANGELOG entries only for packages with actual changes.
+- **`HoneyDrunk.Actions`** — not a versioned .NET solution; packet 04 is a workflow/YAML change. CHANGELOG updated per the repo convention if it keeps one.
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; catalog/doc/governance edits only (packets 00, 01, 06, 07).
+
+## Cross-Cutting Concerns
+
+### Site sync
+
+No site-sync flag. ADR-0045 is internal Ops infrastructure — no public-facing Studios website content changes.
+
+### Notify-Sentry account decommission (deferred item)
+
+Notify's Sentry integration is **config-only** — a scan found no Sentry SDK code, only account/DSN configuration. Packet 05's PR removes the Sentry config references and wires `IErrorReporter`. The Sentry **account/project archival** is a human, post-merge step (a Sentry-portal action) — recorded in packet 05's Human Prerequisites. **It is tracked here, in this dispatch-plan deferred list — not in any catalog.** `catalogs/grid-health.json` node entries carry only `signal`/`version`/`canary_status`/`last_release`/`active_blockers`/`notes`; there is no schema slot for a decommission item. Because the migration is config-only (nothing emits to Sentry from code), there is no parallel-run window — archive the account once `IErrorReporter` is wired and verified.
+
+**Deferred item:** Archive the config-only Notify-Sentry account/project and decommission its DSN after packet 05 merges and errors are confirmed flowing to App Insights.
+
+## Rollback Plan
+
+- **Packets 00–01 (governance/catalog):** revert the PR. ADR returns to Proposed; the error-flow invariant (number 80) and the `contracts.json` entry removed. No runtime impact.
+- **Packet 02 (`IErrorReporter` facade):** revert the PR; the `HoneyDrunk.Pulse` solution version rolls back. No consumer depends on `IErrorReporter` until packet 03's backing and packet 05's Notify wiring land — a revert is contained to the abstraction package; the existing `IErrorSink` is untouched.
+- **Packet 03 (App Insights error backing):** revert the PR. No Node captures errors through the backing until a host composes it — the revert is contained to `HoneyDrunk.Telemetry.Sink.AzureMonitor`. The shared `PiiScrubber` from ADR-0040 packet 05 is consumed, not modified — reverting packet 03 leaves it intact.
+- **Packet 04 (Actions release annotation):** revert the workflow edit; the new inputs default off, so even un-reverted the step is inert until a consumer opts in.
+- **Packet 05 (Notify migration):** revert the PR; `HoneyDrunk.Notify`'s solution version rolls back. The Notify-Sentry account is *not* deleted until the human archival step — so a revert restores the Sentry config cleanly (the account still exists).
+- **Packet 06 (review.md / escalation doc):** revert the PR. Docs only.
+- **Packet 07 (wiring playbook):** revert the PR. Docs only.
+- **Backend-level escape hatch:** ADR-0045 D11's escalation path (Sentry as a dedicated error backend) is the architectural rollback for the *backend choice itself* — `IErrorReporter`/`IErrorSink` stay, the existing `HoneyDrunk.Telemetry.Sink.Sentry` backing is activated as the error sink, the swap is a single Pulse-side config change.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.
+
+**Before pushing:** replace the three cross-initiative placeholders (`Architecture#ADR0040-PACKET00` in packet 00, `Architecture#ADR0040-PACKET03` in packet 02, `Architecture#ADR0040-PACKET05` in packet 03) with the real `Architecture#<issue-number>` values once ADR-0040's packets are filed. A placeholder left in place produces a `::warning::` and an unwired cross-initiative edge.

--- a/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/handoff-wave2-ierror-reporter-abstraction.md
+++ b/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/handoff-wave2-ierror-reporter-abstraction.md
@@ -1,0 +1,43 @@
+# Handoff — Wave 1 → Wave 2: the IErrorReporter facade
+
+**Read once at the Wave 1 → Wave 2 transition. Immutable (invariant 24).**
+
+## What Wave 1 produced
+
+- **ADR-0045 is Accepted** (packet 00). Status flipped; `adrs/README.md` updated. One new error-flow invariant is in `constitution/invariants.md` as **invariant 80** — pre-reserved as part of a 12-ADR batch (the file's verified current maximum is 51; 52–80+ are reserved across the batch). The error-flow invariant: *errors captured for the D8 capture-eligible cases flow through `IErrorReporter`, never via a direct backend SDK call* — and it **references** invariant 8 (secret values never appear in logs, traces, exceptions, or telemetry) rather than restating it. The batch note is attached: if any invariant above 51 lands from outside the batch before merge, shift upward, never reuse.
+- **The Grid catalogs record the `IErrorReporter` contract** (packet 01). `catalogs/contracts.json` registers the `IErrorReporter` facade under the `honeydrunk-pulse` Node, alongside the existing `IErrorSink`/`ITraceSink`/`ILogSink`/`IMetricsSink` — described as a facade over `IErrorSink`, not a duplicate (marked `planned` until packet 02 lands). `catalogs/grid-health.json` was **not** edited — its node-entry schema has no observability/error-tracking readout. The D8 capture-vs-log policy is recorded as a cross-cutting note. The Notify-Sentry decommission is tracked in the dispatch plan's deferred list, not a catalog.
+
+## Wave 2 packet
+
+One packet:
+
+- **Packet 02 (`Actor=Agent`)** — add the `IErrorReporter` facade and the error-model types (`ErrorContext`, `ErrorScope`, `Breadcrumb`, `ErrorLevel`) to `HoneyDrunk.Telemetry.Abstractions` in `HoneyDrunk.Pulse`.
+
+## Critical context for Wave 2 execution
+
+- **Target is `HoneyDrunk.Pulse`, not `HoneyDrunk.Observe`.** Outbound error telemetry belongs to Pulse — Observe's `boundaries.md` states outbound telemetry to external sinks belongs to Pulse; Observe is the inbound observation layer. `HoneyDrunk.Pulse` (v0.3.0, LIVE) already owns the sink contracts including `IErrorSink`.
+- **Reconcile with the existing `IErrorSink`.** `HoneyDrunk.Pulse` already ships `IErrorSink` in `HoneyDrunk.Telemetry.Abstractions/Abstractions/IErrorSink.cs` — `CaptureAsync(ErrorEvent)`, `CaptureExceptionAsync`, `CaptureMessageAsync`, `FlushAsync` — backed by the `ErrorEvent` model (exception, message, severity, `CorrelationId`, `OperationId`, `NodeId`, `UserId`, `Environment`, `Release`, `Tags`, `Extra`). **`IErrorReporter` is NOT a duplicate of `IErrorSink`.** `IErrorReporter` is the application-facing **facade**: it captures ambient context (the current `Activity`/`trace_id`, the Grid `TenantId`/`PrincipalId`, the deployable `Release`), maintains the breadcrumb/scope stack, builds an `ErrorEvent`, and routes it to `IErrorSink`. It adds no new capture mechanism. **Do not modify `IErrorSink` or `ErrorEvent` — the facade is purely additive.**
+- **Cross-initiative dependency on ADR-0040 packet 03.** ADR-0040's Pulse work bumps the `HoneyDrunk.Pulse` solution version (invariant 27). ADR-0045's Pulse work (packets 02, 03) is sequenced *after* ADR-0040's Pulse waves so version-bump ownership is unambiguous. Packet 02's `dependencies:` carries a cross-initiative edge to ADR-0040 packet 03's issue (`Architecture#<n>`). **Do not start packet 02 until ADR-0040's Pulse waves have landed.**
+- **Version-state check.** Per invariant 27, packet 02 checks the `HoneyDrunk.Pulse` solution's in-progress version state at edit time: if ADR-0040's Pulse packets all merged and the solution is at a released version, packet 02 bumps (minor — new public types in `HoneyDrunk.Telemetry.Abstractions`); if an ADR-0040 version bump is still unreleased, packet 02 appends to that entry. Record which case applied.
+- **Abstraction-only — invariant 1.** `HoneyDrunk.Telemetry.Abstractions` takes only `Microsoft.Extensions.*` abstractions plus whatever HoneyDrunk abstraction package it already references. **No App Insights SDK, no Sentry SDK, no Azure type** in `IErrorReporter` or its model types. The SDK lives in packet 03's backing, never the abstraction.
+- **The `IErrorReporter` shape is fixed by ADR-0045 D3 — four members, no more:**
+  ```
+  ValueTask CaptureException(Exception ex, ErrorContext? context = null);
+  ValueTask CaptureMessage(string message, ErrorLevel level, ErrorContext? context = null);
+  IDisposable AddBreadcrumb(Breadcrumb crumb);
+  IDisposable PushScope(ErrorScope scope);
+  ```
+- **Grid naming rule.** `ErrorContext`, `ErrorScope`, `Breadcrumb` are **records** and drop the `I` prefix. `IErrorReporter` is an **interface** and keeps it. `ErrorLevel` is an enum — or reuse the existing `TelemetryEventSeverity` if it already covers the levels; document the choice.
+- **`ErrorContext` fields (D3):** `TraceId`, `TenantId`, `UserId`, `Release`, `Tags`. Reuse the Kernel `TenantId`/`PrincipalId` types if they exist — `user_id` is the opaque `PrincipalId` per ADR-0026, never an email or external identifier. `TenantId` is the dimension the existing `ErrorEvent` does NOT carry — the load-bearing reason the facade exists; the facade carries it onto `ErrorEvent.Tags`. `Breadcrumb`/`ErrorScope` are modeled on Sentry's semantics — backend-portable concepts (App Insights expresses them via custom events; Sentry consumes them natively if D11 fires). The XML docs must state that portability intent.
+
+## Wave 2 exit criteria
+
+- `IErrorReporter` exists in `HoneyDrunk.Telemetry.Abstractions` with exactly the four-member D3 shape; its XML docs state it is a facade over the existing `IErrorSink`, not a duplicate.
+- The existing `IErrorSink` and `ErrorEvent` are unchanged.
+- `ErrorContext`/`ErrorScope`/`Breadcrumb` are records, `ErrorLevel` is an enum (or `TelemetryEventSeverity` reused).
+- `HoneyDrunk.Telemetry.Abstractions` took no new HoneyDrunk runtime dependency and no Azure/Sentry SDK (invariant 1).
+- Every new public member has XML documentation (invariant 13).
+- The invariant-27 version-state check on the `HoneyDrunk.Pulse` solution was performed and the decision recorded.
+- `HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md` and the repo-level `CHANGELOG.md` are updated.
+- The solution builds; model-type tests pass.
+- The confirmed `IErrorReporter` shape is fed back to packet 01's `contracts.json` entry.

--- a/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/handoff-wave3-error-backing-and-deploy-flow.md
+++ b/generated/issue-packets/active/adr-0045-grid-wide-error-tracking/handoff-wave3-error-backing-and-deploy-flow.md
@@ -1,0 +1,41 @@
+# Handoff — Wave 2 → Wave 3: the App Insights error backing and the deploy-flow change
+
+**Read once at the Wave 2 → Wave 3 transition. Immutable (invariant 24).**
+
+## What Wave 2 produced
+
+- **The `IErrorReporter` facade exists** (packet 02) in `HoneyDrunk.Telemetry.Abstractions`, with the fixed four-member D3 shape: `CaptureException`, `CaptureMessage`, `AddBreadcrumb`, `PushScope`. It is a facade over the existing `IErrorSink` — not a duplicate. The error-model types `ErrorContext` (record — `TraceId`/`TenantId`/`UserId`/`Release`/`Tags`), `ErrorScope` (record), `Breadcrumb` (record), and `ErrorLevel` (enum, or the reused `TelemetryEventSeverity`) ship alongside it. The existing `IErrorSink`/`ErrorEvent` are unchanged. The abstraction took no Azure/Sentry SDK (invariant 1). The packet recorded which invariant-27 version-state case applied — read the packet-02 PR for whether the `HoneyDrunk.Pulse` solution version was bumped or appended.
+
+## Wave 3 packets
+
+Two packets, runnable in parallel (different repos, no dependency between them):
+
+- **Packet 03 (`Actor=Agent`, `HoneyDrunk.Pulse`)** — implement the App-Insights-SDK-based error backing + the `IErrorReporter` facade implementation + the error PII `ITelemetryProcessor` in the existing `HoneyDrunk.Telemetry.Sink.AzureMonitor` package.
+- **Packet 04 (`Actor=Agent`, `HoneyDrunk.Actions`)** — amend the reusable deploy workflows with the App Insights release-annotation step.
+
+## Critical context for Packet 03 (the error backing)
+
+- **Target is `HoneyDrunk.Pulse`, and the backing extends the EXISTING `HoneyDrunk.Telemetry.Sink.AzureMonitor` package.** It does not create a new package and does not live in `HoneyDrunk.Observe`. The work is two parts: (1) extend the AzureMonitor sink's error-capture path (`IErrorSink` backing → `TrackException`) and (2) implement the `IErrorReporter` facade — the class that builds an `ErrorEvent` from ambient context and routes it through `IErrorSink`. The facade does not reinvent `IErrorSink`.
+- **Cross-initiative dependency on ADR-0040 packet 05.** ADR-0040 packet 05 builds the PII redaction processors **and the shared, mechanism-agnostic `PiiScrubber` as a shared component from the start** (ADR-0040 packet 05 was corrected to do so). Packet 03's `dependencies:` carries a cross-initiative edge to ADR-0040 packet 05's issue — a **plain hard dependency**. **Do not start packet 03 until ADR-0040 packet 05 has landed** — packet 03 **consumes** that shared scrubber; no refactor needed.
+- **The PII processor — `ITelemetryProcessor` is correct.** ADR-0045 D7 names `ITelemetryProcessor`; ADR-0040 D9 is OTel-native. This is **not a contradiction**: the error path uses the App Insights SDK directly (D3's carve-out), and `ITelemetryProcessor` is the SDK's *only* filter hook. ADR-0040 D9's mechanism choice applies to the **OTLP path**, not the SDK path. Packet 03 **correctly** uses `ITelemetryProcessor` for the error path. The regex scrubbing rules are **not** re-implemented — the error `ITelemetryProcessor` consumes the shared `PiiScrubber` from ADR-0040 packet 05. One regex surface, no duplication, no drift.
+- **No new App Insights resource, no new secret, no new package.** ADR-0045 D2 captures errors into the *same* App Insights resource as traces/metrics/logs. Packet 03 reuses the connection string ADR-0040 packet 02 seeded into the relevant `kv-hd-{service}-{env}` Key Vault, resolved via `ISecretStore` (invariant 9). This is a **Human Prerequisite** on packet 03 — the `dev` App Insights resource must exist (ADR-0040 packet 02); it is not a `dependencies:` edge because cross-initiative `packet:NN` references do not resolve, and provisioning is a portal artifact.
+- **The App Insights SDK goes in `HoneyDrunk.Telemetry.Sink.AzureMonitor` only.** `Microsoft.ApplicationInsights` is referenced by the sink package — never by `HoneyDrunk.Telemetry.Abstractions`, never by a consuming Node. Invariant 80 (the error-flow invariant from packet 00) enforces this.
+- **`operation_id` cross-link (D4).** Map `ErrorContext.TraceId` to the telemetry's `operation_Id` so the App Insights Failures→Transactions→Logs navigation is native — no configured integration.
+- **`evals.sensitive` / Audit carve-outs.** Telemetry with `evals.sensitive=true` is NOT scrubbed of prompt/completion content (ADR-0023/ADR-0040 D9 carve-out). `HoneyDrunk.Audit`-attributed errors are PII-bearing by design — pass through unredacted to the Audit-tagged table.
+- **Version-state check (invariant 27).** Packet 03 appends to the in-progress `HoneyDrunk.Pulse` solution version if packet 02 bumped it; or bumps if packet 02 only appended to a since-released ADR-0040 entry. Read the packet-02 PR; record the decision.
+
+## Critical context for Packet 04 (the deploy-flow change)
+
+- **Independent of the Pulse packets.** Packet 04 depends only on packet 00 — it can run in parallel with packets 02/03, or even earlier. It is grouped into Wave 3 for tidy filing; the `dependencies:` frontmatter is the real signal.
+- **The release-annotation step is never a deploy gate.** A failed or unconfigured annotation must not fail the deploy. The step is gated on the new optional inputs (`app-insights-release-annotation` default `false`, `app-insights-resource-id`); when off or empty, it logs one skipped line and exits 0.
+- **No secret in the workflow.** The annotation call authenticates via the existing OIDC federation the deploy job already uses — no DSN, instrumentation key, or connection string is committed (invariant 8).
+- **Use the current supported annotation mechanism.** `az monitor app-insights` / ARM is the default, supported mechanism — make that the acceptance criterion. The raw `https://aigs1.aisvc.visualstudio.com/...` endpoint is a legacy surface — fallback only if no supported equivalent applies. Research and document the choice.
+- **No version bump.** `HoneyDrunk.Actions` is not a versioned .NET solution — packet 04 is a YAML change; the new inputs are optional and backward-compatible.
+
+## Wave 3 exit criteria
+
+- `HoneyDrunk.Telemetry.Sink.AzureMonitor` captures exceptions into App Insights via the .NET SDK; the `IErrorReporter` facade is implemented over the existing `IErrorSink`; `ErrorContext.TraceId` maps to `operation_Id`; `application_Version` is set; breadcrumbs/scopes work; the error PII `ITelemetryProcessor` scrubs the D7 set by consuming the shared `PiiScrubber`; the `evals.sensitive`/Audit carve-outs pass through; `IErrorReporter` is part of the standard Pulse telemetry registration.
+- The error `ITelemetryProcessor` consumes ADR-0040 packet 05's shared `PiiScrubber` — no re-implementation, no refactor.
+- The invariant-27 version-state check was performed for the `HoneyDrunk.Pulse` solution.
+- The Actions reusable deploy workflows (`job-deploy-container-app.yml`, `job-deploy-function.yml`) carry the gated, default-off, OIDC-authenticated release-annotation step using the current supported mechanism; consumer docs updated.
+- Both solutions build; tests pass; no external service in unit tests (invariant 15).


### PR DESCRIPTION
## Summary
Adds the issue packets for **ADR-0045 — Grid-wide error tracking** under `generated/issue-packets/active/adr-0045-grid-wide-error-tracking/`, plus an **amendment to ADR-0045** itself.

The amendment (dated 2026-05-22) corrects the ADR's original placement of the error path from `HoneyDrunk.Observe` to `HoneyDrunk.Pulse`, matching the Observe/Pulse boundary docs and the companion ADR-0040 amendment. `IErrorReporter` is reconciled as a thin facade over Pulse's existing `IErrorSink`. ADR status stays Proposed.

One of 12 per-ADR PRs from the 2026-05-21 ADR batch — split per ADR so `file-packets.yml` files incrementally per merge rather than firing all 92 packets at once (GraphQL rate limits).

## Merge-order note
**Merge after ADR-0040** (PR #202). This initiative's packets carry placeholder cross-references (`Architecture#ADR0040-PACKETxx`) to ADR-0040's filed issue numbers — substitute the real issue numbers after ADR-0040's packets file, before merging this PR.

## Test plan
- [ ] ADR-0040's real issue numbers substituted into the placeholder cross-references
- [ ] `file-packets.yml` files this ADR's packets on merge and adds them to The Hive
- [ ] No GraphQL rate-limit errors in the filing run

🤖 Generated with [Claude Code](https://claude.com/claude-code)