### PR TITLE
Define ADR-0044 webhook-first review runner

### DIFF
--- a/adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md
+++ b/adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md
@@ -19,7 +19,7 @@ The conclusion: **the slot that needs filling is not "automatic LLM reviewer" ge
 
 The build is small, but the runtime placement matters. The prompt logic exists in `.claude/agents/review.md`. The context-loading contract is defined in ADR-0011 D4. The workflow host exists in HoneyDrunk.Actions, but GitHub Actions should be the cheap trigger/visibility rail, not the reasoning brain. The default v1 runtime is an OpenClaw-hosted Grid Review Runner using Codex through the Studio's existing subscription/session. GitHub Actions emits/validates review requests and exposes advisory status; OpenClaw performs the Grid-aware review and posts the verdict back to the PR.
 
-The cost calculus has also shifted. The April 2026 ADR-0011 D10 rejection was per-PR cloud LLM cost against a low PR volume; at today's volume (~20-50 agent PRs/month), an Anthropic/API-backed GitHub Action makes AI review a recurring variable bill and sends private repo diffs to an external model API by default. The Studio already runs OpenClaw/Codex locally. The cheapest and most controllable v1 is therefore: use GitHub/webhooks/cron to request reviews automatically, run the review in OpenClaw/Codex, track the reviewed head SHA, and comment back only when the PR changed.
+The cost calculus has also shifted. The April 2026 ADR-0011 D10 rejection was per-PR cloud LLM cost against a low PR volume; at today's volume (~20-50 agent PRs/month), an Anthropic/API-backed GitHub Action makes AI review a recurring variable bill and sends private repo diffs to an external model API by default. The Studio already runs OpenClaw/Codex locally. The cheapest and most controllable v1 is therefore: use a signed GitHub-to-OpenClaw webhook as the primary request path, keep a poll/replay fallback for outages, run the review in OpenClaw/Codex, track the reviewed head SHA, and comment back only when the PR changed.
 
 This ADR amends ADR-0011 to **reverse the human-invoked-only stance**, **reverse the CodeRabbit rejection as moot** (we're not adopting an alternative), and add **AI-authored PR discipline** that the automatic Grid Review Runner makes practical to enforce.
 
@@ -34,9 +34,10 @@ The Grid builds, owns, and operates its own automatic Grid-aware code reviewer. 
 - A new reusable workflow, `HoneyDrunk.Actions/.github/workflows/job-review-request.yml`, follows the existing `pr-core.yml` factoring (per ADR-0012) and validates whether a PR should request review.
 - Triggered on `pull_request` events: `opened`, `synchronize`, `ready_for_review`. Not on `draft` PRs (cost discipline; draft is by definition WIP).
 - Emits a review request payload containing the repo, PR number, head SHA, author class, changed-file summary, packet link, and `.honeydrunk-review.yaml` settings.
-- Delivers the request to OpenClaw through the configured webhook path, or leaves a machine-readable artifact/comment for an OpenClaw cron job to pick up when webhooks are unavailable.
+- Delivers the request to OpenClaw through a signed webhook path as the Phase-1 primary transport. The webhook receiver verifies HMAC signature, timestamp/replay window, request size, and idempotency before enqueueing work.
+- Uses a durable poll/replay fallback when webhook delivery is unavailable: the workflow leaves a machine-readable artifact/comment that OpenClaw can discover later, using the same request payload and idempotency key. The fallback is not a second review path; it is the backup transport for the same runner contract.
 - OpenClaw runs the Grid Review Runner using Codex and `.claude/agents/review.md` as the canonical prompt source (per ADR-0007's source-of-truth rule).
-- The runner posts the verdict as a PR comment using the format already defined in `.claude/agents/review.md` and records the reviewed head SHA to avoid re-reviewing unchanged diffs.
+- The runner posts the verdict as a PR comment using the format already defined in `.claude/agents/review.md` and records the reviewed head SHA to avoid re-reviewing unchanged diffs. The idempotency key is `owner/repo#pr@headSha`; webhook retries, duplicate GitHub events, and manual replays must converge on the same queued/reviewed request instead of producing duplicate comments.
 - The workflow/check surface remains **non-required** and advisory, per ADR-0011 D5's posture - preserved by this ADR.
 
 The agent definition itself does not change. The same prompt that runs locally runs through the automatic runner. Drift between execution surfaces is forbidden - all surfaces consume `.claude/agents/review.md` directly.
@@ -366,7 +367,7 @@ ADR-0011's invariants 31-33 are preserved. Final invariant numbers for the two n
 
 - **Per-PR cloud LLM API cost is avoided in v1 by design.** The default runner uses the existing OpenClaw/Codex subscription/session. API-backed execution remains a future fallback only, with explicit caps and provider choice.
 - **OpenClaw availability becomes part of the advisory review surface.** If the local runner is offline, the workflow/request path marks the review pending or unavailable and posts/records that state; PRs remain mergeable because the reviewer is advisory.
-- **GitHub App/webhook credentials are optional v1 infrastructure.** The webhook path may use a narrowly scoped GitHub App or secret; the cron/artifact path can rely on local `gh` authentication. Do not provision Anthropic API credentials for v1.
+- **Webhook credentials are required v1 infrastructure for the primary path.** Phase 1 uses a signed GitHub-to-OpenClaw webhook with a shared secret or narrowly scoped GitHub App/webhook credential. The poll/artifact path remains as a fallback and manual replay surface, not the default. Do not provision Anthropic API credentials for v1.
 - **PR diffs stay in the local OpenClaw/Codex path by default.** They are not sent to Anthropic API as part of v1. Any future external API fallback must be documented and explicitly enabled. Private revenue Nodes (per ADR-0027 D2) are explicitly **excluded from the default v1 rollout** and require an explicit opt-in via `.honeydrunk-review.yaml`.
 - **The manual review invocation remains available** and is the right tool for offline review or pre-PR feedback. The automatic runner does not replace it; it makes the routine case automatic.
 - **Copilot's role diminishes.** It remains enabled (zero marginal cost from the existing subscription) but no longer carries a specific responsibility in the pipeline.
@@ -379,7 +380,7 @@ ADR-0011's invariants 31-33 are preserved. Final invariant numbers for the two n
 - Author the OpenClaw/Codex Grid Review Runner runbook/config in Architecture.
 - Author `authorship-check` and `pr-size-check` jobs in `pr-core.yml`.
 - Author the `audit-sample` post-merge labeling job.
-- If using webhook delivery, create the narrowly scoped GitHub App/webhook credential and store it per ADR-0005/0006. Do not provision an Anthropic API key for v1.
+- Create the narrowly scoped GitHub-to-OpenClaw webhook credential and store it per ADR-0005/0006. Do not provision an Anthropic API key for v1.
 - Author `.honeydrunk-review.yaml` v1 schema doc in this repo (`copilot/review-config-schema.md` or similar).
 - Enable on the Architecture repo (Phase 1).
 - Add `review_risk_class` field to `catalogs/grid-health.json` schema; populate for current Nodes (deferred until Phase 3 activates).

--- a/generated/issue-packets/active/adr-0044-cloud-code-review/02b-architecture-openclaw-grid-review-runner.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/02b-architecture-openclaw-grid-review-runner.md
@@ -23,12 +23,13 @@ ADR-0044 now chooses a subscription-backed OpenClaw/Codex runtime for v1 instead
 
 ## Scope
 - Add Architecture documentation/config for the Grid Review Runner, e.g. `infrastructure/openclaw/grid-review-runner.md`.
-- Define the review request payload consumed by the runner: repo, PR number, head SHA, authorship class, changed-file summary, packet link, and `.honeydrunk-review.yaml` settings.
-- Define reviewed-head-SHA state storage under the OpenClaw workspace or Architecture-managed state file.
+- Define the signed webhook receiver contract consumed by the runner: endpoint path, HMAC/timestamp headers, replay window, request size cap, response codes, and advisory failure behavior.
+- Define the review request payload consumed by the runner: repo, PR number, head SHA, authorship class, changed-file summary, packet link, `.honeydrunk-review.yaml` settings, callback target, and idempotency key.
+- Define durable request/review state storage under the OpenClaw workspace or Architecture-managed state file. The idempotency key is `owner/repo#pr@headSha`; reviewed-head-SHA state prevents unchanged PRs from being reviewed repeatedly.
 - Document both trigger modes:
-  - webhook/request delivery from `job-review-request.yml`;
-  - cron/poll fallback for open PRs when webhook delivery is unavailable.
-- Document local auth expectations: `gh` auth is acceptable for v1; a narrowly scoped GitHub App/webhook credential is optional.
+  - webhook/request delivery from `job-review-request.yml` as the Phase-1 primary path;
+  - cron/poll replay fallback for open PRs when webhook delivery is unavailable, using the same payload and idempotency key.
+- Document local auth expectations: `gh` auth is acceptable for PR checkout/comment writeback in v1; a narrowly scoped webhook signing secret or GitHub App credential is required for the inbound request path.
 
 ## NuGet Dependencies
 None. Markdown/config only.
@@ -36,14 +37,16 @@ None. Markdown/config only.
 ## Acceptance Criteria
 - [ ] OpenClaw/Codex runner runtime is documented/configured in Architecture
 - [ ] The runner consumes `.claude/agents/review.md` as the canonical prompt source
+- [ ] The signed webhook receiver contract is documented, including HMAC/timestamp verification, replay window, request size cap, response codes, and secret storage
 - [ ] The review request payload schema is documented
-- [ ] Reviewed head SHA tracking is specified so unchanged PRs are not re-reviewed
-- [ ] Webhook and cron/poll trigger modes are both documented
+- [ ] Durable request state, idempotency, and reviewed-head-SHA tracking are specified so webhook retries and unchanged PRs do not produce duplicate reviews
+- [ ] Webhook primary delivery and cron/poll replay fallback are both documented
 - [ ] The doc explicitly says no Anthropic API key is required for v1
 - [ ] The doc names the advisory failure behavior when OpenClaw is offline
 
 ## Human Prerequisites
-- [ ] Confirm whether Phase 1 uses webhook delivery first or cron/poll fallback first.
+- [x] Phase 1 uses webhook-first delivery. Cron/poll remains the replay/fallback path.
+- [ ] Provide the OpenClaw webhook URL and signing secret storage location before wiring the Actions workflow.
 
 ## Dependencies
 - `packet:01` — ADR-0044 acceptance/amendment (soft).
@@ -56,6 +59,7 @@ None. Markdown/config only.
 ## Constraints
 - Do not provision or require an Anthropic API key for v1.
 - Do not make review a required blocking check.
+- Do not expose an unsigned or unauthenticated local endpoint. The webhook receiver must verify HMAC/timestamp, enforce replay protection, and persist the request before runner execution.
 - Keep runtime behavior provider-neutral enough that a future API-backed fallback can be added deliberately.
 
 ## Agent Handoff

--- a/generated/issue-packets/active/adr-0044-cloud-code-review/03b-actions-job-review-request-workflow.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/03b-actions-job-review-request-workflow.md
@@ -23,7 +23,7 @@ Replace the originally scoped `job-review-agent.yml` Anthropic/Claude runtime wi
 **Family:** pr-core / advisory review trigger
 
 ## Motivation
-ADR-0044 now keeps reasoning-heavy review in OpenClaw/Codex and uses GitHub Actions as the cheap rail. The workflow should not invoke Anthropic, Claude Agent SDK, or any model API directly. It should collect PR metadata, apply skip/enable rules, and deliver a request to OpenClaw or leave a durable artifact for OpenClaw cron/poll pickup.
+ADR-0044 now keeps reasoning-heavy review in OpenClaw/Codex and uses GitHub Actions as the cheap rail. The workflow should not invoke Anthropic, Claude Agent SDK, or any model API directly. It should collect PR metadata, apply skip/enable rules, sign the request, and deliver it to OpenClaw by webhook. Durable artifact/comment output remains as the replay fallback when the webhook is unavailable.
 
 ## Proposed Change
 1. Add reusable workflow `job-review-request.yml`.
@@ -33,11 +33,11 @@ ADR-0044 now keeps reasoning-heavy review in OpenClaw/Codex and uses GitHub Acti
    - PR has `skip-review`;
    - `.honeydrunk-review.yaml` is absent or `enabled: false`;
    - current head SHA was already marked reviewed if that state is available to the workflow.
-4. Produce a request payload with repo, PR number, head SHA, author class, changed-file summary, packet link, config, and callback/comment target.
-5. Delivery:
-   - preferred: POST to an OpenClaw webhook URL if configured;
-   - fallback: upload artifact and/or post a machine-readable advisory comment that OpenClaw cron can discover.
-6. Set/report advisory status only. Do not fail branch protection if OpenClaw is offline.
+4. Produce a request payload with repo, PR number, head SHA, author class, changed-file summary, packet link, config, callback/comment target, and idempotency key (`owner/repo#pr@headSha`).
+5. Sign the payload with the configured webhook secret and timestamp header.
+6. POST the signed payload to the configured OpenClaw webhook URL.
+7. Fallback: upload the exact same payload as a durable artifact and/or post a machine-readable advisory comment that OpenClaw cron can discover and replay.
+8. Set/report advisory status only. Do not fail branch protection if OpenClaw is offline.
 
 ## NuGet Dependencies
 None. GitHub Actions workflow only.
@@ -46,15 +46,16 @@ None. GitHub Actions workflow only.
 - [ ] `job-review-request.yml` exists in HoneyDrunk.Actions
 - [ ] It contains no Anthropic, Claude Agent SDK, or model API invocation
 - [ ] It applies draft, `skip-review`, and `.honeydrunk-review.yaml enabled` skip rules
-- [ ] It emits the documented review request payload
-- [ ] It supports webhook delivery and durable fallback artifact/comment delivery
+- [ ] It emits the documented review request payload, including `owner/repo#pr@headSha` idempotency key
+- [ ] It signs webhook payloads with timestamped HMAC using the configured secret
+- [ ] It supports webhook-first delivery and durable fallback artifact/comment delivery using the same payload
 - [ ] It reports advisory pending/unavailable state when OpenClaw is offline
 - [ ] `docs/consumer-usage.md` documents how repos call the workflow
 - [ ] `docs/CHANGELOG.md` records the new workflow
 
 ## Human Prerequisites
-- [ ] Choose webhook-first vs artifact/comment-first delivery for Phase 1.
-- [ ] If webhook-first, provide the OpenClaw webhook URL/secret through GitHub Actions secrets.
+- [x] Phase 1 uses webhook-first delivery.
+- [ ] Provide the OpenClaw webhook URL/secret through GitHub Actions secrets or environment-level secrets before enabling the caller workflow.
 
 ## Dependencies
 - `packet:02b` — runner payload/schema and runtime behavior (hard).
@@ -66,6 +67,7 @@ None. GitHub Actions workflow only.
 ## Constraints
 - Do not call Anthropic/OpenAI APIs from GitHub Actions in v1.
 - Do not make review a required blocking check.
+- Do not send unsigned review requests; webhook payloads must be signed and replay-safe.
 - Preserve reusable-workflow factoring per ADR-0012.
 
 ## Agent Handoff

--- a/infrastructure/openclaw/grid-review-runner.md
+++ b/infrastructure/openclaw/grid-review-runner.md
@@ -1,0 +1,196 @@
+# OpenClaw Grid Review Runner
+
+**Status:** Draft / ADR-0044 Phase 1
+**Owner:** HoneyDrunk.Architecture
+**Related:** ADR-0044, ADR-0011, ADR-0012, ADR-0005, ADR-0006
+
+## Goal
+
+The Grid Review Runner is the OpenClaw-hosted execution surface for automatic Grid-aware PR review.
+
+GitHub Actions is the trigger rail. OpenClaw/Codex is the reasoning runtime. The runner consumes the same `.claude/agents/review.md` prompt source used by local/manual review, loads the same Architecture context, comments back on the PR, and records the reviewed head SHA so unchanged diffs are not reviewed repeatedly.
+
+## Phase-1 transport
+
+Phase 1 is **webhook-first**.
+
+1. A caller repo invokes `HoneyDrunk.Actions/.github/workflows/job-review-request.yml` on PR `opened`, `synchronize`, and `ready_for_review` events.
+2. The workflow applies skip rules: draft PR, `skip-review` label, `.honeydrunk-review.yaml` missing or `enabled: false`, or already-reviewed head SHA if state is visible.
+3. The workflow emits one review-request JSON payload.
+4. The workflow signs the payload and posts it to the OpenClaw webhook endpoint.
+5. The OpenClaw receiver verifies the request, persists it durably, and queues the runner.
+6. The runner checks out/updates the target repo and `HoneyDrunk.Architecture`, invokes Codex with `.claude/agents/review.md`, and posts the advisory verdict back to the PR.
+
+Cron/poll is retained as a replay/fallback path only. It discovers the same payload from an artifact or machine-readable PR comment and submits it through the same idempotency/state path.
+
+## Endpoint contract
+
+Recommended endpoint path:
+
+```text
+POST /github/grid-review-request
+```
+
+The concrete host URL is deployment-specific and must not be committed to the repo. For Phase 1 it may be exposed through a tunnel or relay, but the endpoint must never be public without signature verification.
+
+Required request headers:
+
+```text
+Content-Type: application/json
+X-HoneyDrunk-Event: grid-review-request
+X-HoneyDrunk-Delivery: <unique delivery id / GitHub run id>
+X-HoneyDrunk-Timestamp: <unix epoch seconds>
+X-HoneyDrunk-Signature-256: sha256=<hex hmac>
+```
+
+Signature input:
+
+```text
+<timestamp>.<raw request body bytes>
+```
+
+Signature algorithm: HMAC-SHA256 using the configured webhook signing secret.
+
+Replay window: 5 minutes from `X-HoneyDrunk-Timestamp`.
+
+Default body size cap: 256 KiB. The workflow payload is metadata only; PR diffs are loaded by the runner from GitHub, not embedded in the webhook.
+
+## Secret storage
+
+The webhook signing secret follows ADR-0005/ADR-0006 secret discipline. Recommended secret name:
+
+```text
+webhook-github-grid-review-signing-secret
+```
+
+For Phase 1, the same secret value is configured in:
+
+- the caller workflow environment/repo secret used by `job-review-request.yml`; and
+- the OpenClaw receiver secret store.
+
+Do not log the secret or full webhook body. Logs may include delivery id, repo, PR number, head SHA, payload byte count, and a SHA-256 hash prefix of the body.
+
+## Request payload
+
+The payload shape is versioned. Add fields compatibly; breaking changes require a new `schemaVersion`.
+
+```json
+{
+  "schemaVersion": 1,
+  "event": "grid-review-request",
+  "idempotencyKey": "HoneyDrunkStudios/HoneyDrunk.Architecture#123@abcdef123456",
+  "repo": {
+    "owner": "HoneyDrunkStudios",
+    "name": "HoneyDrunk.Architecture",
+    "fullName": "HoneyDrunkStudios/HoneyDrunk.Architecture",
+    "cloneUrl": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture.git"
+  },
+  "pullRequest": {
+    "number": 123,
+    "headSha": "abcdef123456",
+    "baseRef": "main",
+    "headRef": "feature/example",
+    "isDraft": false,
+    "author": "octocat",
+    "url": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/pull/123"
+  },
+  "authorship": {
+    "class": "agent-codex",
+    "source": "pr-body"
+  },
+  "changeSummary": {
+    "changedFiles": 6,
+    "additions": 120,
+    "deletions": 30,
+    "files": ["adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md"]
+  },
+  "context": {
+    "packetUrl": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/170",
+    "packetPath": "generated/issue-packets/active/adr-0044-cloud-code-review/01-architecture-adr-0044-acceptance.md",
+    "adrs": ["ADR-0044"],
+    "node": "honeydrunk-architecture"
+  },
+  "config": {
+    "enabled": true,
+    "runner": "openclaw-codex",
+    "riskClass": "normal"
+  },
+  "callback": {
+    "mode": "github-pr-comment",
+    "prCommentsUrl": "https://api.github.com/repos/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/123/comments",
+    "checksUrl": "https://api.github.com/repos/HoneyDrunkStudios/HoneyDrunk.Architecture/check-runs"
+  }
+}
+```
+
+## Idempotency and state
+
+Idempotency key:
+
+```text
+owner/repo#pr@headSha
+```
+
+The receiver must persist the request before runner execution. A durable state record should track:
+
+- idempotency key;
+- delivery id;
+- repo / PR / head SHA;
+- received timestamp;
+- state: `received`, `queued`, `running`, `commented`, `failed`, `skipped`;
+- last error, if any;
+- PR comment id or URL, if posted.
+
+Duplicate deliveries for the same idempotency key must not create duplicate review comments. They may return success with the existing state or a conflict/in-flight response depending on the current state.
+
+Reviewed-head-SHA tracking is the runner's stop condition: if the same PR head SHA has already reached `commented` or an explicit `skipped` terminal state, the runner does not review again unless manually replayed with a force flag.
+
+## Response codes
+
+The webhook receiver uses a narrow response envelope:
+
+- `202 Accepted` — signature valid; request persisted and queued or already known.
+- `400 Bad Request` — malformed payload, missing required fields, timestamp outside replay window.
+- `401 Unauthorized` — missing or invalid signature.
+- `409 Conflict` — same idempotency key is currently running and cannot accept another concurrent execution.
+- `413 Payload Too Large` — body exceeds cap.
+- `5xx` — receiver/storage failure; GitHub Action may fall back to artifact/comment replay.
+
+The review remains advisory. A failed or unavailable receiver must not fail branch protection.
+
+## Runner context loading
+
+The runner mirrors ADR-0011 D4 and loads:
+
+1. `constitution/invariants.md`
+2. governing ADRs referenced in packet/frontmatter
+3. `catalogs/relationships.json`
+4. `catalogs/contracts.json`
+5. for each target repo: `repos/{node}/overview.md`, `boundaries.md`, `invariants.md`
+6. `copilot/pr-review-rules.md`
+7. the packet file or GitHub issue body linked from the PR
+8. the PR diff
+
+The canonical prompt remains `.claude/agents/review.md`. Do not fork the prompt into workflow YAML or a separate runner-only prompt.
+
+## GitHub auth
+
+For v1, local `gh` authentication is acceptable for:
+
+- checking out/updating target repos;
+- reading PR metadata and diffs;
+- posting advisory comments;
+- updating optional advisory check/status state.
+
+A narrowly scoped GitHub App can replace local `gh` auth later if operational pressure justifies it. No Anthropic/OpenAI model API key is required for v1.
+
+## Offline and fallback behavior
+
+If OpenClaw is offline or the webhook endpoint is unreachable, `job-review-request.yml` should:
+
+1. mark the review request as advisory pending/unavailable;
+2. upload the exact same payload as an artifact or post it in a machine-readable PR comment;
+3. avoid failing the PR check;
+4. allow OpenClaw cron/poll to discover and replay the request later.
+
+Manual replay submits the stored payload through the same idempotency path. Replay with the same idempotency key is safe; forced re-review requires an explicit operator action and should update the existing comment rather than spamming a new one when possible.


### PR DESCRIPTION
## Summary

- updates ADR-0044 to make signed GitHub-to-OpenClaw webhook delivery the Phase 1 primary path
- keeps cron/poll as replay/fallback using the same payload and idempotency key
- updates packets 02b/03b so the runner and Actions trigger rail require signed, replay-safe delivery
- adds `infrastructure/openclaw/grid-review-runner.md` with the endpoint, HMAC headers, payload schema, idempotency/state, response codes, fallback, and auth expectations

## Notes

This does not flip ADR-0044 to Accepted yet; it locks the webhook-first contract so #170/#179/#87 have a concrete target.

## Verification

- `git diff --check`