### PR TITLE
Scope ADR-0072/0079/0080 studio governance and posture

### DIFF
--- a/adrs/ADR-0072-data-access-stance-ef-core-default-dapper-hot-path.md
+++ b/adrs/ADR-0072-data-access-stance-ef-core-default-dapper-hot-path.md
@@ -83,7 +83,7 @@ The committed posture:
 
 ### D4 — Per-Node DbContext, scoped composition
 
-Each Node that touches data owns its own `DbContext`(s). Sharing a DbContext across Nodes is forbidden — it would break the Grid's boundary discipline (per [Invariant 3](../constitution/invariants.md) on dependency direction) and produce hidden coupling across deployable surfaces.
+Each Node that touches data owns its own `DbContext`(s). Sharing a DbContext across Nodes is forbidden — it would break the Grid's boundary discipline (a runtime coupling violation under [invariant 2](../constitution/invariants.md) "Runtime packages depend on Abstractions, never on other runtime packages at the same layer" and [invariant 11](../constitution/invariants.md) "One repo per Node") and produce hidden coupling across deployable surfaces.
 
 The composition shape:
 
@@ -102,7 +102,7 @@ Default EF query patterns, applied at code review per [ADR-0044](./ADR-0044-grid
 - **`Include` is explicit; lazy loading is off.** EF Core's lazy loading is disabled in the default DbContext composition. Eager-loading via `Include` is the only navigation-property mechanism; explicit-loading is permitted where it earns its keep.
 - **N+1 queries are caught at review.** The `review` agent's data-quality category checks for the `foreach (var item in list) { var related = ctx.Related.Where(...).ToList(); }` pattern.
 - **Compiled queries (`EF.CompileQuery`)** are permitted for hot-path reads where the compile cost amortizes — these are the boundary cases where Dapper might also be considered. Compiled query is the EF-side first option; Dapper is the EF-side-escape.
-- **Raw SQL via `FromSqlRaw` is parameterized** — never string-interpolated. Per [Invariant 8](../constitution/invariants.md) and standard secure-SQL discipline.
+- **Raw SQL via `FromSqlRaw` is parameterized** — never string-interpolated. Standard secure-SQL discipline; no existing numbered invariant covers parameterized SQL, so this rule is review-enforced via D5 here, with surface checks in `.claude/agents/review.md` D3 category 13 and depth checks in `.claude/agents/database.md`. ([Invariant 8](../constitution/invariants.md) covers secret values in logs/traces — a distinct concern, not parameterized SQL.)
 
 ### D6 — Testing discipline
 
@@ -234,7 +234,7 @@ Rejected. Without an ADR, each Node re-derives the choice and the Grid ends up w
 ## References
 
 - [`constitution/charter.md`](../constitution/charter.md) — enterprise-grade-substrate framing, many-decade horizon, boring-defaults preference
-- [`constitution/invariants.md`](../constitution/invariants.md) — invariant 3 (dependency direction), invariant 8 (no secrets in logs / parameterized SQL discipline)
+- [`constitution/invariants.md`](../constitution/invariants.md) — invariant 2 (runtime packages depend on Abstractions; same-layer rule) and invariant 11 (one repo per Node), together covering the per-Node DbContext rule; invariant 8 (secret values never in logs/traces) covers a distinct concern from parameterized SQL — the `FromSqlRaw` rule is review-enforced under ADR-0072 D5 with no existing numbered invariant home
 - [ADR-0005](./ADR-0005-configuration-and-secrets-strategy.md) — connection strings via Vault
 - [ADR-0012](./ADR-0012-grid-cicd-control-plane.md) — CI migration runner
 - [ADR-0030](./ADR-0030-grid-wide-audit-substrate.md) / [ADR-0031](./ADR-0031-stand-up-honeydrunk-audit-node.md) — Audit Node (primary write path is EF Core; hot-path forensic queries are Dapper-candidates)

--- a/generated/issue-packets/active/adr-0072-data-access-stance/00-architecture-adr-0072-acceptance.md
+++ b/generated/issue-packets/active/adr-0072-data-access-stance/00-architecture-adr-0072-acceptance.md
@@ -1,0 +1,163 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "core", "docs", "adr-0072", "wave-1"]
+dependencies: []
+adrs: ["ADR-0072"]
+accepts: ["ADR-0072"]
+wave: 1
+initiative: adr-0072-data-access-stance
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0072 — flip status, register the initiative (no new invariants)
+
+## Summary
+Flip ADR-0072 (Data Access Stance — EF Core Default, Dapper for Hot-Path Reads) from Proposed to Accepted: update the ADR header, add the row to the ADR index in `adrs/README.md`, and register the `adr-0072-data-access-stance` initiative in `initiatives/active-initiatives.md`. **No new invariants are added** — ADR-0072 explicitly commits its decisions as review-enforced conventions rather than numbered invariants.
+
+## Context
+ADR-0072 commits the Grid's data-access stance:
+
+- **D1** — **EF Core is the default ORM** for every Node touching a relational store. EF Core current LTS (tracked to the .NET LTS cadence; LTS releases are the even-numbered .NET majors, e.g., .NET 8 / EF Core 8, .NET 10 / EF Core 10). `Microsoft.EntityFrameworkCore.SqlServer` for SQL Server backings; `Microsoft.EntityFrameworkCore.Npgsql` for Postgres backings. EF Migrations is the canonical migration tool per ADR-0048. The negative form: Dapper is not the default; Marten is not adopted; raw ADO.NET is not the default; Entity Framework 6 / Classic is forbidden for new work; RepoDb / Pomelo / freshly-released micro-ORMs are not adopted as defaults.
+- **D2** — **Dapper is the scoped exception** for hot-path read queries where EF Core's generated SQL is measurably worse, allocation profile matters, or the query shape is awkward in LINQ. The evidence burden lives in the PR: the EF-generated query, the hand-written Dapper replacement, and benchmark numbers. Dapper is scoped to **read paths only**; writes go through EF Core's DbContext. Adopting Dapper for one query in a Node does not adopt it for the Node's other queries. `FromSqlRaw` inside EF is the first option when the query still wants EF's change tracking or composition; Dapper is the second.
+- **D3** — **EF Migrations is the migration tool** per ADR-0048. ADR-0072 ratifies the implicit ORM behind ADR-0048's migration tool choice. Per-Node migrations live alongside the Node's DbContext.
+- **D4** — **Per-Node DbContext, scoped composition.** Each Node owns its own `DbContext`(s); sharing across Nodes is forbidden — the Grid's boundary discipline (one repo per Node per invariant 11; runtime packages depend on Abstractions, not other Nodes, per invariant 2) makes a cross-Node `DbContext` a runtime coupling violation. The `HoneyDrunk.<Node>.Data` project hosts the DbContext and entity classes. Connection strings come from Vault per ADR-0005 via `ISecretStore`. Per-tenant partitioning per ADR-0050 is per-Node policy. The repository pattern via `HoneyDrunk.Data` (`IRepository<T>`, `IUnitOfWork`) sits on top of the DbContext.
+- **D5** — **Query discipline**: `AsNoTracking()` on every read-only query; projections (`Select`) preferred over full entity loads when only a subset of columns is needed; `Include` is explicit and lazy loading is off; N+1 queries are caught at review; compiled queries (`EF.CompileQuery`) are permitted for hot paths where the compile cost amortizes; raw SQL via `FromSqlRaw` is parameterized — never string-interpolated (secure-SQL discipline; no existing numbered invariant covers parameterized SQL — review-enforced per ADR-0072 D5).
+- **D6** — **Testing discipline**: in-memory provider (`Microsoft.EntityFrameworkCore.InMemory`) for fast unit tests per ADR-0047 D2; Testcontainers per ADR-0047 D4 (Tier 2b) for integration tests where the actual SQL provider's behavior matters. Dapper code is tested via Testcontainers (Tier 2b) — the in-memory provider does not apply to Dapper.
+- **D7** — **Migration path away from EF Core** is bounded by the `HoneyDrunk.Data` repository abstraction. Consumers depend on `IRepository<T>` / `IUnitOfWork`, not on `DbContext` directly. Swapping the implementation to a different ORM is a per-Node mechanical move; the contract surface stays stable.
+- **D8** — **Out of scope**: specific database engine choice (per-Node decision); NoSQL data-access stance (per-backing SDKs apply); read-replica routing (per-Node); connection pooling and DbContext lifetime tuning (defaults apply); ORM-level data-classification implementation (per-Node enforcement); connection-resiliency policies (per-Node).
+
+ADR-0072 is a **policy / ratification** ADR. The committed implementation (EF Core via `HoneyDrunk.Data.EntityFramework`) already exists in the Data repo; this initiative ratifies it explicitly, lands the discipline in the `review` agent's rubric and the `database` specialist agent's rubric, and updates the Data Node's README/overview. The remaining code-change work (the EF Core implementation itself, per-Node adoption packets, per-Node Dapper hot-path pilots) is deliberately deferred — see the dispatch plan's Cross-Cutting Concerns for the deferred-follow-ups list.
+
+Every other packet in this initiative references ADR-0072's decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## No New Invariants
+
+ADR-0072's Consequences/Invariants section explicitly states:
+
+> No new Grid-wide invariants are introduced in `constitution/invariants.md`. The following are committed conventions enforced by the `review` agent's data-quality category per ADR-0044 D3:
+> - EF Core is the default for relational data access.
+> - Writes go through EF Core's DbContext.
+> - `AsNoTracking()` on read-only queries; explicit `Include`; lazy loading off.
+> - DbContext is per-Node, never shared.
+> - Connection strings come from Vault.
+>
+> If the scope agent judges any of these invariant-class at acceptance time, numbering is added then.
+
+The scope agent's judgment at acceptance time: **none of the five conventions is elevated to a numbered invariant in this packet.** The reasoning per convention:
+
+1. **EF Core as the default ORM** — this is a strong commitment but enforced at PR review by the generalist `review` agent's category 13 (packet 01) and the `database` specialist agent's rubric (packet 02). Elevating it to an invariant would require a per-PR machine-check that "this code uses EF Core" — implementable but redundant with the review-time check.
+2. **Writes go through EF Core's DbContext** — same posture: review-enforced. A Dapper-write path is a hard finding under the rubric; an explicit invariant would be a parallel surface with no new enforcement power.
+3. **`AsNoTracking()` / explicit `Include` / lazy loading off** — these are *coding patterns* rather than architectural rules. They belong in the per-Node rubric, not in the constitution.
+4. **DbContext per-Node, never shared** — this is already covered by the Grid's existing boundary discipline (invariant 11 "one repo per Node" and invariant 2 "runtime packages depend on Abstractions, never on other runtime packages at the same layer"). A `DbContext` shared across Nodes would force a runtime dependency from one Node onto another Node's data layer — a violation of invariant 2's same-layer rule. Adding a redundant invariant would be noise.
+5. **Connection strings from Vault** — already covered by the existing Vault discipline and ADR-0005's commitments. No new invariant needed.
+
+The five conventions live in:
+- `.claude/agents/review.md` D3 category 13 (packet 01 of this initiative)
+- `.claude/agents/database.md` (the `database` specialist agent — file created under sibling initiative `adr-0048-schema-evolution` packet 02; this initiative's packet 02 extends the rubric)
+- `repos/HoneyDrunk.Data/overview.md` (packet 03 of this initiative)
+- `HoneyDrunk.Data/README.md` (packet 04 of this initiative)
+
+**If a future audit determines that any of these conventions needs invariant-level enforcement** (e.g. the `database` specialist agent has caught repeated violations and the review-time enforcement isn't sticking), a follow-up ADR amendment elevates the convention to a numbered invariant. That is not this packet's concern.
+
+## Scope
+- `adrs/ADR-0072-data-access-stance-ef-core-default-dapper-hot-path.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — add a new row for ADR-0072 with Status `Accepted`, Date `2026-05-23`, Sector `Core / cross-cutting`, and an Impact summary.
+- `initiatives/active-initiatives.md` — register the `adr-0072-data-access-stance` initiative with the packet checklist for this folder.
+- **No edit to `constitution/invariants.md`.** Per the above, no invariants are added.
+
+## Proposed Implementation
+1. Edit the ADR-0072 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Add a new row for ADR-0072 to the table in `adrs/README.md`. The ADR is currently absent from the index. Insert the row in numerical order after ADR-0057 (the table's current last entry). Suggested Impact summary text (taken from the ADR's Decision section, distilled):
+   > EF Core as the default ORM for every Node touching a relational store; **Dapper as the scoped exception** for hot-path reads with mandatory evidence (EF query, Dapper query, benchmark numbers) in the PR; writes always through EF Core's DbContext; `AsNoTracking()` / explicit `Include` / lazy loading off as query discipline; per-Node DbContext, scoped composition with `IRepository<T>` / `IUnitOfWork` on top; EF Migrations is the migration tool per ADR-0048; in-memory provider for unit tests, Testcontainers for integration; migration path away bounded by the `HoneyDrunk.Data` abstraction. **No new invariants** — committed as review-enforced conventions in `.claude/agents/review.md` category 13 and the `database` specialist agent's rubric. Marten / Dapper-as-default / raw ADO.NET-as-default / EF 6 explicitly rejected; the per-Node engine choice (Azure SQL vs Postgres vs Cosmos) and NoSQL access stay out of scope.
+3. Register the initiative in `initiatives/active-initiatives.md` under the In Progress section. Add a block in the same format as the existing entries (see ADR-0044, ADR-0047). Include the wave structure and the per-packet checklist for this folder. The block should reference the dispatch plan at `generated/issue-packets/active/adr-0072-data-access-stance/dispatch-plan.md`.
+
+## Affected Files
+- `adrs/ADR-0072-data-access-stance-ef-core-default-dapper-hot-path.md`
+- `adrs/README.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+- [x] No invariant change (ADR-0072 explicitly commits no new invariants — see No New Invariants section).
+
+## Acceptance Criteria
+- [ ] ADR-0072 header reads `**Status:** Accepted`
+- [ ] A new row for ADR-0072 exists in `adrs/README.md` in numerical order after ADR-0057, with Status `Accepted`, Date `2026-05-23`, Sector `Core / cross-cutting`, and the Impact summary text recorded above
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0072-data-access-stance` initiative with a packet checklist matching this folder's contents
+- [ ] `constitution/invariants.md` is **unchanged** by this packet
+- [ ] No catalog schema change in this packet (any catalog updates are in packets 03)
+- [ ] The PR body records the decision *not* to add invariants, with the per-convention reasoning summarized
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0072 D1 — EF Core as the default ORM.** Every Node in the Grid that reads from or writes to a relational database uses Entity Framework Core as the default data-access library. EF Core current LTS, tracked to the .NET LTS cadence. `Microsoft.EntityFrameworkCore.SqlServer` for SQL Server; `Microsoft.EntityFrameworkCore.Npgsql` for Postgres. The .NET ecosystem default; Microsoft's first-party ORM; broadest community familiarity; deepest documentation; most active maintenance; schema-evolution discipline (EF Migrations) built in; model attributes enable cross-cutting policy (PII classification per ADR-0049); DbContext maps onto per-tenant partition strategy per ADR-0050; tooling depth; AI-assistance leverage.
+
+**ADR-0072 D2 — Dapper as the scoped exception.** Permitted for hot-path read queries where (a) EF's generated SQL is measurably worse, (b) allocation profile matters, or (c) the query shape is awkward in LINQ. Evidence-burdened: every Dapper introduction's PR includes the EF-generated query, the hand-written Dapper replacement, and benchmark numbers. Scoped to read paths only; writes go through EF. `FromSqlRaw` inside EF is the first option; Dapper is the second.
+
+**ADR-0072 D3 — EF Migrations is the migration tool per ADR-0048.** Ratifies the implicit ORM behind ADR-0048's migration choice. Per-Node migrations live alongside the Node's DbContext. CI per ADR-0012 runs migrations on the per-environment deploy.
+
+**ADR-0072 D4 — Per-Node DbContext, scoped composition.** Sharing a DbContext across Nodes is forbidden — a runtime coupling violation under the Grid's existing boundary discipline (invariant 11 "one repo per Node" and invariant 2's same-layer rule). `HoneyDrunk.<Node>.Data` hosts the DbContext, entity classes, configurations. `services.AddDbContext<TContext>(opts => ...)` is the standard registration. Connection strings come from Vault per ADR-0005. Per-tenant partitioning per ADR-0050. The repository pattern via `HoneyDrunk.Data` (`IRepository<T>` / `IUnitOfWork`) sits on top — consumers compose against `HoneyDrunk.Data`'s contracts, not against DbContext directly, preserving the migration option in D7.
+
+**ADR-0072 D5 — Query discipline.** `AsNoTracking()` on every read-only query (change tracking is allocation-heavy and serves writes; reads opt out). Projections preferred (narrower SQL, lower allocation, no change-tracking cost). `Include` explicit; lazy loading off (disabled in default DbContext composition). N+1 queries caught at review. Compiled queries permitted for hot paths. Raw SQL via `FromSqlRaw` is parameterized — never string-interpolated (secure-SQL discipline — no existing numbered invariant covers parameterized SQL; the rule is review-enforced under ADR-0072 D5).
+
+**ADR-0072 D6 — Testing discipline.** In-memory provider for unit (Tier 1 per ADR-0047 D2); Testcontainers for integration (Tier 2b per ADR-0047 D4). Dapper code is tested via Testcontainers — the in-memory provider does not apply.
+
+**ADR-0072 D7 — Migration path away from EF Core is bounded.** Consumers depend on `IRepository<T>` / `IUnitOfWork`, not on `DbContext` directly. Swapping the implementation behind those contracts is a per-Node mechanical move. EF Migrations history would be the most painful loss but is bounded — schemas are well-described and migrations are exportable.
+
+**ADR-0072 D8 — Out of scope.** Specific database engine choice (per-Node decision); NoSQL data-access stance (per-backing SDKs apply); read-replica routing (per-Node); connection pooling and DbContext lifetime tuning (defaults); ORM-level data-classification implementation (per-Node enforcement); connection-resiliency policies (per-Node defaults).
+
+**ADR-0072 Consequences — No new invariants.** ADR-0072 commits its five conventions (EF Core default, writes through DbContext, AsNoTracking/Include/lazy-off, per-Node DbContext, connection strings from Vault) as review-enforced, not as numbered invariants. The scope agent's acceptance-time judgment: no convention is elevated. The conventions live in `.claude/agents/review.md` D3 category 13 (packet 01) and `.claude/agents/database.md` rubric (packet 02). See the No New Invariants section above for the per-convention reasoning.
+
+**Invariants 2 and 11 (referenced) — Same-layer dependency rule and one-repo-per-Node.** Together cover the per-Node DbContext rule: a DbContext shared across Nodes would force a runtime dependency from one Node onto another Node's data layer at the same layer (a violation of invariant 2) and would imply two Nodes co-owning a deployable surface (a violation of invariant 11). No new invariant needed.
+
+**`FromSqlRaw` parameterization (review-enforced, not codified as invariant).** No existing numbered invariant covers parameterized SQL. ADR-0072 D5 commits the rule as review-enforced; the generalist `review` agent's D3 category 13 (packet 01) and the `database` specialist agent's rubric (packet 02) carry it. Invariant 8 covers secret values in logs/traces/exceptions/telemetry — a distinct concern; that invariant is **not** the home of the parameterized-SQL rule.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0072 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **No invariants added.** Per the No New Invariants section, do not add any entry to `constitution/invariants.md`. Do not assume a "next free" number; the file is not edited in this packet.
+- **ADR index row insertion.** `adrs/README.md` does not currently have a row for ADR-0072. Insert the row in numerical order after ADR-0057 (the current last row), preserving the table's column structure.
+- **Initiative slug ≤ 39 chars.** `adr-0072-data-access-stance` is 27 chars — well within the limit.
+
+## Labels
+`chore`, `tier-3`, `core`, `docs`, `adr-0072`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0072 to Accepted, add the row to the ADR index, and register the data-access-stance initiative. Do NOT add any invariants.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0072 so the remaining packets in this initiative can reference its decisions as live rules.
+- Feature: ADR-0072 Data Access Stance rollout, Wave 1.
+- ADRs: ADR-0072 (primary), ADR-0008 (initiative/packet conventions), ADR-0044 (review rubric — convention enforcement home).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0072 stays Proposed until this PR merges.
+- **No new invariants.** Do not edit `constitution/invariants.md`. ADR-0072 explicitly commits its decisions as review-enforced conventions.
+- Insert the ADR-0072 row in `adrs/README.md` in numerical order after ADR-0057, with the Impact summary text given in Proposed Implementation.
+- Match the format of existing in-progress initiative entries in `active-initiatives.md`.
+
+**Key Files:**
+- `adrs/ADR-0072-data-access-stance-ef-core-default-dapper-hot-path.md`
+- `adrs/README.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0072-data-access-stance/01-architecture-review-d3-category-13-ef-dapper-discipline.md
+++ b/generated/issue-packets/active/adr-0072-data-access-stance/01-architecture-review-d3-category-13-ef-dapper-discipline.md
@@ -1,0 +1,180 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-3", "meta", "docs", "adr-0072", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0072", "ADR-0044", "ADR-0048"]
+wave: 2
+initiative: adr-0072-data-access-stance
+node: honeydrunk-architecture
+---
+
+# Extend review.md D3 category 13 with ADR-0072 EF Core discipline + Dapper evidence checks
+
+## Summary
+Extend `.claude/agents/review.md` D3 category 13 (Data and persistence integrity) with the ADR-0072 D5 query-discipline checks (`AsNoTracking()`, projections, explicit `Include`, lazy loading off, parameterized `FromSqlRaw`, N+1 detection) and the ADR-0072 D2 Dapper-evidence-burden check (Dapper introductions require the EF query, the hand-written replacement, and benchmark numbers in the PR). These are surface-level checks the generalist `review` agent performs on every PR touching data-layer code; depth review lives in the `database` specialist agent's rubric (packet 02).
+
+## Context
+ADR-0072's Consequences/Invariants section commits five conventions as review-enforced rather than as numbered invariants:
+
+1. EF Core is the default for relational data access (D1).
+2. Writes go through EF Core's DbContext; a Dapper-write path is a hard finding (D2).
+3. `AsNoTracking()` on read-only queries; explicit `Include`; lazy loading off (D5).
+4. DbContext is per-Node, never shared (D4).
+5. Connection strings come from Vault (D4 / ADR-0005).
+
+ADR-0072's Decision D2 also commits Dapper as a **scoped exception with mandatory evidence**: every Dapper introduction's PR carries the EF-generated query, the hand-written Dapper replacement, and benchmark numbers. Without the evidence the introduction is rejected at review.
+
+`.claude/agents/review.md` D3 category 13 (Data and persistence integrity) is the home for the surface-level checks. Category 13 currently carries:
+
+- Data correctness (referential integrity, precision and rounding, idempotency per ADR-0042).
+- Migration safety (backfill, rollback, zero-downtime — extended by sibling initiative `adr-0048-schema-evolution` packet 03).
+- Multi-tenant integrity (isolation per ADR-0026).
+
+This packet appends:
+
+- **EF Core query discipline** (D5 checks) as the per-query review surface.
+- **Dapper-evidence burden** (D2 check) — the generalist flags Dapper introductions for the specialist's evidence review.
+
+**Why surface-level and not depth-level.** The generalist `review` agent runs on every PR. Its category 13 check is a fast, pattern-based scan: "is there an EF query with no `AsNoTracking()` on a read path?", "is there a `FromSqlRaw` with string interpolation?", "is there a new `using Dapper` directive?". When the surface check flags a Dapper introduction, the rubric instructs the operator to invoke the `database` specialist agent for the depth review (the seven-category checklist from ADR-0048 D13 + the ADR-0072 D2/D5 ORM-choice and query-discipline categories from packet 02 of this initiative). The two surfaces compose:
+
+- **Generalist (this packet)** — "Is this a data-layer change? Does it look like it follows the conventions? If not, flag for depth review."
+- **Specialist (packet 02)** — "Is this Dapper introduction backed by evidence? Is the EF query genuinely worse? Are the benchmark numbers credible?"
+
+**Coupling with sibling initiative `adr-0048-schema-evolution`.** ADR-0048's packet 03 also edits `review.md` D3 category 13 — to delegate depth review of migration-touching PRs to the `database` specialist. The two packets edit the same category but different sections of it:
+
+- ADR-0048's packet 03 adds a delegation stanza at the end of category 13 ("for migration-touching PRs, delegate to `database`").
+- This packet adds query-discipline checks alongside the existing data-correctness / migration-safety / multi-tenant-integrity bullets, and adds a Dapper-introduction surface check.
+
+The two edits are additive and order-tolerant. If ADR-0048's packet 03 lands first, this packet's additions land alongside the existing delegation stanza. If this packet lands first, ADR-0048's packet 03 adds its delegation stanza below the query-discipline section. Neither replaces the other's content.
+
+This is a docs/agent-configuration packet. No code, no .NET project.
+
+## Scope
+- `.claude/agents/review.md` — extend D3 category 13 (Data and persistence integrity) with the ADR-0072 D5 query-discipline checks and the D2 Dapper-evidence-burden surface check.
+- No edit to `database.md` (packet 02 owns it).
+- No edit to any other agent file.
+
+## Proposed Implementation
+1. **Locate D3 category 13** in `.claude/agents/review.md`. The categories were established by ADR-0044 packets 04 and 09 (rubric-roll-out); the rubric is a twenty-category list. Category 13 is titled **"Data and persistence integrity"** — confirm the exact title and capitalization at edit time.
+
+2. **Add a new bulleted sub-section under category 13** titled **"EF Core query discipline (per ADR-0072 D5)"**, with the following checks. Match the file's existing bullet style and severity-tag conventions. Each check below is a per-bullet item:
+
+   - **`AsNoTracking()` on read-only queries.** Read-only EF queries (returning a list or a single entity for display, not for modification) carry `AsNoTracking()` to opt out of change tracking. Reads without `AsNoTracking()` are allocation-heavy; the surface check looks for `_context.<DbSet>.Where(...).ToList()` patterns without `.AsNoTracking()` in the chain.
+   - **Projections preferred for column-subset reads.** Where the consumer needs a subset of columns, `.Select(x => new ProjectionType { ... })` is preferred over loading the full entity. The surface check looks for full-entity loads followed by mapping to a smaller shape — that mapping should happen in SQL via `Select`, not in memory.
+   - **`Include` is explicit; lazy loading is off.** Navigation properties are loaded via explicit `Include` calls. Lazy loading is disabled in the default DbContext composition; a `UseLazyLoadingProxies()` call is a **Block** finding. Explicit-loading via `context.Entry(...).Reference(...).Load()` is permitted but should be justified.
+   - **N+1 queries are caught at review.** The `foreach (var item in list) { var related = ctx.Related.Where(r => r.ItemId == item.Id).ToList(); }` pattern is the classic N+1; rewrite as a single query with `Include` or projection. The surface check looks for `.ToList()` inside loops that themselves iterate over a `.ToList()` result.
+   - **Compiled queries permitted for hot paths.** `EF.CompileQuery` is permitted where the compile cost amortizes (high-frequency read paths). The surface check does not block compiled queries; it flags them for the specialist's evidence check if introduced (the compile cost should be justified).
+   - **Raw SQL via `FromSqlRaw` is parameterized.** `FromSqlRaw($"... {input}")` (string interpolation) is a hard **Block** finding — SQL injection risk (review-enforced secure-SQL discipline per ADR-0072 D5; no existing numbered invariant covers parameterized SQL). Use `FromSqlRaw("... {0}", input)` with parameter placeholders, or `FromSqlInterpolated` which parameterizes the interpolated values automatically.
+
+3. **Add a new sub-section under category 13** titled **"Dapper-evidence burden (per ADR-0072 D2)"**, with the following surface checks. Match the file's existing format:
+
+   - **Dapper introductions are flagged for specialist review.** A new `using Dapper;` directive or a new `IDbConnection.Query<T>` / `QueryAsync<T>` call invokes Dapper. The surface check detects this and notes: "Dapper introduction detected — depth review by the `database` specialist agent is required per ADR-0072 D2."
+   - **Dapper-write paths are rejected at the surface.** Dapper writes (`Execute`, `ExecuteAsync`) are scoped out by ADR-0072 D2: writes go through EF Core's DbContext. The surface check rejects Dapper-write introductions as a **Block** finding with the recommendation: "Use EF Core's DbContext for writes; if a write genuinely requires raw SQL, use `MigrationBuilder.Sql(...)` (for schema changes) or `DbContext.Database.ExecuteSqlInterpolated(...)` (for runtime data-layer SQL that still wants EF's connection / transaction management)."
+   - **The evidence-burden checklist is named.** The surface check reminds the operator: "Dapper introductions require (a) the EF-generated query (paste it in the PR body or describe it), (b) the hand-written Dapper replacement, (c) benchmark numbers (BenchmarkDotNet or profiler evidence), and (d) the workload context (expected query frequency, expected row volume, the consuming caller). The `database` specialist agent verifies all four. Missing evidence is a **Block** finding at the specialist's depth review; the generalist's surface check just flags the introduction."
+
+4. **Add a brief connection-strings-from-Vault check** alongside the existing multi-tenant integrity sub-section, since both relate to the per-Node data-layer composition pattern (D4):
+
+   - **Connection strings come from Vault (per ADR-0005 / ADR-0072 D4).** The surface check looks for `appsettings.json` entries with `Server=` / `Host=` / connection-string-shaped values (a regex on `Data Source=`, `Server=`, `Host=`, `Database=`, `User Id=`). A hardcoded connection string in `appsettings.json` or an `IConfiguration` value not routed through `ISecretStore` is a **Block** finding (invariant 9 — Vault is the only source of secrets).
+
+5. **Add a brief per-Node DbContext check** alongside the existing checks:
+
+   - **DbContext is per-Node, never shared (per ADR-0072 D4).** The surface check looks for `using HoneyDrunk.<OtherNode>.Data;` directives in a Node that should not depend on another Node's data layer. A cross-Node DbContext reference is a **Block** finding — under the Grid's boundary discipline (invariant 11 "one repo per Node" and invariant 2's same-layer rule), a cross-Node DbContext forces a runtime dependency between Nodes at the same layer; per ADR-0072 D4, each Node owns its own DbContext.
+
+6. **Severity scale alignment.** Per ADR-0044 D3 / `copilot/pr-review-rules.md`, the rubric uses the Grid severity taxonomy: **Block / Request Changes / Suggest**. The new checks inherit the scale:
+   - **Block**: string-interpolated `FromSqlRaw`, hardcoded connection strings, cross-Node DbContext references, Dapper-write introductions.
+   - **Request Changes**: missing `AsNoTracking()` on a clearly read-only path, lazy-loading proxies enabled, an N+1 pattern.
+   - **Suggest**: a column-subset read without projection, a compiled query without justification, a Dapper-read introduction (flagged for specialist evidence review — the introduction itself is not Block at the generalist surface; the specialist's depth check determines the outcome).
+
+7. **Match the existing format and tone.** Severity tags, capitalization, list style — match the file's established conventions. ADR-0044 packets 04 and 09 set the format; do not invent a parallel structure.
+
+8. **Update the category 13 "Execution detail" and "Severity mapping" paragraphs.** Category 13 currently has trailing paragraphs naming the inspection surface and the severity mapping (block / changes / suggest). Extend the existing text to include the new ORM-discipline surface:
+   - **Execution detail** add-on: "Also inspect EF query patterns (`AsNoTracking()`, projections, `Include`, lazy-loading state, parameterized raw SQL), Dapper introductions (flag for specialist evidence review), connection-string sourcing (Vault per ADR-0005 / invariant 9), and per-Node DbContext boundary (no cross-Node DbContext references — grounded in invariants 2 and 11 per ADR-0072 D4)."
+   - **Severity mapping** add-on (using the Grid severities Block / Request Changes / Suggest per `copilot/pr-review-rules.md`): "Block for string-interpolated `FromSqlRaw`, hardcoded connection strings, cross-Node DbContext references, and Dapper-write introductions. Request Changes for missing `AsNoTracking()` on read paths, lazy-loading proxies, or N+1 patterns. Suggest for unprojected column-subset reads and unjustified compiled queries. Flag Dapper-read introductions for the `database` specialist agent's depth evidence review (generalist itself does not block)."
+
+## Affected Files
+- `.claude/agents/review.md`
+
+## NuGet Dependencies
+None. This packet touches only a Markdown agent-rubric file; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly. `.claude/agents/review.md` is governance content that lives in this repo.
+- [x] No code change in any other repo.
+- [x] The review-rubric is the ADR-0044-established surface; this packet extends category 13 with ORM-discipline checks consistent with ADR-0072 D2/D4/D5's explicit commitments.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/review.md` D3 category 13 (Data and persistence integrity) carries a new sub-section titled "EF Core query discipline (per ADR-0072 D5)" with the six bullet checks: `AsNoTracking()`, projections preferred, explicit `Include` + lazy off, N+1, compiled queries, parameterized `FromSqlRaw`
+- [ ] Category 13 carries a new sub-section titled "Dapper-evidence burden (per ADR-0072 D2)" with the three surface checks: Dapper introductions flagged, Dapper-writes rejected at surface, evidence-burden checklist named (EF query / Dapper query / benchmarks / workload context)
+- [ ] Category 13 carries the connection-strings-from-Vault check and the per-Node DbContext check
+- [ ] The "Execution detail" paragraph at the end of category 13 is extended to include the new ORM-discipline surface
+- [ ] The "Severity mapping" paragraph is extended to include the new Block / Request Changes / Suggest mappings (matching the existing rubric's Grid severity taxonomy)
+- [ ] Existing category-13 checks (data correctness, migration safety extended by `adr-0048-schema-evolution`, multi-tenant integrity) are preserved, not replaced
+- [ ] If `adr-0048-schema-evolution` packet 03's delegation stanza has landed already, it remains intact alongside the new ADR-0072 additions
+- [ ] The severity scale matches the existing rubric's scale (Block / Request Changes / Suggest per ADR-0044 D3 and `copilot/pr-review-rules.md`)
+- [ ] No edits to `database.md` (packet 02 owns it) or `scope.md`
+- [ ] No invariant change in this packet (no edits to `constitution/invariants.md`)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0072 D2 — Dapper as the scoped exception with mandatory evidence.** Every Dapper introduction's PR includes (a) the EF-generated query, (b) the hand-written Dapper replacement, (c) benchmark numbers, (d) the workload context. Dapper is scoped to read paths only; writes go through EF's DbContext. `FromSqlRaw` inside EF is the first option; Dapper is the second. The generalist `review` agent's surface check flags Dapper introductions for the `database` specialist agent's depth evidence review (per packet 02).
+
+**ADR-0072 D4 — Per-Node DbContext, scoped composition.** Each Node owns its own `DbContext`(s); sharing across Nodes is forbidden (grounded in invariants 2 and 11). Connection strings come from Vault per ADR-0005 via `ISecretStore` (invariant 9); `appsettings.json` connection-string-shaped values are **Block**.
+
+**ADR-0072 D5 — Query discipline.** `AsNoTracking()` on every read-only query. Projections preferred. `Include` explicit; lazy loading off. N+1 caught at review. Compiled queries permitted for hot paths. `FromSqlRaw` parameterized — never string-interpolated.
+
+**ADR-0044 D3 — Twenty-category review rubric and severity taxonomy.** Category 13 is "Data and persistence integrity." The rubric uses the Grid severity taxonomy (**Block / Request Changes / Suggest**, per `copilot/pr-review-rules.md` referenced from the rubric file) that the new ADR-0072 checks inherit. The generalist `review` agent owns the surface; depth lives with specialists per ADR-0046.
+
+**ADR-0046 D1 — Specialists complement, do not replace, the `review` agent.** Specialist findings do not gate merge any more than the generalist's. The Dapper-evidence depth review under the `database` specialist (packet 02) is advisory; the merge gate stays with the human.
+
+**ADR-0048 D13 — `database` specialist agent.** Owns the depth review for migration-touching PRs (the seven-category checklist from D13). Sibling initiative `adr-0048-schema-evolution` packet 02 authors the agent file; this initiative's packet 02 extends the rubric with ADR-0072's ORM-choice and query-discipline categories.
+
+**Invariants 2 and 11 (referenced) — Same-layer dependency rule and one-repo-per-Node.** Cross-Node DbContext references force a runtime dependency between Nodes at the same layer (violating invariant 2) and imply two Nodes co-owning a deployable surface (violating invariant 11). The surface check rejects them as **Block**.
+
+**`FromSqlRaw` parameterization (review-enforced).** No existing numbered invariant covers parameterized SQL. ADR-0072 D5 commits the rule as review-enforced; string-interpolated `FromSqlRaw` is a **Block** finding under category 13. Invariant 8 covers secret values in logs/traces — a distinct concern and not the home of this rule.
+
+**ADR-0005 (referenced) — Connection strings come from Vault.** Hardcoded connection-string values in `appsettings.json` are **Block** (invariant 9 — Vault is the only source of secrets).
+
+## Constraints
+- **Additive, not replacing.** Existing category-13 surface checks (data correctness, migration safety, multi-tenant integrity) are kept. The new ORM-discipline sub-sections are appended; they do not delete or rewrite existing language.
+- **Sibling-edit coexistence.** Sibling initiative `adr-0048-schema-evolution` packet 03 adds a delegation stanza to category 13. The two edits are additive and order-tolerant; preserve any delegation language already present, and add the new ADR-0072 sub-sections alongside.
+- **Match the rubric's existing format.** Severity tags, capitalization, list style — match the file's established conventions. ADR-0044 packets 04 and 09 set the format; do not invent a parallel structure.
+- **Severity discipline.** Use the Grid severities **Block / Request Changes / Suggest** per `copilot/pr-review-rules.md`. Block for string-interpolated `FromSqlRaw`, hardcoded connection strings, cross-Node DbContext references, Dapper-write introductions. Request Changes for missing `AsNoTracking()`, lazy-loading proxies, N+1. Suggest for unprojected column-subset reads, unjustified compiled queries, Dapper-read introductions (flagged for specialist evidence review).
+- **No invariant change.** ADR-0072 explicitly does not add invariants; this packet does not edit `constitution/invariants.md`.
+- **Advisory posture preserved.** Both the surface check (generalist) and the depth review (specialist) are advisory. The merge gate stays with the human and CI per ADR-0011 D5 / ADR-0046 D1.
+
+## Labels
+`feature`, `tier-3`, `meta`, `docs`, `adr-0072`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Extend `.claude/agents/review.md` D3 category 13 with the ADR-0072 D5 query-discipline checks and the D2 Dapper-evidence-burden surface check.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land the ADR-0072 review-time conventions as surface checks in the generalist `review` agent's category 13 rubric.
+- Feature: ADR-0072 Data Access Stance rollout, Wave 2.
+- ADRs: ADR-0072 D2/D4/D5 (primary), ADR-0044 D3 (rubric format and Grid severity taxonomy Block / Request Changes / Suggest), ADR-0046 D1 (specialist pattern and advisory posture), ADR-0048 D13 (delegation to `database` specialist for depth review), ADR-0005 (connection strings from Vault).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0072 must be Accepted so the rubric additions cite its decisions as live rules.
+
+**Constraints:**
+- Additive — do not delete existing category-13 surface checks (data correctness, migration safety, multi-tenant integrity).
+- Sibling-edit coexistence — preserve any `adr-0048-schema-evolution` packet 03 delegation language; add new sub-sections alongside.
+- Match the rubric's existing format and Grid severity taxonomy (Block / Request Changes / Suggest).
+- No invariant change.
+- Advisory posture preserved.
+
+**Key Files:**
+- `.claude/agents/review.md` (specifically D3 category 13).
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0072-data-access-stance/02-architecture-database-agent-orm-and-query-discipline.md
+++ b/generated/issue-packets/active/adr-0072-data-access-stance/02-architecture-database-agent-orm-and-query-discipline.md
@@ -1,0 +1,211 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-3", "meta", "docs", "adr-0072", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0072", "ADR-0048", "ADR-0046"]
+wave: 2
+initiative: adr-0072-data-access-stance
+node: honeydrunk-architecture
+---
+
+# Extend the `database` specialist agent rubric with ADR-0072 ORM-choice and query-discipline categories
+
+## Summary
+Extend the `.claude/agents/database.md` specialist review agent (authored under sibling initiative `adr-0048-schema-evolution` packet 02) with two new rubric categories: **ORM choice** (per ADR-0072 D1/D2 — is the implementation EF Core; if Dapper is used, is the evidence burden met?) and **query discipline** (per ADR-0072 D5 — deep checks for `AsNoTracking()` usage, projection adequacy, `Include` explicitness, N+1 patterns, compiled-query justification, raw-SQL parameterization). These are depth-level checks; the generalist `review` agent (packet 01) surfaces flags, and the specialist verifies the evidence.
+
+## Context
+ADR-0072 D2 commits Dapper as a **scoped exception with mandatory evidence**: every Dapper introduction's PR carries the EF-generated query, the hand-written Dapper replacement, benchmark numbers, and the workload context. ADR-0072 D5 commits a per-query discipline (`AsNoTracking()` / projections / explicit `Include` / lazy off / parameterized raw SQL).
+
+ADR-0072's Follow-up Work names: "The `review` agent's checklist gains the Dapper-evidence and EF-discipline checks per D5." The generalist's checklist (packet 01 of this initiative) is the surface; the specialist's rubric is the depth. The depth checks live in the `database` specialist agent's rubric — the file authored under sibling initiative `adr-0048-schema-evolution` packet 02.
+
+**Coupling with `adr-0048-schema-evolution` packet 02.** The `database` agent file at `.claude/agents/database.md` is created by `adr-0048-schema-evolution` packet 02. That packet establishes the seven-category rubric for schema-evolution depth review (D2 expand/contract, D5 window adequacy, D6 online primitives, D8 Audit constraints, D9 tenant scoping, D10 rollback declaration, D12 tests present, plus EF Core idiom). This packet **adds two additional categories** to the same rubric:
+
+- **Category 8 (new) — ORM choice (per ADR-0072 D1/D2).** Is the relational data-layer change using EF Core (the default)? If Dapper is used, are the four evidence items present (EF query, Dapper query, benchmarks, workload context)? If Marten / RepoDb / raw ADO.NET / EF 6 is used, is there an explicit ADR amendment justifying the deviation?
+- **Category 9 (new) — Query discipline (per ADR-0072 D5).** The depth-level review of EF query patterns — `AsNoTracking()` placement, projection adequacy (does the query genuinely need the full entity, or is a `Select` projection appropriate?), `Include` explicitness and `ThenInclude` chains, lazy-loading state (must be off), N+1 patterns at the runtime call site, compiled-query amortization (is the compile cost justified by the call frequency?), raw-SQL parameterization.
+
+The two categories sit alongside the existing seven categories. The `database` agent's rubric grows from 7 to 9 categories total.
+
+**Hard sequencing.** This packet edits a file authored by the sibling initiative `adr-0048-schema-evolution` packet 02. The sibling packet **must merge first**. This packet's `dependencies:` array does not (and cannot) wire a `packet:NN` reference across initiatives — the filing pipeline's `packet:NN` form only resolves within the current initiative folder. Instead, this packet is gated **textually** on the sibling: the executor MUST confirm `.claude/agents/database.md` exists on `main` before opening the PR. If the sibling has not merged, this packet's issue stays open but no PR is opened until the sibling lands. The executor records the sibling sequencing in the PR body. There is no "create a holding document" alternative — that path produces an artifact that `file-packets` cannot route as a single appendable edit. The single canonical action is: append two rubric categories to the existing `.claude/agents/database.md`.
+
+**Why depth-level review for ORM choice and query discipline matters.** The generalist surface check (packet 01) is pattern-based and fast — it flags introductions and obvious violations. The specialist depth review is contextual:
+
+- For the **ORM choice** category — verifying Dapper evidence requires reading benchmark numbers and judging whether the EF-generated SQL is genuinely worse for the consuming workload. Pattern-matching can't do this; a specialist agent reading the PR body and the benchmark output can.
+- For the **query discipline** category — the surface check flags missing `AsNoTracking()` on what looks like a read path. The depth check confirms it's *actually* a read path (the entity is genuinely not modified), confirms the projection shape is the narrowest one the consumer needs, confirms the `Include` chain doesn't pull in a navigation property that the projection doesn't use.
+
+The two together compose the right review surface: fast surface check on every PR, deep evidence check on data-layer PRs flagged by the specialist's invocation.
+
+This is a docs/agent-configuration packet. No code, no .NET project.
+
+## Scope
+- `.claude/agents/database.md` — append two new rubric categories (ORM choice, query discipline) to the existing seven-category rubric. **Sibling sequencing**: this file is authored by `adr-0048-schema-evolution` packet 02. That packet must merge first; this packet's executor confirms the file exists on `main` before opening the PR.
+- No edit to `review.md` (packet 01 owns it).
+- No edit to any other agent file.
+
+## Proposed Implementation
+
+### Step 1. Confirm sibling sequencing
+
+Read `.claude/agents/database.md`. If the file exists with the seven-category rubric from `adr-0048-schema-evolution` packet 02, proceed to Step 2. If the file does not exist (sibling packet 02 has not merged), **do not open the PR**: leave the issue open and wait. Record the sibling-sequencing wait in a comment on the issue. The packet is hard-blocked on the sibling's merge; there is no proposed/holding-document fallback (that path produces an artifact `file-packets` cannot route to a clean append edit).
+
+### Step 2. Append two new rubric categories to the existing `database.md`
+
+The existing rubric has seven categories (numbered, paraphrased from `adr-0048-schema-evolution` packet 02):
+
+1. D2 expand/contract pattern conformance
+2. D5 backward-compatibility window adequacy
+3. D6 online primitives on tables ≥ 100k rows
+4. D8 Audit `AuditEntry` append-only-by-interface constraints
+5. D9 tenant scoping
+6. D10 `[Rollback]` attribute declaration
+7. D12 round-trip test presence
+8. (operational) EF Core idiom — `MigrationBuilder.Sql(...)` and `--idempotent` cleanliness
+
+Add the two new categories below the existing ones. They are not migration-scoped (the first eight are); they are ORM-scoped. They apply to **every PR touching data-layer code**, not only PRs touching `Migrations/` or `Backfill/`. The `database` agent's invocation surface (from the existing rubric) is "PRs touching `Migrations/`, `Backfill/`, or any file referenced from a `DbContext`" — that surface already encompasses the new categories' applicability.
+
+#### Category 9 — ORM choice (per ADR-0072 D1/D2)
+
+The depth review confirms that the data-layer change uses EF Core (the default per D1) and, if Dapper is introduced, that the evidence burden is met.
+
+**Sub-checks:**
+
+- **EF Core is the default.** If the data-layer change uses `Microsoft.EntityFrameworkCore.*` packages (SqlServer or Npgsql), the default is satisfied — no further check.
+- **Marten / RepoDb / raw ADO.NET / EF 6 deviation.** If the change uses any of these, look for an explicit ADR amendment justifying the deviation. Without an amendment, this is a **Block** finding. ADR-0072 D1's negative form: "Dapper is not the default; Marten is not adopted; raw ADO.NET is not the default; Entity Framework 6 / Classic is forbidden for new work; RepoDb / Pomelo / freshly-released micro-ORMs are not adopted as defaults."
+- **Dapper introduction — evidence burden.** If the change introduces Dapper (`using Dapper;` or `IDbConnection.Query<T>` / `QueryAsync<T>` calls), verify all four evidence items are present in the PR body or linked artifacts:
+  - **(a) The EF-generated query.** Either pasted in the PR body (preferred) or described with enough specificity that the reviewer can verify the query shape against EF's `ToQueryString()` output. The expected EF query is the one the PR replaces.
+  - **(b) The hand-written Dapper query.** The actual SQL the Dapper call sends. Present in code (Dapper string literal) plus an explanation of why the hand-written form is materially different from the EF-generated form.
+  - **(c) Benchmark numbers.** BenchmarkDotNet output or profiler evidence comparing the EF path and the Dapper path on the consuming workload's representative shape. The benchmark must show a measurable, workload-relevant difference (e.g., 3× latency reduction on a path called 10k times per minute; not "Dapper is 5% faster on a query called once per hour").
+  - **(d) Workload context.** The expected query frequency, the expected row volume, the consuming caller. The benchmark difference matters only at the consuming workload's scale; the workload context lets the reviewer judge whether the difference matters.
+  Missing any of (a), (b), (c), or (d) is a **Block** finding. The introduction is rejected until evidence is supplied.
+- **Dapper-write introduction.** If the change introduces a Dapper write path (`Execute`, `ExecuteAsync`), this is a **Block** finding regardless of evidence. ADR-0072 D2 scopes Dapper to read paths only; writes go through EF Core's DbContext. Recommendation: "If the write genuinely requires raw SQL, use `MigrationBuilder.Sql(...)` for schema changes or `DbContext.Database.ExecuteSqlInterpolated(...)` for runtime data-layer SQL that still wants EF's connection / transaction management."
+- **Per-Node, per-query scope.** Verify that adopting Dapper for one query in a Node does not implicitly adopt it for the Node's other queries. The EF default still applies to everything else in the Node. If the PR introduces multiple Dapper queries at once, each one needs its own evidence — a blanket "we're using Dapper everywhere in this Node now" is rejected. ADR-0072 D2: "Per-Node, per-query."
+- **`FromSqlRaw` vs Dapper.** ADR-0072 D2: "`FromSqlRaw` inside EF is the in-between answer. It is preferred over Dapper when the hand-written query still wants EF's change tracking or composition." If the Dapper introduction's query is one that could equally well use `FromSqlRaw` and stay inside EF's pipeline (it composes with other EF queries, it benefits from change tracking, the result type is an entity), the depth review's recommendation is: "Consider `FromSqlRaw` inside EF instead of Dapper. Provide the workload reasoning if Dapper is preferred." This is a **Request Changes** finding, not Block.
+
+**Severity mapping** (Grid taxonomy Block / Request Changes / Suggest per `copilot/pr-review-rules.md`): **Block** for Marten/RepoDb/raw-ADO.NET/EF-6 without ADR amendment; **Block** for missing Dapper evidence; **Block** for Dapper-write introductions. **Request Changes** for `FromSqlRaw`-vs-Dapper preference. **Suggest** for blanket-Dapper-adoption flags.
+
+#### Category 10 — Query discipline (per ADR-0072 D5)
+
+The depth review confirms the per-query patterns. The generalist's surface check (packet 01 of this initiative) flags missing patterns; the specialist confirms the flagged sites are genuinely problematic.
+
+**Sub-checks:**
+
+- **`AsNoTracking()` on read-only queries — confirmed read-only?** The surface check looks for `_context.<DbSet>.Where(...).ToList()` without `AsNoTracking()`. The depth check confirms: is the resulting entity actually not modified in the consuming code? If the entity is read for display only and never has any setter called, `AsNoTracking()` is missing and should be added — **Request Changes** finding. If the entity is read and then modified and saved back, the missing `AsNoTracking()` is correct — no finding.
+- **Projection adequacy.** The surface check looks for full-entity loads followed by mapping. The depth check confirms: does the consuming code actually use every column on the entity? If only three columns are touched downstream, the load should be a `Select` projection of those three columns — **Request Changes** finding. If the consumer genuinely uses every column, the full-entity load is correct.
+- **`Include` chain audit.** Confirm that every `Include` and `ThenInclude` in the query corresponds to a navigation property the consumer actually uses. Unused `Include` chains are over-fetching and should be removed — **Request Changes** finding for a clearly-unused chain; **Suggest** for a chain that might be used in an edge case.
+- **Lazy loading off.** Confirm that the DbContext composition does not enable lazy-loading proxies. A `UseLazyLoadingProxies()` call is a **Block** finding. The default DbContext composition has lazy loading off; this is a deviation that requires an explicit ADR amendment.
+- **N+1 at the call site.** Confirm that the surface check's flagged N+1 site is genuinely an N+1 (the inner query is per-iteration with a varying parameter) and not a constant-parameter query that's loop-invariant. The fix is either an `Include` to eager-load the related entities, a `GroupBy` projection, or a `Join`. **Request Changes** finding.
+- **Compiled query justification.** `EF.CompileQuery` is permitted for hot paths where the compile cost amortizes. Confirm the introduction's call site is genuinely hot (high frequency, low latency requirement). If the path is called once an hour, compiled queries are over-engineered — **Suggest** finding to remove. If the path is called thousands of times per minute, compiled queries are appropriate — no finding.
+- **Raw SQL parameterization (depth check).** The surface check rejects string-interpolated `FromSqlRaw` as Block. The depth check confirms that the parameterized form is correctly parameterized (positional `{0}` / `{1}` placeholders match the parameter array order; `FromSqlInterpolated` is used where interpolation is desired). A subtly mis-parameterized `FromSqlRaw` is still a SQL injection risk — **Block** finding.
+- **Tenant predicate presence.** For Nodes where the table has a `TenantId` column (per ADR-0026 multi-tenant primitives), confirm the query carries a tenant predicate or is run under a global query filter that injects one. A tenant-table query without a tenant predicate is a **Block** cross-tenant leakage finding (per the existing category 13 multi-tenant integrity check in `review.md`, but the specialist confirms at depth).
+
+**Severity mapping** (Grid taxonomy Block / Request Changes / Suggest per `copilot/pr-review-rules.md`): **Block** for lazy-loading proxies, mis-parameterized raw SQL, missing tenant predicates on tenant tables. **Request Changes** for genuine missing `AsNoTracking()`, missing projections, unused `Include` chains, confirmed N+1. **Suggest** for over-engineered compiled queries.
+
+### Step 3. Reference the generalist surface from the depth rubric
+
+In both categories 9 and 10, add a brief note that the **generalist `review` agent (per ADR-0044 D3 category 13)** surfaces the introductions / patterns, and the specialist confirms at depth. The two surfaces compose. The phrasing should match the format used by the existing categories (which reference ADR-0048 D-decisions for each category).
+
+### Step 4. Update the agent's invocation surface text
+
+The existing invocation surface from `adr-0048-schema-evolution` packet 02 is: "PRs touching `Migrations/`, `Backfill/`, or any file referenced from a `DbContext`." Extend this to include: "PRs introducing Dapper (`using Dapper;` or `IDbConnection.Query<T>` / `Execute` / `ExecuteAsync`) or modifying EF query patterns (calls to `AsNoTracking()`, `Include`, `Select`, `FromSqlRaw`, `EF.CompileQuery`)." The expanded surface ensures the specialist is invoked on data-layer PRs even when no `Migrations/` or `Backfill/` file is touched.
+
+If the existing agent file already documents the invocation surface elsewhere (e.g., a "When to invoke" section), update that text to include the ADR-0072 Dapper / EF-query trigger surface.
+
+### Step 5. Severity scale consistency
+
+The new categories inherit the Grid severity taxonomy from the existing seven categories (**Block / Request Changes / Suggest** per ADR-0044 D3 and `copilot/pr-review-rules.md`). No new severity is introduced. Each sub-check above is tagged with its severity in line with the existing rubric's tagging.
+
+### Step 6. Reference ADR-0072 decisions inline
+
+Per the self-containment rule (agent file consumers do not have access to ADR text), inline the relevant ADR-0072 D-decision text in each category's header. For category 9, the header text: "**Category 9 — ORM choice (per ADR-0072 D1/D2).** ADR-0072 D1 commits EF Core as the default ORM for every Node touching a relational store. D2 permits Dapper as the scoped exception for hot-path reads where (a) EF's generated SQL is measurably worse, (b) allocation profile matters, or (c) the query shape is awkward in LINQ — with mandatory evidence in the PR." Similar inlining for category 10.
+
+## Affected Files
+- `.claude/agents/database.md` (appended with categories 9 and 10).
+
+## NuGet Dependencies
+None. This packet touches only Markdown agent-rubric files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly. `.claude/agents/` is governance content that lives in this repo.
+- [x] No code change in any other repo.
+- [x] The specialist-agent file is the ADR-0048-D13-committed surface authored by the sibling initiative; this packet extends its rubric consistent with ADR-0072's explicit D2/D5 commitments.
+
+## Acceptance Criteria
+- [ ] The PR body records that `.claude/agents/database.md` existed on `main` before the PR was opened (sibling `adr-0048-schema-evolution` packet 02 has merged)
+- [ ] `.claude/agents/database.md` carries two new rubric categories (9 and 10) appended after the existing seven categories
+- [ ] Category 9 (ORM choice per ADR-0072 D1/D2) carries the sub-checks: EF Core default; deviation justification; Dapper introduction evidence burden (a-d); Dapper-write rejection; per-Node-per-query scope; `FromSqlRaw`-vs-Dapper preference
+- [ ] Category 10 (Query discipline per ADR-0072 D5) carries the sub-checks: `AsNoTracking()` confirmation; projection adequacy; `Include` chain audit; lazy-loading off; N+1 confirmation; compiled-query justification; raw-SQL parameterization depth check; tenant predicate presence
+- [ ] The agent's invocation surface is extended to include Dapper introductions and EF query pattern modifications
+- [ ] Each new category cites ADR-0072 D1/D2/D5 inline (not just by number)
+- [ ] The severity scale matches the existing rubric (**Block / Request Changes / Suggest** per ADR-0044 D3 and `copilot/pr-review-rules.md`)
+- [ ] The reference to the generalist surface (per ADR-0044 D3 category 13, established in packet 01 of this initiative) is present in both new categories
+- [ ] No edit to `review.md` (packet 01 owns it) or any other agent file
+- [ ] No invariant change (no edits to `constitution/invariants.md`)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0072 D1 — EF Core as the default ORM.** Every Node touching a relational store uses EF Core. EF Core current LTS, `Microsoft.EntityFrameworkCore.SqlServer` / `Microsoft.EntityFrameworkCore.Npgsql`. Marten / RepoDb / raw ADO.NET / EF 6 / Pomelo are not defaults; deviations require an explicit ADR amendment.
+
+**ADR-0072 D2 — Dapper as the scoped exception with mandatory evidence.** Every Dapper introduction's PR carries (a) the EF-generated query, (b) the hand-written Dapper replacement, (c) benchmark numbers, (d) the workload context. Dapper is scoped to read paths; writes go through EF's DbContext. Per-Node, per-query. `FromSqlRaw` inside EF is the first option; Dapper is the second.
+
+**ADR-0072 D5 — Query discipline.** `AsNoTracking()` on read-only queries. Projections preferred. `Include` explicit; lazy loading off. N+1 caught at review. Compiled queries permitted for hot paths. `FromSqlRaw` parameterized — never string-interpolated.
+
+**ADR-0048 D13 — `database` specialist agent.** Authored under `.claude/agents/database.md` per ADR-0046's pattern. Walks every PR touching `Migrations/`, `Backfill/`, or any file referenced from a `DbContext`. Owns the seven-category depth rubric from D13 (D2/D5/D6/D8/D9/D10/D12 plus EF Core idiom). ADR-0072 extends this rubric with two additional categories (ORM choice, query discipline).
+
+**ADR-0046 D1 — Specialists complement, do not replace, the `review` agent.** Specialist findings are advisory. The merge gate stays with the human.
+
+**ADR-0046 D3 — Manual invocation at v1.** The operator invokes the specialist; no CI triggers at v1. ADR-0072's depth checks ride on the same manual-invocation surface.
+
+**ADR-0044 D3 — Grid severity taxonomy (Block / Request Changes / Suggest, per `copilot/pr-review-rules.md`).** The new categories inherit the taxonomy.
+
+**ADR-0026 (referenced) — Tenant predicate discipline.** Tenant-table queries without a tenant predicate are **Block** (cross-tenant leakage).
+
+**Invariants 2 and 11 (referenced) — Same-layer dependency rule and one-repo-per-Node.** Cross-Node DbContext references force a runtime dependency between Nodes at the same layer (violating invariant 2) and imply two Nodes co-owning a deployable surface (violating invariant 11). Not a category-9 / category-10 check directly (the generalist surface in packet 01 catches it) but a referenced rule for context.
+
+**`FromSqlRaw` parameterization (review-enforced).** No existing numbered invariant covers parameterized SQL — the rule lives in ADR-0072 D5 and is enforced by this category 10 raw-SQL parameterization sub-check. Mis-parameterized `FromSqlRaw` is a SQL injection risk; **Block** under category 10.
+
+## Constraints
+- **Hard sibling sequencing.** This packet is gated on `adr-0048-schema-evolution` packet 02 having merged. The filing pipeline's `packet:NN` form only resolves intra-initiative; cross-initiative coupling is enforced **textually** here: the executor confirms `.claude/agents/database.md` exists on `main` before opening this packet's PR. If the sibling has not merged, the issue stays open with a wait comment; no PR is opened.
+- **No holding-document fallback.** The earlier "Case B — create a proposed-form holding document" path is removed: it produces an artifact `file-packets` cannot route, and dilutes the packet's single canonical action.
+- **Additive, not replacing.** The existing seven rubric categories from `adr-0048-schema-evolution` packet 02 are kept; the two new categories are appended.
+- **Match the existing rubric format.** Severity tags, category numbering, header style — match the file's established conventions established by the sibling initiative's packet 02.
+- **No invariant change.** ADR-0072 explicitly does not add invariants; this packet does not edit `constitution/invariants.md`.
+- **Advisory posture preserved.** Both surface (generalist) and depth (specialist) findings are advisory per ADR-0046 D1 / ADR-0011 D5.
+- **Inline ADR decisions.** Per the self-containment rule, the new categories cite ADR-0072 D-decisions inline as full text, not just by number.
+
+## Labels
+`feature`, `tier-3`, `meta`, `docs`, `adr-0072`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Extend the `database` specialist agent's rubric with two new ORM-discipline categories from ADR-0072 (ORM choice per D1/D2 and query discipline per D5). **Hard-blocked on `adr-0048-schema-evolution` packet 02 having merged** — confirm `.claude/agents/database.md` exists on `main` before opening the PR. No holding-document fallback.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land the ADR-0072 depth-level review categories in the `database` specialist agent's rubric, so Dapper introductions and EF query patterns get evidence-based depth review.
+- Feature: ADR-0072 Data Access Stance rollout, Wave 2.
+- ADRs: ADR-0072 D1/D2/D5 (primary), ADR-0048 D13 (specialist agent file), ADR-0046 D1/D3 (specialist pattern), ADR-0044 D3 (severity scale).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0072 must be Accepted so the rubric additions cite its decisions as live rules.
+- **Sibling sequencing (textual, not in `dependencies:`)** — `adr-0048-schema-evolution` packet 02 must merge first; that packet creates `.claude/agents/database.md`. The filing pipeline does not support cross-initiative `packet:NN` resolution, so this constraint is enforced by the executor at PR-open time.
+
+**Constraints:**
+- Confirm `.claude/agents/database.md` exists on `main` before opening the PR; otherwise the issue stays open with a wait comment.
+- Additive — preserve the existing seven categories from `adr-0048-schema-evolution` packet 02.
+- Inline ADR-0072 D1/D2/D5 decisions as full text per the self-containment rule.
+- Severity taxonomy matches ADR-0044 D3 (**Block / Request Changes / Suggest** per `copilot/pr-review-rules.md`).
+- No invariant change.
+- Advisory posture preserved.
+
+**Key Files:**
+- `.claude/agents/database.md` (append categories 9 and 10).
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0072-data-access-stance/03a-architecture-data-overview-orm-commitment.md
+++ b/generated/issue-packets/active/adr-0072-data-access-stance/03a-architecture-data-overview-orm-commitment.md
@@ -1,0 +1,147 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-3", "core", "docs", "adr-0072", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0072"]
+wave: 2
+initiative: adr-0072-data-access-stance
+node: honeydrunk-architecture
+---
+
+# Update `repos/HoneyDrunk.Data/overview.md` with the ORM Commitment section
+
+## Summary
+Single governance-doc task from ADR-0072's Follow-up Work: update `repos/HoneyDrunk.Data/overview.md` to record EF Core as the ratified ORM behind `IRepository<T>` / `IUnitOfWork` per ADR-0072 D1/D4. The implementation already exists in `HoneyDrunk.Data.EntityFramework`; this packet ratifies it in the per-Node overview. **The per-Node `integration-points.md` sweep is split out to packet 03b** (which depends on sibling `adr-0048-schema-evolution` packet 01 landing).
+
+## Context
+ADR-0072's Follow-up Work names: "`HoneyDrunk.Data` ratifies EF Core as the implementation behind `IRepository<T>` / `IUnitOfWork`. Existing implementations align (or already align) with this ADR."
+
+`repos/HoneyDrunk.Data/overview.md` is the per-Node governance doc for the Data Node. It currently records the Node's purpose, key packages (including `HoneyDrunk.Data.EntityFramework` as the EF Core repository + unit-of-work implementation), and provider-level packages (`HoneyDrunk.Data.SqlServer`). The overview doc does not yet explicitly cite ADR-0072 — packet 04 of this initiative updates the **Data repo's own README** and CHANGELOG; this packet updates the **Architecture repo's per-Node governance overview** that mirrors the Data Node's posture.
+
+**Why ratify in the Architecture repo and not just the Data repo.** The Architecture repo is the Grid's single source of truth for governance. `repos/HoneyDrunk.<Node>/overview.md` is the canonical "what does this Node do, what does it ship, what are its commitments?" doc — read by other Nodes' integration packets, by the `scope` agent during repo-discovery, and by any agent checking the Node's posture. Recording the ADR-0072 ratification here makes the EF Core commitment discoverable from the Grid's governance surface, not just from the Data repo's own README.
+
+**Split rationale.** The original packet 03 bundled the Data overview update with a per-Node `integration-points.md` sweep across every existing Node. The two tasks have different sequencing: the overview update is purely intra-initiative (only depends on packet 00). The integration-points sweep edits a section that `adr-0048-schema-evolution` packet 01 introduces (`## Migration Coordination`) and therefore depends textually on that sibling packet. Splitting cleanly separates the standalone-actionable work (03a, this packet) from the sibling-sequenced work (03b).
+
+This is a docs/governance packet. No code, no .NET project.
+
+## Scope
+- `repos/HoneyDrunk.Data/overview.md` — add an "ORM Commitment" section recording EF Core as the ratified ORM behind `IRepository<T>` / `IUnitOfWork` per ADR-0072 D1/D4.
+- No edit to any `integration-points.md` file (deferred to packet 03b).
+- No edit to `catalogs/grid-health.json`.
+- No edit to any Node repo.
+
+## Proposed Implementation
+
+Read `repos/HoneyDrunk.Data/overview.md`. It carries:
+- Purpose ("Persistence conventions, repository patterns, tenant-aware data access, and transactional outbox. Provides EF Core and SQL Server implementations.")
+- Key Packages table including `HoneyDrunk.Data.Abstractions`, `HoneyDrunk.Data`, `HoneyDrunk.Data.EntityFramework`, `HoneyDrunk.Data.SqlServer`, `HoneyDrunk.Data.Outbox`, `HoneyDrunk.Data.Outbox.Dispatcher`.
+
+Add a new section titled **"ORM Commitment"** (or "Data-Access Stance" — match the file's existing section-naming style at edit time). Content:
+
+```markdown
+## ORM Commitment
+
+Per ADR-0072 (Data Access Stance), `HoneyDrunk.Data` ratifies **Entity Framework Core** as the implementation behind the `IRepository<T>` and `IUnitOfWork` contracts in `HoneyDrunk.Data.Abstractions`. The implementation lives in `HoneyDrunk.Data.EntityFramework`.
+
+**Decisions:**
+
+- **EF Core current LTS** tracks the .NET LTS cadence (.NET 8 / EF Core 8, .NET 10 / EF Core 10, .NET 12 / EF Core 12, etc.). Per-Node SemVer concerns.
+- **Provider packages:** `HoneyDrunk.Data.SqlServer` for SQL Server backings; future `HoneyDrunk.Data.Npgsql` for Postgres if/when a Node chooses Postgres. Both are EF Core providers.
+- **Dapper is the scoped exception** for hot-path read queries where EF generates poor SQL or where allocation matters. Per-Node, per-query. Evidence-burdened (EF query, Dapper query, benchmarks, workload context in the PR). Dapper writes are not permitted; writes go through EF Core's DbContext. See ADR-0072 D2.
+- **Migration tool is EF Migrations** per ADR-0048. The migration discipline lives in the per-Node `Migrations/` folder (per ADR-0048 D11); the canonical migration runner is the `migrate.yml` workflow in HoneyDrunk.Actions.
+- **Per-Node DbContext.** Each Node owns its own `DbContext`. Sharing across Nodes is forbidden under the Grid's existing boundary discipline (invariant 11 "one repo per Node"; invariant 2's same-layer rule). The per-Node `HoneyDrunk.<Node>.Data` project hosts the DbContext, entity classes, and EF model configurations.
+- **Migration path away from EF Core** is bounded by the `IRepository<T>` / `IUnitOfWork` abstraction. Consumers depend on the contracts, not on `DbContext` directly. If EF Core's trajectory ever turns hostile (license change, hostile maintenance, Microsoft sunset), the migration path is per-Node mechanical rewriting of `HoneyDrunk.Data.EntityFramework` against a different ORM. See ADR-0072 D7.
+
+**Negative form (per ADR-0072 D1 / Alternatives Considered):**
+
+- **Dapper is not the default** — scoped exception only with evidence.
+- **Marten is not adopted as a Grid-wide default** — over-fit for the Grid's CRUD-shaped data; permitted as a per-Node backing for a Node whose specific contract is event-sourcing-shaped, but no such Node exists today.
+- **Raw ADO.NET is not the default** — re-derives change tracking, migration discipline, model composition per Node.
+- **Entity Framework 6 / Classic is forbidden for new work** — maintenance mode, tied to .NET Framework.
+- **RepoDb / Pomelo / freshly-released micro-ORMs are not adopted as defaults** — community / AI-assistance maturity not at Dapper's or EF Core's level in 2026.
+
+**Query discipline (per ADR-0072 D5):** `AsNoTracking()` on read-only queries; projections preferred for column-subset reads; `Include` is explicit and lazy loading is off; N+1 queries are caught at review; compiled queries (`EF.CompileQuery`) are permitted for hot paths; raw SQL via `FromSqlRaw` is parameterized — never string-interpolated. Enforced by the generalist `review` agent's D3 category 13 surface check and the `database` specialist agent's depth rubric.
+
+**Testing discipline (per ADR-0072 D6):** in-memory provider (`Microsoft.EntityFrameworkCore.InMemory`) for fast unit tests per ADR-0047 D2; Testcontainers per ADR-0047 D4 (Tier 2b) for integration tests where the actual SQL provider's behavior matters. Dapper code is tested via Testcontainers — the in-memory provider does not apply.
+```
+
+Place the new section after the existing Key Packages table and before any subsequent sections. Match the file's existing heading hierarchy (probably `##` for top-level Node sections).
+
+## Affected Files
+- `repos/HoneyDrunk.Data/overview.md`
+
+## NuGet Dependencies
+None. This packet touches only a Markdown governance file; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly. `repos/{Node}/...` files are per-Node governance docs that live in the Architecture repo.
+- [x] No code change in any other repo.
+- [x] The per-Node overview is consistent with ADR-0072's D1/D4 commitments.
+
+## Acceptance Criteria
+- [ ] `repos/HoneyDrunk.Data/overview.md` carries a new "ORM Commitment" (or "Data-Access Stance") section recording EF Core as the ratified ORM behind `IRepository<T>` / `IUnitOfWork` per ADR-0072 D1/D4
+- [ ] The new section carries the negative form (Dapper not default, Marten not adopted, raw ADO.NET not default, EF 6 forbidden, RepoDb / Pomelo not adopted) per ADR-0072 D1
+- [ ] The new section carries the query-discipline summary per ADR-0072 D5 and the testing-discipline summary per ADR-0072 D6
+- [ ] The new section names the migration-path-away mechanism per ADR-0072 D7 (bounded by `IRepository<T>` / `IUnitOfWork` abstraction)
+- [ ] No edit to any `integration-points.md` file (that work is packet 03b)
+- [ ] No edit to `catalogs/grid-health.json`
+- [ ] No edit to any Node repo
+- [ ] No invariant change
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0072 D1 — EF Core as the default ORM.** Every Node touching a relational store uses EF Core. Marten / RepoDb / raw ADO.NET / EF 6 / Pomelo are not defaults.
+
+**ADR-0072 D2 — Dapper as the scoped exception with mandatory evidence.** Per-Node, per-query. Scoped to read paths only.
+
+**ADR-0072 D4 — Per-Node DbContext, scoped composition.** Each Node owns its own DbContext. `HoneyDrunk.<Node>.Data` hosts the DbContext, entity classes, EF model configurations. Connection strings come from Vault per ADR-0005.
+
+**ADR-0072 D5 — Query discipline.** `AsNoTracking()` / projections / explicit `Include` / lazy off / parameterized raw SQL.
+
+**ADR-0072 D6 — Testing discipline.** In-memory provider for unit; Testcontainers for integration.
+
+**ADR-0072 D7 — Migration path away from EF Core is bounded.** Consumers depend on `IRepository<T>` / `IUnitOfWork`, not on `DbContext` directly. Swapping the implementation is a per-Node mechanical move.
+
+**Invariants 2 and 11 (referenced) — Same-layer dependency rule and one-repo-per-Node.** Together cover the per-Node DbContext rule: a DbContext shared across Nodes forces a runtime dependency between Nodes at the same layer (violating invariant 2) and implies two Nodes co-owning a deployable surface (violating invariant 11).
+
+## Constraints
+- **Single-file packet.** Touches only `repos/HoneyDrunk.Data/overview.md`. The per-Node `integration-points.md` sweep is packet 03b.
+- **Match existing `overview.md` styling.** Heading hierarchy, list style, link format — match the file's established conventions.
+- **No invariant change.** ADR-0072 explicitly does not add invariants; this packet does not edit `constitution/invariants.md`.
+- **Inline ADR-0072 D-decisions.** Per the self-containment rule, cite full text not just decision numbers in the per-Node documentation.
+
+## Labels
+`feature`, `tier-3`, `core`, `docs`, `adr-0072`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Update `repos/HoneyDrunk.Data/overview.md` to record EF Core as the ratified ORM behind `IRepository<T>` / `IUnitOfWork` per ADR-0072 D1/D4. No `integration-points.md` edits in this packet.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the ADR-0072 EF Core ratification discoverable from the Grid's governance surface (the Architecture repo's per-Node overview).
+- Feature: ADR-0072 Data Access Stance rollout, Wave 2.
+- ADRs: ADR-0072 D1/D2/D4/D5/D6/D7 (primary).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0072 must be Accepted so the overview update cites its decisions as live rules.
+
+**Constraints:**
+- Single-file packet — only `repos/HoneyDrunk.Data/overview.md`.
+- Match existing file styling.
+- No invariant change.
+- Inline ADR-0072 D-decisions as full text.
+
+**Key Files:**
+- `repos/HoneyDrunk.Data/overview.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0072-data-access-stance/03b-architecture-integration-points-data-access-stance-sweep.md
+++ b/generated/issue-packets/active/adr-0072-data-access-stance/03b-architecture-integration-points-data-access-stance-sweep.md
@@ -1,0 +1,167 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-3", "core", "docs", "adr-0072", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0072", "ADR-0048"]
+wave: 2
+initiative: adr-0072-data-access-stance
+node: honeydrunk-architecture
+---
+
+# Add Data-Access Stance to every per-Node `integration-points.md`
+
+## Summary
+Extend every existing `repos/HoneyDrunk.<Node>/integration-points.md` with a **Data-Access Stance** section recording the per-Node ORM posture per ADR-0072 D1/D2/D8. **Hard-blocked on `adr-0048-schema-evolution` packet 01 having merged** — that packet introduces the `## Migration Coordination` section this packet sits alongside, and the `schema_evolution` field in `catalogs/grid-health.json` that determines per-Node default content.
+
+## Context
+ADR-0072's Follow-up Work names the per-Node stance recording: each Node should record its ORM posture (EF Core by default; Dapper exceptions named if any; document-store SDK for NoSQL backings) in a discoverable place.
+
+Per-Node `integration-points.md` files (in `repos/HoneyDrunk.<Node>/integration-points.md`) document the cross-Node integration surface for each Node. Sibling initiative `adr-0048-schema-evolution` packet 01 adds a `## Migration Coordination` section to every existing `integration-points.md`. This packet adds a **Data-Access Stance** section as a sibling to that one, so the per-Node ORM posture and the per-Node migration framework sit side-by-side.
+
+**Hard sequencing.** This packet is gated on `adr-0048-schema-evolution` packet 01 having merged for two reasons:
+
+1. **Section placement.** The Data-Access Stance section is naturally a sibling to `## Migration Coordination`. Without that section existing, this packet has to invent a placement that the sibling's executor would then have to harmonize with — producing a churned edit and a confusing pair of PRs.
+2. **Per-Node default content lookup.** The sibling packet 01 adds the `schema_evolution` field to `catalogs/grid-health.json` (values `ef-core-migrations` / `cosmos-schema-on-read` / `n/a`). This packet's default content per Node reads from that field. Without the field, the executor has to infer the per-Node ORM stance from the actual implementation in each Node repo — a slower, more error-prone path.
+
+The filing pipeline's `packet:NN` form only resolves intra-initiative. Cross-initiative coupling is enforced **textually** here: the executor confirms (a) `catalogs/grid-health.json` contains the `schema_evolution` field on `main`, AND (b) at least one `integration-points.md` has the `## Migration Coordination` section on `main`, before opening this packet's PR. If either condition fails, the issue stays open with a wait comment; no PR is opened.
+
+This is a docs/template packet. No code, no .NET project.
+
+## Scope
+- Every existing `repos/HoneyDrunk.<Node>/integration-points.md` — add a `## Data-Access Stance` section (sibling to `## Migration Coordination`).
+- No edit to `catalogs/grid-health.json` (the `schema_evolution` field's value implies the ORM stance per ADR-0072 D1; no separate `data_access` field is added).
+- No edit to `repos/HoneyDrunk.Data/overview.md` (packet 03a owns it).
+- No edit to any Node repo.
+
+## Proposed Implementation
+
+### 1. Confirm sibling sequencing
+
+Read `catalogs/grid-health.json` and any one `repos/HoneyDrunk.<Node>/integration-points.md` on `main`. If `schema_evolution` is not present and `## Migration Coordination` is not present, **do not open the PR**: leave the issue open with a wait comment naming the sibling `adr-0048-schema-evolution` packet 01. Resume when both conditions are satisfied.
+
+### 2. Sweep every existing `integration-points.md`
+
+Locate every existing `repos/HoneyDrunk.<Node>/integration-points.md` (a `Glob` of `repos/*/integration-points.md` returns the current set). For each file, add a `## Data-Access Stance` section as a sibling to `## Migration Coordination`, immediately after that section (so the two cross-Node data concerns sit side-by-side).
+
+The section template:
+
+```markdown
+## Data-Access Stance
+
+**ORM:** {EF Core (default per ADR-0072 D1) | Document-store SDK (per ADR-0072 D8) | N/A — library only}
+
+**Provider package(s):** {`Microsoft.EntityFrameworkCore.SqlServer` | `Microsoft.EntityFrameworkCore.Npgsql` | `Microsoft.Azure.Cosmos` | `StackExchange.Redis` | N/A}
+
+**Dapper hot-path reads:** {None | List of adopted Dapper queries with PR references and the workload reason}
+
+**Notes:** {anything else relevant — e.g., "Audit's `AuditEntry` table is high-write append-only-by-interface per ADR-0030; Dapper hot-path optimization for forensic queries is a candidate but not adopted today (no production workload yet)."}
+```
+
+### 3. Per-Node defaults driven by `schema_evolution`
+
+Read `catalogs/grid-health.json` (the sibling packet 01 has landed by step 1's gate). For each Node, assign default content by its `schema_evolution` value:
+
+- **`ef-core-migrations`** — ORM: "EF Core (default per ADR-0072 D1)". Provider: as appropriate. Dapper: "None." Notes per Node.
+- **`cosmos-schema-on-read`** — ORM: "Document-store SDK (per ADR-0072 D8 — NoSQL out of scope)." Provider: `Microsoft.Azure.Cosmos`. Dapper: "N/A — NoSQL backing." Notes per Node.
+- **`n/a`** — ORM: "N/A — library only." Provider: "N/A." Dapper: "N/A." Notes: "No persistent store."
+
+Per-Node specific notes worth recording:
+- **HoneyDrunk.Data** — primary affected Node per ADR-0072. ORM: "EF Core (the ratified implementation; see `repos/HoneyDrunk.Data/overview.md` for the full commitment)." Provider package: "`HoneyDrunk.Data.EntityFramework` (the EF Core implementation behind `IRepository<T>` / `IUnitOfWork`)." Dapper: "None at the substrate level; per-Node consumers may adopt Dapper for hot-path reads per ADR-0072 D2 — those adoptions are recorded in the consuming Node's stance, not here."
+- **HoneyDrunk.Notify** — ORM: "EF Core (default per ADR-0072 D1)." Provider: confirm at edit time (likely Azure SQL via `Microsoft.EntityFrameworkCore.SqlServer`). Dapper: "None today; Notify Cloud's send-history queries are a candidate for Dapper hot-path optimization once production workload data exists (per ADR-0072 D2)."
+- **HoneyDrunk.Audit** (Seed) — ORM: "EF Core (default per ADR-0072 D1)." Provider: confirm at standup. Dapper: "Forensic queries are a candidate for Dapper hot-path optimization per ADR-0072 D2; not adopted today."
+- **HoneyDrunk.Kernel** — ORM (for the relational core): "EF Core (default per ADR-0072 D1)." For the document-store sub-pieces (`HoneyDrunk.Kernel.Idempotency.*` etc.): "Document-store SDK per ADR-0072 D8." Dapper: "None."
+- **HoneyDrunk.Vault**, **HoneyDrunk.Auth**, **HoneyDrunk.Transport**, **HoneyDrunk.Web.Rest**, **HoneyDrunk.Architecture**, **HoneyDrunk.Standards**, **HoneyDrunk.Studios**, **HoneyDrunk.Actions**, **HoneyDrunk.AI**, **HoneyDrunk.Capabilities**, **HoneyDrunk.Agents**, **HoneyDrunk.Communications**, **HoneyDrunk.Lore** — "N/A — library only" (Vault stores in Key Vault, not a relational store).
+
+For Nodes that don't exist yet but are cataloged as Seed (Identity per ADR-0060, Files per ADR-0061, Memory per ADR-0022, Knowledge per ADR-0021, Billing per ADR-0037, Notify Cloud per ADR-0027): record the **committed** stance based on the relevant standup ADR. Identity / Files / Memory / Knowledge / Billing all commit to relational stores; their stance is "EF Core (default per ADR-0072 D1). Per-standup-ADR engine choice (Azure SQL vs Postgres) per ADR-0072 D8."
+
+### 4. Do not edit `catalogs/grid-health.json`
+
+The `schema_evolution` field added by sibling packet 01 implies the ORM choice per ADR-0072 D1:
+- `ef-core-migrations` → ORM is EF Core (D1's default).
+- `cosmos-schema-on-read` → ORM is the per-backing SDK (D8's NoSQL carve-out).
+- `n/a` → no ORM (library-only Node).
+
+Adding a separate `data_access` field would be noise; the `schema_evolution` field already carries the signal. This packet does **not** edit `grid-health.json`.
+
+## Affected Files
+- Every existing `repos/HoneyDrunk.<Node>/integration-points.md` (use a `Glob` of `repos/*/integration-points.md` to enumerate).
+
+## NuGet Dependencies
+None. This packet touches only Markdown template files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly. `repos/{Node}/...` files are per-Node governance docs that live in the Architecture repo.
+- [x] No code change in any other repo.
+- [x] The per-Node `integration-points.md` template is the cross-Node integration-surface doc; this packet's addition is consistent with ADR-0072's D1/D2/D8 commitments.
+
+## Acceptance Criteria
+- [ ] The PR body records that (a) `schema_evolution` field exists in `catalogs/grid-health.json` on `main` and (b) at least one `integration-points.md` carries `## Migration Coordination` on `main`, before the PR was opened
+- [ ] Every existing `repos/HoneyDrunk.<Node>/integration-points.md` file carries a `## Data-Access Stance` section placed as a sibling to `## Migration Coordination`
+- [ ] Each Data-Access Stance entry names ORM, provider package(s), Dapper hot-path reads (default "None"), and per-Node notes
+- [ ] For Nodes already cataloged with `schema_evolution: ef-core-migrations` in `catalogs/grid-health.json`, the stance is "EF Core (default per ADR-0072 D1)"
+- [ ] For Nodes with `schema_evolution: cosmos-schema-on-read`, the stance is "Document-store SDK per ADR-0072 D8 — NoSQL out of scope"
+- [ ] For library-only Nodes, the stance is "N/A — library only"
+- [ ] No edit to `catalogs/grid-health.json` (the `schema_evolution` field implies the stance; no separate `data_access` field)
+- [ ] No edit to `repos/HoneyDrunk.Data/overview.md` (packet 03a owns it)
+- [ ] No edit to Node repos
+- [ ] No invariant change
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0072 D1 — EF Core as the default ORM.** Every Node touching a relational store uses EF Core. Marten / RepoDb / raw ADO.NET / EF 6 / Pomelo are not defaults.
+
+**ADR-0072 D2 — Dapper as the scoped exception with mandatory evidence.** Per-Node, per-query. Scoped to read paths only.
+
+**ADR-0072 D4 — Per-Node DbContext, scoped composition.** Each Node owns its own DbContext. Connection strings come from Vault per ADR-0005.
+
+**ADR-0072 D8 — NoSQL out of scope.** Document-store backings (Cosmos, Redis) have their own SDKs; EF Core's Cosmos provider is permitted but not required.
+
+**ADR-0048 (sibling initiative `adr-0048-schema-evolution` packet 01)** — adds the `schema_evolution` field to `catalogs/grid-health.json` and the `## Migration Coordination` section to every existing `integration-points.md`. This packet is hard-blocked on that packet having merged.
+
+**Invariants 2 and 11 (referenced) — Same-layer dependency rule and one-repo-per-Node.** Together cover the per-Node DbContext rule.
+
+## Constraints
+- **Hard sibling sequencing.** This packet is gated on `adr-0048-schema-evolution` packet 01 having merged. The filing pipeline's `packet:NN` form only resolves intra-initiative; cross-initiative coupling is enforced textually: the executor confirms the `schema_evolution` field and `## Migration Coordination` section exist on `main` before opening this packet's PR.
+- **No catalog edit.** Do not add a `data_access` field to `catalogs/grid-health.json`. The `schema_evolution` field implies the ORM choice.
+- **Match existing `integration-points.md` styling.** Heading hierarchy, list style, link format — match the file's established conventions.
+- **No invariant change.** ADR-0072 explicitly does not add invariants; this packet does not edit `constitution/invariants.md`.
+- **Inline ADR-0072 D-decisions.** Per the self-containment rule, cite full text not just decision numbers in the per-Node documentation.
+
+## Labels
+`feature`, `tier-3`, `core`, `docs`, `adr-0072`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add a `## Data-Access Stance` section to every per-Node `integration-points.md`. **Hard-blocked on `adr-0048-schema-evolution` packet 01 having merged** — confirm the `schema_evolution` field and `## Migration Coordination` section exist on `main` before opening the PR.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Record the per-Node ORM posture as a discoverable cross-Node integration concern.
+- Feature: ADR-0072 Data Access Stance rollout, Wave 2.
+- ADRs: ADR-0072 D1/D2/D4/D8 (primary), ADR-0048 (sibling initiative for `schema_evolution` field and `## Migration Coordination` section).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0072 must be Accepted so the stance content cites its decisions as live rules.
+- **Sibling sequencing (textual, not in `dependencies:`)** — `adr-0048-schema-evolution` packet 01 must merge first. The filing pipeline does not support cross-initiative `packet:NN` resolution, so this constraint is enforced by the executor at PR-open time.
+
+**Constraints:**
+- Confirm sibling-packet artifacts exist on `main` before opening the PR; otherwise the issue stays open with a wait comment.
+- No catalog edit (`grid-health.json` not modified — `schema_evolution` field implies the stance).
+- No edit to `repos/HoneyDrunk.Data/overview.md` (packet 03a owns it).
+- Match existing file styling.
+- No invariant change.
+- Inline ADR-0072 D-decisions as full text.
+
+**Key Files:**
+- Every existing `repos/HoneyDrunk.<Node>/integration-points.md` (use `Glob` `repos/*/integration-points.md` to enumerate).
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0072-data-access-stance/04-data-ratify-ef-core-readme-and-changelog.md
+++ b/generated/issue-packets/active/adr-0072-data-access-stance/04-data-ratify-ef-core-readme-and-changelog.md
@@ -1,0 +1,228 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Data
+labels: ["chore", "tier-3", "core", "docs", "adr-0072", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0072"]
+wave: 2
+initiative: adr-0072-data-access-stance
+node: honeydrunk-data
+---
+
+# Ratify EF Core as the implementation behind HoneyDrunk.Data — README + CHANGELOG citations of ADR-0072
+
+## Summary
+Update the Data repo's own README and CHANGELOG to formally cite ADR-0072 as the governing ADR for the EF Core implementation behind `IRepository<T>` / `IUnitOfWork`. The implementation already exists in `HoneyDrunk.Data.EntityFramework`; this packet ratifies it explicitly in the repo's documentation so future maintainers (and AI agents) can trace the ORM commitment back to the governing ADR. No code change; docs-only.
+
+## Context
+ADR-0072's Follow-up Work names: "`HoneyDrunk.Data` ratifies EF Core as the implementation behind `IRepository<T>` / `IUnitOfWork`. Existing implementations align (or already align) with this ADR."
+
+The `HoneyDrunk.Data` repo carries multiple packages:
+
+- **`HoneyDrunk.Data.Abstractions`** — repository, unit-of-work, tenant contracts. The contract surface.
+- **`HoneyDrunk.Data`** — provider-neutral orchestration.
+- **`HoneyDrunk.Data.EntityFramework`** — EF Core repository + unit-of-work implementation. The committed default per ADR-0072 D1.
+- **`HoneyDrunk.Data.SqlServer`** — SQL Server specialization (an EF Core provider package).
+- **`HoneyDrunk.Data.Migrations`** — migration tool support.
+- **`HoneyDrunk.Data.Outbox`** / **`HoneyDrunk.Data.Outbox.Dispatcher`** — outbox pattern.
+
+The repo's current README (at `HoneyDrunk.Data/README.md`) and per-package READMEs do not yet cite ADR-0072 by ID. This packet adds the citations so the EF Core commitment is discoverable from the repo's documentation surface.
+
+**Why docs-only and not a code change.** The committed implementation (EF Core via `HoneyDrunk.Data.EntityFramework`) already exists. ADR-0072 ratifies the existing implementation rather than introducing a new one. The code change ADR-0072 implies — explicitly applying the per-Node DbContext composition, the connection-strings-from-Vault discipline, the query-discipline patterns (`AsNoTracking()` / projections / `Include` / lazy off) — happens **per consuming Node**, not in the `HoneyDrunk.Data` substrate Node itself. The substrate Node ships the abstractions and the EF Core provider; consumers compose against them.
+
+**Per-package CHANGELOG entries vs repo-level CHANGELOG.** Per invariant 12, per-package CHANGELOG entries are added only for packages with actual functional changes. This packet is **citation-only docs work**:
+
+- `HoneyDrunk.Data.Abstractions/README.md` — citation added (no functional change).
+- `HoneyDrunk.Data.EntityFramework/README.md` — citation added (no functional change). This is the package where the EF Core implementation lives; the citation is the most load-bearing one.
+- `HoneyDrunk.Data/README.md` — repo-level README, citation added.
+
+Per-package CHANGELOG entries are warranted **only if the README citation counts as a functional change** worth recording. A pure ADR citation in a README is not a functional change per invariant 12's intent. Repo-level CHANGELOG entry **is warranted** as a record of the ratification — a single repo-level entry recording "ADR-0072 ratified; EF Core formally committed as the implementation behind `IRepository<T>` / `IUnitOfWork`." See the Scope section for the exact placement.
+
+**No version bump.** Per invariants 12/27, no version bump for docs alone. The ADR-0072 citation does not change any public API surface, does not add a feature, does not fix a bug. If a Data release is already in flight for other reasons when this packet executes, the doc rides along; otherwise the doc lands without a version bump.
+
+**No `Thread.Sleep` discipline check** (packet has no test code).
+
+This is a docs/ratification packet in the Data repo. No code, no schema, no migration.
+
+## Scope
+- `HoneyDrunk.Data/README.md` — repo-level README, add an "ORM Commitment" section citing ADR-0072 (mirroring the section added to `repos/HoneyDrunk.Data/overview.md` in packet 03, adapted for the repo's own README format).
+- `HoneyDrunk.Data.Abstractions/README.md` — add a one-paragraph note citing ADR-0072 as the governing ORM-stance ADR for consumers of `IRepository<T>` / `IUnitOfWork`.
+- `HoneyDrunk.Data.EntityFramework/README.md` — add a one-paragraph note citing ADR-0072 as the governing ADR ratifying this package as the default implementation behind the abstractions.
+- `HoneyDrunk.Data/CHANGELOG.md` (repo-level) — add a single ratification entry citing ADR-0072. No version bump.
+- No edit to any `.cs`, `.csproj`, migration, or other code artifact.
+- No edit to per-package CHANGELOG files (no functional change at the package level per invariant 12).
+- **Confirm at execution time** whether a release is in flight in this repo. If yes, the docs ride along with the release's version bump. If no, the docs land without a bump (per invariant 12/27 — no bump for docs alone).
+
+## Proposed Implementation
+
+### 1. Update `HoneyDrunk.Data/README.md`
+
+Read the current repo-level README to understand its structure. Add a new section titled **"ORM Commitment"** (or "Data-Access Stance" — match the file's existing section style). Content:
+
+```markdown
+## ORM Commitment
+
+Per [ADR-0072 (Data Access Stance)](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0072-data-access-stance-ef-core-default-dapper-hot-path.md), `HoneyDrunk.Data` ratifies **Entity Framework Core** as the implementation behind the `IRepository<T>` and `IUnitOfWork` contracts in `HoneyDrunk.Data.Abstractions`. The implementation lives in `HoneyDrunk.Data.EntityFramework`.
+
+**EF Core current LTS** tracks the .NET LTS cadence. Provider packages: `HoneyDrunk.Data.SqlServer` for SQL Server backings; a future `HoneyDrunk.Data.Npgsql` will exist if/when a consuming Node chooses Postgres. Both ride EF Core.
+
+**Dapper is the scoped exception** for hot-path read queries where EF generates poor SQL or where allocation matters. Per-Node, per-query. Mandatory evidence in the PR (EF query, Dapper query, benchmarks, workload context). Writes go through EF Core's DbContext — Dapper-write paths are not permitted.
+
+**Migration tool is EF Migrations** per [ADR-0048 (Schema Evolution)](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0048-data-schema-evolution-and-migration-policy.md). The per-Node `Migrations/` folder hosts migration classes; the canonical migration runner is the `migrate.yml` workflow in `HoneyDrunk.Actions`.
+
+**Per-Node DbContext.** Each consuming Node owns its own `DbContext`. Sharing across Nodes is forbidden. Connection strings come from Vault via `ISecretStore` per [ADR-0005 (Configuration and Secrets)](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0005-configuration-and-secrets-strategy.md).
+
+**Query discipline:** `AsNoTracking()` on read-only queries; projections preferred for column-subset reads; `Include` is explicit and lazy loading is off; N+1 queries are caught at review; raw SQL via `FromSqlRaw` is parameterized — never string-interpolated. See ADR-0072 D5.
+
+**Testing discipline:** in-memory provider (`Microsoft.EntityFrameworkCore.InMemory`) for fast unit tests per [ADR-0047 (Testing Patterns)](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0047-testing-patterns-and-tooling.md) D2; Testcontainers (Tier 2b) for integration tests where the actual SQL provider's behavior matters. Dapper code is tested via Testcontainers — the in-memory provider does not apply.
+
+**Migration path away from EF Core** (per ADR-0072 D7) is bounded by the `IRepository<T>` / `IUnitOfWork` abstraction. Consumers depend on the contracts, not on `DbContext` directly. If EF Core's trajectory ever turns hostile, the migration path is per-Node mechanical rewriting of `HoneyDrunk.Data.EntityFramework` against a different ORM; the contract surface stays stable.
+```
+
+Place the new section in a logical position in the README — likely after the introduction/purpose section and before the package-by-package documentation. Match the file's existing heading hierarchy.
+
+### 2. Update `HoneyDrunk.Data.Abstractions/README.md`
+
+Add a brief paragraph near the top of the file (before any contract reference documentation):
+
+```markdown
+## ORM Stance
+
+This package defines the **provider-neutral contracts** (`IRepository<T>`, `IUnitOfWork`, tenant contracts) that consuming Nodes compose against. Per [ADR-0072 (Data Access Stance)](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0072-data-access-stance-ef-core-default-dapper-hot-path.md), the default implementation behind these contracts is **Entity Framework Core**, shipped in the sibling package `HoneyDrunk.Data.EntityFramework`. Consumers depend on the contracts here, not on `DbContext` directly — this preserves the migration-path-away option per ADR-0072 D7 (swapping the EF Core implementation to a different ORM is a per-Node mechanical move with stable contract surface).
+
+**Dapper is the scoped exception** for hot-path read queries per ADR-0072 D2 — adopted per Node, per query, with mandatory evidence in the introducing PR.
+```
+
+### 3. Update `HoneyDrunk.Data.EntityFramework/README.md`
+
+Add a brief paragraph near the top of the file (this is the load-bearing citation — `HoneyDrunk.Data.EntityFramework` is the package ADR-0072 D1 ratifies):
+
+```markdown
+## ADR-0072 Ratification
+
+This package is the **default EF Core implementation** behind `IRepository<T>` and `IUnitOfWork` in `HoneyDrunk.Data.Abstractions`, ratified by [ADR-0072 (Data Access Stance)](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0072-data-access-stance-ef-core-default-dapper-hot-path.md) D1. EF Core is the Grid's default ORM for every Node touching a relational store; this package provides the implementation. Consumers compose against the contracts in `HoneyDrunk.Data.Abstractions`, not against `DbContext` directly.
+
+**Provider packages** (the EF Core providers) ride this implementation:
+- `HoneyDrunk.Data.SqlServer` — SQL Server backings via `Microsoft.EntityFrameworkCore.SqlServer`.
+- (future) `HoneyDrunk.Data.Npgsql` — Postgres backings via `Microsoft.EntityFrameworkCore.Npgsql`, when first needed.
+
+**EF Migrations** is the migration tool per [ADR-0048 (Schema Evolution)](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0048-data-schema-evolution-and-migration-policy.md). Per-Node migrations live in the consuming Node's `Migrations/` folder; the canonical migration runner is the `migrate.yml` workflow in `HoneyDrunk.Actions`.
+```
+
+### 4. Update `HoneyDrunk.Data/CHANGELOG.md`
+
+The repo-level CHANGELOG records the ratification. Per the user-memory note "No commits under CHANGELOG Unreleased — move to dated versioned section + SemVer bump before committing," this packet handles the entry as follows:
+
+- **If a release is in flight** (a dated versioned section is being prepared for a new patch/minor/major), append a one-line entry under that section: `- Ratified EF Core as the implementation behind `IRepository<T>` / `IUnitOfWork` per [ADR-0072](https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0072-data-access-stance-ef-core-default-dapper-hot-path.md). Docs-only; no API change.`
+- **If no release is in flight** (the docs land standalone), the entry goes in a new dated section with a patch bump. Per invariants 12/27, **docs-only changes do not warrant a version bump on their own**. However, the user-memory rule "No commits under CHANGELOG Unreleased" forces a choice:
+  - Option (a) — **defer the CHANGELOG entry** until the next release-in-flight, and ship the README citations alone without a CHANGELOG line. This is the cleanest path; the README citations are self-contained and the CHANGELOG line rides the next release.
+  - Option (b) — **bump patch + new dated section** for the docs entry. Bumps every non-test `.csproj` per invariant 27. Acceptable but over-engineered for citation-only docs work.
+
+**Default: Option (a)** — README citations land without a CHANGELOG entry; the executor adds the CHANGELOG line during the next Data release that does require a version bump. Record this choice in the PR body. If the operator prefers Option (b), the PR includes the version bump and CHANGELOG entry; the executor records the reason.
+
+### 5. Do not edit per-package CHANGELOGs
+
+Per invariant 12 ("per-package CHANGELOG only for packages with functional changes"), this packet does not add per-package CHANGELOG entries. The README citations in `HoneyDrunk.Data.Abstractions/README.md` and `HoneyDrunk.Data.EntityFramework/README.md` are pure documentation; no functional change in any package's behavior. No per-package CHANGELOG.
+
+### 6. Do not bump versions
+
+Per invariants 12/27, no version bump for docs alone. Confirm at execution time whether a release is in flight; if yes, the docs ride along with that release's bump; if no, no bump.
+
+## Affected Files
+- `HoneyDrunk.Data/README.md` — repo-level README, new "ORM Commitment" section.
+- `HoneyDrunk.Data.Abstractions/README.md` — new "ORM Stance" paragraph.
+- `HoneyDrunk.Data.EntityFramework/README.md` — new "ADR-0072 Ratification" paragraph.
+- `HoneyDrunk.Data/CHANGELOG.md` — conditional ratification entry per Step 4 above.
+
+## NuGet Dependencies
+None. This packet touches only Markdown documentation files; no .NET project file (`.csproj`), no `PackageReference`, no NuGet metadata change.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Data`. Routing rule "data, repository, persistence, EF Core, SQL Server, outbox → HoneyDrunk.Data" maps exactly.
+- [x] No code change.
+- [x] No `relationships.json` edge change (the Data Node's outgoing/incoming edges are unchanged).
+- [x] No `contracts.json` interface change.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Data/README.md` carries an "ORM Commitment" (or equivalent) section citing ADR-0072 with the full content named in Proposed Implementation Step 1 — EF Core default, Dapper scoped exception, EF Migrations, per-Node DbContext, query discipline, testing discipline, migration-path-away mechanism
+- [ ] `HoneyDrunk.Data.Abstractions/README.md` carries an "ORM Stance" paragraph citing ADR-0072 D1/D7
+- [ ] `HoneyDrunk.Data.EntityFramework/README.md` carries an "ADR-0072 Ratification" paragraph naming this package as the default implementation per ADR-0072 D1
+- [ ] The CHANGELOG entry decision is recorded in the PR body (Option (a) = defer to next release; Option (b) = bump patch with new dated section); default is Option (a)
+- [ ] If Option (b) is chosen, every non-test `.csproj` in the Data solution is at the same new patch version per invariant 27
+- [ ] No per-package CHANGELOG entries added (no functional change per invariant 12)
+- [ ] No code change in any `.cs` file
+- [ ] No `.csproj` change unless Option (b) version bump
+- [ ] No migration added
+- [ ] All ADR-0072 D-decisions referenced in the docs are inlined with full text or linked to the ADR, not just cited by number
+- [ ] The `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0072 D1 — EF Core as the default ORM.** Every Node touching a relational store uses EF Core. `HoneyDrunk.Data.EntityFramework` is the ratified default implementation behind `IRepository<T>` / `IUnitOfWork`. Provider packages (`HoneyDrunk.Data.SqlServer` and future `HoneyDrunk.Data.Npgsql`) ride EF Core.
+
+**ADR-0072 D2 — Dapper as the scoped exception.** Per-Node, per-query. Read paths only. Mandatory evidence in the PR.
+
+**ADR-0072 D4 — Per-Node DbContext.** Each consuming Node owns its own DbContext. The `HoneyDrunk.Data` substrate ships the abstractions and the EF Core provider; consumers compose against them. Connection strings come from Vault per ADR-0005.
+
+**ADR-0072 D5 — Query discipline.** `AsNoTracking()` / projections / explicit `Include` / lazy off / parameterized raw SQL.
+
+**ADR-0072 D6 — Testing discipline.** In-memory provider for unit; Testcontainers for integration.
+
+**ADR-0072 D7 — Migration path away from EF Core is bounded.** Consumers depend on `IRepository<T>` / `IUnitOfWork` — swapping the EF Core implementation to a different ORM is a per-Node mechanical move with stable contract surface. EF Migrations history is the most painful loss but bounded — schemas are well-described and migrations are exportable.
+
+**ADR-0048 (referenced) — EF Migrations as the migration tool.** The per-Node `Migrations/` folder; the `migrate.yml` workflow in `HoneyDrunk.Actions`.
+
+**ADR-0005 (referenced) — Connection strings come from Vault.** Per-Node connection strings live in the Node's Vault namespace and are resolved through `ISecretStore`.
+
+**ADR-0047 (referenced) — Testing patterns.** In-memory provider per D2; Testcontainers per D4 (Tier 2b).
+
+**Invariant 12 (referenced) — Per-package CHANGELOG only for packages with functional changes.** No per-package CHANGELOG entries in this packet; the README citations are pure documentation.
+
+**Invariant 27 (referenced) — One version across the solution.** If Option (b) is chosen for the CHANGELOG entry, every non-test `.csproj` bumps to the same new patch version in one commit.
+
+## Constraints
+- **Docs only.** No code change in `.cs` files. No `.csproj` change unless Option (b) version bump. No migration added.
+- **No per-package CHANGELOG entries.** Per invariant 12, citation-only README changes are not functional changes; per-package CHANGELOGs unchanged.
+- **No version bump for docs alone.** Per invariants 12/27. Confirm at execution time whether a release is in flight; if not, default to Option (a) — defer the CHANGELOG line to the next release.
+- **Inline ADR-0072 D-decisions.** Per the self-containment rule, cite full text in the README content or link to the ADR; not just decision numbers.
+- **Match the existing README styling.** Heading hierarchy, link format, code block format — match the file's established conventions.
+- **No `Thread.Sleep` discipline check applies** — this packet has no test code.
+
+## Labels
+`chore`, `tier-3`, `core`, `docs`, `adr-0072`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Update the Data repo's README files and (conditionally) the repo-level CHANGELOG to cite ADR-0072 as the governing ADR for the EF Core implementation behind `IRepository<T>` / `IUnitOfWork`. No code change.
+
+**Target:** `HoneyDrunk.Data`, branch from `main`.
+
+**Context:**
+- Goal: Land the ADR-0072 ratification in the Data repo's own documentation surface, so the EF Core commitment is discoverable from the repo's READMEs.
+- Feature: ADR-0072 Data Access Stance rollout, Wave 2.
+- ADRs: ADR-0072 D1/D2/D4/D5/D6/D7 (primary), ADR-0048 (EF Migrations), ADR-0005 (connection strings from Vault), ADR-0047 (testing patterns).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0072 must be Accepted so the README citations reference its decisions as live rules.
+
+**Constraints:**
+- Docs only — no `.cs` change, no `.csproj` change (unless Option (b) version bump), no migration.
+- No per-package CHANGELOG entries (no functional change per invariant 12).
+- No version bump for docs alone (default Option (a) — defer CHANGELOG line to next release).
+- Inline ADR-0072 D-decisions as full text or link to the ADR.
+- Match existing README styling.
+
+**Key Files:**
+- `HoneyDrunk.Data/README.md` (repo-level, new ORM Commitment section).
+- `HoneyDrunk.Data.Abstractions/README.md` (new ORM Stance paragraph).
+- `HoneyDrunk.Data.EntityFramework/README.md` (new ADR-0072 Ratification paragraph).
+- `HoneyDrunk.Data/CHANGELOG.md` (conditional ratification entry — default Option (a) defers).
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0072-data-access-stance/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0072-data-access-stance/dispatch-plan.md
@@ -1,0 +1,143 @@
+# Dispatch Plan — ADR-0072: Data Access Stance — EF Core Default, Dapper for Hot-Path Reads
+
+**Initiative:** `adr-0072-data-access-stance`
+**ADR:** ADR-0072 (Proposed → Accepted via packet 00)
+**Sector:** Core / cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0072 commits the Grid's data-access stance: **EF Core is the default ORM for every Node touching a relational store** (D1); **Dapper is the scoped exception** for hot-path reads where EF generates poor SQL or where allocation matters, with evidence required in the PR (D2); **EF Migrations is the migration tool** per ADR-0048 (D3); **per-Node DbContext, scoped composition** with the repository pattern on top (D4); **query discipline** — `AsNoTracking()` on reads, projections preferred, `Include` explicit, lazy loading off, raw SQL parameterized (D5); **testing discipline** — in-memory provider for unit, Testcontainers for integration including Dapper paths (D6); **migration path away** bounded by the `HoneyDrunk.Data` abstraction (D7); explicit **out of scope** items including specific engine choice, NoSQL access, and connection-resiliency policy (D8).
+
+The ADR is a **policy / ratification** ADR. The committed implementation (EF Core via `HoneyDrunk.Data.EntityFramework`) already exists in the Data repo; this initiative ratifies it explicitly, lands the discipline in the `review` agent's rubric and the `database` specialist agent's rubric, and updates the Data Node's README/overview to make the stance discoverable.
+
+**6 packets across 2 waves**, targeting **2 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Data`). All 6 are `Actor=Agent`, 0 `Actor=Human`. No Human Prerequisites in any packet — the work is pure docs/governance/rubric editing with no portal clicks or manual deploys. Packets 02 and 03b carry a **textual cross-initiative gate** on `adr-0048-schema-evolution` (the filing pipeline's `packet:NN` form only resolves intra-initiative; cross-initiative sequencing is enforced by the executor at PR-open time).
+
+## Trigger
+
+ADR-0072 is Proposed with no scope. The forcing functions from the ADR's Context:
+
+- **Most Nodes touching relational data are scaffolded but not yet in production**, so the question has not been forced at scale. The few that have data access today (Vault's secret cache backing, AI's cost-rate cache, Communications's pre-implementation preference store) all use ad-hoc compositions. The choice will be made implicitly by the first packet that lands; the precedent will be near-permanent.
+- **ADR-0048 (Schema Evolution)** committed EF Migrations as the canonical migration tool. The ORM that owns the migration tool was implicit; ADR-0072 makes it explicit.
+- **ADR-0049 (PII Handling)** introduced data-classification attributes on entity models. The classification mechanism assumed an ORM with model-attribute support — EF Core fits that shape natively; raw ADO.NET does not.
+- **ADR-0060 (Identity standup)** introduces `IdentityMap`, `UserRecord`, `UserProfile`, `ExternalSubjectMap` — four tables needing EF-model-attribute support per ADR-0049.
+- **ADR-0061 (Files standup)** introduces a blob-metadata table.
+- **ADR-0030/0031 (Audit substrate)** — Audit's primary write path is append-only-by-interface; the underlying table is high-write, query-light, and one of the candidates that might be argued as a "Dapper-only" exception. Settling the default before Audit ships its production-grade backing matters.
+- **ADR-0050 (Tenant lifecycle)** introduces per-tenant data partitions. The partition mechanic leans heavily on EF Core's DbContext model.
+
+The ADR needs decomposition into actionable packets.
+
+## Scope Detection
+
+**Multi-repo (2 repos).** The policy lands in `HoneyDrunk.Architecture` (governance, ADR acceptance, `review` agent rubric, `database` specialist agent rubric, per-Node `overview.md` and `integration-points.md` updates) and `HoneyDrunk.Data` (the README + CHANGELOG ratification for the EF Core implementation that already exists).
+
+**No new-Node scaffolding.** Every target repo is a live, scaffolded Node. The Identity / Files / Audit / Communications / Memory / Knowledge / Billing / Notify Cloud / Consumer-app PDR adoptions named in ADR-0072's Affected Nodes are deliberately **out of scope** for this initiative — each follows in its own standup ADR's track (ADR-0060 for Identity, ADR-0061 for Files, ADR-0031 for Audit, ADR-0019 for Communications, etc.). This initiative ships the foundation and the per-consumer adoption happens in each consumer's standup.
+
+**No new contracts.** ADR-0072 introduces no Grid-wide runtime contracts. No `relationships.json` edge changes; no `contracts.json` interface additions. The existing `IRepository<T>` and `IUnitOfWork` in `HoneyDrunk.Data.Abstractions` are unchanged; ADR-0072 ratifies their EF Core implementation behind those abstractions.
+
+**No new invariants.** ADR-0072 explicitly states in its Consequences/Invariants section: "No new Grid-wide invariants are introduced in `constitution/invariants.md`. The following are committed conventions enforced by the `review` agent's data-quality category per ADR-0044 D3." The conventions (EF Core default, writes through DbContext, `AsNoTracking()` on reads, per-Node DbContext, connection strings via Vault) are enforced at review-time, not codified as numbered invariants. Packet 00 records this stance and does not add invariants.
+
+## Cross-Dependency with sibling ADRs
+
+ADR-0072 references several sibling ADRs as live context:
+
+- **ADR-0048 (Schema Evolution, Proposed)** — committed EF Migrations as the migration tool. ADR-0072 D3 ratifies the implicit ORM. **Strong conceptual coupling** but no hard packet dependency — ADR-0048 is itself Proposed and being scoped in the sibling initiative `adr-0048-schema-evolution`. The `database` specialist agent's rubric (the home for ADR-0072's review checks per packet 02) is being authored in `adr-0048-schema-evolution` packet 02. **Soft dependency** — if ADR-0048's `database` agent file lands first, this initiative's packet 02 amends it. If not, packet 02 documents the rubric additions to be incorporated when the agent file is authored. The two initiatives are sibling threads on the same Core/data sector; they can land independently but co-evolve.
+- **ADR-0049 (PII Classification, Proposed)** — introduced data-classification attributes on entity models. ADR-0072 D1 cites ADR-0049 as one of the forcing functions for choosing an ORM with model-attribute support. **No hard packet dependency** — ADR-0049's classification attributes are documented; ADR-0072 ratifies the ORM that consumes them.
+- **ADR-0044 (Cloud Code Review, Accepted) D3** — names the twenty-category review rubric. Category 13 (Data and persistence integrity) is the home for ADR-0072 D5's query-discipline checks. **Strong coupling** — packet 01 extends category 13 directly. ADR-0044 is Accepted; the rubric exists.
+- **ADR-0046 (Specialist Review Agents, Proposed)** — names the pattern the `database` specialist agent follows. ADR-0072's review checks ride on top of the `database` agent created under ADR-0048. **Soft dependency** — ADR-0046 is Proposed; the pattern is documented regardless of status.
+- **ADR-0047 (Testing Patterns, Accepted) D2 + D11** — names the in-memory provider for unit tests and Testcontainers for integration. ADR-0072 D6 cites both. **No hard dependency** — ADR-0047 is Accepted; the tiers exist.
+- **ADR-0005 (Configuration and Secrets, Accepted)** — connection strings come from Vault via `ISecretStore`. ADR-0072 D4 ratifies this. **No hard dependency** — ADR-0005 is Accepted.
+- **ADR-0050 (Tenant Lifecycle, Proposed)** — per-tenant DbContext composition. ADR-0072 D4 references this. **No hard dependency** — packet 04 documents the per-tenant DbContext as the canonical multi-tenant data-partition mechanic per ADR-0072 + ADR-0050; the implementation per Node ships under the relevant standup ADRs.
+- **ADR-0042 (Idempotency, Proposed)** — names the Cosmos-backed `IIdempotencyStore`. ADR-0072 D8 explicitly carves NoSQL out of scope; document-store backings have their own SDKs (StackExchange.Redis, Microsoft.Azure.Cosmos). **No coupling** — ADR-0072 commits the relational ORM only; document-store access remains per-backing.
+
+**No cross-initiative `dependencies:` edges in this initiative's packets.** The cross-ADR relationships above are conceptual and documentation-level; the filing pipeline does not need to wire `addBlockedBy` between this initiative and the sibling initiatives. The packets cite each sibling ADR by ID in the body for traceability.
+
+## Wave Diagram
+
+### Wave 1 (Foundation — acceptance)
+- [ ] **00** — Architecture: Accept ADR-0072 — flip status, register the initiative. No invariants per ADR's explicit stance. `Actor=Agent`.
+
+### Wave 2 (Rubric updates + Data Node ratification — parallel where unblocked)
+- [ ] **01** — Architecture: extend `.claude/agents/review.md` D3 category 13 (Data and persistence integrity) with the ADR-0072 D5 query-discipline checks + the D2 Dapper-evidence-burden check. `Actor=Agent`. Blocked by: 00.
+- [ ] **02** — Architecture: extend the `database` specialist agent's rubric (authored under sibling initiative `adr-0048-schema-evolution` packet 02) with the ADR-0072 D2/D5 ORM-choice and query-discipline categories. **Hard sibling sequencing**: this packet is gated on `adr-0048-schema-evolution` packet 02 having merged. Executor confirms `.claude/agents/database.md` exists on `main` before opening the PR. No holding-document fallback. `Actor=Agent`. Blocked by: 00 + textual gate on sibling adr-0048 packet 02.
+- [ ] **03a** — Architecture: update `repos/HoneyDrunk.Data/overview.md` to record EF Core as the ratified ORM behind `IRepository<T>` / `IUnitOfWork`. Single-file packet; standalone-actionable. `Actor=Agent`. Blocked by: 00.
+- [ ] **03b** — Architecture: extend every per-Node `integration-points.md` with a `## Data-Access Stance` section. **Hard sibling sequencing**: gated on `adr-0048-schema-evolution` packet 01 having merged (that packet introduces `## Migration Coordination` and the `schema_evolution` catalog field). Executor confirms both artifacts exist on `main` before opening the PR. `Actor=Agent`. Blocked by: 00 + textual gate on sibling adr-0048 packet 01.
+- [ ] **04** — Data: ratify EF Core as the implementation behind `IRepository<T>` / `IUnitOfWork` in the Data repo — update `HoneyDrunk.Data/README.md`, `HoneyDrunk.Data.EntityFramework/README.md`, and the per-package CHANGELOG(s) to cite ADR-0072; add a Data-Access Stance section to the repo-level README documenting the EF Core default and the Dapper exception. `Actor=Agent`. Blocked by: 00.
+
+Within Wave 2, packets **01**, **03a**, and **04** are independently actionable once **00** merges. Packets **02** and **03b** carry textual cross-initiative gates and may queue until the relevant `adr-0048-schema-evolution` packet merges. **Packet 01** edits `review.md`'s category 13 stanza; **packet 02** edits the `database` agent file; **packet 03a** edits `repos/HoneyDrunk.Data/overview.md`; **packet 03b** edits per-Node `integration-points.md` files; **packet 04** edits the Data repo's own README/CHANGELOG. No cross-packet edits to the same file inside this initiative.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0072](./00-architecture-adr-0072-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [review.md D3 category 13 — EF discipline + Dapper evidence checks](./01-architecture-review-d3-category-13-ef-dapper-discipline.md) | Architecture | Agent | 2 | 00 |
+| 02 | [`database` specialist agent rubric — ORM-choice and query-discipline categories](./02-architecture-database-agent-orm-and-query-discipline.md) | Architecture | Agent | 2 | 00 + textual gate on `adr-0048-schema-evolution` packet 02 |
+| 03a | [`repos/HoneyDrunk.Data/overview.md` ORM Commitment](./03a-architecture-data-overview-orm-commitment.md) | Architecture | Agent | 2 | 00 |
+| 03b | [Per-Node `integration-points.md` Data-Access Stance sweep](./03b-architecture-integration-points-data-access-stance-sweep.md) | Architecture | Agent | 2 | 00 + textual gate on `adr-0048-schema-evolution` packet 01 |
+| 04 | [Data repo ratification: EF Core README/CHANGELOG citing ADR-0072](./04-data-ratify-ef-core-readme-and-changelog.md) | Data | Agent | 2 | 00 |
+
+## Version Bumps
+
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution. Catalog/doc/governance/agent edits only (packets 00, 01, 02, 03).
+- **`HoneyDrunk.Data`** — packet 04 is docs-only (README + CHANGELOG citations). **No version bump for docs alone** per invariants 12/27; if a Data release is already in flight, the doc rides along. Confirm at execution time.
+
+## Cross-Cutting Concerns
+
+### Coupling with the `adr-0048-schema-evolution` initiative
+
+ADR-0072 and ADR-0048 are tightly coupled by topic — schema evolution presupposes an ORM, and ratifying the ORM presupposes a schema-evolution story. The two initiatives ship coupled artifacts:
+
+- **`database` specialist agent file** — authored under `adr-0048-schema-evolution` packet 02. ADR-0072's packet 02 adds rubric categories to that file. **Hard sequencing**: this initiative's packet 02 is gated textually on the sibling having merged; no holding-document fallback.
+- **`integration-points.md` per-Node section** — `adr-0048-schema-evolution` packet 01 adds a `## Migration Coordination` section. ADR-0072's packet 03b adds a sibling `## Data-Access Stance` section so the per-Node ORM posture and the per-Node migration framework are recorded side-by-side. **Hard sequencing**: this initiative's packet 03b is gated textually on the sibling having merged.
+- **`catalogs/grid-health.json` `schema_evolution` field** — `adr-0048-schema-evolution` packet 01 adds this field. ADR-0072's stance overlaps semantically — a Node with `schema_evolution: ef-core-migrations` is by definition on the EF Core ORM per ADR-0072 D1. No additional `data_access` field is added in this initiative; the `schema_evolution` field's value implies the ORM choice. Packet 03b reads the field to determine per-Node defaults — another reason for the sibling gate.
+
+**Sequencing.** This initiative's standalone-actionable packets (00, 01, 03a, 04) can land independently of `adr-0048-schema-evolution`. Packets 02 and 03b carry **hard textual gates** on the sibling — packet 02 on sibling packet 02 (the `database.md` agent file), and packet 03b on sibling packet 01 (`## Migration Coordination` + `schema_evolution`). The filing pipeline's `packet:NN` form does not resolve cross-initiative, so these gates are enforced by the executor at PR-open time: leave the issue open with a wait comment until the sibling artifact exists on `main`.
+
+### Identity, Files, Audit, Communications, Memory, Knowledge, Billing, Notify Cloud, Consumer-app PDRs — deliberate deferral
+
+ADR-0072's Affected Nodes section names Identity (ADR-0060), Files (ADR-0061), Audit (ADR-0030/0031), Communications (ADR-0019), Notify Cloud (ADR-0027), consumer-app PDRs (PDR-0003, PDR-0005, PDR-0006, PDR-0008) as future EF Core adopters. This initiative does **not** ship those adoptions, by design:
+
+- **Each per-Node EF Core adoption is part of that Node's standup track**, not this initiative. Per the memory note "New-Node / standup work gets its own ADR; don't bundle into feature packets." ADR-0060's Identity standup is the place where `IdentityMap`/`UserRecord`/`UserProfile`/`ExternalSubjectMap` become EF Core models; ADR-0061's Files standup is where the blob-metadata table becomes an EF Core model; ADR-0031's Audit standup is where the primary write path lands as EF Core; and so on.
+- **The Dapper hot-path read pilots** named in ADR-0072 D2 (Audit forensic queries, Notify Cloud send-history queries) are deliberately deferred — no production workload exists yet to provide the evidence that D2 requires for a Dapper introduction. The first Dapper introduction will be a per-Node packet with the benchmark evidence inline, reviewed by the `database` specialist agent (under the rubric this initiative ships in packet 02).
+
+This initiative ships **the foundation** (governance, rubric, ratification). Every other consumer adopts the shipped policy in its own track. This keeps the initiative bounded and consistent with the Grid's standup-gets-its-own-ADR rule.
+
+### The `EF Core LTS version` is not pinned here
+
+ADR-0072 D1 says EF Core "current LTS, tracked to the .NET LTS cadence." Pinning an exact EF Core version (e.g. `9.0.x` vs `10.0.x`) is a per-Node SemVer concern and a Grid-wide LTS-cadence concern — not in this initiative's scope. The `database` agent's rubric (packet 02) and the Data repo's README (packet 04) refer to "EF Core current LTS" rather than pinning a number, so the docs are forward-stable across the .NET 8 → 10 → 12 LTS hops.
+
+### NoSQL data-access stance — out of scope
+
+ADR-0072 D8 explicitly carves NoSQL data-access out of scope. The Audit Node may use Cosmos DB per ADR-0031; the Kernel idempotency dedup store uses Cosmos per ADR-0042 D2; future caches may use Redis per ADR-0058. These NoSQL backings have their own SDKs (`Microsoft.Azure.Cosmos`, `StackExchange.Redis`, `Azure.Storage.Blobs`); EF Core's Cosmos provider is permitted but not required. The `database` specialist agent's rubric (packet 02) limits its ORM-choice check to relational stores; document-store schema concerns ride under ADR-0048 D7 (schema-on-read) instead.
+
+### Connection-resiliency policies, read-replica routing, DbContext lifetime tuning — out of scope
+
+ADR-0072 D8 explicitly defers these to per-Node decisions. Packets 01 and 02 do not add review checks for these; per-Node Nodes commit their own posture when the need arises (typically `EnableRetryOnFailure` for Azure SQL transient-fault handling; default `Scoped` DbContext lifetime; no read-replica routing today).
+
+### Site sync
+
+No site-sync flag. ADR-0072 is internal Core-sector infrastructure — no public-facing Studios website content changes.
+
+### Deferred follow-ups (explicitly out of scope)
+
+- **Identity / Files / Audit / Communications / Memory / Knowledge / Billing / Notify Cloud / consumer-app EF Core adoption** — each follows in its own standup ADR's track.
+- **First Dapper hot-path read introduction** — a per-Node packet with benchmark evidence, when the workload data exists. Not in this initiative.
+- **EF Core interceptor discipline as a Grid invariant** — ADR-0072's Alternatives Considered section notes this is deferred, not rejected. A follow-up ADR may commit a Grid-wide interceptor pattern once the patterns settle in production.
+- **Marten as a backing option for one specific Node** — ADR-0072 keeps this open as a per-Node Node-specific choice (e.g. a future event-store-shaped Node); the Grid-wide default stays EF Core. No follow-up filed here.
+- **Per-Node tutorial / template for "how to add an entity, write a migration, ship it in CI"** — named in ADR-0072's Follow-up Work as belonging to the DX-baseline ADR. Not in this initiative.
+
+## Rollback Plan
+
+- **Packet 00 (acceptance):** revert the PR. ADR returns to Proposed; the initiative entry in `active-initiatives.md` is removed. No invariants to roll back (none were added). No runtime impact.
+- **Packet 01 (review.md D3 category 13):** revert the PR. The category 13 stanza returns to its prior state; the EF discipline + Dapper evidence checks are removed from the generalist `review` agent's rubric. The `database` specialist agent (if it exists from sibling initiative) still carries the depth checks per packet 02.
+- **Packet 02 (`database` agent rubric):** revert the PR. The `database` agent file's ORM-choice and query-discipline categories are removed. The agent file itself stays (it belongs to the sibling initiative).
+- **Packet 03a (Data overview ORM Commitment):** revert the PR. `repos/HoneyDrunk.Data/overview.md` returns to its prior state. No runtime impact.
+- **Packet 03b (integration-points Data-Access Stance sweep):** revert the PR. Every modified `integration-points.md` loses its `## Data-Access Stance` section. The sibling `## Migration Coordination` sections remain. No runtime impact.
+- **Packet 04 (Data repo ratification):** revert the PR. The Data repo's README and CHANGELOG citations of ADR-0072 are removed. No code change is reverted (the EF Core implementation pre-dates this initiative); only the documentation is removed.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.

--- a/generated/issue-packets/active/adr-0072-data-access-stance/handoff-wave2-rollout.md
+++ b/generated/issue-packets/active/adr-0072-data-access-stance/handoff-wave2-rollout.md
@@ -1,0 +1,115 @@
+# Handoff — Wave 2: ADR-0072 Rollout (Rubric Updates + Data Node Ratification)
+
+**Initiative:** `adr-0072-data-access-stance`
+**Wave:** 2 (rubric updates + Data Node ratification)
+**Trigger:** Packet 00 merged — ADR-0072 is Accepted.
+**Date:** 2026-05-24
+
+> Per ADR-0008 D7 and invariant 24, this handoff is immutable. Read once at the wave transition; it is not a living tracker.
+
+## What landed in Wave 1
+
+**Packet 00** — ADR-0072 flipped to **Accepted**. The ADR row is in `adrs/README.md` after ADR-0057 as the last row. The `adr-0072-data-access-stance` initiative is registered in `initiatives/active-initiatives.md` with the packet checklist for this folder.
+
+**No invariants were added.** ADR-0072 explicitly commits its five conventions (EF Core default, writes through DbContext, `AsNoTracking()` / explicit `Include` / lazy off, per-Node DbContext, connection strings from Vault) as **review-enforced**, not as numbered invariants. Packet 00's `## No New Invariants` section records the scope-time judgment: none of the five conventions is elevated. The enforcement lives in the `review` agent's rubric (packet 01 of this initiative) and the `database` specialist agent's rubric (packet 02), not in `constitution/invariants.md`. If a future audit determines that any convention needs invariant-level enforcement, a follow-up ADR amendment elevates it. That is not Wave 2's concern.
+
+## What Wave 2 ships
+
+Five packets. Three are independently actionable (01, 03a, 04) once packet 00 merges. Two carry **hard textual cross-initiative gates** on `adr-0048-schema-evolution`:
+
+- Packet **02** waits on `adr-0048-schema-evolution` packet 02 (`database.md` agent file).
+- Packet **03b** waits on `adr-0048-schema-evolution` packet 01 (`## Migration Coordination` section + `schema_evolution` catalog field).
+
+The filing pipeline's `packet:NN` form only resolves intra-initiative; cross-initiative gates are enforced by the executor at PR-open time (issue stays open with a wait comment until the sibling artifact exists on `main`).
+
+### Packet 01 — `review.md` D3 category 13 — EF discipline + Dapper evidence checks (Architecture)
+
+Extends `.claude/agents/review.md` D3 category 13 (Data and persistence integrity) with:
+
+- **EF Core query discipline sub-section** (per ADR-0072 D5): `AsNoTracking()`, projections preferred, explicit `Include`, lazy loading off, N+1 detection, compiled-query handling, parameterized `FromSqlRaw`.
+- **Dapper-evidence-burden sub-section** (per ADR-0072 D2): Dapper introductions flagged for specialist depth review; Dapper-write rejection at surface; evidence-burden checklist (EF query / Dapper query / benchmarks / workload context).
+- **Connection-strings-from-Vault check** (per ADR-0072 D4 / ADR-0005 / invariant 9): hardcoded connection strings in `appsettings.json` are **Block**.
+- **Per-Node DbContext check** (per ADR-0072 D4; grounded in invariants 2 and 11, not invariant 3): cross-Node DbContext references are **Block**.
+
+Sibling-edit coexistence note: sibling initiative `adr-0048-schema-evolution` packet 03 also edits category 13 to add a delegation stanza. The two edits are additive and order-tolerant — preserve any delegation language already present.
+
+### Packet 02 — `database` specialist agent rubric — ORM-choice and query-discipline categories (Architecture)
+
+Extends `.claude/agents/database.md` with two new rubric categories (categories 9 and 10 in the existing rubric authored by sibling initiative `adr-0048-schema-evolution` packet 02):
+
+- **Category 9 — ORM choice** (per ADR-0072 D1/D2): EF Core as the default; Marten / RepoDb / raw ADO.NET / EF 6 deviations require ADR amendment; Dapper-introduction evidence burden verification; Dapper-write rejection; per-Node-per-query scope; `FromSqlRaw`-vs-Dapper preference.
+- **Category 10 — Query discipline** (per ADR-0072 D5): `AsNoTracking()` depth confirmation; projection adequacy; `Include` chain audit; lazy-loading off; N+1 confirmation; compiled-query justification; raw-SQL parameterization depth check; tenant predicate presence.
+
+**Hard sibling sequencing**: this packet is gated on `adr-0048-schema-evolution` packet 02 having merged. Executor confirms `.claude/agents/database.md` exists on `main` before opening the PR. No holding-document fallback.
+
+The agent's invocation surface is extended to include Dapper introductions and EF query pattern modifications, so the specialist is invoked on data-layer PRs even when no `Migrations/` or `Backfill/` file is touched.
+
+### Packet 03a — `repos/HoneyDrunk.Data/overview.md` ORM Commitment (Architecture)
+
+Single-file governance task: add an "ORM Commitment" section to `repos/HoneyDrunk.Data/overview.md` recording EF Core as the ratified ORM behind `IRepository<T>` / `IUnitOfWork` per ADR-0072 D1/D4. Includes the negative form (Dapper not default, Marten not adopted, raw ADO.NET not default, EF 6 forbidden, RepoDb / Pomelo not adopted) per D1; the query-discipline summary per D5; the testing-discipline summary per D6; and the migration-path-away mechanism per D7. Standalone-actionable once packet 00 merges.
+
+### Packet 03b — Per-Node `integration-points.md` Data-Access Stance sweep (Architecture)
+
+Extend every existing `repos/HoneyDrunk.<Node>/integration-points.md` with a `## Data-Access Stance` section placed as a sibling to `## Migration Coordination`. Default content per Node based on `schema_evolution` value in `catalogs/grid-health.json`.
+
+**Hard sibling sequencing**: gated on `adr-0048-schema-evolution` packet 01 having merged (that packet introduces `## Migration Coordination` and the `schema_evolution` catalog field). Executor confirms both artifacts exist on `main` before opening the PR.
+
+**No catalog edit.** `catalogs/grid-health.json` is not modified. The `schema_evolution` field implies the ORM choice per ADR-0072 D1 — no separate `data_access` field is needed.
+
+### Packet 04 — Data repo ratification (Data)
+
+Updates the `HoneyDrunk.Data` repo's own documentation:
+
+- **`HoneyDrunk.Data/README.md`** — new ORM Commitment section citing ADR-0072 with the full content (EF Core default, Dapper scoped exception, EF Migrations, per-Node DbContext, query discipline, testing discipline, migration-path-away mechanism).
+- **`HoneyDrunk.Data.Abstractions/README.md`** — new ORM Stance paragraph citing ADR-0072 D1/D7.
+- **`HoneyDrunk.Data.EntityFramework/README.md`** — new ADR-0072 Ratification paragraph naming this package as the default implementation per D1.
+- **`HoneyDrunk.Data/CHANGELOG.md`** — conditional ratification entry. Default Option (a) — defer the CHANGELOG line to the next release that requires a version bump for non-docs reasons. Option (b) — bump patch with new dated section. Operator's choice; record in PR body.
+
+**No code change.** The EF Core implementation already exists in `HoneyDrunk.Data.EntityFramework`; this packet ratifies it explicitly in docs.
+
+**No version bump for docs alone** per invariants 12/27. No per-package CHANGELOG entries (citation-only docs is not a functional change per invariant 12).
+
+## Parallelism
+
+Wave-2 has five packets. Three (**01**, **03a**, **04**) are independently actionable once **00** merges. Two (**02**, **03b**) carry hard textual gates on `adr-0048-schema-evolution` and may queue at PR-open time:
+
+- **01** edits `.claude/agents/review.md` category 13.
+- **02** edits `.claude/agents/database.md` — **waits for** `adr-0048-schema-evolution` packet 02.
+- **03a** edits `repos/HoneyDrunk.Data/overview.md`.
+- **03b** edits every `repos/HoneyDrunk.<Node>/integration-points.md` — **waits for** `adr-0048-schema-evolution` packet 01.
+- **04** edits the `HoneyDrunk.Data` repo's READMEs and (conditionally) CHANGELOG.
+
+None of the five touches the same file as another. The unblocked three can be filed and worked on simultaneously by separate agents; the gated two stay open with wait comments until their sibling artifacts exist on `main`.
+
+## Coupling with sibling initiative `adr-0048-schema-evolution`
+
+ADR-0072 and ADR-0048 are tightly coupled by topic. The two initiatives ship coupled artifacts:
+
+- **`database` specialist agent file** — authored by `adr-0048-schema-evolution` packet 02. ADR-0072's packet 02 extends its rubric. **Hard textual gate**: packet 02 here waits for the sibling to merge.
+- **`review.md` D3 category 13** — `adr-0048-schema-evolution` packet 03 adds a delegation stanza; ADR-0072's packet 01 adds the EF / Dapper discipline checks. Different sub-sections; additive; no gate.
+- **`integration-points.md` per-Node** — `adr-0048-schema-evolution` packet 01 adds `## Migration Coordination`; ADR-0072's packet 03b adds Data-Access Stance as a sibling section. **Hard textual gate**: packet 03b here waits for the sibling to merge.
+- **`catalogs/grid-health.json` `schema_evolution` field** — added by `adr-0048-schema-evolution` packet 01. ADR-0072's stance overlaps semantically; no separate field added. Packet 03b reads the field to determine per-Node defaults — another reason for the sibling gate.
+
+Standalone ADR-0072 packets (00, 01, 03a, 04) can land in any order relative to ADR-0048. The two gated packets (02, 03b) require the sibling artifacts to exist on `main` first; the filing pipeline cannot wire cross-initiative `packet:NN` references, so the executor enforces the gate at PR-open time.
+
+## What this wave does NOT ship
+
+Per the dispatch plan's Cross-Cutting Concerns / Deferred Follow-ups:
+
+- **Per-Node EF Core adoption** for Identity (ADR-0060), Files (ADR-0061), Audit (ADR-0030/0031), Communications (ADR-0019), Memory (ADR-0022), Knowledge (ADR-0021), Billing (ADR-0037), Notify Cloud (ADR-0027), consumer-app PDRs (PDR-0003/0005/0006/0008). Each follows in that Node's standup-ADR track.
+- **First Dapper hot-path read introduction.** No production workload yet to provide the evidence. The first introduction is a per-Node packet with benchmark evidence inline, reviewed by the `database` specialist agent under the rubric this initiative ships.
+- **EF Core interceptor discipline as a Grid invariant.** ADR-0072's Alternatives Considered names this as deferred-not-rejected. A follow-up ADR may commit a Grid-wide interceptor pattern once the patterns settle in production.
+- **Marten as a backing for one specific Node.** ADR-0072 keeps this open as a per-Node choice; no follow-up filed here.
+- **Per-Node tutorial / template for "add an entity, write a migration, ship in CI."** Named in ADR-0072's Follow-up Work as belonging to the DX-baseline ADR. Not in this initiative.
+
+## Acceptance for Wave 2 completion
+
+- [ ] Packet 01 merged — `review.md` D3 category 13 carries the EF / Dapper discipline checks
+- [ ] Packet 02 merged — `database.md` carries categories 9 and 10 (sibling `adr-0048-schema-evolution` packet 02 has merged first)
+- [ ] Packet 03a merged — `repos/HoneyDrunk.Data/overview.md` carries the ORM Commitment section
+- [ ] Packet 03b merged — every `repos/HoneyDrunk.<Node>/integration-points.md` carries the `## Data-Access Stance` section (sibling `adr-0048-schema-evolution` packet 01 has merged first)
+- [ ] Packet 04 merged — Data repo READMEs cite ADR-0072; CHANGELOG entry handled per Option (a) or (b)
+
+When all five Wave-2 packets merge, **the initiative is complete.** There is no Wave 3 — ADR-0072 is a policy ratification, not a code-rollout initiative. Per-Node EF Core adoption is deferred to each Node's standup track. The `database` specialist agent's rubric (extended in packet 02) and the generalist `review` agent's rubric (extended in packet 01) carry the enforcement surface forward into every future data-layer PR.
+
+When the initiative completes, the operator can move the dispatch plan and packets to `generated/issue-packets/completed/` per invariant 37 (the `hive-sync` agent handles this when filed issues close on GitHub).

--- a/generated/issue-packets/active/adr-0079-pr-review-stack/00-architecture-adr-0079-acceptance.md
+++ b/generated/issue-packets/active/adr-0079-pr-review-stack/00-architecture-adr-0079-acceptance.md
@@ -1,0 +1,154 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "docs", "adr-0079", "wave-1"]
+dependencies: []
+adrs: ["ADR-0079", "ADR-0044", "ADR-0046", "ADR-0011"]
+accepts: ["ADR-0079"]
+wave: 1
+initiative: adr-0079-pr-review-stack
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0079 — flip status, add the four PR-review-stack invariants, amend ADR-0044 and clarify ADR-0046
+
+## Summary
+Flip ADR-0079 (Multi-Perspective PR Review Stack) from Proposed to Accepted: update the ADR header, add the ADR-0079 row to `adrs/README.md`, add the four new Code Review invariants ADR-0079 commits in its Consequences/Invariants section to `constitution/invariants.md`, register the `adr-0079-pr-review-stack` initiative in `initiatives/active-initiatives.md`, amend ADR-0044 with an "Amended by ADR-0079" note linking to D8's billing-path discipline, and add a clarifying note on `constitution/invariants.md`'s invariant 53 entry that ADR-0079 D7's dual-model Grid-aware-agent execution is the canonical satisfaction.
+
+## Context
+ADR-0079 commits the **canonical PR-review stack** the Grid has been operating ad-hoc since ADR-0044's acceptance. Three reviewers run on every non-draft PR (GitHub Copilot Code Review, CodeRabbit, the Grid-aware `review` agent via Codex/OpenClaw); a fourth reviewer (the same `.claude/agents/review.md` Grid-aware agent executed through Anthropic's native Claude Code on the web GitHub integration) runs on substantive PRs from the June 15 2026 Claude Agent SDK credit-pool launch onward.
+
+The ADR decides:
+- **D1** — three reviewers (Copilot Code Review, CodeRabbit, Grid-aware via Codex) run on every non-draft PR.
+- **D2** — substantive PRs receive a fourth reviewer: the Grid-aware agent via Anthropic-native Claude Code, billed against the Claude Max Agent SDK credit pool from June 15 2026. Same agent definition, two execution paths, two different model families.
+- **D3** — the substantive-PR classifier is a mechanical safe-list (`*.md`, `*.mdx`, `*.txt`, `docs/**`, `LICENSE*`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `docs/assets/**`). Any PR touching anything outside the safe-list is substantive; a docs-only PR is trivial. Per-PR override is forbidden.
+- **D4** — Greptile is considered and not selected (held in the watch list).
+- **D5** — Codex out-of-the-box review (non-Grid-aware) is considered and not selected.
+- **D6** — cost ceiling: ~$24/mo CodeRabbit + bounded Codex/Anthropic allotment overage. Reviewer 4 does **not** fall back to per-token Anthropic API billing if the credit pool is exhausted.
+- **D7** — Invariant 53 satisfaction: the dual-model execution of the Grid-aware agent (Codex GPT-class + Claude) is the canonical two-independent-Grid-aware-perspectives shape. Pre-June-15 transition is degraded-but-honest.
+- **D8** — amendment to ADR-0044 making the billing-path discipline first-class (Codex via OpenClaw → ChatGPT Pro; Claude via Anthropic-native → Claude Max Agent SDK credit pool) and codifying the `ANTHROPIC_API_KEY` auth-precedence gotcha.
+- **D9** — explicit out-of-scope set (specialist agent invocation, human reviewer involvement, cross-reviewer verdict aggregation, per-Node high-risk classification, trivial-PR Reviewer 1/2/3 suppression, per-PR reviewer override, the content of `.claude/agents/review.md`).
+
+ADR-0079 is a **policy / decision** ADR. The concrete CI work — the substantive-PR classifier in `job-review-request.yml`, the Reviewer 4 trigger workflow, the auth-precedence runner-config doc, the `.coderabbit.yaml` Grid template, the operator-facing four-reviewer expectation doc, the cost-tracking hook — lands in the implementing packets (01–04). Acceptance must land first because every other packet in this initiative references ADR-0079's D-decisions as live rules.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Invariant Numbering
+ADR-0079 adds exactly **four** invariants. Numbering is claimed from the reservation registry, not hardcoded — read `constitution/invariant-reservations.md` and take the next free block of size **four** at the current ceiling (today the registry shows ADR-0079's block as **95–98**, but if a later ADR lands first the implementer shifts upward and updates the registry row + every `{N1}`–`{N4}` placeholder in this packet). Refer to the four new invariants as `{N1}`, `{N2}`, `{N3}`, `{N4}` throughout this packet; replace placeholders with the claimed numbers at edit time. Append the block under the existing `## Code Review Invariants` section in `constitution/invariants.md` (the section ADR-0044 created at invariants 52–53; the new four extend it).
+
+## Scope
+- `adrs/ADR-0079-multi-perspective-pr-review-stack.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — append the ADR-0079 row (Accepted, 2026-05-23, Meta) to the index table. **Scope-creep acknowledgement:** the index currently ends at ADR-0057 (line 64) while ADR files exist on disk through ADR-0079; the ADR-0058 through ADR-0078 README backlog is real but explicitly out-of-scope for this packet. This packet appends only the ADR-0079 row at the end of the existing table; backfilling the missing 21 rows is deferred to a separate housekeeping packet.
+- `adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md` — add an "Amended by ADR-0079" note pointing at ADR-0079 D8's billing-path discipline.
+- `adrs/README.md` — update the ADR-0044 row's description to note the ADR-0079 amendment (one-sentence pointer; the full content stays in ADR-0044).
+- `constitution/invariants.md` — append four new invariants (numbers `{N1}`–`{N4}` — see Invariant Numbering above; claimed via `constitution/invariant-reservations.md`) under `## Code Review Invariants`. Also add a one-line clarifying note on the existing invariant 53 entry that ADR-0079 D7 names the dual-model Grid-aware-agent execution as the canonical satisfaction.
+- `constitution/invariant-reservations.md` — add the ADR-0079 reservation row in the **Active Reservations** table for the claimed block; update the **Current ceiling** line. (This packet's PR is the one that claims the block.)
+- `initiatives/active-initiatives.md` — register the `adr-0079-pr-review-stack` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. **Claim the invariant block.** Read `constitution/invariant-reservations.md`. Identify the next free block of size **four** at the current ceiling. Add the ADR-0079 row to the **Active Reservations** table for that block; update the **Current ceiling** line. Substitute the claimed numbers for `{N1}`, `{N2}`, `{N3}`, `{N4}` everywhere they appear in this packet body (the four invariant texts in step 5, the references in step 4, the Affected Files list, and the Acceptance Criteria). If a later ADR's packet 00 has shifted the ceiling between this packet's authoring and its merge, take the new next-free block and update accordingly.
+2. Edit the ADR-0079 header: `**Status:** Proposed` → `**Status:** Accepted`.
+3. Append an ADR-0079 row to `adrs/README.md`'s index table. **Scope-creep acknowledgement:** the index currently ends at ADR-0057 (line 64) and ADR files exist on disk through ADR-0079 — the 21-row backlog is real but out-of-scope for this packet. Append the ADR-0079 row at the end of the existing table; do not backfill ADR-0058 through ADR-0078. Use the existing column shape (link, title, status, date, sector, description). Title: "Multi-Perspective PR Review Stack — Copilot + CodeRabbit + Grid-Aware Agent (Codex + Claude)". Date: 2026-05-23. Sector: Meta.
+4. Update the ADR-0044 row's description in `adrs/README.md` with a brief "Amended by ADR-0079 (billing-path discipline + Reviewer 4 enablement)" pointer.
+5. Add a `> **Amendment — ADR-0079.** Billing-path discipline is now first-class; see ADR-0079 D8. The `ANTHROPIC_API_KEY` runner-environment rule is codified by invariant `{N4}`.` note near the top of `adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md` (after the Status header, before the Context section — match the established amendment-note convention from earlier ADRs).
+6. Append four new invariants to `constitution/invariants.md` under `## Code Review Invariants` (after invariant 53). Use the numbers claimed in step 1 (`{N1}` through `{N4}`). Text, verbatim-in-substance from ADR-0079's Consequences/Invariants section:
+
+   - **`{N1}` — The canonical PR review stack is four reviewers.** Three reviewers run on every non-draft PR (GitHub Copilot Code Review, CodeRabbit, the Grid-aware `review` agent via Codex/OpenClaw); a fourth reviewer (the same `.claude/agents/review.md` Grid-aware agent executed through Anthropic's native Claude Code on the web GitHub integration) runs on substantive PRs from the June 15 2026 Claude Agent SDK credit-pool launch onward. Adding a fifth canonical reviewer requires an ADR amendment with an explicit forcing function (the charter's anti-performing-visibility warning is the governor). See ADR-0079 D1, D2.
+
+   - **`{N2}` — The substantive-PR classifier is the safe-list in ADR-0079 D3; per-PR override is forbidden.** A PR is trivial only if its entire changeset stays inside the safe-list (`*.md`, `*.mdx`, `*.txt`, `docs/**`, `LICENSE*`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `docs/assets/**`). Any file outside the safe-list makes the PR substantive. The classifier is mechanical — no LLM judgment, no label-based override, no commit-message escape. See ADR-0079 D3.
+
+   - **`{N3}` — The Grid-aware `review` agent's two execution paths (Codex and Claude) must consume the same `.claude/agents/review.md` definition.** Drift between execution surfaces is forbidden. `{N3}` extends ADR-0044 D1's "agent definition is the source of truth" principle to cover both the Codex/OpenClaw and the Anthropic-native Claude Code on the web execution paths. The agent file in the Architecture repo is the canonical source; both runtimes load it directly. See ADR-0079 D2.
+
+   - **`{N4}` — `ANTHROPIC_API_KEY` is not set in the Reviewer 4 runner environment by default.** The Claude Agent SDK credit pool is consumed when the runner authenticates as the operator's Claude Max session — typically via the Claude Code on the web integration's session credentials. If a runner environment has `ANTHROPIC_API_KEY` set as an environment variable, the SDK uses it preferentially and per-token API billing applies silently. The default Reviewer 4 runner configuration leaves `ANTHROPIC_API_KEY` unset; opting into per-token billing requires an ADR amendment per ADR-0079 D6. See ADR-0079 D8.
+
+7. Add a one-line clarifying note to the existing invariant 53 entry in `constitution/invariants.md` (the entry currently reads "Agent-authored PRs touching a high-risk Node receive two independent LLM-review perspectives before merge"): append "Per ADR-0079 D7, the canonical satisfaction is the dual-model execution of the Grid-aware `review` agent — Codex (GPT-class) executes the agent on every PR; Claude (Anthropic-native) executes the same agent on substantive PRs from June 15 2026 onward. Same agent definition, two model families, genuinely independent at the model level."
+8. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder. Place it after the existing ADR-0044 entry (Code Review Stack is the closest topical neighbor).
+
+## Affected Files
+- `adrs/ADR-0079-multi-perspective-pr-review-stack.md`
+- `adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0079 header reads `**Status:** Accepted`
+- [ ] `constitution/invariant-reservations.md` carries an ADR-0079 row in **Active Reservations** for the claimed `{N1}`–`{N4}` block; the **Current ceiling** line is updated
+- [ ] An ADR-0079 row exists in `adrs/README.md`'s index, appended to the end of the existing table, with status Accepted and a faithful one-paragraph description. The ADR-0058–ADR-0078 backlog is acknowledged as out-of-scope and not backfilled
+- [ ] ADR-0044 carries an `> **Amendment — ADR-0079.**` note near the top (after Status, before Context) pointing at ADR-0079 D8's billing-path discipline and naming invariant `{N4}` as the codification of the `ANTHROPIC_API_KEY` rule
+- [ ] The ADR-0044 row in `adrs/README.md` has a brief "Amended by ADR-0079" pointer in its description
+- [ ] `constitution/invariants.md` carries four new invariants under `## Code Review Invariants` numbered with the claimed `{N1}`–`{N4}` block (the four-reviewer stack; the safe-list classifier with no per-PR override; the shared-agent-definition rule for both execution paths; the `ANTHROPIC_API_KEY` runner-environment rule), each citing ADR-0079
+- [ ] The existing invariant 53 entry carries a one-line ADR-0079 D7 clarifying note naming the dual-model Grid-aware-agent execution as the canonical satisfaction
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0079-pr-review-stack` initiative with a packet checklist, placed near the ADR-0044 entry
+- [ ] No `.coderabbit.yaml` change in this packet (that lands in packet 01); no workflow change (packets 02/03); no operator-facing doc change (packet 04)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0079 D1 — Three reviewers on every PR by default.** GitHub Copilot Code Review (zero marginal cost, included in the operator's GitHub Copilot subscription), CodeRabbit (~$24/dev/mo, third-party AI independence from Microsoft and Anthropic), Grid-aware `review` agent via Codex/OpenClaw (against the operator's ChatGPT Pro allotment; API overage on exceedance). Three different perspectives, three different things they catch.
+
+**ADR-0079 D2 — Substantive PRs receive a fourth reviewer.** The same `.claude/agents/review.md` Grid-aware agent executed through Anthropic's native Claude Code on the web GitHub integration; billed against the Claude Max Agent SDK credit pool from June 15 2026; same agent definition, two execution paths, two model families. Pre-June-15 the workflow ships but the enable gate stays off; per-token API billing as a fallback is explicitly out of scope per D6.
+
+**ADR-0079 D3 — Substantive-PR classifier safe-list.** Any PR whose entire changeset stays inside `*.md`, `*.mdx`, `*.txt`, `docs/**`, `LICENSE*`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `docs/assets/**` is trivial. Any file outside makes the PR substantive. Mechanical classifier — no LLM judgment, no per-PR override.
+
+**ADR-0079 D7 — Invariant 53 satisfaction via dual-model execution.** Two genuinely independent model families (GPT-class via Codex, Claude via Anthropic) executing the same Grid-context-loaded agent definition. The two perspectives share the Grid's worldview through `.claude/agents/review.md`; their independence is at the model level. Pre-June-15 the transition state is degraded-but-honest (single Grid-aware perspective + two generic).
+
+**ADR-0079 D8 — Amendment to ADR-0044.** Billing paths are now first-class: Codex via OpenClaw → ChatGPT Pro allotment + API overage; Claude via Anthropic-native → Claude Max Agent SDK credit pool with no per-token fallback by default. The auth-precedence gotcha (`ANTHROPIC_API_KEY` in the runner environment silently flips Claude execution to per-token billing) is codified as invariant `{N4}` and the runner-config docs (packet 03) carry the operator-facing checklist.
+
+**ADR-0079 Consequences — Invariants.** Four new invariants (numbers `{N1}`–`{N4}`, claimed via `constitution/invariant-reservations.md`): the canonical four-reviewer stack; the safe-list classifier with no per-PR override; the shared-agent-definition rule for both execution paths; the `ANTHROPIC_API_KEY` runner-environment rule.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0079 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbering via the reservation registry.** Read `constitution/invariant-reservations.md` and claim the next free block of size **four** at the current ceiling. Add the ADR-0079 reservation row in the same PR that writes invariants. Replace every `{N1}`–`{N4}` placeholder in this packet body with the claimed numbers. Append the new invariants under `## Code Review Invariants`. Do not renumber existing invariants. If a racing PR has shifted the ceiling between this packet's authoring and merge, take the new next-free block.
+- **No new invariants section.** The four new invariants extend the existing `## Code Review Invariants` section (invariants 31–33 and 52–53). Do not create a parallel section.
+- **ADR-0044 amendment is one note, not a rewrite.** A short pointer at the top of ADR-0044 referencing ADR-0079 D8 + invariant `{N4}` is the full amendment. ADR-0044's body is otherwise untouched. The cross-reference in `adrs/README.md`'s ADR-0044 row is a one-sentence "Amended by ADR-0079" pointer.
+- **Invariant 53 clarifying note is one line, appended to the existing entry.** Do not rewrite the invariant 53 text — append the ADR-0079 D7 sentence after the existing body.
+- **`adrs/README.md` is append-only for this packet.** The 21-row backlog (ADR-0058 through ADR-0078) is real but explicitly out-of-scope. Append only the ADR-0079 row; defer the backfill to a separate housekeeping packet.
+- **Initiative registration matches the dispatch plan.** `initiatives/active-initiatives.md` lists the five packets in the same wave structure as `dispatch-plan.md`.
+
+## Labels
+`chore`, `tier-3`, `meta`, `docs`, `adr-0079`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0079 to Accepted, add the four PR-review-stack invariants (claim `{N1}`–`{N4}` from the reservation registry), amend ADR-0044 with the billing-path-discipline pointer, clarify invariant 53's canonical satisfaction, and register the initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0079 so the remaining packets in this initiative can reference its decisions as live rules and so the canonical reviewer stack is bound by invariants.
+- Feature: ADR-0079 Multi-Perspective PR Review Stack, Wave 1.
+- ADRs: ADR-0079 (primary), ADR-0044 (amended), ADR-0046 (Proposed — invariant 53 clarified; note ADR-0046 itself remains Proposed and is referenced for its specialist-agent invocation pattern, not as an Accepted constraint), ADR-0011 (Proposed — base review/merge flow referenced for context), ADR-0008 (initiative/packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0079 stays Proposed until this PR merges.
+- Claim the four-invariant block from `constitution/invariant-reservations.md`; substitute `{N1}`–`{N4}` placeholders with the claimed numbers; append under the existing `## Code Review Invariants` section; do not renumber existing invariants.
+- ADR-0044 amendment is a short note pointing at ADR-0079 D8 and invariant `{N4}` — not a body rewrite.
+- The invariant 53 clarification is one line appended to the existing entry.
+- `adrs/README.md` is append-only for this packet — do not backfill the 21-row ADR-0058–ADR-0078 backlog.
+
+**Key Files:**
+- `adrs/ADR-0079-multi-perspective-pr-review-stack.md`
+- `adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0079-pr-review-stack/01-architecture-coderabbit-template-and-substantive-safe-list.md
+++ b/generated/issue-packets/active/adr-0079-pr-review-stack/01-architecture-coderabbit-template-and-substantive-safe-list.md
@@ -1,0 +1,143 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "docs", "adr-0079", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0079", "ADR-0044"]
+accepts: ["ADR-0079"]
+wave: 1
+initiative: adr-0079-pr-review-stack
+node: honeydrunk-architecture
+---
+
+# Author the `.coderabbit.yaml` Grid template and record the substantive-PR safe-list as a cross-cutting policy note
+
+## Summary
+Author the Grid's reference `.coderabbit.yaml` template — the per-repo CodeRabbit configuration shape every repo can copy when it opts in — and record the ADR-0079 D3 substantive-PR safe-list as a single-source cross-cutting policy note where the Grid keeps such notes. The template and the policy note are governance artifacts; per-repo `.coderabbit.yaml` adoption is a follow-up fan-out item, not in scope here.
+
+## Context
+ADR-0079 D1 names CodeRabbit as Reviewer 2 — a third-party AI reviewer providing vendor-independence (not Microsoft, not Anthropic) for ~$24/dev/mo. CodeRabbit supports a `.coderabbit.yaml` configuration file at repo root for repo-specific patterns (severity floors, path filters, language tunings, the Grid's invariant cross-links). Today, no repo in the Grid carries a `.coderabbit.yaml` — CodeRabbit operates on its defaults across every repo it reviews. This packet establishes the Grid template.
+
+ADR-0079 D3's substantive-PR safe-list (`*.md`, `*.mdx`, `*.txt`, `docs/**`, `LICENSE*`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `docs/assets/**`) is the mechanical classifier for "Reviewer 4 runs" vs "Reviewer 4 skipped." Today the list lives only in ADR-0079's body. The list will be **consumed by `HoneyDrunk.Actions`** (packet 02 embeds the list in-workflow with a CI drift check against this note) — placing it as a cross-cutting policy note in `business/context/`, with packet 02 pointing at this note as the source of truth, ensures the list is **one artifact**, not duplicated between ADR + workflow + docs. `business/context/` today holds only `entity.md` and `operating-costs.md`; this note will be the first cross-cutting policy artifact filed there, and the placement establishes the convention.
+
+**No new App Insights / Azure resource.** This packet is governance/docs only.
+
+**Per-repo `.coderabbit.yaml` adoption is deferred.** Each repo's CodeRabbit configuration is incremental, repo-by-repo, driven by observed reviewer noise — not a blocking pre-condition for ADR-0079. The dispatch plan's "Per-repo `.coderabbit.yaml` fan-out (deferred)" section names the rationale. This packet ships only the **canonical template + placement convention** so per-repo adoption is mechanical when a repo chooses to opt in.
+
+This is a docs/governance packet. No code, no .NET project.
+
+## Scope
+- **A canonical `.coderabbit.yaml` template** at `templates/.coderabbit.yaml` (or the existing templates location in `HoneyDrunk.Architecture`; if no such location exists, create `templates/` and document the convention). The template captures the Grid's reference shape — severity floor, path filters, language tunings, integration-with-Grid-invariants pointer.
+- **A cross-cutting policy note recording the ADR-0079 D3 substantive-PR safe-list** at `business/context/` (the location used by `entity.md` and `operating-costs.md`; this packet establishes the convention for cross-cutting policy notes filed alongside the existing entity/cost context). The note is the **single source of truth** for the safe-list — ADR-0079 binds the principle, this note carries the canonical list, packet 02 reads from it.
+- **A short README accompanying the template** at `templates/README.md` (or appended to an existing templates README) explaining: when to adopt, how to adopt (copy to repo root, no other steps), and that per-repo refinement is incremental.
+- The repo `CHANGELOG.md` updated per repo convention.
+
+## Proposed Implementation
+1. **Create `templates/.coderabbit.yaml`** (or match the existing templates location convention). The template body — based on CodeRabbit's documented configuration surface; if the surface has shifted at execution time, research the current options and adapt — should include at minimum:
+   - **Header comment** stating this is the Grid's reference template, the source-of-truth ADR (ADR-0079 D1), and per-repo refinement is welcome but optional.
+   - **Severity floor** — sensible default (e.g. `suggestions: true`, `nits: false`) so the Grid does not drown in style-only comments.
+   - **Path filters** — skip `**/generated/**`, `**/*.Designer.cs`, `**/*.g.cs`, and the same `docs/assets/**` patterns the substantive-PR safe-list uses for "obvious-no-code-impact" files.
+   - **Language tuning** — opinionated defaults for the Grid's primary languages (C#, TypeScript, YAML, Bicep, Markdown).
+   - **A pointer comment** to the Grid's invariants — CodeRabbit cannot enforce invariants directly, but a comment at the top makes future readers aware that the Grid-aware `review` agent (Reviewer 3/4) is the authoritative invariant-enforcing path; CodeRabbit's role is third-party-vendor-independent generic AI review.
+   - **No secret values, no DSNs, no API keys** (invariant 8 — `.coderabbit.yaml` is a public repo file).
+2. **Add `templates/README.md` (or extend the existing one)** explaining the adoption flow:
+   - When to adopt: any repo where the operator wants to refine CodeRabbit's defaults (severity floor, path filters) for repo-specific patterns. Without a `.coderabbit.yaml`, CodeRabbit uses its own defaults — which is fine for v1.
+   - How to adopt: copy `templates/.coderabbit.yaml` to the repo root, commit, push. No CI change is required — CodeRabbit reads the file automatically.
+   - Per-repo refinement: for example, the Vault repo's secret-handling patterns may want a higher severity floor on `**/Vault/**` paths; the Audit repo may want a stricter review of `**/Audit/**` append-only patterns. These are per-repo decisions; the template is the starting point.
+3. **Add a cross-cutting policy note recording the substantive-PR safe-list.** Create the note at `business/context/` alongside the existing `entity.md` and `operating-costs.md` — this is the first cross-cutting policy note filed there, establishing the convention for future Grid-level policy artifacts that don't naturally fit in `adrs/` or `constitution/`. Title the file along the lines of `pr-review-substantive-safe-list.md`. The note's body must:
+   - State the canonical safe-list verbatim from ADR-0079 D3:
+     - `*.md`
+     - `*.mdx`
+     - `*.txt`
+     - `docs/**`
+     - `LICENSE*`
+     - `SECURITY.md`
+     - `CODE_OF_CONDUCT.md`
+     - `CONTRIBUTING.md`
+     - `docs/assets/**`
+   - State the classification rule: a PR whose entire changeset is inside the safe-list is **trivial** (Reviewer 4 skipped); any file outside the safe-list makes the PR **substantive** (all four reviewers run, where Reviewer 4 is enabled post-June-15).
+   - State the mechanical-classifier discipline: no LLM judgment, no label-based override, no commit-message escape (invariant 55).
+   - Name itself as the single source of truth — `HoneyDrunk.Actions`'s classifier workflow (packet 02) reads from this note's safe-list, never from a duplicated copy.
+   - Reference invariant 55 (the safe-list-classifier invariant) and ADR-0079 D3.
+4. **Update the repo `CHANGELOG.md`** per repo convention with a one-line entry referencing this packet and ADR-0079.
+
+## Affected Files
+- `templates/.coderabbit.yaml` (new)
+- `templates/README.md` (new or extended)
+- A safe-list cross-cutting policy note at `business/context/` (new — first cross-cutting policy note in that directory; convention established by this packet).
+- `CHANGELOG.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown, YAML configuration templates, and governance notes; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No per-repo `.coderabbit.yaml` is adopted by this packet — the template lands; per-repo adoption is the deferred fan-out.
+- [x] No CI/workflow change — packet 02 is the workflow change.
+
+## Acceptance Criteria
+- [ ] `templates/.coderabbit.yaml` exists, contains the Grid's reference CodeRabbit configuration shape, carries a header comment naming ADR-0079 D1 as the source ADR, and contains no secret values or API keys (invariant 8)
+- [ ] `templates/README.md` (new or extended) documents when to adopt, how to adopt, and per-repo refinement guidance
+- [ ] A cross-cutting policy note in `business/context/` records the ADR-0079 D3 substantive-PR safe-list verbatim, states the classification rule and the mechanical-classifier discipline, names itself as the single source of truth for downstream consumers, and references invariant `{N2}` (packet 00's safe-list classifier invariant)
+- [ ] No per-repo `.coderabbit.yaml` is adopted by this packet — the deferred fan-out remains explicit in the dispatch plan
+- [ ] The repo `CHANGELOG.md` is updated per repo convention
+- [ ] No invariant change (the four PR-review-stack invariants land in packet 00)
+- [ ] No workflow change (the classifier lands in packet 02)
+
+## Human Prerequisites
+- [ ] **CodeRabbit subscription provisioning.** ADR-0079 D1 names CodeRabbit at ~$24/dev/mo. The operator's CodeRabbit account / GitHub App must be installed on the relevant repos for CodeRabbit reviews to fire. This is a one-time portal step (or per-repo install) outside this packet's scope; until done, packet 01's template is inert in any repo that adopts it.
+
+## Referenced ADR Decisions
+**ADR-0079 D1 — CodeRabbit is Reviewer 2.** Third-party AI reviewer providing vendor-independence (not Microsoft Copilot, not Anthropic Claude). ~$24/dev/mo. Supports `.coderabbit.yaml` for repo-specific patterns. Generic, not Grid-aware — the Grid-aware role belongs to Reviewers 3/4 (the `review` agent).
+
+**ADR-0079 D3 — Substantive-PR classifier safe-list.** Mechanical file-path-glob check. Any PR whose entire changeset stays inside the safe-list is trivial; any file outside makes the PR substantive. No LLM judgment, no per-PR override.
+
+**ADR-0079 D9 — Per-PR reviewer override is forbidden.** No label, no commit message can opt out of a reviewer. The classifier is mechanical.
+
+**Invariant 8 (referenced) — Secret values never appear in logs, traces, exceptions, or telemetry — or in workflow / config files.** The `.coderabbit.yaml` template carries no secret values, no DSNs, no API keys; CodeRabbit authenticates via its installed GitHub App.
+
+**Invariant `{N2}` (packet 00) — Substantive-PR classifier is the safe-list in ADR-0079 D3; per-PR override is forbidden.** This note is the canonical single source of truth for the list.
+
+## Constraints
+> **Invariant 8 — No secrets in config files.** The `.coderabbit.yaml` template is a public-repo artifact — no DSNs, no API keys, no secret values.
+
+- **One source of truth for the safe-list.** The policy note is the single canonical list; ADR-0079's body and `HoneyDrunk.Actions`'s classifier (packet 02) point at this note, never duplicate the list. If a future change to the safe-list is needed, edit the note + reference an amendment to ADR-0079 — not multiple files.
+- **Template is sensible defaults, not exhaustive opinions.** The template captures shared baseline (severity floor, path filters, language tunings); per-repo refinement is the per-repo operator's decision.
+- **No per-repo adoption in this packet.** Per-repo `.coderabbit.yaml` adoption is the deferred fan-out. This packet ships only the template + placement convention.
+- **Header comment on `.coderabbit.yaml` names ADR-0079 D1.** Future readers should see immediately that the template's shape is ADR-bound.
+
+## Labels
+`feature`, `tier-2`, `meta`, `docs`, `adr-0079`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Author the Grid's reference `.coderabbit.yaml` template and record the ADR-0079 D3 substantive-PR safe-list as a single-source cross-cutting policy note.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Establish the canonical CodeRabbit configuration shape every repo can copy, and the canonical safe-list every downstream consumer (workflow, docs, future audit) reads from.
+- Feature: ADR-0079 Multi-Perspective PR Review Stack rollout, Wave 1.
+- ADRs: ADR-0079 D1/D3/D9 (primary), ADR-0044 (the cloud-code-review baseline ADR-0079 amends).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0079 should be Accepted before its decisions are recorded as a template + canonical policy note.
+
+**Constraints:**
+- One source of truth for the safe-list — the policy note is canonical; packet 02 will point at it.
+- The template is sensible defaults, not exhaustive opinions — per-repo refinement is per-repo operator's call.
+- No per-repo adoption in this packet — per-repo `.coderabbit.yaml` is the deferred fan-out.
+- No secrets in the template (invariant 8).
+
+**Key Files:**
+- `templates/.coderabbit.yaml`
+- `templates/README.md`
+- The safe-list policy note in `business/context/` (new file — first cross-cutting policy note in that directory).
+- `CHANGELOG.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0079-pr-review-stack/02-actions-substantive-pr-classifier.md
+++ b/generated/issue-packets/active/adr-0079-pr-review-stack/02-actions-substantive-pr-classifier.md
@@ -1,0 +1,141 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["ci", "tier-2", "meta", "adr-0079", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0079", "ADR-0044", "ADR-0012"]
+accepts: ["ADR-0079"]
+wave: 2
+initiative: adr-0079-pr-review-stack
+node: honeydrunk-actions
+---
+
+# Add the ADR-0079 D3 substantive-PR classifier to the PR-review workflow and expose `is_substantive` as a workflow output
+
+## Summary
+Add the ADR-0079 D3 substantive-PR classifier to `HoneyDrunk.Actions`'s PR-review workflow surface — a mechanical file-path-glob check that compares a PR's changed files against the canonical safe-list (`*.md`, `*.mdx`, `*.txt`, `docs/**`, `LICENSE*`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `docs/assets/**`) and surfaces a boolean `is_substantive` output that downstream jobs (packet 03's Reviewer 4 trigger) consume to gate themselves.
+
+## Target Workflow
+**Files:** `.github/workflows/job-review-request.yml` (and/or its caller `pr-core.yml` — choose the surface where the boolean has the widest correct consumer reach; if both must change to expose the output to the caller, change both).
+**Family:** pr-core / review-request.
+
+## Motivation
+ADR-0079 D3 commits the substantive-PR classifier as the cost-discipline mechanism for Reviewer 4 — the fourth (Anthropic-native Claude Code) reviewer runs only when the PR is substantive. The classifier is mechanical: a file-path-glob check against the canonical safe-list. Per invariant `{N2}` (packet 00), the classifier carries no LLM judgment, no label-based override, no commit-message escape.
+
+The canonical safe-list lives in **packet 01's cross-cutting policy note** in the `HoneyDrunk.Architecture` repo (single source of truth). The practical default for this workflow — which runs in `HoneyDrunk.Actions`, a sibling repo — is to **embed a documented copy of the safe-list in-workflow** with an explicit `# Source: HoneyDrunk.Architecture/business/context/<safe-list-policy-note>.md` header comment, and to **add a drift-detection CI check** that flags any divergence between the in-workflow copy and the canonical policy note. A cross-repo runtime read of the policy note on every PR is operationally awkward (auth, latency, failure modes) and is not the preferred shape; in-workflow copy + drift CI is the practical default and is the approach this packet specifies.
+
+`HoneyDrunk.Actions` already owns the PR-review trigger rail (`job-review-request.yml` per ADR-0044 packet 03b; `pr-core.yml` aggregates the PR-time jobs per ADR-0012 making Actions the Grid's CI/CD control plane). This packet adds the classifier as a new step (or new job in `pr-core.yml` if the placement is cleaner) and exposes `is_substantive` as a workflow output.
+
+This is a workflow/YAML packet. No .NET project.
+
+## Proposed Change
+
+### Classifier step (mechanical)
+A new step that:
+1. Reads the safe-list from the in-workflow copy (the practical default — see Motivation). The in-workflow copy carries a `# Source: HoneyDrunk.Architecture/business/context/<safe-list-policy-note>.md` header comment naming the canonical policy note as the source of truth. A separate CI check (see Drift detection below) flags any divergence between the in-workflow copy and the canonical note.
+2. Enumerates the PR's changed files via `gh pr diff --name-only` or the equivalent GitHub event payload field.
+3. Sets `is_substantive=true` if **any** changed file fails to match **any** safe-list glob; otherwise `is_substantive=false`.
+4. Emits `is_substantive` and a list of "files outside safe-list" (for diagnostic logging) as workflow outputs.
+
+The classifier must:
+- Apply the safe-list globs case-sensitively or insensitively to match how GitHub normalizes paths (research the convention at execution time; document the choice).
+- Treat a deleted file the same as an added or modified file (a deletion of a code file is still a substantive change; a deletion of a docs-only file is still trivial).
+- Treat a rename as the union of the source path and the destination path (a rename moving a code file to `docs/` is substantive on the source path).
+- Handle the empty-diff edge case (e.g. an empty draft PR or a PR with only commit-message changes) by defaulting to `is_substantive=false` and logging the empty-diff observation — the safe-list's "no file outside the safe-list" rule maps cleanly.
+
+### Output surfacing
+`is_substantive` is a workflow output on `job-review-request.yml` so:
+- `pr-core.yml` consumers can read it.
+- Packet 03's Reviewer 4 trigger workflow gates itself on `needs.<classifier-job>.outputs.is_substantive == 'true'`.
+- Diagnostic logging surfaces the list of files outside the safe-list when `is_substantive=true` (helpful when a docs PR turned substantive because of an unintended addition).
+
+### No new credentials, no new secrets
+The classifier reads the safe-list (a public-repo file) and the PR's changed files (via the existing `github-token` already used by `job-review-request.yml`). No new credential, no new secret.
+
+### Existing reviewer behavior unchanged
+Reviewers 1 (Copilot), 2 (CodeRabbit), and 3 (Grid-aware via Codex/OpenClaw) continue to run on **every** non-draft PR. Per ADR-0079 D9 ("trivial-PR Reviewer 1/2/3 suppression" is explicitly out of scope), the classifier output is consumed **only** by Reviewer 4's trigger (packet 03). Reviewers 1–3 are not gated.
+
+### Drift detection (required — in-workflow copy is the practical default)
+The in-workflow safe-list copy is the practical default for the cross-repo case (see Motivation). A separate CI check must flag drift between the workflow's copy and the canonical policy note. This is the same drift-detection pattern ADR-0044 packet 17 established for the D3 review rubric — re-use that pattern's shape (a small script that fetches the canonical source and diffs against the in-workflow copy; fail the check on any difference).
+
+## Consumer Impact
+- Existing consumers of `job-review-request.yml` and `pr-core.yml` are unaffected — the classifier step is additive; the new output is consumed only when explicitly read.
+- No PR will see any reviewer behavior change as a direct consequence of this packet — the classifier is wired but no downstream gate consumes it yet (packet 03 is the first consumer).
+- Diagnostic logging surfaces the classification on every PR (useful for an operator audit and for verifying the safe-list matches intent).
+
+## Breaking Change?
+- [ ] Yes
+- [x] No — additive classifier step; new workflow output; no behavior change for existing consumers.
+
+## Acceptance Criteria
+- [ ] `job-review-request.yml` (or `pr-core.yml`, whichever exposes the output cleanly to consumers) carries a classifier step that reads the in-workflow safe-list copy and outputs `is_substantive` as a boolean
+- [ ] The in-workflow safe-list copy carries a `# Source: HoneyDrunk.Architecture/business/context/<safe-list-policy-note>.md` header comment naming the canonical policy note as the source of truth
+- [ ] A drift-detection CI check flags any divergence between the in-workflow copy and the canonical policy note (re-use the ADR-0044 packet 17 drift-detection pattern shape)
+- [ ] The classifier handles deletions (same as adds/modifies), renames (union of source and destination paths), and empty diffs (default `is_substantive=false`) correctly
+- [ ] Diagnostic logging surfaces the list of files outside the safe-list when `is_substantive=true`
+- [ ] No new credential or secret is introduced — the classifier reads the in-workflow safe-list copy and the PR's changed files (via the existing `github-token`)
+- [ ] No change to Reviewers 1, 2, or 3 — they continue to run on every non-draft PR (ADR-0079 D9)
+- [ ] `is_substantive` is exposed as a workflow output that packet 03's Reviewer 4 trigger can consume
+- [ ] `docs/consumer-usage.md` (or the equivalent referenced docs) is updated to document the new output
+- [ ] The repo `CHANGELOG.md` is updated if the repo keeps one for the workflow surface
+- [ ] Existing consumers of the deploy/review workflows are unaffected — additive change only
+
+## Human Prerequisites
+- [ ] None for the workflow edit itself.
+- [ ] The first **consumer** of `is_substantive` is packet 03's Reviewer 4 trigger; until packet 03 lands and is enabled, this packet's output is informational only.
+
+## Referenced ADR Decisions
+**ADR-0079 D3 — Substantive-PR classifier safe-list.** Any PR whose entire changeset is inside `*.md`, `*.mdx`, `*.txt`, `docs/**`, `LICENSE*`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `docs/assets/**` is trivial. Any file outside makes the PR substantive. Mechanical classifier — no LLM judgment, no per-PR override.
+
+**ADR-0079 D9 — Trivial-PR Reviewer 1/2/3 suppression is out of scope.** Reviewers 1, 2, and 3 continue to run on every non-draft PR; only Reviewer 4 (packet 03) is gated on `is_substantive`.
+
+**ADR-0012 — `HoneyDrunk.Actions` is the Grid's CI/CD control plane.** The reusable workflows for PR review are Actions's surface. New cross-cutting CI gates land here.
+
+**Invariant `{N2}` (packet 00) — Substantive-PR classifier is the safe-list in ADR-0079 D3; per-PR override is forbidden.** The classifier carries no label-based override, no commit-message escape, no LLM judgment.
+
+**Invariant 8 (referenced) — Secret values never appear in workflow files.** The classifier authenticates via the existing `github-token`; no new credential is added; no DSN, instrumentation key, or API key is committed.
+
+## Constraints
+> **Invariant 31 — Every PR traverses the tier-1 gate before merge.** The classifier is additive — it must not become a required check that can block a merge. Workflow output only.
+
+> **Invariant `{N2}` — Substantive-PR classifier is the safe-list; per-PR override is forbidden.** The classifier is mechanical — no label, no commit-message, no LLM judgment can flip the output. Any future change to the safe-list must come from amending ADR-0079 + updating packet 01's policy note + updating the in-workflow copy in the same coordinated PR set.
+
+- **One source of truth for the safe-list.** The canonical safe-list lives in packet 01's policy note (`HoneyDrunk.Architecture/business/context/`). The in-workflow copy in this packet is a drift-checked mirror, not a parallel source. Drift detection is required, not optional.
+- **No new credential.** Reuse `github-token`. No DSN, no API key.
+- **Additive, backward-compatible.** Existing consumers of `job-review-request.yml` / `pr-core.yml` are unaffected — the classifier step is new; the output is new; no existing input or output changes shape.
+- **Diagnostic logging.** Every PR gets a one-line classification log entry; substantive PRs additionally log the list of files outside the safe-list.
+
+## Labels
+`ci`, `tier-2`, `meta`, `adr-0079`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add the ADR-0079 D3 substantive-PR classifier as a step in the PR-review workflow surface; expose `is_substantive` as a workflow output for packet 03 (Reviewer 4 trigger) to consume.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Wire the mechanical classifier that distinguishes substantive from trivial PRs. The classifier is the cost-discipline mechanism for Reviewer 4 (per ADR-0079 D2/D3/D6).
+- Feature: ADR-0079 Multi-Perspective PR Review Stack rollout, Wave 2.
+- ADRs: ADR-0079 D3/D9 (primary), ADR-0044 (the PR-review-workflow baseline), ADR-0012 (Actions as CI/CD control plane).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — hard. The classifier's policy backing (the `{N2}` safe-list-classifier invariant) lands in packet 00.
+- `packet:01` — hard. The canonical safe-list policy note is packet 01's deliverable; this packet's in-workflow copy mirrors it and the drift CI fails against it.
+
+**Constraints:**
+- Canonical safe-list in packet 01's policy note; the in-workflow copy is a drift-checked mirror (in-workflow copy + drift CI is the practical default for this cross-repo case).
+- Mechanical classifier — no LLM judgment, no per-PR override (invariant `{N2}`).
+- No new credential, no new secret (invariant 8).
+- Additive, backward-compatible — existing consumers unaffected.
+
+**Key Files:**
+- `.github/workflows/job-review-request.yml` (and/or `.github/workflows/pr-core.yml`).
+- `docs/consumer-usage.md` (or the equivalent referenced docs).
+- `CHANGELOG.md` (if maintained for the workflow surface).
+
+**Contracts:** Exposes `is_substantive` as a workflow output. Packet 03 consumes it.

--- a/generated/issue-packets/active/adr-0079-pr-review-stack/03-actions-reviewer4-claude-trigger-and-auth-gotcha.md
+++ b/generated/issue-packets/active/adr-0079-pr-review-stack/03-actions-reviewer4-claude-trigger-and-auth-gotcha.md
@@ -1,0 +1,187 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["ci", "tier-2", "meta", "adr-0079", "wave-2"]
+dependencies: ["packet:00", "packet:02"]
+adrs: ["ADR-0079", "ADR-0044", "ADR-0012"]
+accepts: ["ADR-0079"]
+wave: 2
+initiative: adr-0079-pr-review-stack
+node: honeydrunk-actions
+---
+
+# Wire the Reviewer 4 trigger (Anthropic-native Claude Code on the web) gated on substantive PRs and document the `ANTHROPIC_API_KEY` auth-precedence gotcha
+
+## Summary
+Author the workflow that triggers **Reviewer 4** per ADR-0079 D2 — the same `.claude/agents/review.md` Grid-aware agent executed through Anthropic's native Claude Code on the web GitHub integration, billed against the Claude Max Agent SDK credit pool — gated on packet 02's `is_substantive` output and the explicit `enabled` flag (which stays off until the June 15 2026 credit-pool launch). Document the ADR-0079 D8 auth-precedence gotcha (`ANTHROPIC_API_KEY` in the runner environment silently flips Claude execution to per-token billing) in the runner-configuration docs and at the top of the workflow file itself.
+
+## Target Workflow
+**Files:**
+- `.github/workflows/job-claude-review.yml` (new — name and exact path subject to GitHub Actions convention at execution time; if a more idiomatic name exists in the Grid's workflow taxonomy, prefer it and document the choice).
+- The runner-configuration docs that the Grid keeps for `HoneyDrunk.Actions` (e.g. `docs/runner-configuration.md` if it exists; otherwise the consumer-usage doc with a dedicated section).
+
+**Family:** pr-core / review-request.
+
+## Motivation
+ADR-0079 D2 names Reviewer 4 as the canonical satisfaction of Invariant 53's "two independent Grid-aware perspectives" requirement: the same `.claude/agents/review.md` definition, executed through Anthropic's native Claude Code on the web GitHub integration, against the Claude Max Agent SDK credit pool (available from **June 15, 2026**). The execution path does **not** go through OpenClaw — Anthropic's native integration is its own runtime per D2's "Trigger path" callout.
+
+ADR-0079 D8 codifies the **auth-precedence gotcha** as invariant 57: setting `ANTHROPIC_API_KEY` in the runner environment silently flips the Claude execution to per-token API billing (the SDK prefers env-var auth over session credentials). Per-token billing for Reviewer 4 is **explicitly out of scope by default** per ADR-0079 D6; opting in requires an ADR amendment. The mitigation is documenting the gotcha at every runner-configuration touchpoint and enforcing the default-unset rule at the workflow level.
+
+ADR-0079 D7 names the **pre-June-15 transition state**: until the Agent SDK credit pool is available, Reviewer 4 does not run, and the workflow's `enabled` gate stays off. This packet ships the workflow file with the gate off; flipping it on is a one-line edit + an ADR-0079-mandated invariant-53-satisfaction-now-complete log entry.
+
+### Gate: this packet authors against post-June-15 2026 Anthropic documentation
+
+**The Anthropic native Claude Code on the web GitHub integration's workflow shape (event triggers, credential mechanism, error signals for credit-pool exhaustion, payload shape) is not fully documented as of this packet's authoring (2026-05-24).** The June 15 2026 Claude Agent SDK credit-pool launch is expected to be accompanied by official documentation describing the GitHub-integration shape that this workflow must conform to.
+
+**Implementer gate:** before authoring `job-claude-review.yml`, confirm Anthropic's official documentation for the Claude Code on the web GitHub integration is available. If it is not (e.g., the implementer reaches this packet before June 15 2026 or shortly after with no docs visible yet), **defer this packet** and file a discovery follow-up to monitor for the docs. Do not author the workflow from inference. The pre-June-15 transition state per ADR-0079 D7 is the operating mode until the workflow lands.
+
+The Proposed Change section below describes the **intended shape**; the implementer adapts to the actual documented surface at the moment of authoring. Where the Proposed Change makes a structural assumption that the docs override, the docs win; record the deviation in the workflow's header comment and in `CHANGELOG.md`.
+
+## Proposed Change
+
+### New workflow: `job-claude-review.yml`
+A new reusable workflow that:
+1. **Gates on three conditions:**
+   - `enabled` input is `true` (default `false` — flipped on by the operator at or after June 15, 2026).
+   - `is_substantive` input is `true` (read from packet 02's classifier output by the caller workflow).
+   - The PR is not a draft (per ADR-0044 D1's cost discipline; the upstream `job-review-request.yml` already filters this, but the gate is repeated here for defense-in-depth).
+2. **Authenticates via Anthropic's native session credentials**, **not** an `ANTHROPIC_API_KEY` environment variable. The exact credential mechanism depends on Anthropic's GitHub integration shape at execution time — research the documented mechanism (typically a session-credential secret stored at the runner level, configured once via the Claude Code on the web GitHub App installation). Document the choice.
+3. **Loads `.claude/agents/review.md`** from the consuming repo's checkout — the same agent definition Reviewer 3 (Codex/OpenClaw) consumes per invariant `{N3}` (packet 00). The shared-agent-definition rule is the structural enforcement of the "two execution paths, one source of truth" discipline.
+4. **Loads Grid context** the same way Reviewer 3 does — invariants, ADRs, catalogs, the packet via PR-body link (per ADR-0044 D2's context-loading contract; the review-agent's context-loading section in `.claude/agents/review.md` is the source of truth).
+5. **Posts the Reviewer 4 verdict** as a separate PR comment (per ADR-0079 D9 — there is no cross-reviewer verdict aggregation; each reviewer posts its own comment).
+6. **Falls back gracefully** if the Agent SDK credit pool is exhausted: per ADR-0079 D6, Reviewer 4 is **skipped** on subsequent PRs that day with an advisory comment. Per-token API billing as a fallback is **forbidden by default** (opting in requires an ADR amendment). The workflow detects credit-pool exhaustion via the Anthropic SDK's documented error signal and exits with a "skipped — credit pool exhausted" comment, **not** by falling through to API billing.
+
+### Gate the workflow off by default
+The new `enabled` input defaults to `false`. The caller workflow (`pr-core.yml` or `job-review-request.yml`) invokes `job-claude-review.yml` with `enabled: false` until the operator flips it on at or after June 15, 2026. The flip is a one-line edit + a CHANGELOG entry noting "Reviewer 4 enabled — Invariant 53 fully satisfied on substantive PRs."
+
+### Top-of-file gotcha banner
+The workflow file (`job-claude-review.yml`) carries a prominent header comment naming the `ANTHROPIC_API_KEY` rule:
+
+```yaml
+# ==============================================================================
+# Reviewer 4 — Grid-Aware Agent via Anthropic-Native Claude Code
+# ==============================================================================
+# Source ADR: ADR-0079 D2.
+# Invariant {N3} (packet 00): this workflow consumes .claude/agents/review.md —
+# the SAME agent definition Reviewer 3 (Codex/OpenClaw) consumes. Drift between
+# execution paths is forbidden.
+# Invariant {N4} (packet 00): do NOT set ANTHROPIC_API_KEY in the runner
+# environment of this workflow. The Agent SDK credit pool is consumed when
+# authentication is via the operator's Claude Max session credentials. Setting
+# ANTHROPIC_API_KEY silently flips execution to per-token API billing — which
+# is explicitly out of scope per ADR-0079 D6 (an ADR amendment is required to
+# opt in).
+# ==============================================================================
+```
+
+### Runner-configuration docs
+Add (or extend the existing equivalent) a `docs/runner-configuration.md` section titled "Reviewer 4 — `ANTHROPIC_API_KEY` precedence" with the following content:
+
+- The Agent SDK credit pool is consumed when the runner authenticates as the operator's Claude Max session (via the Claude Code on the web GitHub integration's session credentials).
+- If a runner environment variable named `ANTHROPIC_API_KEY` is set, the SDK uses it preferentially and per-token API billing applies silently. The operator may not notice for a billing cycle.
+- The default Reviewer 4 runner configuration leaves `ANTHROPIC_API_KEY` unset.
+- Operator-facing checklist for setting up Reviewer 4: install the Claude Code on the web GitHub App on the relevant repos; configure session credentials via the documented Anthropic mechanism; verify `ANTHROPIC_API_KEY` is **not** set in the runner environment; enable the workflow gate.
+- Opting into per-token billing is forbidden by default; requires an ADR-0079 amendment.
+
+### No change to Reviewers 1, 2, or 3
+Reviewers 1 (Copilot), 2 (CodeRabbit), and 3 (Grid-aware via Codex/OpenClaw) continue to run on every non-draft PR. Per ADR-0079 D9, only Reviewer 4 is gated on `is_substantive`.
+
+## Consumer Impact
+- No PR sees Reviewer 4 behavior **until** the operator flips the `enabled` gate post-June-15. Existing reviewer behavior is unchanged.
+- The runner-configuration docs gain an operator-facing checklist for Reviewer 4 enablement.
+- The workflow file itself is inert until the gate flips — landing the file before June 15 is safe.
+
+## Breaking Change?
+- [ ] Yes
+- [x] No — the new workflow defaults to disabled; flipping it on is a deliberate operator action post-June-15.
+
+## Acceptance Criteria
+- [ ] **Pre-authoring gate confirmed:** Anthropic's official documentation for the Claude Code on the web GitHub integration is available at the moment of authoring; if not, this packet is deferred and a discovery follow-up is filed. Record the docs URL consulted in the workflow's header comment.
+- [ ] `.github/workflows/job-claude-review.yml` (or the chosen idiomatic name) exists and contains the Reviewer 4 reusable workflow per Proposed Change (adapted to the actual documented surface — docs win where they override the Proposed Change's structural assumptions)
+- [ ] The workflow gates on `enabled` (default `false`), `is_substantive` (from packet 02's output), and non-draft PR status; all three must be true for Reviewer 4 to run
+- [ ] The workflow loads `.claude/agents/review.md` from the consuming repo's checkout — the same agent definition Reviewer 3 consumes (invariant `{N3}`)
+- [ ] The workflow authenticates via Anthropic's documented native session-credential mechanism; the workflow file does **not** set or rely on `ANTHROPIC_API_KEY` (invariant `{N4}`)
+- [ ] The workflow falls back gracefully on Agent SDK credit-pool exhaustion: posts a "skipped — credit pool exhausted" comment and exits; does **not** fall through to per-token API billing (ADR-0079 D6)
+- [ ] The workflow posts its verdict as a **separate** PR comment (no cross-reviewer aggregation per ADR-0079 D9)
+- [ ] The workflow file carries the prominent top-of-file gotcha banner naming invariant `{N3}` (shared agent definition) and invariant `{N4}` (no `ANTHROPIC_API_KEY`)
+- [ ] `docs/runner-configuration.md` (or the equivalent referenced docs) carries a "Reviewer 4 — `ANTHROPIC_API_KEY` precedence" section documenting the gotcha and the operator-facing enablement checklist
+- [ ] No change to Reviewers 1, 2, or 3 — they continue to run on every non-draft PR
+- [ ] No new secret committed to the repo (invariant 8); session credentials are configured at the runner level via the documented Anthropic mechanism
+- [ ] The repo `CHANGELOG.md` is updated if the repo keeps one for the workflow surface, noting the workflow lands disabled and naming the docs URL the workflow was authored against
+- [ ] Existing consumers of the PR-review workflows are unaffected — additive change only
+
+## Human Prerequisites
+- [ ] **Anthropic's Claude Code on the web GitHub integration documentation is available.** This packet's authoring is gated on documented workflow shape (event triggers, credential mechanism, error signals). If the documentation is not yet available at the moment of authoring, defer this packet and file a discovery follow-up.
+- [ ] **Anthropic native Claude Code on the web GitHub App installed** on the relevant repos. One-time portal step per repo or per-organization. The workflow is inert without it.
+- [ ] **Claude Max session credentials configured** at the runner level per Anthropic's documented mechanism. The exact configuration shape may change between the packet authoring (2026-05-24) and June 15 launch — the workflow author researches the current documented surface at execution time.
+- [ ] **Explicit operator decision to flip the `enabled` gate** at or after June 15, 2026. This is the moment Invariant 53 transitions from "degraded-but-honest" to "fully satisfied on substantive PRs." Record the flip in `CHANGELOG.md` and in the dispatch plan.
+- [ ] **Verify `ANTHROPIC_API_KEY` is not set** in the runner environment for this workflow before enabling. The gotcha is silent — the operator must check explicitly.
+
+## Referenced ADR Decisions
+**ADR-0079 D2 — Reviewer 4 is the Grid-aware `review` agent via Anthropic-native Claude Code on the web.** Same `.claude/agents/review.md` agent definition as Reviewer 3, executed through Anthropic's native Claude Code on the web GitHub integration. Trigger path: GitHub webhook → Anthropic's native integration → Claude Code on the web session → agent execution → PR comment. Billing: against the operator's Claude Max Agent SDK credit pool, available from June 15, 2026.
+
+**ADR-0079 D6 — Per-token Anthropic API billing as a fallback is out of scope by default.** If the Agent SDK credit pool is exhausted, Reviewer 4 is skipped on subsequent PRs that day with an advisory comment. Opting into per-token billing requires an ADR amendment.
+
+**ADR-0079 D7 — Pre-June-15 transition state.** Reviewer 4 does not run until the Agent SDK credit pool is available. Invariant 53's full satisfaction degrades to "single Grid-aware perspective + two generic perspectives" until then — degraded-but-honest.
+
+**ADR-0079 D8 — `ANTHROPIC_API_KEY` auth-precedence gotcha.** Setting `ANTHROPIC_API_KEY` in the runner environment silently flips Claude execution to per-token billing. Codified as invariant `{N4}`. The gotcha is documented at the runner-configuration level and at the top of the workflow file.
+
+**ADR-0079 D9 — Each reviewer posts its own PR comment.** No cross-reviewer verdict aggregation; aggregation is a future-state concern.
+
+**Invariant `{N3}` (packet 00) — Shared agent definition across execution paths.** Both Reviewer 3 (Codex/OpenClaw) and Reviewer 4 (Anthropic-native Claude) consume the same `.claude/agents/review.md` definition. Drift between execution paths is forbidden.
+
+**Invariant `{N4}` (packet 00) — `ANTHROPIC_API_KEY` not set in Reviewer 4 runner environment by default.** Codified rule; per-token billing is opt-in via ADR amendment only.
+
+**Invariant 8 (referenced) — Secret values never appear in workflow files.** Session credentials are configured at the runner level via Anthropic's documented mechanism; no secret value is committed to the repo.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in workflow files.** No DSN, no API key, no session-credential value is committed. The runner-level credential configuration is the operator's responsibility per Human Prerequisites.
+
+> **Invariant `{N3}` — Shared agent definition across execution paths.** This workflow loads `.claude/agents/review.md` from the consuming repo's checkout — the same file Reviewer 3 (Codex/OpenClaw) consumes. The two execution paths must consume the same agent definition; drift is forbidden.
+
+> **Invariant `{N4}` — `ANTHROPIC_API_KEY` not set in the Reviewer 4 runner environment by default.** The workflow file does not set this variable; the runner-configuration docs name the rule; the operator-facing checklist verifies the variable is unset before enabling Reviewer 4.
+
+- **Default `enabled: false`.** The workflow ships disabled. Flipping it on is a deliberate post-June-15 operator action.
+- **No fallback to per-token billing.** Credit-pool exhaustion → skip + advisory comment. Falling through to API billing is forbidden by default (ADR-0079 D6).
+- **Separate PR comment.** No cross-reviewer aggregation (ADR-0079 D9).
+- **Defense-in-depth gating.** The workflow re-checks `is_substantive` and the draft-PR filter even though the caller workflow filters them — the cost of an accidental Reviewer 4 run on a trivial or draft PR is non-zero credit-pool consumption.
+
+## Labels
+`ci`, `tier-2`, `meta`, `adr-0079`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author the Reviewer 4 reusable workflow (Anthropic-native Claude Code) gated on `is_substantive` and the explicit `enabled` flag (default off until June 15, 2026); document the `ANTHROPIC_API_KEY` auth-precedence gotcha at the runner-configuration level and at the top of the workflow file.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Ship the Reviewer 4 trigger workflow as the second Grid-aware reviewer (same agent definition, different model family) — the canonical satisfaction of Invariant 53 per ADR-0079 D7.
+- Feature: ADR-0079 Multi-Perspective PR Review Stack rollout, Wave 2.
+- ADRs: ADR-0079 D2/D6/D7/D8/D9 (primary), ADR-0044 (the Grid-aware-reviewer baseline ADR-0079 amends), ADR-0012 (Actions as CI/CD control plane).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — hard. Reviewer 4's invariant backing (`{N1}`, `{N3}`, `{N4}`) lands in packet 00.
+- `packet:02` — hard. The `is_substantive` output the gate consumes is packet 02's deliverable.
+- **Anthropic docs availability** — hard external gate. The Claude Code on the web GitHub integration's workflow shape must be documented at the moment of authoring; if not, defer.
+
+**Constraints:**
+- Default `enabled: false`; flipped on by deliberate operator action post-June-15.
+- No fallback to per-token API billing on credit-pool exhaustion (ADR-0079 D6).
+- Shared agent definition (invariant `{N3}`) — load `.claude/agents/review.md` from the consuming repo.
+- `ANTHROPIC_API_KEY` unset in the runner environment by default (invariant `{N4}`).
+- Separate PR comment, no cross-reviewer aggregation (ADR-0079 D9).
+- No secret committed (invariant 8).
+- Docs-availability gate — defer if Anthropic's documentation for the Claude Code on the web GitHub integration is not available at the moment of authoring.
+
+**Key Files:**
+- `.github/workflows/job-claude-review.yml` (new).
+- `docs/runner-configuration.md` (or the equivalent referenced docs).
+- `docs/consumer-usage.md` (or the equivalent — note the new gated workflow).
+- `CHANGELOG.md` (if maintained for the workflow surface).
+
+**Contracts:** Consumes packet 02's `is_substantive` workflow output. Loads `.claude/agents/review.md` per invariant 56.

--- a/generated/issue-packets/active/adr-0079-pr-review-stack/04-architecture-operator-doc-watchlist-cost-hook.md
+++ b/generated/issue-packets/active/adr-0079-pr-review-stack/04-architecture-operator-doc-watchlist-cost-hook.md
@@ -1,0 +1,141 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "docs", "adr-0079", "wave-3"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0079", "ADR-0046", "ADR-0052", "ADR-0044"]
+accepts: ["ADR-0079"]
+wave: 3
+initiative: adr-0079-pr-review-stack
+node: honeydrunk-architecture
+---
+
+# Update operator-facing docs with the four-reviewer expectation, record the Greptile/Codex-OOTB watch-list, and hook reviewer-stack cost monitoring into ADR-0052
+
+## Summary
+Three governance documentation tasks from ADR-0079's Follow-up Work: (1) extend the operator-facing onboarding / `CONTRIBUTING.md` aggregator with the four-reviewer expectation so the operator (and any AI agent helping the operator) understands the canonical stack; (2) record the Greptile + Codex-OOTB-review watch-list with reconsideration triggers so future-state decisions have a documented starting point; (3) wire reviewer-stack cost monitoring (CodeRabbit + Codex overage + Anthropic credit pool consumption) into ADR-0052's cost-governance surface so the per-month spend is tracked alongside the rest of the Grid's recurring costs.
+
+## Context
+ADR-0079's Follow-up Work names three doc/governance tasks beyond the workflow plumbing of packets 02 and 03:
+- "Operator-facing onboarding doc (or `CONTRIBUTING.md` aggregator) explains the four-reviewer expectation."
+- "Watch list: Greptile re-evaluation if a class of missed bugs emerges; Codex out-of-the-box review re-evaluation if its Grid-context-loading capability improves; specialist agents per ADR-0046 invocation logic stays per-Node."
+- "Cost monitoring per ADR-0052 tracks CodeRabbit + Codex overage + Anthropic credit pool consumption."
+
+These three are operator-facing or governance-tracking artifacts; they depend only on the acceptance flip (packet 00) and are independent of the workflow plumbing (packets 02/03). They are grouped into one packet because they share the same target repo, the same governance surface, and benefit from being authored together to avoid drift between the operator doc, the watch list, and the cost-tracking entry.
+
+ADR-0079 D9 explicitly preserves ADR-0046 (Proposed)'s specialist-agent invocation logic — the watch-list note for "specialist agents stay per-Node" is a non-decision, captured here only to make the preservation explicit and prevent a future drift conversation. ADR-0046 itself remains Proposed; the watch-list note describes the preservation of the pattern ADR-0046 proposes, not an Accepted constraint.
+
+`business/context/` today holds only `entity.md` and `operating-costs.md`. The watch-list note created here is a new cross-cutting artifact in that directory; packet 01 also lands a note there (the safe-list policy note). These two packets together establish the convention for cross-cutting policy notes in `business/context/`. The ADR-0052 cost-tracking hook extends the existing `operating-costs.md` ledger (the Planned Additions table already names CodeRabbit as a pending line item). The four-reviewer expectation lives in `CONTRIBUTING.md` at the Architecture repo root — this file **does not exist today** and is created by this packet.
+
+This is a docs/governance packet. No code, no .NET project. No workflow change.
+
+## Scope
+- **Operator-facing four-reviewer expectation doc.** **Create** `CONTRIBUTING.md` at the Architecture repo root (the file does not exist today). The initial body is a "Code review on the Grid" section naming the four reviewers, the substantive-vs-trivial distinction, and what to expect on a PR. Future operator-onboarding content (welcome, contributor workflow, etc.) can extend the same file as new packets need it; this packet seeds the file with the reviewer-stack content only.
+- **Watch-list note in `business/context/`.** Create a new note (e.g. `pr-review-watch-list.md`) recording Greptile, Codex-OOTB review, and the ADR-0046 (Proposed) specialist-agent preservation as a single artifact — the reconsideration-triggers note for the reviewer stack.
+- **Cost-tracking hook in `business/context/operating-costs.md`.** Extend the existing recurring-cost ledger with the reviewer-stack line items: CodeRabbit (~$24/mo — already named as a Planned Addition; promote to a recurring line once provisioned per packet 01's Human Prerequisites), Codex API overage (bounded variable), Anthropic Claude Max Agent SDK credit pool (no per-token by default; opt-in via ADR amendment only). The ADR-0052 cost-governance surface itself is referenced; the line items land in `operating-costs.md` (the Grid's recurring-cost ledger of record).
+
+## Proposed Implementation
+1. **Operator-facing four-reviewer expectation.** **Create** `CONTRIBUTING.md` at the Architecture repo root (the file does not exist today). Seed it with a top-level "Code review on the Grid" section:
+   - The four canonical reviewers, each one paragraph:
+     - **Reviewer 1: GitHub Copilot Code Review** — GitHub-native, zero marginal cost, generic code quality.
+     - **Reviewer 2: CodeRabbit** — third-party AI, ~$24/dev/mo, vendor-independent of Microsoft and Anthropic.
+     - **Reviewer 3: Grid-aware `review` agent via Codex/OpenClaw** — runs `.claude/agents/review.md`, loads Grid context (invariants, ADRs, catalogs, packet).
+     - **Reviewer 4: Grid-aware `review` agent via Anthropic-native Claude Code** — same agent definition, different model family, runs on substantive PRs from June 15 2026 onward; the dual-model satisfaction of Invariant 53.
+   - The substantive-vs-trivial distinction with a pointer to the canonical safe-list (packet 01's policy note).
+   - "What to expect on a PR": three reviewer comments on a trivial PR; four reviewer comments on a substantive PR (post-June-15). On a high-risk-Node PR, ADR-0046's specialist agent (Proposed pattern) adds a fifth (the operational maximum per the charter's anti-performing-visibility warning).
+   - Reference the source ADRs: ADR-0079 (the canonical stack), ADR-0044 (the Grid-aware reviewer), ADR-0046 (specialist agents — Proposed), and the relevant invariants (52, 53, and the `{N1}`–`{N4}` block packet 00 claims).
+2. **Watch-list note.** Create a new note in `business/context/` (e.g. `pr-review-watch-list.md`) titled along the lines of "ADR-0079 reviewer-stack watch list". Body:
+   - **Greptile** (held in watch list per ADR-0079 D4). Reconsideration trigger: a class of bugs the current four-reviewer stack consistently misses, AND Greptile's cross-file context awareness or other capability would plausibly have caught the class. If the trigger fires, the next ADR amendment evaluates Greptile against the current stack's perspective coverage.
+   - **Codex out-of-the-box review** (held in watch list per ADR-0079 D5). Reconsideration trigger: Codex OOTB review gains Grid-context-loading capability comparable to running `.claude/agents/review.md` directly, AND the OOTB review covers a perspective the current Grid-aware agent does not (which is hard to imagine given the agent's design, but the watch list is honest about uncertainty).
+   - **ADR-0046 (Proposed) specialist agents** (no decision pending; ADR-0079 D9 preserves ADR-0046's invocation logic). Note: when a substantive PR touches a high-risk Node, ADR-0046's specialist agent (security, performance, accessibility, etc.) composes on top of the four-reviewer stack — a five-reviewer operational maximum on the most-sensitive PRs.
+   - **Cap discipline.** The charter's anti-performing-visibility warning explicitly bounds reviewer count. Adding a fifth canonical reviewer (beyond ADR-0046 specialists) requires an ADR amendment with an explicit forcing function — not a "let's add another bot for thoroughness" decision.
+3. **Cost-tracking hook in `business/context/operating-costs.md`.** Extend the existing recurring-cost ledger (the file already exists; CodeRabbit is named in its Planned Additions table). Add line items:
+   - **CodeRabbit** — promote from Planned Additions to a recurring line at ~$24/dev/mo × 1 seat = ~$24/mo (do this once the operator's CodeRabbit subscription is provisioned per packet 01's Human Prerequisites; until then, keep it in Planned Additions with a footnote). Trigger for re-evaluation: > $30/mo (a price hike) or > $50/mo (a multi-seat trigger if a second developer joins, which is a separate ADR conversation per the charter's solo-developer posture).
+   - **Codex API overage** — bounded variable, against the operator's ChatGPT Pro allotment first. Trigger for re-evaluation: monthly overage > $50/mo sustained for two consecutive months (the ADR-0052 cost-pressure inflection — reconsider Reviewer 3's allotment or move some Codex work off-allotment).
+   - **Anthropic Claude Max Agent SDK credit pool** — no per-token billing by default (ADR-0079 D6). Trigger for re-evaluation: credit-pool exhaustion frequency > 1 day/month sustained for two consecutive months → ADR amendment to opt into per-token billing or to add a second Max subscription. Per-token API billing as a fallback is **forbidden by default**; an amendment is required.
+   - **Total recurring contribution from the reviewer stack** — ~$24/mo + bounded overage. Within the Grid's broader cost ceiling.
+4. **Repo `CHANGELOG.md`** — one-line entry per repo convention referencing this packet and ADR-0079.
+
+## Affected Files
+- `CONTRIBUTING.md` at the Architecture repo root (new — does not exist today).
+- A watch-list note in `business/context/` (new file).
+- `business/context/operating-costs.md` (existing — extend the recurring-cost ledger and/or promote the existing CodeRabbit Planned Additions entry).
+- `CHANGELOG.md`.
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance/operator docs; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture` — `CONTRIBUTING.md`, `business/context/`, and `CHANGELOG.md` all live here. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No workflow change — packets 02 and 03 are the workflow changes.
+
+## Acceptance Criteria
+- [ ] `CONTRIBUTING.md` is created at the Architecture repo root with a "Code review on the Grid" section naming the four canonical reviewers each with a one-paragraph description; the substantive-vs-trivial distinction with a pointer to packet 01's safe-list policy note; the "what to expect on a PR" expectation (three vs four reviewer comments, plus specialist agents on high-risk Nodes); references to ADR-0079, ADR-0044, ADR-0046 (Proposed), and invariants 52, 53, and the `{N1}`–`{N4}` block packet 00 claims
+- [ ] A new watch-list note in `business/context/` records Greptile, Codex-OOTB review, and the ADR-0046 (Proposed) specialist-agent preservation as reconsideration triggers with explicit conditions for each; the cap-discipline statement (no fifth canonical reviewer without an ADR amendment + forcing function) is included
+- [ ] `business/context/operating-costs.md` is extended with the three reviewer-stack line items (CodeRabbit promoted from Planned Additions once provisioned, Codex API overage, Anthropic credit pool); each line names its re-evaluation trigger; the per-token-billing-forbidden default is noted on the Anthropic line
+- [ ] The repo `CHANGELOG.md` is updated per repo convention
+- [ ] No invariant change (the four PR-review-stack invariants land in packet 00); no `.coderabbit.yaml` change (packet 01); no workflow change (packets 02/03)
+
+## Human Prerequisites
+- [ ] None for the doc edits themselves.
+- [ ] The cost-ledger entries become real numbers once the CodeRabbit subscription is provisioned (the operator's one-time portal step per packet 01's Human Prerequisites) and once Reviewer 4 is enabled post-June-15 (per packet 03's Human Prerequisites). Until then, the ledger entries are forward-looking estimates.
+
+## Referenced ADR Decisions
+**ADR-0079 D1/D2 — The four-reviewer canonical stack.** Three reviewers on every non-draft PR (Copilot, CodeRabbit, Grid-aware via Codex); a fourth reviewer (Grid-aware via Anthropic-native Claude) on substantive PRs from June 15 2026 onward.
+
+**ADR-0079 D4 — Greptile held in watch list.** Reconsideration trigger: a class of missed bugs the current stack consistently misses AND a Greptile-unique capability not otherwise covered.
+
+**ADR-0079 D5 — Codex OOTB review held in watch list.** Reconsideration trigger: Grid-context-loading capability gains in Codex OOTB.
+
+**ADR-0079 D6 — Per-token Anthropic API billing forbidden by default.** Credit-pool exhaustion → skip; opting in requires an ADR amendment.
+
+**ADR-0079 D9 — ADR-0046 specialist-agent invocation preserved.** A substantive PR touching a high-risk Node receives Reviewers 1–4 plus ADR-0046's specialist agent (five reviewers — the operational maximum).
+
+**ADR-0044 — Grid-aware cloud code reviewer.** Reviewers 3 and 4 execute the same `.claude/agents/review.md` agent defined by ADR-0044.
+
+**ADR-0046 (Proposed) — Specialist review agents.** Narrower reviewers (security, performance, accessibility) invoked when their domain is touched; ADR-0079 preserves the per-Node invocation logic of this Proposed pattern.
+
+**ADR-0052 (Proposed) — Cost governance, budget alerts, and kill switches.** The reviewer-stack cost line items register against the broader Grid cost-governance surface this Proposed ADR describes; the immediate ledger of record is `business/context/operating-costs.md`.
+
+**Invariant `{N1}` (packet 00) — Canonical four-reviewer stack.** Adding a fifth canonical reviewer requires an ADR amendment with an explicit forcing function.
+
+## Constraints
+- **Operator-facing language.** `CONTRIBUTING.md` and the watch-list note are read by the operator (and any AI agent assisting). Plain-spoken; no jargon-as-pretext.
+- **Watch list is reconsideration-trigger documentation, not state.** The watch list does not say "add Greptile next month" — it says "if X happens, reconsider Greptile." Trigger-driven.
+- **Cap discipline is explicit.** The fifth-canonical-reviewer prohibition (without ADR amendment + forcing function) is named in the watch-list note. ADR-0046 specialists are the documented exception (per-Node, ADR-bound).
+- **Per-token-billing-forbidden default is loud.** The Anthropic credit-pool ledger entry names the forbidden-default rule explicitly so a future operator does not flip on per-token billing without an ADR amendment (the same defense-in-depth as invariant `{N4}` + packet 03's workflow gotcha banner).
+- **No invariant or catalog change here.** Invariants land in packet 00; the safe-list policy note lands in packet 01; the workflow changes land in packets 02/03.
+
+## Labels
+`chore`, `tier-3`, `meta`, `docs`, `adr-0079`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Update the operator-facing onboarding doc with the four-reviewer expectation, record the Greptile/Codex-OOTB-review watch list with reconsideration triggers, and hook reviewer-stack cost monitoring into the ADR-0052 cost-governance surface.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the four-reviewer expectation visible to the operator (and any helping AI agent); document the watch list as trigger-driven reconsideration; track reviewer-stack costs against the Grid's recurring-cost ledger (`business/context/operating-costs.md`).
+- Feature: ADR-0079 Multi-Perspective PR Review Stack rollout, Wave 3.
+- ADRs: ADR-0079 D1/D2/D4/D5/D6/D9 (primary), ADR-0044 (the Grid-aware reviewer baseline), ADR-0046 (Proposed — specialist agents preserved per ADR-0079 D9), ADR-0052 (Proposed — cost-governance surface referenced; ledger of record is `operating-costs.md`).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0079 should be Accepted before its policy is bound into operator docs and the cost ledger. Independent of packets 01/02/03 — can run in parallel with the CI plumbing.
+
+**Constraints:**
+- Operator-facing language; trigger-driven watch list (not scheduled state); explicit cap discipline; the per-token-billing-forbidden default is loud.
+- No invariant or catalog change here.
+
+**Key Files:**
+- `CONTRIBUTING.md` at the Architecture repo root (new — does not exist today).
+- The watch-list note in `business/context/` (new file).
+- `business/context/operating-costs.md` (existing — extend the recurring-cost ledger).
+- `CHANGELOG.md`.
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0079-pr-review-stack/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0079-pr-review-stack/dispatch-plan.md
@@ -1,0 +1,112 @@
+# Dispatch Plan — ADR-0079: Multi-Perspective PR Review Stack
+
+**Initiative:** `adr-0079-pr-review-stack`
+**ADR:** ADR-0079 (Proposed → Accepted via packet 00)
+**Sector:** Meta (governance + CI)
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0079 commits the canonical PR-review stack: **three reviewers on every non-draft PR** (GitHub Copilot Code Review, CodeRabbit, Grid-aware `review` agent via Codex/OpenClaw) and **a fourth reviewer on substantive PRs** (the same `.claude/agents/review.md` Grid-aware agent executed through Anthropic's native Claude Code on the web GitHub integration). The fourth reviewer is the cleanest available satisfaction of Invariant 53 ("two independent LLM-review perspectives on high-risk Nodes") because it runs the same Grid-context-loaded agent against a different model family (Claude vs. Codex's GPT-class). A mechanical safe-list distinguishes substantive from trivial PRs; trivial (docs-only) PRs skip Reviewer 4 to preserve cost discipline.
+
+This initiative delivers: ADR acceptance + four new Code Review invariants + the `.coderabbit.yaml` Grid template + the substantive-PR classifier wired into `HoneyDrunk.Actions`'s PR-review pipeline + the Reviewer 4 trigger (gated on the June 15 2026 Claude Agent SDK credit-pool availability) + the auth-precedence runner-config gotcha doc + the operator-facing four-reviewer expectation note + the cost-tracking hook into ADR-0052.
+
+**5 packets across 3 waves**, targeting **2 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Actions`). All 5 `Actor=Agent`, 0 `Actor=Human`. Multiple packets carry Human Prerequisites — CodeRabbit subscription provisioning (one-time), Anthropic Claude Max session credential setup for the GitHub-Actions runner (post-June-15), and the explicit decision to enable Reviewer 4 across the Grid — but the code/YAML/docs work itself is fully delegable.
+
+## Trigger
+
+ADR-0079 is Proposed with no scope. Forcing functions from the ADR's Context:
+
+- **AI-authored PR volume has grown** — wave-style rollouts emit 5–15 agent PRs per window; the reviewer stack must be cost-efficient per-PR or it bottlenecks the throughput.
+- **Invariant 53's "two independent perspectives" requirement is unsatisfied today** on substantive Node PRs — today's stack carries only one Grid-aware reviewer.
+- **Anthropic's June 15 2026 Claude Agent SDK credit pool** for Claude Max subscribers creates a new no-per-token billing path that did not exist when ADR-0044 was authored.
+- **The Grid has no formal substantive-vs-trivial PR classifier** — without one, every reviewer runs on every docs-only PR.
+- **The charter's anti-performing-visibility warning** explicitly bounds reviewer count.
+
+## Scope Detection
+
+**Multi-repo.** ADR-0079 touches `HoneyDrunk.Architecture` (acceptance, four invariants, the safe-list catalog/policy note, the operator-facing expectation doc, the ADR-0052 cost-tracking hook) and `HoneyDrunk.Actions` (the classifier in the PR-review workflow, the Reviewer 4 trigger workflow, the auth-precedence runner-config doc). The `.coderabbit.yaml` template (Architecture packet 01) is the Grid's reference shape — per-repo `.coderabbit.yaml` adoption is deliberately deferred to a follow-up fan-out (see Out-of-scope below) rather than fanned into premature per-Node packets.
+
+**No new-Node scaffolding.** Both target repos are live. No empty cataloged repo is touched; no standup ADR needed.
+
+## Wave Diagram
+
+### Wave 1 (governance + foundation)
+- [ ] **00** — Architecture: Accept ADR-0079, add the four new Code Review invariants (numbers **54, 55, 56, 57**), register the initiative, amend ADR-0044 with the "Amended by ADR-0079" note, clarify ADR-0046 Invariant 53 satisfaction. `Actor=Agent`.
+- [ ] **01** — Architecture: author the `.coderabbit.yaml` Grid template and record the substantive-PR safe-list as a cross-cutting policy note in `business/context/` (or the established location). `Actor=Agent`. Blocked by: 00.
+
+### Wave 2 (CI plumbing — parallel)
+- [ ] **02** — Actions: add the substantive-PR classifier to `job-review-request.yml` (or its caller `pr-core.yml`), surfacing a boolean output for downstream jobs. `Actor=Agent`. Blocked by: 00, 01.
+- [ ] **03** — Actions: wire the Reviewer 4 trigger (Anthropic-native Claude Code on the web GitHub integration) gated on substantive-PR true; document the auth-precedence (`ANTHROPIC_API_KEY`) gotcha at the runner-configuration level. `Actor=Agent`. Blocked by: 00, 02.
+
+### Wave 3 (operator-facing + cost tracking)
+- [ ] **04** — Architecture: update the operator-facing onboarding doc (`CONTRIBUTING.md` aggregator and the operator quickstart) with the four-reviewer expectation; record the watch-list (Greptile, Codex OOTB review) for future-state reconsideration; wire the cost-monitoring hook into the ADR-0052 reviewer-stack cost surface. `Actor=Agent`. Blocked by: 00. (Parallel with 02/03 — depends only on the acceptance flip.)
+
+Packets within a wave run in parallel. The `dependencies:` frontmatter is the real ordering signal — packet 04 unblocks as soon as packet 00 lands (the Wave 3 grouping is for tidy filing only).
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0079](./00-architecture-adr-0079-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [`.coderabbit.yaml` template + safe-list policy](./01-architecture-coderabbit-template-and-substantive-safe-list.md) | Architecture | Agent | 1 | 00 |
+| 02 | [Substantive-PR classifier in `job-review-request.yml`](./02-actions-substantive-pr-classifier.md) | Actions | Agent | 2 | 00, 01 |
+| 03 | [Reviewer 4 trigger + auth-precedence runner doc](./03-actions-reviewer4-claude-trigger-and-auth-gotcha.md) | Actions | Agent | 2 | 00, 02 |
+| 04 | [Four-reviewer operator doc + watch-list + cost hook](./04-architecture-operator-doc-watchlist-cost-hook.md) | Architecture | Agent | 3 | 00 |
+
+## Invariant Numbering
+
+The verified current maximum invariant number in `constitution/invariants.md` is **53**. ADR-0079's Consequences/Invariants section names exactly four new rules (D1+D2's four-reviewer stack, D3's safe-list, the shared-agent-definition discipline that extends ADR-0044 D1, and the `ANTHROPIC_API_KEY` runner-environment rule from D8). These are numbered **54, 55, 56, 57** under the existing `## Code Review Invariants` section — appended after invariant 53. ADR-0079 was not part of the 12-ADR pre-reservation batch (ADR-0044/0045/0046 etc.); its numbering is sequential.
+
+If invariants land between numbers 54–57 from another ADR before packet 00 merges, shift this block upward, never reuse. As of 2026-05-24, no overlap is visible.
+
+## Cross-Cutting Concerns
+
+### Pre-June-15 transition state
+
+ADR-0079 D2 + D7 are explicit: until **June 15, 2026** (the Claude Agent SDK credit-pool launch), Reviewer 4 does not run. Packets 02 and 03 ship with the substantive-PR classifier wired and the Reviewer 4 workflow file authored, but the workflow's `enabled` gate stays off until the credit pool is available. Reviewers 1, 2, and 3 operate normally during transition. Invariant 53's full satisfaction degrades to "single Grid-aware perspective + two generic perspectives" until June 15 — degraded-but-honest per D7.
+
+### Per-repo `.coderabbit.yaml` fan-out (deferred)
+
+Packet 01 ships the Grid-canonical `.coderabbit.yaml` template + the placement convention. Per-repo adoption across the 12+ Grid repos is a follow-up fan-out item, *not* in scope here. The justification: CodeRabbit's defaults are sensible without a per-repo config; the per-repo config refines for repo-specific patterns (e.g. Vault's secret-handling patterns, Audit's append-only constraints). The fan-out can be incremental, repo-by-repo, driven by observed reviewer noise — not a blocking pre-condition for ADR-0079.
+
+### Coupling with ADR-0046 specialist agents
+
+ADR-0079 D9 explicitly **does not** change ADR-0046's specialist-agent invocation logic. A substantive PR touching a high-risk Node receives Reviewers 1–4 *plus* whatever specialist agent ADR-0046 invokes for the touched domain — a five-reviewer operational maximum on the most-sensitive PRs. The cap is real; the charter's anti-performing-visibility warning bounds further additions to a future ADR with an explicit forcing function.
+
+### Watch list — Greptile and Codex out-of-the-box review
+
+ADR-0079 D4 and D5 hold both in the watch list. Packet 04 records the triggers under which each is reconsidered (a class of bugs the current stack consistently misses; a Greptile-unique capability not otherwise covered; Codex OOTB Grid-context-loading improvements). The watch list is not state to be reconciled; it is a documented reconsideration trigger.
+
+## Version Bumps
+
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; catalog/doc/governance edits only (packets 00, 01, 04). The repo `CHANGELOG.md` is updated per repo convention.
+- **`HoneyDrunk.Actions`** — not a versioned .NET solution; workflow/YAML changes (packets 02, 03). The repo `CHANGELOG.md` is updated per repo convention if it keeps one for the workflow surface.
+
+## Rollback Plan
+
+- **Packet 00 (governance):** revert the PR. ADR returns to Proposed; the four new invariants and the ADR-0044/0046 amendment notes are removed. No runtime impact.
+- **Packet 01 (`.coderabbit.yaml` template + safe-list policy):** revert the PR. Docs/template only. No repo has yet adopted the template (per-repo adoption is the deferred fan-out).
+- **Packet 02 (substantive-PR classifier):** revert the workflow edit. The classifier output is consumed only by packet 03's gate; reverting it makes the gate evaluate as "trivial" (Reviewer 4 skipped) — safe failure mode.
+- **Packet 03 (Reviewer 4 trigger + auth-precedence doc):** revert the workflow edit and the doc change. Reviewer 4 simply does not run; Reviewers 1, 2, 3 operate normally. No tenant-facing or runtime impact.
+- **Packet 04 (operator doc + watch-list + cost hook):** revert the PR. Docs only.
+- **Architectural escape hatch:** if Reviewer 4 produces low-value review noise post-June-15, the operator can flip `enabled: false` on the Reviewer 4 workflow gate — Invariant 53 satisfaction degrades to the pre-June-15 transition state until a fix lands or the ADR is amended.
+
+## Out-of-scope items from ADR-0079
+
+- **Per-repo `.coderabbit.yaml` fan-out** — the Grid template + placement convention land in packet 01; per-repo adoption is incremental, not scoped here. Each repo's adoption is a small follow-up PR against observed reviewer noise.
+- **Specialist agent invocation changes** — ADR-0046's invocation logic is preserved per ADR-0079 D9.
+- **Cross-reviewer verdict aggregation** — ADR-0079 D9 names this as a future-state concern. No packet here.
+- **Per-PR reviewer override (label-based opt-out)** — D9 forbids this. No packet here.
+- **Greptile / Codex OOTB review packets** — D4 and D5 hold both in the watch list. Reconsideration is trigger-driven, not scheduled. Packet 04 records the triggers.
+- **Pre-June-15 paying-per-token for Reviewer 4** — D6 explicitly out of scope; opting in requires an ADR amendment.
+
+## Cross-Cutting — site sync
+
+No site-sync flag. ADR-0079 is internal CI/governance infrastructure — no Studios public-facing content changes.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.

--- a/generated/issue-packets/active/adr-0080-vendor-lockin/00-architecture-adr-0080-acceptance.md
+++ b/generated/issue-packets/active/adr-0080-vendor-lockin/00-architecture-adr-0080-acceptance.md
@@ -1,0 +1,140 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "docs", "adr-0080", "wave-1"]
+dependencies: []
+adrs: ["ADR-0080"]
+accepts: ["ADR-0080"]
+wave: 1
+initiative: adr-0080-vendor-lockin
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0080 — flip status, add the three vendor-posture invariants, register the initiative
+
+## Summary
+Flip ADR-0080 (Vendor Lock-In Posture and Exit-Readiness Hedges) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, add the three new vendor-posture invariants ADR-0080 commits in its Consequences/Invariants section to `constitution/invariants.md`, and register the `adr-0080-vendor-lockin` initiative in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0080 commits the Grid's **vendor posture as a chosen position** rather than accidental drift. Across the last twelve months the Grid has accumulated vendor relationships at every layer (Azure for compute/config/secrets/telemetry/cache/identity; GitHub for source/CI/projects; Cloudflare for DNS/edge; Stripe for payments; Anthropic and OpenAI for AI; Resend/Twilio/Expo for Notify default providers). Each source ADR picked the right vendor for its surface; none of them, individually or collectively, stated the Grid's posture toward vendor lock-in as a chosen position — what is accepted, what is hedged, what is abstracted, what triggers a re-evaluation, and what the honest exit cost looks like per vendor.
+
+The ADR decides:
+
+- **D1** — Per-vendor posture is one of three: **Accept (deep, intentional)**, **Hedge (active)**, or **Abstract (already portable)**. The three-posture vocabulary is the only vendor-posture language the Grid uses; "multi-cloud," "vendor-neutral," "cloud-agnostic," and similar enterprise-shaped framings are explicitly not in the Grid's vocabulary (per D8's rejection of multi-cloud-by-default).
+- **D2** — Per-vendor posture table. Azure and GitHub are Accept (deep, intentional). Cloudflare, Stripe, Twilio, and Expo are Hedge (active). Anthropic, OpenAI, and Resend are Abstract (already portable). Posture is a per-surface concern, not a per-vendor concern — a vendor with multiple Grid surfaces may carry different postures per surface.
+- **D3** — Cheap Grid-wide hedges already in place at the code level: provider abstractions held at every boundary (per invariants 1, 2, 3, 44); no vendor-proprietary features in application code; EF Core LINQ kept provider-agnostic (per ADR-0072); Bicep modules by concern (per ADR-0077 D2); OTel-first telemetry emit (per ADR-0040); per-vendor governance files at `governance/vendor-postures/{vendor}.md` for Accept-posture vendors.
+- **D4** — Decision-point triggers (not kill clocks): deprecation/material price increase, sustained reliability problems (two or more incidents exceeding one hour of impact within a single calendar quarter), terms-change conflicts with charter, mature alternative emerges (after twelve-month maturation), adjacent Grid decision changes the math, vendor acquisition/corporate event. The trigger fires a **conversation**, not a migration. The conversation produces one of three outcomes: Stay / Hedge harder / Exit. Triggers are not promises.
+- **D5** — Per-vendor exit-playbook stubs for Accept-posture vendors. Two stubs created with this ADR's acceptance: `governance/vendor-postures/azure.md` and `governance/vendor-postures/github.md`. Hedge and Abstract postures use the source ADR as document-of-record; no separate governance file required at acceptance.
+- **D6** — Explicit non-commitments: this ADR does not commit to any exit, does not budget engineering time for portability work, does not require multi-cloud-by-default, and does not override the workshop framing.
+- **D7** — Cross-reference to AI-sector invariants (28/29/44/45) as the **proof of concept** that the discipline works.
+- **D8** — Out of scope: multi-cloud-by-default, per-vendor SLA negotiation, vendor-cost optimization (owned by ADR-0052), per-vendor security review (owned by ADR-0056), full content of the per-vendor governance files (D5 stubs only at acceptance; body deferred).
+
+ADR-0080 is a **posture / governance** ADR. The concrete artifacts — the `governance/vendor-postures/azure.md` stub, the `governance/vendor-postures/github.md` stub, and the cross-link updates to ADR-0076/0077/0078's Follow-up Work and References sections — land in packets 01–03. Every other packet in this initiative references ADR-0080's D-decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — add or update the ADR-0080 row in the index table. If a row already exists, update its Status column to Accepted. If no row exists, append one in the existing table format, citing the ADR's Sector (`Meta / Infrastructure / cross-cutting`), Date (`2026-05-23`), and a one-sentence impact summary.
+- `constitution/invariants.md` — add the three new vendor-posture invariants (see Proposed Implementation for exact text), numbered **{N1}, {N2}, {N3}** per the reservation claimed in `constitution/invariant-reservations.md` (see Constraints for the numbering rationale).
+- `constitution/invariant-reservations.md` — claim the next free block of size 3 above the highest existing reservation; add an `Active Reservations` row for ADR-0080 with the placeholder numbers.
+- `initiatives/active-initiatives.md` — register the `adr-0080-vendor-lockin` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0080 header: `**Status:** Proposed` → `**Status:** Accepted`. While editing the ADR, amend the D2 per-vendor posture table's Microsoft Azure row to surface the per-surface posture mismatch the table currently flattens: the App Insights / Azure Monitor surface is **Accept with strong hedge** (the OTel-first emit per ADR-0040 reduces traces/metrics/logs backend swap to a configuration change — days, not weeks — with the error path as the carve-out described in D3's "OTel-first telemetry emit" bullet). The Azure row's `Posture` column may stay "Accept (deep, intentional)" as the vendor-level posture; add a parenthetical note that App Insights / Azure Monitor specifically carries "Accept with strong hedge" as its per-surface posture, consistent with `governance/vendor-postures/azure.md`'s per-surface table that packet 01 ships. This is the only D2 text change in this packet; no other D-decision is touched.
+2. Update the ADR-0080 index row in `adrs/README.md`. The repo's `adrs/README.md` currently has rows through ADR-0057; ADR-0058–0080 are not yet in the table. **Either** (a) append a new row in the existing table format with `Status: Accepted` for ADR-0080 specifically (consistent with what `hive-sync` would do per ADR-0014's ADR-acceptance reconciliation), **or** (b) leave the index alone if the policy is that `hive-sync` is responsible for back-filling rows. Pick (a) — append the row directly — to keep the index consistent and avoid a `hive-sync` drift report flag. Match the existing row format (`| ADR-XXXX | Title | Status | Date | Sector | Impact |`).
+3. **Claim the invariant-number block.** Open `constitution/invariant-reservations.md`. Read the `Active Reservations` table and find the highest reservation already claimed. Pick the next contiguous block of three numbers above that ceiling — these become `{N1}`, `{N2}`, `{N3}` for this packet. Add a row to the `Active Reservations` table with `Range | ADR-0080 | Proposed | <one-line description and (N1)–(N3) summary; packet 00 path>` matching the format of sibling rows. If two ADR packet-00s race to merge, the second one's author shifts upward by editing `invariant-reservations.md` plus every `{N1}/{N2}/{N3}` placeholder in this packet's body — that is the "first merge wins" mechanic the file documents.
+4. Add three new invariants to `constitution/invariants.md`, numbered **{N1}, {N2}, {N3}** per step 3 (see Constraints). The text, taken verbatim-in-substance from ADR-0080's Consequences "Invariants" section:
+   - **{N1} — Every vendor surface in the Grid carries one of the three postures from ADR-0080 D1: Accept (deep, intentional), Hedge (active), or Abstract (already portable).** Posture is documented in ADR-0080's per-vendor table (D2) or, for new vendors introduced after this ADR's acceptance, in the source ADR that adopts the vendor. The three-posture vocabulary is the only vendor-posture language the Grid uses; "multi-cloud," "vendor-neutral," "cloud-agnostic," and similar enterprise-shaped framings are explicitly not in the Grid's vocabulary. See ADR-0080 D1, D2.
+   - **{N2} — No vendor-proprietary feature is consumed in application code.** Proprietary features (Azure Cache for Redis modules, Entra-proprietary claims, Stripe-specific webhook semantics, Cloudflare Workers, Twilio Studio flows, etc.) are allowed only at the `*.Providers.*` package layer; application code consumes Grid-defined interfaces and standard protocols (Redis-protocol-only per ADR-0076 D3, OIDC-standard claims only per ADR-0078 D3, OTel-first emit per ADR-0040, EF Core LINQ provider-agnostic per ADR-0072, normalized webhook intake per ADR-0062). This follows the same abstraction/runtime/provider shape that invariants 1, 2, 3 codify for internal Grid packaging, and that invariant 44 codifies for the AI sector; invariants 9 / 9a / 47 / 48 are the per-surface analogues already in place for Vault secrets and Audit append-by-interface. See ADR-0080 D3.
+   - **{N3} — "Accept (deep, intentional)" posture vendors have a per-vendor governance file under `governance/vendor-postures/{vendor}.md`.** The file documents the lock-in honestly: every surface depended on, the exit cost per surface, the cheap hedges already in place, the canonical home for "vendor-exit playbook" references from source ADRs. Hedge and Abstract posture vendors use the source ADR as document-of-record; no separate governance file is required at acceptance, with the bar for promotion being "the source ADR's cited hedge is no longer the only relevant context." See ADR-0080 D5.
+   - Create a new `## Vendor Posture Invariants` section. The file's existing sectioning convention groups invariants by topic (Dependency / Context / Secrets / Packaging / Testing / Infrastructure & Configuration / Work Tracking / AI / Code Review / Hosting Platform / Hive Sync / Multi-Tenant Boundary / Communications / Audit). Vendor posture is a new cross-cutting topic; place the new section after `## Audit Invariants` (or after the existing tail section, whichever is structurally last).
+5. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder. Match the format used by ADR-0042, ADR-0045, ADR-0077, and other sibling ADR-acceptance initiative entries.
+
+## Affected Files
+- `adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency — vendor posture is a governance concern; no contract cascade.
+
+## Acceptance Criteria
+- [ ] ADR-0080 header reads `**Status:** Accepted`
+- [ ] An ADR-0080 row exists in `adrs/README.md` with Status `Accepted`, the correct Date (`2026-05-23`), Sector (`Meta / Infrastructure / cross-cutting`), and a one-sentence impact summary in the existing row format
+- [ ] `constitution/invariant-reservations.md` carries an `Active Reservations` row claiming a contiguous block of size 3 for ADR-0080 above the highest existing reservation, with `(N1)`–`(N3)` summaries and the packet 00 path
+- [ ] `constitution/invariants.md` carries the three new vendor-posture invariants (every vendor surface carries one of three postures; no vendor-proprietary feature in application code; Accept-posture vendors have a per-vendor governance file) numbered with the `{N1}/{N2}/{N3}` block claimed in `invariant-reservations.md`, under a new `## Vendor Posture Invariants` section, each citing ADR-0080
+- [ ] Invariant `{N2}`'s text follows the same abstraction/runtime/provider shape that invariants 1, 2, 3 codify for internal Grid packaging and that invariant 44 codifies for the AI sector — the relationship is named, not implied; invariants 9 / 9a / 47 / 48 are referenced as the per-surface analogues already in place
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0080-vendor-lockin` initiative with a packet checklist matching the structure used by sibling initiative entries (ADR-0042, ADR-0045, ADR-0077)
+- [ ] No catalog schema change in this packet (no `catalogs/contracts.json`, `catalogs/grid-health.json`, `catalogs/relationships.json`, or `catalogs/nodes.json` edit — see dispatch plan §"Why no catalog packet")
+- [ ] No `governance/vendor-postures/` directory creation in this packet (that lands in packet 01)
+- [ ] No edits to ADR-0076, ADR-0077, or ADR-0078 in this packet (cross-link footnotes land in packet 03)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0080 D1 — Three-posture vocabulary.** Accept (deep, intentional) / Hedge (active) / Abstract (already portable). This is the only vendor-posture vocabulary the Grid uses. Enterprise-shaped framings (multi-cloud, vendor-neutral, cloud-agnostic) are explicitly not in the Grid's vocabulary per D8's rejection of multi-cloud-by-default.
+
+**ADR-0080 D2 — Per-vendor posture table.** Azure and GitHub are Accept (deep, intentional). Cloudflare, Stripe, Twilio, Expo are Hedge (active). Anthropic, OpenAI, Resend are Abstract (already portable). Posture is per-surface, not per-vendor — a vendor with multiple Grid surfaces may carry different postures per surface.
+
+**ADR-0080 D3 — Cheap Grid-wide hedges.** Most are already true at the code level: provider abstractions at every boundary, no vendor-proprietary features in application code, EF Core LINQ provider-agnostic per ADR-0072, Bicep modules by concern per ADR-0077 D2, OTel-first telemetry per ADR-0040, per-vendor governance files under `governance/vendor-postures/{vendor}.md` for Accept vendors. This ADR adds the **posture** layer above the code-level discipline; no new code changes implied.
+
+**ADR-0080 D5 — Per-vendor governance file structure.** `governance/vendor-postures/` is the canonical home for per-vendor posture documentation. Azure and GitHub stubs created at acceptance; full content deferred. Hedge and Abstract postures use the source ADR as document-of-record; no separate file required.
+
+**ADR-0080 D7 — Cross-reference to AI-sector invariants.** Invariants 28, 29, 44, and 45 instantiated the discipline for the AI sector. This ADR generalizes them to every vendor surface — what those four did for Anthropic and OpenAI through `IModelRouter` and `HoneyDrunk.AI.Abstractions`, the rest of the Grid does for Azure, Cloudflare, Stripe, Resend, Twilio, and Expo through the abstractions and hedges in D3.
+
+**ADR-0080 Consequences — Invariants.** ADR-0080 adds exactly three invariants: (1) every vendor surface carries one of three postures; (2) no vendor-proprietary feature is consumed in application code (same abstraction/runtime/provider shape that 1, 2, 3 codify for internal packaging and that 44 codifies for the AI sector); (3) Accept-posture vendors have a per-vendor governance file.
+
+**Invariants 1, 2, 3, 44 (referenced by invariant {N2}).** Invariants 1, 2, 3 codify the abstraction/runtime/provider split for internal Grid packaging; invariant 44 codifies the same shape for the AI sector specifically. Invariant {N2} restates that shape at the vendor-surface boundary, and points at invariants 9 / 9a / 47 / 48 as the per-surface analogues already in place for Vault secrets and Audit append-by-interface. None of the upstream invariants are modified.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0080 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbers `{N1}/{N2}/{N3}` — claim via the reservation registry.** Do not hardcode invariant numbers in this packet. Read `constitution/invariant-reservations.md`, pick the next contiguous block of three above the current ceiling, add the `Active Reservations` row in the same PR that writes this packet, and substitute the chosen numbers for the `{N1}/{N2}/{N3}` placeholders throughout this packet body and in the invariants section of `constitution/invariants.md`. "First merge wins" applies — if two ADR packet-00s race, the second author shifts upward by editing the registry plus every placeholder before pushing. Never reuse a number already claimed by another sibling reservation (today: ADR-0051 54–57; ADR-0049 58–60; ADR-0054 61–63; ADR-0060 64–66; ADR-0050 67–68; ADR-0063 69–73; ADR-0064 74–77; ADR-0065 78–79; ADR-0066 80–82; ADR-0068 83–86; ADR-0071 87–89; ADR-0077 90–92; ADR-0078 93–94; ADR-0079 95–98).
+- **New section.** The three vendor-posture invariants are a new cross-cutting topic; create a `## Vendor Posture Invariants` section after the existing tail section (currently `## Audit Invariants`) rather than appending to an unrelated section.
+- **Invariant `{N2}` names its upstream relationship explicitly but precisely.** The text must state that it follows the same abstraction/runtime/provider shape that invariants 1, 2, 3 codify for internal Grid packaging and that invariant 44 codifies for the AI sector, and name invariants 9 / 9a / 47 / 48 as the per-surface analogues already in place — not the looser "generalizes 1, 2, 3, 44 across all vendor surfaces" framing. Invariants 1/2/3 are intra-Grid packaging rules, not vendor-portability rules; the connection is structural shape, not scope expansion. The upstream invariants are not modified; `{N2}` is additive.
+- **No catalog edits, no governance/ directory creation, no ADR-0076/0077/0078 edits in this packet.** Those land in subsequent packets per the dispatch plan. This packet is the governance/invariants flip only.
+- **Match the existing `adrs/README.md` row format.** The repo's ADR index uses a six-column markdown table (`| ID | Title | Status | Date | Sector | Impact |`). Append the ADR-0080 row in that format. Do not invent a new column or alter the table header.
+
+## Labels
+`chore`, `tier-3`, `meta`, `docs`, `adr-0080`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0080 to Accepted, add the three vendor-posture invariants to `constitution/invariants.md`, and register the vendor-lockin initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0080 so packets 01–03 can reference its decisions as live rules and start shipping the `governance/vendor-postures/` substrate.
+- Feature: ADR-0080 Vendor Lock-In Posture rollout, Wave 1.
+- ADRs: ADR-0080 (primary), invariants 1/2/3/44 (referenced by invariant 88), ADR-0008 (initiative/packet conventions), ADR-0014 (ADR-acceptance reconciliation pattern that `hive-sync` follows).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0080 stays Proposed until this PR merges.
+- Claim the invariant-number block via `constitution/invariant-reservations.md` — read the registry, pick the next contiguous block of three above the current ceiling, add the row, substitute `{N1}/{N2}/{N3}` throughout the packet body and in `constitution/invariants.md`. Do not renumber existing invariants; create a new `## Vendor Posture Invariants` section.
+- Invariant `{N2}` follows the same abstraction/runtime/provider shape that invariants 1, 2, 3 codify for internal Grid packaging and that invariant 44 codifies for the AI sector; cites 9 / 9a / 47 / 48 as the per-surface analogues already in place. Not the looser "generalizes 1, 2, 3, 44" framing.
+- No catalog edits, no `governance/vendor-postures/` directory creation, no ADR-0076/0077/0078 edits in this packet.
+- Match the existing `adrs/README.md` row format when appending the ADR-0080 row.
+
+**Key Files:**
+- `adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0080-vendor-lockin/01-architecture-governance-vendor-postures-azure-stub.md
+++ b/generated/issue-packets/active/adr-0080-vendor-lockin/01-architecture-governance-vendor-postures-azure-stub.md
@@ -1,0 +1,190 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "docs", "adr-0080", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0080"]
+wave: 2
+initiative: adr-0080-vendor-lockin
+node: honeydrunk-architecture
+---
+
+# Create governance/vendor-postures/ and ship the Azure exit-playbook stub
+
+## Summary
+Create the new `governance/vendor-postures/` directory and ship `governance/vendor-postures/azure.md` as the **stub** documenting Azure's Accept (deep, intentional) posture, the cheap hedges already in place across Azure surfaces (Redis-protocol-only per ADR-0076 D3, Bicep modules by concern per ADR-0077 D2, OIDC-standard claims only per ADR-0078 D3, OTel-first emit per ADR-0040, `ISecretStore`/`IConfigProvider` per ADR-0005), and an honest per-surface exit-cost narrative. Per ADR-0080 D5 and D8, this is the **structure-and-canonical-home** packet; the full per-surface content is deferred.
+
+## Context
+ADR-0080 D5 creates `governance/vendor-postures/` as the canonical home for per-vendor governance documentation for Accept (deep, intentional) posture vendors. Azure is one of two such vendors (the other is GitHub, in packet 02). The directory does not yet exist in `HoneyDrunk.Architecture`.
+
+The Azure surfaces the Grid currently depends on, per ADR-0080 D2:
+
+- Container Apps (ADR-0015)
+- Key Vault (ADR-0005)
+- App Configuration (ADR-0005)
+- Application Insights / Azure Monitor (ADR-0040, ADR-0045)
+- Cache for Redis (ADR-0076)
+- Bicep (ADR-0077)
+- Entra External ID (ADR-0078)
+
+Each surface carries a different exit cost (weeks per individual surface; multi-month re-platforming if exiting all surfaces together). The cheap hedges already in place at the code level for each surface — per the source ADRs — are the per-surface part of the "vendor-exit playbook" the candidate-surface document and ADR-0076/0077/0078 each cite. ADR-0080's D5 resolves the pointer by giving the playbook a canonical home; this packet ships the file.
+
+**This is a stub at acceptance.** ADR-0080 D8 explicitly says: *"The full content of the per-vendor governance files (D5). The stubs are created with this ADR; the full content is a follow-up packet. The stub commits the structure and the canonical home; the body is filled in incrementally."* The stub commits the surfaces, postures, current hedges (cited by ADR), and exit-cost framing per ADR-0080 D2; the per-surface migration mechanics are out of scope.
+
+This is a docs/governance packet. No code, no .NET project.
+
+## Scope
+- Create directory `governance/vendor-postures/` (does not exist today).
+- Create file `governance/vendor-postures/azure.md` with the stub structure described in Proposed Implementation.
+
+## Proposed Implementation
+1. Create `governance/vendor-postures/` at the repo root, alongside `adrs/`, `constitution/`, `catalogs/`, etc. The directory is the canonical home per ADR-0080 D5.
+2. Create `governance/vendor-postures/azure.md` with the following stub structure:
+
+   ```markdown
+   # Azure — Vendor Posture: Accept (deep, intentional)
+
+   **Posture:** Accept (deep, intentional) per [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) D2.
+   **Last reviewed:** 2026-05-24 (initiative `adr-0080-vendor-lockin` packet 01).
+   **Status:** Stub. Full per-surface migration mechanics deferred per ADR-0080 D8.
+
+   ## Surfaces
+
+   The Grid depends on Azure across the following surfaces. Each row names the surface, the source ADR, the cheap hedge already in place at the code level (the "pre-paid" part of any future migration cost), and the honest estimated exit cost.
+
+   | Surface | Per-surface posture | Source ADR | Cheap hedge in place | Estimated exit cost |
+   |---|---|---|---|---|
+   | Container Apps | Accept (deep, intentional) | [ADR-0015](../../adrs/ADR-0015-container-hosting-platform.md) | Container Apps spec is OCI-standard; per-Node Dockerfiles are portable to any container platform. | Weeks. Replace the Container Apps environment, port Bicep templates for compute. |
+   | Key Vault | Accept (deep, intentional) | [ADR-0005](../../adrs/ADR-0005-configuration-and-secrets-strategy.md), [ADR-0006](../../adrs/ADR-0006-secret-rotation-and-lifecycle.md) | `ISecretStore` abstraction in HoneyDrunk.Vault.Abstractions; application code never reads secrets directly per [invariant 9](../../constitution/invariants.md). | Weeks per environment. Swap the `ISecretStore` implementation to another backing (HashiCorp Vault, AWS Secrets Manager, etc.). |
+   | App Configuration | Accept (deep, intentional) | [ADR-0005](../../adrs/ADR-0005-configuration-and-secrets-strategy.md) | `IConfigProvider` abstraction; application code reads through the abstraction, never direct App Configuration SDK calls. | Weeks per environment. Swap `IConfigProvider` to another backing. |
+   | Application Insights / Azure Monitor | **Accept with strong hedge** | [ADR-0040](../../adrs/ADR-0040-telemetry-backend-and-retention.md), [ADR-0045](../../adrs/ADR-0045-grid-wide-error-tracking.md) | OTel-first emit per [ADR-0040](../../adrs/ADR-0040-telemetry-backend-and-retention.md); App Insights is the *backend*, not the *API*. A backend swap (Honeycomb, Grafana Cloud, self-hosted Tempo+Loki+Mimir) is an OTel exporter configuration change. Error path is a documented carve-out (App Insights SDK directly for non-OTLP fields) with `IErrorReporter` facade per [ADR-0045](../../adrs/ADR-0045-grid-wide-error-tracking.md) D3 abstracting the error backend; Sentry is the documented D11 escalation path. The "with strong hedge" qualifier names the OTel-first posture honestly: traces/metrics/logs are days-to-swap, errors are weeks because of the carve-out — this is materially different from the surfaces above where exit cost compounds with surface scope. | Days for traces/metrics/logs. Weeks if errors need a separate path. |
+   | Cache for Redis | Accept (deep, intentional) | [ADR-0076](../../adrs/ADR-0076-cache-backing-azure-cache-for-redis.md) | Standard Redis protocol only per [ADR-0076](../../adrs/ADR-0076-cache-backing-azure-cache-for-redis.md) D3. No Azure-specific Cache modules consumed in application code. | Weeks. Swap managed Redis (Redis Cloud, KeyDB, Dragonfly, Valkey, self-hosted Redis on Container Apps); no code rewrite. |
+   | Bicep (IaC) | Accept (deep, intentional) | [ADR-0077](../../adrs/ADR-0077-infrastructure-as-code-bicep.md) | Bicep modules organized by concern per [ADR-0077](../../adrs/ADR-0077-infrastructure-as-code-bicep.md) D2. A future Terraform port has module boundaries to mirror 1:1. | Weeks per concern. Re-author each module in the target IaC tool; the per-concern structure preserves the mental model. |
+   | Entra External ID | Accept (deep, intentional) | [ADR-0078](../../adrs/ADR-0078-end-user-identity-entra-external-id.md) | OIDC-standard claims only per [ADR-0078](../../adrs/ADR-0078-end-user-identity-entra-external-id.md) D3. Entra-proprietary claims (`oid`, `tid`) are not load-bearing in application logic. | Weeks. Swap to any OIDC-compliant IdP (Auth0, Keycloak, Cognito, etc.); claim mapping work is the per-IdP migration. |
+
+   **Total estimated exit cost (all surfaces, sequential):** multi-month re-platforming. Per-surface migration is bounded to weeks each; the multi-month framing applies if every surface is exited at once.
+
+   ## Why Accept (deep, intentional)
+
+   See [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) Context and D2 reasoning:
+
+   - The productivity gain from a deep, well-understood single-vendor stack outweighs the optionality of a never-exercised second-vendor capability for a solo-dev workshop.
+   - The hedges in D3 — already in place via the source ADRs — keep the per-surface migration cost bounded to weeks each.
+   - The charter's many-decade horizon licenses the workshop framing over the enterprise framing; multi-cloud-by-default is a permanent tax in service of a hypothetical migration, explicitly rejected in ADR-0080's Alternatives Considered.
+
+   ## Decision-Point Triggers
+
+   The triggers in [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) D4 apply to Azure as to every Accept-posture vendor:
+
+   - Deprecation or material price increase on a depended-on surface (handoff to [ADR-0052](../../adrs/ADR-0052-cost-governance-budget-alerts-and-kill-switches.md)'s cost-governance threshold).
+   - Sustained reliability problems — two or more incidents exceeding one hour of impact within a single calendar quarter on a depended-on surface (handoff to [ADR-0054](../../adrs/ADR-0054-incident-response-and-on-call-model-for-a-one-person-studio.md)).
+   - Terms change conflicts with charter — e.g. license-change patterns matching the Redis 2024 BSL/SSPL shift (handoff to [ADR-0039](../../adrs/ADR-0039-grid-open-source-license-policy.md) for OSS posture impact).
+   - Mature alternative emerges and matures for twelve or more months before being considered as a serious replacement candidate.
+   - Adjacent Grid decision changes the math — e.g. a future multi-region ADR, a substantially different compute model, a Node whose workload no longer fits the current vendor's tier ceiling.
+   - Vendor acquisition / corporate event — Microsoft acquires, restructures, or changes strategic direction in a way that risks a depended-on surface.
+
+   A trigger fires the **conversation**, not the migration. Outcomes: Stay / Hedge harder / Exit. All three are valid.
+
+   ## Reviewed-and-Held Concerns
+
+   *None at acceptance. This section logs decision-point trigger observations that were reviewed and the assessment was "stay" or "hedge harder." Empty until the first review event occurs.*
+
+   ## Pending Per-Surface Detail
+
+   Per [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) D8, the full per-surface migration mechanics — the concrete steps for moving each surface to a named replacement, the per-surface dependency walk, the per-surface canary that proves portability — are deferred to follow-up packets when a real trigger fires. This stub commits the structure and the canonical home; the body is filled in incrementally.
+
+   ## Source ADRs
+
+   - [ADR-0005](../../adrs/ADR-0005-configuration-and-secrets-strategy.md) — Key Vault + App Configuration
+   - [ADR-0006](../../adrs/ADR-0006-secret-rotation-and-lifecycle.md) — secret rotation lifecycle
+   - [ADR-0015](../../adrs/ADR-0015-container-hosting-platform.md) — Container Apps
+   - [ADR-0040](../../adrs/ADR-0040-telemetry-backend-and-retention.md) — Azure Monitor / App Insights, OTel-first
+   - [ADR-0045](../../adrs/ADR-0045-grid-wide-error-tracking.md) — App Insights error tracking, `IErrorReporter` facade
+   - [ADR-0076](../../adrs/ADR-0076-cache-backing-azure-cache-for-redis.md) — Cache for Redis, Redis-protocol-only
+   - [ADR-0077](../../adrs/ADR-0077-infrastructure-as-code-bicep.md) — Bicep, per-concern modules
+   - [ADR-0078](../../adrs/ADR-0078-end-user-identity-entra-external-id.md) — Entra External ID, OIDC-standard claims only
+   - [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) — vendor posture umbrella (this file's authorizing ADR)
+   ```
+
+   The link paths above use `../../adrs/` because `governance/vendor-postures/azure.md` is two directories deep. Verify the relative-path resolution matches the repo's existing convention for inter-document links — match how `adrs/`-to-`constitution/` links are written today.
+
+3. Do **not** create `governance/vendor-postures/github.md` in this packet — it lands in packet 02.
+4. Do **not** create any `governance/vendor-postures/README.md` or other index file in this packet. ADR-0080 D5 names `governance/vendor-postures/` as the canonical home; an index file is not required and inventing one would be scope creep. If the operator later wants an index, that is its own follow-up packet.
+
+## Affected Files
+- `governance/vendor-postures/` (new directory)
+- `governance/vendor-postures/azure.md` (new file)
+
+## NuGet Dependencies
+None. This packet creates a new directory and one new Markdown file; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] `governance/vendor-postures/` directory exists at the repo root
+- [ ] `governance/vendor-postures/azure.md` exists with the stub structure from Proposed Implementation: header (posture/last-reviewed/status), Surfaces table covering all seven Azure surfaces (Container Apps, Key Vault, App Configuration, App Insights/Azure Monitor, Cache for Redis, Bicep, Entra External ID) with per-surface-posture + source-ADR cite + cheap-hedge + estimated-exit-cost per row; App Insights/Azure Monitor row carries the **Accept with strong hedge** posture (the OTel-first emit and Sentry escalation are the named hedge), every other surface row carries Accept (deep, intentional); Why Accept reasoning, Decision-Point Triggers (the six from ADR-0080 D4), Reviewed-and-Held Concerns (empty placeholder), Pending Per-Surface Detail note, Source ADRs reference list
+- [ ] All ADR cross-link relative paths resolve from `governance/vendor-postures/azure.md` (two directories deep — `../../adrs/...`)
+- [ ] The file is explicitly named a **stub** in the Status line and the Pending Per-Surface Detail note — full per-surface migration mechanics deferred per ADR-0080 D8
+- [ ] No `governance/vendor-postures/github.md` created in this packet (lands in packet 02)
+- [ ] No `governance/vendor-postures/README.md` or index file created (not authorized by ADR-0080 D5)
+- [ ] No edits to ADR-0076, ADR-0077, ADR-0078, or any other ADR file (cross-link footnotes land in packet 03)
+- [ ] No edits to `constitution/invariants.md` (invariants land in packet 00)
+- [ ] No edits to `catalogs/*.json` (no catalog packet in this initiative)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0080 D5 — Per-vendor exit-playbook stubs.** For Accept (deep, intentional) vendors — Azure and GitHub — create placeholder per-vendor governance files under `governance/vendor-postures/{vendor}.md`. Documents the lock-in honestly: every surface depended on, the exit cost per surface, the cheap hedges already in place. The file is a stub at this ADR's acceptance; the full content lives in a follow-up packet.
+
+**ADR-0080 D2 — Per-vendor posture table.** Azure is Accept (deep, intentional) at the vendor level. At the per-surface level the App Insights / Azure Monitor surface carries **Accept with strong hedge** because OTel-first emit (ADR-0040) reduces backend swap to a configuration change for traces/metrics/logs (days), with the error path as a documented carve-out (weeks via `IErrorReporter` and Sentry as the D11 escalation per ADR-0045 D3). Every other Azure surface (Container Apps, Key Vault, App Configuration, Cache for Redis, Bicep, Entra External ID) carries Accept (deep, intentional). The cheap hedges already in place: standard Redis protocol only (ADR-0076 D3), OIDC-standard claims only (ADR-0078 D3), Bicep modules per concern (ADR-0077 D2), OTel-first telemetry emit (ADR-0040 post-PR-164), `ISecretStore`/`IConfigProvider` abstractions (ADR-0005/ADR-0006). Estimated exit cost: multi-month re-platforming if exiting all surfaces; weeks per individual surface (days for App Insights traces/metrics/logs given the OTel hedge).
+
+**ADR-0080 D4 — Decision-point triggers.** Six triggers cause a posture re-evaluation conversation: deprecation/material price increase, sustained reliability problems (two or more incidents exceeding one hour of impact within a single calendar quarter), terms-change conflicts with charter, mature alternative emerging (twelve-month maturation period), adjacent Grid decision changing the math, vendor acquisition/corporate event. The trigger fires a conversation, not a migration. Outcomes: Stay / Hedge harder / Exit.
+
+**ADR-0080 D8 — Out of scope.** "The full content of the per-vendor governance files (D5). The stubs are created with this ADR; the full content is a follow-up packet."
+
+**Invariant 89 (added by packet 00, referenced here) — "Accept (deep, intentional)" posture vendors have a per-vendor governance file under `governance/vendor-postures/{vendor}.md`.**
+
+## Constraints
+- **Stub, not full content.** The file is explicitly a stub per ADR-0080 D8. The structure (surfaces, postures, current hedges, exit-cost ranges, triggers) is committed; the per-surface migration mechanics are deferred. Do not invent per-surface migration steps that ADR-0080 does not author.
+- **Cite, do not restate, source ADRs.** Every per-surface row in the Surfaces table cites the source ADR by link; the hedge text is a one-line summary, not a copy of the source ADR's full hedge discussion. The reader follows the link for the source ADR's depth.
+- **Match relative-path convention.** `governance/vendor-postures/azure.md` is two directories deep; ADR cross-links use `../../adrs/{ADR-file}`. Verify against how `adrs/` content links to `constitution/` files today.
+- **Do not create a `README.md` for the directory.** ADR-0080 D5 names `governance/vendor-postures/` as the canonical home; an index is not authorized.
+- **Do not edit any ADR or invariant in this packet.** ADR-0076/0077/0078 cross-link footnotes land in packet 03; invariants land in packet 00.
+- **The Reviewed-and-Held Concerns section is intentionally empty.** It is a placeholder for future trigger-event entries per ADR-0080 D4's "Stay" outcome. The empty section is the correct state at acceptance.
+
+## Labels
+`feature`, `tier-2`, `meta`, `docs`, `adr-0080`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Create the new `governance/vendor-postures/` directory and ship the Azure stub at `governance/vendor-postures/azure.md` per ADR-0080 D5.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Establish the canonical home for per-vendor Accept-posture governance documentation, and resolve the "vendor-exit playbook" footnote pointers from ADR-0076/0077/0078 to a real artifact.
+- Feature: ADR-0080 Vendor Lock-In Posture rollout, Wave 2.
+- ADRs: ADR-0080 D5 (primary — creates the directory and stub structure), ADR-0080 D2 (the per-surface Azure posture and hedges), ADR-0080 D4 (the triggers section), ADR-0080 D8 (the stub-vs-full-content scoping). Source ADRs for each Azure surface: ADR-0005, ADR-0006, ADR-0015, ADR-0040, ADR-0045, ADR-0076, ADR-0077, ADR-0078.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0080 must be Accepted (and the three vendor-posture invariants in place) before its D5 substrate ships.
+
+**Constraints:**
+- Stub only — full per-surface migration mechanics deferred per ADR-0080 D8.
+- Cite, do not restate, source ADRs.
+- No `README.md` for the new directory.
+- No edits to any ADR, invariant, or catalog file in this packet.
+
+**Key Files:**
+- `governance/vendor-postures/` (new)
+- `governance/vendor-postures/azure.md` (new)
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0080-vendor-lockin/02-architecture-governance-vendor-postures-github-stub.md
+++ b/generated/issue-packets/active/adr-0080-vendor-lockin/02-architecture-governance-vendor-postures-github-stub.md
@@ -1,0 +1,203 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "docs", "adr-0080", "wave-2"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0080"]
+wave: 2
+initiative: adr-0080-vendor-lockin
+node: honeydrunk-architecture
+---
+
+# Ship the GitHub exit-playbook stub in governance/vendor-postures/
+
+## Summary
+Ship `governance/vendor-postures/github.md` as the **stub** documenting GitHub's Accept (deep, intentional) posture: full intentional lock-in with no active hedge, the surfaces depended on (source, Actions, Projects, PR workflow, OpenClaw integration, per-Node CI), the honest exit-cost narrative (months), and — most importantly — the SCM-migration pre-condition framing per ADR-0080 D5. Per ADR-0080 D8, this is the structure-and-canonical-home packet; the full migration mechanics are deferred.
+
+## Context
+ADR-0080 D5 creates two stubs at acceptance — Azure (packet 01) and GitHub (this packet). GitHub is the second of two Accept (deep, intentional) posture vendors per ADR-0080 D2.
+
+GitHub's posture is distinct from Azure's: ADR-0080 D2 names **no hedges in place** for GitHub. The "Specific hedges in place" column for GitHub in ADR-0080 D2 reads literally: *"None. Full lock-in is the correct posture; GitHub is the substrate for the operator's solo-dev workflow and the SDLC depends on its specific affordances."* That framing — full lock-in as the correct posture — is the stub's load-bearing message. The SCM-migration **pre-condition** is *another SCM with equivalent affordances for solo-dev + AI-agent SDLC*, not "GitLab can host the source." ADR-0080 D5 makes that distinction explicit.
+
+The GitHub surfaces the Grid currently depends on, per ADR-0080 D2:
+
+- Source (every Node's repository)
+- GitHub Actions (every Node's CI/CD pipeline, the `HoneyDrunk.Actions` reusable-workflow library per ADR-0012)
+- GitHub Projects (The Hive — org Project #4 per ADR-0008)
+- PR workflow (the cloud-wired review agent per ADR-0044, advisory comments via OpenClaw)
+- OpenClaw integration (Signed webhook receipt, advisory PR comments)
+- Per-repo CI (`pr-core.yml` reusable workflow as branch-protection gate per ADR-0011/ADR-0012)
+
+The exit cost is honestly **months**, not weeks. A full SCM migration requires porting source, PR history, Actions, the project board, OpenClaw integration, and the per-Node CI surface to another SCM platform — and the per-Node CI surface alone is non-trivial because every Node depends on the `HoneyDrunk.Actions` reusable-workflow contract (per ADR-0012's invariants 34–36 and the broader Actions control-plane decision).
+
+**This is a stub at acceptance.** Same framing as packet 01: ADR-0080 D8 explicitly defers full content to a follow-up packet. The stub commits the surfaces, the posture, the SCM-migration pre-condition framing, and the exit-cost range; the per-surface migration mechanics are out of scope.
+
+This is a docs/governance packet. No code, no .NET project.
+
+## Scope
+- Create file `governance/vendor-postures/github.md` with the stub structure described in Proposed Implementation.
+
+## Proposed Implementation
+1. The `governance/vendor-postures/` directory must already exist from packet 01. If it does not, this packet cannot proceed — stop and flag.
+2. Create `governance/vendor-postures/github.md` with the following stub structure:
+
+   ```markdown
+   # GitHub — Vendor Posture: Accept (deep, intentional)
+
+   **Posture:** Accept (deep, intentional) per [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) D2.
+   **Last reviewed:** 2026-05-24 (initiative `adr-0080-vendor-lockin` packet 02).
+   **Status:** Stub. Full migration mechanics deferred per ADR-0080 D8.
+
+   ## Surfaces
+
+   The Grid depends on GitHub across the following surfaces. **No hedges are in place by design** — per [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) D2, full lock-in is the correct posture for GitHub: it is the substrate for the operator's solo-dev workflow and the SDLC depends on its specific affordances.
+
+   | Surface | Source ADR(s) | Lock-in shape | Estimated exit cost |
+   |---|---|---|---|
+   | Source (every Node's repository) | — (substrate) | Every Grid repo lives on GitHub. Branch protection, repo settings, secret scanning, Dependabot alerts (per [ADR-0009](../../adrs/ADR-0009-package-scanning-policy.md)), CODEOWNERS, repo-level governance all encoded as GitHub-native settings. | Months. Mirror the source tree to another SCM; port branch-protection equivalents; reconcile commit-author identities. |
+   | GitHub Actions (CI/CD) | [ADR-0012](../../adrs/ADR-0012-grid-cicd-control-plane.md) | `HoneyDrunk.Actions` is the canonical CI/CD control plane per [ADR-0012](../../adrs/ADR-0012-grid-cicd-control-plane.md). Every Node consumes its reusable workflows (`pr-core.yml`, the `job-*` library); per-Node `.github/workflows/*.yml` calls them. The Actions invariants (34, 35, 36 per [ADR-0015](../../adrs/ADR-0015-container-hosting-platform.md)) reference Actions semantics directly. | Months. Re-author every reusable workflow in the target CI platform's primitives (GitLab CI, Buildkite, etc.); rewire OIDC federation for Azure deploy per [ADR-0005](../../adrs/ADR-0005-configuration-and-secrets-strategy.md). |
+   | GitHub Projects (The Hive) | [ADR-0008](../../adrs/ADR-0008-work-tracking-and-execution-flow.md), [ADR-0014](../../adrs/ADR-0014-hive-architecture-reconciliation-agent.md) | The Hive (org Project #4) is the source of truth for in-flight work per [ADR-0008](../../adrs/ADR-0008-work-tracking-and-execution-flow.md); `hive-sync` reconciles Architecture-repo state against it per [ADR-0014](../../adrs/ADR-0014-hive-architecture-reconciliation-agent.md). The `file-packets.yml` workflow files issues + sets board fields + wires `addBlockedBy` automatically. | Weeks-to-months. Replicate the board schema (custom fields: Status, Wave, Node, Tier, Actor, Initiative, ADR) in the target tool; re-author `file-packets.yml` and `hive-sync` against the target's API; migrate historical packets and their issue references. |
+   | PR workflow + cloud-wired review | [ADR-0044](../../adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md), [ADR-0079](../../adrs/ADR-0079-multi-perspective-pr-review-stack.md) | `job-review-request.yml` triggers the OpenClaw-wired `.claude/agents/review.md` agent on every non-draft PR; review comments post via the GitHub API. The `.honeydrunk-review.yaml` per-repo opt-in lives in the repo per [invariant 52](../../constitution/invariants.md). | Weeks. Re-author the review-request trigger against the target's webhook/PR-comment API; preserve the OpenClaw agent definition (it is SCM-independent). |
+   | OpenClaw integration | [ADR-0044](../../adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md), reference doc `repos/OpenClaw/` (if present in the workspace) | OpenClaw subscribes to GitHub webhooks, posts advisory comments, runs the review agent under a managed-Chromium subscription model. The integration shape is GitHub-native (webhook signature, PR-comment API, repo-permission model). | Weeks. Re-author the OpenClaw integration against the target's webhook signature and PR-comment API; the agent definition is preserved. |
+   | Per-repo CI (branch-protection gate) | [ADR-0011](../../adrs/ADR-0011-code-review-and-merge-flow.md) (Proposed), [ADR-0012](../../adrs/ADR-0012-grid-cicd-control-plane.md) | Branch protection on `main` requires the tier-1 gate (`pr-core.yml`) per ADR-0011 D2 (Proposed) — the GitHub-native branch-protection rule plus required-status-check semantics is the substrate. The contract is GitHub-native (required status checks, admin override semantics). | Weeks per repo. Re-encode branch-protection rules in the target's primitives; preserve the gate's substantive content. |
+
+   **Total estimated exit cost (all surfaces):** months. An SCM migration is not a weekend project — it is its own multi-month initiative under the standard Grid SDLC, scoped only after a D4 trigger fires and the re-evaluation conversation produces "Exit."
+
+   ## Why Accept (deep, intentional) — and why no hedges
+
+   See [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) D2's GitHub row explicitly:
+
+   > **None. Full lock-in is the correct posture; GitHub is the substrate for the operator's solo-dev workflow and the SDLC depends on its specific affordances.**
+
+   The reasoning, made explicit:
+
+   1. **The SDLC depends on GitHub-native affordances.** Branch protection semantics, required status checks, the GraphQL Projects API (and its blockedBy edges), Actions matrix concurrency, OIDC federation to Azure per [ADR-0005](../../adrs/ADR-0005-configuration-and-secrets-strategy.md), the Repo permission model, CODEOWNERS, secret scanning, Dependabot alerts per [ADR-0009](../../adrs/ADR-0009-package-scanning-policy.md). Hedging would mean abstracting every one of those over a portable layer — a permanent tax against a hypothetical migration.
+   2. **Per [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) Alternatives Considered:** "Pure abstraction discipline (vendor-agnostic everywhere)" was considered and rejected. The abstractions are the **code-level** vendor-exit posture; the posture document captures what the abstractions alone cannot.
+   3. **Solo-dev + AI-agent SDLC is the operator's posture.** The OpenClaw integration, the `file-packets.yml` automation, the `hive-sync` reconciliation, the cloud-wired review agent — these are all built against GitHub's specific shape. Re-architecting them against a portability layer would erode the AI-multiplier discipline the charter explicitly underwrites.
+
+   ## The SCM-Migration Pre-Condition
+
+   Per [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) D5 explicitly:
+
+   > The SCM-migration pre-condition is *another SCM with equivalent affordances for solo-dev + AI-agent SDLC* — not "GitLab can host the source," but the full workflow story.
+
+   "Equivalent affordances" means, at minimum:
+
+   - Reusable-workflow library equivalence (the target supports composable CI workflows with the same primitive set as `pr-core.yml` / `job-*.yml`).
+   - Project-board equivalence with the custom-field schema The Hive uses (Status, Wave, Node, Tier, Actor, Initiative, ADR) and an automation API matching what `file-packets.yml` and `hive-sync` consume.
+   - Webhook signature + PR-comment API equivalence sufficient for OpenClaw integration.
+   - OIDC federation to Azure equivalence (or another mechanism that preserves the no-stored-secret deploy posture per [ADR-0005](../../adrs/ADR-0005-configuration-and-secrets-strategy.md)).
+   - Branch-protection-rule equivalence supporting required status checks and admin-override semantics.
+
+   No target SCM today fully matches this pre-condition for the Grid's specific solo-dev + AI-agent shape. That is the **honest** state, not a marketing claim.
+
+   ## Decision-Point Triggers
+
+   The triggers in [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) D4 apply to GitHub as to every Accept-posture vendor:
+
+   - Deprecation or material price increase on a depended-on surface (e.g., a change to the Actions pricing model that crosses the cost-governance threshold per [ADR-0052](../../adrs/ADR-0052-cost-governance-budget-alerts-and-kill-switches.md)).
+   - Sustained reliability problems — two or more incidents exceeding one hour of impact within a single calendar quarter on a depended-on surface (handoff to [ADR-0054](../../adrs/ADR-0054-incident-response-and-on-call-model-for-a-one-person-studio.md)).
+   - Terms change conflicts with charter — e.g., new restrictions on commercial use, mandatory data-residency conflicts, or license-change patterns that conflict with the Grid's build-in-public stance per [ADR-0039](../../adrs/ADR-0039-grid-open-source-license-policy.md).
+   - Mature alternative emerges and matures for twelve or more months — the pre-condition above is the bar.
+   - Adjacent Grid decision changes the math — e.g., a future ADR that adopts a fundamentally different SDLC model.
+   - Vendor acquisition / corporate event — Microsoft's ownership of GitHub itself is the existing context; subsequent strategic shifts are the trigger.
+
+   A trigger fires the **conversation**, not the migration.
+
+   ## Reviewed-and-Held Concerns
+
+   *None at acceptance. This section logs decision-point trigger observations that were reviewed and the assessment was "stay" or "hedge harder." Empty until the first review event occurs.*
+
+   ## Pending Migration Mechanics
+
+   Per [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) D8, the concrete per-surface migration mechanics — the specific steps for moving source, Actions, Projects, OpenClaw, and per-repo CI to a named replacement — are deferred until a real trigger fires and the re-evaluation conversation produces "Exit." This stub commits the structure, the SCM-migration pre-condition, and the honest cost range; the per-surface mechanics are filled in at the migration's own initiative.
+
+   ## Source ADRs
+
+   - [ADR-0008](../../adrs/ADR-0008-work-tracking-and-execution-flow.md) — Work tracking, The Hive
+   - [ADR-0011](../../adrs/ADR-0011-code-review-and-merge-flow.md) — Code review and merge flow (tier-1 gate)
+   - [ADR-0012](../../adrs/ADR-0012-grid-cicd-control-plane.md) — HoneyDrunk.Actions as Grid CI/CD control plane
+   - [ADR-0014](../../adrs/ADR-0014-hive-architecture-reconciliation-agent.md) — Hive-Architecture reconciliation agent
+   - [ADR-0044](../../adrs/ADR-0044-grid-aware-cloud-code-review-and-ai-authored-pr-discipline.md) — Grid-aware cloud code review
+   - [ADR-0079](../../adrs/ADR-0079-multi-perspective-pr-review-stack.md) — Multi-perspective PR review stack
+   - [ADR-0080](../../adrs/ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) — vendor posture umbrella (this file's authorizing ADR)
+   ```
+
+3. Verify relative-path resolution against the convention packet 01 established. Both files live at `governance/vendor-postures/{name}.md` (two directories deep); ADR cross-links use `../../adrs/{ADR-file}`.
+
+4. Do **not** create any other file in this packet. Packet 03 handles the ADR-0076/0077/0078 cross-link footnotes.
+
+## Affected Files
+- `governance/vendor-postures/github.md` (new file)
+
+## NuGet Dependencies
+None. This packet creates one new Markdown file; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] `governance/vendor-postures/github.md` exists with the stub structure from Proposed Implementation: header (posture/last-reviewed/status), Surfaces table covering all six GitHub surfaces (source, Actions, Projects, PR workflow + cloud-wired review, OpenClaw integration, per-repo CI) with source-ADR cite + lock-in shape + estimated-exit-cost per row, Why Accept reasoning (no hedges by design), SCM-Migration Pre-Condition framing, Decision-Point Triggers (the six from ADR-0080 D4), Reviewed-and-Held Concerns (empty placeholder), Pending Migration Mechanics note, Source ADRs reference list
+- [ ] The "no hedges by design" framing is explicit in the Why Accept section — quoting ADR-0080 D2's "None. Full lock-in is the correct posture..." text
+- [ ] The SCM-Migration Pre-Condition section names the five equivalence requirements (reusable workflows, project board with The Hive's custom-field schema, webhook + PR-comment API for OpenClaw, OIDC federation to Azure, branch-protection equivalence) and the honest "no target SCM today fully matches" statement
+- [ ] All ADR cross-link relative paths resolve from `governance/vendor-postures/github.md` (two directories deep — `../../adrs/...`)
+- [ ] The file is explicitly named a **stub** in the Status line and the Pending Migration Mechanics note — full mechanics deferred per ADR-0080 D8
+- [ ] The `governance/vendor-postures/` directory already exists (from packet 01); this packet does not re-create it
+- [ ] No edits to ADR-0076, ADR-0077, ADR-0078, or any other ADR file (cross-link footnotes land in packet 03)
+- [ ] No edits to `constitution/invariants.md` (invariants land in packet 00)
+- [ ] No edits to `catalogs/*.json` (no catalog packet in this initiative)
+- [ ] No edits to `governance/vendor-postures/azure.md` (packet 01's content is preserved)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0080 D5 — Per-vendor exit-playbook stubs.** GitHub is one of two Accept (deep, intentional) vendors. The stub documents that lock-in is full and intentional; names the surfaces (source, Actions, Projects, OpenClaw, per-repo CI) and the migration cost; explicitly notes that the SCM-migration pre-condition is *another SCM with equivalent affordances for solo-dev + AI-agent SDLC* — not "GitLab can host the source," but the full workflow story.
+
+**ADR-0080 D2 — GitHub posture: Accept (deep, intentional) with "None" in the hedges column.** The literal text from ADR-0080 D2: "None. Full lock-in is the correct posture; GitHub is the substrate for the operator's solo-dev workflow and the SDLC depends on its specific affordances." Estimated exit cost: "Months. A full SCM migration would require porting source, PR history, Actions, project board, OpenClaw integration, and the per-Node CI surface."
+
+**ADR-0080 D4 — Decision-point triggers.** Apply to GitHub the same as to every Accept-posture vendor.
+
+**ADR-0080 D8 — Out of scope.** "The full content of the per-vendor governance files (D5). The stubs are created with this ADR; the full content is a follow-up packet."
+
+**Invariant 89 (added by packet 00, referenced here) — "Accept (deep, intentional)" posture vendors have a per-vendor governance file under `governance/vendor-postures/{vendor}.md`.**
+
+## Constraints
+- **Stub, not full content.** The file is explicitly a stub per ADR-0080 D8. Do not invent per-surface migration mechanics that ADR-0080 does not author.
+- **"No hedges by design" is the load-bearing message.** This is not an oversight to be quietly corrected. ADR-0080 D2 explicitly assigns GitHub the "None" hedges value because the SDLC depends on GitHub's specific affordances. The stub must carry that framing intact, not soften it.
+- **The SCM-migration pre-condition is not negotiable.** ADR-0080 D5 names the pre-condition explicitly: *not "GitLab can host the source," but the full workflow story*. The stub names the five equivalence requirements (reusable-workflow library, project-board schema, webhook+PR-comment API, OIDC federation, branch-protection rules) and states honestly that no current target meets the bar.
+- **Match the file structure established in packet 01.** Same section headers (Surfaces / Why Accept / Decision-Point Triggers / Reviewed-and-Held Concerns / Pending — with the section title varied for GitHub's distinct framing / Source ADRs); same relative-path convention.
+- **Packet 01 must merge first.** The directory `governance/vendor-postures/` is created by packet 01; this packet adds the GitHub file alongside the Azure file. If packet 01 has not landed, stop and flag.
+
+## Labels
+`feature`, `tier-2`, `meta`, `docs`, `adr-0080`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Ship `governance/vendor-postures/github.md` as the stub for GitHub's Accept (deep, intentional) posture per ADR-0080 D5.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Complete the second of two Accept-posture vendor stubs, with explicit "no hedges by design" framing and the SCM-migration pre-condition.
+- Feature: ADR-0080 Vendor Lock-In Posture rollout, Wave 2.
+- ADRs: ADR-0080 D2/D5 (primary — GitHub posture and stub structure), ADR-0080 D4 (triggers), ADR-0080 D8 (stub-vs-full scoping). Source ADRs for each GitHub surface: ADR-0008, ADR-0011, ADR-0012, ADR-0014, ADR-0044, ADR-0079.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — `governance/vendor-postures/` directory must exist; the Azure stub establishes the file structure and relative-path convention.
+
+**Constraints:**
+- "No hedges by design" framing is load-bearing — preserve ADR-0080 D2's exact stance.
+- The SCM-migration pre-condition (the five equivalence requirements) is the stub's distinguishing content.
+- Stub only — full migration mechanics deferred per ADR-0080 D8.
+
+**Key Files:**
+- `governance/vendor-postures/github.md` (new)
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0080-vendor-lockin/03-architecture-cross-link-azure-deep-adrs.md
+++ b/generated/issue-packets/active/adr-0080-vendor-lockin/03-architecture-cross-link-azure-deep-adrs.md
@@ -1,0 +1,172 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "meta", "docs", "adr-0080", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0080", "ADR-0076", "ADR-0077", "ADR-0078"]
+wave: 2
+initiative: adr-0080-vendor-lockin
+node: honeydrunk-architecture
+---
+
+# Cross-link ADR-0076, ADR-0077, and ADR-0078 to governance/vendor-postures/azure.md
+
+## Summary
+Update the three Azure-deep ADRs that currently cite a future "vendor-exit playbook" with no defined home — **ADR-0076** (Cache for Redis), **ADR-0077** (Bicep IaC), and **ADR-0078** (Entra External ID) — so their Follow-up Work and References sections point at `governance/vendor-postures/azure.md` as the resolved canonical home. **Citation-only edits**; no decisions, invariants, or scope claims change in any of the three ADRs.
+
+## Context
+ADR-0080's Context section names the load-bearing observation: each of ADR-0076, ADR-0077, and ADR-0078 cites a future "vendor-exit playbook" or "vendor-exit hedge" against the candidate-surface document (`generated/adr-drafts/2026-05-23-charter-aware-adr-and-node-candidates.md` cluster 2.1). ADR-0080 D5 creates `governance/vendor-postures/azure.md` as the resolved canonical home; packet 01 ships the stub.
+
+This packet completes the resolution by updating each of the three ADRs to point at the new canonical home instead of the draft.
+
+The specific cross-link sites in each ADR (locate by phrase, not line number — files drift; the **phrase** is the anchor):
+
+- **ADR-0076-cache-backing-azure-cache-for-redis.md:**
+  - Context / D3 reasoning paragraph containing the phrase *"Azure-deep-but-protocol-portable posture"* with a citation to *"future vendor-exit playbooks named in [charter-aware draft] cluster 2.1."*
+  - Consequences section entry containing the phrase *"The vendor-exit playbook for Azure Cache for Redis"* with a citation to *"[charter-aware draft] cluster 2.1."*
+  - References section entry containing the phrase *"vendor-exit playbook (future)"* citing the charter-aware draft cluster 2.1.
+
+- **ADR-0077-infrastructure-as-code-bicep.md:**
+  - Context paragraph containing the phrase *"A vendor-exit playbook ([charter-aware draft cluster 2.1]) is the right complement."*
+  - D5 / Decision paragraph containing the phrase *"Per the vendor-exit posture (D5), if the Grid ever migrates to Terraform."*
+  - Operational Consequences paragraph containing the phrase *"A vendor-exit playbook for Azure (per [charter-aware draft cluster 2.1]) is named as follow-up work."*
+  - Out of Scope item containing the phrase *"Vendor-exit playbook content. Named as follow-up."*
+  - Follow-up Work item containing the phrase *"Author the vendor-exit playbook for Azure per [charter-aware draft cluster 2.1] (separate ADR)."*
+  - References section entry containing the phrase *"vendor-exit playbook (follow-up)"* citing the charter-aware draft cluster 2.1.
+
+- **ADR-0078-end-user-identity-entra-external-id.md:**
+  - D3 reasoning paragraph containing the phrase *"This is the cheap vendor-exit hedge (the same pattern from [ADR-0076] D3 and [ADR-0077] D5)."* (No candidate-doc citation here; the cross-link goes to `governance/vendor-postures/azure.md` as the new home.)
+  - Invariants section text *"vendor-exit hedge"* — already explicit and does not cite the candidate doc; add a parenthetical pointing at `governance/vendor-postures/azure.md`.
+  - Consequences section paragraph containing the phrase *"The Azure-deep posture is reinforced. Identity is one more Azure-native binding; the vendor-exit cost compounds."* (Add a footnote/reference to the Azure governance file.)
+  - References section (if it has a cluster-2.1 entry): replace with a reference to `governance/vendor-postures/azure.md` and ADR-0080.
+
+The edits are **wording-only**. No decisions change. No invariants change. No scope claims change. The three ADRs continue to commit exactly what they commit today — only their pointer for the "future vendor-exit playbook" is rerouted from the candidate doc to ADR-0080's new canonical home.
+
+ADR-0080's Affected Nodes section names this packet's scope explicitly: *"ADR-0076, ADR-0077, ADR-0078 — the three ADRs whose 'cheap vendor-exit hedge' language now points at this ADR's `governance/vendor-postures/azure.md` per D5. No amendments required; the cross-reference is by-convention."*
+
+This is a docs/cross-link packet. No code, no .NET project.
+
+## Scope
+- `adrs/ADR-0076-cache-backing-azure-cache-for-redis.md` — update the three citation sites listed above.
+- `adrs/ADR-0077-infrastructure-as-code-bicep.md` — update the six citation sites listed above.
+- `adrs/ADR-0078-end-user-identity-entra-external-id.md` — update the citation sites listed above; add a parenthetical/footnote where the existing text is "vendor-exit hedge" without a citation.
+
+## Proposed Implementation
+
+For each of the three ADRs, follow this edit pattern at every citation site:
+
+1. **Where the existing text cites the candidate-surface doc** (`generated/adr-drafts/2026-05-23-charter-aware-adr-and-node-candidates.md` cluster 2.1) **as a future "vendor-exit playbook":** replace the citation with a reference to `governance/vendor-postures/azure.md` (the resolved canonical home per ADR-0080 D5) and to ADR-0080 as the authorizing ADR. Preserve the rest of the sentence — only the pointer changes.
+
+   Example replacement pattern (ADR-0077 Context paragraph):
+   - **Before:** *"A vendor-exit playbook ([charter-aware draft cluster 2.1]) is the right complement; this ADR pre-stages the modularization that makes that playbook cheaper."*
+   - **After:** *"A vendor-exit playbook ([`governance/vendor-postures/azure.md`](../governance/vendor-postures/azure.md), authorized by [ADR-0080](./ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md)) is the right complement; this ADR pre-stages the modularization that makes that playbook cheaper."*
+
+2. **Where the existing text mentions a "vendor-exit hedge" or "vendor-exit posture" without a citation:** add a parenthetical reference to `governance/vendor-postures/azure.md` and ADR-0080 so the reader can find the canonical home.
+
+   Example replacement pattern (ADR-0078 D3 reasoning):
+   - **Before:** *"This is the cheap vendor-exit hedge (the same pattern from ADR-0076 D3 and ADR-0077 D5)."*
+   - **After:** *"This is the cheap vendor-exit hedge (the same pattern from ADR-0076 D3 and ADR-0077 D5; the Grid's umbrella posture and canonical Azure governance file are [ADR-0080](./ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) and [`governance/vendor-postures/azure.md`](../governance/vendor-postures/azure.md))."*
+
+3. **In each ADR's References section:** wherever the cluster-2.1 entry appears, replace it (or supplement it) with entries for both ADR-0080 and `governance/vendor-postures/azure.md`. The candidate-surface doc itself can remain in References if useful for historical context, but the cluster-2.1 description should no longer read "future" — the "future" has been resolved.
+
+   Example replacement pattern (ADR-0077 References entry):
+   - **Before:** `- [generated/adr-drafts/2026-05-23-charter-aware-adr-and-node-candidates.md] cluster 2.1 — vendor-exit playbook (follow-up)`
+   - **After:** Two entries:
+     - `- [ADR-0080](./ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md) — vendor lock-in posture umbrella (resolves the future-playbook footnote)`
+     - `- [governance/vendor-postures/azure.md](../governance/vendor-postures/azure.md) — Azure exit-playbook canonical home (stub at acceptance; full per-surface content deferred)`
+
+4. **For ADR-0077 specifically:** the Follow-up Work item "Author the vendor-exit playbook for Azure per [charter-aware draft cluster 2.1] (separate ADR)" should be retired or marked as **resolved**, because ADR-0080 has now authored the umbrella and the canonical home. Recommended replacement: *"~~Author the vendor-exit playbook for Azure per [charter-aware draft cluster 2.1] (separate ADR).~~ **Resolved 2026-05-24:** authorized by [ADR-0080](./ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md); the Azure canonical home is [`governance/vendor-postures/azure.md`](../governance/vendor-postures/azure.md). Full per-surface content remains deferred per ADR-0080 D8."*
+
+5. **For ADR-0076 specifically:** the Consequences entry — *"The vendor-exit playbook for Azure Cache for Redis (when authored per [charter-aware draft] cluster 2.1) cites D3 as the hedge that pre-pays the migration cost."* — update similarly. Pattern: *"The vendor-exit playbook for Azure (per [ADR-0080](./ADR-0080-vendor-lock-in-posture-and-exit-readiness-hedges.md), canonical home [`governance/vendor-postures/azure.md`](../governance/vendor-postures/azure.md)) cites D3 as the hedge that pre-pays the migration cost for the Cache for Redis surface specifically."*
+
+6. **Do NOT modify any decision, invariant, scope claim, or non-citation text.** The edits are surgical. Every D-decision, every Invariants-section entry, every scope/non-scope claim in each ADR remains exactly as written.
+
+7. **Verify path resolution.** From `adrs/{ADR-file}.md`, the relative path to `governance/vendor-postures/azure.md` is `../governance/vendor-postures/azure.md`. Confirm against the existing convention used elsewhere in the same ADR (e.g., how `adrs/` content links to `constitution/invariants.md` or `catalogs/nodes.json`).
+
+8. **If an ADR's wording does not match the phrase-cite from the Context section above** (e.g., the file has been edited since 2026-05-24 when this packet was authored): apply the same edit pattern to the current text using `grep` against the cited phrase as the locator. The phrase-cites above are anchors, not contracts; the **pattern** is the contract.
+
+## Affected Files
+- `adrs/ADR-0076-cache-backing-azure-cache-for-redis.md`
+- `adrs/ADR-0077-infrastructure-as-code-bicep.md`
+- `adrs/ADR-0078-end-user-identity-entra-external-id.md`
+
+## NuGet Dependencies
+None. This packet touches only ADR Markdown files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+- [x] No D-decision, Invariants, or scope-claim text changes in any of the three target ADRs — citation-only edits.
+
+## Acceptance Criteria
+- [ ] ADR-0076 — every "vendor-exit playbook" / "vendor-exit hedge" citation that pointed at the candidate-surface document (`generated/adr-drafts/2026-05-23-charter-aware-adr-and-node-candidates.md` cluster 2.1) now points at `governance/vendor-postures/azure.md` and references ADR-0080; the References section carries entries for both
+- [ ] ADR-0077 — every "vendor-exit playbook" citation now points at `governance/vendor-postures/azure.md` and references ADR-0080; the Follow-up Work item "Author the vendor-exit playbook for Azure" is marked **resolved** with the date 2026-05-24 and a pointer to ADR-0080; the References section carries entries for both
+- [ ] ADR-0078 — the existing "vendor-exit hedge" mentions carry parenthetical pointers to `governance/vendor-postures/azure.md` and ADR-0080; the References section (if present) carries entries for both
+- [ ] No D-decision text in any of the three ADRs is modified — diffs against pre-edit show only citation/footnote changes
+- [ ] No Invariants section text in any of the three ADRs is modified
+- [ ] No Status flip in any of the three ADRs (they retain their current Proposed/Accepted state)
+- [ ] All new relative paths from `adrs/{ADR-file}.md` to `governance/vendor-postures/azure.md` resolve correctly (`../governance/vendor-postures/azure.md`)
+- [ ] The candidate-surface document (`generated/adr-drafts/2026-05-23-charter-aware-adr-and-node-candidates.md`) is NOT modified by this packet — it remains a historical artifact recording the candidate-surfacing observation
+- [ ] No edits to `governance/vendor-postures/azure.md` itself (packet 01's content is preserved)
+- [ ] No edits to `governance/vendor-postures/github.md` (packet 02's content is preserved)
+- [ ] No edits to `constitution/invariants.md` (invariants land in packet 00)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0080 Affected Nodes — ADR-0076, ADR-0077, ADR-0078.** Explicit: *"the three ADRs whose 'cheap vendor-exit hedge' language now points at this ADR's `governance/vendor-postures/azure.md` per D5. No amendments required; the cross-reference is by-convention."*
+
+**ADR-0080 D5 — Per-vendor exit-playbook stubs and canonical home.** `governance/vendor-postures/` is the canonical home for per-vendor governance documentation. Future ADRs that name new vendor relationships cite this directory as the place where Accept-posture documentation lives.
+
+**ADR-0080 Follow-up Work.** Names this packet's scope: *"Update ADR-0076, ADR-0077, and ADR-0078 follow-up notes to cite `governance/vendor-postures/azure.md` as the home for the future-state 'vendor-exit playbook' they reference (citation-only; no decision change)."*
+
+**ADR-0076 D3 (preserved by this packet, not modified).** Standard Redis protocol only is the cheap vendor-exit hedge. The hedge text is preserved; only the pointer to where the playbook lives is updated.
+
+**ADR-0077 D2/D5 (preserved by this packet, not modified).** Modularize by concern; the vendor-exit posture is acknowledged. The decisions are preserved; only the pointer is updated.
+
+**ADR-0078 D3 (preserved by this packet, not modified).** OIDC-standard claims only is the cheap vendor-exit hedge. The decision is preserved; only the pointer is updated.
+
+## Constraints
+- **Citation-only edits.** No D-decision, Invariants-section, or scope-claim text changes in any of the three target ADRs. The edits are surgical pointers and References entries.
+- **Pattern, not line numbers.** The Proposed Implementation locates each citation site by **phrase**, not by line number. Files drift; line numbers stale; phrases survive. Use `grep` (or equivalent) against the cited phrase to locate each edit site in the current file state.
+- **Preserve the candidate-surface document.** The cluster-2.1 candidate doc is a historical artifact; do not edit it or remove its mention from References — supplement it with the new canonical-home entry. The candidate doc records the surfacing observation; this ADR resolves it.
+- **Mark the ADR-0077 Follow-up Work item resolved, do not delete it.** The resolved-with-date pattern preserves the trail of how the item was closed. Same pattern as completed checkboxes in `initiatives/active-initiatives.md`.
+- **Path resolution from `adrs/`.** `../governance/vendor-postures/azure.md` — one level up from `adrs/`, then into `governance/vendor-postures/`. Verify against the convention the ADR already uses for `constitution/` or `catalogs/` links.
+- **Packet 01 must merge first.** The cross-link target `governance/vendor-postures/azure.md` must exist before this packet's edits land. If packet 01 has not landed, the cross-link points at a non-existent file.
+- **No edits to ADRs outside the three named.** ADR-0080, ADR-0040, ADR-0045, ADR-0005, and others mention vendor-exit concerns; their integration is by the ADR-0080 umbrella, not by per-ADR cross-link. Only ADR-0076, ADR-0077, ADR-0078 had the explicit "future playbook" footnote that this packet resolves.
+
+## Labels
+`chore`, `tier-2`, `meta`, `docs`, `adr-0080`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Update ADR-0076, ADR-0077, and ADR-0078 so their "future vendor-exit playbook" citations point at `governance/vendor-postures/azure.md` (the resolved canonical home authorized by ADR-0080 D5).
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Resolve the dangling footnote pointers. The three ADRs each cite a future playbook that now exists as a stub at `governance/vendor-postures/azure.md`; the cross-link makes the resolution discoverable.
+- Feature: ADR-0080 Vendor Lock-In Posture rollout, Wave 2.
+- ADRs: ADR-0080 D5 + Follow-up Work (primary — authorizes this packet); ADR-0076, ADR-0077, ADR-0078 (the three ADRs whose text is edited — citation-only).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — `governance/vendor-postures/azure.md` must exist before this packet's cross-links can resolve.
+
+**Constraints:**
+- Citation-only — no D-decision, Invariants, or scope-claim text changes.
+- Preserve the candidate-surface doc as a historical artifact; supplement, do not erase.
+- Apply the **pattern** by phrase-search; the packet cites no line numbers and the citation sites are anchored by phrase, not position.
+- Only the three named ADRs (ADR-0076, ADR-0077, ADR-0078) are edited.
+
+**Key Files:**
+- `adrs/ADR-0076-cache-backing-azure-cache-for-redis.md`
+- `adrs/ADR-0077-infrastructure-as-code-bicep.md`
+- `adrs/ADR-0078-end-user-identity-entra-external-id.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0080-vendor-lockin/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0080-vendor-lockin/dispatch-plan.md
@@ -1,0 +1,118 @@
+# Dispatch Plan — ADR-0080: Vendor Lock-In Posture and Exit-Readiness Hedges
+
+**Initiative:** `adr-0080-vendor-lockin`
+**ADR:** ADR-0080 (Proposed → Accepted via packet 00)
+**Sector:** Meta / Infrastructure / cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0080 commits the Grid's **vendor posture as a chosen position** rather than accidental drift. It assigns each load-bearing vendor one of three postures — **Accept (deep, intentional)**, **Hedge (active)**, or **Abstract (already portable)** — names the cheap hedges that apply Grid-wide, defines the decision-point triggers that fire a posture re-evaluation conversation (the charter's "decision points are in, kill clocks are out" framing), and creates a new `governance/vendor-postures/` canonical home for per-vendor governance files. The two **Accept**-posture vendors (Azure, GitHub) get placeholder stubs at this initiative's acceptance; full content is deliberately deferred.
+
+This initiative delivers: ADR acceptance + the three new vendor-posture invariants + initiative registration (Architecture); the new `governance/vendor-postures/` directory (Architecture); the `azure.md` stub documenting Azure's Accept posture, its current hedges (Redis-protocol-only per ADR-0076 D3, Bicep modules per ADR-0077 D2, OIDC-standard-claims-only per ADR-0078 D3, OTel-first emit per ADR-0040, `ISecretStore`/`IConfigProvider` per ADR-0005), and the honest per-surface exit-cost narrative (Architecture); the `github.md` stub documenting GitHub's Accept posture, the SCM-migration-pre-condition framing, and the honest exit-cost narrative (Architecture); and the citation-only follow-up edits to ADR-0076, ADR-0077, and ADR-0078 redirecting their pending "vendor-exit playbook" references to `governance/vendor-postures/azure.md` (Architecture).
+
+**4 packets across 2 waves**, targeting **1 repo** (`HoneyDrunk.Architecture`). All 4 are `Actor=Agent`, 0 `Actor=Human`. No code, no .NET project, no workflow. Pure governance.
+
+## Trigger
+
+ADR-0080 is Proposed with no scope. The forcing functions (from the ADR's Context):
+
+- **Three ADRs already cite the same pattern.** ADR-0076 D3, ADR-0077 D5, and ADR-0078 D3 each name Redis-protocol-only, Bicep modules by concern, and OIDC-standard claims only as "the cheap vendor-exit hedge." Three ADRs cite the same pattern; none of them is the umbrella that says it is Grid-wide discipline rather than three coincidences.
+- **AI-sector invariants already prove the discipline works.** Invariants 28, 29, 44, and 45 instantiated the pattern for the AI sector through `IModelRouter` and `HoneyDrunk.AI.Abstractions`. ADR-0080 generalizes the same discipline to every vendor surface.
+- **The candidate-surface doc explicitly names this artifact.** `generated/adr-drafts/2026-05-23-charter-aware-adr-and-node-candidates.md` cluster 2.1 observes that *"each vendor ADR cites a future 'vendor-exit playbook' without a defined home or shape."* The ADRs are leaving footnotes that point nowhere. ADR-0080 resolves the pointer.
+- **The charter's many-decade horizon.** A studio with a 12-month horizon may treat lock-in as "future-self's problem." A studio with a multi-decade horizon will see at least one of its vendor relationships turn — through pricing, terms, acquisition, deprecation, or simple drift in alignment. The hedges are cheap **only because** they are pre-paid before lock-in compounds.
+
+This ADR explicitly does **not** enable cheap migration; it makes the lock-in deliberate. All hedges in D3 are already true at the code level via the existing invariants and source ADRs — no code changes are implied by acceptance. The initiative is **governance-shaped**, not code-shaped.
+
+## Scope Detection
+
+**Single-repo (`HoneyDrunk.Architecture` only).** ADR-0080's Affected Nodes section is explicit: *"No application-code Node is directly affected by this ADR. The hedges in D3 are already in place at the code level via the source ADRs and the existing invariants (1, 2, 3, 28, 29, 44, 45)."* The work surface is the Architecture repo's governance, ADR, and invariants files — and the three cross-link footnotes in ADR-0076/0077/0078 that point at the new `governance/vendor-postures/azure.md` canonical home.
+
+**No new-Node scaffolding.** No empty cataloged repo is touched; no standup ADR is needed. No catalog schema change is needed — `governance/vendor-postures/` is its own canonical home, named in ADR-0080 D5; it does not need a `catalogs/contracts.json` or `catalogs/grid-health.json` entry.
+
+## Wave Diagram
+
+### Wave 1 (No Dependencies — governance acceptance)
+- [ ] **00** — Architecture: Accept ADR-0080, claim a 3-invariant block in `constitution/invariant-reservations.md` and add the three vendor-posture invariants under that block (placeholders `{N1}/{N2}/{N3}`), register the initiative. `Actor=Agent`.
+
+> **Invariant numbering.** Packet 00 reads `constitution/invariant-reservations.md`, picks the next contiguous block of size 3 above the highest existing reservation, and adds an `Active Reservations` row for ADR-0080 in the same PR that writes packet 00. The packet body uses `{N1}/{N2}/{N3}` placeholders; the registry's "first merge wins" mechanic handles races. As of authoring, the highest reservation in the registry is ADR-0079 at 95–98, putting ADR-0080's block at **99–101** — but the load-bearing claim lives in the registry, not in this paragraph.
+
+### Wave 2 (Per-vendor governance stubs + cross-link — depends on Wave 1, parallel)
+- [ ] **01** — Architecture: create `governance/vendor-postures/` and ship the Azure stub (`governance/vendor-postures/azure.md`). `Actor=Agent`. Blocked by: 00.
+- [ ] **02** — Architecture: ship the GitHub stub (`governance/vendor-postures/github.md`). `Actor=Agent`. Blocked by: 00. (Parallel with 01 — different file in the same directory created by 01; sequencing handled inside the wave by directory existence.)
+- [ ] **03** — Architecture: cross-link the three Azure-deep ADRs (ADR-0076, ADR-0077, ADR-0078) and their Follow-up Work sections at `governance/vendor-postures/azure.md` (citation-only; no decision change). `Actor=Agent`. Blocked by: 01.
+
+Packets 01 and 02 are file-creation tasks in the same directory. Packet 01 creates the directory and the Azure stub; packet 02 adds the GitHub stub alongside it. To avoid a race on directory creation, **packet 02 declares packet 01 as a dependency** in `dependencies:` — they sequence one after the other, not strictly in parallel, but the two together take less than a single human-review cycle. Packet 03 also depends on packet 01 because its cross-link target is `governance/vendor-postures/azure.md`, which packet 01 creates.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0080](./00-architecture-adr-0080-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [governance/vendor-postures/ + azure.md stub](./01-architecture-governance-vendor-postures-azure-stub.md) | Architecture | Agent | 2 | 00 |
+| 02 | [governance/vendor-postures/github.md stub](./02-architecture-governance-vendor-postures-github-stub.md) | Architecture | Agent | 2 | 01 |
+| 03 | [Cross-link ADR-0076/0077/0078 to azure.md](./03-architecture-cross-link-azure-deep-adrs.md) | Architecture | Agent | 2 | 01 |
+
+## Version Bumps
+
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; governance/docs edits only. No CHANGELOG version bump required by these packets (the repo-level CHANGELOG may receive a dated entry per the repo's existing convention for ADR-acceptance events; match what ADR-0042/0045/0077 acceptance packets did).
+- **No other repo touched.** Zero .NET solution version bumps.
+
+## Cross-Cutting Concerns
+
+### Why no catalog packet
+
+This initiative deliberately omits a catalog packet. The new `governance/vendor-postures/` directory is its own canonical home per ADR-0080 D5 — *"The `governance/vendor-postures/` directory is the canonical home for per-vendor posture documentation."* It is not a Node contract; it is governance documentation. `catalogs/contracts.json` registers Node contracts (interfaces, workflows, schemas); `catalogs/grid-health.json` tracks Node readiness state; neither has a slot for governance-document directories. Inventing a slot would be a phantom catalog entry — the same anti-pattern ADR-0045 packet 01 documented for the Notify-Sentry decommission and the phantom observability section. **Skip the catalog packet entirely.**
+
+### Why no code/workflow/test packets
+
+The ADR's Operational Consequences section says it explicitly:
+
+> No today-cost on any active workstream. All hedges in D3 are already true at the code level via the existing invariants and source ADRs. This ADR adds the **posture** layer above the code-level discipline; no code changes are implied by acceptance.
+
+The new invariants (per D3 / Consequences §Invariants) restate existing structural discipline as Grid-wide policy. Invariant 1, 2, 3, and 44 already enforce the abstraction/runtime/provider split for Vault, Transport, AI, Communications, Audit. The new "no vendor-proprietary feature in application code" invariant generalizes those four — but it does not create a new structural rule. Existing application code already complies. There is no canary to add (the existing per-Node contract-shape canaries already cover their respective Abstractions packages); there is no test to write (the abstraction boundary is the test); there is no provider package to split (every Node already has `*.Abstractions` / `*.Providers.*` shape per invariant 3).
+
+The Grid-aware review agent (per ADR-0044) is the structural enforcement point for the new invariant going forward — at PR time, on any code that touches a vendor SDK or proprietary feature. ADR-0080's Operational Consequences explicitly cites this: *"The discipline is enforced through the standard Grid review mechanisms — invariants are checked by canary tests and architecture review; provider-package vs. application-code boundaries are checked by the Grid-aware review agent per ADR-0044; the `.coderabbit.yaml` per ADR-0079 Reviewer 2 can carry vendor-leakage rules over time."*
+
+A *future* packet may add a vendor-leakage rule to `.claude/agents/review.md` when a real vendor-leakage anti-pattern is observed at PR time (per ADR-0080 Follow-up Work watch-list item). That packet is **not** part of this initiative — it is reactive, triggered by an observed event, and would be its own scope under the ADR-0044 governance.
+
+### Why no `governance/vendor-postures/` packet for Hedge or Abstract postures
+
+ADR-0080 D5 is explicit: *"For 'Hedge (active)' and 'Abstract (already portable)' vendors, no separate file is required at this ADR's acceptance. The source ADR is the document of record; the hedge is named in the source ADR; the per-vendor governance file becomes useful only when the surface area grows enough to justify it."*
+
+So this initiative ships **only** the Azure and GitHub stubs — the two Accept-posture vendors. Cloudflare, Stripe, Anthropic, OpenAI, Resend, Twilio, and Expo each have their source ADRs (0029, 0037, 0041, 0073) as the canonical posture record. If a future surface area expansion warrants promoting one of them to its own governance file, that promotion is the subject of a future packet, not this initiative.
+
+### Decision-point triggers — not packets
+
+ADR-0080 D4 names six triggers that cause a posture re-evaluation conversation: deprecation/material price increase, sustained reliability problems (two or more incidents exceeding one hour of impact within a single calendar quarter), terms-change conflicts with charter, mature alternatives, adjacent Grid decisions changing the math, and vendor acquisition / corporate event. **These triggers fire conversations, not migrations** — and the conversations are not scheduled work. The initiative does not pre-create any "watch for trigger X" packet. The Operational Consequences explicit framing — *"The trigger fires the conversation, not the migration"* — applies. When a trigger is observed, the operator opens a re-evaluation conversation; the conversation's outcome is "stay," "hedge harder," or "exit." Only the "exit" outcome produces a follow-up ADR and an associated initiative.
+
+### Coordination with ADR-0076, ADR-0077, ADR-0078
+
+The three Azure-deep ADRs each cite a future "vendor-exit playbook" with no defined home (per ADR-0080's Context and the candidate-surface document). Packet 03 adds **citation-only** updates to their Follow-up Work and References sections — pointing at `governance/vendor-postures/azure.md` as the resolved home. **No decisions in those ADRs change**; the cross-link is wording-only. The packet must not modify any D-decision, invariant, or scope claim in ADR-0076/0077/0078 — only the references-to-future-work text.
+
+ADR-0076 is currently Proposed (its acceptance is in `adr-0076-cache-backing-redis` if scoped). ADR-0077 is currently Proposed (its acceptance is in the sibling `adr-0077-iac-bicep` initiative). ADR-0078 is currently Proposed (no initiative folder yet). Packet 03 edits the cross-link text regardless of each ADR's acceptance state — the text being edited is the **Follow-up Work** / **References** sections, which exist in all three ADRs at draft time. If any of those ADRs has its acceptance packet land while packet 03 is in flight, packet 03 still operates against the current ADR text (the cross-link goes into Follow-up Work, which is preserved on acceptance).
+
+### Site sync
+
+No site-sync flag. ADR-0080 is internal Grid governance; the `governance/vendor-postures/` directory is internal documentation, not a public-facing Studios website surface. No `HoneyDrunk.Studios` packet needed.
+
+### No CHANGELOG impact in any other repo
+
+This initiative is contained entirely in `HoneyDrunk.Architecture`. No `.NET` solution version bump, no per-package CHANGELOG entry in any consuming Node, no NuGet feed impact. The repo-level `HoneyDrunk.Architecture/CHANGELOG.md` (if maintained) may receive a dated entry per the repo's convention for ADR-acceptance events — match what ADR-0042 and ADR-0077 acceptance packets did.
+
+## Rollback Plan
+
+- **Packet 00 (acceptance + invariants):** revert the PR. ADR-0080 returns to Proposed; the three vendor-posture invariants (`{N1}/{N2}/{N3}` — the block claimed in `invariant-reservations.md`) are removed; the reservation row is removed; the initiative entry in `active-initiatives.md` is removed. No runtime impact.
+- **Packet 01 (azure.md stub + directory creation):** revert the PR. `governance/vendor-postures/` and `governance/vendor-postures/azure.md` are deleted. No runtime impact; the ADR's Follow-up Work item "Ship stub azure.md" returns to open.
+- **Packet 02 (github.md stub):** revert the PR. `governance/vendor-postures/github.md` is deleted; the directory persists if packet 01 has merged. No runtime impact.
+- **Packet 03 (cross-link footnotes):** revert the PR. ADR-0076/0077/0078 Follow-up Work / References sections return to their pre-cross-link state, pointing at the candidate-surface document instead of `governance/vendor-postures/azure.md`. No decisions change in those ADRs (the cross-link is wording-only); revert is purely a documentation correction.
+
+The full initiative is governance-only — no rollback affects any deployed code, infrastructure, or runtime behavior.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.
+
+No cross-initiative `{Repo}#N` dependencies to substitute — every dependency in this initiative is a `packet:NN` reference, all of which resolve within this folder once filed.


### PR DESCRIPTION
## Summary

- Second of 3 staged PRs from the 2026-05-23 ADR batch. Governance-only — no code lands in any Node.
- Three initiatives: ADR-0072 (data access stance — EF Core default, Dapper for measured hot paths), ADR-0079 (multi-perspective PR review stack — 4 reviewers, substantive-PR classifier), ADR-0080 (vendor lock-in posture — Accept / Hedge / Abstract framing per vendor).
- Cross-ADR amendment: ADR-0072 — invariant misattributions fixed (D4 cites invariants 2 + 11, not 3; D5 `FromSqlRaw` rule explicitly named as review-enforced — no existing numbered invariant covers it; severity scale aligned to actual `review.md` rubric: Block / Request Changes / Suggest).

## Validation

- Markdown + JSON only; no code changed.
- ADR-0072 amendment renders cleanly.
- `governance/vendor-postures/` directory creation (packets 01/02 of ADR-0080) is the right shape per ADR-0080 D5.
- `file-packets.yml` will file the 17 packet files on merge — verify in The Hive.

## Authorship

Authorship: agent-claude-code

## Notes

- This PR is `out-of-band` per ADR-0011 D9 / invariant 32 — ships packet files but doesn't execute any single packet.
- Reservation registry (`constitution/invariant-reservations.md`) is inherited from #288. None of these three ADRs add numbered invariants, so no rows are claimed in this PR.
- ADR-0079 packet 03 (Reviewer 4 Claude trigger) has a hard gate on Anthropic's Claude Code on the web GitHub integration docs being available — packet flags this as a pre-execution prerequisite.
- ADR-0080 packet 03 (cross-link Azure-deep ADRs) edits ADR-0076, ADR-0077, ADR-0078 by phrase-search; line numbers were dropped from the packet per refine feedback.