### PR TITLE
docs(adr-0044): remove ultra review path

### DIFF
--- a/adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md
+++ b/adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md
@@ -299,18 +299,16 @@ The catalog of high-risk Nodes lives in `catalogs/grid-health.json` under a new 
 - Switches to the highest-quality locally available Codex review profile for the first pass.
 - Triggers a second pass automatically using a deliberately contrarian prompt ("identify ways the first reviewer was wrong"). The two passes are independent sessions, posted as separate comments.
 
-Alternative escalation paths the human may invoke instead:
-- `/ultrareview` - multi-agent cloud review (billed separately).
-- `refine` agent against the PR's packet + diff (skeptical-senior-dev archetype).
+The human may also invoke the `refine` agent against the PR's packet + diff (skeptical-senior-dev archetype) when a deeper manual escalation is warranted.
 
-The PR body records which path was used. Two same-runner passes is the default because it is cheapest and automatic under the OpenClaw/Codex setup; the alternatives exist for cases the human judges warrant deeper scrutiny.
+Two same-runner passes remain the default because they are cheapest and automatic under the OpenClaw/Codex setup. Separate multi-agent cloud review modes are intentionally out of scope for ADR-0044; the review system should stay subscription-backed, local/runtime-owned, and low-noise unless a future ADR deliberately reopens provider-backed review.
 
 ### D9 - Post-merge sampling audit
 
 Every Nth agent-authored merged PR (starting N=10, tunable via the weekly briefing per ADR-0043) is selected for a deeper post-merge audit:
 
 - Selection is automatic (CI labels the chosen PR `audit-sample` at merge time).
-- Audit runs `/ultrareview` against the merged PR's diff.
+- Audit reruns the canonical OpenClaw/Codex Grid Review Runner against the merged PR's diff using an audit prompt that asks what the pre-merge review missed.
 - Output is committed to `generated/post-merge-audits/{YYYY-MM-DD}-{repo}-{pr-number}.md`.
 - Findings at `Block` or `Request Changes` severity become Reactive packets per ADR-0043's Reactive source taxonomy.
 

--- a/adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md
+++ b/adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md
@@ -303,16 +303,18 @@ The human may also invoke the `refine` agent against the PR's packet + diff (ske
 
 Two same-runner passes remain the default because they are cheapest and automatic under the OpenClaw/Codex setup. Separate multi-agent cloud review modes are intentionally out of scope for ADR-0044; the review system should stay subscription-backed, local/runtime-owned, and low-noise unless a future ADR deliberately reopens provider-backed review.
 
+Filed ADR-0044 issue packets are immutable per invariant 24. Any legacy packet text that still references `/ultrareview` is superseded by this ADR text and must not be used to implement or revive a separate multi-agent cloud review mode.
+
 ### D9 - Post-merge sampling audit
 
 Every Nth agent-authored merged PR (starting N=10, tunable via the weekly briefing per ADR-0043) is selected for a deeper post-merge audit:
 
 - Selection is automatic (CI labels the chosen PR `audit-sample` at merge time).
-- Audit reruns the canonical OpenClaw/Codex Grid Review Runner against the merged PR's diff using an audit prompt that asks what the pre-merge review missed.
+- Audit reruns the canonical OpenClaw/Codex Grid Review Runner against the merged PR's diff using an audit-mode instruction block that asks what the pre-merge review missed.
 - Output is committed to `generated/post-merge-audits/{YYYY-MM-DD}-{repo}-{pr-number}.md`.
 - Findings at `Block` or `Request Changes` severity become Reactive packets per ADR-0043's Reactive source taxonomy.
 
-The audit measures **the review process's own quality**, not individual bugs (the code already shipped). Findings feed back into `.claude/agents/review.md` and this ADR. Without this loop, review-process drift would surface only as production incidents.
+The audit measures **the review process's own quality**, not individual bugs (the code already shipped). The audit-mode instruction block is owned by the canonical review-agent prompt/config used by the OpenClaw/Codex Grid Review Runner, not forked into workflow YAML or a runner-only prompt. The workflow selects audit mode and supplies the merged PR diff plus original review artifacts; the reviewer prompt remains the single source of review behavior. Findings feed back into `.claude/agents/review.md` and this ADR. Without this loop, review-process drift would surface only as production incidents.
 
 ### D10 - Relationship to ADR-0011
 

--- a/constitution/invariants.md
+++ b/constitution/invariants.md
@@ -146,7 +146,7 @@ Rules that must never be violated across the HoneyDrunk Grid. Canary tests enfor
     A repo is `enabled` when it carries a `.honeydrunk-review.yaml` with `enabled: true`. Skip is via the `skip-review` PR label or `enabled: false` config — both explicit, both visible. See ADR-0044 D1 and D11.
 
 53. **Agent-authored PRs touching a high-risk Node receive two independent LLM-review perspectives before merge.**
