### PR TITLE
docs(adr-0044): expand review and authoring discipline

### DIFF
--- a/.claude/agents/adr-composer.md
+++ b/.claude/agents/adr-composer.md
@@ -98,6 +98,20 @@ When investigating a question:
 - Read existing copilot-instructions or agent instructions in affected repos for repo-specific constraints
 - Check CHANGELOG.md files for recent changes that might inform the decision
 
+## ADR-0044 D3 Decision Rubric
+
+ADR-0044 D3 makes the twenty-category review rubric a shared upstream authoring standard, not the review agent's private checklist. When proposing or amending an ADR, reason explicitly against the categories the decision can affect so the downstream packets and reviews inherit the same standard.
+
+For architecture decisions, the load-bearing categories are:
+
+- **2. Architectural integrity** — Node boundaries, sector ownership, contract-first shape, and consistency with prior ADRs.
+- **6. Performance and scalability** — cost, latency, scale, and operational impact where the decision changes runtime behavior.
+- **9. Security** and **10. Enterprise readiness** — auth, secrets, compliance, auditability, tenancy, and operational control.
+- **18. AI and agent-specific concerns** — agent execution surfaces, reviewability, provenance, circuit breakers, and autonomous-change risks.
+- **19. Anti-entropy and long-term system health** — whether the decision reduces or increases architectural drift, duplicate policy, or maintenance burden.
+
+Updates to the rubric are ADR-0044 D3 amendments first, then propagated into agent-file edits per ADR-0007's source-of-truth rule. Drift between D3, `review.md`, and this category subset is an anti-pattern; `hive-sync` reconciles that drift per ADR-0014.
+
 ## Constraints
 
 - Do not make decisions for the user — present analysis and recommend, but always ask for confirmation

--- a/.claude/agents/node-audit.md
+++ b/.claude/agents/node-audit.md
@@ -159,6 +159,20 @@ Synthesize. Return:
 - The two or three most important findings — not the longest list, the load-bearing ones.
 - A recommended handoff: which agent executes which fix. (`scope` for packet-able work, `adr-composer` for decisions that need architectural approval first, `site-sync` for catalog divergence, `review` for any PR that follows.)
 
