### PR TITLE
Close ADR-0044 runner runtime contract

### DIFF
--- a/generated/issue-packets/active/adr-0044-cloud-code-review/02b-architecture-openclaw-grid-review-runner.md
+++ b/generated/issue-packets/active/adr-0044-cloud-code-review/02b-architecture-openclaw-grid-review-runner.md
@@ -35,18 +35,18 @@ ADR-0044 now chooses a subscription-backed OpenClaw/Codex runtime for v1 instead
 None. Markdown/config only.
 
 ## Acceptance Criteria
-- [ ] OpenClaw/Codex runner runtime is documented/configured in Architecture
-- [ ] The runner consumes `.claude/agents/review.md` as the canonical prompt source
-- [ ] The signed webhook receiver contract is documented, including HMAC/timestamp verification, replay window, request size cap, response codes, and secret storage
-- [ ] The review request payload schema is documented
-- [ ] Durable request state, idempotency, and reviewed-head-SHA tracking are specified so webhook retries and unchanged PRs do not produce duplicate reviews
-- [ ] Webhook primary delivery and cron/poll replay fallback are both documented
-- [ ] The doc explicitly says no Anthropic API key is required for v1
-- [ ] The doc names the advisory failure behavior when OpenClaw is offline
+- [x] OpenClaw/Codex runner runtime is documented/configured in Architecture
+- [x] The runner consumes `.claude/agents/review.md` as the canonical prompt source
+- [x] The signed webhook receiver contract is documented, including HMAC/timestamp verification, replay window, request size cap, response codes, and secret storage
+- [x] The review request payload schema is documented
+- [x] Durable request state, idempotency, and reviewed-head-SHA tracking are specified so webhook retries and unchanged PRs do not produce duplicate reviews
+- [x] Webhook primary delivery and cron/poll replay fallback are both documented
+- [x] The doc explicitly says no Anthropic API key is required for v1
+- [x] The doc names the advisory failure behavior when OpenClaw is offline
 
 ## Human Prerequisites
 - [x] Phase 1 uses webhook-first delivery. Cron/poll remains the replay/fallback path.
-- [ ] Provide the OpenClaw webhook URL and signing secret storage location before wiring the Actions workflow.
+- [ ] Provide the OpenClaw webhook URL and signing secret storage location before wiring the Actions workflow. This remains an Actions#87 prerequisite, not a blocker for this Architecture runtime contract.
 
 ## Dependencies
 - `packet:01` — ADR-0044 acceptance/amendment (soft).

--- a/infrastructure/openclaw/grid-review-runner.md
+++ b/infrastructure/openclaw/grid-review-runner.md
@@ -1,8 +1,24 @@
 # OpenClaw Grid Review Runner
 
-**Status:** Draft / ADR-0044 Phase 1
+**Status:** ADR-0044 Phase 1 runtime contract
 **Owner:** HoneyDrunk.Architecture
 **Related:** ADR-0044, ADR-0011, ADR-0012, ADR-0005, ADR-0006
+**Tracking:** Architecture#179
+
+## Packet 02b acceptance mapping
+
+This document satisfies ADR-0044 packet 02b by defining:
+
+- the OpenClaw/Codex runner runtime contract;
+- `.claude/agents/review.md` as the canonical prompt source;
+- the signed webhook receiver contract, including HMAC/timestamp verification, replay window, size cap, response codes, and secret storage;
+- the review request payload schema;
+- durable request state, idempotency, and reviewed-head-SHA behavior;
+- webhook-primary delivery plus cron/poll replay fallback;
+- advisory failure behavior when OpenClaw is offline; and
+- the v1 rule that no Anthropic/OpenAI model API key is required.
+
+The concrete webhook URL and signing-secret value are intentionally not recorded here. They are deployment secrets required before wiring `job-review-request.yml` in HoneyDrunk.Actions.
 
 ## Goal
 


### PR DESCRIPTION
## Summary

- marks ADR-0044 packet 02b acceptance criteria complete
- promotes `infrastructure/openclaw/grid-review-runner.md` from draft to the Phase 1 runtime contract
- adds an explicit packet acceptance mapping for webhook contract, payload schema, idempotency/state, fallback, offline advisory behavior, and no model API key requirement
- keeps webhook URL/signing-secret provisioning as an Actions#87 prerequisite rather than an Architecture#179 blocker

Closes #179.

## Verification

- `git diff --check`