-    The catalog of high-risk Nodes lives in `catalogs/grid-health.json` under the `review_risk_class` field once ADR-0044 packet 13 lands. Until that field exists, this invariant is accepted as the Phase-3 target state but is not enforceable. The second perspective is a contrarian-prompt pass by default; `/ultrareview` or a `refine` pass are alternative escalation paths the human may invoke. See ADR-0044 D8.
+    The catalog of high-risk Nodes lives in `catalogs/grid-health.json` under the `review_risk_class` field once ADR-0044 packet 13 lands. Until that field exists, this invariant is accepted as the Phase-3 target state but is not enforceable. The second perspective is a contrarian-prompt pass by default; the human may also invoke `refine` against the packet and diff for manual escalation. Separate multi-agent cloud review modes are intentionally out of scope for ADR-0044. See ADR-0044 D8.
 
 ## Hosting Platform Invariants
 

--- a/initiatives/active-initiatives.md
+++ b/initiatives/active-initiatives.md
@@ -21,7 +21,7 @@ Tracked initiatives currently in progress or planned. Completed and cancelled in
 
 **Tracking (Wave 2 — Phase 2: live Node rollout + discipline foundations):**
 - [x] Actions#85: Add authorship-check and pr-size-check jobs to `pr-core.yml` (packet 07; shipped via Actions PR #100, closed 2026-05-23)
-- [ ] Actions#86: Seed `large-pr`, `audit-sample`, and `skip-review` labels Grid-wide (packet 08; labels-as-code and seed/fanout workflows shipped via Actions PR #100; fanout run + verification still pending)
+- [x] Actions#86: Seed `large-pr`, `audit-sample`, and `skip-review` labels Grid-wide (packet 08; labels-as-code and seed/fanout workflows shipped via Actions PR #100; fanout repair shipped via Actions PR #101; fanout run verified 2026-05-24)
 - [x] Architecture#175: Roll the D3 rubric into upstream authoring agents (packet 09; shipped via PR #279)
 - [x] Architecture#176: Amend execution-surface prompts for `Authorship:` and D3 checklist (packet 10; shipped via PR #279)
 - [ ] Architecture#182: Enable the OpenClaw/Codex reviewer on the 10 remaining live Nodes (packet 11)
@@ -40,7 +40,7 @@ Tracked initiatives currently in progress or planned. Completed and cancelled in
 
 **Exit criteria:** ADR-0044 is Accepted; Phase 1 MVP (`job-review-request.yml` + Grid Review Runner) is enabled on `HoneyDrunk.Architecture` only and running on every non-draft PR; each phase's dispatch-plan go/no-go criterion is satisfied before the next wave starts.
 
-> **Sync (2026-05-23):** Phase 1 is functionally complete in artifact-plus-cron/poll mode: ADR-0044 is Accepted, `job-review-request.yml` is live, Architecture has `.honeydrunk-review.yaml` and the caller workflow, and OpenClaw posted advisory PR comments for reviewed head SHAs. Webhook provisioning remains the transport hardening gap; the temporary OpenClaw cron/poll jobs should be disabled after signed webhook delivery is configured and verified. Wave 2 Architecture-side docs/prompts (#175, #176, #183) have landed. Actions#85 is closed via Actions PR #100; Actions#86 has its labels-as-code and seed/fanout workflow code merged, but remains open until the `seed-labels-fanout.yml` run is completed/verified (or explicitly deferred) before broad Node fan-out (#182).
+> **Sync (2026-05-24):** Phase 1 is functionally complete in artifact-plus-cron/poll mode: ADR-0044 is Accepted, `job-review-request.yml` is live, Architecture has `.honeydrunk-review.yaml` and the caller workflow, and OpenClaw posted advisory PR comments for reviewed head SHAs. Webhook provisioning remains the transport hardening gap; the temporary OpenClaw cron/poll jobs should be disabled after signed webhook delivery is configured and verified. Wave 2 Architecture-side docs/prompts (#175, #176, #183) have landed. Actions#85 is closed via Actions PR #100; Actions#86 is closed after the `seed-labels-fanout.yml` run completed successfully on 2026-05-24. ADR-0044 no longer uses the deprecated multi-agent cloud-review path; broad Node fan-out (#182) is unblocked.
 
 ### ADR-0047 Testing Patterns and Tooling
 **Status:** In Progress


### PR DESCRIPTION
## Summary

- Remove the ADR-0044 `/ultrareview` escalation path and make separate multi-agent cloud review explicitly out of scope.
- Keep high-risk review on the cheap/local OpenClaw/Codex two-pass model, with `refine` as the manual escalation path.
- Change post-merge sampling audits to rerun the canonical OpenClaw/Codex Grid Review Runner in audit mode.
- Update ADR-0044 initiative tracking to mark Actions#86 fan-out complete and broad Node fan-out unblocked.

## Validation

- `git diff --check`
- Searched Architecture markdown for `/ultrareview` / `ultrareview`; no remaining non-legacy hits after cleanup.
- Verified `seed-labels-fanout.yml` succeeded after Actions PR #101 merge and all target labels are present.

## Authorship

Authorship: agent-codex
Out-of-band reason: ADR-0044 cleanup requested directly during live execution; no generated packet exists for this governance cleanup PR.