+## ADR-0044 D3 Systemic-Health Rubric
+
+ADR-0044 D3 makes the twenty-category review rubric a shared upstream authoring standard, not the review agent's private checklist. For node audits, use D3 as the systemic-health rubric: the review agent applies it to a PR diff; node-audit applies it to the whole repo and its Architecture definition.
+
+Walk the full `review.md` rubric by reference, with special attention to repo-wide signals that span PRs rather than living in a single diff:
+
+- **2. Architectural integrity** — Node identity, boundaries, sector fit, and undocumented scope expansion.
+- **4. Reuse and ecosystem cohesion** and **5. SOLID and design principles** — duplicate Grid patterns, misplaced abstractions, and policy logic that should be shared.
+- **7. Reliability and resilience**, **8. Observability and diagnostics**, and **9. Security** — operational gaps, missing telemetry, context drops, secret/auth violations.
+- **11. Testing quality**, **12. API and contract design**, and **15. CI/CD and delivery** — producer/consumer contract health, canaries, release hygiene, and workflow coverage.
+- **18. AI and agent-specific concerns** and **19. Anti-entropy and long-term system health** — agent-surface drift, stale instructions, recurring exceptions, and long-term entropy.
+
+Findings should flow to packets per ADR-0043 rather than being fixed directly by node-audit. Updates to the rubric are ADR-0044 D3 amendments first, then propagated into agent-file edits per ADR-0007's source-of-truth rule. Drift between D3, `review.md`, and this category subset is an anti-pattern; `hive-sync` reconciles that drift per ADR-0014.
+
 ## Output Format
 
 ```markdown

--- a/.claude/agents/pdr-composer.md
+++ b/.claude/agents/pdr-composer.md
@@ -131,6 +131,21 @@ Once the user decides:
 4. If the decision requires follow-up ADRs, tell the user to delegate to the adr-composer agent.
 5. If the decision requires work in repos, tell the user to delegate to the scope agent.
 
+## ADR-0044 D3 Product-Decision Rubric
+
+ADR-0044 D3 makes the twenty-category review rubric a shared upstream authoring standard, not the review agent's private checklist. When shaping a PDR, apply the relevant categories before recording the decision so the resulting work is product-sound and reviewable.
+
+For product decisions, the load-bearing categories are:
+
+- **2. Architectural integrity** — product surfaces must still respect Node ownership and Grid boundaries.
+- **6. Performance and scalability** — cost-to-serve, operational load, and scaling shape of the product promise.
+- **9. Security** and **10. Enterprise readiness** — trust, tenancy, auditability, support posture, and operational control.
+- **17. Product and business alignment** — extra weight: fit with the charter, positioning, user value, pricing/tier implications, and whether this is worth building now.
+- **18. AI and agent-specific concerns** — agent-facing product promises, generated-output risks, provenance, and oversight.
+- **19. Anti-entropy and long-term system health** — extra weight: whether the product direction concentrates the Grid or creates long-term sprawl.
+
+Updates to the rubric are ADR-0044 D3 amendments first, then propagated into agent-file edits per ADR-0007's source-of-truth rule. Drift between D3, `review.md`, and this category subset is an anti-pattern; `hive-sync` reconciles that drift per ADR-0014.
+
 ## Constraints
 
 - Do not make decisions for the user — present analysis and recommend, but always ask for confirmation

--- a/.claude/agents/refine.md
+++ b/.claude/agents/refine.md
@@ -113,6 +113,23 @@ Ask: "Doesn't ADR-{N} say we decided against this?"
 
 Ask: "How does this work when {edge case}?"
 
+## ADR-0044 D3 Rubric-Completeness Check
+
+ADR-0044 D3 makes the twenty-category review rubric a shared upstream authoring standard, not the review agent's private checklist. During refinement, check whether the packet or dispatch plan accounts for the categories it clearly touches. A packet that ignores Reliability, Observability, Security, Testing, AI/agent, or Anti-Entropy concerns where those apply is a refinement finding.
+
+Use the exact category names and numbering from `review.md`. Do not duplicate the full rubric; verify coverage and call out gaps:
+
+- **1. Correctness and functional integrity** — acceptance criteria prove the intended behavior and scope.
+- **7. Reliability and resilience** — failure modes, rollback, retries, and partial-failure behavior are addressed.
+- **8. Observability and diagnostics** — logs, metrics, traces, health checks, and correlation evidence are specified.
+- **9. Security** and **10. Enterprise readiness** — secrets, auth, tenancy, compliance, and audit requirements are explicit.
+- **11. Testing quality** — verification is specific, realistic, and includes boundary/negative cases where relevant.
+- **15. CI/CD and delivery** — release, migration, and non-blocking/advisory semantics are clear.
+- **18. AI and agent-specific concerns** — handoff context, authorship, idempotency, and replay/circuit-breaker concerns are clear.
+- **19. Anti-entropy and long-term system health** — exceptions, duplicated patterns, and future cleanup are tracked instead of hidden.
+
+Updates to the rubric are ADR-0044 D3 amendments first, then propagated into agent-file edits per ADR-0007's source-of-truth rule. Drift between D3, `review.md`, and this category subset is an anti-pattern; `hive-sync` reconciles that drift per ADR-0014.
+
 ## Output Format
 
 ```markdown

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -417,33 +417,46 @@ This is the category most organizations never formalize, and the one that determ
 **Verdict:** {Approved | Request Changes | Block}
 
 ## Summary
-{One paragraph: what this PR does and overall assessment}
+{One paragraph: what this PR does and overall assessment. If clean, explicitly say no blocking findings, requested changes, or suggestions were found.}
+
+## Reviewed Scope / Evidence Checked
+
+- **Packet / PR scope:** {packet path or out-of-band label status; acceptance criteria checked}
+- **Governing ADRs:** {ADR ids read, or "None referenced"}
+- **Grid invariants:** `constitution/invariants.md` checked for relevant numbered invariants: {ids or "none implicated"}
+- **Repo boundaries:** {repo boundary files read, or "Architecture repo meta-doc boundary"}
+- **Contracts / downstream:** {catalog files checked; downstream Nodes affected or "none detected"}
+- **Security / secrets:** {secret, auth, tenant, permission, and data-classification checks performed}
+- **Cost / CI discipline:** {workflow/model/API/Azure/resource cost checks performed}
+- **Testing / verification:** {tests, CI, docs-only rationale, or verification gap}
+- **Idempotency / review state:** {head SHA reviewed; duplicate-review behavior considered when relevant}
+- **Files inspected:** {concise list of key changed files reviewed}
 
 ## Findings
 
 ### Blocking
