### PR TITLE
ci(adr-0044): enable Architecture review pilot

### DIFF
--- a/.github/workflows/grid-review-request.yml
+++ b/.github/workflows/grid-review-request.yml
@@ -1,0 +1,29 @@
+name: Grid Review Request
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+env:
+  # ADR-0044 Phase 1 pilot starts in fallback mode until the OpenClaw
+  # webhook receiver and signing secret are provisioned. This preserves
+  # review-request payloads as artifacts/comments without blocking PRs.
+  OPENCLAW_GRID_REVIEW_WEBHOOK_URL: ""
+
+jobs:
+  request-grid-review:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-review-request.yml@main
+    with:
+      openclaw-webhook-url: ${{ vars.OPENCLAW_GRID_REVIEW_WEBHOOK_URL || '' }}
+      review-config-path: .honeydrunk-review.yaml
+      upload-fallback-artifact: true
+      post-fallback-comment: true
+      artifact-name: grid-review-request
+    secrets:
+      openclaw-webhook-secret: ${{ secrets.OPENCLAW_GRID_REVIEW_WEBHOOK_SECRET }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/grid-review-request.yml
+++ b/.github/workflows/grid-review-request.yml
@@ -22,7 +22,10 @@ jobs:
       openclaw-webhook-url: ${{ vars.OPENCLAW_GRID_REVIEW_WEBHOOK_URL || '' }}
       review-config-path: .honeydrunk-review.yaml
       upload-fallback-artifact: true
-      post-fallback-comment: true
+      # Artifact-only fallback for the first Architecture pilot run.
+      # PR comment fallback needs token/permission hardening because GitHub
+      # rejected addComment from the reusable workflow token on PR #278.
+      post-fallback-comment: false
       artifact-name: grid-review-request
     secrets:
       openclaw-webhook-secret: ${{ secrets.OPENCLAW_GRID_REVIEW_WEBHOOK_SECRET }}

--- a/.honeydrunk-review.yaml
+++ b/.honeydrunk-review.yaml
@@ -1,0 +1,8 @@
+enabled: true
+runner: openclaw-codex
+severity_floor: Suggest
+skip_paths:
+  - "**/*.Designer.cs"
+  - "**/*.g.cs"
+  - "**/generated/**"
+cost_cap_per_pr_usd: 0.00

--- a/docs/adr-0044/phase-1-pilot-evidence.md
+++ b/docs/adr-0044/phase-1-pilot-evidence.md
@@ -22,7 +22,7 @@ Phase 1 starts with fallback transport only:
 
 - GitHub Actions emits the `grid-review-request` payload.
 - The OpenClaw webhook URL is intentionally empty until the receiver and signing secret are provisioned.
-- The workflow uploads `review-request.json` as an artifact and posts the machine-readable replay pointer comment.
+- The workflow uploads `review-request.json` as an artifact. Machine-readable replay pointer comments are disabled for the first Architecture pilot run until reusable-workflow token permissions are hardened.
 - OpenClaw cron/poll discovers pending Architecture review requests and runs the Grid Review Runner.
 
 ## OpenClaw Polling Window
@@ -60,5 +60,6 @@ Cron/poll is a temporary fallback transport, not the long-term primary path.
 - [ ] `skip-review` PRs do not request review.
 - [ ] A real/test Architecture PR receives a Grid Review Runner comment.
 - [ ] Re-running on the same head SHA does not duplicate review work.
-- [ ] OpenClaw-offline behavior is advisory/pending, not a hard failure.
+- [x] OpenClaw-offline behavior is advisory/pending, not a hard failure via artifact fallback.
+- [ ] PR comment fallback is re-enabled after token/permission hardening.
 - [ ] Phase 1 go/no-go result is recorded.

--- a/docs/adr-0044/phase-1-pilot-evidence.md
+++ b/docs/adr-0044/phase-1-pilot-evidence.md
@@ -1,0 +1,64 @@
+# ADR-0044 Phase 1 Pilot Evidence
+
+**Status:** Pending pilot PR merge and first live review request
+**Pilot repo:** `HoneyDrunk.Architecture`
+**Runner:** `openclaw-codex`
+**Transport:** cron/poll fallback first; webhook later
+
+## Pilot Wiring
+
+This repo opts into ADR-0044 Phase 1 with:
+
+- `.honeydrunk-review.yaml`
+- `.github/workflows/grid-review-request.yml`
+
+The workflow calls `HoneyDrunk.Actions/.github/workflows/job-review-request.yml@main` on pull request `opened`, `synchronize`, and `ready_for_review` events.
+
+The pilot is advisory only. It must not become a required branch-protection check during Phase 1.
+
+## Current Transport Choice
+
+Phase 1 starts with fallback transport only:
+
+- GitHub Actions emits the `grid-review-request` payload.
+- The OpenClaw webhook URL is intentionally empty until the receiver and signing secret are provisioned.
+- The workflow uploads `review-request.json` as an artifact and posts the machine-readable replay pointer comment.
+- OpenClaw cron/poll discovers pending Architecture review requests and runs the Grid Review Runner.
+
+## OpenClaw Polling Window
+
+Temporary cron/poll cadence:
+
+```text
+*/15 8-21 * * * America/New_York
+0 22 * * * America/New_York
+```
+
+Interpretation:
+
+- Poll every 15 minutes.
+- Start at 8:00 AM Eastern.
+- Run the final daily poll at 10:00 PM Eastern.
+- Polling is Architecture-only for the Phase 1 pilot.
+
+## Webhook Cutover Rule
+
+When the OpenClaw webhook receiver is live and `OPENCLAW_GRID_REVIEW_WEBHOOK_URL` plus `OPENCLAW_GRID_REVIEW_WEBHOOK_SECRET` are configured:
+
+1. Enable webhook delivery for the caller workflow.
+2. Verify a real Architecture PR request reaches OpenClaw by webhook.
+3. Disable the temporary cron/poll job.
+4. Record the cutover evidence in this file or a follow-up note.
+
+Cron/poll is a temporary fallback transport, not the long-term primary path.
+
+## Go/No-Go Evidence Checklist
+
+- [ ] `.honeydrunk-review.yaml` exists with `enabled: true` and `runner: openclaw-codex`.
+- [ ] Architecture PR workflow invokes `job-review-request.yml`.
+- [ ] Draft PRs do not request review.
+- [ ] `skip-review` PRs do not request review.
+- [ ] A real/test Architecture PR receives a Grid Review Runner comment.
+- [ ] Re-running on the same head SHA does not duplicate review work.
+- [ ] OpenClaw-offline behavior is advisory/pending, not a hard failure.
+- [ ] Phase 1 go/no-go result is recorded.


### PR DESCRIPTION
## Summary

- adds `.honeydrunk-review.yaml` to opt Architecture into ADR-0044 Phase 1 with `runner: openclaw-codex`
- adds `.github/workflows/grid-review-request.yml` to call the reusable Actions review-request workflow on PR opened/synchronize/ready_for_review
- starts the pilot in artifact/comment fallback mode until the OpenClaw webhook receiver and signing secret are provisioned
- records pilot evidence, the temporary polling cadence, and the webhook cutover rule in `docs/adr-0044/phase-1-pilot-evidence.md`

Closes #181.

## Pilot transport

For now, OpenClaw should poll Architecture review requests every 15 minutes from 8:00 AM Eastern through 10:00 PM Eastern:

```text
*/15 8-21 * * * America/New_York
0 22 * * * America/New_York
```

When webhook delivery is enabled and verified, disable this temporary cron/poll job.

## Verification

- YAML parsed with `ruamel.yaml` for `.github/workflows/grid-review-request.yml` and `.honeydrunk-review.yaml`
- `git diff --check`