### PR TITLE
Scope ADR-0046 — specialist review agents

### DIFF
--- a/generated/issue-packets/active/adr-0046-specialist-review-agents/01-architecture-adr-0046-acceptance.md
+++ b/generated/issue-packets/active/adr-0046-specialist-review-agents/01-architecture-adr-0046-acceptance.md
@@ -1,0 +1,120 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "docs", "adr-0046", "wave-1"]
+dependencies: []
+adrs: ["ADR-0046", "ADR-0044", "ADR-0011", "ADR-0007"]
+accepts: ["ADR-0046"]
+wave: 1
+initiative: adr-0046-specialist-review-agents
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0046 — flip status, finalize the new invariant, register the specialist-review-agents initiative
+
+## Summary
+Flip ADR-0046 (Specialist Review Agents) from Proposed to Accepted: update the ADR header, update the ADR index, record the one new specialist-review invariant in `constitution/invariants.md`, and register the `adr-0046-specialist-review-agents` initiative in the tracking files.
+
+## Context
+ADR-0046 codifies the **pattern** of specialist review agents — narrow-lens, deeper-rigor agents (`cfo`, `security`, `performance`, `ai-safety`, `a11y`) that complement the generalist `review` agent's twenty-category rubric from ADR-0044. It layers above ADR-0044 (does not amend it) and names an initial roster of five agents whose definition files land as follow-up packets in this same initiative. Every other packet here references ADR-0046's decisions (D2 roster, D4 file structure, D5 upstream-awareness, D8 priority order, D10 phasing) as live rules, so the flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project. It is `Actor=Agent`, but the human should sanity-check the final invariant number before merge (see Constraints).
+
+## Scope
+- `adrs/ADR-0046-specialist-review-agents.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- The ADR index (`adrs/README.md` or equivalent index file) — update the ADR-0046 row to Accepted.
+- `constitution/invariants.md` — append the one new invariant ADR-0046 introduces (see below).
+- `initiatives/active-initiatives.md` — register the `adr-0046-specialist-review-agents` initiative with a packet checklist (8 packets).
+- `initiatives/proposed-adrs.md` — ADR-0046 moves from "Awaiting" to "In Progress" once packets are filed; the `hive-sync` agent maintains this surface, so this packet only needs to ensure the initiative is registered in `active-initiatives.md`.
+
+## Proposed Implementation
+
+### The one new invariant
+ADR-0046's Consequences/Invariants section adds exactly one. **Its reserved number is 81.**
+
+**Why 81 and not the file's apparent next-free number.** Invariant 81 is pre-reserved as part of a 12-ADR batch — each ADR in that batch gets a reserved invariant number, allocated up front to avoid cross-ADR numbering races. The true current maximum invariant number in `constitution/invariants.md` is **51** (verified 2026-05-22); the gap between 51 and 81 is intentional reservation headroom for the batch, not an error. Assign **81** to this invariant.
+
+**If a number above 51 lands from outside the batch before merge.** `constitution/invariants.md` is topic-grouped and NOT contiguously numbered, so always scan the whole file for the true maximum before assigning. If, at flip time, any invariant above 51 has landed from an ADR *outside* this 12-ADR batch, shift the batch's reserved numbers upward — never reuse a number. In that case assign the next free number above the batch's adjusted floor and note the shift in the PR body. The `hive-sync` agent reconciles final numbering.
+
+Invariant text to add (verbatim intent from ADR-0046 Consequences):
+
+> **Specialist review agents are advisory and complementary to the `review` agent.** A specialist's findings do not gate merge any more than the generalist `review` agent's do — the advisory posture of ADR-0011 D5 is preserved. The `review` agent remains the baseline reviewer with the full twenty-category rubric and runs on every PR; specialists run only when their lens specifically applies and are invoked manually at v1. The human is the final arbiter of which findings warrant action. See ADR-0046 D1, D3.
+
+This invariant belongs in the **Code Review Invariants** topic group (alongside invariants 31–33), since it governs the review surface. The execution agent records the placement and the assigned number (81, unless a batch-external shift applies) in the PR body.
+
+## Affected Files
+- `adrs/ADR-0046-specialist-review-agents.md`
+- `adrs/README.md` (or the ADR index file in use)
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0046 header reads `**Status:** Accepted`
+- [ ] ADR index row for ADR-0046 reflects Accepted
+- [ ] `constitution/invariants.md` carries the one new invariant numbered **81** (or batch-shifted upward if a number above 51 landed from outside the 12-ADR batch), with no "(Proposed)" qualifier, placed in the Code Review Invariants group
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0046-specialist-review-agents` initiative with a packet checklist (8 packets)
+- [ ] The PR body records which invariant number was assigned and notes the `hive-sync` reconciliation expectation
+- [ ] No agent file is created and no `agent-capability-matrix.md` change in this packet (those land in packets 02–07)
+
+## Human Prerequisites
+- [ ] Confirm the invariant number before merge. The reserved number is **81** — pre-allocated as part of a 12-ADR batch; the true current maximum invariant number in `constitution/invariants.md` is 51 (verified 2026-05-22), and the 51→81 gap is intentional batch-reservation headroom, not an error. The file is topic-grouped and NOT contiguously numbered, so scan the whole file for the true maximum. If any invariant above 51 has landed from an ADR *outside* this batch before merge, shift the batch's reserved numbers upward — never reuse a number — and confirm the adjusted assignment.
+
+## Dependencies
+None. This is the first packet in the initiative.
+
+## Referenced ADR Decisions
+
+**ADR-0046 D1** — Specialist agents complement, do not replace, the `review` agent. `review` remains the baseline reviewer running the full twenty-category rubric on every PR; specialists are depth-on-demand, invoked selectively when their lens applies. Specialist findings do not displace `review` findings — both are advisory.
+**ADR-0046 D2** — Initial roster of five specialist agents: `cfo` (cost + AI-cost), `security`, `performance`, `ai-safety`, `a11y`.
+**ADR-0046 D3** — Manual invocation only at v1. No CI triggers; the operator decides when a lens applies.
+**ADR-0046 D7** — This ADR layers above ADR-0044, does not amend it. The twenty-category rubric stays the baseline; specialists deepen five of the twenty categories.
+**ADR-0046 D8 / D10** — Per-agent definition files land as follow-up packets in priority order (`cfo` → `security` → `performance` → `ai-safety` → `a11y`), each in a phased go/no-go rollout.
+**ADR-0044** — Establishes the generalist `review` agent and its twenty-category rubric; the baseline this ADR layers on. Not amended.
+**ADR-0011 D5** — The review agent is advisory; findings do not gate merge. ADR-0046's new invariant preserves this posture for specialists.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0046 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **The reserved invariant number is 81.** Invariant 81 is pre-reserved as part of a 12-ADR batch; if any invariant above 51 lands from outside this batch before merge, shift upward, never reuse a number. Do not write a specific number into the ADR text itself — the ADR delegates numbering; the number is recorded only in `constitution/invariants.md` and the PR body.
+- **Do not amend ADR-0044.** ADR-0046 layers above it (D7). No edit to ADR-0044's text, status, or rubric in this packet.
+- **Do not create agent files in this packet.** The five agent definitions are scoped to packets 03–07; the pattern doc and matrix registration are in packet 02. This packet is the governance flip only.
+
+## Labels
+`chore`, `tier-3`, `meta`, `docs`, `adr-0046`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0046 to Accepted, record its one new invariant in `constitution/invariants.md`, and register the initiative in the trackers.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0046 so the specialist-agent build packets can reference its decisions as live rules.
+- Feature: ADR-0046 Specialist Review Agents rollout, Phase 1.
+- ADRs: ADR-0046 (primary), ADR-0044 (baseline, not amended), ADR-0011 (advisory posture preserved), ADR-0007 (agent-definition source of truth).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0046 stays Proposed until this PR merges.
+- Assign the next free invariant number; do not reserve a number in ADR text.
+- Do not amend ADR-0044; do not create agent files.
+
+**Key Files:**
+- `adrs/ADR-0046-specialist-review-agents.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0046-specialist-review-agents/02-architecture-specialist-agent-pattern-and-roster-doc.md
+++ b/generated/issue-packets/active/adr-0046-specialist-review-agents/02-architecture-specialist-agent-pattern-and-roster-doc.md
@@ -1,0 +1,141 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-2", "meta", "adr-0046", "wave-1"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0046", "ADR-0044", "ADR-0007", "ADR-0011"]
+accepts: ["ADR-0046"]
+wave: 1
+initiative: adr-0046-specialist-review-agents
+node: honeydrunk-architecture
+---
+
+# Codify the specialist-agent pattern and register the roster in the capability matrix
+
+## Summary
+Author the shared specialist-agent reference doc (`copilot/specialist-review-rules.md`) that codifies ADR-0046's pattern — what a specialist agent is, the per-agent definition-file template all five must follow (D4), the manual-invocation discipline (D3), and the upstream-awareness clause (D5) — and register the five roster agents (`cfo`, `security`, `performance`, `ai-safety`, `a11y`) in `constitution/agent-capability-matrix.md` as "planned" rows so the names are visible at ADR/PDR drafting time before the individual definition files land.
+
+## Context
+ADR-0046 D2 names the roster but the per-agent definition files land incrementally (packets 03–07, phased over Week 1 through "when UI work starts"). Two problems follow from that staggering:
+
+1. **The five definition files need a common template.** ADR-0046 D4 specifies six required prose sections for every `.claude/agents/{name}.md` specialist file (identity/scope, mandatory context load, rubric, severity taxonomy, output format, trigger conditions). On top of those six, every real agent definition in this repo opens with a **YAML frontmatter block** (`name:`, `description:`, `tools:`) before any prose — without it the file does not register in Claude Code at all. The template must therefore codify a mandatory **section zero: YAML frontmatter** ahead of the six prose sections. Authoring that template once — rather than re-deriving it in each of packets 03–07 — keeps the five files structurally consistent and gives each downstream packet a concrete skeleton to fill.
+2. **The roster must be legible before the files exist.** ADR-0046's Operational Consequences explicitly states the mitigation for the manual-invocation discipline-failure risk ("I should have invoked `cfo` here and didn't") is that "the agent-capability-matrix is visible during ADR/PDR drafting in Claude Code; the names suggest themselves at the right moment." That mitigation only works if all five names are in the matrix from the start — including `a11y`, whose file may not land for months.
+
+This packet is the pattern-codification half of Wave 1; packet 01 is the governance flip. Together they make ADR-0046's pattern real before any specialist file is authored.
+
+## Scope
+- `copilot/specialist-review-rules.md` — **new file.** The shared reference for the specialist-agent pattern: definition, the D4 six-section template, the D3 manual-invocation rule, the D5 upstream-awareness clause, and the D7 relationship to ADR-0044's twenty-category rubric.
+- `constitution/agent-capability-matrix.md` — add five new rows (`cfo`, `security`, `performance`, `ai-safety`, `a11y`) to "The Agents" table, marked as planned/rolling-out, and a status note explaining the phased D8/D10 authoring order. Add the five to the Decision Tree where natural (a "Do I need a deep single-lens review?" branch pointing at the specialist roster).
+- No `.claude/agents/{name}.md` specialist files (those are packets 03–07).
+- No change to `.claude/agents/review.md` (the generalist is unchanged per ADR-0046 Consequences — "Existing agents are not modified").
+
+## Proposed Implementation
+
+### `copilot/specialist-review-rules.md`
+The file establishes, in order:
+
+1. **What a specialist agent is.** A narrow-lens, deeper-rigor reviewer that complements the generalist `review` agent. Quote ADR-0046 D1's cost/benefit boundary: `review` answers "Does this PR pass the Grid's shared standard across all 20 categories?" and runs always; a specialist answers "Does this PR pass the high bar on **this specific lens**?" and runs selectively. A specialist's findings do not displace `review` findings — both are advisory comments; the human is the final arbiter.
+2. **The definition-file template — section zero plus the D4 six sections.** Every `.claude/agents/{name}.md` specialist file MUST open with **section zero: YAML frontmatter**, then carry the six D4 prose sections.
+
+   **Section zero — YAML frontmatter (mandatory).** A `---`-delimited YAML block at the very top of the file, before any prose. Without it the file will NOT register in Claude Code. It matches the shape of every existing agent definition in this repo (see `.claude/agents/review.md`):
+   - `name:` — the agent's invocation name (`cfo`, `security`, `performance`, `ai-safety`, `a11y`).
+   - `description:` — a folded scalar (`>-`) describing the lens and when to invoke the agent; this is what surfaces in agent-selection UIs.
+   - `tools:` — the tool allowlist. Specialist review agents are **review-only**: they read code and produce advisory findings, they do not modify the repo. Their `tools` list is therefore exactly `Read`, `Grep`, `Glob`, `WebSearch` — and explicitly **not** `Edit`, `Write`, `Bash`, or `Agent`. (This is narrower than the generalist `review` agent, which carries `Agent` and `TodoWrite`; a single-lens specialist does not delegate or track tasks.)
+
+   The six D4 prose sections follow the frontmatter: (a) **Identity and scope** — the lens covered and what is explicitly out of scope; (b) **Mandatory context load** — files read before forming a verdict, paralleling ADR-0044 D2 for the generalist; (c) **Rubric** — the per-lens checklist, parallel to but **deeper than** the corresponding ADR-0044 D3 category; (d) **Severity taxonomy** — `Block` / `Request Changes` / `Suggest`, identical to `copilot/pr-review-rules.md`; (e) **Output format** — the structured verdict the human consumes; (f) **Trigger conditions** — described, not enforced at v1 (the human is the trigger). Provide section zero plus all six as a copy-paste skeleton so packets 03–07 fill it rather than re-derive it.
+3. **The D3 manual-invocation rule.** Specialists are invoked manually by the human at v1 — no CI triggers, no PR-event-driven runs. The operator decides when a lens applies and invokes the named specialist via Claude Code or the cloud-wired review runner with the specialist agent named explicitly. State the three reasons from D3: trigger conditions are heuristic not exact; five specialists on every PR breaches the cost budget; the highest-value invocations are at ADR/PDR drafting time, not PR review time. State that CI-triggered invocation is a deferred follow-up (D9).
+4. **The D5 upstream-awareness clause.** Specialists are not just PR reviewers — their lens applies at authoring time too. A specialist file must explicitly describe its authoring-time use cases (e.g. `cfo` invoked against an ADR draft, `security` invoked against a `scope` packet), not only its review-time use cases. State the load-bearing intent: lens depth applied upstream is materially cheaper than applied downstream.
+5. **The D7 relationship to ADR-0044.** This pattern layers above ADR-0044's twenty-category rubric; it does not amend or subtract from it. Each specialist *deepens* a specific subset of the twenty categories — `cfo` deepens category 17 (cost sub-bullet), the cost/resource side of category 6, and the token/model-cost concerns within category 18; `security` deepens category 9; `performance` deepens category 6 (runtime characteristics, not dollar cost); `ai-safety` deepens category 18 (except the token/cost sub-bullet); `a11y` deepens the consumer-UX surface lightly addressed in category 16. The generalist `review` still runs all twenty.
+6. **Cost discipline (D6).** Specialist invocations are LLM calls; the discipline that bounds them at v1 is manual invocation alone. Specialist cost rolls up under ADR-0044's review budget — no separate budget line.
+
+### `constitution/agent-capability-matrix.md`
+Add five rows to "The Agents" table. Suggested content (the execution agent may tighten wording):
+
+| Agent | Trigger | Consumes | Produces | Does NOT do |
+|-------|---------|----------|----------|-------------|
+| **cfo** | Manual — ADR/PDR draft or PR touching cost, vendors, SKUs, recurring spend, or `IChatClient`/`IModelRouter`/`IAgent` code | The draft or PR diff, cost-relevant ADRs, App Configuration cost-rate context | Advisory cost-discipline findings (`Block`/`Request Changes`/`Suggest`) | Gate merge, make spend decisions, replace `review` |
+| **security** | Manual — PR/packet touching Auth, Vault, tenant boundaries, public APIs, dependency updates | The diff or packet, security-relevant ADRs, OWASP body of practice | Advisory security findings | Gate merge, replace `review` |
+| **performance** | Manual — PR touching hot paths, deployable Nodes, data-access layers, load-sensitive code | The diff, performance-relevant ADRs | Advisory runtime-performance findings | Gate merge, replace `review` |
+| **ai-safety** | Manual — PR/ADR touching AI-sector Nodes, capability registrations, or `IChatClient`/`IModelRouter`/`IAgent` code | The diff or ADR, AI-sector ADRs | Advisory AI/agent-safety findings | Gate merge, replace `review` |
+| **a11y** | Manual — PR/PDR touching UI surfaces (Studios site, future consumer apps) | The diff or PDR, WCAG body of practice | Advisory accessibility findings | Gate merge, replace `review` |
+
+Add a status note below the table: the five specialists roll out across ADR-0046 packets 03–07 in priority order (`cfo` Phase 1, `security` Phase 2, `performance` Phase 3, `ai-safety` Phase 4, `a11y` Phase 5 when UI work starts); the rows are listed now so the roster is legible at ADR/PDR drafting time even before each definition file lands. The note also records that **the five rows are flipped from planned to live in a single later packet (packet 08)** once all five definition files exist — not incrementally by packets 03–07 — to avoid five concurrent edits to the same table region. In the Decision Tree, add a branch: "Do I need a deeper single-lens review than the generalist gives (cost, security, performance, AI-safety, accessibility)? → yes → the matching specialist agent (manual invocation)."
+
+## Affected Files
+- `copilot/specialist-review-rules.md` (new)
+- `constitution/agent-capability-matrix.md`
+
+## NuGet Dependencies
+None. This packet creates and edits Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `copilot/` and `constitution/` are Architecture-repo governance directories. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any repo.
+- [x] No specialist `.claude/agents/{name}.md` file created here — those are packets 03–07.
+
+## Acceptance Criteria
+- [ ] `copilot/specialist-review-rules.md` exists and codifies: the specialist-vs-generalist boundary (D1), the definition-file template as a copy-paste skeleton — **section zero (mandatory YAML frontmatter: `name`/`description`/`tools`, with `tools` fixed to `Read, Grep, Glob, WebSearch` for these review-only agents) plus the D4 six prose sections** — the D3 manual-invocation rule with its three justifications, the D5 upstream-awareness clause, the D7 relationship to ADR-0044's twenty categories, and the D6 cost-discipline note
+- [ ] The template's section-zero frontmatter block is shown verbatim as copy-paste skeleton and states explicitly that without frontmatter the agent file does not register in Claude Code
+- [ ] `constitution/agent-capability-matrix.md` carries five new rows (`cfo`, `security`, `performance`, `ai-safety`, `a11y`) in "The Agents" table
+- [ ] A status note in the matrix explains the phased D8/D10 authoring order and states the rows precede the definition files deliberately
+- [ ] The Decision Tree carries a branch routing to the specialist roster for deep single-lens reviews
+- [ ] No `.claude/agents/{name}.md` specialist file is created in this packet
+- [ ] `.claude/agents/review.md` is unchanged (the generalist is not modified per ADR-0046 Consequences)
+- [ ] The repo-level `CHANGELOG.md` gets an entry for the governance addition (new `copilot/` reference doc + matrix roster expansion)
+
+## Human Prerequisites
+None. Pure Architecture-repo governance-doc authoring.
+
+## Dependencies
+- `packet:01` — ADR-0046 acceptance. The pattern doc references ADR-0046's decisions as live rules; soft dependency, but the doc should not land before the ADR is Accepted.
+
+## Referenced ADR Decisions
+
+**ADR-0046 D1** — Specialists complement, do not replace, `review`. The cost/benefit boundary: `review` runs always against twenty categories; specialists run selectively at high rigor on one lens. Both advisory.
+**ADR-0046 D3** — Manual invocation only at v1. No CI triggers. Three justifications: heuristic triggers, cost budget, highest-value invocations are at drafting time.
+**ADR-0046 D4** — Each specialist has its own `.claude/agents/{name}.md` file with six required prose sections (identity/scope, mandatory context load, rubric, severity taxonomy, output format, trigger conditions). The template adds a mandatory section zero — YAML frontmatter — ahead of the six, matching every existing agent definition in this repo, because Claude Code will not register a file that lacks it.
+**ADR-0046 D5** — Specialists are upstream-aware; the ADR-0044 upstream-awareness clause applies recursively. Specialist files describe authoring-time use cases, not only review-time ones.
+**ADR-0046 D6** — Cost discipline through manual invocation alone at v1; specialist cost rolls up under ADR-0044's review budget.
+**ADR-0046 D7** — Layers above ADR-0044, does not amend it. Specialists deepen five of the twenty categories; no category is removed or downgraded.
+**ADR-0046 D8 / D10** — Per-agent definitions are follow-up packets, authored in priority order across a phased rollout.
+**ADR-0007** — `.claude/agents/` is the single source of truth for agent definitions; the capability matrix is the quick-reference card over it.
+
+## Constraints
+> **ADR-0046 Consequences — "Existing agents are not modified."** `review` keeps its twenty-category rubric; `scope`/`adr-composer`/`pdr-composer`/`refine`/`node-audit` keep their ADR-0044 upstream-awareness references. Specialists layer on top. Do not edit `review.md` or any existing agent file in this packet.
+
+- **Do not author the specialist agent files here.** The five `.claude/agents/{name}.md` files are packets 03–07. This packet authors only the shared pattern doc and the matrix rows.
+- **The template is a skeleton, not a filled file.** `specialist-review-rules.md` provides the section-zero-plus-six-section structure; the per-lens rubric content is authored per-agent in packets 03–07.
+- **Section zero is non-negotiable.** The template must require the YAML frontmatter block (`name`/`description`/`tools`) as the file's opening, with `tools` fixed to `Read, Grep, Glob, WebSearch`. A specialist file without frontmatter does not register in Claude Code.
+- **Do not amend ADR-0044.** The relationship is layering (D7), not amendment.
+
+## Labels
+`docs`, `tier-2`, `meta`, `adr-0046`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Author `copilot/specialist-review-rules.md` codifying ADR-0046's specialist-agent pattern and the D4 six-section template, and register the five roster agents in `constitution/agent-capability-matrix.md`.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make ADR-0046's pattern real and the roster legible before any specialist definition file lands.
+- Feature: ADR-0046 Specialist Review Agents rollout, Phase 1.
+- ADRs: ADR-0046 (D1/D3/D4/D5/D6/D7/D8/D10), ADR-0044 (baseline rubric, not amended), ADR-0007 (agent source of truth), ADR-0011 (advisory posture).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — ADR-0046 acceptance (soft).
+
+**Constraints:**
+- Do not create specialist agent files (packets 03–07).
+- Do not modify `review.md` or any existing agent file.
+- Do not amend ADR-0044.
+
+**Key Files:**
+- `copilot/specialist-review-rules.md` (new)
+- `constitution/agent-capability-matrix.md`
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0046-specialist-review-agents/03-architecture-author-cfo-agent.md
+++ b/generated/issue-packets/active/adr-0046-specialist-review-agents/03-architecture-author-cfo-agent.md
@@ -1,0 +1,129 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-2", "meta", "adr-0046", "wave-2"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0046", "ADR-0044", "ADR-0041", "ADR-0007"]
+accepts: ["ADR-0046"]
+wave: 2
+initiative: adr-0046-specialist-review-agents
+node: honeydrunk-architecture
+---
+
+# Author the `cfo` specialist agent (cost + AI-cost discipline)
+
+## Summary
+Author `.claude/agents/cfo.md` — the cost-discipline specialist review agent. Its lens is cost impact and vendor discipline, **including AI-cost** (token usage, model selection, prompt efficiency, prompt-caching, per-call and per-tenant cost ceilings). It is the **first** specialist authored per ADR-0046 D8 priority order, because it has the strongest retroactive justification: a `cfo` agent reviewing the ADR-0040/0045 first drafts would have caught the proposed ~$200/month Grafana Cloud + Sentry overcommit before it froze.
+
+## Context
+ADR-0046 D8 sequences the five specialist agents and puts `cfo` first: it has immediate retroactive value, it applies to every infrastructure/vendor ADR in flight or queued, and its AI-cost discipline applies as soon as any AI-Node code lands. ADR-0046 D10 Phase 1 is exactly this packet plus the retroactive calibration run that follows it (packet 08).
+
+The `cfo` agent consolidates general cost discipline and AI-cost into one agent (ADR-0046 D2's consolidation note and the "Carve AI-cost out as its own agent" rejected alternative): the analytical framework — free-tier-first reasoning, justify-the-spend, prefer-cheaper-where-equivalent, document escalation triggers — is the same whether the subject is an Azure SKU choice or an LLM model choice. The per-domain detail lives in the rubric, not in a second agent.
+
+This packet depends on packet 02, which authors `copilot/specialist-review-rules.md` — the definition-file template (mandatory section zero YAML frontmatter plus the six D4 prose sections) `cfo.md` must follow.
+
+## Scope
+- `.claude/agents/cfo.md` — **new file.** The `cfo` specialist agent definition, following the section-zero-plus-six-section template from `copilot/specialist-review-rules.md`.
+- No change to `constitution/agent-capability-matrix.md` — the `cfo` row stays "planned" here. The five matrix rows are flipped to "live" together in packet 08, after all five definition files exist, to avoid concurrent edits to the same table region.
+- No change to `review.md` or any other agent file.
+
+## Proposed Implementation
+`cfo.md` follows the template from `copilot/specialist-review-rules.md` — a mandatory **section zero: YAML frontmatter**, then the six D4 prose sections.
+
+**Section zero — YAML frontmatter (mandatory).** The file MUST open with a `---`-delimited YAML block before any prose; without it Claude Code will not register the agent. Match the shape of every existing agent definition in this repo (see `.claude/agents/review.md`):
+- `name: cfo`
+- `description:` — a folded scalar (`>-`) describing the cost + AI-cost lens and when to invoke `cfo` (ADR/PDR drafts and PRs touching cost, vendors, SKUs, recurring spend, or `IChatClient`/`IModelRouter`/`IAgent` code).
+- `tools:` — exactly `Read`, `Grep`, `Glob`, `WebSearch`. `cfo` is a review-only agent: it reads code and produces advisory findings, it does not modify the repo. Do NOT include `Edit`, `Write`, `Bash`, or `Agent`.
+
+The six D4 prose sections follow:
+
+1. **Identity and scope.** Lens: cost impact and vendor discipline, including AI-cost. **In scope:** free-tier-first reasoning, vendor relationship consolidation, recurring-spend justification, paid-tier defaults questioned, sunk-cost leverage, and the AI-cost sub-discipline (token usage analysis, model selection, prompt efficiency, prompt-caching opportunities, per-call and per-tenant cost ceilings). **Out of scope:** runtime performance characteristics that carry no dollar implication — that is the `performance` agent's lens (ADR-0046 D7 explicitly splits the cost sub-concern of category 6 to `cfo` and the runtime characteristics to `performance`).
+2. **Mandatory context load.** Files `cfo` reads before forming a verdict — at minimum the subject (ADR/PDR draft, PR diff, or `scope` packet), plus the cost-relevant Grid context: the project's stated Azure subscription model and naming convention, any cost-rate or routing-policy App Configuration context, and recent ADRs that set cost precedent. Mirror the structure of ADR-0044 D2's context-loading list for the generalist.
+3. **Rubric — the cost-discipline checklist.** Author it in two parts. **General cost discipline:** Is a free or already-paid-for tier viable before a new paid tier? Does this add a new vendor relationship when an existing one covers the use case? Is recurring spend justified and documented? Is a paid-tier default questioned rather than accepted silently? Is sunk cost (already-paid Azure capacity) leveraged before new spend? **AI-cost discipline:** Is model selection deliberate — a cheaper-model default with documented escalation triggers, rather than a premium model by reflex? Is token usage analyzed? Are prompt-caching opportunities taken? Are per-call cost ceilings and per-tenant period ceilings respected? The rubric is parallel to but **deeper than** ADR-0044 D3's cost sub-bullet of category 17, the cost/resource side of category 6, and the token/model-cost concerns within category 18 — name those three category touchpoints explicitly so the relationship to the baseline rubric is legible.
+4. **Severity taxonomy.** `Block` / `Request Changes` / `Suggest`, identical to `copilot/pr-review-rules.md`. Note the advisory posture: per the new ADR-0046 invariant, `cfo` findings do not gate merge — the human is the final arbiter.
+5. **Output format.** A structured verdict the human consumes: an overall cost-posture summary, then findings grouped by severity, each naming the specific cost concern and a cheaper-or-justified alternative.
+6. **Trigger conditions (described, not enforced).** ADRs/PDRs touching infrastructure, dependencies, vendors, SKUs, or recurring costs; PRs adding new Azure resources or external service usage; any code calling `IChatClient` / `IModelRouter` / `IAgent`; capability registrations with cost implications. State that at v1 the human is the trigger (ADR-0046 D3).
+
+**Upstream-awareness section (D5).** `cfo.md` must explicitly describe its authoring-time use case, not only its PR-review use case: invoked against an ADR or PDR draft, `cfo` challenges cost commitments **before they freeze**. Cite the load-bearing example — the ADR-0040/0045 pivot (Grafana Cloud + Sentry, ~$200/month) would have happened in the first draft rather than after a user-pushback round. State explicitly that catching a vendor overcommitment in an ADR draft costs an ADR amendment, while catching it after the account is created and the integration is built costs a migration.
+
+Reference ADR-0041's cost profile (the AI model registry's Sonnet-default vs Opus-escalation policy) as the canonical model-selection precedent the AI-cost rubric draws on.
+
+## Affected Files
+- `.claude/agents/cfo.md` (new)
+
+## NuGet Dependencies
+None. This packet creates and edits Markdown agent-definition files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `.claude/agents/` is the single source of truth for agent definitions (ADR-0007); it lives in `HoneyDrunk.Architecture`. Correct repo.
+- [x] No code change in any repo.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/cfo.md` exists and follows the template from `copilot/specialist-review-rules.md` — section zero (YAML frontmatter) plus the six D4 prose sections
+- [ ] The file opens with a YAML frontmatter block: `name: cfo`, a `description:`, and `tools:` set to exactly `Read, Grep, Glob, WebSearch` (no `Edit`/`Write`/`Bash`/`Agent`)
+- [ ] The rubric covers both general cost discipline and the AI-cost sub-discipline (token usage, model selection, prompt efficiency, caching, per-call and per-tenant ceilings)
+- [ ] The file names the three ADR-0044 D3 category touchpoints `cfo` deepens (category 17 cost sub-bullet, the cost/resource side of category 6, the token/model-cost concerns within category 18)
+- [ ] The file explicitly scopes runtime performance characteristics OUT (they belong to the `performance` agent)
+- [ ] The upstream-awareness section describes the ADR/PDR-drafting use case and cites the ADR-0040/0045 example
+- [ ] The severity taxonomy is `Block`/`Request Changes`/`Suggest` and the file states findings are advisory (the new ADR-0046 invariant)
+- [ ] No edit to `constitution/agent-capability-matrix.md` in this packet — the `cfo` row stays "planned"; the matrix flip to "live" is consolidated into packet 08
+- [ ] The repo-level `CHANGELOG.md` gets an entry for the new agent
+
+## Human Prerequisites
+- [ ] After this PR merges, **re-sync the global agent hardlinks** so `cfo` registers in `~/.claude/agents/`. The Architecture agents are hardlinked into `~/.claude/agents/`; a newly added agent file is not picked up until the hardlink re-sync command is run and Claude Code is restarted. See the re-sync note in the project memory entry on globally-linked Architecture agents.
+
+## Dependencies
+- `packet:01` — ADR-0046 acceptance (the agent definition references ADR-0046 decisions as live rules).
+- `packet:02` — the specialist-agent pattern doc and the definition-file template (section zero plus the six D4 sections) `cfo.md` must follow.
+
+## Referenced ADR Decisions
+
+**ADR-0046 D2** — `cfo` is the cost + AI-cost specialist; AI-cost is folded into `cfo` rather than carved out because the analytical framework is identical.
+**ADR-0046 D4** — Six prose-section definition-file structure (identity/scope, mandatory context load, rubric, severity taxonomy, output format, trigger conditions), preceded by a mandatory section zero — YAML frontmatter — required for the file to register in Claude Code.
+**ADR-0046 D5** — Upstream-aware: `cfo` invoked against an ADR draft challenges cost commitments before they freeze.
+**ADR-0046 D7** — `cfo` deepens category 17's cost sub-bullet, the cost/resource side of category 6, and the token/model-cost concerns of category 18. The runtime side of category 6 stays with `performance`.
+**ADR-0046 D8 / D10** — `cfo` is the first specialist authored; Phase 1 is this packet plus the retroactive calibration run (packet 08).
+**ADR-0041** — The AI model registry's cost profile (Sonnet-default, Opus-escalation) is the model-selection precedent the AI-cost rubric draws on.
+**ADR-0044** — The generalist `review` rubric `cfo` deepens; not amended.
+
+## Constraints
+> **New ADR-0046 invariant:** Specialist review agents are advisory and complementary to the `review` agent. `cfo` findings do not gate merge — the human is the final arbiter. The agent file must state this posture.
+
+- **`cfo` is one agent covering two domains.** Do not split AI-cost into a separate file — ADR-0046 D2 explicitly consolidates it.
+- **Do not duplicate the `performance` lens.** Runtime characteristics with no dollar implication are out of `cfo`'s scope.
+- **Follow the packet-02 template.** `cfo.md` must use the section-zero-plus-six-section structure from `copilot/specialist-review-rules.md`, not an ad-hoc layout. Section zero (YAML frontmatter with `name`/`description`/`tools`) is mandatory — a file without it does not register in Claude Code.
+
+## Labels
+`docs`, `tier-2`, `meta`, `adr-0046`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author `.claude/agents/cfo.md` — the cost + AI-cost discipline specialist agent — following the template (section zero YAML frontmatter plus the six D4 prose sections).
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land the first specialist agent (ADR-0046 D8 priority #1); enables the Phase-1 retroactive calibration run in packet 08.
+- Feature: ADR-0046 Specialist Review Agents rollout, Phase 1.
+- ADRs: ADR-0046 (primary), ADR-0044 (baseline rubric), ADR-0041 (AI cost profile), ADR-0007 (agent source of truth).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — ADR-0046 acceptance.
+- `packet:02` — the specialist-agent pattern doc and template.
+
+**Constraints:**
+- One agent, two domains (cost + AI-cost); do not split.
+- Runtime performance with no dollar implication is out of scope.
+- Follow the packet-02 template: mandatory YAML frontmatter section zero (`tools: Read, Grep, Glob, WebSearch`) plus the six D4 prose sections.
+- Do not edit `constitution/agent-capability-matrix.md` — the matrix flip is consolidated into packet 08.
+
+**Key Files:**
+- `.claude/agents/cfo.md` (new)
+- `.claude/agents/review.md` (frontmatter-shape reference)
+- `copilot/specialist-review-rules.md` (template reference)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0046-specialist-review-agents/04-architecture-author-security-agent.md
+++ b/generated/issue-packets/active/adr-0046-specialist-review-agents/04-architecture-author-security-agent.md
@@ -1,0 +1,129 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-2", "meta", "adr-0046", "wave-2"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0046", "ADR-0044", "ADR-0031", "ADR-0005", "ADR-0009", "ADR-0007"]
+accepts: ["ADR-0046"]
+wave: 2
+initiative: adr-0046-specialist-review-agents
+node: honeydrunk-architecture
+---
+
+# Author the `security` specialist agent (security review)
+
+## Summary
+Author `.claude/agents/security.md` — the security-review specialist agent. Its lens is security: OWASP top 10, threat modeling, auth/secret/PII handling, supply chain, injection surfaces, and trust-boundary integrity. It is the **second** specialist authored per ADR-0046 D8 priority order; ADR-0046 D10 Phase 2.
+
+## Context
+ADR-0046 D8 places `security` second: it applies to ADR-0034 (NuGet signing), ADR-0037 (Stripe integration), ADR-0038 (sender deliverability), and ongoing Auth/Vault/public-API/dependency PRs that are routine but not constant. The generalist `review` agent covers category 9 (Security) broadly; the `security` specialist deepens it with OWASP rigor and threat-modeling discipline a generalist cannot apply within the per-PR cost budget.
+
+This packet depends on packet 02, which authors `copilot/specialist-review-rules.md` — the definition-file template (mandatory section zero YAML frontmatter plus the six D4 prose sections) `security.md` must follow.
+
+## Scope
+- `.claude/agents/security.md` — **new file.** The `security` specialist agent definition, following the section-zero-plus-six-section template.
+- No change to `constitution/agent-capability-matrix.md` — the `security` row stays "planned" here. The five matrix rows are flipped to "live" together in packet 08, after all five definition files exist, to avoid concurrent edits to the same table region.
+- No change to `review.md` or any other agent file.
+
+## Proposed Implementation
+`security.md` follows the template from `copilot/specialist-review-rules.md` — a mandatory **section zero: YAML frontmatter**, then the six D4 prose sections.
+
+**Section zero — YAML frontmatter (mandatory).** The file MUST open with a `---`-delimited YAML block before any prose; without it Claude Code will not register the agent. Match the shape of every existing agent definition in this repo (see `.claude/agents/review.md`):
+- `name: security`
+- `description:` — a folded scalar (`>-`) describing the security-review lens and when to invoke `security` (PRs/packets touching Auth, Vault, tenant boundaries, public APIs, dependency updates).
+- `tools:` — exactly `Read`, `Grep`, `Glob`, `WebSearch`. `security` is a review-only agent: it reads code and produces advisory findings, it does not modify the repo. Do NOT include `Edit`, `Write`, `Bash`, or `Agent`.
+
+The six D4 prose sections follow:
+
+1. **Identity and scope.** Lens: security review. **In scope:** OWASP top 10, threat modeling, authentication/authorization handling, secret handling, PII handling, supply-chain risk, injection surfaces, trust-boundary integrity. **Out of scope:** AI/agent-specific safety concerns (prompt injection, tool-permission scoping, agent guardrails) — those belong to the `ai-safety` agent. Note the deliberate adjacency: an AI-Node PR may warrant both `security` and `ai-safety`; the human invokes both when both lenses apply.
+2. **Mandatory context load.** The subject (PR diff or `scope` packet), plus the security-relevant Grid context: the Grid's secret-handling invariants (Vault is the only source of secrets; secret values never appear in logs/traces/exceptions/telemetry), the tenant-boundary invariants, the Auth posture (Auth validates tokens, never issues them), and the dependency-update posture from ADR-0009.
+3. **Rubric — the security checklist.** Author it against recognized practice: OWASP top 10 coverage (injection, broken auth, sensitive-data exposure, etc.); threat-model questions (what is the trust boundary, what crosses it, who can reach this surface); secret-handling (no hardcoded secrets, all access via `ISecretStore`, no secret values in logs/traces); PII-handling (redaction before persistence or logging); supply-chain (new dependency provenance, lockfile discipline, the ADR-0009 alerts-yes/auto-PRs-no stance); injection-surface review (every external input crossing a trust boundary). The rubric is parallel to but **deeper than** ADR-0044 D3's category 9 — name that category touchpoint explicitly.
+4. **Severity taxonomy.** `Block` / `Request Changes` / `Suggest`, identical to `copilot/pr-review-rules.md`. State the advisory posture per the new ADR-0046 invariant.
+5. **Output format.** A structured verdict: an overall security-posture summary, then findings grouped by severity, each naming the specific vulnerability class and a remediation.
+6. **Trigger conditions (described, not enforced).** PRs touching Auth (ADR-0031), Vault (ADR-0005/0006), tenant boundaries (ADR-0026), public APIs, and dependency updates (ADR-0009). State that at v1 the human is the trigger.
+
+**Upstream-awareness section (D5).** `security.md` must describe its authoring-time use case: invoked against a `scope` agent's packet for any Auth/Vault/tenant-boundary work, `security` surfaces threat modeling **before code is written**. State the load-bearing intent — surfacing a trust-boundary gap at packet-scoping time costs a packet revision; surfacing it after the code ships costs an incident plus a fix.
+
+## Affected Files
+- `.claude/agents/security.md` (new)
+
+## NuGet Dependencies
+None. This packet creates and edits Markdown agent-definition files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `.claude/agents/` is the single source of truth for agent definitions (ADR-0007); it lives in `HoneyDrunk.Architecture`. Correct repo.
+- [x] No code change in any repo.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/security.md` exists and follows the template from `copilot/specialist-review-rules.md` — section zero (YAML frontmatter) plus the six D4 prose sections
+- [ ] The file opens with a YAML frontmatter block: `name: security`, a `description:`, and `tools:` set to exactly `Read, Grep, Glob, WebSearch` (no `Edit`/`Write`/`Bash`/`Agent`)
+- [ ] The rubric covers OWASP top 10, threat modeling, secret/PII handling, supply chain, injection surfaces, and trust-boundary integrity
+- [ ] The file names the ADR-0044 D3 category touchpoint it deepens (category 9, Security)
+- [ ] The file explicitly scopes AI/agent-specific safety OUT (that is the `ai-safety` agent's lens) and notes both may apply to one AI-Node PR
+- [ ] The upstream-awareness section describes the `scope`-packet threat-modeling use case
+- [ ] The severity taxonomy is `Block`/`Request Changes`/`Suggest` and the file states findings are advisory
+- [ ] No edit to `constitution/agent-capability-matrix.md` in this packet — the `security` row stays "planned"; the matrix flip to "live" is consolidated into packet 08
+- [ ] The repo-level `CHANGELOG.md` gets an entry for the new agent
+
+## Human Prerequisites
+- [ ] After this PR merges, **re-sync the global agent hardlinks** so `security` registers in `~/.claude/agents/`. A newly added Architecture agent file is not picked up until the hardlink re-sync command is run and Claude Code is restarted.
+
+## Dependencies
+- `packet:01` — ADR-0046 acceptance.
+- `packet:02` — the specialist-agent pattern doc and the definition-file template (section zero plus the six D4 sections).
+
+## Referenced ADR Decisions
+
+**ADR-0046 D2** — `security` is the security-review specialist; OWASP is the body of practice it draws on.
+**ADR-0046 D4** — Six prose-section definition-file structure, preceded by a mandatory section zero — YAML frontmatter — required for the file to register in Claude Code.
+**ADR-0046 D5** — Upstream-aware: `security` invoked against a `scope` packet surfaces threat modeling before code is written.
+**ADR-0046 D7** — `security` deepens category 9 (Security) — same lens, more rigor; no category removed or downgraded.
+**ADR-0046 D8 / D10** — `security` is the second specialist authored; Phase 2.
+**ADR-0044** — The generalist `review` rubric `security` deepens; not amended.
+**ADR-0009** — Dependabot stance: alerts yes, auto-PRs no; the supply-chain rubric reflects this.
+
+## Constraints
+> **New ADR-0046 invariant:** Specialist review agents are advisory and complementary to the `review` agent. `security` findings do not gate merge — the human is the final arbiter. The agent file must state this posture.
+
+> **Invariant 8:** Secret values never appear in logs, traces, exceptions, or telemetry. Only secret names/identifiers may be traced. The `security` rubric must check for violations of this.
+
+> **Invariant 9:** Vault is the only source of secrets. No Node reads secrets directly from environment variables, config files, or provider SDKs — all access goes through `ISecretStore`. The `security` rubric must check for violations of this.
+
+- **Do not duplicate the `ai-safety` lens.** Prompt injection, tool-permission scoping, and agent guardrails are out of `security`'s scope.
+- **Follow the packet-02 template.** Use the section-zero-plus-six-section structure, not an ad-hoc layout. Section zero (YAML frontmatter with `name`/`description`/`tools`) is mandatory — a file without it does not register in Claude Code.
+- **Do not edit `constitution/agent-capability-matrix.md`** — the matrix flip is consolidated into packet 08.
+
+## Labels
+`docs`, `tier-2`, `meta`, `adr-0046`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author `.claude/agents/security.md` — the security-review specialist agent — following the template (section zero YAML frontmatter plus the six D4 prose sections).
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land the second specialist agent (ADR-0046 D8 priority #2); applicable to ADR-0034/0037/0038 reviews.
+- Feature: ADR-0046 Specialist Review Agents rollout, Phase 2.
+- ADRs: ADR-0046 (primary), ADR-0044 (baseline rubric), ADR-0031 (Auth), ADR-0005 (Vault), ADR-0009 (dependency stance), ADR-0007 (agent source of truth).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — ADR-0046 acceptance.
+- `packet:02` — the specialist-agent pattern doc and template.
+
+**Constraints:**
+- AI/agent-specific safety is out of scope (that is `ai-safety`).
+- The rubric must check invariants 8 and 9 (secret handling).
+- Follow the packet-02 template: mandatory YAML frontmatter section zero (`tools: Read, Grep, Glob, WebSearch`) plus the six D4 prose sections.
+- Do not edit `constitution/agent-capability-matrix.md` — the matrix flip is consolidated into packet 08.
+
+**Key Files:**
+- `.claude/agents/security.md` (new)
+- `.claude/agents/review.md` (frontmatter-shape reference)
+- `copilot/specialist-review-rules.md` (template reference)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0046-specialist-review-agents/05-architecture-author-performance-agent.md
+++ b/generated/issue-packets/active/adr-0046-specialist-review-agents/05-architecture-author-performance-agent.md
@@ -1,0 +1,126 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-2", "meta", "adr-0046", "wave-2"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0046", "ADR-0044", "ADR-0015", "ADR-0028", "ADR-0042", "ADR-0007"]
+accepts: ["ADR-0046"]
+wave: 2
+initiative: adr-0046-specialist-review-agents
+node: honeydrunk-architecture
+---
+
+# Author the `performance` specialist agent (runtime performance and scalability)
+
+## Summary
+Author `.claude/agents/performance.md` — the runtime-performance specialist review agent. Its lens is runtime performance and scalability: allocations in hot paths, blocking calls in async code, inefficient loops, serialization overhead, N+1 queries, missing indexes, scalability under 10× load, concurrency safety, backpressure handling, batching, and resource efficiency. It is the **third** specialist authored per ADR-0046 D8 priority order; ADR-0046 D10 Phase 3.
+
+## Context
+ADR-0046 D8 places `performance` third: it applies to the deployable Nodes (Notify.Functions, Notify.Worker, Pulse.Collector) actively being deployed in the ADR-0015 rollout, and it should land ahead of any meaningful Notify Cloud volume. ADR-0046 D2 records that `performance` was promoted into the v1 roster on user direction (it was originally a D9 follow-up candidate).
+
+The crucial scoping line, from ADR-0046 D7: `performance` focuses on **runtime characteristics, not dollar cost**. The cost-discipline sub-concern within ADR-0044 D3 category 6 stays with `cfo`; `performance` takes the runtime side of the same category. The agent file must make this split explicit.
+
+This packet depends on packet 02, which authors `copilot/specialist-review-rules.md` — the definition-file template (mandatory section zero YAML frontmatter plus the six D4 prose sections) `performance.md` must follow.
+
+## Scope
+- `.claude/agents/performance.md` — **new file.** The `performance` specialist agent definition, following the section-zero-plus-six-section template.
+- No change to `constitution/agent-capability-matrix.md` — the `performance` row stays "planned" here. The five matrix rows are flipped to "live" together in packet 08, after all five definition files exist, to avoid concurrent edits to the same table region.
+- No change to `review.md` or any other agent file.
+
+## Proposed Implementation
+`performance.md` follows the template from `copilot/specialist-review-rules.md` — a mandatory **section zero: YAML frontmatter**, then the six D4 prose sections.
+
+**Section zero — YAML frontmatter (mandatory).** The file MUST open with a `---`-delimited YAML block before any prose; without it Claude Code will not register the agent. Match the shape of every existing agent definition in this repo (see `.claude/agents/review.md`):
+- `name: performance`
+- `description:` — a folded scalar (`>-`) describing the runtime-performance-and-scalability lens and when to invoke `performance` (PRs touching hot paths, deployable Nodes, data-access layers, load-sensitive code).
+- `tools:` — exactly `Read`, `Grep`, `Glob`, `WebSearch`. `performance` is a review-only agent: it reads code and produces advisory findings, it does not modify the repo. Do NOT include `Edit`, `Write`, `Bash`, or `Agent`.
+
+The six D4 prose sections follow:
+
+1. **Identity and scope.** Lens: runtime performance and scalability. **In scope:** allocations in hot paths, blocking calls in async code, inefficient loops, serialization overhead, N+1 queries, missing indexes, query patterns, scalability under 10× load, concurrency safety, backpressure handling, batching opportunities, resource efficiency (memory pressure, connection exhaustion, cache abuse, thread starvation, queue flooding). **Out of scope:** dollar cost of the resources consumed — that is the `cfo` agent's lens (ADR-0046 D7 splits category 6: runtime characteristics here, cost there).
+2. **Mandatory context load.** The subject (PR diff or `scope` packet), plus the performance-relevant Grid context: which Nodes are deployable (Notify.Functions, Notify.Worker, Pulse.Collector per ADR-0015), the event-driven boundaries (ADR-0028) and async message-consumer paths, the idempotency contract for async boundaries (ADR-0042), and any tier-aware data-access patterns.
+3. **Rubric — the runtime-performance checklist.** Author against recognized practice: hot-path allocation review (avoidable allocations in request handlers, message consumers, agent execution loops); async correctness (no blocking calls — `.Result`, `.Wait()`, `Thread.Sleep` — on async paths); algorithmic efficiency (loop nesting, repeated work); serialization overhead; data-access patterns (N+1 queries, missing indexes, unbatched round-trips); scalability questions (does this hold up at 10× current load); concurrency safety (shared mutable state, race conditions); backpressure and batching (does an async consumer handle flooding gracefully); resource efficiency (connection pooling, cache sizing, thread-pool pressure, queue depth). The rubric is parallel to but **deeper than** ADR-0044 D3's category 6 — name that category touchpoint explicitly and state the cost sub-concern is excluded (it belongs to `cfo`).
+4. **Severity taxonomy.** `Block` / `Request Changes` / `Suggest`, identical to `copilot/pr-review-rules.md`. State the advisory posture per the new ADR-0046 invariant.
+5. **Output format.** A structured verdict: an overall performance-posture summary, then findings grouped by severity, each naming the specific runtime concern and a remediation, with the hot-path or load scenario that makes it matter.
+6. **Trigger conditions (described, not enforced).** PRs touching hot paths (request handlers, message consumers per ADR-0028/ADR-0042, agent execution loops); deployable Nodes (Notify.Functions, Notify.Worker, Pulse.Collector per ADR-0015); data-access layers; load-sensitive code in Notify Cloud (ADR-0027). State that at v1 the human is the trigger.
+
+**Upstream-awareness section (D5).** `performance.md` must describe its authoring-time use case: invoked against an ADR draft or a `scope` packet for a deployable Node, `performance` surfaces scalability concerns **before the code is written** — e.g. a message-consumer design that will not handle queue flooding, caught at packet-scoping time, costs a packet revision rather than a production incident under load.
+
+## Affected Files
+- `.claude/agents/performance.md` (new)
+
+## NuGet Dependencies
+None. This packet creates and edits Markdown agent-definition files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `.claude/agents/` is the single source of truth for agent definitions (ADR-0007); it lives in `HoneyDrunk.Architecture`. Correct repo.
+- [x] No code change in any repo.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/performance.md` exists and follows the template from `copilot/specialist-review-rules.md` — section zero (YAML frontmatter) plus the six D4 prose sections
+- [ ] The file opens with a YAML frontmatter block: `name: performance`, a `description:`, and `tools:` set to exactly `Read, Grep, Glob, WebSearch` (no `Edit`/`Write`/`Bash`/`Agent`)
+- [ ] The rubric covers hot-path allocations, async-blocking calls, algorithmic efficiency, serialization overhead, N+1 queries / missing indexes, scalability under 10× load, concurrency safety, backpressure/batching, and resource efficiency
+- [ ] The file names the ADR-0044 D3 category touchpoint it deepens (category 6, Performance and Scalability) and explicitly excludes the cost sub-concern (which belongs to `cfo`)
+- [ ] The upstream-awareness section describes the deployable-Node scalability use case at ADR/packet drafting time
+- [ ] The severity taxonomy is `Block`/`Request Changes`/`Suggest` and the file states findings are advisory
+- [ ] No edit to `constitution/agent-capability-matrix.md` in this packet — the `performance` row stays "planned"; the matrix flip to "live" is consolidated into packet 08
+- [ ] The repo-level `CHANGELOG.md` gets an entry for the new agent
+
+## Human Prerequisites
+- [ ] After this PR merges, **re-sync the global agent hardlinks** so `performance` registers in `~/.claude/agents/`. A newly added Architecture agent file is not picked up until the hardlink re-sync command is run and Claude Code is restarted.
+
+## Dependencies
+- `packet:01` — ADR-0046 acceptance.
+- `packet:02` — the specialist-agent pattern doc and the definition-file template (section zero plus the six D4 sections).
+
+## Referenced ADR Decisions
+
+**ADR-0046 D2** — `performance` is the runtime-performance-and-scalability specialist; promoted into the v1 roster on user direction.
+**ADR-0046 D4** — Six prose-section definition-file structure, preceded by a mandatory section zero — YAML frontmatter — required for the file to register in Claude Code.
+**ADR-0046 D5** — Upstream-aware: `performance` invoked against an ADR/packet for a deployable Node surfaces scalability concerns before code is written.
+**ADR-0046 D7** — `performance` deepens category 6 (runtime characteristics); the cost sub-concern of category 6 stays with `cfo`.
+**ADR-0046 D8 / D10** — `performance` is the third specialist authored; Phase 3.
+**ADR-0015** — Names the deployable Nodes (Notify.Functions, Notify.Worker, Pulse.Collector) the `performance` lens weights toward.
+**ADR-0028 / ADR-0042** — Event-driven architecture and the idempotency contract for async boundaries; the message-consumer hot paths the rubric inspects.
+**ADR-0044** — The generalist `review` rubric `performance` deepens; not amended.
+
+## Constraints
+> **New ADR-0046 invariant:** Specialist review agents are advisory and complementary to the `review` agent. `performance` findings do not gate merge — the human is the final arbiter. The agent file must state this posture.
+
+- **Runtime characteristics only — not dollar cost.** ADR-0046 D7 splits category 6: `performance` takes runtime, `cfo` takes cost. Do not let the `performance` rubric drift into cost analysis.
+- **Follow the packet-02 template.** Use the section-zero-plus-six-section structure, not an ad-hoc layout. Section zero (YAML frontmatter with `name`/`description`/`tools`) is mandatory — a file without it does not register in Claude Code.
+- **Do not edit `constitution/agent-capability-matrix.md`** — the matrix flip is consolidated into packet 08.
+
+## Labels
+`docs`, `tier-2`, `meta`, `adr-0046`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author `.claude/agents/performance.md` — the runtime-performance-and-scalability specialist agent — following the template (section zero YAML frontmatter plus the six D4 prose sections).
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land the third specialist agent (ADR-0046 D8 priority #3); applicable to deployable-Node PRs in the ADR-0015 rollout.
+- Feature: ADR-0046 Specialist Review Agents rollout, Phase 3.
+- ADRs: ADR-0046 (primary), ADR-0044 (baseline rubric), ADR-0015 (deployable Nodes), ADR-0028/0042 (async boundaries), ADR-0007 (agent source of truth).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — ADR-0046 acceptance.
+- `packet:02` — the specialist-agent pattern doc and template.
+
+**Constraints:**
+- Runtime characteristics only — dollar cost belongs to `cfo`.
+- Follow the packet-02 template: mandatory YAML frontmatter section zero (`tools: Read, Grep, Glob, WebSearch`) plus the six D4 prose sections.
+- Do not edit `constitution/agent-capability-matrix.md` — the matrix flip is consolidated into packet 08.
+
+**Key Files:**
+- `.claude/agents/performance.md` (new)
+- `.claude/agents/review.md` (frontmatter-shape reference)
+- `copilot/specialist-review-rules.md` (template reference)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0046-specialist-review-agents/06-architecture-author-ai-safety-agent.md
+++ b/generated/issue-packets/active/adr-0046-specialist-review-agents/06-architecture-author-ai-safety-agent.md
@@ -1,0 +1,135 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-2", "meta", "adr-0046", "wave-2"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0046", "ADR-0044", "ADR-0016", "ADR-0017", "ADR-0007"]
+accepts: ["ADR-0046"]
+wave: 2
+initiative: adr-0046-specialist-review-agents
+node: honeydrunk-architecture
+---
+
+# Author the `ai-safety` specialist agent (AI / agent safety)
+
+## Summary
+Author `.claude/agents/ai-safety.md` — the AI/agent-safety specialist review agent. Its lens is AI and agent safety: prompt injection resistance, tool-permission scoping (least privilege), agent guardrails, output validation at trust boundaries, memory scoping, human override paths, and audit completeness for AI decisions. It is the **fourth** specialist authored per ADR-0046 D8 priority order; ADR-0046 D10 Phase 4.
+
+## Context
+ADR-0046 D8 places `ai-safety` fourth: its applicability climbs as the AI-sector standup wave progresses, and the AI-sector Node standup-ADR acceptance reviews would benefit from it. Today the need is low; it climbs to several invocations per week once Seed Nodes start shipping.
+
+**AI-sector Node ADR range — verified.** The AI-sector Seed Node standup ADRs are ADR-0016 (HoneyDrunk.AI), ADR-0017 (Capabilities), ADR-0018 (Operator), and ADR-0020 through ADR-0025 (Agents, Knowledge, Memory, Evals, Flow, Sim) — nine ADRs in total. **ADR-0019 is HoneyDrunk.Communications, which is not an AI-sector Node** (it is an orchestration layer above Notify); it must be excluded from the `ai-safety` trigger range. The trigger range is therefore "ADR-0016 through ADR-0025, excluding ADR-0019."
+
+The scoping line, from ADR-0046 D7: `ai-safety` deepens ADR-0044 D3 category 18 (AI / Agent-Specific) **except the token/cost sub-bullet**, which belongs to `cfo`. The agent file must make this split explicit — `ai-safety` covers behavioral safety; `cfo` covers token/model cost.
+
+This packet depends on packet 02, which authors `copilot/specialist-review-rules.md` — the definition-file template (mandatory section zero YAML frontmatter plus the six D4 prose sections) `ai-safety.md` must follow.
+
+## Scope
+- `.claude/agents/ai-safety.md` — **new file.** The `ai-safety` specialist agent definition, following the section-zero-plus-six-section template.
+- No change to `constitution/agent-capability-matrix.md` — the `ai-safety` row stays "planned" here. The five matrix rows are flipped to "live" together in packet 08, after all five definition files exist, to avoid concurrent edits to the same table region.
+- No change to `review.md` or any other agent file.
+
+## Proposed Implementation
+`ai-safety.md` follows the template from `copilot/specialist-review-rules.md` — a mandatory **section zero: YAML frontmatter**, then the six D4 prose sections.
+
+**Section zero — YAML frontmatter (mandatory).** The file MUST open with a `---`-delimited YAML block before any prose; without it Claude Code will not register the agent. Match the shape of every existing agent definition in this repo (see `.claude/agents/review.md`):
+- `name: ai-safety`
+- `description:` — a folded scalar (`>-`) describing the AI/agent-safety lens and when to invoke `ai-safety` (PRs/ADRs touching AI-sector Nodes, capability registrations, or `IChatClient`/`IModelRouter`/`IAgent` code).
+- `tools:` — exactly `Read`, `Grep`, `Glob`, `WebSearch`. `ai-safety` is a review-only agent: it reads code and produces advisory findings, it does not modify the repo. Do NOT include `Edit`, `Write`, `Bash`, or `Agent`.
+
+The six D4 prose sections follow:
+
+1. **Identity and scope.** Lens: AI / agent safety. **In scope:** prompt injection resistance, tool-permission scoping (least privilege), agent guardrails, output validation at trust boundaries, memory scoping, human override paths, audit completeness for AI decisions. **Out of scope:** the token/cost side of AI work — model selection, prompt efficiency, token budgets — that is `cfo`'s lens (ADR-0046 D7). Also out of scope: general (non-AI) security — that is `security`'s lens; note that an AI-Node PR may warrant both `ai-safety` and `security`, and the human invokes both when both lenses apply.
+2. **Mandatory context load.** The subject (PR diff, AI-sector standup ADR, or capability definition), plus the AI-relevant Grid context: the AI-sector Node catalog and the abstraction/runtime split (downstream AI-sector Nodes depend only on `HoneyDrunk.AI.Abstractions`), the capability-registration model (ADR-0017), and the AI invariants in `constitution/invariants.md` (model selection via `IModelRouter`, never hardcoded; routing policies and capability declarations sourced from App Configuration).
+3. **Rubric — the AI-safety checklist.** Author against recognized AI-safety practice: prompt-injection resistance (is untrusted input that reaches a prompt treated as hostile); tool-permission scoping (does each tool/capability grant the least privilege necessary); agent guardrails (are there limits on what an agent loop can do unsupervised); output validation at trust boundaries (is model output validated before it crosses out of the AI boundary); memory scoping (is agent memory scoped per tenant/project, not globally readable); human override paths (can a human interrupt or veto an agent decision); audit completeness for AI decisions (is every consequential AI decision recorded attributably). The rubric is parallel to but **deeper than** ADR-0044 D3's category 18 — name that category touchpoint explicitly and state the token/cost sub-bullet is excluded (it belongs to `cfo`).
+4. **Severity taxonomy.** `Block` / `Request Changes` / `Suggest`, identical to `copilot/pr-review-rules.md`. State the advisory posture per the new ADR-0046 invariant.
+5. **Output format.** A structured verdict: an overall AI-safety-posture summary, then findings grouped by severity, each naming the specific safety concern and a remediation.
+6. **Trigger conditions (described, not enforced).** PRs touching AI-sector Nodes — the nine Seed Node standup ADRs are ADR-0016 through ADR-0025 **excluding ADR-0019** (ADR-0019 is HoneyDrunk.Communications, not an AI-sector Node); any code calling `IChatClient` / `IModelRouter` / `IAgent`; capability registrations (ADR-0017). State that at v1 the human is the trigger.
+
+**Upstream-awareness section (D5).** `ai-safety.md` must describe its authoring-time use case: invoked against an AI-sector standup ADR (the AI-sector standup ADRs — ADR-0016 through ADR-0025 excluding ADR-0019 — are still Proposed), `ai-safety` reviews **capability definitions and trust boundaries before the implementing Node ships**. State the load-bearing intent — a missing human-override path or an over-broad tool permission caught in the standup ADR costs an ADR amendment; caught after the Node ships costs a rebuild of the safety surface.
+
+## Affected Files
+- `.claude/agents/ai-safety.md` (new)
+
+## NuGet Dependencies
+None. This packet creates and edits Markdown agent-definition files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `.claude/agents/` is the single source of truth for agent definitions (ADR-0007); it lives in `HoneyDrunk.Architecture`. Correct repo.
+- [x] No code change in any repo.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/ai-safety.md` exists and follows the template from `copilot/specialist-review-rules.md` — section zero (YAML frontmatter) plus the six D4 prose sections
+- [ ] The file opens with a YAML frontmatter block: `name: ai-safety`, a `description:`, and `tools:` set to exactly `Read, Grep, Glob, WebSearch` (no `Edit`/`Write`/`Bash`/`Agent`)
+- [ ] The trigger range names AI-sector Node standup ADRs as ADR-0016 through ADR-0025 excluding ADR-0019 (Communications, not an AI-sector Node)
+- [ ] The rubric covers prompt injection resistance, tool-permission scoping, agent guardrails, output validation at trust boundaries, memory scoping, human override paths, and audit completeness for AI decisions
+- [ ] The file names the ADR-0044 D3 category touchpoint it deepens (category 18, AI / Agent-Specific) and explicitly excludes the token/cost sub-bullet (which belongs to `cfo`)
+- [ ] The file explicitly scopes general non-AI security OUT (that is the `security` agent's lens) and notes both may apply to one AI-Node PR
+- [ ] The upstream-awareness section describes the AI-sector standup-ADR review use case
+- [ ] The severity taxonomy is `Block`/`Request Changes`/`Suggest` and the file states findings are advisory
+- [ ] No edit to `constitution/agent-capability-matrix.md` in this packet — the `ai-safety` row stays "planned"; the matrix flip to "live" is consolidated into packet 08
+- [ ] The repo-level `CHANGELOG.md` gets an entry for the new agent
+
+## Human Prerequisites
+- [ ] After this PR merges, **re-sync the global agent hardlinks** so `ai-safety` registers in `~/.claude/agents/`. A newly added Architecture agent file is not picked up until the hardlink re-sync command is run and Claude Code is restarted.
+
+## Dependencies
+- `packet:01` — ADR-0046 acceptance.
+- `packet:02` — the specialist-agent pattern doc and the definition-file template (section zero plus the six D4 sections).
+
+## Referenced ADR Decisions
+
+**ADR-0046 D2** — `ai-safety` is the AI/agent-safety specialist.
+**ADR-0046 D4** — Six prose-section definition-file structure, preceded by a mandatory section zero — YAML frontmatter — required for the file to register in Claude Code.
+**ADR-0046 D5** — Upstream-aware: `ai-safety` invoked against an AI-sector standup ADR reviews capability definitions and trust boundaries before the Node ships.
+**ADR-0046 D7** — `ai-safety` deepens category 18 except the token/cost sub-bullet, which is `cfo`'s.
+**ADR-0046 D8 / D10** — `ai-safety` is the fourth specialist authored; Phase 4.
+**ADR-0016** — HoneyDrunk.AI standup; the abstraction/runtime split (downstream AI-sector Nodes depend only on `HoneyDrunk.AI.Abstractions`).
+**ADR-0017** — Capabilities standup; the capability-registration model the `ai-safety` rubric inspects for tool-permission scoping.
+**ADR-0044** — The generalist `review` rubric `ai-safety` deepens; not amended.
+
+## Constraints
+> **New ADR-0046 invariant:** Specialist review agents are advisory and complementary to the `review` agent. `ai-safety` findings do not gate merge — the human is the final arbiter. The agent file must state this posture.
+
+> **Invariant 28:** Application code must never hardcode a model name or provider — all model selection goes through `IModelRouter`. The `ai-safety` rubric should flag any hardcoded model/provider as both a safety and a governance concern.
+
+- **Do not duplicate the `cfo` or `security` lens.** Token/model cost belongs to `cfo`; general non-AI security belongs to `security`. `ai-safety` covers behavioral AI/agent safety only.
+- **The AI-sector trigger range excludes ADR-0019.** ADR-0019 (HoneyDrunk.Communications) is not an AI-sector Node. The AI-sector Node standup ADRs are ADR-0016 through ADR-0025 excluding ADR-0019.
+- **Follow the packet-02 template.** Use the section-zero-plus-six-section structure, not an ad-hoc layout. Section zero (YAML frontmatter with `name`/`description`/`tools`) is mandatory — a file without it does not register in Claude Code.
+- **Do not edit `constitution/agent-capability-matrix.md`** — the matrix flip is consolidated into packet 08.
+
+## Labels
+`docs`, `tier-2`, `meta`, `adr-0046`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author `.claude/agents/ai-safety.md` — the AI/agent-safety specialist agent — following the template (section zero YAML frontmatter plus the six D4 prose sections).
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land the fourth specialist agent (ADR-0046 D8 priority #4); applicable to AI-sector standup-ADR reviews.
+- Feature: ADR-0046 Specialist Review Agents rollout, Phase 4.
+- ADRs: ADR-0046 (primary), ADR-0044 (baseline rubric), ADR-0016 (AI standup), ADR-0017 (Capabilities), ADR-0007 (agent source of truth).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — ADR-0046 acceptance.
+- `packet:02` — the specialist-agent pattern doc and template.
+
+**Constraints:**
+- Token/model cost is out of scope (that is `cfo`); general non-AI security is out of scope (that is `security`).
+- The AI-sector trigger range is ADR-0016 through ADR-0025 excluding ADR-0019 (Communications).
+- The rubric should flag hardcoded model/provider names (invariant 28).
+- Follow the packet-02 template: mandatory YAML frontmatter section zero (`tools: Read, Grep, Glob, WebSearch`) plus the six D4 prose sections.
+- Do not edit `constitution/agent-capability-matrix.md` — the matrix flip is consolidated into packet 08.
+
+**Key Files:**
+- `.claude/agents/ai-safety.md` (new)
+- `.claude/agents/review.md` (frontmatter-shape reference)
+- `copilot/specialist-review-rules.md` (template reference)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0046-specialist-review-agents/07-architecture-author-a11y-agent.md
+++ b/generated/issue-packets/active/adr-0046-specialist-review-agents/07-architecture-author-a11y-agent.md
@@ -1,0 +1,125 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-2", "meta", "adr-0046", "wave-3"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0046", "ADR-0044", "ADR-0029", "ADR-0007"]
+accepts: ["ADR-0046"]
+wave: 3
+initiative: adr-0046-specialist-review-agents
+node: honeydrunk-architecture
+---
+
+# Author the `a11y` specialist agent (accessibility / WCAG)
+
+## Summary
+Author `.claude/agents/a11y.md` — the accessibility specialist review agent. Its lens is accessibility (WCAG): semantic HTML, keyboard navigation, screen-reader behavior, focus management, color contrast, ARIA correctness, and form labels. It is the **fifth and last** specialist authored per ADR-0046 D8 priority order; ADR-0046 D10 Phase 5.
+
+## Context
+ADR-0046 D8 places `a11y` fifth with explicit reasoning: there is **zero immediate need** — no UI work is in flight today — but the file should land before the first consumer-app PR so accessibility is baked in rather than bolted on. ADR-0046 D10 Phase 5 is gated on "when UI work starts."
+
+This packet is placed in **Wave 3** of the initiative rather than Wave 2 deliberately, to reflect that `a11y` has no near-term invocation surface. It is still authored within this initiative — rather than deferred to a future ADR — because ADR-0046's Operational Consequences require the full roster legible in the capability matrix from the start, and authoring all five files keeps the roster real rather than aspirational. The file sits ready; the human invokes it when consumer-app UI work begins.
+
+This packet depends on packet 02, which authors `copilot/specialist-review-rules.md` — the definition-file template (mandatory section zero YAML frontmatter plus the six D4 prose sections) `a11y.md` must follow.
+
+## Scope
+- `.claude/agents/a11y.md` — **new file.** The `a11y` specialist agent definition, following the section-zero-plus-six-section template.
+- No change to `constitution/agent-capability-matrix.md` — the `a11y` row stays "planned" here. The five matrix rows are flipped to "live" together in packet 08, after all five definition files exist, to avoid concurrent edits to the same table region.
+- No change to `review.md` or any other agent file.
+
+## Proposed Implementation
+`a11y.md` follows the template from `copilot/specialist-review-rules.md` — a mandatory **section zero: YAML frontmatter**, then the six D4 prose sections.
+
+**Section zero — YAML frontmatter (mandatory).** The file MUST open with a `---`-delimited YAML block before any prose; without it Claude Code will not register the agent. Match the shape of every existing agent definition in this repo (see `.claude/agents/review.md`):
+- `name: a11y`
+- `description:` — a folded scalar (`>-`) describing the accessibility/WCAG lens and when to invoke `a11y` (PRs/PDRs touching UI surfaces — the Studios site and future consumer apps).
+- `tools:` — exactly `Read`, `Grep`, `Glob`, `WebSearch`. `a11y` is a review-only agent: it reads code and produces advisory findings, it does not modify the repo. Do NOT include `Edit`, `Write`, `Bash`, or `Agent`.
+
+The six D4 prose sections follow:
+
+1. **Identity and scope.** Lens: accessibility (WCAG). **In scope:** semantic HTML, keyboard navigation, screen-reader behavior, focus management, color contrast, ARIA correctness, form labels. **Out of scope:** general developer-experience and non-accessibility UX — the generalist `review` agent's category 16 covers that broadly; `a11y` is the accessibility-specific deepening of the consumer-UX surface. Out of scope also: backend/API code with no rendered UI.
+2. **Mandatory context load.** The subject (PR diff or PDR draft), plus the UI-relevant Grid context: the Studios marketing site stack (ADR-0029) and, when they exist, the consumer-app stacks; the WCAG body of practice (WCAG 2.2 AA as the baseline target unless a PDR sets otherwise).
+3. **Rubric — the accessibility checklist.** Author against WCAG: semantic HTML (correct landmark and heading structure, native elements over `div` soup); keyboard navigation (every interactive element reachable and operable by keyboard, logical tab order); screen-reader behavior (meaningful accessible names, no announcement gaps); focus management (visible focus indicators, focus moved correctly on route/modal changes, no focus traps); color contrast (text and UI components meet WCAG AA contrast ratios); ARIA correctness (ARIA used only where native semantics fall short, no broken or redundant ARIA); form labels (every input has a programmatically associated label, errors announced). The rubric is parallel to but **deeper than** what ADR-0044 D3 category 16 lightly addresses — name that category touchpoint explicitly and note ADR-0046 D7's observation that the baseline rubric only lightly covers consumer UX because the Grid is solo-dev-API-heavy today.
+4. **Severity taxonomy.** `Block` / `Request Changes` / `Suggest`, identical to `copilot/pr-review-rules.md`. State the advisory posture per the new ADR-0046 invariant.
+5. **Output format.** A structured verdict: an overall accessibility-posture summary, then findings grouped by severity, each naming the WCAG success criterion at issue and a remediation.
+6. **Trigger conditions (described, not enforced).** PRs touching UI surfaces — the Studios marketing site (ADR-0029) and future consumer apps (PDR-0003 / 0005 / 0006 / 0007 / 0008). State that at v1 the human is the trigger and that the lens is dormant until consumer-app UI work begins.
+
+**Upstream-awareness section (D5).** `a11y.md` must describe its authoring-time use case: invoked at **PDR-composition time** for consumer apps (PDR-0003 onward), `a11y` bakes accessibility into the product definition rather than bolting it on at UI-implementation time. State the load-bearing intent — accessibility designed into a product definition costs nothing extra; accessibility retrofitted onto a shipped UI costs a rework pass and risks the accessibility-lawsuit failure mode ADR-0046 D2 names.
+
+## Affected Files
+- `.claude/agents/a11y.md` (new)
+
+## NuGet Dependencies
+None. This packet creates and edits Markdown agent-definition files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] `.claude/agents/` is the single source of truth for agent definitions (ADR-0007); it lives in `HoneyDrunk.Architecture`. Correct repo.
+- [x] No code change in any repo.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/a11y.md` exists and follows the template from `copilot/specialist-review-rules.md` — section zero (YAML frontmatter) plus the six D4 prose sections
+- [ ] The file opens with a YAML frontmatter block: `name: a11y`, a `description:`, and `tools:` set to exactly `Read, Grep, Glob, WebSearch` (no `Edit`/`Write`/`Bash`/`Agent`)
+- [ ] The rubric covers semantic HTML, keyboard navigation, screen-reader behavior, focus management, color contrast, ARIA correctness, and form labels, against WCAG 2.2 AA as the baseline
+- [ ] The file names the ADR-0044 D3 category touchpoint it deepens (category 16, Developer Experience — the consumer-UX surface) and notes the baseline rubric covers it only lightly
+- [ ] The upstream-awareness section describes the PDR-composition-time use case for consumer apps
+- [ ] The severity taxonomy is `Block`/`Request Changes`/`Suggest` and the file states findings are advisory
+- [ ] No edit to `constitution/agent-capability-matrix.md` in this packet — the `a11y` row stays "planned"; the matrix flip to "live" (with the dormant-lens note) is consolidated into packet 08
+- [ ] The repo-level `CHANGELOG.md` gets an entry for the new agent
+
+## Human Prerequisites
+- [ ] After this PR merges, **re-sync the global agent hardlinks** so `a11y` registers in `~/.claude/agents/`. A newly added Architecture agent file is not picked up until the hardlink re-sync command is run and Claude Code is restarted. (This also completes the five-agent roster — re-sync once after this packet covers it if packets 03–06 were merged together.)
+
+## Dependencies
+- `packet:01` — ADR-0046 acceptance.
+- `packet:02` — the specialist-agent pattern doc and the definition-file template (section zero plus the six D4 sections).
+
+## Referenced ADR Decisions
+
+**ADR-0046 D2** — `a11y` is the accessibility specialist; WCAG is the body of practice it draws on. Accessibility lawsuits are a named high-stakes failure mode.
+**ADR-0046 D4** — Six prose-section definition-file structure, preceded by a mandatory section zero — YAML frontmatter — required for the file to register in Claude Code.
+**ADR-0046 D5** — Upstream-aware: `a11y` invoked at PDR-composition for consumer apps bakes accessibility into the product definition.
+**ADR-0046 D7** — `a11y` deepens what is implicitly in category 16 (the consumer-UX surface the baseline rubric only lightly addresses).
+**ADR-0046 D8 / D10** — `a11y` is the fifth and last specialist authored; Phase 5, gated on "when UI work starts." Placed in Wave 3 of this initiative to reflect zero near-term invocation surface.
+**ADR-0029** — The Studios marketing-site stack — the existing UI surface `a11y` reviews.
+**ADR-0044** — The generalist `review` rubric `a11y` deepens; not amended.
+
+## Constraints
+> **New ADR-0046 invariant:** Specialist review agents are advisory and complementary to the `review` agent. `a11y` findings do not gate merge — the human is the final arbiter. The agent file must state this posture.
+
+- **The agent file is authored now; the lens is dormant.** ADR-0046 D8 is explicit that `a11y` has zero immediate need — the file lands ready, invocation waits for consumer-app UI work. Do not treat dormancy as a reason to defer authoring.
+- **Follow the packet-02 template.** Use the section-zero-plus-six-section structure, not an ad-hoc layout. Section zero (YAML frontmatter with `name`/`description`/`tools`) is mandatory — a file without it does not register in Claude Code.
+- **Do not edit `constitution/agent-capability-matrix.md`** — the matrix flip is consolidated into packet 08.
+
+## Labels
+`docs`, `tier-2`, `meta`, `adr-0046`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Author `.claude/agents/a11y.md` — the accessibility/WCAG specialist agent — following the template (section zero YAML frontmatter plus the six D4 prose sections).
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land the fifth and last specialist agent (ADR-0046 D8 priority #5); the file sits ready ahead of the first consumer-app UI PR.
+- Feature: ADR-0046 Specialist Review Agents rollout, Phase 5.
+- ADRs: ADR-0046 (primary), ADR-0044 (baseline rubric), ADR-0029 (Studios site), ADR-0007 (agent source of truth).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — ADR-0046 acceptance.
+- `packet:02` — the specialist-agent pattern doc and template.
+
+**Constraints:**
+- Author the file now even though the lens is dormant until UI work starts.
+- Follow the packet-02 template: mandatory YAML frontmatter section zero (`tools: Read, Grep, Glob, WebSearch`) plus the six D4 prose sections.
+- Do not edit `constitution/agent-capability-matrix.md` — the matrix flip is consolidated into packet 08.
+
+**Key Files:**
+- `.claude/agents/a11y.md` (new)
+- `.claude/agents/review.md` (frontmatter-shape reference)
+- `copilot/specialist-review-rules.md` (template reference)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0046-specialist-review-agents/08-architecture-cfo-phase-1-calibration-run.md
+++ b/generated/issue-packets/active/adr-0046-specialist-review-agents/08-architecture-cfo-phase-1-calibration-run.md
@@ -1,0 +1,125 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["docs", "tier-2", "meta", "adr-0046", "wave-3"]
+dependencies: ["packet:03", "packet:04", "packet:05", "packet:06", "packet:07"]
+adrs: ["ADR-0046", "ADR-0044", "ADR-0040", "ADR-0045"]
+accepts: ["ADR-0046"]
+wave: 3
+initiative: adr-0046-specialist-review-agents
+node: honeydrunk-architecture
+---
+
+# Phase-1 calibration — invoke `cfo`, record the go/no-go finding, and flip the capability-matrix roster live
+
+## Summary
+Run the ADR-0046 D10 Phase-1 calibration: retroactively invoke the newly authored `cfo` agent against the calibration PR (the ADR-0044/0046 review-agent ADR family — see step 0 to verify the PR number/state before use) and the recent observability ADRs (ADR-0040 / ADR-0045), capture the findings, and record the Phase-1 go/no-go verdict in a calibration note. The exit criterion is binary: did `cfo` produce findings the human would act on? If yes, operational Phase 2 (`security`) proceeds; if no, the specialist pattern itself is reconsidered before more specialists are *operated*.
+
+This packet also performs the **consolidated capability-matrix flip**: it flips all five specialist rows (`cfo`, `security`, `performance`, `ai-safety`, `a11y`) in `constitution/agent-capability-matrix.md` from "planned" to "live" in one edit. Packets 03–07 deliberately leave the matrix untouched so the five row-flips do not collide as concurrent edits to the same table region; this packet runs after all five definition files exist and makes the flip once.
+
+## Context
+ADR-0046 D10 Phase 1 has two halves: author `.claude/agents/cfo.md` (packet 03), then **calibrate** — invoke `cfo` retroactively to test whether it earns its keep. ADR-0046 D10 is explicit: "Phase 1's exit criterion is 'did `cfo` produce findings the human acted on?' — if yes, Phase 2 starts; if no, the pattern itself is reconsidered before adding more specialists." This packet is that calibration half.
+
+The calibration target is well-chosen by the ADR: the ADR-0040/0045 first drafts proposed Grafana Cloud + Sentry at ~$200/month before considering that Azure was already paid for and App Insights covered the use case. ADR-0046's Context cites this as the retroactively-justifying use case for `cfo`. Running `cfo` against the as-revised ADRs (and PR #162) tests whether the agent surfaces useful cost-discipline findings even against already-revised material — a stringent bar, since the obvious overcommit was already corrected.
+
+This packet is the **gate** between the specialist roster's authoring and its operational rollout. It is `Actor=Agent` for the mechanical invocation, note-writing, and matrix flip, but the **go/no-go decision itself is the human's** (recorded as a Human Prerequisite). Note the scope distinction: the five specialist agent *files* are all authored by Wave 2 (packets 03–07) regardless of the calibration outcome — the calibration verdict governs operational *use*, not whether the roster files exist.
+
+## Scope
+- **Step 0 — verify the calibration PR.** Before invoking `cfo`, confirm the PR number and state with `gh pr view <number> -R HoneyDrunkStudios/HoneyDrunk.Architecture --json number,state,title`. The intended target is the ADR-0044/0046 review-agent ADR family PR (recorded at scope time as PR #162, "docs(adr): add 11 Proposed ADRs 0034-0044…", MERGED). If the number or state has drifted, use the actual PR for that ADR family and record the corrected reference in the calibration note.
+- Invoke the `cfo` agent (from packet 03) retroactively against:
+  - The verified calibration PR — the ADR-0044/0046 review-agent ADR family.
+  - ADR-0040 (Telemetry Backend and Retention) and ADR-0045 (Grid-Wide Error Tracking) — the observability ADRs whose first drafts carried the cost overcommit.
+- `generated/post-merge-audits/` or a calibration note under the initiative folder — record the `cfo` findings and the Phase-1 go/no-go verdict. The execution agent picks the location consistent with current convention (ADR-0044 packet 15 created `generated/post-merge-audits/`; if that directory exists, a calibration note there is the natural home; otherwise a `cfo-phase-1-calibration.md` note alongside the dispatch plan in this initiative folder is acceptable).
+- Capture any concrete cost-discipline findings `cfo` produces against the calibration PR's branch as commits on that branch, per ADR-0046 D10 Phase 1 ("capture any findings as commits on the same branch") — only if the PR is still open and the findings are actionable; if the PR has merged (as PR #162 has), record the findings in the calibration note as retrospective observations.
+- `constitution/agent-capability-matrix.md` — **flip all five specialist rows** (`cfo`, `security`, `performance`, `ai-safety`, `a11y`) from "planned" to "live" in a single edit, and update the status note accordingly. This flip records that the five definition files now exist (which is true once packets 03–07 merge, independent of the calibration verdict). For `a11y`, the row note retains that the lens is dormant until consumer-app UI work begins.
+
+## Proposed Implementation
+1. **Verify the calibration PR (step 0).** Run `gh pr view 162 -R HoneyDrunkStudios/HoneyDrunk.Architecture --json number,state,title`. Confirm it is the ADR-0044/0046 review-agent ADR family PR; record number and state in the calibration note. If drifted, find and use the correct PR.
+2. With `cfo.md` in place (packet 03) and the global hardlink re-synced (packet 03's Human Prerequisite), invoke `cfo` against each calibration target. For the ADRs, this is the upstream-awareness use case (D5): `cfo` reviewing an ADR's cost commitments.
+3. Collect the findings into a calibration note. The note records, per target: what `cfo` flagged, at what severity (`Block` / `Request Changes` / `Suggest`), and whether the finding is one the human would have acted on had it surfaced at draft time.
+4. Write the Phase-1 verdict: **Go** if `cfo` produced at least one finding the human judges actionable (the pattern earns its keep — operational Phase 2 proceeds); **No-go / reconsider** if `cfo` produced only noise (the specialist pattern is reconsidered before `security` is *operated* — its lens should not be used in anger until the reconsideration concludes).
+5. Flip all five rows in `constitution/agent-capability-matrix.md` from "planned" to "live." This flip reflects that the definition files exist and is independent of the calibration verdict — a No-go verdict pauses *operational use* of the lenses, not the legibility of the roster.
+6. Note the calibration outcome's effect on the rest of the initiative: a No-go verdict does not retroactively un-author any specialist file or undo the matrix flip, but it pauses *operational use* of `security`/`performance`/`ai-safety`/`a11y` pending a human decision on whether to amend ADR-0046's roster.
+
+## Affected Files
+- A calibration note — `generated/post-merge-audits/cfo-phase-1-calibration.md` or `generated/issue-packets/active/adr-0046-specialist-review-agents/cfo-phase-1-calibration.md` (execution agent chooses per convention).
+- `constitution/agent-capability-matrix.md` — the consolidated five-row flip from "planned" to "live."
+- Possibly commits on the calibration PR's branch (only if that PR is open and findings are actionable; PR #162 is merged, so this is unlikely).
+
+## NuGet Dependencies
+None. This packet runs an agent and writes a Markdown note; no .NET project is created or modified.
+
+## Boundary Check
+- [x] The calibration note, the matrix flip, and any branch commits are in `HoneyDrunk.Architecture`. Correct repo.
+- [x] No code change in any other repo.
+- [x] Invoking an agent, recording its output, and flipping matrix rows are Meta-sector governance activities.
+
+## Acceptance Criteria
+- [ ] Step 0 ran: the calibration PR's number and state were verified via `gh pr view` and recorded in the calibration note (intended target PR #162, MERGED)
+- [ ] `cfo` has been invoked retroactively against the verified calibration PR, ADR-0040, and ADR-0045
+- [ ] A calibration note records, per target, what `cfo` flagged, at what severity, and whether the finding is actionable
+- [ ] The note states an explicit Phase-1 verdict: Go (operational Phase 2 proceeds) or No-go (specialist pattern reconsidered before the other lenses are operated)
+- [ ] If the calibration PR is open and `cfo` produced actionable findings, those are captured as commits on that branch; if it has merged, the findings are recorded in the note as retrospective observations
+- [ ] `constitution/agent-capability-matrix.md` has all five specialist rows (`cfo`, `security`, `performance`, `ai-safety`, `a11y`) flipped from "planned" to "live," with the status note updated and the `a11y` dormant-lens note retained
+- [ ] The note states the effect of the verdict on operational rollout (a No-go pauses operational *use* of `security`/`performance`/`ai-safety`/`a11y` pending a roster-reconsideration decision; it does not un-author any file or undo the matrix flip)
+- [ ] The repo-level `CHANGELOG.md` gets an entry for the capability-matrix roster going live
+
+## Human Prerequisites
+- [ ] **Make the Phase-1 go/no-go decision.** ADR-0046 D10 makes this a human judgment: did `cfo` produce findings worth acting on? The agent assembles the evidence and proposes a verdict; the human ratifies or overturns it. A No-go means the operational *use* of `security`/`performance`/`ai-safety`/`a11y` is paused pending a decision on whether to amend ADR-0046's roster — that pause is a human call, not an automated one. The agent files themselves remain authored and the matrix flip stands regardless.
+- [ ] Confirm that `cfo.md` (and ideally the other four specialist files) is hardlink-synced into `~/.claude/agents/` and Claude Code has been restarted, so the `cfo` agent is actually invocable before this calibration runs (this is the carry-over of packets 03–07's Human Prerequisites — a single re-sync covers the batch).
+
+## Dependencies
+- `packet:03` — `cfo.md` must exist before it can be invoked.
+- `packet:04`, `packet:05`, `packet:06`, `packet:07` — all five specialist definition files must exist before this packet's consolidated capability-matrix row-flip can mark the full roster "live." The calibration itself only needs `cfo` (packet 03), but the matrix flip needs all five.
+
+## Referenced ADR Decisions
+
+**ADR-0046 D10 Phase 1** — Author `cfo.md`, then retroactively invoke it against the ADR-0044/0046 review-agent ADR family PR (recorded as PR #162 — verify before use), capturing findings as commits on the same branch. The retroactive run is the v1 calibration: if `cfo` produces useful findings against an already-revised PR, it earns its keep.
+**ADR-0046 D10** — Each phase is a discrete go/no-go. Phase 1's exit criterion: did `cfo` produce findings the human acted on? Yes → Phase 2 starts; no → the pattern is reconsidered before adding more specialists.
+**ADR-0046 Context** — The ADR-0040/0045 first-draft cost overcommit (~$200/month Grafana Cloud + Sentry) is the retroactively-justifying use case for `cfo`.
+**ADR-0046 D5** — Specialists are upstream-aware; invoking `cfo` against an ADR is the authoring-time application of the lens.
+**ADR-0040 / ADR-0045** — The observability ADRs whose first drafts carried the cost overcommit; the calibration targets.
+**ADR-0044** — The calibration PR (PR #162 at scope time) is part of the ADR-0044/0046 review-agent ADR family; the cloud-review machinery `cfo` complements.
+
+## Constraints
+> **New ADR-0046 invariant:** Specialist review agents are advisory and complementary to the `review` agent. `cfo` findings do not gate merge — the human is the final arbiter. The calibration measures finding *quality*, not a pass/fail gate.
+
+- **Verify the calibration PR first.** Step 0 is mandatory — confirm PR #162's number and state via `gh pr view` before invoking `cfo` against it; do not assume the number.
+- **The verdict is the human's.** The agent assembles evidence and proposes; the human decides. Do not record a Go verdict without the human's ratification.
+- **A No-go pauses operational use, not authoring.** A No-go verdict pauses the operational *use* of the `security`/`performance`/`ai-safety`/`a11y` lenses pending a roster-reconsideration decision; it does not delete any already-authored specialist file and does not undo the capability-matrix flip — all five files are authored by Wave 2 regardless of the verdict.
+- **Calibrate against as-revised material.** The ADR-0040/0045 obvious overcommit was already corrected — `cfo` is being tested against the stringent bar of finding value in already-revised ADRs, which is the deliberate point.
+
+## Labels
+`docs`, `tier-2`, `meta`, `adr-0046`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Verify the calibration PR, run the ADR-0046 D10 Phase-1 calibration — retroactively invoke `cfo` against that PR and ADR-0040/0045, record findings, propose a go/no-go verdict for the human to ratify — and flip all five specialist rows in the capability matrix to "live."
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Test whether the `cfo` specialist earns its keep before *operating* more specialists; mark the full roster live in the capability matrix.
+- Feature: ADR-0046 Specialist Review Agents rollout, Phase 1 calibration.
+- ADRs: ADR-0046 (D10 primary), ADR-0040/0045 (calibration targets), ADR-0044 (calibration-PR context).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — `cfo.md` must exist (calibration target agent).
+- `packet:04`, `packet:05`, `packet:06`, `packet:07` — all five definition files must exist before the consolidated matrix flip.
+
+**Constraints:**
+- Step 0 is mandatory: verify PR #162's number/state via `gh pr view` before invoking `cfo`.
+- The go/no-go verdict is the human's to ratify.
+- A No-go pauses operational *use* of the other lenses; it does not un-author any file or undo the matrix flip.
+- Calibrate against as-revised material — the stringent-bar test is deliberate.
+
+**Key Files:**
+- `generated/post-merge-audits/cfo-phase-1-calibration.md` (or a calibration note in this initiative folder)
+- `.claude/agents/cfo.md` (the agent being calibrated)
+- `constitution/agent-capability-matrix.md` (the consolidated five-row flip)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0046-specialist-review-agents/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0046-specialist-review-agents/dispatch-plan.md
@@ -1,0 +1,111 @@
+# Dispatch Plan: Specialist Review Agents (ADR-0046)
+
+**Date:** 2026-05-22 (initial scope).
+**Trigger:** ADR-0046 (Specialist Review Agents) — Proposed 2026-05-21; scoped 2026-05-22.
+**Type:** Single-repo. Every packet targets `HoneyDrunk.Architecture`. ADR-0046's Consequences are explicit: "No code-Node changes. This is entirely a Meta-sector decision about the agent surface." The five specialist agents review code across every Node, but the *agent definitions themselves* — and the pattern doc, the capability-matrix rows, the governance flip — live entirely in the Architecture repo.
+**Sector:** Meta (ADR governance + agent definitions + reference docs + capability matrix).
+**Status:** Draft — pending ADR-0046 acceptance. Packet 01 is the mechanically-coupled acceptance flip. Filing is automated on push to `main` via `file-packets.yml`.
+**Site sync required:** No. ADR-0046 produces governance docs and agent definitions; nothing public-facing on the Studios site.
+**Rollback plan:** Every packet is Markdown — the ADR flip, one new invariant, a `copilot/` reference doc, five `.claude/agents/{name}.md` files, capability-matrix rows, a calibration note. All revert cleanly via `git revert`. The five agent files revert by deletion (each is a self-contained definition with no consumer that breaks on its absence — specialists are manually invoked, never imported). The phased D10 rollout is itself the blast-radius control: each phase is a discrete go/no-go, and packet 08's calibration gate stops the roster expanding if `cfo` underperforms.
+
+## Summary
+
+ADR-0046 codifies the **pattern** of specialist review agents — narrow-lens, deeper-rigor reviewers that complement the generalist `review` agent's twenty-category rubric from ADR-0044. It names a roster of five (`cfo`, `security`, `performance`, `ai-safety`, `a11y`), commits to manual invocation at v1, and stages the per-agent definition files as follow-up packets in D8 priority order. This initiative ships **eight packets across three waves**: the governance flip + pattern doc (Wave 1), the four near-term agent files plus the calibration gate (Wave 2 / 3), and the dormant `a11y` agent (Wave 3).
+
+The relationship to ADR-0044 is **layering, not amendment** (ADR-0046 D7): ADR-0044's twenty-category rubric and the generalist `review` agent are untouched; specialists deepen five of the twenty categories on demand. This initiative does not modify `.claude/agents/review.md` or any existing agent — it only *adds* the five new specialist files plus the shared pattern doc.
+
+## Relationship to ADR-0044
+
+ADR-0046 is a **strict superset-by-addition** on top of the already-scoped ADR-0044 initiative (`active/adr-0044-cloud-code-review/`). The dependency is conceptual, not packet-level:
+
+- **No `dependencies:` edge to ADR-0044 packets.** ADR-0046's packets do not block on ADR-0044's packets in the filing pipeline. ADR-0046 references ADR-0044's *decisions* (the twenty-category rubric, the upstream-awareness clause, the cloud review runner) as context, but the specialist agent files can be authored whether or not ADR-0044's rollout is complete — specialists are manually invoked and do not require the cloud-wired `job-review-agent.yml`.
+- **The generalist `review` agent (ADR-0044) is the baseline; specialists layer above it.** ADR-0046 D1/D7 are explicit that specialists complement and do not replace `review`. The twenty-category rubric stays the shared standard; `cfo` deepens categories 6/17/18, `security` deepens 9, `performance` deepens 6 (runtime side), `ai-safety` deepens 18 (minus token/cost), `a11y` deepens 16.
+- **Practical sequencing recommendation.** Although there is no hard blocking edge, it is cleaner to land ADR-0046's Wave 1 *after* ADR-0044 is Accepted, so the new ADR-0046 invariant (specialists are advisory) sits in `constitution/invariants.md` in the Code Review Invariants group cleanly. Packet 01 assigns the **reserved invariant number 81** — pre-allocated as part of a 12-ADR batch. The true current maximum invariant number in `constitution/invariants.md` is 51 (verified 2026-05-22); the 51→81 gap is intentional batch-reservation headroom. **If any invariant above 51 lands from outside this 12-ADR batch before merge, shift upward, never reuse a number** — packet 01's Human Prerequisite carries this rule.
+- **OpenClaw runner (ADR-0024 / ADR-0044 packet 02b).** ADR-0046 D3 mentions specialists may be invoked "via Claude Code or the cloud-wired `job-review-agent.yml` (per ADR-0044) with the specialist agent named explicitly." At v1 this is **manual invocation only** — no CI trigger, no automatic OpenClaw firing. So ADR-0046 does *not* add work to the OpenClaw Grid Review Runner: the runner runs `review.md` (the generalist); specialists are a human-invoked path on top. If ADR-0046 D9's deferred CI-triggered invocation ever lands, *that* follow-up ADR would wire specialists into the runner — out of scope here.
+
+**No overlap, no duplication.** ADR-0044 builds the review *machinery* (runner, workflow, twenty-category rubric, risk-class catalog, post-merge audits). ADR-0046 adds *more reviewer minds* on top of that machinery. The two initiatives touch the same conceptual surface (`.claude/agents/`, `copilot/`, `constitution/invariants.md`) but distinct files — ADR-0046 creates new files and adds rows; it edits nothing ADR-0044 created.
+
+## Phase ↔ Wave mapping
+
+ADR-0046 D10 stages a five-phase rollout. This initiative's three waves map to the phases as follows — the waves build the *artifacts*; the ADR's phases are the *operational milestones* layered on top.
+
+- **Wave 1** = ADR-0046 D10 pre-Phase-1 foundation: the governance flip (packet 01) and the pattern doc + roster registration (packet 02).
+- **Wave 2** = the four near-term agent files. Packet 03 (`cfo`) is D10 Phase 1; packets 04/05/06 (`security`/`performance`/`ai-safety`) are D10 Phases 2/3/4. All four are authored as Wave 2 because authoring is delegable work with no inter-agent dependency — but their *operational* phases (when each lens is first used in anger) remain staggered per D10. The five specialist agent **files** are all authored by the end of Wave 2/3 regardless of the calibration outcome; packet 08's go/no-go gate governs operational *use* of the non-`cfo` lenses, not whether the roster is built.
+- **Wave 3** = packet 07 (`a11y`, D10 Phase 5 — zero near-term need, file authored ready) and packet 08 (the D10 Phase-1 calibration gate plus the consolidated capability-matrix flip). Packets 03–07 deliberately do **not** edit `constitution/agent-capability-matrix.md` — the five "planned → live" row-flips are consolidated into packet 08 so they do not collide as concurrent edits to the same table region.
+
+**Authoring order vs operational order.** ADR-0046 D8 gives a *priority* order for authoring (`cfo` → `security` → `performance` → `ai-safety` → `a11y`); the packet ordinals 03–07 follow it exactly. The packets carry the right `dependencies:` so the filing pipeline wires the graph; the *operational* go-live of each lens still follows D10's phased cadence, which is a human-cadence matter, not a packet dependency.
+
+## Wave Diagram
+
+### Wave 1 — Foundation
+
+Packet 01 first (the acceptance flip). Then packet 02 — depends only on 01.
+
+- [ ] `HoneyDrunk.Architecture`: **Accept ADR-0046** — flip status, finalize the one new invariant, register the initiative — [`01-architecture-adr-0046-acceptance.md`](01-architecture-adr-0046-acceptance.md)
+- [ ] `HoneyDrunk.Architecture`: Codify the specialist-agent pattern (`copilot/specialist-review-rules.md`) and register the five-agent roster in the capability matrix — [`02-architecture-specialist-agent-pattern-and-roster-doc.md`](02-architecture-specialist-agent-pattern-and-roster-doc.md)
+  - Blocked by: `packet:01`.
+
+### Wave 2 — Near-term specialist agents
+
+Runs after Wave 1. Packets 03, 04, 05, 06 — each depends on the acceptance flip (01) and the pattern doc / template (02). They can run in parallel.
+
+- [ ] `HoneyDrunk.Architecture`: Author the `cfo` specialist agent (cost + AI-cost) — [`03-architecture-author-cfo-agent.md`](03-architecture-author-cfo-agent.md)
+  - Blocked by: `packet:01`, `packet:02`.
+- [ ] `HoneyDrunk.Architecture`: Author the `security` specialist agent — [`04-architecture-author-security-agent.md`](04-architecture-author-security-agent.md)
+  - Blocked by: `packet:01`, `packet:02`.
+- [ ] `HoneyDrunk.Architecture`: Author the `performance` specialist agent — [`05-architecture-author-performance-agent.md`](05-architecture-author-performance-agent.md)
+  - Blocked by: `packet:01`, `packet:02`.
+- [ ] `HoneyDrunk.Architecture`: Author the `ai-safety` specialist agent — [`06-architecture-author-ai-safety-agent.md`](06-architecture-author-ai-safety-agent.md)
+  - Blocked by: `packet:01`, `packet:02`.
+
+### Wave 3 — Dormant agent and the calibration gate
+
+Runs after Wave 2. Packet 07 has zero near-term invocation surface (D10 Phase 5); packet 08 is the D10 Phase-1 calibration gate plus the consolidated capability-matrix flip — it depends on `cfo` (packet 03) for the calibration and on all five definition files (packets 03–07) for the matrix row-flip.
+
+- [ ] `HoneyDrunk.Architecture`: Author the `a11y` specialist agent (file authored ready; lens dormant until UI work starts) — [`07-architecture-author-a11y-agent.md`](07-architecture-author-a11y-agent.md)
+  - Blocked by: `packet:01`, `packet:02`.
+- [ ] `HoneyDrunk.Architecture`: Phase-1 calibration — invoke `cfo`, record the go/no-go finding, flip the five-agent roster live in the capability matrix — [`08-architecture-cfo-phase-1-calibration-run.md`](08-architecture-cfo-phase-1-calibration-run.md)
+  - Blocked by: `packet:03`, `packet:04`, `packet:05`, `packet:06`, `packet:07`.
+
+## Blocking relationships
+
+The filing pipeline wires `addBlockedBy` from each packet's `dependencies:` frontmatter. For reference:
+
+- `02` ← `01`
+- `03` ← `01`, `02`
+- `04` ← `01`, `02`
+- `05` ← `01`, `02`
+- `06` ← `01`, `02`
+- `07` ← `01`, `02`
+- `08` ← `03`, `04`, `05`, `06`, `07`
+
+Note: packet 08 depends on `03` (`cfo`) because the calibration invokes `cfo`, and on `04`–`07` because its consolidated capability-matrix row-flip marks all five specialist rows "live" and therefore needs all five definition files to exist first. The calibration verdict itself only concerns `cfo`; it *gates* the operational *use* of the other four lenses by D10's go/no-go discipline, but that operational pause is a human-cadence matter (see "Actor classification"), not a filing-pipeline dependency. The five agent files are all authored regardless of the verdict.
+
+## Actor classification
+
+Every packet is **`Actor=Agent`** — all eight are Markdown governance / agent-definition / reference-doc edits within delegable reach. No packet carries the `human-only` label. Several packets carry Human Prerequisites that are not blockers on the agent's critical path:
+
+- **Packet 01** — the human confirms the assigned invariant number before merge. The reserved number is **81**, pre-allocated as part of a 12-ADR batch (true current max in `constitution/invariants.md` is 51, verified 2026-05-22; the gap is intentional reservation headroom). If an invariant above 51 lands from outside the batch before merge, shift upward — never reuse a number.
+- **Packets 03, 04, 05, 06, 07** — after each PR merges, the human must **re-sync the global agent hardlinks** so the new specialist registers in `~/.claude/agents/`, then restart Claude Code. The Architecture agents are hardlinked globally; a newly added file is not picked up until the re-sync. This is a post-PR manual action, not in the agent's critical path. If packets 03–06 land in close succession, one re-sync after the batch covers them all; packet 07 (`a11y`) may merge later and warrant its own re-sync.
+- **Packet 08** — the human makes the Phase-1 go/no-go call on the `cfo` calibration. ADR-0046 D10 makes this an explicit human judgment: did `cfo` produce findings worth acting on? A No-go pauses the *operational use* of the `security`/`performance`/`ai-safety`/`a11y` lenses pending a roster-reconsideration decision; it does not un-author any specialist file (all five are authored by Wave 2/3 regardless) and does not undo packet 08's consolidated capability-matrix flip. Packet 08 also requires a `gh pr view` verification of the calibration PR (#162) before invoking `cfo`.
+
+## Out-of-scope items from ADR-0046
+
+- **CI-triggered invocation (D9).** ADR-0046 D3 commits to manual invocation only at v1. If the manual cadence proves insufficient, a follow-up ADR amends D3 to add trigger-based automatic invocation — and *that* ADR would wire specialists into the OpenClaw Grid Review Runner / `job-review-agent.yml`. ADR-0046 D9 says to consider it only after Phase 1's manual cadence is observed for ≥30 days. **Not a packet here.**
+- **Output-format standardization (D9).** Moot under manual invocation; becomes load-bearing only if D9's automatic invocation lands. **Not a packet here.**
+- **Failure-mode discipline (D9).** "What stops `cfo` from blocking every PR?" is moot under manual invocation. **Not a packet here.**
+- **Roster expansion (D9).** Privacy/GDPR, SRE, migration safety, anti-entropy, DX are named follow-up candidates. Each lands as a future ADR amendment with the same D2-shaped justification. **Not a packet here.**
+- **Specialist-of-specialists meta-agent (D9).** Speculative; only relevant if D9's automation lands. **Not a packet here.**
+- **The operational go-live of each lens.** Packets 03–07 *author* the agent files and packet 08 marks the roster "live" in the capability matrix; D10's phased cadence governs *when each lens is first used in anger*. The first-use milestones are operational matters the human runs on the cadence, not packets. Packet 08's go/no-go verdict gates *operational use* of the non-`cfo` lenses from Phase 2 onward — it does not gate whether the agent files are built (they all are, by Wave 2/3).
+
+## Notes
+
+- **Acceptance precedes flip.** ADR-0046 stays Proposed until packet 01's PR merges. Packet 01 is the mechanically-coupled acceptance flip.
+- **Single-repo initiative.** Every packet targets `HoneyDrunk.Architecture`. The dispatch plan exists because the eight packets have a real three-wave dependency chain and a conceptual relationship to ADR-0044 worth documenting — not because the work spans repos.
+- **Global hardlink re-sync.** Each new agent file (packets 03–07) needs the `~/.claude/agents/` hardlink re-sync and a Claude Code restart before the agent is invocable. This is called out as a Human Prerequisite in every agent-authoring packet and is the single recurring manual action in this initiative.
+- **`review.md` is not touched.** ADR-0046 Consequences: "Existing agents are not modified." This initiative only *adds* files and rows. Invariant 33 (review/scope context-loading coupling) is not engaged — no existing agent's context-loading section changes.
+- **The dispatch plan is the one exception to packet immutability** (ADR-0008 D7). It is updated at wave boundaries as the historical record.
+
+## Archival
+
+Per ADR-0008 D10, when every packet reaches `Done` on The Hive and ADR-0046's Phase-1 go decision is recorded (packet 08), the `active/adr-0046-specialist-review-agents/` folder moves to `completed/` in a single commit. The D10 Phase 2–5 operational go-lives and any D9 follow-up ADR are tracked separately — they are not appended to this initiative folder.


### PR DESCRIPTION
## Summary
Adds the issue packets for **ADR-0046 — Specialist review agents** under `generated/issue-packets/active/adr-0046-specialist-review-agents/`.

One of 12 per-ADR PRs from the 2026-05-21 ADR batch — split per ADR so `file-packets.yml` files incrementally per merge rather than firing all 92 packets at once (GraphQL rate limits).

## Test plan
- [ ] `file-packets.yml` files this ADR's packets on merge and adds them to The Hive
- [ ] No GraphQL rate-limit errors in the filing run

🤖 Generated with [Claude Code](https://claude.com/claude-code)