-- **{Category}**: {Description}. {File and line if applicable}. {What needs to change}.
+- {"None." or **{Category}**: {Description}. {File and line if applicable}. {What needs to change}.}
 
 ### Changes Requested
-- **{Category}**: {Description}. {Suggestion}.
+- {"None." or **{Category}**: {Description}. {Suggestion}.}
 
 ### Suggestions
-- **{Category}**: {Description}. {Optional improvement}.
+- {"None." or **{Category}**: {Description}. {Optional improvement}.}
 
 ## Downstream Impact
 {List of downstream Nodes affected, or "None detected"}
 
 ## Checklist
 - [x] Packet resolved and scope verified (or PR marked out-of-band)
-- [x] Boundary compliance
-- [x] Contract safety
-- [ ] Invariant preservation — {issue found}
-- [x] Code quality
-- [x] Context propagation
-- [x] Cost discipline
-- [x] Tests present
-- [ ] CHANGELOG updated
-- [ ] README updated (if public API or installation changed)
+- [x] Boundary compliance checked
+- [x] Contract safety checked
+- [x] Relevant invariants checked
+- [x] ADR-0044 D3 rubric applied
+- [x] Cost discipline checked
+- [x] Security/secrets checked
+- [x] Tests/verification assessed
+- [x] Downstream impact assessed
+- [x] Clean PR does not get manufactured findings
 ```
 
 ## Severity Guide
@@ -460,4 +473,4 @@ This is the category most organizations never formalize, and the one that determ
 - Don't block for style. Style issues are Suggest-level unless they violate HoneyDrunk.Standards.
 - If you're unsure whether something is a violation, flag it as a question rather than a block.
 - Be specific: name the file, the line, the invariant number, the interface. Vague feedback is not actionable.
-- If the PR is clean, say so. Don't manufacture findings.
+- If the PR is clean, say so. Don't manufacture findings. Still fill out Reviewed Scope / Evidence Checked so silence is not ambiguous.

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -422,8 +422,8 @@ This is the category most organizations never formalize, and the one that determ
 ## Reviewed Scope / Evidence Checked
 
 - **Packet / PR scope:** {packet path or out-of-band label status; acceptance criteria checked}
-- **Governing ADRs:** {ADR ids read, or "None referenced"}
-- **Grid invariants:** `constitution/invariants.md` checked for relevant numbered invariants: {ids or "none implicated"}
+- **Governing ADRs:** ADR-0011 and ADR-0044 always, plus packet-referenced ADR ids or "no additional ADRs referenced"
+- **Grid invariants:** all numbered invariants in `constitution/invariants.md` checked against the diff; implicated invariants: {ids or "none implicated"}
 - **Repo boundaries:** {repo boundary files read, or "Architecture repo meta-doc boundary"}
 - **Contracts / downstream:** {catalog files checked; downstream Nodes affected or "none detected"}
 - **Security / secrets:** {secret, auth, tenant, permission, and data-classification checks performed}

--- a/.claude/agents/scope.md
+++ b/.claude/agents/scope.md
@@ -209,6 +209,22 @@ active/{initiative-slug}/handoff-rotation-bringup.md
 
 Each handoff must be self-contained: upstream changes, new package versions, interface signatures, invariants, acceptance criteria. Per ADR-0008 D7, handoffs are **read once at the wave transition** — ephemeral baton passes, not live trackers. They are immutable under invariant 24.
 
+## ADR-0044 D3 Authoring Rubric
+
+ADR-0044 D3 makes the twenty-category review rubric a shared upstream authoring standard, not the review agent's private checklist. When decomposing work, apply the relevant subset before emitting packets so execution agents receive the right constraints up front.
+
+For scoping, the load-bearing categories are:
+
+- **1. Correctness and functional integrity** — packet scope adherence, edge cases, idempotency, and acceptance criteria that prove the intended behavior.
+- **7. Reliability and resilience** — failure modes, retries, rollback, partial failure, and production recovery paths.
+- **8. Observability and diagnostics** — required logs, metrics, traces, health checks, correlation IDs, and review evidence.
+- **9. Security** — secret handling, auth boundaries, token/RBAC implications, and blast radius.
+- **11. Testing quality** — concrete verification strategy, including negative paths and contract/canary coverage where relevant.
+- **18. AI and agent-specific concerns** — agent handoff clarity, authorship, idempotency, context boundaries, and replay safety.
+- **19. Anti-entropy and long-term system health** — whether the packet introduces exceptions, drift, or duplicate policy surfaces.
+
+Updates to the rubric are ADR-0044 D3 amendments first, then propagated into agent-file edits per ADR-0007's source-of-truth rule. Drift between D3, `review.md`, and this category subset is an anti-pattern; `hive-sync` reconciles that drift per ADR-0014.
+
 ## Phase 5: Output
 
 ### Step 1 — Create issues

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,6 +63,32 @@ Custom agents are defined in `.github/agents/`. Each agent has a specific purpos
 | `site-sync` | Sync website with architecture changes |
 | `netrunner` | Navigate the Grid and surface what's next |
 
+## ADR-0044 D3/D6 Authoring Discipline
+
+ADR-0044 D3 makes the review rubric an upstream authoring standard for Copilot-assisted work too. Before accepting or shaping a diff, help the developer apply the checklist rather than leaving those concerns for review.
+
+Apply the brief ADR-0044 D3 authoring checklist before producing a diff:
+
+- **1. Correctness and functional integrity** — the change satisfies the packet/intent and handles edge cases.
+- **3. Maintainability** — the implementation is readable and locally understandable.
+- **5. SOLID and design principles** — responsibilities stay cohesive; no speculative abstraction.
+- **4. Reuse and ecosystem cohesion** — reuse existing Grid patterns; avoid duplicate helpers/policy.
+- **9. Security** — no secret leakage, auth bypass, or widened blast radius.
+- **6. Performance and scalability** — no avoidable hot-path, cost, or unbounded-work risk.
+- **11. Testing quality** — verification is meaningful and covers the changed behavior.
+- **18. AI and agent-specific concerns** — authorship, idempotency, context, and replay risks are explicit.
+- **20. Human factors** — PRs are easy for Oleg to review and do not hide operational trade-offs.
+
+The remaining D3 categories are still in scope by reference through `.claude/agents/review.md`; do not treat this short list as exhaustive.
+
+Per ADR-0044 D6, Copilot-assisted accepted PRs must declare authorship. Because Copilot does not autonomously open the PR, direct the human to choose the accurate D6 class:
+
+- Use `Authorship: agent-copilot` when the accepted implementation was materially Copilot-assisted.
+- Use `Authorship: mixed` when meaningful work came from multiple surfaces or substantial human + agent co-authoring.
+- Use `Authorship: human` when Copilot only supplied trivial autocomplete or non-material suggestions.
+
+Include the same class in the PR body line and commit trailer. Use only the five D6 classes: `human`, `agent-codex`, `agent-copilot`, `agent-claude-code`, or `mixed`.
+
 ## Commit Format
 
 All commits — in this repo and in any target repo you execute against — **must** follow [Conventional Commits](https://www.conventionalcommits.org/) 1.0.0:

--- a/copilot/global-instructions.md
+++ b/copilot/global-instructions.md
@@ -30,6 +30,31 @@ These rules apply to all agents operating within the HoneyDrunk Grid.
 - Do not create generic utility dumping grounds. Keep shared code close to its domain unless it is clearly cross-cutting.
 - If duplication is intentional because two paths are expected to diverge, call that out in the PR or a short code comment.
 
+## ADR-0044 D3/D6 Authoring Discipline
+
+ADR-0044 D3 makes the review rubric an upstream authoring standard. Claude Code and shared Grid agents must apply it while authoring, not wait for review to catch preventable issues.
+
+Apply the brief ADR-0044 D3 authoring checklist before producing a diff:
+
+- **1. Correctness and functional integrity** — the change satisfies the packet/intent and handles edge cases.
+- **3. Maintainability** — the implementation is readable and locally understandable.
+- **5. SOLID and design principles** — responsibilities stay cohesive; no speculative abstraction.
+- **4. Reuse and ecosystem cohesion** — reuse existing Grid patterns; avoid duplicate helpers/policy.
+- **9. Security** — no secret leakage, auth bypass, or widened blast radius.
+- **6. Performance and scalability** — no avoidable hot-path, cost, or unbounded-work risk.
+- **11. Testing quality** — verification is meaningful and covers the changed behavior.
+- **18. AI and agent-specific concerns** — authorship, idempotency, context, and replay risks are explicit.
+- **20. Human factors** — PRs are easy for Oleg to review and do not hide operational trade-offs.
+
+The remaining D3 categories are still in scope by reference through `.claude/agents/review.md`; do not treat this short list as exhaustive.
+
+Per ADR-0044 D6, Claude Code-authored PRs must declare authorship in both places:
+
+- PR body line: `Authorship: agent-claude-code`
+- Commit trailer: `Authorship: agent-claude-code`
+
+When work is materially mixed with another surface, use one of the five D6 classes only: `human`, `agent-codex`, `agent-copilot`, `agent-claude-code`, or `mixed`. Do not invent authorship classes.
+
 ## Communication
 
 - Be direct and concise

--- a/routing/sdlc.md
+++ b/routing/sdlc.md
@@ -153,6 +153,31 @@ This can be delivered as:
 
 ---
 
+## ADR-0044 D3/D6 Codex Authoring Discipline
+
+When Codex executes a packet, ADR-0044 D3 requires the review rubric to be applied upstream before producing the diff. The handoff should keep this checklist visible so Codex authors against the same standard the review agent later evaluates.
+
+Apply the brief ADR-0044 D3 authoring checklist before producing a diff:
+
+- **1. Correctness and functional integrity** — the change satisfies the packet/intent and handles edge cases.
+- **3. Maintainability** — the implementation is readable and locally understandable.
+- **5. SOLID and design principles** — responsibilities stay cohesive; no speculative abstraction.
+- **4. Reuse and ecosystem cohesion** — reuse existing Grid patterns; avoid duplicate helpers/policy.
+- **9. Security** — no secret leakage, auth bypass, or widened blast radius.
+- **6. Performance and scalability** — no avoidable hot-path, cost, or unbounded-work risk.
+- **11. Testing quality** — verification is meaningful and covers the changed behavior.
+- **18. AI and agent-specific concerns** — authorship, idempotency, context, and replay risks are explicit.
+- **20. Human factors** — PRs are easy for Oleg to review and do not hide operational trade-offs.
+
+The remaining D3 categories are still in scope by reference through `.claude/agents/review.md`; do not treat this short list as exhaustive.
+
+Per ADR-0044 D6, Codex-authored PRs must declare authorship in both places:
+
+- PR body line: `Authorship: agent-codex`
+- Commit trailer: `Authorship: agent-codex`
+
+When Codex materially shares authorship with another surface, use `Authorship: mixed`. Use only the five D6 classes: `human`, `agent-codex`, `agent-copilot`, `agent-claude-code`, or `mixed`.
+
 ## Handoff Protocol: Codex → Developer (PR Review)
 
 When Codex opens a PR, the developer evaluates:


### PR DESCRIPTION
## Summary
- expand ADR-0044 review output with `Reviewed Scope` / `Evidence Checked` details so clean reviews still show what was inspected
- roll ADR-0044 D3 rubric subsets into upstream authoring agents: scope, ADR/PDR composer, refine, and node-audit
- add ADR-0044 D3/D6 authoring discipline to execution surfaces for Claude Code, Copilot, and Codex, including authorship lines/trailers

Authorship: agent-claude-code

## Issue Packets
- `generated/issue-packets/active/adr-0044-cloud-code-review/09-architecture-d3-rubric-upstream-agent-rollout.md`
- `generated/issue-packets/active/adr-0044-cloud-code-review/10-architecture-execution-surface-authorship-and-rubric.md`

## Verification
- `git diff --check`
- acceptance string checks for ADR-0044 #175/#176 category coverage and authorship classes

Refs #175
Refs #176
