### PR TITLE
Scope ADR-0063/0066/0069 Kernel foundation contracts

### DIFF
--- a/generated/issue-packets/active/adr-0063-clock-policy/00-architecture-adr-0063-acceptance.md
+++ b/generated/issue-packets/active/adr-0063-clock-policy/00-architecture-adr-0063-acceptance.md
@@ -1,0 +1,122 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "core", "docs", "adr-0063", "wave-1"]
+dependencies: ["packet:01", "packet:02", "packet:03"]
+adrs: ["ADR-0063"]
+accepts: ["ADR-0063"]
+wave: 1
+initiative: adr-0063-clock-policy
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0063 — flip status, add the date/time invariants, register the initiative
+
+## Summary
+Flip ADR-0063 (Grid-Wide Date, Time, and Clock Policy) from Proposed to Accepted: update the ADR header, add an ADR-0063 row to `adrs/README.md`, add the five new date/time invariants ADR-0063 commits in its Consequences/Invariants section to `constitution/invariants.md`, and register the `adr-0063-clock-policy` initiative in `initiatives/active-initiatives.md`. ADR-0063 stays Proposed in the *file* until the analyzer rule (packet 03) and the Kernel DI helpers (packet 02) ship — but the **acceptance flip itself** is this packet's job, scheduled to land last in the initiative per the ADR's own follow-up checklist. This packet is the **acceptance-tracking packet**; its PR is opened first as a documentation-only acceptance trail and merged last, after packets 01–03 land. (See Constraints — this is the only packet in the initiative whose merge order does not match its number.)
+
+## Context
+ADR-0063 settles date/time handling broadly across the Grid: storage format (UTC at rest, D2), .NET type usage (`DateTimeOffset` / `DateOnly` / `TimeOnly` / `TimeSpan` — `DateTime` banned per D3), the wall-clock substrate (BCL `TimeProvider`, no HoneyDrunk-owned wrapper, D1 + D11), serialization (ISO 8601 with `Z`, D4), time-zone IDs (IANA-only, D5), cadence specification (5-field cron in UTC + ISO 8601 durations, D6), the test substrate (`FakeTimeProvider`, D7), audit timestamp authority (read-once at emit, D8), idempotency TTL semantics (D9), Gregorian-only scope cap (D10), and the migration path (D12). The ADR was authored 2026-05-23 in response to a convergence of forcing functions across in-flight packets (ADR-0042 idempotency, ADR-0030 audit, ADR-0019 Communications cadence, ADR-0027 Notify retries, ADR-0047 Tier-2b Testcontainers, ADR-0068 background-job substrate) all reaching for the same sub-decisions in slightly different ways.
+
+ADR-0063 D1, D2, D3, and D11 are the decisions promoted into numbered invariants here. The others (D4, D5, D6, D7, D8, D9, D10, D12) remain ADR-only — they govern specific contracts and migration discipline but are not themselves Grid-wide enforcement rules.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0063-date-time-and-clock-policy.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — add a new ADR-0063 row (one does not exist yet — the index currently runs through ADR-0079 in the file list but the README table stops earlier; insert in numerical position).
+- `constitution/invariants.md` — add the five new date/time invariants (see Proposed Implementation for exact text), numbered **{N1}, {N2}, {N3}, {N4}, {N5}** under a new `## Date and Time Invariants` section. **{N1}–{N5}** is the contiguous block claimed for this ADR in `constitution/invariant-reservations.md` (range **69–73** at the time of authoring, after the ADR-0050 reservation at 67–68; resolve placeholders against the reservation row at execution time in case the block shifted upward per a first-merge-wins collision). The current verified maximum in `constitution/invariants.md` is **53**.
+- `constitution/invariant-reservations.md` — confirm the ADR-0063 row exists in **Active Reservations** with the block of five (`{N1}`–`{N5}`); if a colliding ADR's packet 00 has already merged into a higher block since this packet was filed, shift this ADR's reservation upward to the next free block of five and update every `{N*}` placeholder reference in this packet and packet 03's Acceptance Criteria/HD0054 note accordingly.
+- `initiatives/active-initiatives.md` — register the `adr-0063-clock-policy` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0063 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Add a new ADR-0063 row to `adrs/README.md`, in numerical order, with status Accepted and a one-line summary matching the existing row prose style.
+3. Add five new invariants to `constitution/invariants.md`, numbered **{N1}, {N2}, {N3}, {N4}, {N5}** under a new `## Date and Time Invariants` section placed after `## Audit Invariants`. Resolve `{N1}`–`{N5}` against the block claimed in `constitution/invariant-reservations.md` for ADR-0063 (range **69–73** at the time of authoring; shift upward if the row has moved due to a parallel ADR's first-merge-wins claim). The text, taken verbatim-in-substance from ADR-0063's "New invariants" Consequences section:
+   - **{N1} — Production code reads time via `TimeProvider`.** Direct calls to `DateTime.UtcNow`, `DateTime.Now`, `DateTimeOffset.UtcNow`, or `DateTimeOffset.Now` are forbidden outside documented interop boundaries. Production composition wires `TimeProvider.System`; tests wire `Microsoft.Extensions.TimeProvider.Testing.FakeTimeProvider`. The opt-out attribute on the analyzer rule (per packet 03) permits documented interop cases. See ADR-0063 D1, D11.
+   - **{N2} — All persisted and transmitted timestamps are UTC.** Database columns, Service Bus message envelopes and user-properties, audit records, cache TTL boundaries, idempotency expiry instants, configuration timestamps, and any JSON document persisted in the Grid carry UTC instants. Local-time storage and local-time on-wire formats are forbidden. Conversion to a user's or tenant's display timezone happens at the presentation boundary, never before. See ADR-0063 D2.
+   - **{N3} — `DateTime` is banned in new code.** `DateTimeOffset` is the committed type for instants; `DateOnly` for calendar dates; `TimeOnly` for wall-clock times; `TimeSpan` for durations. `DateTime`'s `Kind` discipline has historically been the source of timezone bugs at .NET-ecosystem scale; `DateTimeOffset` carries the offset in the type. Exceptions for legacy interop are opt-in via the analyzer attribute. See ADR-0063 D3.
+   - **{N4} — Tests that depend on time advance `FakeTimeProvider`.** `Microsoft.Extensions.TimeProvider.Testing.FakeTimeProvider` is the committed test substrate. Tests advance time via `Advance(TimeSpan)` or `SetUtcNow(DateTimeOffset)`; they never `Thread.Sleep` (invariant 51), never `await Task.Delay()` as a "wait for time-driven event" pattern (a real wall-clock wait is not a fake), and never wall-clock-poll. **Enforcement note:** the `Thread.Sleep` clause is already analyzer-enforced by `HD0051` (invariant 51). The `Task.Delay`-as-wait and wall-clock-poll clauses are **reviewer-judgment-enforced** — no analyzer ships in this initiative for them. A future packet may add a paired analyzer (e.g., `HD00xx-TaskDelayAsWallClockWaitInTests`), but that is out of scope here. Add this enforcement note as a parenthetical at the end of the invariant text so reviewers know the line. See ADR-0063 D7.
+   - **{N5} — Stored time-zone identifiers are IANA.** When a Node persists or transmits a time zone identifier (tenant default timezone, user preference, business-hours window timezone), the value is an IANA string (`"America/New_York"`, `"Europe/London"`). Windows time-zone IDs (`"Eastern Standard Time"`, `"GMT Standard Time"`) are forbidden in stored or transmitted data — they are a Windows-platform convention that does not survive cross-platform interop. Intake converts Windows TZ IDs to IANA at the API boundary. See ADR-0063 D5.
+4. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder.
+
+## Affected Files
+- `adrs/ADR-0063-date-time-and-clock-policy.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md` (confirm/shift the ADR-0063 row; consume the reservation by moving it to **Reservation History** with the merge date)
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0063 header reads `**Status:** Accepted`
+- [ ] `adrs/README.md` has a new ADR-0063 row in numerical order with status Accepted
+- [ ] `constitution/invariants.md` carries the five new date/time invariants (production code reads time via `TimeProvider`; all persisted and transmitted timestamps are UTC; `DateTime` is banned in new code; tests that depend on time advance `FakeTimeProvider`; stored time-zone identifiers are IANA), numbered **{N1}, {N2}, {N3}, {N4}, {N5}** (resolve from `constitution/invariant-reservations.md` — range **69–73** at authoring time) under a new `## Date and Time Invariants` section, each citing ADR-0063. The `FakeTimeProvider` invariant carries the parenthetical noting `Thread.Sleep` is `HD0051`-enforced and the `Task.Delay`-as-wait / wall-clock-poll clauses are reviewer-judgment-enforced
+- [ ] `constitution/invariant-reservations.md` row for ADR-0063 is moved from **Active Reservations** to **Reservation History** with the merge date, and the resolved numbers replace the `{N1}`–`{N5}` placeholders inline
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0063-clock-policy` initiative with a packet checklist
+- [ ] No catalog schema change in this packet (catalog/docs sweep lands in packet 01)
+- [ ] Packets 01, 02, and 03 are merged before this packet's PR is merged (the ADR's own "If Accepted" checklist requires the analyzer rule and the DI helpers to ship before the Status flip)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0063 D1 — `TimeProvider` is the Grid-wide clock abstraction.** Every Node reads "now" via `System.TimeProvider.GetUtcNow()`. Direct calls to `DateTimeOffset.UtcNow`, `DateTimeOffset.Now`, `DateTime.UtcNow`, and `DateTime.Now` are forbidden in production code. Documented interop and process-startup carve-outs only.
+
+**ADR-0063 D2 — UTC at rest, everywhere.** All persisted timestamps are UTC. No Node stores a local-time timestamp; no Node stores a timezone offset alongside a local instant. Conversion to display timezone happens at the presentation boundary.
+
+**ADR-0063 D3 — Type usage policy.** `DateTimeOffset` for instants; `DateOnly` for calendar dates; `TimeOnly` for wall-clock times; `TimeSpan` for durations. `DateTime` is banned in new code; exceptions are interop-only, opt-in via analyzer attribute.
+
+**ADR-0063 D5 — Time zone IDs use IANA, never Windows.** Storage format pinned to IANA; intake converts Windows TZ IDs at the API boundary.
+
+**ADR-0063 D7 — `FakeTimeProvider` is the test substrate.** `Microsoft.Extensions.TimeProvider.Testing` is the committed package; tests `Advance` or `SetUtcNow`, never sleep, never wall-clock-poll, never `Task.Delay` to wait for a time-driven event.
+
+**ADR-0063 D11 — Where the contract lives.** Kernel ships DI registration helpers (`AddSystemTimeProvider`, `AddFakeTimeProvider`); no HoneyDrunk-owned `IGridClock` wrapper — the BCL's `TimeProvider` is the contract.
+
+**ADR-0063 "If Accepted — Required Follow-Up Work" — Scope agent flips Status → Accepted after the analyzer rule lands and the DI helpers ship in Kernel.** This packet is the trailing flip, sequenced after packets 02 (Kernel helpers) and 03 (Standards analyzer).
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0063 stays Proposed in the file until this packet's PR merges. Do not flip the ADR in any other packet.
+- **This packet merges last in the initiative.** The ADR's own "If Accepted" checklist commits the scope agent to flipping Status only after the analyzer rule and the DI helpers ship — so packets 02 and 03 must merge first. Packet 01 (catalog/docs sweep) is also a hard prerequisite via `dependencies:` so packet 00 lands strictly after the other three. Sequence: file all four packets together; merge 02 → 03 → 01 → 00. The `dependencies: ["packet:01", "packet:02", "packet:03"]` array on this packet encodes the gate so the file-packets pipeline wires `blockedBy` edges and The Hive will surface packet 00 as blocked until the other three close. This is the safe form when packets are dispatched to parallel autonomous agents — without the edge, packet 00 could merge first and flip the ADR before the analyzer/helpers/docs ship, contradicting the ADR's own "If Accepted" checklist.
+- **Invariant numbers — claimed via `constitution/invariant-reservations.md`.** This packet claims a contiguous block of five (`{N1}`–`{N5}`); at authoring time the reservation row sits at **69–73** (after the ADR-0050 reservation at 67–68). The current verified max accepted invariant in `constitution/invariants.md` is **53**. If a colliding ADR's packet 00 lands a higher block between filing and merge, edit the ADR-0063 reservation row in `invariant-reservations.md` to shift upward to the new "next free" block of five, then update every `{N1}`–`{N5}` placeholder reference in this packet (Scope, Proposed Implementation, Acceptance Criteria) and in packet 03 (Acceptance Criteria invariant-number references, the HD0054 stability note) to match. Do not reuse a claimed number; do not silently renumber existing invariants.
+- **New section.** The five date/time invariants are a new cross-cutting topic; create a `## Date and Time Invariants` section after `## Audit Invariants` rather than appending to an unrelated section.
+
+## Labels
+`chore`, `tier-3`, `core`, `docs`, `adr-0063`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0063 to Accepted, add the five date/time invariants to `constitution/invariants.md`, add the ADR-0063 row to `adrs/README.md`, and register the date/time-policy initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0063 so the date/time policy is a live Grid rule and unblocks ADR-0068's cron-format pin and the in-flight cadence/idempotency/audit packets.
+- Feature: ADR-0063 Date, Time, and Clock Policy rollout, Wave 1 closeout.
+- ADRs: ADR-0063 (primary), ADR-0008 (initiative/packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None expressed in `dependencies:`. Operator-enforced merge ordering: merge after packets 02 and 03 (and 01 for cleanliness) per the ADR's own "If Accepted" checklist.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0063 stays Proposed until this PR merges.
+- Add the five new invariants as numbers **54, 55, 56, 57, 58** under a new `## Date and Time Invariants` section; do not renumber existing invariants. Current verified max is 53. If any invariant above 53 lands from outside this initiative before merge, shift this block upward, never reuse a claimed number.
+- Merge this packet last in the initiative — packets 02 (Kernel helpers) and 03 (Standards analyzer) must land first per the ADR.
+
+**Key Files:**
+- `adrs/ADR-0063-date-time-and-clock-policy.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0063-clock-policy/01-architecture-date-time-catalog-and-cross-references.md
+++ b/generated/issue-packets/active/adr-0063-clock-policy/01-architecture-date-time-catalog-and-cross-references.md
@@ -1,0 +1,157 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "core", "docs", "adr-0063", "wave-1"]
+dependencies: []
+adrs: ["ADR-0063", "ADR-0047", "ADR-0057", "ADR-0068"]
+wave: 1
+initiative: adr-0063-clock-policy
+node: honeydrunk-architecture
+---
+
+# Record the date/time policy in Kernel docs, tech-stack, and cross-reference ADRs 0047/0057/0068
+
+## Summary
+Land the ADR-0063 documentation sweep across the Architecture repo: a new "Date and Time" section in `repos/HoneyDrunk.Kernel/overview.md`, a date/time-policy ownership note in `repos/HoneyDrunk.Kernel/boundaries.md`, a new "Date and Time" row in `infrastructure/reference/tech-stack.md` referencing `TimeProvider` (production) and `Microsoft.Extensions.TimeProvider.Testing` (tests), a cross-reference in ADR-0047 pointing the testing-pattern doc and test-project template at `FakeTimeProvider`, a cross-reference in ADR-0057's serialization detail pinning ISO 8601 with `Z` per ADR-0063 D4, and a cross-reference in ADR-0068 confirming the cron-string format pin (5-field UTC) is sourced from ADR-0063 D6. No catalog (`catalogs/*.json`) entry — ADR-0063 commits no new HoneyDrunk-owned contract; it pins to the BCL's `TimeProvider`.
+
+## Context
+ADR-0063 "Required Follow-Up Work" lists three Architecture-repo doc updates and three cross-reference touches:
+
+1. `repos/HoneyDrunk.Kernel/overview.md` — add a "Date and Time" section pointing at ADR-0063.
+2. `repos/HoneyDrunk.Kernel/boundaries.md` — record the date/time policy ownership. Kernel is the home for the DI registration helpers, but no Kernel-owned interface wraps `TimeProvider` (it is a BCL type — see ADR-0063 D11).
+3. `infrastructure/reference/tech-stack.md` — add a "Date and Time" row referencing `TimeProvider` (production) and `Microsoft.Extensions.TimeProvider.Testing` (tests).
+4. ADR-0047 cascade — reference `FakeTimeProvider` as the committed test substrate for time-dependent code in the testing-pattern doc and the test-project templates. ADR-0047 D10 owns the `Directory.Build.props` for the unit-test stack; this packet adds a "Time-dependent tests" sub-bullet to the testing-pattern guidance, and notes the template addition for the ADR-0047 packet that ships `Directory.Build.props`.
+5. ADR-0057 serialization section — the D-series covering envelope/payload shape should pin ISO 8601 with `Z` for instants, `YYYY-MM-DD` for dates, and ISO 8601 duration strings for spans, consistent with ADR-0063 D4. Cross-reference is one-way: ADR-0063 pins the format; ADR-0057 governs the API surface.
+6. ADR-0068 — pairs with ADR-0063 and pins the cron-string format. ADR-0068 D5 references ADR-0063 D6 for the cron format; this packet adds the one-line cross-reference back to ADR-0063 D6 in ADR-0068's serialization-related section if not already present, and confirms the matching cross-reference exists from ADR-0063 D6 → ADR-0068.
+
+ADR-0063 also says, under Catalog obligations: "`catalogs/nodes.json` — no entry to add. This ADR adds no Node. `catalogs/contracts.json` — no entry to add. This ADR commits no HoneyDrunk-owned contract (it commits to using the BCL's `TimeProvider`)." So this packet is deliberately **not** a catalog-json packet — it does not edit `catalogs/contracts.json`, `catalogs/relationships.json`, or `catalogs/nodes.json`. The DI helpers `AddSystemTimeProvider`/`AddFakeTimeProvider` ship in `HoneyDrunk.Kernel` (packet 02); they are *extension methods*, not new contracts in the catalog sense — the catalog already lists `HoneyDrunk.Kernel`'s contract surface; helper methods are not entries.
+
+This is a docs-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `repos/HoneyDrunk.Kernel/overview.md` — add a "Date and Time" section.
+- `repos/HoneyDrunk.Kernel/boundaries.md` — add a "Date and Time" entry under both "What Kernel Owns" (DI registration helpers for `TimeProvider`) and "What Kernel Does NOT Own" (a `TimeProvider` wrapper — `TimeProvider` is a BCL type and Kernel does not wrap it; the existing "BCL wrappers" note already covers this — add a one-line `TimeProvider` clarification).
+- `infrastructure/reference/tech-stack.md` — add a "Date and Time" section listing `TimeProvider` (production) and `Microsoft.Extensions.TimeProvider.Testing` (tests).
+- `adrs/ADR-0047-testing-patterns-and-tooling.md` — add a one-paragraph cross-reference to ADR-0063 in the D10 section (Naming and structure conventions / the section that owns `Directory.Build.props` defaults), noting `FakeTimeProvider` is the committed test substrate for time-dependent code.
+- `adrs/ADR-0057-public-http-api-versioning-and-client-sdk-strategy.md` — add the ISO 8601 with `Z` serialization detail to the appropriate D-section (the envelope/payload shape series), cross-referencing ADR-0063 D4 as the authoritative pin.
+- `adrs/ADR-0068-background-job-and-recurring-work-substrate.md` — confirm the existing ADR-0068 → ADR-0063 cross-reference for the cron-format pin reads correctly; add the back-reference if missing. ADR-0068 is Proposed, paired with ADR-0063.
+- **NOT edited:** `catalogs/contracts.json`, `catalogs/relationships.json`, `catalogs/nodes.json` (per ADR-0063 Catalog obligations — no entry to add).
+
+## Proposed Implementation
+1. **`repos/HoneyDrunk.Kernel/overview.md`** — append a new section after "Identity Primitives":
+   ```markdown
+   ## Date and Time
+
+   The Grid reads "now" via the BCL `System.TimeProvider` — no `IGridClock` wrapper. Kernel ships two DI registration helpers — `AddSystemTimeProvider()` (production, wires `TimeProvider.System`) and `AddFakeTimeProvider()` (tests, wires `Microsoft.Extensions.TimeProvider.Testing.FakeTimeProvider`). All persisted and transmitted timestamps are UTC; ISO 8601 with `Z` is the on-wire format. See ADR-0063.
+   ```
+2. **`repos/HoneyDrunk.Kernel/boundaries.md`** — under "What Kernel Owns" add the bullet:
+   ```markdown
+   - DI registration helpers for the BCL `TimeProvider` (`AddSystemTimeProvider`, `AddFakeTimeProvider`) — Kernel does not wrap `TimeProvider` itself
+   ```
+   And under "What Kernel Does NOT Own", extend the existing "BCL wrappers" note:
+   ```markdown
+   - **BCL wrappers** — No `IClock`, `IIdGenerator`, `ILogSink`, no `IGridClock` wrapping `TimeProvider`. Use the BCL directly; Kernel ships only the DI registration helpers.
+   ```
+3. **`infrastructure/reference/tech-stack.md`** — add a new section between "Resilience" and "Identity and Auth":
+   ```markdown
+   ## Date and Time
+
+   | Technology | Version | Used By |
+   |-----------|---------|---------|
+   | `System.TimeProvider` (BCL) | .NET 10.0 | All production code reads "now" via `TimeProvider.GetUtcNow()` |
+   | Microsoft.Extensions.TimeProvider.Testing | 9.x | Test projects (`FakeTimeProvider`) |
+
+   The Grid uses the BCL `TimeProvider` directly — no HoneyDrunk-owned clock interface. DI registration helpers ship from `HoneyDrunk.Kernel`. See ADR-0063.
+   ```
+   Update the **Last Updated** date to the merge date.
+4. **`adrs/ADR-0047-testing-patterns-and-tooling.md`** — add to D10 (Naming and structure conventions, which already owns the `Directory.Build.props` unit-test stack):
+   ```markdown
+   **Time-dependent tests.** Tests that depend on time use `Microsoft.Extensions.TimeProvider.Testing.FakeTimeProvider`, added to the test-project template via `Directory.Build.props`. Tests advance time via `Advance(TimeSpan)` or `SetUtcNow(DateTimeOffset)`; `Thread.Sleep` (invariant 51) and `Task.Delay`-as-wall-clock-wait (invariant 57) are forbidden. See ADR-0063 D7.
+   ```
+   The actual addition of the `PackageReference` to the test-project `Directory.Build.props` is owned by the ADR-0047 packet that ships that template (in the `adr-0047-testing-patterns-and-tooling` initiative). This cross-reference paragraph commits the contract; the template change ships in that initiative.
+5. **`adrs/ADR-0057-public-http-api-versioning-and-client-sdk-strategy.md`** — add an "ISO 8601 with `Z`" paragraph to the appropriate D-section (envelope/payload shape — locate the section that already discusses RFC 7807 Problem Details, cursor pagination, and `Idempotency-Key` headers; add the timestamp serialization paragraph next to it):
+   ```markdown
+   **Date/time serialization.** Instants serialize as ISO 8601 with the `Z` suffix (`"2026-05-23T14:30:00Z"`); calendar dates as `"YYYY-MM-DD"`; wall-clock times as `"HH:MM:SS"`; durations as ISO 8601 duration strings (`"PT5M"`, `"PT1H30M"`, `"P1D"`). The format is pinned by ADR-0063 D4; this ADR governs the API surface that carries it.
+   ```
+6. **`adrs/ADR-0068-background-job-and-recurring-work-substrate.md`** — ADR-0068 is Proposed and already cites ADR-0063 D6 for the cron-format pin per ADR-0063's own Context section ("ADR-0068 D5 references this ADR's D6"). Read ADR-0068's current text. If the back-reference from ADR-0068 → ADR-0063 D6 is in place, no edit is needed — confirm it reads correctly. If it's missing, add a one-line cross-reference in ADR-0068's D5 (or equivalent serialization decision): "The cron-string format (5-field, UTC) is pinned by ADR-0063 D6." Do **not** flip ADR-0068's Status — it remains Proposed; this packet only checks/sharpens the cross-reference. If ADR-0068's existing text contradicts ADR-0063 D6 (e.g. specifies 6-field cron), flag it in the PR description and do not silently edit — that warrants an ADR-0068 amendment, not a docs sweep edit.
+
+## Affected Files
+- `repos/HoneyDrunk.Kernel/overview.md`
+- `repos/HoneyDrunk.Kernel/boundaries.md`
+- `infrastructure/reference/tech-stack.md`
+- `adrs/ADR-0047-testing-patterns-and-tooling.md`
+- `adrs/ADR-0057-public-http-api-versioning-and-client-sdk-strategy.md`
+- `adrs/ADR-0068-background-job-and-recurring-work-substrate.md` (read-and-confirm; edit only if the back-reference is missing or contradicts)
+
+## NuGet Dependencies
+None. This packet touches only Markdown documentation; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No `catalogs/*.json` change — ADR-0063 explicitly states no catalog entry is needed (D11: `TimeProvider` is a BCL primitive; Kernel does not wrap it). Helper methods are not catalog entries.
+
+## Acceptance Criteria
+- [ ] `repos/HoneyDrunk.Kernel/overview.md` has a new "Date and Time" section pointing at ADR-0063 and naming the two DI helpers
+- [ ] `repos/HoneyDrunk.Kernel/boundaries.md` records the date/time policy ownership: DI helpers under "What Kernel Owns", and the `TimeProvider`-no-wrapper note in the existing BCL-wrappers entry
+- [ ] `infrastructure/reference/tech-stack.md` has a new "Date and Time" section/table referencing `System.TimeProvider` (production) and `Microsoft.Extensions.TimeProvider.Testing` (tests), with the Last Updated date refreshed
+- [ ] `adrs/ADR-0047-testing-patterns-and-tooling.md` D10 references `FakeTimeProvider` as the test substrate for time-dependent code, citing ADR-0063 D7
+- [ ] `adrs/ADR-0057-public-http-api-versioning-and-client-sdk-strategy.md` carries the ISO 8601 with `Z` serialization detail, citing ADR-0063 D4 as the authoritative pin
+- [ ] `adrs/ADR-0068-background-job-and-recurring-work-substrate.md` references ADR-0063 D6 for the cron-format pin (existing or added); any contradiction is flagged in the PR description, not silently edited
+- [ ] No `catalogs/contracts.json`, `catalogs/relationships.json`, or `catalogs/nodes.json` edits — ADR-0063 commits no HoneyDrunk-owned contract
+- [ ] No invariant change in this packet (invariants land in packet 00)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0063 D1 — `TimeProvider` is the Grid-wide clock abstraction.** No HoneyDrunk-owned wrapper; the BCL is the contract. Production wires `TimeProvider.System`; tests wire `FakeTimeProvider`.
+
+**ADR-0063 D4 — ISO 8601 with `Z` for serialization.** Instants `"2026-05-23T14:30:00Z"`; dates `"YYYY-MM-DD"`; times `"HH:MM:SS"`; durations `"PT5M"` / `"PT1H30M"` / `"P1DT2H"`. Pinned for Web.Rest payloads, Service Bus envelopes, audit records, App Configuration values, and any persisted JSON.
+
+**ADR-0063 D6 — Cadence specification.** 5-field cron strings in UTC for recurring; ISO 8601 durations for delays. 6-field-with-seconds explicitly rejected. ADR-0068 D5 references this decision.
+
+**ADR-0063 D7 — `FakeTimeProvider` is the test substrate.** Tests advance time via `Advance(TimeSpan)` or `SetUtcNow(DateTimeOffset)`; never sleep, never wall-clock-poll, never `Task.Delay` to wait for a time-driven event. Added to test projects via `Directory.Build.props` per ADR-0047 D10.
+
+**ADR-0063 D11 — Where the contract lives — Kernel helpers, no Kernel interface.** Kernel ships DI registration helpers (`AddSystemTimeProvider`, `AddFakeTimeProvider`); Kernel does NOT publish `IGridClock` or any HoneyDrunk-owned wrapper around `TimeProvider`. The BCL is the contract.
+
+**ADR-0063 Catalog obligations.** "`catalogs/nodes.json` — no entry to add. This ADR adds no Node. `catalogs/contracts.json` — no entry to add. This ADR commits no HoneyDrunk-owned contract (it commits to using the BCL's `TimeProvider`)."
+
+## Constraints
+- **No catalog JSON edits.** ADR-0063 commits no HoneyDrunk-owned contract; `catalogs/*.json` stays untouched. DI helper methods are not catalog entries.
+- **Cross-references are one-way.** ADR-0063 is the authority on the format / substrate; the touched ADRs (0047, 0057, 0068) reference back to ADR-0063, not the reverse. Do not weaken ADR-0063's decisions by introducing equivalent-language pins in the other ADRs.
+- **Do not flip ADR-0068's Status.** ADR-0068 remains Proposed; this packet only sharpens or confirms an existing cross-reference. If ADR-0068 contradicts ADR-0063 D6 (e.g. 6-field cron), flag in the PR — do not silently edit.
+- **`Directory.Build.props` change ships in the ADR-0047 initiative, not here.** This packet commits the documentation/contract; the per-test-template `PackageReference` change belongs in `adr-0047-testing-patterns-and-tooling`.
+
+## Labels
+`feature`, `tier-2`, `core`, `docs`, `adr-0063`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Land the ADR-0063 documentation sweep — Kernel docs, tech-stack, and cross-references in ADRs 0047/0057/0068.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Keep the Grid documentation surface consistent with ADR-0063's decisions so consumers and review agents read a single source of truth on date/time policy.
+- Feature: ADR-0063 Date, Time, and Clock Policy rollout, Wave 1 (docs sweep).
+- ADRs: ADR-0063 (primary), ADR-0047 D10 (test template), ADR-0057 (API serialization), ADR-0068 (cron format pin).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This packet has no hard dependency on packet 00 — ADR-0063's decisions are the source whether or not the Status flag is flipped yet. Operator-enforced merge ordering: this packet may merge before or after packets 02/03; it should merge before packet 00 (the acceptance flip) so packet 00's invariant block can cite landed cross-references, but no `dependencies:` edge enforces it.
+
+**Constraints:**
+- No catalog JSON edits — ADR-0063 commits no HoneyDrunk-owned contract.
+- ADR-0068 stays Proposed; this packet only confirms/sharpens cross-references.
+- The `Directory.Build.props` test-template change is owned by the ADR-0047 initiative, not here — this packet commits the cross-reference paragraph only.
+- Cross-references point back to ADR-0063 as authoritative; do not duplicate the pin in the referenced ADRs.
+
+**Key Files:**
+- `repos/HoneyDrunk.Kernel/overview.md`, `boundaries.md`.
+- `infrastructure/reference/tech-stack.md`.
+- `adrs/ADR-0047-testing-patterns-and-tooling.md`, `adrs/ADR-0057-public-http-api-versioning-and-client-sdk-strategy.md`, `adrs/ADR-0068-background-job-and-recurring-work-substrate.md`.
+
+**Contracts:** None changed — docs-only.

--- a/generated/issue-packets/active/adr-0063-clock-policy/02-kernel-time-provider-di-helpers.md
+++ b/generated/issue-packets/active/adr-0063-clock-policy/02-kernel-time-provider-di-helpers.md
@@ -1,0 +1,167 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Kernel
+labels: ["feature", "tier-2", "core", "adr-0063", "wave-1"]
+dependencies: []
+adrs: ["ADR-0063"]
+wave: 1
+initiative: adr-0063-clock-policy
+node: honeydrunk-kernel
+---
+
+# Add AddSystemTimeProvider and AddFakeTimeProvider DI helpers to HoneyDrunk.Kernel
+
+## Summary
+Add two `IServiceCollection` extension methods to `HoneyDrunk.Kernel` per ADR-0063 D1 and D11: `AddSystemTimeProvider()` registers the BCL `TimeProvider.System` as the singleton `TimeProvider` for production hosts; `AddFakeTimeProvider(DateTimeOffset? initialInstant = null)` registers `Microsoft.Extensions.TimeProvider.Testing.FakeTimeProvider` for test fixtures and exposes the concrete fake on the service collection so individual tests can retrieve and drive it. **Kernel does not wrap `TimeProvider` — no `IGridClock`, no proxy interface.** This is the version-bumping packet for the `HoneyDrunk.Kernel` solution: `0.7.0` → `0.8.0`.
+
+## Context
+ADR-0063 commits the BCL `TimeProvider` as the Grid-wide clock abstraction (D1) and places the DI registration helpers in `HoneyDrunk.Kernel` (D11). The rationale is stated explicitly in D11: "The platform-level abstraction is the contract; layering an additional interface on top is ceremony without value." Kernel's role is to make `TimeProvider.System` and `FakeTimeProvider` trivial to compose at the host level via DI — not to introduce a `HoneyDrunk.Kernel.IClock` or any wrapper.
+
+`HoneyDrunk.Kernel/boundaries.md` is consistent with this: "BCL wrappers — No `IClock`, `IIdGenerator`, `ILogSink`. Use BCL directly." `TimeProvider` is a BCL type; Kernel ships the host-time composition helpers, not a wrapper.
+
+`HoneyDrunk.Kernel` is a live Node currently at v0.7.0 (.NET 10.0), two packages: `HoneyDrunk.Kernel.Abstractions` (zero-dependency contracts) and `HoneyDrunk.Kernel` (runtime). This packet is the **first packet on the `HoneyDrunk.Kernel` solution in this initiative** — per invariant 27 it bumps every non-test `.csproj` to the same new minor version (`0.7.0` → `0.8.0`; new feature, additive helpers, no break).
+
+> **Placement note — helpers ship in the `HoneyDrunk.Kernel` runtime package, not `HoneyDrunk.Kernel.Abstractions`.** The helpers take a `PackageReference` on `Microsoft.Extensions.TimeProvider.Testing` for `FakeTimeProvider`; `HoneyDrunk.Kernel.Abstractions` has zero runtime dependencies on third-party packages beyond `Microsoft.Extensions.*` abstractions (invariant 1). The helpers themselves are runtime code (DI composition), not contracts — they belong in the runtime package.
+>
+> **`Microsoft.Extensions.TimeProvider.Testing` is a runtime `PackageReference` on the Kernel runtime package, not test-project-only.** Reason: `AddFakeTimeProvider()` instantiates `FakeTimeProvider` at compose time, and that helper is part of Kernel's public runtime API. The package is MIT-licensed Microsoft and small; the dependency is acceptable (the ADR's Negative consequence explicitly accepts this cost). Hosts that call only `AddSystemTimeProvider()` still get the transitive package on their Kernel reference, which is intentional — having `FakeTimeProvider` available for any host (e.g. a host running in a synthetic-time mode for replay) is the point of putting both helpers next to each other.
+
+## Scope
+- `HoneyDrunk.Kernel` (runtime package) — new public extension methods:
+  - `IServiceCollection AddSystemTimeProvider(this IServiceCollection services)` — registers `TimeProvider.System` as the singleton `TimeProvider`.
+  - `IServiceCollection AddFakeTimeProvider(this IServiceCollection services, DateTimeOffset? initialInstant = null)` — registers `FakeTimeProvider` as the singleton `TimeProvider` and *also* registers `FakeTimeProvider` itself as a resolvable singleton (so test fixtures can `serviceProvider.GetRequiredService<FakeTimeProvider>().Advance(...)`).
+- `HoneyDrunk.Kernel` `.csproj` — add `PackageReference` on `Microsoft.Extensions.TimeProvider.Testing`.
+- Unit tests in `HoneyDrunk.Kernel.Tests` covering both helpers.
+- Both `.csproj` files in the solution version-bumped to `0.8.0` (invariant 27).
+- `HoneyDrunk.Kernel` package `CHANGELOG.md` and `README.md` updated. `HoneyDrunk.Kernel.Abstractions` gets no per-package CHANGELOG entry (alignment bump only — no functional change in Abstractions).
+- Repo-level `CHANGELOG.md` gets a new `[0.8.0]` entry.
+
+## Proposed Implementation
+1. **`AddSystemTimeProvider`** — a one-liner extension method that calls `services.TryAddSingleton<TimeProvider>(TimeProvider.System)`. Use `TryAddSingleton` (idempotent, doesn't overwrite a previously-registered `TimeProvider`) — so a test fixture that already wired `AddFakeTimeProvider` upstream is not silently overridden if the host's composition path also calls `AddSystemTimeProvider`. XML-doc the idempotency.
+2. **`AddFakeTimeProvider`** — registers a `FakeTimeProvider` singleton both as `TimeProvider` (the abstract base) AND as the concrete `FakeTimeProvider` type, so callers can resolve either. The shape:
+   ```
+   public static IServiceCollection AddFakeTimeProvider(
+       this IServiceCollection services,
+       DateTimeOffset? initialInstant = null)
+   {
+       var fake = new FakeTimeProvider(initialInstant ?? DateTimeOffset.UtcNow);
+       services.AddSingleton(fake);
+       services.AddSingleton<TimeProvider>(fake);
+       return services;
+   }
+   ```
+   The `initialInstant` parameter defaults to `DateTimeOffset.UtcNow` — note this is one of the documented carve-outs for `DateTimeOffset.UtcNow` (process-startup bootstrap; DI not yet up at this exact composition moment). Document the carve-out in an XML-doc remark. If the analyzer rule (packet 03) flags this call, the helper opt-out attribute applies — the helper itself is the boundary.
+   Use straight `AddSingleton` (not `TryAddSingleton`) — calling `AddFakeTimeProvider` is an explicit decision to use the fake; overwriting a prior registration is the intended behaviour in test composition.
+3. **XML documentation** — both helpers carry full XML-doc explaining:
+   - Why Kernel ships these as helpers, not as a `TimeProvider` wrapper (cite ADR-0063 D11).
+   - The idempotency posture of each (`TryAddSingleton` vs `AddSingleton`).
+   - That `AddFakeTimeProvider` registers `FakeTimeProvider` separately so tests can drive the clock via `IServiceProvider.GetRequiredService<FakeTimeProvider>().Advance(...)`.
+4. **Unit tests** — `HoneyDrunk.Kernel.Tests` adds:
+   - `AddSystemTimeProvider_RegistersTimeProviderSystem` — calling it and resolving `TimeProvider` returns `TimeProvider.System`.
+   - `AddSystemTimeProvider_IsIdempotent` — calling twice does not throw; resolving still works.
+   - `AddSystemTimeProvider_DoesNotOverrideExistingRegistration` — pre-register a `TimeProvider`, call `AddSystemTimeProvider`, resolve → still the pre-registered one.
+   - `AddFakeTimeProvider_RegistersFakeAsTimeProvider` — resolves `TimeProvider` → instance is the same `FakeTimeProvider`.
+   - `AddFakeTimeProvider_RegistersConcreteFakeType` — resolves `FakeTimeProvider` directly → same instance as the `TimeProvider` registration (assert reference equality).
+   - `AddFakeTimeProvider_InitialInstant_IsRespected` — pass an `initialInstant`; resolve `TimeProvider`; `GetUtcNow()` returns that instant.
+   - `AddFakeTimeProvider_Advance_AffectsResolvedTimeProvider` — `Advance(5 minutes)`; `GetUtcNow()` advances by 5 minutes.
+   - No `Thread.Sleep` (invariant 51); no `await Task.Delay()`-as-wait (invariant 57 once packet 00 lands).
+5. **Version bump** — both `.csproj` files in the solution to `0.8.0`. Append a repo-level `[0.8.0]` CHANGELOG entry: "Added `AddSystemTimeProvider` and `AddFakeTimeProvider` DI helpers in `HoneyDrunk.Kernel` per ADR-0063 D11." Add a per-package CHANGELOG entry to `HoneyDrunk.Kernel`. `HoneyDrunk.Kernel.Abstractions` gets no per-package CHANGELOG entry (no functional change — alignment bump only per invariant 12/27).
+6. **README update** — `HoneyDrunk.Kernel/README.md` documents the two helpers in the public-API section. Repo-level `README.md` gets a short "Date and Time" subsection if a Date/Time section is not already present.
+
+## Affected Files
+- `HoneyDrunk.Kernel/` — new `TimeProviderServiceCollectionExtensions.cs` (or split into `SystemTimeProviderExtensions.cs` and `FakeTimeProviderExtensions.cs` — match the repo's existing file-per-extension-area convention).
+- `HoneyDrunk.Kernel/HoneyDrunk.Kernel.csproj` — version bump and new `PackageReference` on `Microsoft.Extensions.TimeProvider.Testing`.
+- `HoneyDrunk.Kernel.Abstractions/HoneyDrunk.Kernel.Abstractions.csproj` — version bump (alignment).
+- `HoneyDrunk.Kernel/CHANGELOG.md`, `HoneyDrunk.Kernel/README.md`.
+- Repo-level `CHANGELOG.md`, `README.md`.
+- `HoneyDrunk.Kernel.Tests/` — new test class(es) for both helpers.
+
+## NuGet Dependencies
+- **`HoneyDrunk.Kernel`** — new `PackageReference`:
+  - `Microsoft.Extensions.TimeProvider.Testing` — latest stable major-version-matched to .NET 10 / `Microsoft.Extensions.*` 10.x (so `9.x` if 9 is current latest GA — the package follows the `Microsoft.Extensions.*` cadence; check the current major before pinning).
+- **`HoneyDrunk.Kernel.Abstractions`** — no new `PackageReference`. The DI helpers ship in the runtime package, not Abstractions (invariant 1 preserved).
+- **`HoneyDrunk.Kernel.Tests`** — no new `PackageReference` strictly required (it transits the runtime's reference). If the test project wants to use `FakeTimeProvider` types directly outside of the helper-test code paths, add `Microsoft.Extensions.TimeProvider.Testing` as a direct reference too.
+
+## Boundary Check
+- [x] DI helpers belong in `HoneyDrunk.Kernel` per ADR-0063 D11. Routing rule "context, GridContext, NodeContext, ... lifecycle, DI helpers → HoneyDrunk.Kernel" maps exactly. Kernel's `boundaries.md` already names DI composition helpers as in-scope.
+- [x] No new contract in `HoneyDrunk.Kernel.Abstractions` — these are runtime composition helpers, not contracts.
+- [x] No HoneyDrunk-owned `IGridClock` or proxy interface — Kernel does not wrap `TimeProvider` (invariant added in packet 00; ADR-0063 D11). Routing rule "BCL wrappers — Use BCL directly" applies.
+- [x] No reference to any other HoneyDrunk runtime package (invariant 4, DAG preserved).
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Kernel` exposes `IServiceCollection AddSystemTimeProvider(this IServiceCollection services)` that registers `TimeProvider.System` as the singleton `TimeProvider` using `TryAddSingleton`
+- [ ] `HoneyDrunk.Kernel` exposes `IServiceCollection AddFakeTimeProvider(this IServiceCollection services, DateTimeOffset? initialInstant = null)` that registers `FakeTimeProvider` as both `TimeProvider` and the concrete `FakeTimeProvider` type via `AddSingleton`
+- [ ] `AddSystemTimeProvider` is idempotent and does NOT override an already-registered `TimeProvider`
+- [ ] `AddFakeTimeProvider` overwrites a prior registration when called (explicit composition wins; unit-tested)
+- [ ] Resolving `TimeProvider` after `AddFakeTimeProvider` returns the same instance as resolving `FakeTimeProvider` (reference-equal)
+- [ ] `Advance(TimeSpan)` on the resolved `FakeTimeProvider` updates the `GetUtcNow()` of the resolved `TimeProvider`
+- [ ] Both helpers carry full XML documentation including the rationale ("ADR-0063 D11 — Kernel does not wrap `TimeProvider`; ships DI helpers instead")
+- [ ] `HoneyDrunk.Kernel` `.csproj` has a `PackageReference` on `Microsoft.Extensions.TimeProvider.Testing` (current stable major matched to `Microsoft.Extensions.*` 10.x cadence)
+- [ ] `HoneyDrunk.Kernel.Abstractions` has NO `PackageReference` change (invariant 1 — zero runtime HoneyDrunk-owned-contract change; the testing package does not land in Abstractions)
+- [ ] No `IGridClock`, `IClock`, or any HoneyDrunk-owned wrapper around `TimeProvider` is introduced (invariant 54 from packet 00 + ADR-0063 D11)
+- [ ] Both non-test `.csproj` files in the solution are at version `0.8.0` in a single commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new `[0.8.0]` entry dated to the merge
+- [ ] `HoneyDrunk.Kernel/CHANGELOG.md` has a `[0.8.0]` entry describing the DI helpers
+- [ ] `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md` gets NO entry (alignment bump only — invariant 12/27)
+- [ ] `HoneyDrunk.Kernel/README.md` documents both helpers
+- [ ] Unit tests contain no `Thread.Sleep` (invariant 51) and no `Task.Delay`-as-wall-clock-wait (invariant 57 once packet 00 lands)
+- [ ] The `pr-core.yml` tier-1 gate and any Kernel contract-shape canary pass — the additions are runtime helpers (not Abstractions-shape changes), paired with the `0.8.0` bump
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0063 D1 — `TimeProvider` is the Grid-wide clock abstraction.** Every Node reads "now" via `System.TimeProvider.GetUtcNow()`. Production wires `TimeProvider.System`; tests wire `FakeTimeProvider`. The DI registration helpers live in `HoneyDrunk.Kernel` per D11.
+
+**ADR-0063 D7 — `FakeTimeProvider` is the test substrate.** `Microsoft.Extensions.TimeProvider.Testing.FakeTimeProvider` is the committed package. Tests advance time via `Advance(TimeSpan)` or `SetUtcNow(DateTimeOffset)`.
+
+**ADR-0063 D11 — Where the contract lives — Kernel helpers, no Kernel interface.** "Kernel does not wrap [`TimeProvider`]. Kernel does not publish `IGridClock` or `IClock` or any HoneyDrunk-owned interface that proxies `TimeProvider`. The platform-level abstraction is the contract; layering an additional interface on top is ceremony without value. What Kernel does provide: DI registration helpers in `HoneyDrunk.Kernel` — `services.AddSystemTimeProvider()`, `services.AddFakeTimeProvider(DateTimeOffset? initialInstant = null)`."
+
+**ADR-0063 Operational Consequences — `Microsoft.Extensions.TimeProvider.Testing` is a Microsoft NuGet package and adds a test-project dependency.** "It is MIT-licensed and stewardship is Microsoft; the trust posture is good. The dependency itself is small. Acceptable cost." (This packet places the `PackageReference` on the Kernel runtime package, not test-project-only, because `AddFakeTimeProvider` is a Kernel runtime API — see the Placement note in Context.)
+
+## Constraints
+- **Invariant 1 — Abstractions have zero runtime dependencies on other HoneyDrunk packages.** The helpers ship in the `HoneyDrunk.Kernel` runtime package, not `HoneyDrunk.Kernel.Abstractions`. Do not add `Microsoft.Extensions.TimeProvider.Testing` to `Abstractions.csproj`.
+- **Invariant 4 — DAG; Kernel is at the root.** No `PackageReference` to any other HoneyDrunk runtime package.
+- **Invariant 13 — all public APIs have XML documentation.** Both helpers carry doc-comments with the ADR-0063 D11 rationale.
+- **Invariant 27 — all projects in a solution share one version and move together.** Both `.csproj` files go to `0.8.0` in one commit. Partial bumps are forbidden. This is the bumping packet.
+- **Invariant 12 — per-package CHANGELOGs are updated only for packages with functional changes.** `HoneyDrunk.Kernel` gets an entry; `HoneyDrunk.Kernel.Abstractions` (alignment bump only) gets none.
+- **No `IGridClock` wrapper.** ADR-0063 D11 is explicit: Kernel ships helpers, not an interface. This packet is the test of that commitment — the implementing agent does not introduce a "thin wrapper for testability" or any equivalent. If you feel the urge to introduce one, the ADR's Alternatives Considered section ("Wrap `TimeProvider` in a HoneyDrunk-owned `IGridClock` interface") already answers it: rejected.
+- **`AddFakeTimeProvider`'s default `initialInstant`.** The default is `DateTimeOffset.UtcNow` at the moment the helper is called — a documented carve-out per ADR-0063 D1's process-startup-bootstrap exception. The analyzer rule from packet 03 will need the opt-out attribute on this exact call site (or the rule must not flag this single specific line). Apply the opt-out attribute when packet 03 lands; for now, document the carve-out in XML-doc.
+
+## Labels
+`feature`, `tier-2`, `core`, `adr-0063`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Add `AddSystemTimeProvider` and `AddFakeTimeProvider` DI helpers to `HoneyDrunk.Kernel` per ADR-0063 D11, and bump the `HoneyDrunk.Kernel` solution to `0.8.0`.
+
+**Target:** `HoneyDrunk.Kernel`, branch from `main`.
+
+**Context:**
+- Goal: Ship the host-time composition surface so every production host calls `AddSystemTimeProvider()` and every test fixture calls `AddFakeTimeProvider()` — no other surface needed, no wrapper.
+- Feature: ADR-0063 Date, Time, and Clock Policy rollout, Wave 1.
+- ADRs: ADR-0063 D1/D7/D11 (primary), ADR-0008 (packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None expressed in `dependencies:`. Packet 02 can land before packet 00 (the acceptance flip) — the helpers compile and ship against a Proposed ADR; the invariant that bans direct `DateTime.UtcNow` is only an *invariant* once packet 00 lands, and only *enforced* when packet 03 ships the analyzer rule. The merge ordering is operator discipline; this packet does not block on any other packet in the initiative.
+
+**Constraints:**
+- Helpers ship in the `HoneyDrunk.Kernel` runtime package, not Abstractions (invariant 1).
+- No `IGridClock` or any HoneyDrunk-owned wrapper around `TimeProvider` (ADR-0063 D11).
+- `AddSystemTimeProvider` uses `TryAddSingleton` (idempotent); `AddFakeTimeProvider` uses `AddSingleton` (explicit composition wins).
+- Bump both non-test `.csproj` files to `0.8.0` in one commit (invariant 27).
+- No `Thread.Sleep`, no `Task.Delay`-as-wall-clock-wait in tests.
+
+**Key Files:**
+- `HoneyDrunk.Kernel/TimeProviderServiceCollectionExtensions.cs` (or split per repo convention).
+- `HoneyDrunk.Kernel/HoneyDrunk.Kernel.csproj` — version bump + new `PackageReference`.
+- `HoneyDrunk.Kernel.Abstractions/HoneyDrunk.Kernel.Abstractions.csproj` — version bump (alignment).
+- `HoneyDrunk.Kernel/CHANGELOG.md`, `README.md`; repo-level `CHANGELOG.md`.
+- `HoneyDrunk.Kernel.Tests/` — new test class.
+
+**Contracts:**
+- `AddSystemTimeProvider(this IServiceCollection services)` (new extension on `HoneyDrunk.Kernel`) — registers `TimeProvider.System` as singleton `TimeProvider` via `TryAddSingleton`.
+- `AddFakeTimeProvider(this IServiceCollection services, DateTimeOffset? initialInstant = null)` (new extension on `HoneyDrunk.Kernel`) — registers `FakeTimeProvider` as both `TimeProvider` and the concrete `FakeTimeProvider` via `AddSingleton`.
+- Consumes the BCL `System.TimeProvider` and `Microsoft.Extensions.TimeProvider.Testing.FakeTimeProvider`. No HoneyDrunk contract is added or changed.

--- a/generated/issue-packets/active/adr-0063-clock-policy/03-standards-date-time-now-analyzer-rule.md
+++ b/generated/issue-packets/active/adr-0063-clock-policy/03-standards-date-time-now-analyzer-rule.md
@@ -1,0 +1,165 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Standards
+labels: ["feature", "tier-2", "core", "adr-0063", "wave-1"]
+dependencies: []
+adrs: ["ADR-0063"]
+wave: 1
+initiative: adr-0063-clock-policy
+node: honeydrunk-standards
+---
+
+# Add the analyzer rule that flags direct DateTime.UtcNow / DateTimeOffset.UtcNow in production code
+
+## Summary
+Add a Roslyn analyzer rule (proposed diagnostic id `HD0054`, matching the invariant number this packet's packet-00 sibling lands) to `HoneyDrunk.Standards.Analyzers` that flags direct invocations of `System.DateTime.UtcNow`, `System.DateTime.Now`, `System.DateTimeOffset.UtcNow`, and `System.DateTimeOffset.Now` in **production code** (anything *not* in a `*.Tests.*` project), with an `[AllowSystemClock]` (or equivalent name — see naming below) opt-out attribute for documented interop boundaries per ADR-0063 D3. The rule ships at **warning severity** initially per ADR-0063 D12; the user flips it to error once the bulk of touched code paths have migrated.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Standards`
+
+## Motivation
+ADR-0063 D1 forbids direct calls to `DateTime.UtcNow`, `DateTime.Now`, `DateTimeOffset.UtcNow`, and `DateTimeOffset.Now` in production code. The "If Accepted" follow-up list names this rule explicitly: "Add a new analyzer rule (or extend `HoneyDrunk.Standards`) that flags `DateTime.UtcNow`, `DateTime.Now`, `DateTimeOffset.UtcNow`, and `DateTimeOffset.Now` in non-test code, with an opt-out attribute for documented interop exceptions per D3." ADR-0063 D12 also names the migration path: "ship the rule at warning severity initially; flip to error after the natural touch points have migrated."
+
+Without this rule, ADR-0063 D1 is a policy with no enforcement, and packet 00's invariant 54 ("Production code reads time via `TimeProvider`") would be reviewer-judgment only. ADR-0063's enforcement story is built around this rule firing at compile time.
+
+`HoneyDrunk.Standards` already ships the Grid's analyzer pack — the `HoneyDrunk.Standards.Analyzers` project under `HoneyDrunk.Standards/HoneyDrunk.Standards/HoneyDrunk.Standards.Analyzers/` ships at least `HD0051` (the `ThreadSleepInTestsAnalyzer` for invariant 51). This new analyzer follows the same pattern.
+
+## Proposed Implementation
+The implementing agent reads the existing `ThreadSleepInTestsAnalyzer.cs` as the structural model.
+
+1. **Diagnostic ID and severity:**
+   - Proposed ID: `HD0054` (matches invariant 54 from packet 00). If the Standards repo's ID numbering convention disagrees, follow the repo's existing convention and surface the chosen ID in the PR — the invariant cross-reference still applies.
+   - Initial severity: **`Warning`** (per ADR-0063 D12 — "ship the rule at warning severity initially; flip to error after the natural touch points have migrated"). Documented in the analyzer descriptor.
+   - Default-enabled: yes.
+2. **Banned APIs:**
+   - `System.DateTime.UtcNow` (property getter)
+   - `System.DateTime.Now` (property getter)
+   - `System.DateTimeOffset.UtcNow` (property getter)
+   - `System.DateTimeOffset.Now` (property getter)
+   - These are property getters, not method invocations — register on `OperationKind.PropertyReference` (not `OperationKind.Invocation`), and inspect `IPropertyReferenceOperation.Property` for the four target getters. Compare via `SymbolEqualityComparer.Default` against the resolved property symbols on `compilation.GetTypeByMetadataName("System.DateTime")` and `compilation.GetTypeByMetadataName("System.DateTimeOffset")`.
+3. **Project scoping — opposite of `HD0051`:**
+   - `HD0051` (`Thread.Sleep`) fires only in **test** projects (`build_property.HD_IsGridTestProject == true`).
+   - `HD0054` (this rule) fires only in **non-test** projects. Use the same `HD_IsGridTestProject` analyzer-config property and invert the check: register the analysis action only when the property is absent or `false`.
+   - This is symmetric to `HD0051`: both gate off the same MSBuild property; they fire in mutually-exclusive project sets.
+4. **Opt-out attribute for documented interop:**
+   - Define a public `[AllowSystemClock]` attribute (or `[SystemClockUsageAllowed]`, or whatever naming the Standards repo's existing opt-out attributes use — match the repo's existing convention; if there is no existing convention, prefer `[AllowSystemClock]` as the most readable and ship a brief XML-doc).
+   - Attribute target: `[AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Property | AttributeTargets.Class)]` — allow opt-out at the smallest reasonable scope.
+   - The attribute lives in the public assembly that consumers will reference. `HoneyDrunk.Standards.Analyzers` is the analyzer assembly (netstandard2.0); attributes must live where consumer code can reference them. Likely placement: a small `HoneyDrunk.Standards` (or `HoneyDrunk.Standards.Annotations`) runtime assembly that consumers `PackageReference` alongside the analyzer. If the Standards repo already ships such an assembly, place the attribute there; if not, the implementing agent chooses the most idiomatic placement (a new shared annotations package, or extend the existing analyzers package with a public attribute type usable from C# consumers via a separate small reference assembly). The chosen placement is recorded in the PR.
+   - Suppression: when the analyzer fires on a `DateTime.UtcNow` / `DateTimeOffset.UtcNow` etc. reference, it walks the enclosing symbols (method, then containing type) checking for the opt-out attribute. If found, the diagnostic is not reported. The opt-out attribute requires a `Reason` string property (or constructor argument) — the analyzer does NOT inspect the reason, but the attribute requires one as a documentation discipline. Example use:
+     ```csharp
+     [AllowSystemClock(Reason = "Process bootstrap log line — DI not yet up; see ADR-0063 D1.")]
+     private static void LogStartupTime() => Console.WriteLine($"Started at {DateTimeOffset.UtcNow:O}");
+     ```
+5. **Carve-outs the rule must NOT flag:**
+   - `Stopwatch.GetTimestamp()`, `Environment.TickCount`, `Environment.TickCount64` — these are elapsed-time mechanisms, explicitly out of scope per ADR-0063's "Use `Stopwatch` or `Environment.TickCount` for elapsed-time measurements" clarification. The analyzer is scoped to the four named property reads — these other APIs are not touched.
+   - `TimeProvider.System.GetUtcNow()` — explicitly *the* committed call. The analyzer is keyed on `DateTime.UtcNow` / `DateTimeOffset.UtcNow` / `.Now`; `TimeProvider.GetUtcNow()` is a method call on a different type, not a property of `DateTime` or `DateTimeOffset`.
+   - `DateTime.UtcNow` reads inside a `*.Tests.*` project — explicitly out of scope (test code may use direct reads where the test isn't time-dependent, or wires its own discipline via `FakeTimeProvider`).
+6. **Migration discipline (per ADR-0063 D12):**
+   - The rule ships at `Warning` initially. Flipping to `Error` is a one-line severity change in the `DiagnosticDescriptor`, gated on the user's judgment — not on a CI metric and not a separate packet. Document the flip path in the rule's XML-doc and in the repo `README.md`: "When the bulk of direct `DateTime`/`DateTimeOffset.UtcNow` reads have been migrated to `TimeProvider`, change `DiagnosticSeverity.Warning` to `DiagnosticSeverity.Error` and re-publish."
+   - This packet does NOT migrate any existing call site. The rule fires (at warning) on every existing direct `UtcNow` read across the Grid the day after the analyzer ships; per ADR-0063 D12 those migrations are "amortized across the natural touch points" — each touching packet converts the reads it crosses. Do not include a bulk-migration sweep in this packet.
+7. **Unit tests:** add tests under `HoneyDrunk.Standards.Tests` covering:
+   - A non-test project reading `DateTime.UtcNow` is flagged (one diagnostic at the property-reference site).
+   - A non-test project reading `DateTime.Now`, `DateTimeOffset.UtcNow`, `DateTimeOffset.Now` is flagged (one diagnostic per read).
+   - A test project (`HD_IsGridTestProject = true`) reading `DateTime.UtcNow` is NOT flagged.
+   - A non-test method annotated `[AllowSystemClock(Reason = "...")]` reading `DateTime.UtcNow` is NOT flagged (opt-out works).
+   - A non-test method calling `TimeProvider.GetUtcNow()` is NOT flagged (correct usage).
+   - A non-test method calling `Stopwatch.GetTimestamp()` and `Environment.TickCount64` is NOT flagged (carve-outs).
+8. **README and CHANGELOG:**
+   - Document the rule (ID, scope, severity, the `[AllowSystemClock]` opt-out, the carve-outs) in the Standards repo `README.md`.
+   - Repo-level `CHANGELOG.md` — new version entry per `HoneyDrunk.Standards`'s own versioning (it sits at 0.2.9 per the Kernel `.csproj` reference; check the current Standards version at execution time and bump per its CHANGELOG cadence).
+   - Per-package `CHANGELOG.md` for `HoneyDrunk.Standards.Analyzers` — describe `HD0054`, severity Warning, the opt-out attribute.
+
+## Affected Packages
+- `HoneyDrunk.Standards.Analyzers` — gains `DateTimeNowInProductionAnalyzer` (or similarly named, matching repo convention) with diagnostic `HD0054`.
+- The runtime annotations assembly (whichever Standards-shipped package consumers reference for attributes; the implementing agent picks the most idiomatic placement and records it in the PR) — gains the `[AllowSystemClock]` attribute.
+
+## NuGet Dependencies
+- No new `PackageReference`. The analyzer uses `Microsoft.CodeAnalysis.*` already referenced by `HoneyDrunk.Standards.Analyzers`.
+- If a new shared annotations assembly is introduced (e.g., `HoneyDrunk.Standards.Annotations`) to host the `[AllowSystemClock]` attribute, it follows the repo's existing project-creation discipline (CHANGELOG, README, `Directory.Build.props`, version aligned with the solution per invariant 27).
+
+## Boundary Check
+- [x] Grid-wide analyzer rules belong in `HoneyDrunk.Standards` — the existing `HD0051` precedent is the template (invariant 26).
+- [x] No Node behavior change; this packet ships a compile-time diagnostic.
+- [x] Does not duplicate any other Node's responsibility.
+- [x] No analyzer fired on `TimeProvider.GetUtcNow()` (correct usage) — only the four banned property reads.
+- [x] Symmetric to `HD0051`: opposite project scoping (`HD0054` fires in non-test code; `HD0051` fires in test code), same `HD_IsGridTestProject` MSBuild property gates both.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Standards.Analyzers` ships a new `DiagnosticAnalyzer` keyed on `OperationKind.PropertyReference` that flags `DateTime.UtcNow`, `DateTime.Now`, `DateTimeOffset.UtcNow`, `DateTimeOffset.Now` reads
+- [ ] Diagnostic ID is `HD0054` (or the equivalent the repo's numbering convention assigns; documented in PR)
+- [ ] Severity is `DiagnosticSeverity.Warning` (per ADR-0063 D12)
+- [ ] The rule fires ONLY in non-test projects (gated off `build_property.HD_IsGridTestProject` — fires when absent or `false`; suppressed when `true`)
+- [ ] An `[AllowSystemClock]` (or equivalently-named) attribute exists in a consumer-referenceable assembly, with a required `Reason` string, allowed targets `Method | Constructor | Property | Class`
+- [ ] The analyzer walks enclosing symbols (method → containing type) for the opt-out attribute and suppresses the diagnostic when found
+- [ ] The analyzer does NOT fire on `TimeProvider.GetUtcNow()`, `Stopwatch.GetTimestamp()`, `Environment.TickCount`, or `Environment.TickCount64`
+- [ ] Unit tests cover all four banned reads, the test-project carve-out, the opt-out attribute, and the correct-usage / out-of-scope-API negatives
+- [ ] `HoneyDrunk.Standards/README.md` documents the rule ID, scope, severity, opt-out attribute usage, and the migration path (warning → error per ADR-0063 D12)
+- [ ] Repo-level `CHANGELOG.md` and `HoneyDrunk.Standards.Analyzers/CHANGELOG.md` updated; version bumped per Standards solution cadence (invariant 27 — all `.csproj` move together)
+- [ ] Build green; existing `HoneyDrunk.Standards` consumers are unaffected at *error* severity (they may see new *warnings* — that is the intended migration signal per ADR-0063 D12)
+- [ ] No bulk migration of existing `DateTime.UtcNow` reads in this packet — the rule surfaces them; remediation is per-Node, packet-driven per ADR-0063 D12
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0063 D1 — `TimeProvider` is the Grid-wide clock abstraction.** Direct calls to `DateTimeOffset.UtcNow`, `DateTimeOffset.Now`, `DateTime.UtcNow`, and `DateTime.Now` are forbidden in production code. The documented exceptions: interop with libraries that demand `DateTime` directly, and process-startup-time concerns where DI is not yet available. The opt-out attribute applies to both carve-outs.
+
+**ADR-0063 D3 — Type usage policy.** `DateTime` is banned in new code; `DateTimeOffset` is the strict replacement for instants. The analyzer flags `DateTime` usage in non-test code per the "If Accepted" follow-up checklist; the opt-out attribute permits documented interop cases.
+
+**ADR-0063 D12 — Migration path for existing code.** "The analyzer rule has a configurable severity: at first introduction it ships as a **warning**; once the bulk of touched code paths have migrated (judged by the user, no metric committed), it flips to **error**. This is the same migration discipline applied to other Grid-wide analyzer rules."
+
+**ADR-0063 "Use `Stopwatch` or `Environment.TickCount` for elapsed-time measurements instead of `TimeProvider`" — clarified, not rejected.** "This ADR governs wall-clock reads (`GetUtcNow()`) and time-driven decisions (TTLs, cadence, retries). Elapsed-time measurements for telemetry purposes (`Stopwatch`, `Environment.TickCount`) are out of scope; they are a Pulse/observability concern and the existing usage stands. The analyzer rule per D12 does not flag `Stopwatch` usage."
+
+## Referenced Invariants
+> **Invariant 54 — Production code reads time via `TimeProvider`.** "Direct calls to `DateTime.UtcNow`, `DateTime.Now`, `DateTimeOffset.UtcNow`, or `DateTimeOffset.Now` are forbidden outside documented interop boundaries. Production composition wires `TimeProvider.System`; tests wire `Microsoft.Extensions.TimeProvider.Testing.FakeTimeProvider`. The opt-out attribute on the analyzer rule (per packet 03) permits documented interop cases. See ADR-0063 D1, D11." (Lands via packet 00 in this initiative.)
+
+> **Invariant 56 — `DateTime` is banned in new code.** "`DateTimeOffset` is the committed type for instants; `DateOnly` for calendar dates; `TimeOnly` for wall-clock times; `TimeSpan` for durations. Exceptions for legacy interop are opt-in via the analyzer attribute. See ADR-0063 D3." (Lands via packet 00.)
+
+> **Invariant 26 — StyleCop + EditorConfig analyzers ship from `HoneyDrunk.Standards`.** The same package owns this new analyzer.
+
+## Constraints
+- **Scope to non-test code only.** Test code may legitimately use `DateTime.UtcNow` for non-time-dependent tests (e.g., a test that constructs a sample value); firing in test projects would be a false-positive storm. The `HD_IsGridTestProject` property gates this — opposite of `HD0051`.
+- **Warning severity at first introduction.** Do NOT ship at error. ADR-0063 D12 is explicit. The flip-to-error is a follow-up under user judgment, not in this packet's scope.
+- **Cover all four reads.** `DateTime.UtcNow`, `DateTime.Now`, `DateTimeOffset.UtcNow`, `DateTimeOffset.Now`. Both `UtcNow` and `Now` for both types.
+- **Property reads, not method calls.** These are property getters in the BCL — register on `OperationKind.PropertyReference`, not `OperationKind.Invocation`.
+- **Do not flag `TimeProvider.GetUtcNow()`.** That is the committed correct usage. The analyzer is keyed on the property symbols, not on the name `UtcNow` as a string — symbol-based comparison via `SymbolEqualityComparer.Default`.
+- **Do not flag `Stopwatch`, `Environment.TickCount`, `Environment.TickCount64`.** ADR-0063 explicitly clarifies these are out of scope.
+- **`[AllowSystemClock]` requires a `Reason` string.** Discipline-of-documentation: the analyzer does not parse the reason, but the attribute's required string forces the author to write one.
+- **Do not migrate existing call sites in this packet.** ADR-0063 D12: "No bulk-migration packet is filed; the burden is amortized across the natural touch points."
+
+## Labels
+`feature`, `tier-2`, `core`, `adr-0063`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Add a warning-severity analyzer rule to `HoneyDrunk.Standards.Analyzers` that flags direct `DateTime.UtcNow` / `DateTime.Now` / `DateTimeOffset.UtcNow` / `DateTimeOffset.Now` reads in non-test projects, with an `[AllowSystemClock]` opt-out attribute for documented interop.
+
+**Target:** `HoneyDrunk.Standards`, branch from `main`.
+
+**Context:**
+- Goal: Make ADR-0063 D1 (invariant 54 once packet 00 lands) enforceable at compile time across every Node. Ship at warning per D12 to enable opportunistic migration.
+- Feature: ADR-0063 Date, Time, and Clock Policy rollout, Wave 1.
+- ADRs: ADR-0063 (D1, D3, D12 primary).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None expressed in `dependencies:`. Packet 03 can land before packet 00 — the rule encodes ADR-0063 D1 regardless of whether the invariant is numbered yet. Operator-enforced merge ordering: packet 03 should merge before packet 00 (the acceptance flip), since the ADR's own "If Accepted" checklist commits the Status flip "after the analyzer rule lands."
+
+**Constraints:**
+- Non-test projects only — gated off `build_property.HD_IsGridTestProject` (opposite of `HD0051`).
+- Warning severity at introduction (ADR-0063 D12), not error.
+- Cover all four property reads: `DateTime.UtcNow`, `DateTime.Now`, `DateTimeOffset.UtcNow`, `DateTimeOffset.Now`.
+- Register on `OperationKind.PropertyReference`, not `OperationKind.Invocation`.
+- Do not flag `TimeProvider.GetUtcNow()`, `Stopwatch`, or `Environment.TickCount`.
+- `[AllowSystemClock]` requires a `Reason` string property.
+- No bulk migration of existing call sites — surface only.
+
+**Key Files:**
+- `HoneyDrunk.Standards.Analyzers/DateTimeNowInProductionAnalyzer.cs` (new) — model on existing `ThreadSleepInTestsAnalyzer.cs`.
+- Annotations assembly — placement chosen by implementing agent; new attribute type `AllowSystemClockAttribute`.
+- `HoneyDrunk.Standards.Tests/` — analyzer tests.
+- `README.md`, `CHANGELOG.md` (repo-level + per-package), `.csproj` version bumps per solution cadence (invariant 27).
+
+**Contracts:** None — build-time diagnostic. The `[AllowSystemClock]` attribute is the only consumer-facing public surface added; it ships in whatever Standards-published assembly consumers already reference for the existing analyzer set.

--- a/generated/issue-packets/active/adr-0063-clock-policy/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0063-clock-policy/dispatch-plan.md
@@ -1,0 +1,118 @@
+# Dispatch Plan — ADR-0063: Grid-Wide Date, Time, and Clock Policy
+
+**Initiative:** `adr-0063-clock-policy`
+**ADR:** ADR-0063 (Proposed → Accepted via packet 00, the trailing flip)
+**Sector:** Core / cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0063 settles date/time handling broadly across the Grid in a single ADR rather than letting each in-flight packet (ADR-0042 idempotency, ADR-0030 audit, ADR-0019 Communications cadence, ADR-0027 Notify retries, ADR-0047 Tier-2b Testcontainers, ADR-0068 background jobs) reach for the same sub-decisions in slightly different ways. The decisions span twelve D-sections covering storage format (UTC at rest), .NET type usage (`DateTimeOffset` / `DateOnly` / `TimeOnly` / `TimeSpan` — `DateTime` banned), the wall-clock substrate (BCL `TimeProvider`, no HoneyDrunk-owned wrapper), serialization (ISO 8601 with `Z`), time-zone IDs (IANA-only), cadence specification (5-field cron in UTC + ISO 8601 durations), the test substrate (`FakeTimeProvider`), audit timestamp authority, idempotency TTL semantics, Gregorian-only scope cap, and the migration path.
+
+This initiative delivers: the ADR acceptance + the five new date/time invariants (Architecture); the documentation sweep across Kernel docs / tech-stack / ADR cross-references (Architecture); the DI registration helpers `AddSystemTimeProvider` / `AddFakeTimeProvider` in `HoneyDrunk.Kernel`; and the warning-severity Roslyn analyzer rule in `HoneyDrunk.Standards` flagging direct `DateTime.UtcNow` / `.Now` / `DateTimeOffset.UtcNow` / `.Now` reads in non-test projects with an `[AllowSystemClock]` opt-out attribute.
+
+**4 packets across 1 wave**, targeting **3 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Kernel`, `HoneyDrunk.Standards`). All 4 are `Actor=Agent`, 0 `Actor=Human`. No packet carries Human Prerequisites — every piece of work is code/docs and fully delegable.
+
+## Trigger
+
+ADR-0063 is Proposed with no scope. The forcing functions (from the ADR's Context section): the **ADR-0047 Tier-2b Testcontainers pilots** are about to hit "how do I make this deterministic" questions and invariant 51's ban on `Thread.Sleep` has no committed alternative; **ADR-0042 idempotency TTLs**, **ADR-0006 rotation deadlines**, audit timestamps per **ADR-0030**, **ADR-0019** Communications cadence, and future Memory expirations all need a single "now" source; **ADR-0028** Service Bus event timestamps and **ADR-0030** audit timestamps have no pinned on-wire format; **ADR-0057** governs public HTTP API shape but defers the date/time serialization detail to a future cross-cutting decision (this ADR is that decision); the **Communications drip-campaign / cadence-policy** work needs cron strings and the clock through a substrate that tests can fake; **ADR-0068** (Proposed, paired with this ADR) pins the cron-string format and depends on this ADR's `TimeProvider` decision.
+
+Every consumer reaches for the same sub-decisions in slightly different ways — without a single Grid-level pin, the divergence between "what packets do" (inject `TimeProvider` in test paths) and "what production code does" (`DateTimeOffset.UtcNow` directly) keeps widening.
+
+## Scope Detection
+
+**Multi-repo, single wave.** ADR-0063 touches `HoneyDrunk.Architecture` (governance/docs/cross-references), `HoneyDrunk.Kernel` (the DI registration helpers and the `Microsoft.Extensions.TimeProvider.Testing` `PackageReference`), and `HoneyDrunk.Standards` (the analyzer rule + opt-out attribute). No contract cascade to downstream Nodes — ADR-0063 explicitly commits no HoneyDrunk-owned contract; it pins to the BCL's `TimeProvider`. Per ADR-0063 D11 the Catalog obligations are nil: "`catalogs/nodes.json` — no entry to add. `catalogs/contracts.json` — no entry to add."
+
+**No new-Node scaffolding.** All three target repos are live, scaffolded Nodes.
+
+**Single wave, four parallel packets.** No code dependency between the packets:
+- Packet 00 (acceptance) writes invariants and flips Status — depends operationally on packets 02 and 03 landing first per the ADR's own checklist, but no `dependencies:` edge.
+- Packet 01 (docs sweep) is pure documentation — independent of all others.
+- Packet 02 (Kernel helpers) ships runtime code against the BCL — independent of acceptance status; the ADR's decisions hold whether or not the Status flag is flipped.
+- Packet 03 (analyzer rule) ships a warning-severity rule against the BCL property reads — independent of acceptance status.
+
+The merge ordering is operator discipline (see "Merge Ordering" below), not encoded as `dependencies:` edges, because none of the packets *blocks* on another in the compile-against / consume-from sense. Filing them concurrently is correct; merging them in the documented order is the discipline.
+
+## Wave Diagram
+
+### Wave 1 (all four packets, parallel by `dependencies:`)
+- [ ] **00** — Architecture: Accept ADR-0063, add the five date/time invariants (numbers **54, 55, 56, 57, 58**), register the initiative. `Actor=Agent`. **Merge last** per ADR-0063's own "If Accepted" checklist.
+- [ ] **01** — Architecture: Kernel docs + tech-stack + cross-references in ADRs 0047/0057/0068. `Actor=Agent`. May merge any time in the wave; merging before 00 lets packet 00's invariant block cite landed cross-references.
+- [ ] **02** — Kernel: `AddSystemTimeProvider()` and `AddFakeTimeProvider()` DI helpers; bump solution `0.7.0` → `0.8.0`. `Actor=Agent`. **Version-bumping packet for `HoneyDrunk.Kernel`.**
+- [ ] **03** — Standards: `HD0054` analyzer rule at warning severity + `[AllowSystemClock]` opt-out attribute. `Actor=Agent`. Standards version bumps per its own solution cadence.
+
+> **Invariant numbering.** The current verified maximum in `constitution/invariants.md` is **53**. Packet 00 claims numbers **54, 55, 56, 57, 58**. If any invariant above 53 lands from outside this initiative before packet 00 merges, shift the block upward (e.g., 55, 56, 57, 58, 59); never reuse a number.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0063](./00-architecture-adr-0063-acceptance.md) | Architecture | Agent | 1 | — (operator merges last) |
+| 01 | [Date/time docs + cross-references](./01-architecture-date-time-catalog-and-cross-references.md) | Architecture | Agent | 1 | — |
+| 02 | [Kernel `TimeProvider` DI helpers](./02-kernel-time-provider-di-helpers.md) | Kernel | Agent | 1 | — |
+| 03 | [Standards analyzer rule + opt-out attribute](./03-standards-date-time-now-analyzer-rule.md) | Standards | Agent | 1 | — |
+
+## Merge Ordering — operator discipline, not `dependencies:` edges
+
+The `dependencies:` arrays are all empty. The intended merge ordering, per ADR-0063's "If Accepted — Required Follow-Up Work" checklist:
+
+1. **Packet 02** (Kernel helpers) **and Packet 03** (Standards analyzer) — merge first, in either order. The ADR commits the Status flip to "after the analyzer rule lands and the DI helpers ship in Kernel."
+2. **Packet 01** (docs sweep) — merge any time; merging before 00 is cleaner so 00's invariant block can reference settled docs.
+3. **Packet 00** (acceptance) — merge last. This packet flips the Status flag and lands the invariant block.
+
+Why not encode this as `dependencies:` edges? Two reasons:
+
+- The file-packets pipeline reads `dependencies:` and wires `addBlockedBy`. A `blockedBy` edge means "this issue cannot be worked on until the blocker is closed" — a *work-start* gate. For packets 01–03 there is no work-start gate; they can be authored against ADR-0063 whether it is Proposed or Accepted (the ADR's decisions hold either way). The gate is on *packet 00*'s merge order, and "merge after these other PRs land" is not a `dependencies:` semantic.
+- The ADR's own "If Accepted" checklist is the source of truth on the merge order. Operators reading this dispatch plan see the order; the issue board does not artificially block 01–03.
+
+If the operator prefers to encode strict ordering, the safe form is to set packet 00's `dependencies:` to `["packet:01", "packet:02", "packet:03"]` after the other three are filed and their packet numbers are stable. This is *optional* and reflects taste, not a correctness requirement.
+
+## Version Bumps
+
+- **`HoneyDrunk.Kernel`** — packet 02 is the bumping packet: every non-test `.csproj` moves from `0.7.0` → `0.8.0` in one commit (invariant 27; new feature: DI helpers; additive, no break). Per-package CHANGELOG: `HoneyDrunk.Kernel` gets an entry (functional change); `HoneyDrunk.Kernel.Abstractions` gets no per-package entry (alignment bump only — invariant 12/27).
+- **`HoneyDrunk.Standards`** — packet 03 bumps the Standards solution per its own cadence (current at 0.2.9 per `HoneyDrunk.Kernel.csproj`'s `PackageReference`; confirm at execution time). All `.csproj` in the Standards solution move together per invariant 27. The new analyzer rule + new annotations attribute is a new feature; recommend a patch or minor bump per Standards' established CHANGELOG pattern.
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; governance/catalog/docs edits only.
+
+## Cross-Cutting Concerns
+
+### No HoneyDrunk-owned clock wrapper — D11 is the test of taste
+
+ADR-0063 D11 is explicit: "Kernel does not wrap [`TimeProvider`]. Kernel does not publish `IGridClock` or `IClock` or any HoneyDrunk-owned interface that proxies `TimeProvider`. The platform-level abstraction is the contract; layering an additional interface on top is ceremony without value." Packet 02's review must hold the line. The ADR's Alternatives Considered section ("Wrap `TimeProvider` in a HoneyDrunk-owned `IGridClock` interface") already answers the temptation: rejected. The dispatch plan's review notes call this out so the executing agent and any reviewer remember this is a deliberate decision, not an omission.
+
+### `Microsoft.Extensions.TimeProvider.Testing` is a runtime `PackageReference` on Kernel, not test-only
+
+Packet 02 places the `PackageReference` on the Kernel runtime package because `AddFakeTimeProvider()` is part of Kernel's public runtime API — instantiating `FakeTimeProvider` is a runtime operation, not a test-time one. Hosts that only call `AddSystemTimeProvider()` still transit the package; ADR-0063 Operational Consequences accepts this cost ("MIT-licensed, stewardship is Microsoft; the trust posture is good; the dependency itself is small"). Packet 02's NuGet section confirms this placement explicitly.
+
+Separately, the ADR-0047 testing initiative will eventually add `Microsoft.Extensions.TimeProvider.Testing` to the test-project `Directory.Build.props` so `FakeTimeProvider` is available to every test project without per-Node opt-in. That `Directory.Build.props` change is owned by ADR-0047, not this initiative — packet 01 here commits the cross-reference paragraph in ADR-0047; the actual file change ships in the `adr-0047-testing-patterns-and-tooling` initiative's relevant packet.
+
+### Existing direct `DateTime.UtcNow` reads — surfaced, not migrated
+
+Per ADR-0063 D12, "Existing code is migrated opportunistically. When a packet touches a code path that reads `DateTimeOffset.UtcNow`, that read is converted to `TimeProvider.GetUtcNow()` in the same packet. No bulk-migration packet is filed; the burden is amortized across the natural touch points." Packet 03 ships the analyzer at **warning** severity exactly so the day-after-it-lands experience is informational, not build-breaking — every Node will see warnings on every direct `UtcNow` read, and each touching packet will clear the warnings as it visits the code. The flip-to-error gate is the user's call once the bulk has migrated; that flip is a future one-line severity change in the descriptor, not a separate packet here.
+
+### Cascading invariant 47 — audit timestamp authority
+
+ADR-0063 D8 is "Audit timestamps are read once at emit, never regenerated." This sharpens invariant 47 (Audit substrate) without changing it textually — the existing wording already names `IAuditLog` as the timestamp authority. No invariant edit in this initiative for D8; it is governed by the existing invariant 47 plus the ADR-0063 D8 narrative. If a future Audit Node implementation packet regenerates a timestamp downstream, ADR-0063 D8 is the cite for the violation.
+
+### Reviewer note — symmetry with ADR-0047 / `HD0051`
+
+Packet 03's analyzer is structurally symmetric to `HD0051` (`ThreadSleepInTestsAnalyzer`): same `HD_IsGridTestProject` MSBuild property gates both, in opposite directions (`HD0054` fires in non-test projects; `HD0051` fires in test projects). A reviewer reading packet 03 should confirm the existing `HD0051` precedent is the structural model and that the new analyzer follows the same `RegisterCompilationStartAction` → `IsGridTestProject` → `RegisterOperationAction` pattern, just with the gate inverted.
+
+### Site sync
+
+No site-sync flag. ADR-0063 is internal Core-sector infrastructure — no public-facing Studios website content changes.
+
+## Rollback Plan
+
+- **Packet 00 (acceptance):** revert the PR. ADR returns to Proposed; the five date/time invariants and the `## Date and Time Invariants` section are removed. No runtime impact.
+- **Packet 01 (docs sweep):** revert the PR. Kernel docs, tech-stack, and the ADR cross-references return to pre-merge state. No runtime impact.
+- **Packet 02 (Kernel helpers):** revert the PR. `HoneyDrunk.Kernel` rolls back `0.8.0` → `0.7.0`; the two DI helpers and the `Microsoft.Extensions.TimeProvider.Testing` `PackageReference` leave the runtime package. Additive — no consuming Node depends on the helpers at runtime until it composes them, so the revert is contained to `HoneyDrunk.Kernel`. Operational escape hatch if the helpers prove broken before any consumer adopts them: revert; if a consumer has already adopted (unlikely in the same merge window), patch forward rather than revert.
+- **Packet 03 (Standards analyzer):** revert the PR. `HD0054` and `[AllowSystemClock]` leave the Standards package; Standards rolls back its version. The warnings stop firing across the Grid. No runtime impact (it was a build-time diagnostic at warning severity, not a gate).
+- **Operational escape hatch — flip severity back, not revert.** If the analyzer's warnings turn out to be too noisy or hit a false-positive class on day one, the cheaper escape is a `.editorconfig` or `Directory.Build.props` severity-override (`dotnet_diagnostic.HD0054.severity = none`) rather than reverting the whole packet. Document this in packet 03's PR description as the standard rollback for analyzer noise.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.
+
+The `dependencies:` arrays in this initiative's packets are all empty, so no `addBlockedBy` edges are wired. The merge ordering described in "Merge Ordering — operator discipline" is enforced by the operator at PR-merge time, not by the file-packets pipeline. If the operator chooses to encode strict ordering, the safe edit is to set packet 00's `dependencies:` to `["packet:01", "packet:02", "packet:03"]` before pushing this folder — that is optional, reflecting taste rather than correctness.

--- a/generated/issue-packets/active/adr-0066-health-endpoints/00-architecture-adr-0066-acceptance.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/00-architecture-adr-0066-acceptance.md
@@ -1,0 +1,135 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "core", "docs", "adr-0066", "wave-1"]
+dependencies: []
+adrs: ["ADR-0066"]
+accepts: ["ADR-0066"]
+wave: 1
+initiative: adr-0066-health-endpoints
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0066 — flip status, add health-endpoint invariants, register initiative
+
+## Summary
+Flip ADR-0066 (Health, Readiness, and Liveness Endpoint Contract) from Proposed to Accepted: update the ADR header, insert the ADR-0066 row into `adrs/README.md` (the README index currently stops at ADR-0057 — ADR-0066 is not yet listed), add the three new health-endpoint invariants ADR-0066 commits to `constitution/invariants.md`, and register the `adr-0066-health-endpoints` initiative in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0066 commits the Grid-wide health-endpoint contract: three endpoints per HTTP-fronted deployable Node (`/health/live`, `/health/ready`, `/health`), the IETF `health+json` response shape on `/health`, the empty-body 200/503 shape on the probe endpoints, the `IHealthContributor` worst-status-wins aggregation rule with criticality refinement, Container Apps probe defaults, the `ReadinessPolicy` model, the auth posture (probes anonymous, `/health` auth-required), the PII rule for contributor messages, the implementation home in `HoneyDrunk.Kernel`, and the Pulse telemetry contribution per probe outcome.
+
+The ADR decides:
+- **D1** — three endpoints uniformly named `/health/live`, `/health/ready`, `/health` (Functions-host prefix `/api/` accommodated environment-dependently).
+- **D2** — probe endpoints return empty body with `200` (healthy/degraded) or `503` (unhealthy); `/health` returns IETF `application/health+json` shape with per-contributor entries.
+- **D3** — the Kernel `HealthStatus` enum is the wire enum (`Healthy`/`Degraded`/`Unhealthy`), mapped to `pass`/`warn`/`fail` on the IETF body.
+- **D4** — worst-status-wins aggregation across `IHealthContributor` instances; a `Degraded` from a critical contributor escalates to `Unhealthy`; a throwing contributor is treated as `Unhealthy` and the aggregator continues; `IHealthCheck` is the simpler internal-component primitive and is NOT consulted by the endpoint.
+- **D5** — Container Apps probe defaults: `livenessProbe` `/health/live` 30s period 10s initial delay 3s timeout 3 failure threshold; `readinessProbe` `/health/ready` 10s period 5s initial delay 3 failure threshold; `startupProbe` `/health/live` 5s period 30 failure threshold (~150s warm-up runway). Revision health-gate at `100%` traffic requires `/health/ready` to return `200` for three consecutive periods.
+- **D6** — `/health/live` and `/health/ready` are anonymous (probes cannot supply auth); `/health` is auth-required (Studios-internal, tenant-admin, or Azure Monitor scrape credential).
+- **D7** — `ReadinessPolicy` enum with three values: `Required` (gates `/health/ready`; default), `OptionalReported` (appears in `/health` aggregate, does not affect `/health/ready`), `NotReadinessRelevant` (only in `/health`).
+- **D8** — contributor `output` strings must not carry connection strings, secrets, tenant identifiers, or provider opaque IDs; the contributor is responsible for redaction at the report site; the `security` specialist review gains a checklist item.
+- **D9** — implementation home is `HoneyDrunk.Kernel.Hosting.AspNetCore.HealthEndpoints` (runtime package, not Abstractions) with `MapHoneyDrunkHealthEndpoints`; a Functions-host helper for the Notify.Functions case; the underlying substrate is `Microsoft.Extensions.Diagnostics.HealthChecks` with a Kernel-shipped IETF response writer; `INotifyHealthContributor` in Notify is bridged via `NotifyHealthContributorAdapter` then removed.
+- **D10** — probe outcomes contribute Pulse signals: counter `honeydrunk.health.probes` with `(node, endpoint, status_code, outcome)` dimensions, structured logs at Warning/Error on failure, contributor-duration histogram. Probe outcomes are NOT audit events (D10 explicit).
+- **D11** — out of scope: public status page, cross-Node aggregate dashboard, per-tenant readiness, synthetic monitoring details, tenant-visible SLA signal.
+
+ADR-0066 is a **policy / contract** ADR. Concrete code — the Kernel endpoint helpers, the IETF response writer, the `ReadinessPolicy` enum, the contributor execution timeout, the Functions-host helper, the Pulse.Collector amendment, the Notify amendment + follow-up, the per-Node Container Apps probe declarations, the deploy-workflow readiness-gate switch — lands in subsequent packets. Catalog updates land in packet 01. Every other packet references ADR-0066's D-decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Invariant Numbering
+ADR-0066 adds exactly **three** new invariants. The reservation block lives in `constitution/invariant-reservations.md` — read that file at packet-execution time to confirm the claimed block (size 3) and the assigned numbers `{N1}/{N2}/{N3}`. As of authoring, the ADR-0066 row in `invariant-reservations.md` claims **80, 81, 82**; if the reservation file's `next free` cursor has moved upward before this packet merges (because another ADR's packet 00 raced and won), shift this block to the new next-free sequential triple, update both `invariant-reservations.md` (move ADR-0066's row to the new range) and every `{N1}/{N2}/{N3}` placeholder in this initiative's packets. Group the three under a new `## Health Endpoint Invariants` section placed after the existing topic-grouped sections (e.g. after `## Audit Invariants`). Do not renumber any existing invariant. Never reuse a claimed number.
+
+## Scope
+- `adrs/ADR-0066-health-readiness-liveness-endpoints.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — **insert** the ADR-0066 row (and incidentally any missing intervening rows for ADR-0058 through ADR-0066 if they exist as Proposed files — the README index currently stops at ADR-0057 even though ADR files through ADR-0080 exist; at minimum, add the ADR-0066 row). Status column: Accepted.
+- `constitution/invariants.md` — add the three new health-endpoint invariants as `{N1}/{N2}/{N3}` (read `constitution/invariant-reservations.md` for the claimed numbers) under a new `## Health Endpoint Invariants` section.
+- `constitution/invariant-reservations.md` — confirm or shift the ADR-0066 reservation row (claimed block is currently 80–82); the row was added at packet-authoring time.
+- `initiatives/active-initiatives.md` — register the `adr-0066-health-endpoints` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0066 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update `adrs/README.md`: insert a new row for ADR-0066 in numeric order. The README currently ends at the ADR-0057 row even though ADR-0058 through ADR-0080 markdown files exist in `adrs/`. **In scope for this packet: add the ADR-0066 row as Accepted.** Inserting the other missing rows is desirable hygiene but not required to land this packet; if doing so is trivial, do it as a single index sweep, otherwise leave them for a separate README-index packet.
+3. Read `constitution/invariant-reservations.md` to confirm the claimed `{N1}/{N2}/{N3}` block for ADR-0066 (currently **80, 81, 82**). If the reservation file's `next free` cursor has moved upward (another ADR's packet 00 merged ahead of this one), shift the ADR-0066 reservation row to the new contiguous triple and update every `{N1}/{N2}/{N3}` placeholder in this initiative's packets.
+4. Add three new invariants to `constitution/invariants.md`, numbered `{N1}/{N2}/{N3}`, under a new `## Health Endpoint Invariants` section placed after `## Audit Invariants`. The text, taken verbatim-in-substance from ADR-0066's Consequences "Invariants" subsection:
+   - **{N1} — Every HTTP-fronted deployable Node exposes `/health/live`, `/health/ready`, and `/health` via Kernel's `MapHoneyDrunkHealthEndpoints` extension (or the Functions-host equivalent), aggregating `IHealthContributor` instances per the readiness-policy model.** The path suffix is uniform across Nodes; host-imposed prefixes (e.g. Functions' `/api/`) are accommodated. The `/health` endpoint returns the IETF `application/health+json` shape; the probe endpoints return empty body with `200`/`503`. Enforced at standup; the canary surface gains a "health endpoints reachable" check. See ADR-0066 D1, D2, D9.
+   - **{N2} — `/health/live` and `/health/ready` are anonymous; `/health` is auth-required.** Probe sources cannot supply auth headers, so the probe endpoints must be anonymous. `/health` is auth-gated with a **two-token posture**: tenant-bounded Notify probes (and other tenant-visible Nodes) accept a **tenant-administrator token**; cross-tenant operator probes (Studios-staff fleet checks, Operator/Agents/HoneyHub interactions across tenants) accept a **Studios-internal token**. Azure Monitor scrape credentials are accepted on either path. Enforced by the `security` specialist review (per ADR-0046) and by the per-Node host composition. See ADR-0066 D6.
+   - **{N3} — `IHealthContributor` `output` strings must not carry secrets, connection strings, tenant identifiers, or other restricted-tier data per ADR-0049's data-classification taxonomy.** Redaction is the contributor implementation's responsibility at the report site. The Kernel-supplied helpers do not auto-redact. **PII enforcement aggregates contributors to Node-level only**, never per-tenant — the IETF `checks` dictionary surfaces Node-scoped contributor state, not tenant-partitioned state. The `security` specialist review checklist gains an item for contributor message review. This invariant complements (does not restate) invariant 8 ("Secret values never appear in logs, traces, exceptions, or telemetry"); the `/health` body is part of telemetry-adjacent surface but the rule is stated separately because it covers a broader class of restricted data (tenant identifiers and provider opaque IDs in addition to secrets). See ADR-0066 D8.
+   - Create the new `## Health Endpoint Invariants` section. Place it after the `## Audit Invariants` section to match the file's topic-grouped sectioning convention.
+5. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder.
+
+## Affected Files
+- `adrs/ADR-0066-health-readiness-liveness-endpoints.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md` (confirm or shift the ADR-0066 row; currently claims 80–82)
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0066 header reads `**Status:** Accepted`
+- [ ] `adrs/README.md` carries an ADR-0066 row reflecting Accepted, placed in numeric order between ADR-0057 (or whatever the prior row currently is) and the next ADR row
+- [ ] `constitution/invariant-reservations.md` carries an ADR-0066 row claiming a contiguous block of size 3 (currently `{N1}/{N2}/{N3}` = **80/81/82**); if it had to shift because of a race, the new range is reflected here and in every packet's `{N1}/{N2}/{N3}` placeholder
+- [ ] `constitution/invariants.md` carries the three new health-endpoint invariants (three endpoints exposed via Kernel helper; probes anonymous and `/health` auth-required with the two-token posture; contributor messages free of secrets/connection strings/tenant identifiers/provider opaque IDs with Node-level aggregation only), numbered `{N1}/{N2}/{N3}` under a new `## Health Endpoint Invariants` section, each citing ADR-0066
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0066-health-endpoints` initiative with a packet checklist
+- [ ] No catalog schema change in this packet (catalog updates land in packet 01)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0066 D1 — Three endpoints.** `/health/live` (liveness), `/health/ready` (readiness), `/health` (full aggregate). Path scheme is fixed; Functions-host prefix `/api/` is the host's, not the Grid's.
+
+**ADR-0066 D2 — Response shape.** Probes return empty body with `200` on healthy/degraded or `503` on unhealthy. `/health` returns IETF `application/health+json` shape with `status` (`pass`/`warn`/`fail`), `version`, `releaseId`, and per-contributor `checks` entries (`status`, `time`, optional `output`).
+
+**ADR-0066 D6 — Auth posture.** `/health/live` and `/health/ready` are anonymous (probes cannot supply auth); `/health` is auth-required (Studios staff token, tenant-admin token, or Azure Monitor scrape credential).
+
+**ADR-0066 D8 — PII / secrets rule.** Contributor `output` strings must not carry connection strings, secrets, tenant identifiers, provider opaque IDs. Redaction is the contributor's responsibility. The `security` specialist review gains a checklist item.
+
+**ADR-0066 Consequences — Invariants.** ADR-0066 adds exactly three invariants (the three-endpoint exposure rule, the auth-posture rule with the tenant-admin / Studios-internal two-token model, and the contributor-message PII rule with Node-level aggregation). Reserved numbers `{N1}/{N2}/{N3}` — see `constitution/invariant-reservations.md` (currently 80/81/82).
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0066 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbers via reservation file.** Read `constitution/invariant-reservations.md` to confirm `{N1}/{N2}/{N3}` (currently 80/81/82). Do not renumber existing invariants. If the reservation cursor has moved before this packet merges, shift the ADR-0066 row to the new contiguous triple and update every `{N1}/{N2}/{N3}` placeholder in this initiative's packets. Never reuse a claimed number.
+- **README insert, do not replace.** The ADR-0066 row is a new row; insert it in numeric order. Adding rows for the other missing ADR files (ADR-0058 through ADR-0080) is hygiene, not required to land this packet.
+- **Reference invariant 8, do not restate.** Invariant `{N3}` is broader (tenant identifiers, provider opaque IDs) than invariant 8 (secrets in telemetry). Cite invariant 8 as a complementary rule; do not duplicate its text.
+
+## Labels
+`chore`, `tier-3`, `core`, `docs`, `adr-0066`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0066 to Accepted, add the three health-endpoint invariants to `constitution/invariants.md`, insert the README index row, and register the health-endpoints initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0066 so the remaining packets in this initiative can reference its decisions as live rules.
+- Feature: ADR-0066 Health, Readiness, and Liveness Endpoint Contract rollout, Wave 1.
+- ADRs: ADR-0066 (primary), ADR-0008 (initiative/packet conventions), ADR-0046 (specialist review reference), ADR-0049 (data-classification reference in Invariant `{N3}`).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0066 stays Proposed until this PR merges.
+- Read `constitution/invariant-reservations.md` for `{N1}/{N2}/{N3}` (claimed block is currently 80/81/82). If a race shifted the cursor, shift the ADR-0066 row to the new contiguous triple and update every `{N1}/{N2}/{N3}` placeholder in this initiative's packets. Group the three under a new `## Health Endpoint Invariants` section.
+- Insert (do not replace) the ADR-0066 row in `adrs/README.md`.
+- Invariant `{N3}` complements (does not restate) invariant 8.
+
+**Key Files:**
+- `adrs/ADR-0066-health-readiness-liveness-endpoints.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md` (confirm or shift the ADR-0066 row)
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0066-health-endpoints/01-architecture-health-endpoint-catalog.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/01-architecture-health-endpoint-catalog.md
@@ -1,0 +1,123 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "core", "docs", "adr-0066", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0066"]
+wave: 1
+initiative: adr-0066-health-endpoints
+node: honeydrunk-architecture
+---
+
+# Register ADR-0066 health-endpoint contract surface in the Grid catalogs
+
+## Summary
+Record ADR-0066's new contract surface as catalog data: register the `ReadinessPolicy` enum, the `IHealthContributor` registration extension (the contributor + readiness-policy registration helper), the `MapHoneyDrunkHealthEndpoints` extension (and its Functions-host equivalents `ExecuteHealthLiveAsync` / `ExecuteHealthReadyAsync` / `ExecuteHealthAggregateAsync`), and the IETF response-shape DTOs by appending to the `interfaces` array of the `honeydrunk-kernel` block inside the top-level `contracts` array in `catalogs/contracts.json` (schema verified at packet-authoring time: top-level key is `contracts`; each block's per-node entries live under the `interfaces` array). Append the new type names to the `honeydrunk-kernel` entry's `exposes.contracts` array in `catalogs/relationships.json`. Update `repos/HoneyDrunk.Kernel/integration-points.md` with the health-endpoint contract entry and `repos/HoneyDrunk.Notify/integration-points.md` with the contributor-interface reconciliation note.
+
+## Context
+ADR-0066 D9 places the endpoint mapping helpers in `HoneyDrunk.Kernel.Hosting.AspNetCore.HealthEndpoints` (the runtime package). The contract-surface additions split as follows:
+- **`HoneyDrunk.Kernel.Abstractions`** gains `ReadinessPolicy` (enum) and the contributor-registration extension members the host calls at composition time to declare a contributor's policy. ADR-0066 D7 names the three values (`Required`, `OptionalReported`, `NotReadinessRelevant`) and pins `Required` as the default. The IETF response DTOs (`HealthCheckResponse`, `HealthCheckEntry`, etc.) likely live in `Kernel.Abstractions` too because they shape the wire format Notify/Pulse code references in their amendment packets.
+- **`HoneyDrunk.Kernel`** (runtime) gains `HoneyDrunk.Kernel.Hosting.AspNetCore.HealthEndpoints` with `MapHoneyDrunkHealthEndpoints` and the Functions-host static helper class. These compose with ASP.NET Core and are not contract-surface for downstream consumption — they are runtime extensions a host wires. Catalog them as `extension`/`type` rather than `interface`.
+
+The Grid catalogs are the discoverability surface — `catalogs/contracts.json` has a top-level `contracts` array; each entry is a per-Node block carrying `node`, `node_name`, `package`, `status`, and an `interfaces` array of contract entries. `catalogs/relationships.json` lists each Node's contract names under `exposes.contracts`. This packet keeps both catalogs accurate so packets 02–07 and any downstream Node have an accurate contract/dependency graph. The naming asymmetry is the schema's: top-level `contracts` array vs per-node `interfaces` array — both names are load-bearing.
+
+The integration-points docs for `HoneyDrunk.Kernel` and `HoneyDrunk.Notify` need to reflect (a) the Kernel health-endpoint contract Kernel exposes and (b) the Notify-private `INotifyHealthContributor` interface's reconciliation onto `IHealthContributor` (ADR-0066 D9).
+
+This is a catalog/docs packet. No code, no .NET project.
+
+## Scope
+- `catalogs/contracts.json` — inside the top-level `contracts` array, locate the block whose `node` value is `honeydrunk-kernel`; append entries to that block's `interfaces` array for the new contract surface (`ReadinessPolicy`, the contributor-registration extension, the endpoint-mapping extension, the Functions-host helper, the IETF response DTOs).
+- `catalogs/relationships.json` — append the new type names to the `honeydrunk-kernel` entry's `exposes.contracts` array. No new top-level Node-to-Node edge — every affected Node already consumes `HoneyDrunk.Kernel.Abstractions`.
+- `repos/HoneyDrunk.Kernel/integration-points.md` — add the health-endpoint contract entry (the three endpoints, their consumers — Container Apps probes, Azure Monitor scrapes, the deploy workflow's revision-health gate).
+- `repos/HoneyDrunk.Notify/integration-points.md` — add the contributor-interface reconciliation note (Notify-private `INotifyHealthContributor` bridged via `NotifyHealthContributorAdapter` in packet 05, removed in packet 07).
+- `catalogs/nodes.json` — **not edited.** nodes.json entries have no `exposes` field; the contract surface lives in relationships.json and contracts.json (precedent: ADR-0042 packet 01).
+
+## Proposed Implementation
+1. **`catalogs/contracts.json`** — locate the node block whose `node` value is `honeydrunk-kernel` (do not rely on line numbers). Append entries to that block's `interfaces` array, matching the existing `{ "name", "kind", "description" }` shape:
+   - `ReadinessPolicy` — `kind: type` — "Enum declaring whether an IHealthContributor gates traffic at /health/ready. Values: Required (default; degraded/unhealthy fails /health/ready); OptionalReported (appears in /health body but does not gate readiness); NotReadinessRelevant (only in /health, never in readiness aggregation)."
+   - `HealthContributorRegistration` — `kind: type` — "Extension methods on IServiceCollection (or the equivalent registration surface) that register an IHealthContributor with an explicit ReadinessPolicy. Default policy is Required."
+   - `MapHoneyDrunkHealthEndpoints` — `kind: extension` — "IEndpointRouteBuilder extension that maps /health/live, /health/ready, and /health on the host. Anonymous routes for the probe endpoints; auth-required attribute on /health (host wires the auth scheme)."
+   - `HealthFunctionExtensions` — `kind: type` — "Functions-host helper exposing ExecuteHealthLiveAsync, ExecuteHealthReadyAsync, ExecuteHealthAggregateAsync that consumers compose into their own HttpTrigger functions when running on the Functions host."
+   - `HealthCheckResponse` — `kind: type` — "Record/DTO mapping the IETF Health Check Response Format for HTTP APIs (application/health+json) body emitted by /health. Carries status (pass/warn/fail), version, releaseId, and per-contributor checks dictionary."
+   - `HealthCheckEntry` — `kind: type` — "Record/DTO for a single contributor's entry in the /health body. Carries status (pass/warn/fail), time (ISO-8601), and optional output (the contributor's message string, subject to the PII rule from ADR-0066 D8)."
+   - Drop the leading `I` from record/DTO names per the Grid naming rule (records drop the `I`); interfaces keep the `I`. The contract-shape names here are records/types/extensions, not interfaces, so no `I` prefix.
+2. **`catalogs/relationships.json`** — append `ReadinessPolicy`, `HealthContributorRegistration`, `MapHoneyDrunkHealthEndpoints`, `HealthFunctionExtensions`, `HealthCheckResponse`, `HealthCheckEntry` to the `honeydrunk-kernel` entry's `exposes.contracts` array. Do not touch existing entries. The existing `IHealthContributor` and `IReadinessContributor` entries stay as-is.
+3. **`catalogs/nodes.json`** — no edit. nodes.json has no `exposes` field; do not invent one (precedent: ADR-0042 packet 01).
+4. **`repos/HoneyDrunk.Kernel/integration-points.md`** — add a "Health endpoints (ADR-0066)" subsection. State: (a) Kernel exposes `MapHoneyDrunkHealthEndpoints` and the Functions-host helper; (b) consumers are Container Apps probes (livenessProbe/readinessProbe/startupProbe per ADR-0066 D5), Azure Monitor scrapes on `/health`, and the `job-deploy-container-app.yml` revision-health gate which probes `/health/ready`; (c) the substrate is `Microsoft.Extensions.Diagnostics.HealthChecks` with a Kernel-shipped IETF response writer.
+5. **`repos/HoneyDrunk.Notify/integration-points.md`** — add a "Health contributor reconciliation (ADR-0066)" subsection. State: (a) Notify currently ships `INotifyHealthContributor` in `HoneyDrunk.Notify.Hosting.AspNetCore.Health`; (b) packet 05 introduces `NotifyHealthContributorAdapter : IHealthContributor` to bridge existing Notify contributor implementations onto the Kernel-shaped aggregate; (c) packet 07 amends Notify contributors to implement `IHealthContributor` directly and removes the Notify-private interface; (d) during the transitional period, the bridge keeps Notify's CHANGELOG entry from being a breaking event.
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+- `repos/HoneyDrunk.Kernel/integration-points.md`
+- `repos/HoneyDrunk.Notify/integration-points.md`
+
+## NuGet Dependencies
+None. This packet touches only catalog JSON and Markdown integration-points docs; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] Catalog data and integration-points narrative only; the Kernel/Pulse/Notify code lands in packets 02–07.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` registers all six new entries in the `honeydrunk-kernel` node block's `interfaces` array, matching the existing entry shape
+- [ ] `catalogs/relationships.json` `honeydrunk-kernel` entry lists all six new type names in `exposes.contracts`, with all existing entries (including `IHealthContributor` and `IReadinessContributor`) untouched
+- [ ] `catalogs/nodes.json` is NOT modified (it has no `exposes` field)
+- [ ] No new top-level Node-to-Node edge is created (every affected Node already consumes `HoneyDrunk.Kernel.Abstractions`)
+- [ ] `repos/HoneyDrunk.Kernel/integration-points.md` gains a "Health endpoints (ADR-0066)" subsection naming the endpoints, consumers, and substrate
+- [ ] `repos/HoneyDrunk.Notify/integration-points.md` gains a "Health contributor reconciliation (ADR-0066)" subsection naming the bridge-then-deprecate sequencing
+- [ ] No invariant change in this packet (invariants land in packet 00)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0066 D7 — `ReadinessPolicy` enum.** Three values: `Required` (default, gates readiness), `OptionalReported` (in `/health` body only), `NotReadinessRelevant` (only in `/health`). Default at registration is `Required` — a contributor without an explicit policy is presumed to gate traffic.
+
+**ADR-0066 D9 — Implementation home.** `HoneyDrunk.Kernel.Hosting.AspNetCore.HealthEndpoints` with `MapHoneyDrunkHealthEndpoints` (ASP.NET Core), plus `HealthFunctionExtensions` for the Functions host. Substrate is `Microsoft.Extensions.Diagnostics.HealthChecks` with a Kernel-shipped IETF response writer. `INotifyHealthContributor` is reconciled with `IHealthContributor`; transitional `NotifyHealthContributorAdapter` bridge.
+
+**ADR-0066 D2 — IETF `application/health+json` response shape.** `status` (`pass`/`warn`/`fail`), `version`, `releaseId`, and a `checks` dictionary keyed by contributor name carrying per-contributor `status`/`time`/optional `output`.
+
+**ADR-0066 Consequences — Affected Nodes.** Kernel gains the helper and the `ReadinessPolicy` enum. Pulse and Notify are amended in this initiative (packets 05/06/07). Notify.Cloud (planned per ADR-0027), Operator (ADR-0018), Agents (ADR-0020), HoneyHub (ADR-0002/0003), Audit (ADR-0031), Communications (ADR-0028 D4 — composes inside Notify.Cloud's host) all compose the helper at their own standup. **Web.Rest has no current `/health` code** (library-only Node at packet-authoring time, audited via `repos/HoneyDrunk.Web.Rest/`); the Web.Rest amendment is anticipatory — no Web.Rest packet exists in this initiative. When a future Web.Rest deployable consumer first ships, that consumer's host PR composes the Kernel helper. See dispatch plan's "Web.Rest is mentioned but has no current `/health` code" section.
+
+## Constraints
+- **Records/types drop the `I`; interfaces keep it.** Grid-wide naming rule: `ReadinessPolicy`, `HealthCheckResponse`, `HealthCheckEntry`, `HealthContributorRegistration`, `HealthFunctionExtensions` are types/extensions/records — no `I` prefix. The existing `IHealthContributor` / `IReadinessContributor` stay `I`-prefixed.
+- **No new Node-to-Node edge.** Every affected Node already consumes `HoneyDrunk.Kernel.Abstractions`. The contracts are additive; only `exposes.contracts` is enriched.
+- **nodes.json is NOT edited.** nodes.json has no `exposes` field; precedent set in ADR-0042 packet 01.
+- **Match existing entry shape.** Match the `{ "name", "kind", "description" }` shape already used in `contracts.json` for the `honeydrunk-kernel` block.
+
+## Labels
+`feature`, `tier-2`, `core`, `docs`, `adr-0066`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Register ADR-0066's health-endpoint contract surface in the Grid catalogs and update the Kernel/Notify integration-points docs.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Keep the contract/dependency catalogs accurate so implementation packets 02–07 read a correct graph.
+- Feature: ADR-0066 Health, Readiness, and Liveness Endpoint Contract rollout, Wave 1.
+- ADRs: ADR-0066 D2/D7/D9 (primary).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0066 should be Accepted before its contract surface is recorded as catalog data.
+
+**Constraints:**
+- Records/types drop the `I`; interfaces keep it. `IHealthContributor` and `IReadinessContributor` stay as-is.
+- No new top-level Node-to-Node edge — only `exposes.contracts` enrichment.
+- `catalogs/nodes.json` is NOT edited — it has no `exposes` field.
+- Match the existing `{ "name", "kind", "description" }` shape in `contracts.json`.
+
+**Key Files:**
+- `catalogs/contracts.json` — new entries in the `honeydrunk-kernel` block's `interfaces` array.
+- `catalogs/relationships.json` — `honeydrunk-kernel` `exposes.contracts` enrichment.
+- `repos/HoneyDrunk.Kernel/integration-points.md` — new health-endpoint subsection.
+- `repos/HoneyDrunk.Notify/integration-points.md` — new contributor-reconciliation subsection.
+
+**Contracts:** None changed — this packet only records catalog metadata for contracts that packet 02 (Abstractions additions) and packet 03 (runtime endpoints) implement.

--- a/generated/issue-packets/active/adr-0066-health-endpoints/02-kernel-readiness-policy-and-response-shape.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/02-kernel-readiness-policy-and-response-shape.md
@@ -1,0 +1,170 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Kernel
+labels: ["feature", "tier-2", "core", "adr-0066", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0066"]
+wave: 2
+initiative: adr-0066-health-endpoints
+node: honeydrunk-kernel
+---
+
+# Add ReadinessPolicy and the IETF response-shape contracts to HoneyDrunk.Kernel.Abstractions
+
+## Summary
+Add the ADR-0066 contract surface that downstream packets compile against to `HoneyDrunk.Kernel.Abstractions`: the `ReadinessPolicy` enum (D7), the IETF `health+json` response DTOs (`HealthCheckResponse`, `HealthCheckEntry`), and the contributor-registration helper signatures the Kernel runtime helper consumes. Pure contracts — zero HoneyDrunk runtime dependencies. **This is the version-bumping packet for the `HoneyDrunk.Kernel` solution in this initiative.**
+
+## Context
+ADR-0066 D7 commits a `ReadinessPolicy` enum with three values (`Required` (default), `OptionalReported`, `NotReadinessRelevant`) that declares whether an `IHealthContributor` gates traffic at `/health/ready` or only appears in the `/health` aggregate. The enum is `Kernel.Abstractions`-side because every contributor implementation needs to declare its policy at registration time and the host wiring composes against it.
+
+ADR-0066 D2 commits the IETF `application/health+json` response shape for `/health`. The wire-shape DTOs (`HealthCheckResponse`, `HealthCheckEntry`) live in `Kernel.Abstractions` so that downstream Nodes amending their health-endpoint code (Pulse.Collector, Notify) can reference the shape if they need typed access to it. Per ADR-0066 D3 the Kernel `HealthStatus` enum stays the implementation surface; the wire encoding (`Healthy`→`"pass"`, `Degraded`→`"warn"`, `Unhealthy`→`"fail"`) maps from `HealthStatus` to the IETF string at the response-writer boundary in packet 03.
+
+This packet ships **contracts only** — the enum, the records, and the registration-helper signatures (interface or static-method shape per existing Kernel registration patterns). The endpoint mapping (`MapHoneyDrunkHealthEndpoints`), the IETF response writer, the Functions-host helper, and the contributor-execution timeout wrapper land in packet 03 (the runtime package). Splitting contract-from-runtime keeps `HoneyDrunk.Kernel.Abstractions` honest under invariant 1 (Abstractions have zero runtime dependencies on other HoneyDrunk packages).
+
+`HoneyDrunk.Kernel` is a live Node currently at v0.7.0 (.NET 10.0), two packages: `HoneyDrunk.Kernel.Abstractions` (zero-dependency contracts) and `HoneyDrunk.Kernel` (runtime). This packet is the **first packet on the `HoneyDrunk.Kernel` solution in this initiative** — per invariant 27 it bumps every non-test `.csproj` to the same new minor version (`0.7.0` → `0.8.0`; new feature, additive contracts, no break). Packet 03 (also Kernel) appends to the in-progress `[0.8.0]` CHANGELOG entry; packet 04 (Kernel docs) is repo-state-only.
+
+> **Cross-initiative version coordination.** ADR-0042 packet 02 *also* bumps `HoneyDrunk.Kernel` to `0.8.0` (its own contract additions: `IGridMessageEnvelope`, `IIdempotencyStore`, etc.). If both initiatives run concurrently, they share the same `0.8.0` line. Coordinate at execution time: if ADR-0042 packet 02 has already merged when this packet starts, the solution is already at `0.8.0` and this packet **appends to the existing `[0.8.0]` CHANGELOG entry without bumping** (per invariant 27, two simultaneous initiatives must not partially overlap a single version line via parallel bumps). If neither has merged yet, this packet is the bumping packet; coordinate with the ADR-0042 packet-02 author to share the version-bumping commit if both go in the same PR window. State the chosen sequence in the PR.
+
+## Scope
+- `HoneyDrunk.Kernel.Abstractions` — new contract types:
+  - `ReadinessPolicy` — `enum` with `Required` (default), `OptionalReported`, `NotReadinessRelevant`.
+  - `HealthCheckResponse` — record/DTO for the `/health` body root (`status`, `version`, `releaseId`, `checks`).
+  - `HealthCheckEntry` — record/DTO for a per-contributor entry inside `checks` (`status`, `time`, optional `output`).
+  - The registration helper signature for declaring a contributor's `ReadinessPolicy` at composition time. Match the existing Kernel registration pattern (likely an extension method on `IServiceCollection` or a registration-options shape consumed by `MapHoneyDrunkHealthEndpoints` in packet 03 — pick the shape that matches existing Kernel registration conventions and document it in the PR).
+- Both `.csproj` files in the solution version-bumped to `0.8.0` (invariant 27) — **see Cross-Initiative Version Coordination above; defer the bump if ADR-0042 packet 02 has already landed it**.
+- `HoneyDrunk.Kernel.Abstractions` package `CHANGELOG.md` and `README.md` updated.
+- Repo-level `CHANGELOG.md` gets a `[0.8.0]` entry (new or appended depending on the ADR-0042 sequencing).
+
+## Proposed Implementation
+1. **`ReadinessPolicy`** — an enum with three named values:
+   - `Required` (default) — contributor degraded/unhealthy fails `/health/ready`.
+   - `OptionalReported` — contributor appears in `/health` body but does not affect `/health/ready`.
+   - `NotReadinessRelevant` — contributor only appears in `/health`, never participates in readiness aggregation.
+   XML-doc each value with ADR-0066 D7's prose. Make `Required` the zero/default value (so a `default(ReadinessPolicy)` resolves to `Required`, matching D7's "default at registration is `Required`").
+2. **`HealthCheckResponse`** — a record matching the IETF `application/health+json` minimum payload from ADR-0066 D2:
+   ```csharp
+   public sealed record HealthCheckResponse
+   {
+       public required string Status { get; init; }       // "pass" | "warn" | "fail"
+       public string? Version { get; init; }
+       public string? ReleaseId { get; init; }
+       public IReadOnlyDictionary<string, IReadOnlyList<HealthCheckEntry>> Checks { get; init; } =
+           new Dictionary<string, IReadOnlyList<HealthCheckEntry>>();
+   }
+   ```
+   The IETF draft allows multiple entries per check key (some checks report multiple instances over time); honour that by typing `Checks` as `name → list-of-entries`. ADR-0066 D2's sample carries a single-element list per key — match that.
+3. **`HealthCheckEntry`** — a record for a single per-contributor entry:
+   ```csharp
+   public sealed record HealthCheckEntry
+   {
+       public required string Status { get; init; }       // "pass" | "warn" | "fail"
+       public required DateTimeOffset Time { get; init; }
+       public string? Output { get; init; }
+   }
+   ```
+   XML-doc the `Output` property with the ADR-0066 D8 PII rule (must not carry secrets, connection strings, tenant identifiers, or provider opaque IDs — the contributor is responsible for redaction at the report site).
+4. **Registration helper.** The shape depends on whether existing Kernel registration uses options-pattern, extension-methods, or DI-keyed registrations. Choose the shape that matches existing Kernel conventions for registering `IStartupHook` / `IHealthContributor` / `IReadinessContributor` today. Likely candidate: a new overload of the existing contributor-registration extension that takes a `ReadinessPolicy` parameter, plus a property-shaped form for the policy on a registration record. Whatever shape is chosen must be reachable from packet 03's `MapHoneyDrunkHealthEndpoints` so the aggregator can read per-contributor policy at runtime. State the chosen shape in the PR.
+5. **Records use `init` members, not positional syntax** (per ADR-0035 D-record convention; also the Grid naming-rule memory note that records drop the `I`).
+6. All public types get full XML documentation (invariant 13).
+7. **Version bump.** Bump both `.csproj` files to `0.8.0` (or skip the bump if ADR-0042 packet 02 has already shipped it — see Cross-Initiative Version Coordination above; in that case this packet only adds new types and appends to the existing CHANGELOG entry).
+8. **CHANGELOG.** Add a `[0.8.0]` repo-level entry (or append to the existing one). Add a `[0.8.0]` per-package entry to `HoneyDrunk.Kernel.Abstractions` (it has real changes). The `HoneyDrunk.Kernel` runtime package gets no per-package CHANGELOG entry in *this* packet (no functional change yet — packet 03 adds the runtime code and its entry); it is still version-bumped to `0.8.0` to keep the solution aligned, with no noise entry (invariant 12/27).
+9. **README.** Update `HoneyDrunk.Kernel.Abstractions/README.md` — the public API surface gained the readiness-policy enum and the IETF response DTOs; document them in the API-surface section.
+
+## Affected Files
+- `HoneyDrunk.Kernel.Abstractions/` — new contract type files. Likely under `Lifecycle/` (next to `IHealthContributor.cs` and `IReadinessContributor.cs`) for `ReadinessPolicy`; under `Health/` (next to `HealthStatus.cs`) for the IETF response DTOs.
+- `HoneyDrunk.Kernel.Abstractions/HoneyDrunk.Kernel.Abstractions.csproj` — version bump (conditional).
+- `HoneyDrunk.Kernel/HoneyDrunk.Kernel.csproj` — version bump (alignment, conditional).
+- `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md`, `HoneyDrunk.Kernel.Abstractions/README.md`.
+- Repo-level `CHANGELOG.md`.
+- `HoneyDrunk.Kernel.Tests` (the existing test project) — tests for `ReadinessPolicy` default value, `HealthCheckResponse`/`HealthCheckEntry` JSON round-trip (using the IETF field names).
+
+## NuGet Dependencies
+- **`HoneyDrunk.Kernel.Abstractions`** — no new `PackageReference`. Per invariant 1, Abstractions takes only `Microsoft.Extensions.*` abstractions. The records use BCL types (`DateTimeOffset`, `IReadOnlyDictionary<,>`); JSON serialization is the consumer's concern at the response-writer boundary (packet 03). `HoneyDrunk.Standards` is already referenced (`PrivateAssets: all`).
+- **`HoneyDrunk.Kernel`** — no new `PackageReference` in this packet (runtime code lands in packet 03).
+- The unit-test project follows the repo's existing test stack (ADR-0047 stack: xUnit v2 + NSubstitute + AwesomeAssertions); no new packages introduced by this packet beyond what the test project already references.
+
+## Boundary Check
+- [x] `ReadinessPolicy`, the IETF response DTOs, and the registration-helper signatures are Kernel contracts per ADR-0066 D7/D2/D9. Routing rule "context, GridContext, ... health contributor → HoneyDrunk.Kernel" maps here.
+- [x] No dependency on ASP.NET Core in `Abstractions` (the ASP.NET-coupled `MapHoneyDrunkHealthEndpoints` lands in the runtime package in packet 03).
+- [x] Contracts only; the endpoint mapping (packet 03), Pulse amendment (packet 05), and Notify amendments (packets 06, 07) are separate packets.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Kernel.Abstractions` exposes `ReadinessPolicy` as an enum with values `Required`, `OptionalReported`, `NotReadinessRelevant`
+- [ ] `Required` is the default (zero-value) member of the enum
+- [ ] `HoneyDrunk.Kernel.Abstractions` exposes `HealthCheckResponse` as a record matching the IETF `application/health+json` minimum payload (`status`, `version`, `releaseId`, `checks`)
+- [ ] `HoneyDrunk.Kernel.Abstractions` exposes `HealthCheckEntry` as a record (`status`, `time`, `output?`)
+- [ ] The registration-helper shape for declaring a contributor's `ReadinessPolicy` is added, matching existing Kernel registration conventions; the chosen shape is described in the PR
+- [ ] Records use `init` members, not positional syntax (ADR-0035 convention)
+- [ ] All new public types have XML documentation; `HealthCheckEntry.Output` XML doc references the ADR-0066 D8 PII rule (no secrets, connection strings, tenant identifiers, or provider opaque IDs)
+- [ ] `HoneyDrunk.Kernel.Abstractions` has zero runtime `PackageReference` on any HoneyDrunk package (invariant 1)
+- [ ] Both non-test `.csproj` files in the solution are at the agreed version (`0.8.0` if this packet bumps; same as current if ADR-0042 packet 02 already bumped — see Cross-Initiative Version Coordination); they move together in a single commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a `[0.8.0]` entry (new or appended) for the readiness-policy enum + IETF DTOs
+- [ ] `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md` has a `[0.8.0]` entry describing the new types
+- [ ] `HoneyDrunk.Kernel/CHANGELOG.md` gets NO entry in this packet (alignment bump only — invariant 12/27)
+- [ ] `HoneyDrunk.Kernel.Abstractions/README.md` documents the new types in the public-API section
+- [ ] The `pr-core.yml` tier-1 gate and the Kernel contract-shape canary pass — the new contracts are additive, paired with the `0.8.0` line
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0066 D7 — `ReadinessPolicy` enum.** Three values: `Required` (default; degraded/unhealthy fails `/health/ready`), `OptionalReported` (in `/health` body only), `NotReadinessRelevant` (only in `/health`). Default at registration is `Required`.
+
+**ADR-0066 D2 — IETF `application/health+json` response shape.** Minimum payload: `status` (`pass`/`warn`/`fail`), `version`, `releaseId`, `checks` keyed by contributor name carrying per-entry `status`/`time`/optional `output`.
+
+**ADR-0066 D3 — Status mapping.** Kernel `HealthStatus` enum stays the implementation surface; wire encoding is `Healthy`→`"pass"`, `Degraded`→`"warn"`, `Unhealthy`→`"fail"`. The mapping lives at the response-writer boundary in the Kernel runtime helper (packet 03), not in the DTO itself — the DTO carries the wire-string form.
+
+**ADR-0066 D8 — Contributor message PII rule.** The DTO's `Output` field carries the contributor's message string; per D8 this string must never carry secrets, connection strings, tenant identifiers, or provider opaque IDs. Redaction is the contributor's responsibility at the report site, not the DTO's or the response writer's. XML-doc the rule on `Output` so consumers see the constraint when they reference the type.
+
+**ADR-0066 D9 — Implementation home.** The endpoint helpers live in `HoneyDrunk.Kernel` (runtime, not Abstractions — runtime composes with ASP.NET Core which Abstractions does not). The substrate is `Microsoft.Extensions.Diagnostics.HealthChecks` plus a Kernel-shipped response writer.
+
+## Constraints
+- **Invariant 1 — Abstractions have zero runtime dependencies on other HoneyDrunk packages.** Only `Microsoft.Extensions.*` abstractions permitted. No ASP.NET-Core types in Abstractions; the endpoint mapping helper is runtime-package territory.
+- **Invariant 4 — DAG; Kernel is at the root.** No reference to other HoneyDrunk runtime packages from `HoneyDrunk.Kernel.Abstractions`.
+- **Invariant 13 — all public APIs have XML documentation.** Enforced by `HoneyDrunk.Standards` analyzers.
+- **Invariant 27 — all projects in a solution share one version and move together.** Both `.csproj` files go to `0.8.0` in one commit. Partial bumps are forbidden. Coordinate with ADR-0042 packet 02 if both initiatives are concurrent — see Cross-Initiative Version Coordination above.
+- **Invariant 12 — per-package CHANGELOGs are updated only for packages with functional changes.** `HoneyDrunk.Kernel.Abstractions` gets an entry; `HoneyDrunk.Kernel` (alignment bump only here) gets none.
+- **ADR-0035 — records use `init` members, not positional syntax.** No record positional declarations.
+- **Records drop the `I`; interfaces keep it.** `ReadinessPolicy`, `HealthCheckResponse`, `HealthCheckEntry` are enum/records — no `I` prefix. The existing `IHealthContributor` / `IReadinessContributor` stay `I`-prefixed.
+- **`Required` is the zero default of `ReadinessPolicy`.** A `default(ReadinessPolicy)` resolves to `Required`, matching ADR-0066 D7's "default at registration is `Required`" prose.
+
+## Labels
+`feature`, `tier-2`, `core`, `adr-0066`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add the ADR-0066 contract surface (`ReadinessPolicy`, IETF response DTOs, contributor-registration shape) to `HoneyDrunk.Kernel.Abstractions`.
+
+**Target:** `HoneyDrunk.Kernel`, branch from `main`.
+
+**Context:**
+- Goal: Ship the contracts every other packet in this initiative (packet 03 runtime, packet 05 Pulse, packets 06/07 Notify) compiles against.
+- Feature: ADR-0066 Health, Readiness, and Liveness Endpoint Contract rollout, Wave 2 (the foundation).
+- ADRs: ADR-0066 D2/D3/D7/D8/D9 (primary), ADR-0035 (additive minor-bump policy + record convention), ADR-0008 (packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0066 Accepted and its three invariants live before the contracts are built against them.
+
+**Constraints:**
+- Abstractions stay zero-HoneyDrunk-dependency (invariant 1). No reference to ASP.NET-Core types.
+- Records use `init` members (ADR-0035).
+- Records/enums drop the `I`; existing `IHealthContributor` / `IReadinessContributor` keep it.
+- `Required` is the zero-default `ReadinessPolicy`.
+- Bump both non-test `.csproj` files together (invariant 27). Coordinate with ADR-0042 packet 02 if both initiatives concurrently target `0.8.0`.
+
+**Key Files:**
+- `HoneyDrunk.Kernel.Abstractions/Lifecycle/ReadinessPolicy.cs` (new — alongside `IHealthContributor.cs` and `IReadinessContributor.cs`).
+- `HoneyDrunk.Kernel.Abstractions/Health/HealthCheckResponse.cs` (new — alongside `HealthStatus.cs`).
+- `HoneyDrunk.Kernel.Abstractions/Health/HealthCheckEntry.cs` (new).
+- `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md`, `README.md`; repo-level `CHANGELOG.md`.
+- Both `.csproj` files for the (conditional) version bump.
+
+**Contracts:**
+- `ReadinessPolicy` (new enum) — `Required` / `OptionalReported` / `NotReadinessRelevant`.
+- `HealthCheckResponse` (new record) — IETF `health+json` body root.
+- `HealthCheckEntry` (new record) — per-contributor entry inside `checks`.
+- Contributor-registration shape (signature TBD by existing Kernel conventions; documented in the PR).

--- a/generated/issue-packets/active/adr-0066-health-endpoints/03-kernel-health-endpoints-runtime.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/03-kernel-health-endpoints-runtime.md
@@ -1,0 +1,229 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Kernel
+labels: ["feature", "tier-2", "core", "adr-0066", "wave-3"]
+dependencies: ["packet:02"]
+adrs: ["ADR-0066"]
+wave: 3
+initiative: adr-0066-health-endpoints
+node: honeydrunk-kernel
+---
+
+# Add MapHoneyDrunkHealthEndpoints, IETF response writer, Functions-host helper, and contributor execution timeout
+
+## Summary
+Add the runtime half of ADR-0066 to the `HoneyDrunk.Kernel` runtime package: the `MapHoneyDrunkHealthEndpoints` ASP.NET Core extension that maps the three endpoints (`/health/live`, `/health/ready`, `/health`), the IETF `application/health+json` response writer for `/health`, the `HealthFunctionExtensions` static helper for Functions-host composition, the aggregator that drives `IHealthContributor` instances per the readiness-policy model with worst-status-wins + critical-degraded escalation (D4), and the per-contributor 1-second timeout wrapper (D-Operational-Consequences). Append to the in-progress `[0.8.0]` CHANGELOG entry packet 02 opened.
+
+## Context
+Packet 02 ships the ADR-0066 *contracts* in `HoneyDrunk.Kernel.Abstractions` (`ReadinessPolicy`, `HealthCheckResponse`, `HealthCheckEntry`). This packet ships the *runtime endpoints + aggregator* in the `HoneyDrunk.Kernel` package: the extension method every HTTP-fronted Node calls in its host composition, and the Functions-host helper for the Notify.Functions case (D9).
+
+ADR-0066 D9 is explicit:
+- Implementation home: `HoneyDrunk.Kernel.Hosting.AspNetCore.HealthEndpoints` (runtime — not Abstractions — because it composes with ASP.NET Core types).
+- Substrate: `Microsoft.Extensions.Diagnostics.HealthChecks` (the existing framework health-checks middleware) where it composes. Where the substrate's default response writer diverges from the IETF shape (it does — the default is a plain status string), Kernel ships its own response writer that emits the D2 shape.
+- Functions-host shape: a static helper class `HealthFunctionExtensions` exposing `ExecuteHealthLiveAsync`, `ExecuteHealthReadyAsync`, `ExecuteHealthAggregateAsync` that consumers compose into their own `HttpTrigger` function (the Functions host is per-function-binding; consumers wire the helper inside their function).
+
+ADR-0066 D4 commits the aggregation rules:
+- Contributors invoked in `Priority` order (lower first).
+- Aggregate is the **worst** of all contributor statuses, with **criticality refinement**: a `Degraded` from a contributor whose `IsCritical == true` escalates to `Unhealthy` for the aggregate.
+- A throwing contributor is treated as `Unhealthy`, the exception message becomes the contributor's `output` (subject to D8 PII rule), and aggregation continues — one contributor's failure does not short-circuit others.
+- `IHealthCheck` (the simpler internal-component primitive) is **not** consulted by the endpoint.
+
+ADR-0066 D7 commits the readiness-policy aggregation refinement: `/health/ready` reflects only the subset of contributors with `ReadinessPolicy.Required` (its degraded/unhealthy status fails the endpoint); `OptionalReported` contributors appear in `/health` body but do not affect `/health/ready`; `NotReadinessRelevant` contributors only appear in `/health`. The default at registration is `Required`.
+
+ADR-0066 Operational Consequences names the per-contributor timeout: the Kernel aggregator wraps each contributor in a **1-second timeout by default**, configurable per registration. A slow contributor (Vault, etc.) past 1 second is treated as `Unhealthy` with an output like "contributor timed out after 1s" — the readiness gate fails fast rather than letting a slow contributor delay the entire probe past Container Apps' 3-second timeout (which would fail the probe and take the Node out of rotation).
+
+ADR-0066 D6 commits the auth posture: `/health/live` and `/health/ready` are anonymous; `/health` is auth-required. The `MapHoneyDrunkHealthEndpoints` extension wires this — the probe endpoints get an `AllowAnonymous` attribute (or the equivalent endpoint-routing convention) and `/health` is left to the host's default auth policy (the host configures the auth scheme; the extension declares the endpoint as requiring auth).
+
+ADR-0066 D10 commits the telemetry contribution: every probe invocation contributes a `honeydrunk.health.probes` counter with `(node, endpoint, status_code, outcome)` dimensions, a `honeydrunk.health.contributor.duration` histogram with `(node, contributor)` dimensions, structured logs at Warning (failed probe) / Error (failed critical contributor / first-time-after-success 503). All via Kernel's existing `ITelemetryActivityFactory` — not a separate sink (D10 prose).
+
+This packet is the **second packet on the `HoneyDrunk.Kernel` solution in this initiative**. Per invariant 27, packet 02 already bumped the solution to `0.8.0`; this packet does NOT bump again — it appends to the in-progress `[0.8.0]` CHANGELOG entry and adds a per-package CHANGELOG entry to `HoneyDrunk.Kernel` (which now has real functional changes). Coordinate the working branch with packet 02's: land 02 first (or rebase 03 onto 02's merge) so `0.8.0` is consistent.
+
+## Scope
+- `HoneyDrunk.Kernel` (runtime package) — new types and extensions in the `HoneyDrunk.Kernel.Hosting.AspNetCore.HealthEndpoints` namespace:
+  - `MapHoneyDrunkHealthEndpoints(this IEndpointRouteBuilder endpoints)` — ASP.NET Core endpoint mapper.
+  - The IETF response writer that serializes the aggregator's output into `application/health+json`.
+  - The contributor aggregator with worst-status-wins + critical-degraded-to-unhealthy escalation + 1-second per-contributor timeout (configurable).
+  - The Pulse telemetry hooks (counter + histogram + structured log) per ADR-0066 D10.
+- **New separate optional package** `HoneyDrunk.Kernel.Hosting.Functions` — pinned decision (no executor choice). Ships `HoneyDrunk.Kernel.Hosting.AspNetCore.HealthFunctionExtensions` (same namespace) exposing `ExecuteHealthLiveAsync`, `ExecuteHealthReadyAsync`, `ExecuteHealthAggregateAsync` for the Functions-host case. Splitting keeps `Microsoft.Azure.Functions.Worker` out of pure-ASP.NET-Core consumers (`HoneyDrunk.Kernel` stays ASP.NET-Core-only). The new package ships with its own `CHANGELOG.md` + `README.md` from the first commit (invariant 12) and joins the solution at the same `0.8.0` version (invariant 27). It gets registered in `catalogs/relationships.json` as a follow-up catalog update (packet 01 catalogs the helper names, not the package split).
+- Unit tests for: the response shape, aggregator semantics, criticality escalation, throwing-contributor handling, timeout behaviour, readiness-policy filtering, the keyless-ASP.NET case (host that has no auth scheme wired — `/health` should require auth, the absence of an auth scheme is a host configuration error not a runtime fallback).
+- `HoneyDrunk.Kernel/CHANGELOG.md` gets a `[0.8.0]` per-package entry; repo-level `CHANGELOG.md` `[0.8.0]` entry is appended to (not newly created — packet 02 created it).
+- `HoneyDrunk.Kernel/README.md` updated for the new runtime API surface.
+- `HoneyDrunk.Kernel/docs/Health.md` is **not** edited in this packet — packet 04 amends the docs (separately, to keep this packet code-focused).
+
+## Proposed Implementation
+1. **Aggregator.** Implement an internal `HealthAggregator` (name TBD; live next to the endpoint helper). It takes an `IEnumerable<IHealthContributor>` (resolved from DI), a per-contributor `ReadinessPolicy` lookup (registered alongside each contributor per packet 02's shape), an `ITelemetryActivityFactory`, an `INodeContext` (for the `node` telemetry dimension and the `Version` / `releaseId` fields in the IETF response), and a configurable per-contributor timeout (`TimeSpan`, default 1 second).
+   - Invokes contributors in `Priority` order.
+   - Each contributor's call is wrapped in `Task.WhenAny(CheckHealthAsync(...), Task.Delay(timeout))`. On timeout: treat as `Unhealthy` with `output = "contributor timed out after {timeout}"`.
+   - On exception: catch, treat as `Unhealthy`, set `output = ex.Message` (subject to D8 PII rule — the *exception* is the contributor's surface here, and the contributor is responsible for not throwing PII-laden messages). Aggregation continues — do not short-circuit.
+   - Returns two surfaces: (a) the **aggregate** `HealthStatus` after worst-status-wins + criticality refinement (`Degraded` + `IsCritical == true` → `Unhealthy`); (b) the **per-contributor entries** for the IETF body.
+   - For readiness, the aggregator exposes a separate "readiness aggregate" that filters by `ReadinessPolicy.Required` only — `/health/ready` reads this.
+2. **`MapHoneyDrunkHealthEndpoints`** — an `IEndpointRouteBuilder` extension that maps three endpoints:
+   - **`/health/live`** — anonymous; returns `200 OK` with empty body unless the host process is in the `Stopping`/`Stopped` lifecycle stage (per the existing `NodeLifecycleHealthContributor`), in which case `503`. **Does not consult contributors** (ADR-0066 D7) — protects against feedback-loop restarts on dependency hiccups.
+   - **`/health/ready`** — anonymous; calls the aggregator's readiness-aggregate; returns `200` (healthy or degraded) or `503` (unhealthy) with **empty body** (ADR-0066 D2 — probes don't consume bodies, empty body avoids PII leak).
+   - **`/health`** — auth-required (uses the host's default auth scheme; declared via `RequireAuthorization()` or equivalent); calls the aggregator's full aggregate; returns the IETF `application/health+json` body with the per-contributor breakdown.
+3. **IETF response writer.** A small writer that turns the aggregator's output into the D2-shaped JSON:
+   ```json
+   {
+     "status": "pass" | "warn" | "fail",
+     "version": "...",
+     "releaseId": "...",
+     "checks": {
+       "<contributor-name>": [{ "status": "...", "time": "...", "output": "..." }]
+     }
+   }
+   ```
+   Status mapping: `Healthy`→`"pass"`, `Degraded`→`"warn"`, `Unhealthy`→`"fail"` (ADR-0066 D3). `version` and `releaseId` from the assembly metadata (`AssemblyInformationalVersionAttribute` is the standard source; pick the one matching what the existing Kernel surfaces use for `IGridContext`'s release identification, if any). Content-Type header `application/health+json`.
+4. **`HealthFunctionExtensions`** — static helper in the new `HoneyDrunk.Kernel.Hosting.Functions` package exposing:
+   ```csharp
+   public static Task<HttpResponseData> ExecuteHealthLiveAsync(HttpRequestData req, ...);
+   public static Task<HttpResponseData> ExecuteHealthReadyAsync(HttpRequestData req, ...);
+   public static Task<HttpResponseData> ExecuteHealthAggregateAsync(HttpRequestData req, ...);
+   ```
+   Each takes an `HttpRequestData` (Functions host) plus whatever DI services the consumer's function resolves (the aggregator, etc.) and returns an `HttpResponseData` with the same shape as the ASP.NET Core endpoint. The Functions consumer composes them into a `[Function(...)]` `[HttpTrigger(...)]`-bound function (precedent: `HoneyDrunk.Notify.Functions.HealthFunction` will call `ExecuteHealthAggregateAsync` once packet 06 wires it). **Package split is pinned:** the type lives in `HoneyDrunk.Kernel.Hosting.Functions`, not in `HoneyDrunk.Kernel` — pure-ASP.NET-Core consumers (Pulse.Collector, future Notify.Worker for the Worker side) take a dependency only on `HoneyDrunk.Kernel`; only Functions-host consumers (Notify.Functions today) take a dependency on `HoneyDrunk.Kernel.Hosting.Functions`.
+5. **Telemetry per D10.**
+   - Counter `honeydrunk.health.probes` with dimensions `(node, endpoint, status_code, outcome)`. `endpoint` is `live`/`ready`/`health`; `outcome` is `healthy`/`degraded`/`unhealthy`.
+   - Histogram `honeydrunk.health.contributor.duration` with `(node, contributor)`. Recorded inside the aggregator's per-contributor invocation.
+   - Structured log at **Warning** on a failed probe (`503` or contributor exception). **Error** if the failing contributor is `IsCritical`. **Error** on a first-time-after-success `503` (track the per-endpoint last-status in a small in-memory cache; the first transition healthy→unhealthy logs at Error unconditionally, sustained failures aggregate into the counter).
+   - All emitted via Kernel's existing `ITelemetryActivityFactory` (D10 prose: "the same surface used by every other Kernel-instrumented operation"). Probe outcomes are NOT audit events (D10 prose).
+6. **Auth posture.** The probe endpoints carry `AllowAnonymous`; `/health` carries `RequireAuthorization()` (no explicit policy name — the host configures the default policy / scheme). XML-doc the `/health` mapping to state that the host is responsible for configuring an auth scheme; if no scheme is configured, the host's default `RequireAuthorization()` behaviour applies (which on most hosts returns `401` — that is the right behaviour, not a fallback to anonymous). **No Kernel-side no-throw fallback ships in this packet.** A host that calls `MapHoneyDrunkHealthEndpoints` without an auth scheme wired will surface ASP.NET Core's default startup behaviour (the host's existing auth scheme is consulted; if none, the host's default policy applies). Packets 05/06 carry a Human Prerequisite requiring the host has an auth scheme wired before adopting the helper — invariant `{N2}` is enforced at the host, not by the Kernel helper.
+7. **Unit tests** — using the InMemory `IHealthContributor` test doubles from the Kernel test stack:
+   - Three healthy contributors → aggregate `Healthy`, IETF body has three `pass` entries.
+   - One critical contributor reporting `Degraded` → aggregate escalated to `Unhealthy` (D4).
+   - One non-critical contributor reporting `Degraded` → aggregate stays `Degraded`.
+   - Throwing contributor → treated as `Unhealthy`, exception message in `output`, aggregation continues.
+   - Slow contributor (drive via injected `TimeProvider` / cancellation token, no `Thread.Sleep` — invariant 51) → timed-out, `Unhealthy`, `output` says "timed out".
+   - `/health/ready` filters to `ReadinessPolicy.Required` only; `OptionalReported` + `NotReadinessRelevant` contributors do not affect it.
+   - `/health/live` does not consult contributors at all; returns `200` regardless of contributor state; returns `503` only when the lifecycle stage is `Stopping`/`Stopped`.
+   - `/health` body matches the IETF wire shape (round-trip a JSON sample from ADR-0066 D2).
+   - The `/health` endpoint requires auth — a request without credentials returns `401` (with the host's default scheme).
+8. **Versioning** — do NOT bump versions; packet 02 already set the solution to `0.8.0`. Append the runtime additions to the existing repo-level `[0.8.0]` CHANGELOG entry. Add a `[0.8.0]` entry to `HoneyDrunk.Kernel/CHANGELOG.md` (this package now has real changes). Update `HoneyDrunk.Kernel/README.md`.
+
+## Affected Files
+- `HoneyDrunk.Kernel/Hosting/HealthEndpoints.cs` (or `HoneyDrunk.Kernel/Hosting/AspNetCore/HealthEndpoints.cs` if a deeper namespace is preferred to match the existing `Hosting/` folder layout — the existing `Hosting/` folder is `HoneyDrunkApplicationBuilderExtensions.cs`-shaped, single-level).
+- `HoneyDrunk.Kernel/Hosting/HealthFunctionExtensions.cs` (or under `Hosting/Functions/`).
+- `HoneyDrunk.Kernel/Health/HealthAggregator.cs` (next to `CompositeHealthCheck.cs`).
+- `HoneyDrunk.Kernel/Health/IetfHealthResponseWriter.cs` (or similar).
+- `HoneyDrunk.Kernel/Diagnostics/HealthProbeTelemetry.cs` (the counter/histogram/log emit helper).
+- `HoneyDrunk.Kernel/CHANGELOG.md`, `HoneyDrunk.Kernel/README.md`.
+- Repo-level `CHANGELOG.md` — append to the existing `[0.8.0]` entry.
+- The Kernel unit-test project — new tests.
+
+## NuGet Dependencies
+- **`HoneyDrunk.Kernel`** — gains (or already has):
+  - `Microsoft.AspNetCore.Routing` (or whatever the Kernel runtime already uses for `IEndpointRouteBuilder`/endpoint mapping — check the existing `HoneyDrunk.Kernel/Hosting/HoneyDrunkApplicationBuilderExtensions.cs` for the current set; reuse).
+  - `Microsoft.AspNetCore.Authorization` (for `RequireAuthorization` / `AllowAnonymous`) if not already present.
+  - `Microsoft.Extensions.Diagnostics.HealthChecks` — the substrate per ADR-0066 D9 (only if the existing helper does not already pull it in).
+  - `System.Text.Json` (BCL — likely already a transitive).
+  - **Does NOT take** a `PackageReference` on `Microsoft.Azure.Functions.Worker.*` — the Functions-host helper is split into the new `HoneyDrunk.Kernel.Hosting.Functions` package (see below).
+- **`HoneyDrunk.Kernel.Hosting.Functions`** — new optional package:
+  - `Microsoft.Azure.Functions.Worker` and `Microsoft.Azure.Functions.Worker.Extensions.Http`.
+  - `PackageReference` on `HoneyDrunk.Kernel` (re-uses the aggregator + IETF response writer).
+  - `HoneyDrunk.Standards` (`PrivateAssets: all`) like every other published package.
+  - Joins the solution at `0.8.0` (invariant 27). Ships its own `CHANGELOG.md` + `README.md` from the first commit (invariant 12).
+- **`HoneyDrunk.Kernel.Abstractions`** — no new `PackageReference`.
+- **Kernel unit-test project** — the repo's existing test stack (ADR-0047: xUnit v2 + NSubstitute + AwesomeAssertions + coverlet); add `Microsoft.AspNetCore.Mvc.Testing` (or `WebApplicationFactory`) only if the endpoint tests need a full pipeline — otherwise unit-test the aggregator + response writer + extension methods directly. State the choice in the PR.
+
+## Boundary Check
+- [x] `MapHoneyDrunkHealthEndpoints` (in `HoneyDrunk.Kernel`) and `HealthFunctionExtensions` (in the new `HoneyDrunk.Kernel.Hosting.Functions` package) are the runtime encoding of ADR-0066 D9.
+- [x] No `PackageReference` from `HoneyDrunk.Kernel` to `HoneyDrunk.Transport` or other runtime HoneyDrunk packages (invariant 4, DAG preserved). `HoneyDrunk.Kernel.Hosting.Functions` depends only on `HoneyDrunk.Kernel`.
+- [x] Runtime code in the `HoneyDrunk.Kernel` runtime package and the new sibling package, not in `Abstractions` (invariant 1/2).
+- [x] The Functions-host helper does not force Functions packages onto ASP.NET-Core-only consumers (pinned: `HoneyDrunk.Kernel.Hosting.Functions` is a separate optional package).
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Kernel` exposes `MapHoneyDrunkHealthEndpoints(this IEndpointRouteBuilder endpoints)` returning the `IEndpointRouteBuilder` for chaining
+- [ ] `/health/live` is mapped, anonymous, returns `200` with empty body when the process is alive, `503` only when the lifecycle stage is `Stopping`/`Stopped`; does NOT consult contributors
+- [ ] `/health/ready` is mapped, anonymous, calls the readiness aggregate (`ReadinessPolicy.Required` contributors only), returns `200` or `503` with empty body
+- [ ] `/health` is mapped, auth-required (via `RequireAuthorization()` or equivalent), calls the full aggregate, returns the IETF `application/health+json` body
+- [ ] The aggregator runs contributors in `Priority` order, applies worst-status-wins with `Degraded` + `IsCritical == true` escalating to `Unhealthy` (D4)
+- [ ] A throwing contributor is treated as `Unhealthy` with the exception message as `output`; aggregation continues without short-circuiting
+- [ ] Each contributor is wrapped in a configurable per-contributor timeout (default 1 second); timed-out contributors become `Unhealthy` with an "contributor timed out after {timeout}" output
+- [ ] The IETF response writer emits `application/health+json` matching ADR-0066 D2's sample (status pass/warn/fail; version; releaseId; checks dictionary keyed by contributor name with per-entry status/time/output)
+- [ ] `HealthFunctionExtensions` exposes `ExecuteHealthLiveAsync`, `ExecuteHealthReadyAsync`, `ExecuteHealthAggregateAsync` with `HttpRequestData` → `HttpResponseData` shapes; **ships in the new `HoneyDrunk.Kernel.Hosting.Functions` package (pinned), not in `HoneyDrunk.Kernel`**
+- [ ] Telemetry per D10: counter `honeydrunk.health.probes` with `(node, endpoint, status_code, outcome)` dimensions; histogram `honeydrunk.health.contributor.duration` with `(node, contributor)` dimensions; Warning log on failed probe, Error on failed critical contributor and on first-time-after-success `503`
+- [ ] Probe outcomes are NOT emitted as audit events
+- [ ] `IHealthCheck` (the simpler internal-component primitive) is NOT consulted by the endpoint or aggregator (D4)
+- [ ] All new public types have XML documentation (invariant 13)
+- [ ] No `PackageReference` to other HoneyDrunk runtime packages (invariant 4)
+- [ ] No version bump in this packet — the solution stays at `0.8.0` from packet 02
+- [ ] `HoneyDrunk.Kernel/CHANGELOG.md` has a `[0.8.0]` entry for the new runtime endpoints + aggregator + helpers
+- [ ] Repo-level `CHANGELOG.md` `[0.8.0]` entry is extended (not duplicated) with the runtime additions
+- [ ] `HoneyDrunk.Kernel/README.md` documents `MapHoneyDrunkHealthEndpoints` and the Functions-host helper
+- [ ] The new `HoneyDrunk.Kernel.Hosting.Functions` package ships with its own `CHANGELOG.md` + `README.md` from the first commit and is at `0.8.0` (invariants 12, 27)
+- [ ] Unit tests cover: worst-status-wins, critical-degraded escalation, throwing-contributor, timeout, readiness-policy filtering, `/health/live` not consulting contributors, IETF response round-trip, `/health` requires auth
+- [ ] Unit tests contain no `Thread.Sleep` (invariant 51) — timing driven by injected `TimeProvider` / cancellation tokens
+- [ ] The `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0066 D1 — Three endpoints.** `/health/live` (liveness — process alive, no dep checks), `/health/ready` (readiness — required deps reachable), `/health` (full aggregate, auth-required).
+
+**ADR-0066 D2 — Response shape.** Probes: empty body + `200`/`503`. `/health`: IETF `application/health+json` body with `status`/`version`/`releaseId`/`checks`. Status mapping `Healthy`→`pass`, `Degraded`→`warn`, `Unhealthy`→`fail` (D3).
+
+**ADR-0066 D4 — Aggregation.** Worst-status-wins across contributors, in `Priority` order. **Criticality refinement: a `Degraded` from a contributor whose `IsCritical == true` escalates to `Unhealthy`.** A throwing contributor → `Unhealthy`, exception message as `output`, aggregation continues. `IHealthCheck` (simpler internal primitive) is NOT consulted by the endpoint — it stays the internal-component shape.
+
+**ADR-0066 D6 — Auth posture.** `/health/live` and `/health/ready` anonymous; `/health` auth-required (host configures scheme).
+
+**ADR-0066 D7 — Readiness-policy aggregation.** `/health/ready` aggregates only `ReadinessPolicy.Required` contributors. Default at registration is `Required`. `OptionalReported` and `NotReadinessRelevant` appear in `/health` body (D7 prose; `NotReadinessRelevant` is even more restricted — only `/health`).
+
+**ADR-0066 D9 — Implementation home + substrate.** `HoneyDrunk.Kernel.Hosting.AspNetCore.HealthEndpoints` with `MapHoneyDrunkHealthEndpoints`. Substrate: `Microsoft.Extensions.Diagnostics.HealthChecks` plus a Kernel-shipped IETF response writer. Functions-host helper class with three static `ExecuteHealth*Async` methods. The `INotifyHealthContributor` reconciliation (the Notify-private interface bridging) is packet 06's work, not this packet's.
+
+**ADR-0066 D10 — Telemetry.** Counter `honeydrunk.health.probes` with `(node, endpoint, status_code, outcome)`. Histogram `honeydrunk.health.contributor.duration` with `(node, contributor)`. Warning log on failed probe; Error on failed critical contributor; first-time-after-success `503` logs at Error. Emitted via `ITelemetryActivityFactory`. Probe outcomes are NOT audit events.
+
+**ADR-0066 Operational Consequences — Contributor timeout.** "Contributors must be aggressively bounded (sub-100ms target, hard timeout enforced by the aggregator). The Kernel aggregator wraps each contributor in a 1-second timeout by default; configurable per registration."
+
+**ADR-0066 D11 — Out of scope.** No public status page, no cross-Node aggregate dashboard, no per-tenant readiness, no tenant-visible SLA signal from this endpoint — those are future concerns that compose against the contract this packet ships.
+
+## Constraints
+- **Invariant 2 — runtime packages depend on Abstractions, never on another runtime package at the same layer.** `HoneyDrunk.Kernel` depends on `HoneyDrunk.Kernel.Abstractions`.
+- **Invariant 4 — DAG; Kernel is at the root.** `HoneyDrunk.Kernel` must NOT take a `PackageReference` on any other HoneyDrunk runtime package.
+- **Invariant 13 — all public APIs have XML documentation.**
+- **Invariant 27 — one version across the solution.** Packet 02 already bumped to `0.8.0`; this packet does NOT bump again — it appends to the in-progress `[0.8.0]` CHANGELOG. If a new optional Functions-host package is introduced, it lands at the same `0.8.0` version.
+- **Invariant 51 — no `Thread.Sleep` in test code.** Timeout/duration tests drive an injected `TimeProvider` or cancellation token.
+- **Invariant 12 — new packages ship CHANGELOG.md and README.md from the first commit.** If the optional Functions-host package is introduced, both files exist from the first commit.
+- **Probe outcomes are NOT audit events.** ADR-0066 D10 explicit — probes flow telemetry only, never `IAuditLog`.
+- **`IHealthCheck` is not consulted by the endpoint.** ADR-0066 D4 — the simpler primitive stays internal-component shape; only `IHealthContributor` participates in endpoint aggregation.
+- **`/health/live` does not consult contributors.** ADR-0066 D7 — it returns based on lifecycle stage only, to prevent feedback-loop restarts.
+
+## Labels
+`feature`, `tier-2`, `core`, `adr-0066`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Add the ADR-0066 runtime endpoints, aggregator, IETF response writer, Functions-host helper, contributor timeout wrapper, and Pulse telemetry contribution to the `HoneyDrunk.Kernel` runtime package.
+
+**Target:** `HoneyDrunk.Kernel`, branch from `main` (after packet 02 has merged — rebase if needed so `0.8.0` is consistent).
+
+**Context:**
+- Goal: Ship the endpoint surface every other Node calls in its host composition.
+- Feature: ADR-0066 Health, Readiness, and Liveness Endpoint Contract rollout, Wave 3.
+- ADRs: ADR-0066 D1/D2/D3/D4/D6/D7/D9/D10 (primary), ADR-0008 (packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — `ReadinessPolicy`, `HealthCheckResponse`, `HealthCheckEntry` ship in `HoneyDrunk.Kernel.Abstractions` `0.8.0`. Land 02 first or rebase onto its merge.
+
+**Constraints:**
+- No `PackageReference` to other HoneyDrunk runtime packages (invariant 4).
+- No version bump — packet 02 set `0.8.0`; append to the in-progress `[0.8.0]` CHANGELOG.
+- Probe outcomes flow as telemetry, never as audit events (D10).
+- `IHealthCheck` is not consulted by the endpoint; only `IHealthContributor` (D4).
+- `/health/live` does not consult contributors; it returns based on lifecycle stage only (D7).
+- Contributor execution wrapped in a 1-second default timeout (configurable per registration).
+- Records / types drop the `I`; interfaces keep it.
+
+**Key Files:**
+- `HoneyDrunk.Kernel/Hosting/HealthEndpoints.cs` — ASP.NET Core endpoint mapper.
+- `HoneyDrunk.Kernel/Health/HealthAggregator.cs`, `IetfHealthResponseWriter.cs`.
+- `HoneyDrunk.Kernel/Diagnostics/HealthProbeTelemetry.cs`.
+- `HoneyDrunk.Kernel.Hosting.Functions/` — new project: `HealthFunctionExtensions.cs`, `HoneyDrunk.Kernel.Hosting.Functions.csproj`, `CHANGELOG.md`, `README.md`.
+- `HoneyDrunk.Kernel/CHANGELOG.md`, `README.md`; repo-level `CHANGELOG.md`.
+
+**Contracts:**
+- `MapHoneyDrunkHealthEndpoints` (new extension in `HoneyDrunk.Kernel` runtime) — maps `/health/live`, `/health/ready`, `/health`.
+- `HealthFunctionExtensions` (new static class in the new `HoneyDrunk.Kernel.Hosting.Functions` package) — Functions-host helper with three `ExecuteHealth*Async` methods.
+- Consumes `ReadinessPolicy`, `HealthCheckResponse`, `HealthCheckEntry`, `IHealthContributor` from `HoneyDrunk.Kernel.Abstractions` `0.8.0`.

--- a/generated/issue-packets/active/adr-0066-health-endpoints/04-kernel-docs-health-md-amendment.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/04-kernel-docs-health-md-amendment.md
@@ -1,0 +1,154 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Kernel
+labels: ["chore", "tier-1", "core", "docs", "adr-0066", "wave-3"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0066"]
+wave: 3
+initiative: adr-0066-health-endpoints
+node: honeydrunk-kernel
+---
+
+# Amend HoneyDrunk.Kernel/docs/Health.md with the ADR-0066 endpoint contract
+
+## Summary
+Amend `HoneyDrunk.Kernel/docs/Health.md` to document the ADR-0066 health endpoint contract (`/health/live`, `/health/ready`, `/health`), the `ReadinessPolicy` model (D7), the auth posture (D6), the aggregation rules (D4), the IETF response shape (D2), the Pulse telemetry contribution (D10), and the per-contributor timeout. The current docs describe the distinction between `IHealthCheck` (internal primitive) and `IHealthContributor` (Node-level aggregation) but predate the endpoint contract — extend the file with the new sections without removing the existing primitive-vs-contributor narrative.
+
+## Context
+ADR-0066 follow-up list explicitly calls for: "Update `HoneyDrunk.Kernel/docs/Health.md` to document the endpoint contract and the contributor readiness policies." This packet does that.
+
+The current `docs/Health.md` (state as of ADR-0066 acceptance):
+- Documents `IHealthCheck` (the simpler internal-component primitive).
+- Documents `HealthStatus` (the three-state enum).
+- Documents `CompositeHealthCheck` (the simple aggregator for `IHealthCheck`).
+- Documents the relationship between `IHealthCheck` (Health) and `IHealthContributor` (Lifecycle).
+- Names "Kubernetes-style" liveness probes — needs an addendum that the Grid is on Container Apps with the D5 probe defaults.
+
+What ADR-0066 adds that this packet must document:
+- The three endpoints `/health/live`, `/health/ready`, `/health` and their paths (D1).
+- The IETF `application/health+json` response shape on `/health` (D2).
+- The `ReadinessPolicy` enum and its three values (D7).
+- The aggregation rules: worst-status-wins, critical-degraded escalation, throwing-contributor handling, contributor timeout (D4 + Operational Consequences).
+- The auth posture: probes anonymous, `/health` auth-required (D6).
+- The Container Apps probe defaults (D5).
+- The Pulse telemetry contribution (D10).
+- The PII rule for contributor `output` strings (D8).
+- The `MapHoneyDrunkHealthEndpoints` extension and the Functions-host helper (D9) — pointing to the runtime package, not Abstractions.
+
+This packet runs in Wave 3 alongside packet 03 (the runtime endpoints) because the docs reference types and APIs that packet 03 introduces — the docs are accurate only once packet 03's code is on the same branch / merged. Hard-block this packet on packet 03's merge to avoid stale doc references.
+
+This is a Kernel-repo docs packet. No code, no `.csproj` change, no version bump (per invariant 27 — packets 02 + 03 own the `0.8.0` bump and the per-package CHANGELOG entries; this packet appends to the existing `[0.8.0]` repo-level `CHANGELOG.md` entry as a docs note).
+
+## Scope
+- `HoneyDrunk.Kernel/docs/Health.md` — extend with new sections covering the ADR-0066 endpoint contract.
+- Repo-level `CHANGELOG.md` — append a docs note to the in-progress `[0.8.0]` entry.
+
+## Proposed Implementation
+1. Read the existing `docs/Health.md`. Keep the **Overview**, **`IHealthCheck.cs`**, **`HealthStatus.cs`**, and **`CompositeHealthCheck`** sections — they remain accurate.
+2. Amend the **Relationship to Lifecycle** section: the comparison table is correct ("`IHealthCheck` for internal checks; `IHealthContributor` for Node-level aggregation exposed to orchestrators") but the "Kubernetes liveness/readiness" framing predates the Container Apps decision (ADR-0015). Update the framing to "Container Apps liveness/readiness probes (per ADR-0015 / ADR-0066)" while keeping the conceptual table intact.
+3. Add a new top-level section **Endpoint Contract (ADR-0066)** with subsections:
+   - **The three endpoints** — `/health/live`, `/health/ready`, `/health`. Semantics per ADR-0066 D1.
+   - **Response shapes** — probes return empty body with `200`/`503`; `/health` returns IETF `application/health+json` (D2). Include the sample JSON body from ADR-0066 D2.
+   - **Status mapping** — `HealthStatus.Healthy` → `"pass"`, `Degraded` → `"warn"`, `Unhealthy` → `"fail"` (D3). The Kernel enum stays the implementation surface; the wire string appears only on the IETF body.
+   - **`ReadinessPolicy`** — the three values (`Required`, `OptionalReported`, `NotReadinessRelevant`), what each means for `/health/ready` aggregation, and the registration default (`Required`).
+   - **Aggregation rules** — worst-status-wins; `Degraded` + `IsCritical == true` → `Unhealthy`; throwing contributor → `Unhealthy` with exception message in `output`; one contributor's failure does not short-circuit others (D4). Note that `IHealthCheck` is **not** consulted by the endpoint — it remains the internal-component primitive (the existing section in this file is still the right reference for that primitive).
+   - **`/health/live` does not consult contributors** — it returns based on lifecycle stage only (D7), protecting against feedback-loop restarts on dependency hiccups.
+   - **Contributor timeout** — the Kernel aggregator wraps each contributor in a 1-second timeout by default; configurable per registration. Targets sub-100ms contributor execution.
+   - **Auth posture** — probe endpoints anonymous; `/health` auth-required (host configures scheme). Cross-reference Invariant `{N2}`.
+   - **Contributor message PII rule** — contributor `output` strings must not carry secrets, connection strings, tenant identifiers, or provider opaque IDs (D8). Cross-reference invariants 8 and 56 and ADR-0049.
+4. Add a new top-level section **Wiring the endpoints** with subsections:
+   - **ASP.NET Core host** — call `endpoints.MapHoneyDrunkHealthEndpoints()` in the host's endpoint route configuration. Show a minimal sample.
+   - **Functions host** — use `HealthFunctionExtensions.ExecuteHealthLiveAsync` / `ExecuteHealthReadyAsync` / `ExecuteHealthAggregateAsync` from inside a `[Function]` `[HttpTrigger]`-bound function. Show a minimal sample matching the pattern Notify.Functions adopts in packet 06.
+   - **Registering contributors with a `ReadinessPolicy`** — the registration extension shape from packet 02; show the three policy values in use (required DB, optional Pulse export, diagnostic-only NotReadinessRelevant contributor).
+5. Add a new top-level section **Container Apps probe configuration (ADR-0066 D5)** with the probe-defaults table from the ADR:
+
+   | Probe | Path | Period | Initial delay | Timeout | Failure threshold | Success threshold |
+   |---|---|---|---|---|---|---|
+   | `livenessProbe` | `/health/live` | 30s | 10s | 3s | 3 | 1 |
+   | `readinessProbe` | `/health/ready` | 10s | 5s | 3s | 3 | 1 |
+   | `startupProbe` | `/health/live` | 5s | 0s | 3s | 30 | 1 |
+
+   And the revision health-gate rule: a new revision is shifted to 100% traffic only after `/health/ready` returns `200` for at least three consecutive periods on the revision's direct FQDN. Reference invariant 36 (Container App revision-mode-Multiple with traffic splitting).
+6. Add a new top-level section **Telemetry (ADR-0066 D10)** with:
+   - Counter `honeydrunk.health.probes` with `(node, endpoint, status_code, outcome)`.
+   - Histogram `honeydrunk.health.contributor.duration` with `(node, contributor)`.
+   - Log severity: Warning on failed probe; Error on failed critical contributor; first-time-after-success `503` logs at Error.
+   - Note: probe outcomes are **not** audit events (D10 prose).
+7. Add a short **Migration note for existing Nodes** subsection (or at the bottom):
+   - `HoneyDrunk.Pulse.Collector` — its existing static `MapHealthEndpoints` is amended in this initiative (packet 05) to call `MapHoneyDrunkHealthEndpoints` from Kernel. Link to packet 05's planned change.
+   - `HoneyDrunk.Notify` — `NotifyHealthEndpointsExtensions` is amended in packet 06; `INotifyHealthContributor` is bridged via `NotifyHealthContributorAdapter` in packet 06 and removed in packet 07. The Functions-host `HealthFunction` is amended in packet 06 to use the Functions-host helper.
+8. Append a docs note to the repo-level `CHANGELOG.md`'s in-progress `[0.8.0]` entry: "docs: document the ADR-0066 health-endpoint contract and Container Apps probe defaults in `docs/Health.md`." No version bump (invariant 27).
+
+## Affected Files
+- `HoneyDrunk.Kernel/docs/Health.md`
+- Repo-level `CHANGELOG.md` (`[0.8.0]` docs append).
+
+## NuGet Dependencies
+None. This packet touches only Markdown docs; no .NET project is created or modified.
+
+## Boundary Check
+- [x] Kernel-repo docs change describing Kernel's contract surface and the Container Apps integration. Routing rule "context, ... health contributor → HoneyDrunk.Kernel" maps here.
+- [x] No code change.
+- [x] No new dependency.
+
+## Acceptance Criteria
+- [ ] `docs/Health.md` retains the existing `IHealthCheck` / `HealthStatus` / `CompositeHealthCheck` / Relationship-to-Lifecycle sections (the internal-primitive narrative stays accurate)
+- [ ] The "Relationship to Lifecycle" section is amended from generic "Kubernetes" framing to Container-Apps-specific framing (referencing ADR-0015 / ADR-0066)
+- [ ] A new **Endpoint Contract (ADR-0066)** section documents the three endpoints, response shapes (with the IETF body sample), status mapping, `ReadinessPolicy`, aggregation rules, `/health/live` not consulting contributors, contributor timeout, auth posture, and the contributor-message PII rule
+- [ ] A new **Wiring the endpoints** section shows minimal samples for both ASP.NET Core and Functions host, plus a sample of registering contributors with each `ReadinessPolicy` value
+- [ ] A new **Container Apps probe configuration (ADR-0066 D5)** section carries the probe-defaults table and the revision-health-gate rule
+- [ ] A new **Telemetry (ADR-0066 D10)** section lists the counter, histogram, log severities, and the "not audit events" note
+- [ ] A migration note names the packet-05 (Pulse) and packet-06/07 (Notify) amendments
+- [ ] Cross-references to invariants 8, 36, 55, 56 and ADR-0049 are present where appropriate
+- [ ] No code change; no `.csproj` change; no version bump
+- [ ] Repo-level `CHANGELOG.md` `[0.8.0]` entry has a docs-note append
+- [ ] `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0066 D1/D2/D3/D4/D5/D6/D7/D8/D9/D10** — the full ADR is referenced; this packet documents the contract end-to-end in the Kernel docs.
+
+**ADR-0015 — Container Apps as hosting platform.** The Container Apps probe defaults (D5) compose against ADR-0015's hosting choice; the docs reference both ADRs together for context.
+
+**ADR-0049 — Data classification.** Invariant `{N3}` cites ADR-0049; the docs reference it for the contributor-message PII rule.
+
+## Constraints
+- **Invariant 27 — no version bump in this packet.** Packet 02 owns the version bump; this packet appends a docs note to the in-progress `[0.8.0]` repo-level `CHANGELOG.md` entry.
+- **Keep the existing `IHealthCheck`/`HealthStatus`/`CompositeHealthCheck` narrative.** It remains accurate; the new sections extend the file rather than replacing existing content.
+- **`IHealthCheck` is not consulted by the endpoint.** The docs must state this clearly to avoid the readers' natural assumption that the simpler primitive is the endpoint's source.
+- **Cross-reference invariant 8.** The contributor-message PII rule (Invariant `{N3}`) is broader than "secrets in telemetry" (invariant 8) but does not replace it; the docs reference both.
+
+## Labels
+`chore`, `tier-1`, `core`, `docs`, `adr-0066`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Document the ADR-0066 endpoint contract, `ReadinessPolicy` model, aggregation rules, Container Apps probe defaults, and Pulse telemetry contribution in `HoneyDrunk.Kernel/docs/Health.md`.
+
+**Target:** `HoneyDrunk.Kernel`, branch from `main` (after packet 03 has merged so the docs reference live code).
+
+**Context:**
+- Goal: Make `docs/Health.md` the authoritative implementation guide for the contract every Node calls.
+- Feature: ADR-0066 Health, Readiness, and Liveness Endpoint Contract rollout, Wave 3 (alongside packet 03's runtime code).
+- ADRs: ADR-0066 (full), ADR-0015 (Container Apps), ADR-0049 (data classification, referenced via Invariant `{N3}`), ADR-0008.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — the runtime code (`MapHoneyDrunkHealthEndpoints`, the Functions-host helper, the aggregator) must be on the branch before the docs reference it.
+
+**Constraints:**
+- Keep the existing `IHealthCheck` / `HealthStatus` / `CompositeHealthCheck` narrative (the internal-primitive story stays accurate).
+- State clearly that `IHealthCheck` is NOT consulted by the endpoint — only `IHealthContributor` participates in endpoint aggregation.
+- No version bump (invariant 27); docs append to the in-progress `[0.8.0]` `CHANGELOG.md` entry.
+- Cross-reference invariants 8, 36, 55, 56 where appropriate.
+
+**Key Files:**
+- `HoneyDrunk.Kernel/docs/Health.md`
+- Repo-level `CHANGELOG.md`.
+
+**Contracts:** None changed — docs-only packet.

--- a/generated/issue-packets/active/adr-0066-health-endpoints/05-pulse-collector-adopt-kernel-helper.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/05-pulse-collector-adopt-kernel-helper.md
@@ -1,0 +1,148 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Pulse
+labels: ["feature", "tier-2", "ops", "adr-0066", "wave-4"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0066"]
+wave: 4
+initiative: adr-0066-health-endpoints
+node: honeydrunk-pulse
+---
+
+# Amend Pulse.Collector to call MapHoneyDrunkHealthEndpoints from Kernel
+
+## Summary
+Amend `HoneyDrunk.Pulse.Collector`'s existing static `HealthEndpoints.cs` to call `MapHoneyDrunkHealthEndpoints` from `HoneyDrunk.Kernel` (per ADR-0066 D9). The current hand-rolled static endpoints return `200 OK { "Status": "..." }` for `/health`, `/health/live`, `/health/ready` regardless of any contributor state. After this packet, the endpoints follow the Grid-wide contract: `/health/live` and `/health/ready` are empty-body 200/503 (consulting the aggregator); `/health` returns the IETF `application/health+json` body (auth-required).
+
+## Context
+ADR-0066 Context audited the current state: `HoneyDrunk.Pulse.Collector/Endpoints/HealthEndpoints.cs` ships three endpoints (`/health`, `/health/ready`, `/health/live`) — each returning a static `200 OK` with a one-field `Status` body. None consult `IHealthContributor` aggregation; they are placeholders. ADR-0066 D9 and the Consequences "Affected Nodes" entry name Pulse.Collector as one of the amendments: "Pulse.Collector amends its existing `HealthEndpoints.cs` to call `MapHoneyDrunkHealthEndpoints` from Kernel. The hand-rolled static responders are removed."
+
+The current file is small (one static `MapHealthEndpoints` method, no contributors), so the amendment is a strict simplification: replace the hand-rolled `MapGet` calls with a single delegation to `MapHoneyDrunkHealthEndpoints`. The host composition for Pulse.Collector must:
+- Register Pulse.Collector's contributors (if any exist today — at minimum the `NodeLifecycleHealthContributor` from Kernel) with their `ReadinessPolicy` values (default `Required`).
+- Wire the host's default auth scheme so `/health` is auth-gated (per invariant `{N2}`). Pulse.Collector's existing auth posture must be confirmed and the `/health` auth gate honoured.
+- Confirm Pulse.Collector's Container App probe configuration matches the ADR-0066 D5 defaults (or document the deliberate per-Node override). The Container App YAML is **not** in this repo — it's deployed via `HoneyDrunk.Actions`. This packet does NOT touch Container App YAML; that lands in packet 08 (per-Node infrastructure walkthroughs).
+
+`HoneyDrunk.Pulse` is a live Node currently at v0.3.0 (per `CHANGELOG.md`). This packet is the only packet on the `HoneyDrunk.Pulse` solution in this initiative — per invariant 27 it bumps the whole solution to the next minor version (`0.3.0` → `0.4.0`; new feature, the Kernel-helper adoption changes the on-the-wire body shape of `/health` from `{ Status: "Healthy" }` to the IETF body, and the probe endpoints' body becomes empty — these are visible behaviour changes that warrant a minor bump). Confirm exact current version at execution time.
+
+Pulse.Collector is the **first non-Kernel adopter** of `MapHoneyDrunkHealthEndpoints`. The Pulse.Collector amendment validates the Kernel helper end-to-end before Notify's larger amendment in packet 06 runs.
+
+## Scope
+- `Pulse.Collector/Endpoints/HealthEndpoints.cs` — replace hand-rolled `MapGet` calls with `MapHoneyDrunkHealthEndpoints`.
+- Pulse.Collector host composition — register Pulse.Collector's contributors with their `ReadinessPolicy` values; confirm the host's auth scheme is wired so `/health` is auth-gated.
+- Pulse.Collector unit/integration tests — assert the three endpoints respond per the ADR-0066 contract (probe endpoints empty body 200/503; `/health` IETF body, auth-required).
+- Version bump across the `HoneyDrunk.Pulse` solution (invariant 27).
+- Repo-level `CHANGELOG.md` new-version entry; per-package CHANGELOGs only for changed packages (Pulse.Collector is a deployable host, not a published NuGet package — confirm the per-package CHANGELOG policy for the deployable's project).
+
+## Proposed Implementation
+1. **Replace `HealthEndpoints.MapHealthEndpoints`.** Open `Pulse.Collector/Endpoints/HealthEndpoints.cs`. The current code maps three endpoints with hand-rolled `MapGet` calls. Replace the method body with `return endpoints.MapHoneyDrunkHealthEndpoints();` and remove the three hand-rolled mappings. The method name stays (downstream callers keep their call site). XML doc updated to reflect the Kernel delegation and the new behaviour.
+2. **Host composition.** Pulse.Collector's `Program.cs` (or equivalent host file) wires DI. Confirm:
+   - `NodeLifecycleHealthContributor` (Kernel) is registered — if not already, add it. Its `ReadinessPolicy` is `Required` (the default; the lifecycle stage is the canonical readiness signal).
+   - Any Pulse-specific contributor (e.g. a `PulseExportContributor` if one exists today) is registered with `ReadinessPolicy.OptionalReported` per ADR-0066 D7 — Pulse export readiness is a credible "should I be in rotation" signal but Pulse.Collector itself should not fail readiness if its own export is degraded. State the chosen policy for each contributor in the PR.
+   - The host's auth scheme is wired so `/health` is auth-gated. Pulse.Collector is **Studios-internal fleet infrastructure**, not tenant-bounded — per the invariant `{N2}` two-token model the scheme accepts a **Studios-internal token** (no tenant-admin path; tenants do not probe Pulse). Azure Monitor scrape credentials are accepted as a parallel scheme for fleet-wide observability scrapes. If Pulse.Collector currently has no auth scheme, this packet must add one — do not leave `/health` anonymous to ship faster.
+3. **Tests.** Pulse.Collector has unit/integration tests (the existing `Pulse.Tests` project). Add or amend tests to:
+   - `/health/live` returns `200` with empty body when the process is alive.
+   - `/health/ready` returns `200` with empty body when all `Required` contributors are healthy; `503` with empty body when one is unhealthy.
+   - `/health` returns the IETF `application/health+json` body (`status`, `version`, `releaseId`, `checks` shape) on an authenticated request.
+   - `/health` returns `401` (or the host's configured denial response) on an unauthenticated request.
+   - No `Thread.Sleep` (invariant 51).
+4. **Versioning.** Bump every non-test `.csproj` in the `HoneyDrunk.Pulse` solution to the next minor version (`0.3.0` → `0.4.0`) in one commit (invariant 27). Repo-level `CHANGELOG.md` new `[0.4.0]` entry. Per-package CHANGELOGs: Pulse.Collector's deployable project gets an entry; library projects (Telemetry.*) that have no functional change in this packet get NO entry (invariant 12, 27).
+5. **README.** Update Pulse.Collector's `README.md` if its health-endpoint section documents the wire shape — the shape has changed (probes are empty body; `/health` is IETF). If the README does not document the wire shape, no update required.
+
+## Affected Files
+- `Pulse.Collector/Endpoints/HealthEndpoints.cs`
+- `Pulse.Collector/Program.cs` (or wherever host composition lives) — contributor registration with `ReadinessPolicy`; auth scheme wiring (if needed).
+- `Pulse.Tests/` — endpoint tests.
+- Every non-test `.csproj` in the solution — version bump.
+- Repo-level `CHANGELOG.md`; per-package CHANGELOG for Pulse.Collector deployable.
+- `Pulse.Collector/README.md` (only if it documents the wire shape).
+
+## NuGet Dependencies
+- **Pulse.Collector** — gains `HoneyDrunk.Kernel` `0.8.0` (provides `MapHoneyDrunkHealthEndpoints`). If Pulse.Collector already references `HoneyDrunk.Kernel`, update the version to `0.8.0`; otherwise add the reference.
+- **Pulse.Collector** — gains `HoneyDrunk.Kernel.Abstractions` `0.8.0` (transitively, or explicit) for the `ReadinessPolicy` enum used in contributor registration.
+- If a separate optional Functions-host package was introduced in packet 03 (per packet 03's package-split decision), Pulse.Collector does NOT need it — Pulse.Collector is an ASP.NET Core host, not a Functions host.
+- `HoneyDrunk.Standards` is already on every project; no change.
+- Pulse.Tests gains no new packages — uses the existing ADR-0047 test stack.
+- Confirm exact current versions at execution time — packets 02 and 03 set them on the Kernel side.
+
+## Boundary Check
+- [x] All code change is in `HoneyDrunk.Pulse` — its own host endpoint file, host composition, and tests. Routing rule "telemetry, ... collector → HoneyDrunk.Pulse" maps here.
+- [x] No contract change — Pulse.Collector consumes the ADR-0066 contracts as shipped by packets 02–03.
+- [x] No Container App YAML change in this repo — the YAML lives in `HoneyDrunk.Actions` and is amended in packet 08.
+
+## Acceptance Criteria
+- [ ] `Pulse.Collector/Endpoints/HealthEndpoints.cs`'s `MapHealthEndpoints` delegates to `MapHoneyDrunkHealthEndpoints` from `HoneyDrunk.Kernel`; the three hand-rolled `MapGet` calls are removed
+- [ ] Pulse.Collector's host composition registers `NodeLifecycleHealthContributor` with `ReadinessPolicy.Required`; any Pulse-specific contributor is registered with the policy stated in the PR (Pulse-export-style contributors should be `OptionalReported` per the ADR-0066 D7 rationale)
+- [ ] Pulse.Collector's host has an auth scheme wired so `/health` is auth-gated; the wired scheme accepts the Studios-internal token (and optionally a parallel Azure Monitor scrape credential), pinned per the two-token posture for Studios-internal fleet infrastructure
+- [ ] If wiring auth is non-trivial, a follow-up packet is filed and `/health` is NOT left anonymous on the assumption "we'll add auth later" — invariant `{N2}` is a hard rule
+- [ ] `/health/live` returns `200` with empty body when alive; `503` with empty body only when the lifecycle stage is `Stopping`/`Stopped`
+- [ ] `/health/ready` returns `200` with empty body when `Required` contributors are healthy; `503` with empty body when any `Required` contributor is unhealthy
+- [ ] `/health` returns IETF `application/health+json` body matching the ADR-0066 D2 sample shape on an authenticated request
+- [ ] `/health` returns `401` (or the host's configured denial) on an unauthenticated request
+- [ ] Tests cover the four endpoint outcomes above and contain no `Thread.Sleep` (invariant 51)
+- [ ] Every non-test `.csproj` in the `HoneyDrunk.Pulse` solution is at the same new minor version in one commit (`0.3.0` → `0.4.0`); confirm current version at execution time (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new `[0.4.0]` entry; Pulse.Collector deployable CHANGELOG entry; no noise entries for unchanged library packages
+- [ ] `Pulse.Collector/README.md` updated if it documents the wire shape; otherwise no change
+- [ ] `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **Host auth scheme wired before adopting `MapHoneyDrunkHealthEndpoints`.** The Kernel helper calls `RequireAuthorization()` on `/health` without specifying a policy name — the host's default auth scheme is consulted. Pulse.Collector's host must already have an auth scheme registered (Studios-internal token, Azure Monitor scrape credential, or other) before this packet adopts the helper. **The Kernel helper ships no no-throw fallback**; absence of a scheme is a host configuration error, not a runtime fallback to anonymous. If Pulse.Collector has no auth scheme today, this packet's first step is to wire one — and that wiring is what's documented in the PR. Do NOT ship this packet with `/health` anonymous on the assumption "we'll add auth later." Invariant `{N2}` is a hard rule.
+- [ ] **Publish the upstream Kernel NuGet packages before this packet can compile.** This packet references `HoneyDrunk.Kernel` / `HoneyDrunk.Kernel.Abstractions` `0.8.0` (packets 02 + 03). Those artifacts exist on the package feed only after a human pushes a git release tag on `HoneyDrunk.Kernel` — agents never tag or publish. Before this Wave-4 packet starts: at the Wave 2→3 boundary tag/release `HoneyDrunk.Kernel.Abstractions` `0.8.0` from packet 02; at the Wave 3→4 boundary tag/release `HoneyDrunk.Kernel` `0.8.0` carrying the runtime types from packet 03. (Practically: a single `0.8.0` Kernel release after both packets 02 and 03 have merged satisfies both.)
+- [ ] **Confirm the deploy-workflow readiness gate.** The Pulse.Collector deploy workflow currently probes `/health` (per ADR-0066 Context). Once this packet lands and `/health` becomes auth-required, an unauthenticated probe will return `401`, breaking the deploy gate. Packet 10 amends the deploy workflow to probe `/health/ready` (unauthenticated) instead. Until packet 10 lands, Pulse.Collector's deploy gate may need a temporary credential, a temporary fallback to `/health/live`, or a temporary skip of the gate. Coordinate the sequencing of packets 05 and 10 in deploy windows — both can be merged independently, but Pulse.Collector deploys should not roll until packet 10's workflow change is also live in the deploy environment.
+
+## Referenced ADR Decisions
+**ADR-0066 D1 — Three endpoints.** `/health/live`, `/health/ready`, `/health` — uniformly mapped via `MapHoneyDrunkHealthEndpoints`.
+
+**ADR-0066 D2 — Response shape.** Probes return empty body with `200`/`503`. `/health` returns IETF `application/health+json`. Pulse.Collector's current `{ Status: "Healthy" }` body is replaced by these contract shapes.
+
+**ADR-0066 D6 — Auth posture.** Probe endpoints anonymous; `/health` auth-required. Pulse.Collector's host configures the auth scheme.
+
+**ADR-0066 D7 — `ReadinessPolicy`.** Pulse.Collector's contributors are registered with explicit `ReadinessPolicy` values. Pulse-export-style contributors are good candidates for `OptionalReported` — degraded export should not pull Pulse.Collector out of traffic rotation.
+
+**ADR-0066 D9 — Implementation home.** "Pulse.Collector's existing static endpoints are amended to call into the Kernel helpers in a follow-up amendment." This is that amendment.
+
+**ADR-0066 Operational Consequences — "The Pulse.Collector amendment is a strict simplification."** The hand-rolled static responders disappear; the Kernel helper takes over. Net code reduction.
+
+## Constraints
+- **Invariant 4 — DAG.** Pulse depends on Kernel; no inversion.
+- **Invariant 9 — Vault is the only source of secrets.** Any auth credential `/health` requires (e.g. the Studios-internal token) resolves via `ISecretStore`.
+- **Invariant 13 — XML documentation on public types.**
+- **Invariant 27 — one version across the solution.** Bump every non-test `.csproj` together; per-package CHANGELOGs only for changed packages.
+- **Invariant 51 — no `Thread.Sleep` in test code.**
+- **Invariant `{N2}` — `/health/live` and `/health/ready` anonymous; `/health` auth-required.** Hard rule; do not ship Pulse.Collector with `/health` anonymous on the assumption of a follow-up.
+- **Invariant `{N3}` — contributor messages free of secrets/connection strings/tenant identifiers/provider opaque IDs.** Audit any new Pulse contributor `output` strings before they ship.
+- **Do NOT touch Container App YAML.** That lives in `HoneyDrunk.Actions` and is amended in packet 08; this packet stays within the Pulse repo.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0066`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Amend `HoneyDrunk.Pulse.Collector` to use `MapHoneyDrunkHealthEndpoints` from Kernel, register its contributors with explicit `ReadinessPolicy` values, and wire host auth so `/health` is auth-gated.
+
+**Target:** `HoneyDrunk.Pulse`, branch from `main`.
+
+**Context:**
+- Goal: End Pulse.Collector's static placeholder endpoints — bring it onto the Grid-wide contract with a strict simplification.
+- Feature: ADR-0066 Health, Readiness, and Liveness Endpoint Contract rollout, Wave 4 (parallel with packet 06 Notify amendment).
+- ADRs: ADR-0066 D1/D2/D6/D7/D9 (primary), ADR-0008 (packet conventions), ADR-0015 (Container Apps context — but no YAML change in this packet).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — `MapHoneyDrunkHealthEndpoints` ships in `HoneyDrunk.Kernel` `0.8.0`.
+
+**Constraints:**
+- The hand-rolled `MapGet` calls are removed; delegation to the Kernel helper is the entire endpoint mapping.
+- `/health` must be auth-gated before this packet ships (invariant `{N2}`).
+- Container App YAML is NOT touched here — packet 08 owns probe configuration; packet 10 owns the deploy-workflow readiness-gate switch.
+- Bump the whole `HoneyDrunk.Pulse` solution one minor version (invariant 27).
+
+**Key Files:**
+- `Pulse.Collector/Endpoints/HealthEndpoints.cs`
+- `Pulse.Collector/Program.cs` (or equivalent host composition file)
+- `Pulse.Tests/` (endpoint tests)
+- Every non-test `.csproj`; repo-level `CHANGELOG.md`.
+
+**Contracts:** None changed — Pulse.Collector consumes `MapHoneyDrunkHealthEndpoints`, `ReadinessPolicy`, `IHealthContributor` as shipped by packets 02–03.

--- a/generated/issue-packets/active/adr-0066-health-endpoints/06-notify-bridge-adapter-and-adopt-kernel-helper.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/06-notify-bridge-adapter-and-adopt-kernel-helper.md
@@ -1,0 +1,190 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["feature", "tier-2", "ops", "adr-0066", "wave-4"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0066"]
+wave: 4
+initiative: adr-0066-health-endpoints
+node: honeydrunk-notify
+---
+
+# Bridge INotifyHealthContributor via adapter and adopt MapHoneyDrunkHealthEndpoints
+
+## Summary
+Amend `HoneyDrunk.Notify` to adopt the Grid-wide health-endpoint contract per ADR-0066 D9: replace `NotifyHealthEndpointsExtensions`'s hand-rolled endpoint mapping with a delegation to `MapHoneyDrunkHealthEndpoints` from Kernel; amend `HealthFunction` (Notify.Functions) to use the Functions-host helper from Kernel; introduce a transitional `NotifyHealthContributorAdapter : IHealthContributor` so existing `INotifyHealthContributor` implementations land in the Kernel-shaped aggregate **without rewrite**. Existing Notify contributors (e.g. `DefaultNotifyHealthContributor`) keep their `INotifyHealthContributor` shape during this packet — they are amended to implement `IHealthContributor` directly in packet 07 (which then removes `INotifyHealthContributor`).
+
+## Context
+ADR-0066 Context audited Notify's current state: `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthEndpointsExtensions.cs` ships three endpoints (`/health`, `/health/live`, `/health/ready`) — `/health` and `/health/live` are dependency-free liveness signals (`200 OK { "status": "Healthy" }` / `{ "status": "Live" }`); `/health/ready` aggregates `INotifyHealthContributor` instances via `NotifyHealthEvaluator` and returns `503` on unhealthy. `HoneyDrunk.Notify.Functions/HealthFunction.cs` is bound to `/api/health` and consumes the same `NotifyHealthEvaluator`. `INotifyHealthContributor` is a Notify-private interface that parallels (but does not unify with) `IHealthContributor`.
+
+ADR-0066 D9: "`INotifyHealthContributor` in `HoneyDrunk.Notify` is reconciled with `IHealthContributor` in Kernel. The Notify-private interface is removed in a follow-up amendment packet; existing Notify contributors are amended to implement `IHealthContributor` directly. The transitional period uses an adapter (`NotifyHealthContributorAdapter : IHealthContributor`) so existing contributor implementations land in the Kernel-shaped aggregate without rewrite."
+
+The two-packet sequencing:
+- **Packet 06 (this one)** — introduces the bridge adapter, amends the endpoint extensions to use the Kernel helper, amends `HealthFunction` to use the Functions-host helper, registers existing `INotifyHealthContributor` implementations through the adapter. Notify ships in a **transitional** state: the Notify-private interface still exists, but every endpoint goes through the Kernel-aggregator-on-`IHealthContributor` path.
+- **Packet 07 (next)** — amends Notify contributors to implement `IHealthContributor` directly; removes the adapter; removes `INotifyHealthContributor`; removes `NotifyHealthEvaluator` and `NotifyHealthReport` and `NotifyHealthStatus`. After packet 07 there is no Notify-private health interface.
+
+The bridge keeps Notify's CHANGELOG entry from being a breaking event — existing Notify contributor implementations compile against an unchanged `INotifyHealthContributor` for one minor release; packet 07 is the breaking event (the interface is gone) and bumps accordingly.
+
+Notify is a live deployable Node currently at v0.3.0 (per `CHANGELOG.md`). This packet is the **first packet on the `HoneyDrunk.Notify` solution in this initiative** — per invariant 27 it bumps the whole solution to the next minor version. Confirm exact current version at execution time. The Functions host (`HoneyDrunk.Notify.Functions`) and the ASP.NET Core host (`HoneyDrunk.Notify.Worker`) both go through the version bump together (invariant 27).
+
+Notify's deploy workflow (`release-worker.yml` per ADR-0066 Context) gates traffic on `/health`. Once this packet lands, `/health` becomes auth-required (invariant `{N2}`). Coordinate sequencing with packet 10 (the Actions-side deploy-workflow change that switches the readiness gate from `/health` to `/health/ready`) — same caveat as packet 05.
+
+## Scope
+- `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthContributorAdapter.cs` — **new** transitional adapter: `class NotifyHealthContributorAdapter(INotifyHealthContributor inner, string name, int priority, bool isCritical, ReadinessPolicy policy) : IHealthContributor`. Maps `NotifyHealthReport` → `(HealthStatus, string?)` per the existing `NotifyHealthStatus` → `HealthStatus` mapping.
+- `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthEndpointsExtensions.cs` — replace the hand-rolled `MapGet`s with `MapHoneyDrunkHealthEndpoints` from Kernel. Keep `MapNotifyHealthEndpoints` as the exposed method name (downstream callers keep their call site).
+- `HoneyDrunk.Notify.Functions/HealthFunction.cs` — amend to use `HealthFunctionExtensions.ExecuteHealthAggregateAsync` from Kernel (per ADR-0066 D9). The route stays `health` (the Functions binding adds `/api/` prefix automatically).
+- Notify host composition (`HoneyDrunkNotifyServiceCollectionExtensions` or equivalent) — wrap each registered `INotifyHealthContributor` in a `NotifyHealthContributorAdapter`, register the adapter as `IHealthContributor` with a `ReadinessPolicy` value (see Implementation step 4 for the per-contributor policy choices).
+- Notify tests — assert the three endpoints behave per the ADR-0066 contract through the adapter path.
+- `INotifyHealthContributor`, `NotifyHealthEvaluator`, `NotifyHealthReport`, `NotifyHealthStatus`, `DefaultNotifyHealthContributor` — **kept as-is** in this packet; removed/amended in packet 07.
+- Version bump across the `HoneyDrunk.Notify` solution (invariant 27).
+
+## Proposed Implementation
+1. **Adapter (`NotifyHealthContributorAdapter`).** New file in `HoneyDrunk.Notify.Hosting.AspNetCore/Health/`. Implements `IHealthContributor` from `HoneyDrunk.Kernel.Abstractions.Lifecycle`. Constructor takes:
+   - `INotifyHealthContributor inner` — the wrapped Notify-private contributor.
+   - `string name` — passed through as `IHealthContributor.Name`.
+   - `int priority` — passed through as `IHealthContributor.Priority`.
+   - `bool isCritical` — passed through as `IHealthContributor.IsCritical`.
+   - `ReadinessPolicy policy` — recorded for the host's registration step (the policy is read from the registration-shape packet 02 ships; the adapter itself doesn't gate, but it exposes the policy alongside it).
+   Method `CheckHealthAsync`: calls `inner.CheckAsync(cancellationToken)`; maps `NotifyHealthReport` to `(HealthStatus, string?)`:
+   - `NotifyHealthStatus.Healthy` → `HealthStatus.Healthy`.
+   - `NotifyHealthStatus.Degraded` → `HealthStatus.Degraded`.
+   - `NotifyHealthStatus.Unhealthy` → `HealthStatus.Unhealthy`.
+   `string?` is `report.Message`, subject to invariant `{N3}` — audit existing Notify contributors' `Message` strings before this packet ships (they should already be safe per the original code, but verify).
+2. **`NotifyHealthEndpointsExtensions`.** Replace the `MapGet` calls with `endpoints.MapHoneyDrunkHealthEndpoints()`. The method name `MapNotifyHealthEndpoints` stays. XML doc updated:
+   - Old (paraphrased): "`/health` and `/health/live` are dependency-free liveness; `/health/ready` aggregates `INotifyHealthContributor` via `NotifyHealthEvaluator`."
+   - New: "`/health/live` and `/health/ready` are anonymous probes (empty body 200/503 per the IETF model); `/health` is the auth-required IETF `application/health+json` aggregate. Notify's existing `INotifyHealthContributor` implementations are wrapped in `NotifyHealthContributorAdapter` during this transition; see ADR-0066 D9."
+3. **`HealthFunction` (Notify.Functions).** Amend the function's `Run` method to call `HealthFunctionExtensions.ExecuteHealthAggregateAsync(request, ...)` from Kernel. Match the Functions host's binding patterns (the existing `HealthFunction` resolves `NotifyHealthEvaluator` via DI; the new code resolves whatever DI surface the Kernel helper consumes — likely the aggregator plus `INodeContext`). State the chosen wiring in the PR. The `[Function]` binding name and the `health` route stay the same; only the body of `Run` changes. Per ADR-0066 D11 the Functions-host `/api/` prefix is the host's, not the Grid's — no route literal changes.
+4. **Contributor registration with `ReadinessPolicy`.** Notify's existing `INotifyHealthContributor` implementations (e.g. `DefaultNotifyHealthContributor`) are registered in DI through the Hosting.AspNetCore composition. Amend the registration so each is wrapped in `NotifyHealthContributorAdapter` and registered as `IHealthContributor` with an explicit `ReadinessPolicy`:
+   - `DefaultNotifyHealthContributor` (and any contributor that signals Notify's core readiness — provider connectivity, template loading, secrets resolution) — `ReadinessPolicy.Required`.
+   - Any contributor that reports a non-critical optional signal (e.g. a future Pulse-export-status contributor, an optional connector) — `ReadinessPolicy.OptionalReported`.
+   - Document the policy choice for each existing contributor in the PR.
+   The host also keeps the **existing** registration of `INotifyHealthContributor` if any other code path resolves it directly (e.g. `NotifyHealthEvaluator` if it still exists in this packet's tree). The dual registration is acceptable transitionally; packet 07 removes the Notify-private surface and consolidates.
+5. **`NotifyHealthEvaluator` and friends.** Kept in this packet as **dead-from-the-endpoint-path code** — no endpoint calls them anymore, but they remain compileable so existing tests / consumers don't break. Mark them `[Obsolete("Removed in packet 07 — INotifyHealthContributor reconciled to IHealthContributor")]` if the project supports Obsolete attributes without failing the build (it should — `pr-core.yml` does not treat `[Obsolete]` warnings as errors). Document the deprecation in `HoneyDrunk.Notify.Hosting.AspNetCore`'s per-package `CHANGELOG.md`.
+6. **Auth scheme — pinned two-token posture.** Notify is **tenant-bounded** per the invariant `{N2}` two-token model: Notify's `/health` accepts a **tenant-administrator token** for tenant-scoped probes, plus an Azure Monitor scrape credential as a parallel scheme for fleet-wide scrapes. Studios-internal tokens are NOT in scope for Notify (those are reserved for cross-tenant operator probes in Operator/Agents/HoneyHub). Notify already uses `HoneyDrunk.Auth` for inbound API authentication on its REST surface — check `HoneyDrunk.Notify.HostBootstrap` for the existing wiring; confirm the tenant-admin scheme reaches the `/health` route, and either extend the wiring or add a parallel Azure Monitor scrape scheme. Document the chosen approach in the PR. **Do not** ship Notify with `/health` anonymous on the assumption of a follow-up — invariant `{N2}`.
+7. **Tests.** Amend or add tests in the existing Notify test projects (`HoneyDrunk.Notify.Tests`, `HoneyDrunk.Notify.IntegrationTests`):
+   - The adapter maps `NotifyHealthStatus` → `HealthStatus` correctly and surfaces the message.
+   - `/health/live` returns `200` with empty body when alive; `503` only when lifecycle stage is `Stopping`/`Stopped`.
+   - `/health/ready` returns `200` with empty body when `Required` contributors (through the adapter) are healthy; `503` with empty body when any `Required` contributor is unhealthy.
+   - `/health` returns IETF `application/health+json` body matching ADR-0066 D2 shape on an authenticated request.
+   - `/health` returns `401` on an unauthenticated request.
+   - Both the ASP.NET Core (`Worker`) and Functions (`Functions`) hosts pass the endpoint contract tests.
+   - No `Thread.Sleep` (invariant 51).
+8. **Versioning.** Bump every non-test `.csproj` in the `HoneyDrunk.Notify` solution to the next minor version in one commit (invariant 27). Repo-level `CHANGELOG.md` new entry. Per-package CHANGELOGs:
+   - `HoneyDrunk.Notify.Hosting.AspNetCore` — entry: adapter introduced; endpoint extension amended; `INotifyHealthContributor` marked obsolete.
+   - `HoneyDrunk.Notify.Functions` — entry: `HealthFunction` amended to use Kernel Functions-host helper.
+   - `HoneyDrunk.Notify` (core) — entry only if it carries any functional change in this packet (unlikely — most changes live in Hosting.AspNetCore); no noise entry if no change.
+9. **README.** Update `HoneyDrunk.Notify.Hosting.AspNetCore/README.md` (if it exists) and the repo-level Notify `README.md` if either documents the wire shape — the shape has changed (probes empty body; `/health` IETF; auth required).
+
+## Affected Files
+- `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthContributorAdapter.cs` — **new**.
+- `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthEndpointsExtensions.cs` — body replaced.
+- `HoneyDrunk.Notify.Hosting.AspNetCore/Health/INotifyHealthContributor.cs` — marked `[Obsolete]` (if supported).
+- `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthEvaluator.cs`, `NotifyHealthReport.cs`, `NotifyHealthStatus.cs`, `DefaultNotifyHealthContributor.cs` — marked `[Obsolete]` where applicable; otherwise unchanged this packet.
+- `HoneyDrunk.Notify.Hosting.AspNetCore/ServiceCollectionExtensions/HoneyDrunkNotifyServiceCollectionExtensions.cs` (or wherever contributor registration lives) — wrap registered `INotifyHealthContributor` instances in the adapter and register as `IHealthContributor` with `ReadinessPolicy`.
+- `HoneyDrunk.Notify.Functions/HealthFunction.cs` — body replaced to call `ExecuteHealthAggregateAsync`.
+- `HoneyDrunk.Notify.HostBootstrap/` and/or `HoneyDrunk.Notify.Worker/` — confirm auth scheme covers `/health`; extend if needed.
+- `HoneyDrunk.Notify.Tests/`, `HoneyDrunk.Notify.IntegrationTests/` — endpoint and adapter tests.
+- Every non-test `.csproj` in the solution — version bump.
+- Repo-level `CHANGELOG.md`; per-package CHANGELOGs as noted.
+- `HoneyDrunk.Notify.Hosting.AspNetCore/README.md` and repo-level Notify `README.md` if either documents the wire shape.
+
+## NuGet Dependencies
+- **`HoneyDrunk.Notify.Hosting.AspNetCore`** — gains (or updates):
+  - `HoneyDrunk.Kernel` — `0.8.0` (provides `MapHoneyDrunkHealthEndpoints`, the aggregator, `ReadinessPolicy` consumption).
+  - `HoneyDrunk.Kernel.Abstractions` — `0.8.0` (provides `IHealthContributor`, `ReadinessPolicy`, `HealthCheckResponse`, `HealthCheckEntry`).
+- **`HoneyDrunk.Notify.Functions`** — gains (or updates):
+  - `HoneyDrunk.Kernel` — `0.8.0` (for `HealthFunctionExtensions`) OR a separate optional Functions-host package if packet 03 split it out. State the choice in the PR; the package name is whichever packet 03 shipped.
+- **Notify test projects** — no new packages (existing ADR-0047 test stack).
+- `HoneyDrunk.Standards` is already on every project; no change.
+- Confirm exact current versions at execution time; packets 02 + 03 set the Kernel side.
+
+## Boundary Check
+- [x] All code change is in `HoneyDrunk.Notify` — its own host endpoint extension, Functions function, host composition, and adapter. Routing rule "notification, ... notify, channel → HoneyDrunk.Notify" maps here.
+- [x] No contract change in Notify's hot path — `INotificationSender` / `INotificationGateway` shapes are not touched; the Communications-hot-path canary (invariant 43) stays green.
+- [x] The Notify-private `INotifyHealthContributor` stays in this packet (transitional); it is removed in packet 07.
+- [x] No Container App YAML change in this repo — packet 08 handles probe configuration; packet 10 handles the deploy-workflow readiness-gate switch.
+
+## Acceptance Criteria
+- [ ] `NotifyHealthContributorAdapter` is a new class in `HoneyDrunk.Notify.Hosting.AspNetCore.Health` implementing `IHealthContributor`; wraps an `INotifyHealthContributor`; maps `NotifyHealthStatus` to `HealthStatus` correctly
+- [ ] `NotifyHealthEndpointsExtensions.MapNotifyHealthEndpoints` delegates to `MapHoneyDrunkHealthEndpoints` from Kernel; the hand-rolled `MapGet` calls are removed
+- [ ] `HealthFunction.Run` calls `HealthFunctionExtensions.ExecuteHealthAggregateAsync` from Kernel (or whichever method matches the Functions-host helper's name in packet 03); the function binding name and `health` route are unchanged
+- [ ] Notify's host composition registers existing `INotifyHealthContributor` instances through the adapter as `IHealthContributor`, with explicit `ReadinessPolicy` values; the policy choice for each is documented in the PR
+- [ ] `INotifyHealthContributor`, `NotifyHealthEvaluator`, `NotifyHealthReport`, `NotifyHealthStatus` are marked `[Obsolete]` (if the project supports it) with a message naming packet 07 as the removal point
+- [ ] Notify's host auth scheme covers `/health` so it is auth-gated; auth wiring is documented in the PR
+- [ ] `/health/live` returns `200` with empty body when alive
+- [ ] `/health/ready` returns `200`/`503` with empty body based on `Required` contributors
+- [ ] `/health` returns IETF `application/health+json` body on authenticated request, `401` on unauthenticated
+- [ ] Both Worker and Functions hosts pass endpoint contract tests
+- [ ] Tests have no `Thread.Sleep` (invariant 51)
+- [ ] Every non-test `.csproj` in the `HoneyDrunk.Notify` solution is at the same new minor version in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` new-version entry; per-package CHANGELOGs only for packages with functional changes (Hosting.AspNetCore + Functions get entries; core Notify gets none if untouched)
+- [ ] READMEs updated if they documented the wire shape
+- [ ] No change to Notify hot-path contracts (`INotificationSender`, `INotificationGateway`) — invariants 41–43 unaffected
+- [ ] `pr-core.yml` tier-1 gate passes; the Worker and Functions deploy gates may need temporary accommodation until packet 10 lands (see Human Prerequisites)
+
+## Human Prerequisites
+- [ ] **Host auth scheme wired before adopting `MapHoneyDrunkHealthEndpoints`.** Both Notify Worker (ASP.NET Core) and Notify Functions hosts must have an auth scheme registered before this packet adopts the Kernel helpers. The Kernel helper calls `RequireAuthorization()` without a policy name — the host's default scheme is consulted; **the Kernel helper ships no no-throw fallback**, absence of a scheme is a host configuration error. The two-token posture (invariant `{N2}`): Notify is tenant-bounded, so the wired scheme accepts a **tenant-administrator token** for tenant-scoped probes (a tenant admin can hit `/health` for the Notify Worker/Functions in their tenant context); Azure Monitor scrape credentials are accepted as a parallel scheme for fleet-wide observability scrapes. Studios-internal tokens are NOT in scope for Notify (those are reserved for Operator/Agents/HoneyHub cross-tenant operator probes). Notify already uses `HoneyDrunk.Auth` for its public REST API today; confirm the same scheme works for `/health`, or wire a separate scheme. If the wiring is non-trivial it may need an explicit secret seeded into `kv-hd-notify-{env}`. **Do NOT ship this packet with `/health` anonymous on the assumption of a follow-up — invariant `{N2}` is a hard rule.**
+- [ ] **Publish the upstream Kernel NuGet packages.** This packet references `HoneyDrunk.Kernel` / `HoneyDrunk.Kernel.Abstractions` `0.8.0` (packets 02 + 03) and `HoneyDrunk.Kernel.Hosting.Functions` `0.8.0` (the new optional package from packet 03, pinned). A human tags/releases `HoneyDrunk.Kernel` `0.8.0` AND `HoneyDrunk.Kernel.Hosting.Functions` `0.8.0` after packets 02 and 03 merge. Wave 4 cannot build against unpublished packages. Agents never tag or publish.
+- [ ] **Coordinate the deploy-workflow readiness gate.** Notify Worker's `release-worker.yml` currently probes `/health` per ADR-0066 Context. After this packet, `/health` is auth-required and an unauthenticated probe returns `401`. Packet 10 amends the deploy workflow to probe `/health/ready` (unauthenticated). Until packet 10 lands in the deploy environment, the Notify deploy may need: (a) a temporary credential supplied to the deploy probe, (b) a temporary fallback to `/health/live`, or (c) deferral of the deploy until packet 10 lands. The same applies to the Functions-host's deploy gate if it has one. Coordinate sequencing with packet 10's deploy-workflow change.
+
+## Referenced ADR Decisions
+**ADR-0066 D1/D2/D6 — Endpoint contract.** Three endpoints, IETF body on `/health`, empty body on probes, probe endpoints anonymous, `/health` auth-required.
+
+**ADR-0066 D7 — `ReadinessPolicy`.** Notify contributors are registered with explicit policies. Critical readiness signals are `Required`; optional reported signals are `OptionalReported`.
+
+**ADR-0066 D9 — Implementation home + Notify reconciliation.** Notify's `INotifyHealthContributor` is reconciled with `IHealthContributor`. The transitional period uses `NotifyHealthContributorAdapter`; existing contributors are amended to implement `IHealthContributor` directly in the follow-up (packet 07). The Functions-host helper from Kernel replaces Notify's hand-rolled `HealthFunction` body.
+
+**ADR-0066 Operational Consequences — "The Notify amendment requires care."** "The amendment packet stages: (1) bridge adapter lands, (2) Notify contributors amend to `IHealthContributor` directly, (3) `INotifyHealthContributor` is removed. The bridge keeps Notify's CHANGELOG entry from being a breaking event." This packet is stage (1); packet 07 is stages (2) and (3).
+
+## Constraints
+- **Invariant 4 — DAG.** Notify depends on Kernel; no inversion.
+- **Invariant 9 — Vault is the only source of secrets.** Any auth credential `/health` requires resolves via `ISecretStore`.
+- **Invariants 41–43 — Notify hot-path contracts.** Do NOT change `INotificationSender`, `INotificationGateway`, decision-log or cadence shapes. This packet only touches the health-endpoint surface.
+- **Invariant 13 — XML documentation on new public types.** The adapter is public; the existing `INotifyHealthContributor` stays as-is (now marked Obsolete).
+- **Invariant 27 — one version across the solution.** Bump every non-test `.csproj` together; per-package CHANGELOGs only for changed packages.
+- **Invariant 51 — no `Thread.Sleep` in test code.**
+- **Invariant `{N2}` — `/health` auth-required.** Hard rule.
+- **Invariant `{N3}` — contributor messages free of secrets/connection strings/tenant identifiers/provider opaque IDs.** Audit existing Notify contributor `Message` strings before they ship through the adapter.
+- **Keep `INotifyHealthContributor` compileable in this packet.** Packet 07 removes it; this packet only marks it `[Obsolete]`. Removal is a breaking event; the bridge in this packet prevents that.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0066`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Adopt the Kernel health-endpoint helper in Notify's AspNetCore and Functions hosts, introduce a transitional bridge adapter for `INotifyHealthContributor`, mark the Notify-private interface obsolete.
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: Bring Notify onto the Grid-wide contract without breaking existing contributor implementations.
+- Feature: ADR-0066 Health, Readiness, and Liveness Endpoint Contract rollout, Wave 4 (parallel with packet 05 Pulse).
+- ADRs: ADR-0066 D1/D2/D6/D7/D9 (primary), ADR-0008 (packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — `MapHoneyDrunkHealthEndpoints`, `HealthFunctionExtensions`, the aggregator ship in `HoneyDrunk.Kernel` `0.8.0`.
+
+**Constraints:**
+- Existing `INotifyHealthContributor` implementations stay unchanged in this packet — they are wrapped in the adapter. Packet 07 amends them to implement `IHealthContributor` directly and removes the Notify-private interface.
+- `/health` must be auth-gated before this packet ships (invariant `{N2}`).
+- No change to Notify hot-path contracts (`INotificationSender`, `INotificationGateway`) — invariants 41–43 hold.
+- Container App YAML / deploy workflows are NOT touched here — packet 08 / packet 10 own those.
+- Bump the whole Notify solution one minor version (invariant 27); both Worker and Functions hosts go to the same version together.
+
+**Key Files:**
+- `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthContributorAdapter.cs` (new), `NotifyHealthEndpointsExtensions.cs` (body replaced), `INotifyHealthContributor.cs` / `NotifyHealthEvaluator.cs` / `NotifyHealthReport.cs` / `NotifyHealthStatus.cs` (mark `[Obsolete]`).
+- `HoneyDrunk.Notify.Hosting.AspNetCore/ServiceCollectionExtensions/HoneyDrunkNotifyServiceCollectionExtensions.cs` (contributor registration through adapter).
+- `HoneyDrunk.Notify.Functions/HealthFunction.cs` (body replaced).
+- `HoneyDrunk.Notify.HostBootstrap/` / `HoneyDrunk.Notify.Worker/` — auth-scheme wiring for `/health`.
+- Notify test projects.
+- Every non-test `.csproj`; repo-level `CHANGELOG.md`.
+
+**Contracts:**
+- Consumes `IHealthContributor`, `ReadinessPolicy`, `HealthCheckResponse` from `HoneyDrunk.Kernel.Abstractions` `0.8.0`.
+- Consumes `MapHoneyDrunkHealthEndpoints`, `HealthFunctionExtensions` from `HoneyDrunk.Kernel` `0.8.0`.
+- `INotifyHealthContributor` stays public (now `[Obsolete]`); removed in packet 07.
+- `NotifyHealthContributorAdapter` is a new public type in `HoneyDrunk.Notify.Hosting.AspNetCore` (transitional — also removed in packet 07).

--- a/generated/issue-packets/active/adr-0066-health-endpoints/07-notify-remove-private-contributor-interface.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/07-notify-remove-private-contributor-interface.md
@@ -1,0 +1,150 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["feature", "tier-2", "ops", "adr-0066", "wave-5"]
+dependencies: ["packet:06"]
+adrs: ["ADR-0066"]
+wave: 5
+initiative: adr-0066-health-endpoints
+node: honeydrunk-notify
+---
+
+# Amend Notify contributors to implement IHealthContributor directly; remove INotifyHealthContributor
+
+## Summary
+Amend every Notify-private `INotifyHealthContributor` implementation to implement `IHealthContributor` from `HoneyDrunk.Kernel.Abstractions.Lifecycle` directly; remove `NotifyHealthContributorAdapter`, `INotifyHealthContributor`, `NotifyHealthEvaluator`, `NotifyHealthReport`, and `NotifyHealthStatus` from `HoneyDrunk.Notify.Hosting.AspNetCore`. Closes ADR-0066 D9's reconciliation: after this packet there is no Notify-private health interface; every Notify contributor implements the Kernel-shaped `IHealthContributor` directly. This is a **breaking change** in the public API surface of `HoneyDrunk.Notify.Hosting.AspNetCore` (removing `INotifyHealthContributor` is a major API removal) — but ADR-0066 Operational Consequences names the bridge in packet 06 as the accommodation that prevents the *aggregate* Notify CHANGELOG from being a breaking event. This packet bumps the Notify solution one minor version (per the additive-removal-by-`[Obsolete]` pattern in ADR-0035 — `[Obsolete]` was applied in packet 06; removal one minor later is the standard deprecation cycle).
+
+## Context
+ADR-0066 D9 names the three-stage Notify reconciliation:
+1. Bridge adapter lands (packet 06 — done).
+2. Notify contributors amend to `IHealthContributor` directly (this packet).
+3. `INotifyHealthContributor` is removed (this packet).
+
+Stages 2 and 3 are bundled because once existing contributors implement `IHealthContributor` directly, the adapter has no remaining purpose and the Notify-private interface has no remaining implementations — removing both together keeps Notify's surface clean and avoids a partial-removal state. The deprecation window between packet 06's `[Obsolete]` and this packet's removal is the standard ADR-0035 60-day window (or whatever shorter window the operator decides; ADR-0035 D5 names 60 days as the minimum for member removals — for an internal-only Notify type that has no external consumers documented, a tighter window is acceptable if the operator decides so. Document the window choice in the PR.).
+
+Notify's existing contributors (audited at packet 06 time):
+- `DefaultNotifyHealthContributor` in `HoneyDrunk.Notify.Hosting.AspNetCore/Health/`.
+- Possibly more inside `HoneyDrunk.Notify.Worker` / `HoneyDrunk.Notify.HostBootstrap` (audit at execution time).
+
+Per the existing `DefaultNotifyHealthContributor` shape: it implements `INotifyHealthContributor.CheckAsync` returning `Task<NotifyHealthReport>`. After this packet it implements `IHealthContributor.CheckHealthAsync` returning `Task<(HealthStatus, string?)>`, plus the three properties (`Name`, `Priority`, `IsCritical`) that `IHealthContributor` exposes. The mapping is the same the adapter performed in packet 06; the contributor now does it directly.
+
+This packet is the **second packet on the `HoneyDrunk.Notify` solution in this initiative**. Per invariant 27 it bumps the whole solution to the next minor version above what packet 06 set (a removal is a minor-bump-with-`[Obsolete]`-removal-window in the ADR-0035 model). The repo-level `CHANGELOG.md` gets a new minor-version entry; per-package CHANGELOG entries note: "Removed: `INotifyHealthContributor`, `NotifyHealthEvaluator`, `NotifyHealthReport`, `NotifyHealthStatus`, `NotifyHealthContributorAdapter`. All Notify health contributors now implement `IHealthContributor` directly."
+
+## Scope
+- Every `INotifyHealthContributor` implementation in the Notify repo — amended to implement `IHealthContributor` directly. Map `Task<NotifyHealthReport> CheckAsync(...)` → `Task<(HealthStatus, string?)> CheckHealthAsync(...)`. Add `Name`, `Priority`, `IsCritical` properties (likely already implicitly present via constructor parameters in some form; explicit now).
+- `HoneyDrunk.Notify.Hosting.AspNetCore/Health/` — remove `INotifyHealthContributor.cs`, `NotifyHealthEvaluator.cs`, `NotifyHealthReport.cs`, `NotifyHealthStatus.cs`, `NotifyHealthContributorAdapter.cs`.
+- `HoneyDrunk.Notify.Hosting.AspNetCore/ServiceCollectionExtensions/HoneyDrunkNotifyServiceCollectionExtensions.cs` — drop the adapter-wrapping registration; register contributors directly as `IHealthContributor` with `ReadinessPolicy` values (the policies stay the same as packet 06 chose; document any change in the PR).
+- Notify tests — remove tests targeting the removed types; amend tests that exercised contributors through the Notify-private surface to exercise them through the Kernel-shaped surface.
+- Version bump across the `HoneyDrunk.Notify` solution (invariant 27).
+
+## Proposed Implementation
+1. **Audit.** Enumerate every `INotifyHealthContributor` implementation in the Notify repo. State the list in the PR. (Expected at minimum: `DefaultNotifyHealthContributor`; possibly more.)
+2. **Amend each contributor.** For each implementation:
+   - Change the class declaration: `: INotifyHealthContributor` → `: IHealthContributor`.
+   - Add (or expose) `Name`, `Priority`, `IsCritical` per the `IHealthContributor` contract. If the existing contributor was registered with these values externally (e.g. via constructor injection or DI registration data), surface them on the class directly.
+   - Rename `Task<NotifyHealthReport> CheckAsync(...)` → `Task<(HealthStatus status, string? message)> CheckHealthAsync(...)`.
+   - Map the existing body's `NotifyHealthStatus` results to `HealthStatus` results (same mapping the adapter performed in packet 06: `Healthy`→`Healthy`, `Degraded`→`Degraded`, `Unhealthy`→`Unhealthy`).
+   - The contributor's message string still must obey Invariant `{N3}` (no secrets, connection strings, tenant identifiers, or provider opaque IDs). Re-audit each contributor's message strings during the rewrite.
+3. **Remove the Notify-private surface.** Delete:
+   - `HoneyDrunk.Notify.Hosting.AspNetCore/Health/INotifyHealthContributor.cs`
+   - `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthEvaluator.cs`
+   - `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthReport.cs`
+   - `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthStatus.cs`
+   - `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthContributorAdapter.cs` (the bridge from packet 06, no longer needed).
+4. **Amend the host composition.** In `HoneyDrunkNotifyServiceCollectionExtensions` (or wherever contributor registration lives), drop the adapter-wrapping registration calls. Register each contributor directly as `IHealthContributor` with its `ReadinessPolicy`. The policies stay the same as packet 06 chose unless audit reveals a needed change — document any change in the PR.
+5. **Tests.** Remove tests targeting the removed types. Amend tests that previously exercised contributors via the Notify-private surface to exercise them via `IHealthContributor`. Confirm endpoint contract tests (from packet 06) still pass — they should, since the endpoints already go through the Kernel aggregator and the adapter was the only thing between the contributors and the aggregator.
+6. **Versioning.** Bump every non-test `.csproj` in the `HoneyDrunk.Notify` solution to the next minor version in one commit (invariant 27). The bump reflects: (a) removal of public API (`INotifyHealthContributor` and friends — major-bump-with-deprecation-window per ADR-0035, mitigated by the `[Obsolete]` warning from packet 06; treat as minor bump under ADR-0035's "removal after `[Obsolete]` deprecation window" allowance), and (b) the visible behavioural completion of the reconciliation.
+7. **CHANGELOG and README.**
+   - Repo-level `CHANGELOG.md` new-version entry naming the removal: "`INotifyHealthContributor`, `NotifyHealthEvaluator`, `NotifyHealthReport`, `NotifyHealthStatus`, `NotifyHealthContributorAdapter` removed. Notify health contributors now implement `IHealthContributor` directly."
+   - `HoneyDrunk.Notify.Hosting.AspNetCore/CHANGELOG.md` (or per-package equivalent) — same removal note.
+   - `HoneyDrunk.Notify.Hosting.AspNetCore/README.md` — if the README documented `INotifyHealthContributor` as a public extension point, remove that documentation and replace with the now-canonical `IHealthContributor` guidance (cross-link to `HoneyDrunk.Kernel/docs/Health.md` from packet 04).
+
+## Affected Files
+- Each Notify `INotifyHealthContributor` implementation — class declaration, method signatures, body amendments.
+- `HoneyDrunk.Notify.Hosting.AspNetCore/Health/` — five file removals.
+- `HoneyDrunk.Notify.Hosting.AspNetCore/ServiceCollectionExtensions/HoneyDrunkNotifyServiceCollectionExtensions.cs` — registration changes.
+- Notify test projects — test removals and amendments.
+- Every non-test `.csproj` in the solution — version bump.
+- Repo-level `CHANGELOG.md`; `HoneyDrunk.Notify.Hosting.AspNetCore` per-package CHANGELOG.
+- `HoneyDrunk.Notify.Hosting.AspNetCore/README.md` (if affected).
+
+## NuGet Dependencies
+- No new `PackageReference`. The dependencies on `HoneyDrunk.Kernel` / `HoneyDrunk.Kernel.Abstractions` `0.8.0` from packet 06 stay; versions may move forward to the latest released Kernel `0.8.x` if a patch has shipped, otherwise unchanged.
+- `HoneyDrunk.Standards` is already on every project; no change.
+
+## Boundary Check
+- [x] All code change is in `HoneyDrunk.Notify` — its own contributors, host composition, and tests. Routing rule maps here.
+- [x] No contract change in Notify's hot path — `INotificationSender` / `INotificationGateway` shapes are not touched.
+- [x] Removing `INotifyHealthContributor` is a Notify-internal API removal; the Kernel-shaped `IHealthContributor` is the canonical surface and remains stable.
+- [x] No Container App YAML change; no deploy-workflow change in this packet.
+
+## Acceptance Criteria
+- [ ] Every Notify `INotifyHealthContributor` implementation now implements `IHealthContributor` from `HoneyDrunk.Kernel.Abstractions.Lifecycle` directly
+- [ ] `INotifyHealthContributor`, `NotifyHealthEvaluator`, `NotifyHealthReport`, `NotifyHealthStatus`, `NotifyHealthContributorAdapter` source files are removed from `HoneyDrunk.Notify.Hosting.AspNetCore`
+- [ ] Host composition registers contributors directly as `IHealthContributor` with `ReadinessPolicy` values; the chosen policies match packet 06 unless documented otherwise in the PR
+- [ ] Existing endpoint contract tests (from packet 06) continue to pass — the three endpoints still behave per ADR-0066 D2 contract
+- [ ] Contributor `output` strings continue to obey Invariant `{N3}` (no secrets, connection strings, tenant identifiers, or provider opaque IDs) — re-audited during the rewrite
+- [ ] Every non-test `.csproj` in the `HoneyDrunk.Notify` solution is at the next minor version above what packet 06 set, in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` carries a new-version entry naming the removed types and the reconciliation closure
+- [ ] `HoneyDrunk.Notify.Hosting.AspNetCore` per-package `CHANGELOG.md` carries the same removal note
+- [ ] `HoneyDrunk.Notify.Hosting.AspNetCore/README.md` updated if it previously documented `INotifyHealthContributor` as a public extension point
+- [ ] No `Thread.Sleep` in tests (invariant 51)
+- [ ] `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **Confirm the deprecation window between packet 06's `[Obsolete]` marking and this removal.** ADR-0035 D5 names 60 days as the minimum for member removals. For an internal-Notify type with no documented external consumers, a tighter window is acceptable if the operator decides so. Document the chosen window in the PR description. If a 60-day minimum is honoured, do not file this packet earlier than 60 days after packet 06 merges; if a tighter window is chosen, justify it.
+
+## Referenced ADR Decisions
+**ADR-0066 D9 — Notify reconciliation.** Three-stage: bridge adapter, contributor amendments, interface removal. This packet closes stages 2 and 3.
+
+**ADR-0066 Operational Consequences — "The Notify amendment requires care."** "The amendment packet stages: (1) bridge adapter lands, (2) Notify contributors amend to `IHealthContributor` directly, (3) `INotifyHealthContributor` is removed. The bridge keeps Notify's CHANGELOG entry from being a breaking event." Stages (2) + (3) are bundled in this packet; stage (1) was packet 06.
+
+**ADR-0035 — Deprecation window.** Member removals after a 60-day `[Obsolete]` deprecation window are allowed at minor-bump cadence. Packet 06 marked the Notify-private types `[Obsolete]`; this packet removes them.
+
+## Constraints
+- **Invariant 4 — DAG.** Notify depends on Kernel; no inversion.
+- **Invariants 41–43 — Notify hot-path contracts.** Do NOT change `INotificationSender`, `INotificationGateway`, decision-log or cadence shapes. This packet only finalizes the health-contributor reconciliation.
+- **Invariant 13 — XML documentation on public types.** Contributor classes are public; their `IHealthContributor` member implementations carry XML documentation.
+- **Invariant 27 — one version across the solution.** Bump every non-test `.csproj` together; per-package CHANGELOG only for packages with functional changes.
+- **Invariant 51 — no `Thread.Sleep` in test code.**
+- **Invariant `{N3}` — contributor messages free of secrets/connection strings/tenant identifiers/provider opaque IDs.** Re-audit each contributor's message strings during the rewrite.
+- **ADR-0035 deprecation window.** Honour at least 60 days between packet 06's `[Obsolete]` marking and this packet's removal, OR document the chosen tighter window in the PR.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0066`, `wave-5`
+
+## Agent Handoff
+
+**Objective:** Amend every Notify `INotifyHealthContributor` implementation to implement `IHealthContributor` directly, then remove the Notify-private health surface (the interface, the evaluator, the report, the status enum, and the bridge adapter).
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: Close ADR-0066 D9's reconciliation — no Notify-private health interface; the Kernel-shaped contract is the only surface.
+- Feature: ADR-0066 Health, Readiness, and Liveness Endpoint Contract rollout, Wave 5 (final wave).
+- ADRs: ADR-0066 D9 (primary), ADR-0035 (deprecation window), ADR-0008.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:06` — the bridge adapter, the `[Obsolete]` marking, and the host registration via the adapter were introduced. The deprecation window between packet 06 and this packet is honoured (default 60 days per ADR-0035 minimum, or document a tighter window in the PR).
+
+**Constraints:**
+- Bundle stages (2) + (3) of the Notify reconciliation in this packet — partial states (contributors amended but interface not removed, or vice versa) are explicitly excluded by the bundling.
+- No change to Notify hot-path contracts.
+- Re-audit each contributor's message strings against Invariant `{N3}` during the rewrite.
+- Bump the whole Notify solution one minor version (invariant 27).
+
+**Key Files:**
+- Each Notify `INotifyHealthContributor` implementation (audit at execution time; at minimum `DefaultNotifyHealthContributor`).
+- `HoneyDrunk.Notify.Hosting.AspNetCore/Health/` (five file removals).
+- `HoneyDrunk.Notify.Hosting.AspNetCore/ServiceCollectionExtensions/HoneyDrunkNotifyServiceCollectionExtensions.cs` (registration changes).
+- Notify test projects.
+- Every non-test `.csproj`; repo-level `CHANGELOG.md`.
+
+**Contracts:**
+- Removed: `INotifyHealthContributor`, `NotifyHealthEvaluator`, `NotifyHealthReport`, `NotifyHealthStatus`, `NotifyHealthContributorAdapter` (all in `HoneyDrunk.Notify.Hosting.AspNetCore`).
+- Consumed: `IHealthContributor`, `ReadinessPolicy` from `HoneyDrunk.Kernel.Abstractions` `0.8.0+`.
+- Notify hot-path contracts unchanged.

--- a/generated/issue-packets/active/adr-0066-health-endpoints/08-architecture-container-apps-probe-walkthroughs.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/08-architecture-container-apps-probe-walkthroughs.md
@@ -1,0 +1,154 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "infra", "docs", "adr-0066", "wave-6"]
+dependencies: ["packet:00", "packet:03"]
+adrs: ["ADR-0066", "ADR-0015"]
+wave: 6
+initiative: adr-0066-health-endpoints
+node: honeydrunk-architecture
+---
+
+# Document Container Apps probe configuration for every containerized deployable Node
+
+## Summary
+Add the ADR-0066 D5 Container Apps probe declarations to each containerized deployable Node's infrastructure walkthrough doc under `repos/HoneyDrunk.{Node}/`. The walkthrough is a portal-step recipe (per the user's portal-over-CLI preference) describing the probe configuration the operator clicks into the Container App's "Health probes" blade. Covers the live deployable lines today — **Pulse.Collector**, **Notify.Worker** — and the planned containerized Nodes named in ADR-0066 D11 Affected Nodes: **Notify.Cloud**, **Operator**, **Agents**, **HoneyHub**. For the planned-but-not-yet-deployed Nodes, the walkthrough lives in the standup ADR's destination doc and inherits from this template.
+
+## Context
+ADR-0066 D5 commits the probe defaults; ADR-0066's follow-up list calls for "per-Node Container Apps probe declarations to each containerized Node's infrastructure walkthrough — Pulse, Notify (Worker), future Notify.Cloud, Operator, Agents, HoneyHub."
+
+ADR-0015 D4 named the deployable lines: Notify.Worker and Pulse.Collector are containerized today; Notify.Functions stays on Functions; Notify.Cloud/Operator/Agents/HoneyHub are planned containerized Nodes per their standup ADRs.
+
+Container Apps probe defaults per ADR-0066 D5:
+
+| Probe | Path | Period | Initial delay | Timeout | Failure threshold | Success threshold |
+|---|---|---|---|---|---|---|
+| `livenessProbe` | `/health/live` | 30s | 10s | 3s | 3 | 1 |
+| `readinessProbe` | `/health/ready` | 10s | 5s | 3s | 3 | 1 |
+| `startupProbe` | `/health/live` | 5s | 0s | 3s | 30 | 1 |
+
+The user prefers portal-over-CLI walkthroughs (memory note: "use portal UI walkthroughs, not CLI commands"). The walkthrough format follows the existing repo convention: short portal step-by-step ("click the Container App → Health probes → Add → ...") with the values from the table above.
+
+The walkthroughs live under `repos/HoneyDrunk.{Node}/` per the existing repo-overview convention. The exact filename and location vary by Node — likely `infrastructure.md` or a sibling to `integration-points.md`. Check each Node's existing repo-overview docs and place the walkthrough where the existing infrastructure docs live, or add a new `infrastructure-container-apps.md` if no infrastructure doc exists.
+
+This is a docs/governance packet. No code, no .NET project. Tier-2 (not tier-1) because the walkthroughs are content-heavy and span six target Nodes.
+
+## Scope
+**Folder existence pre-flagged at packet-authoring time** (verified by directory listing of `repos/`):
+- `repos/HoneyDrunk.Pulse/` — **exists**. Add or extend the infrastructure walkthrough for Pulse.Collector.
+- `repos/HoneyDrunk.Notify/` — **exists**. Add or extend the infrastructure walkthrough for Notify.Worker. Notify.Functions runs on Functions, not Container Apps — exclude it (the Functions deploy gate is handled in packet 10).
+- `repos/HoneyDrunk.Notify.Cloud/` — **does NOT exist** at packet-authoring time. Skip in this packet. Defer the walkthrough to ADR-0027's standup destination doc; note the deferral in the PR.
+- `repos/HoneyDrunk.Operator/` — **exists**. Add the walkthrough stub.
+- `repos/HoneyDrunk.Agents/` — **exists**. Add the walkthrough stub.
+- `repos/HoneyHub/` — **exists**. Add the walkthrough stub.
+- **No discovery cycles required.** The folder-existence audit is complete; the executor adds walkthroughs to the five existing folders (Pulse, Notify, Operator, Agents, HoneyHub) and explicitly defers Notify.Cloud.
+- The shared probe defaults table from ADR-0066 D5 — extracted into a reusable Markdown snippet (e.g. `repos/_shared/container-apps-probe-defaults.md` or inline in each walkthrough). Inline is simpler; the cost is duplication across five docs. Choose inline for the first round (matches the lean-doc convention) and link from each Node's walkthrough back to the ADR-0066 source of truth.
+
+## Proposed Implementation
+1. For **`repos/HoneyDrunk.Pulse/`**:
+   - Add a section titled "Container Apps probe configuration (ADR-0066)" to the existing infrastructure doc (or add a new `infrastructure-container-apps.md` if no infrastructure doc exists). Include the ADR-0066 D5 probe defaults table verbatim.
+   - Add a portal walkthrough: "In the Azure portal, navigate to your Pulse.Collector Container App (`ca-hd-pulse-{env}` per invariant 34). Go to Application → Containers → Edit and deploy → select the container → Health probes → Add. Add the three probes with the values from the table above. Save → Create."
+   - Note any per-Node overrides (D5 prose: "per-Node overrides are permitted with reason recorded in the Node's `infrastructure/` walkthrough"). Pulse.Collector probably uses defaults — state that in the walkthrough.
+   - Reference packet 10 for the deploy-workflow change that switches the readiness gate from `/health` to `/health/ready`.
+2. For **`repos/HoneyDrunk.Notify/`**:
+   - Same shape, targeting Notify.Worker's Container App (`ca-hd-notify-{env}` or whatever the actual name is — check the Notify infrastructure docs).
+   - **Note explicitly that Notify.Functions is NOT a Container App** — it runs on Functions and its deploy gate is handled by packet 10's deploy-workflow change.
+   - Notify.Worker may have a longer warm-up due to Vault secrets resolution and provider-template loading; document any per-Node override to the startup probe's failure threshold if the operator decides one is warranted, or state "defaults apply" if not.
+3. For **`repos/HoneyDrunk.Operator/`**, **`repos/HoneyDrunk.Agents/`**, **`repos/HoneyHub/`** (all three exist at packet-authoring time):
+   - Add the same walkthrough as a stub: probe defaults table + portal step-by-step + the note "this Node is planned per ADR-0018 / ADR-0020 / ADR-0002-0003 standup; the walkthrough applies when the Container App is first provisioned."
+4. For **`repos/HoneyDrunk.Notify.Cloud/`** (does NOT exist at packet-authoring time):
+   - Skip. Defer the walkthrough to ADR-0027's standup destination doc. State the deferral in the PR and add a note to ADR-0027's follow-up list.
+   - **Do not create the folder in this packet** — the standup ADR creates it.
+5. Inline the probe-defaults table in each walkthrough rather than centralizing in a shared file — easier to read, low duplication cost (five copies of a small table). Each walkthrough links back to ADR-0066 D5 as the source of truth.
+6. State the cross-reference to packet 10: "The deploy workflow's readiness gate probes `/health/ready` (not `/health`, which is auth-required per invariant `{N2}`). See packet 10 in this initiative for the Actions-side workflow change."
+
+## Affected Files
+- `repos/HoneyDrunk.Pulse/infrastructure*.md` (or wherever the Pulse infrastructure walkthroughs live).
+- `repos/HoneyDrunk.Notify/infrastructure*.md`.
+- `repos/HoneyDrunk.Operator/infrastructure*.md` (folder exists; add walkthrough).
+- `repos/HoneyDrunk.Agents/infrastructure*.md` (folder exists; add walkthrough).
+- `repos/HoneyHub/infrastructure*.md` (folder exists; add walkthrough).
+- `repos/HoneyDrunk.Notify.Cloud/` — NOT edited (folder does not exist; deferred to ADR-0027 standup).
+
+## NuGet Dependencies
+None. This packet touches only Markdown docs; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture` under `repos/{Node}/` — the Grid-wide repo-overview convention.
+- [x] No code change in any other repo.
+- [x] No Container App YAML change in this packet — the YAML lives in `HoneyDrunk.Actions` (the deployable's release workflow inputs the probe config to the deploy step). Those YAML files are amended in packet 10.
+
+## Acceptance Criteria
+- [ ] `repos/HoneyDrunk.Pulse/` infrastructure walkthrough has a "Container Apps probe configuration (ADR-0066)" section with the D5 probe-defaults table and a portal-step walkthrough for Pulse.Collector
+- [ ] `repos/HoneyDrunk.Notify/` infrastructure walkthrough has the same for Notify.Worker, plus an explicit note that Notify.Functions is NOT a Container App
+- [ ] `repos/HoneyDrunk.Operator/`, `repos/HoneyDrunk.Agents/`, `repos/HoneyHub/` each carry a walkthrough stub (folders exist at packet-authoring time)
+- [ ] `repos/HoneyDrunk.Notify.Cloud/` is NOT touched (folder does not exist); the deferral to ADR-0027's standup is documented in the PR and a follow-up note is added to ADR-0027
+- [ ] Each walkthrough is portal-step-style, not CLI-style (user preference: portal-over-CLI)
+- [ ] Each walkthrough links to ADR-0066 D5 as the source of truth and notes that per-Node overrides are permitted with reason recorded in the walkthrough
+- [ ] Each walkthrough cross-references packet 10 for the deploy-workflow readiness-gate switch
+- [ ] No code change; no `.csproj` change; no version bump (Architecture is not a versioned .NET solution)
+- [ ] `pr-core.yml` tier-1 gate passes (markdown lint, link check if configured)
+
+## Human Prerequisites
+- [ ] **Portal-side action: apply the probe configuration to each existing Container App.** For Pulse.Collector and Notify.Worker — the deployables that are live today — the operator must click through the portal walkthrough to set the three probes on the running Container Apps in each environment (`dev`, `staging`, `prod`). This is a deploy-time action, not a code action; the walkthrough exists to guide it. The walkthrough docs land in this packet's PR; the portal application happens after merge.
+- [ ] **Probe configuration coordinates with the deploy workflow.** The Container App revision-health gate (per invariant 36 and ADR-0066 D5) reads `/health/ready` on a new revision. Coordinate the portal probe configuration with packet 10's deploy-workflow change so the gate consistently uses `/health/ready`.
+- [ ] **Notify.Cloud is deferred.** `repos/HoneyDrunk.Notify.Cloud/` does not exist at packet-authoring time; the walkthrough belongs in ADR-0027's standup destination doc. Track this in ADR-0027's follow-up list.
+
+## Referenced ADR Decisions
+**ADR-0066 D5 — Container Apps probe defaults.** The table verbatim:
+
+| Probe | Path | Period | Initial delay | Timeout | Failure threshold | Success threshold |
+|---|---|---|---|---|---|---|
+| `livenessProbe` | `/health/live` | 30s | 10s | 3s | 3 | 1 |
+| `readinessProbe` | `/health/ready` | 10s | 5s | 3s | 3 | 1 |
+| `startupProbe` | `/health/live` | 5s | 0s | 3s | 30 | 1 |
+
+Per-Node overrides permitted with reason recorded in the walkthrough.
+
+**ADR-0066 D5 — Revision health gating.** A new revision is shifted to 100% traffic only after `/health/ready` returns `200` for at least three consecutive periods on the revision's direct FQDN. The deploy workflow (packet 10) holds the gate.
+
+**ADR-0015 D4 — Containerized deployable lines.** Notify.Worker, Pulse.Collector, plus the planned Notify.Cloud, Operator, Agents, HoneyHub. Notify.Functions stays on Functions.
+
+**Invariant 34 — Container App naming.** `ca-hd-{service}-{env}` — referenced in the walkthrough for each Node's resource name.
+
+**Invariant 36 — Container App revision mode is Multiple.** The probe configuration above interacts with the traffic-splitting revision gate.
+
+## Constraints
+- **Portal over CLI.** Walkthroughs are click-by-click, not CLI commands. User preference per memory.
+- **Inline the probe-defaults table.** Six copies across the walkthroughs is the chosen tradeoff over a centralized shared file; readability wins.
+- **Do NOT create `repos/{Node}/` folders that do not exist.** Standup ADRs create those folders; this packet only adds walkthroughs where the folder already exists.
+- **No Container App YAML change.** The deployable's release workflow in `HoneyDrunk.Actions` owns the YAML; packet 10 amends those workflows.
+- **Cross-reference packet 10.** Each walkthrough names the deploy-workflow readiness-gate switch as a dependency for consistent operation.
+
+## Labels
+`feature`, `tier-2`, `infra`, `docs`, `adr-0066`, `wave-6`
+
+## Agent Handoff
+
+**Objective:** Add ADR-0066 D5 Container Apps probe walkthroughs to each containerized deployable Node's infrastructure docs under `repos/HoneyDrunk.{Node}/`.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Give the operator a portal-step recipe for applying the D5 probe configuration to every live and planned Container App.
+- Feature: ADR-0066 Health, Readiness, and Liveness Endpoint Contract rollout, Wave 6 (infra walkthroughs + agent updates).
+- ADRs: ADR-0066 D5 (primary), ADR-0015 D4 (containerized lines), ADR-0008.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0066 Accepted; the walkthroughs cite live Invariant `{N1}`, 55, 56.
+- `packet:03` — the Kernel helper exists, so the walkthroughs are not pointing at unshipped runtime.
+
+**Constraints:**
+- Portal-step walkthroughs, not CLI commands (user preference).
+- Inline the probe-defaults table in each walkthrough; link back to ADR-0066 D5.
+- Do NOT create `repos/{Node}/` folders that do not exist — standup ADRs own those.
+- Cross-reference packet 10 for the deploy-workflow readiness-gate switch.
+
+**Key Files:**
+- `repos/HoneyDrunk.Pulse/`, `repos/HoneyDrunk.Notify/`, `repos/HoneyDrunk.Operator/`, `repos/HoneyDrunk.Agents/`, `repos/HoneyHub/` infrastructure walkthroughs (all five folders exist; pre-verified). `repos/HoneyDrunk.Notify.Cloud/` does NOT exist — skip and defer to ADR-0027.
+
+**Contracts:** None changed — docs-only packet.

--- a/generated/issue-packets/active/adr-0066-health-endpoints/09-architecture-review-agent-and-security-specialist-checklist.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/09-architecture-review-agent-and-security-specialist-checklist.md
@@ -1,0 +1,143 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "docs", "adr-0066", "wave-6"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0066", "ADR-0046"]
+wave: 6
+initiative: adr-0066-health-endpoints
+node: honeydrunk-architecture
+---
+
+# Add health-endpoint checklist to review.md and the security specialist prompt
+
+## Summary
+Amend `.claude/agents/review.md` (the canonical Grid-aware code review agent per ADR-0044) and the `security` specialist agent prompt (per ADR-0046) with an ADR-0066 health-endpoint checklist. The checklist covers: three endpoints mapped, auth posture correct, contributor messages reviewed for PII per Invariant `{N3}`, contributor execution time bounded. Surfaces Invariant `{N1}`, 55, 56 at the PR-review boundary so a regression on the contract gets caught at PR time rather than at deploy time.
+
+## Context
+ADR-0066's follow-up list calls for: "Update `.claude/agents/review.md` and the `security` specialist prompt with a health-endpoint checklist: three endpoints mapped, auth posture correct, contributor messages reviewed for PII, contributor execution time bounded."
+
+ADR-0066 D8 cites the security-specialist coupling explicitly: "The `security` specialist review per ADR-0046 gains a checklist item for contributor message review."
+
+Two review surfaces:
+1. **`.claude/agents/review.md`** — the canonical Grid-aware code-review agent that runs on every non-draft PR per ADR-0044 / invariant 52. Used by every consumer of the cloud-wired reviewer. Adding the checklist here means every PR touching health endpoints, contributors, or host composition gets the check.
+2. **`security` specialist** — per ADR-0046, a narrower-scope deeper-rigor specialist invoked manually on Auth/Vault/tenant/public-API touches. ADR-0066 D8 specifically asks the security checklist to include contributor-message review.
+
+The checklist for the review agent (broad coverage):
+- The three endpoints (`/health/live`, `/health/ready`, `/health`) are mapped via `MapHoneyDrunkHealthEndpoints` or the Functions-host equivalent — not hand-rolled (Invariant `{N1}`).
+- `/health/live` and `/health/ready` are anonymous; `/health` is auth-required (Invariant `{N2}`).
+- Any new `IHealthContributor` registers with an explicit `ReadinessPolicy` value (D7); the default (`Required`) is the conservative fallback if no policy is declared.
+- Contributor `output` strings do not carry secrets, connection strings, tenant identifiers, or provider opaque IDs (Invariant `{N3}` + ADR-0049 references).
+- Contributor execution time is bounded — the Kernel aggregator applies a 1-second default timeout; contributors should target sub-100ms.
+- `/health/live` does NOT consult contributors (returns based on lifecycle stage only — protection against feedback-loop restarts on dependency hiccups; D7).
+- The host has an auth scheme wired so `/health` resolves to `401` for unauthenticated requests (Invariant `{N2}`).
+- Container App probe configuration (if the PR touches infrastructure walkthroughs) matches the D5 defaults or documents the per-Node override reason.
+
+The security-specialist checklist (deeper, narrower):
+- Re-emphasize the contributor-message PII rule (Invariant `{N3}`) with concrete examples: connection strings, vault URIs, tenant ULIDs, Stripe IDs.
+- Audit the host's auth scheme for `/health` — confirm it resolves to `401` on unauthenticated, not anonymous fallback.
+- Verify probe outcomes flow as telemetry (Pulse counter / log) and NOT as audit events (D10 — probe volume is high, not forensically interesting).
+- If the PR introduces a new contributor whose execution is dependent on a Vault secret or external dependency, confirm it is appropriately classified (`Required` if it truly gates readiness, `OptionalReported` if not) — a misclassified contributor can pull a Node out of rotation on a non-critical dep hiccup.
+
+This is a docs/governance packet. No code, no .NET project. The `review.md` file is in `.claude/agents/` — the canonical location per ADR-0007.
+
+## Scope
+- `.claude/agents/review.md` — add the ADR-0066 health-endpoint checklist to the appropriate rubric section. Per ADR-0044 D3 the review agent uses a twenty-category rubric; the health-endpoint checklist most naturally fits under multiple categories (security, reliability, observability, contracts). Choose a placement — most likely under "Reliability" (the endpoints are part of the operational reliability surface) — and cross-link from "Security" and "Observability" if the file structure supports cross-links.
+- `.claude/agents/security.md` (or wherever the `security` specialist agent prompt lives — check `.claude/agents/` for the file matching the ADR-0046 roster name) — add the deeper contributor-message audit checklist. If the file does not exist yet (ADR-0046 specialist standup may be ongoing), defer the security-specialist amendment to ADR-0046's standup follow-up and document the deferral in the PR.
+- **Coupling reminder per invariant 33:** `.claude/agents/scope.md` (this scope agent's own file) has a context-loading contract that the review agent's context-loading contract must be a superset of. This packet does NOT change either context-loading contract — only the rubric/checklist content. If the operator wants the review agent to load any new file at PR-review time, that change is a separate packet.
+
+## Proposed Implementation
+1. **`.claude/agents/review.md`.** Open the file. Find the rubric section (per ADR-0044 D3 it carries a twenty-category rubric). Place the ADR-0066 health-endpoint checklist as a subsection under "Reliability" (or the closest matching category — read the existing structure and choose). The checklist (write each as a bullet the reviewer evaluates):
+   - "Three endpoints (`/health/live`, `/health/ready`, `/health`) are exposed via `MapHoneyDrunkHealthEndpoints` (or `HealthFunctionExtensions` for Functions hosts) — not hand-rolled `MapGet` calls. **Invariant `{N1}`.**"
+   - "`/health/live` and `/health/ready` are anonymous (no `RequireAuthorization`); `/health` is auth-required (`RequireAuthorization` or equivalent). **Invariant `{N2}`.**"
+   - "Every registered `IHealthContributor` declares its `ReadinessPolicy` explicitly. The default (`Required`) is conservative; non-blocking contributors must declare themselves `OptionalReported` or `NotReadinessRelevant` explicitly. **ADR-0066 D7.**"
+   - "Contributor `output` strings do not carry secrets, connection strings, tenant identifiers, or provider opaque IDs. Cross-reference invariants 8 and 56 and ADR-0049. **Invariant `{N3}`.**"
+   - "Contributor execution is bounded — the Kernel aggregator applies a 1-second default timeout, configurable per registration. New contributors should target sub-100ms execution and call out any unavoidable overrun with a configured timeout. **ADR-0066 Operational Consequences.**"
+   - "`/health/live` does NOT consult contributors. Reviewer flags any host code that wires contributors into the liveness path (e.g. a custom `/health/live` handler that calls the aggregator). **ADR-0066 D7.**"
+   - "If the PR introduces infrastructure walkthrough changes for a Container App probe, the configuration matches ADR-0066 D5 defaults or documents the per-Node override reason. **ADR-0066 D5.**"
+   Add the section with an "ADR-0066 (Health endpoints)" header so the rubric category is browsable.
+2. **`.claude/agents/security.md`** (or matching file). If the security-specialist agent file exists (per ADR-0046 specialist standup), add a "Health endpoints (ADR-0066)" section with the deeper checklist:
+   - "Audit every `IHealthContributor.CheckHealthAsync` implementation's message string for: connection strings, Vault URIs, tenant ULIDs, Stripe customer IDs, Azure resource IDs, provider opaque tokens. The contributor is responsible for redaction at the report site; the Kernel aggregator and the response writer do NOT redact. **Invariant `{N3}` + ADR-0049.**"
+   - "Verify the host's auth scheme for `/health` resolves to `401` on unauthenticated requests — not anonymous fallback, not a redirect to a sign-in page that a probe credential would not follow."
+   - "Verify probe outcomes flow as Pulse telemetry (counter `honeydrunk.health.probes`, histogram `honeydrunk.health.contributor.duration`, structured Warning/Error logs) and NOT as `IAuditLog` events. Probes are high-volume and not forensically interesting. **ADR-0066 D10.**"
+   - "If the PR introduces a contributor whose `CheckHealthAsync` depends on a Vault secret, external HTTP call, or database round-trip, confirm its `ReadinessPolicy` accurately reflects whether the dep is required-for-traffic or merely-reported. Misclassification can pull a Node out of rotation on a non-critical hiccup. **ADR-0066 D7.**"
+   - If `.claude/agents/security.md` does not yet exist, defer this step and document the deferral in the PR. ADR-0046's standup will own the file's creation and the security-specialist amendment lands in the standup or as a separate ADR-0046 follow-up packet.
+3. **Confirm invariant 33's superset relationship is unchanged.** The review-agent's context-loading contract (per `.claude/agents/review.md`) must remain a superset of the scope-agent's (per `.claude/agents/scope.md`). This packet does NOT add a new file to either agent's context-loading list — only adds rubric content. If the operator wants either agent to load a new file at PR-review or scope-time, that's a separate ADR-0011 D4 / invariant 33 packet.
+
+## Affected Files
+- `.claude/agents/review.md`
+- `.claude/agents/security.md` (if it exists; defer otherwise)
+
+## NuGet Dependencies
+None. This packet touches only agent prompt files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture/.claude/agents/` — the canonical agent location per ADR-0007.
+- [x] No code change in any other repo.
+- [x] No context-loading contract change (invariant 33 superset relationship unchanged).
+
+## Acceptance Criteria
+- [ ] `.claude/agents/review.md` carries an "ADR-0066 (Health endpoints)" section with the seven-bullet rubric checklist
+- [ ] The checklist cites Invariant `{N1}`, 55, 56 by number AND by full text where they appear (the agent has access to `constitution/invariants.md`, but inlining the load-bearing text keeps the prompt readable)
+- [ ] The checklist references ADR-0049 in the contributor-message PII bullet
+- [ ] `.claude/agents/security.md` carries the four-bullet deeper checklist (if the file exists; otherwise the deferral is documented in the PR)
+- [ ] The review-agent context-loading contract (per the file's "Context" section) is NOT changed in this packet
+- [ ] The scope-agent context-loading contract (per `.claude/agents/scope.md`) is NOT changed in this packet
+- [ ] No code change; no `.csproj` change; no version bump (Architecture is not a versioned .NET solution)
+- [ ] `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0066 D7 — `ReadinessPolicy`.** The reviewer's check enforces explicit policy declaration on every new contributor.
+
+**ADR-0066 D8 — Contributor message PII rule.** "The `security` specialist review per ADR-0046 gains a checklist item for contributor message review." This packet is that addition.
+
+**ADR-0066 D10 — Probe outcomes are NOT audit events.** Security-specialist check verifies probes flow to telemetry, never to `IAuditLog`.
+
+**ADR-0066 Operational Consequences — Contributor execution time.** "The Kernel aggregator wraps each contributor in a 1-second timeout by default; configurable per registration." Reviewer flags slow contributors before deploy time.
+
+**ADR-0044 D3 — Review-agent rubric.** Twenty-category rubric. The ADR-0066 checklist fits under Reliability with cross-links from Security and Observability.
+
+**ADR-0046 — `security` specialist.** Manual-invocation specialist; the contributor-message audit is a natural deep-lens check for it.
+
+**Invariant 33 — Review/scope context-loading symmetry.** Not changed in this packet; only rubric content is added.
+
+## Constraints
+- **Invariant 33 — context-loading symmetry.** The review-agent's load list must be a superset of the scope-agent's. This packet does NOT change either load list — only adds rubric content.
+- **ADR-0007 — `.claude/agents/` is the canonical location for agent definitions.** Edits target that path; do NOT introduce a parallel definition elsewhere.
+- **If `.claude/agents/security.md` does not exist, defer.** ADR-0046 specialist standup owns the file's creation; do not author it as a side-effect of this packet.
+- **Inline invariant text where load-bearing.** Per the scope-agent's authoring rules ("Inline invariant text. Never write 'Invariant 17' — write the actual rule text"), the review-agent rubric cites invariant numbers AND inlines the rule text where the wording matters.
+
+## Labels
+`chore`, `tier-1`, `meta`, `docs`, `adr-0066`, `wave-6`
+
+## Agent Handoff
+
+**Objective:** Add the ADR-0066 health-endpoint checklist to `.claude/agents/review.md` and `.claude/agents/security.md`.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Surface Invariant `{N1}`, 55, 56 at the PR-review boundary; surface the deeper contributor-message audit at the security-specialist boundary.
+- Feature: ADR-0066 Health, Readiness, and Liveness Endpoint Contract rollout, Wave 6.
+- ADRs: ADR-0066 D7/D8/D10 + Operational Consequences (primary), ADR-0044 (review-agent rubric), ADR-0046 (specialist agents), ADR-0007 (`.claude/agents/` canonical location).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — Invariant `{N1}`, 55, 56 must exist before the rubric cites them by number.
+
+**Constraints:**
+- Do NOT change the context-loading contract of either agent (invariant 33 symmetry).
+- Inline invariant text where load-bearing — agent rubrics rely on it.
+- If `.claude/agents/security.md` does not exist (ADR-0046 standup state), defer the security-specialist amendment and document the deferral.
+
+**Key Files:**
+- `.claude/agents/review.md`
+- `.claude/agents/security.md` (conditional)
+
+**Contracts:** None changed — agent rubric content only.

--- a/generated/issue-packets/active/adr-0066-health-endpoints/10-actions-deploy-workflow-readiness-gate-switch.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/10-actions-deploy-workflow-readiness-gate-switch.md
@@ -1,0 +1,137 @@
+---
+name: CI Change
+type: ci-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci", "adr-0066", "wave-6"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0066", "ADR-0015", "ADR-0033"]
+wave: 6
+initiative: adr-0066-health-endpoints
+node: honeydrunk-actions
+---
+
+# Switch the Container Apps deploy workflow's readiness gate from /health to /health/ready
+
+## Summary
+Amend the Container Apps deploy workflow in `HoneyDrunk.Actions` so the post-deploy readiness gate probes `/health/ready` (anonymous, empty-body 200/503 contract per ADR-0066 D2) rather than `/health` (which becomes auth-required after this initiative — Invariant `{N2}`). The change preserves invariant 36's traffic-shift-on-revision-health gate while removing the inconsistency between the deploy probe and the Grid-wide contract. The Notify Worker `release-worker.yml` (per ADR-0066 Context) and any parallel Container Apps deploy workflow (Pulse.Collector's release workflow, the shared `job-deploy-container-app.yml` per ADR-0015) all switch in this single PR so deploys are consistent across the deployable lines.
+
+## Context
+ADR-0066 Context names the inconsistency: "The Worker's release workflow (`release-worker.yml`) gates traffic on `/health`; the readiness endpoint exists for monitoring rather than for the deploy gate." After this initiative `/health` is auth-required (Invariant `{N2}`), so an unauthenticated probe from the deploy workflow returns `401`, breaking the deploy gate. The fix is to probe `/health/ready` instead — which is anonymous (D6), returns the right semantics ("is this revision ready to serve traffic?"), and matches invariant 36's revision-health gate.
+
+ADR-0066 D5 makes the rule explicit: "Container-App revision health gating: a new revision is shifted to `100%` traffic only after `/health/ready` has returned `200` for at least three consecutive periods on the revision's direct FQDN. The probe configuration above provides the timing; the deploy workflow (`job-deploy-container-app.yml` per ADR-0015) holds the gate."
+
+ADR-0066 follow-up list calls this out specifically: "Coordinate with the deploy-workflow owner (ADR-0015's `job-deploy-container-app.yml` in `HoneyDrunk.Actions`) to confirm the readiness-gate probe target switches from `/health` to `/health/ready` for new revisions."
+
+The Notify.Functions deploy gate is a related but separate path — Notify.Functions is on the Functions host, not Container Apps. Its `release-functions-host` (or equivalent) workflow gates on `/api/health` (the Functions-host prefixed equivalent of `/health`). If the Functions deploy gate probes `/api/health`, it has the same problem after this initiative — `/health` is auth-required. The fix is to probe `/api/health/ready` (Functions-host prefixed `/health/ready`). Include the Functions deploy gate in this packet.
+
+This packet runs in Wave 6 alongside packet 08 (per-Node infrastructure walkthroughs) and packet 09 (review-agent updates). It hard-blocks behind packet 03 only — the Kernel runtime endpoints must exist before the deploy gate probes them. It does NOT block on packets 05/06 (the Node-side amendments) because the workflow change is environment-independent — once the workflow targets `/health/ready`, it works against any revision that exposes that endpoint per the ADR-0066 contract; whether the revision was built before or after packet 05/06 merged is irrelevant to the gate's correctness as long as `/health/ready` is reachable on that revision.
+
+**The sequencing risk:** if packet 10 lands before packets 05/06 finish deploying, a Container App revision whose code is from before packet 05/06 may not have `/health/ready` mapped at all (in Pulse.Collector's case, the placeholder endpoint exists; in Notify.Worker's case, the readiness endpoint exists but the body shape and contributor wiring change). In practice the workflow probes the path regardless of body shape (it consumes the status code), and the path exists on both old and new revisions. So packet 10 is safe to land in any order relative to packets 05/06; the operator should still verify in the deploy log that the probe is hitting the right endpoint.
+
+`HoneyDrunk.Actions` is the CI/CD control plane per ADR-0012. The workflows live in `.github/workflows/` of the Actions repo, with reusable workflows shared via the `workflow_call` trigger. Confirm at execution time where the relevant workflows live (likely `job-deploy-container-app.yml` per ADR-0015 D14, plus the per-deployable callers like `release-worker.yml` if they hold their own gate logic).
+
+## Scope
+- `HoneyDrunk.Actions/.github/workflows/job-deploy-container-app.yml` — the reusable Container Apps deploy workflow per ADR-0015. Change the readiness-gate probe target from `/health` to `/health/ready`.
+- `HoneyDrunk.Actions/.github/workflows/release-worker.yml` (or the Notify Worker release caller's workflow file — confirm name at execution time) — same change if it holds its own probe call rather than using the reusable workflow.
+- The Pulse.Collector release workflow (whichever file holds it) — same change.
+- The Notify.Functions deploy gate's workflow — change `/api/health` to `/api/health/ready` (Functions-host prefixed `/health/ready`).
+- Workflow tests / smoke tests if the Actions repo has them.
+- Repo-level `CHANGELOG.md` (if the Actions repo carries one — confirm convention).
+
+## Proposed Implementation
+1. **Locate the workflows.** Identify the workflows that contain the readiness-gate probe call. Likely candidates: `job-deploy-container-app.yml` (the reusable per ADR-0015), `release-worker.yml`, a Pulse.Collector release workflow (name TBD), a Notify.Functions deploy workflow. State the located workflows in the PR.
+2. **Change the probe target.**
+   - For Container Apps deploys (Notify.Worker, Pulse.Collector): change the probe URL path from `/health` to `/health/ready`. The probe call is likely a `curl -fsSL https://{revision-direct-fqdn}/health/ready` or an Azure CLI `az containerapp` probe-check step — confirm the exact shape and amend it. The probe expects `200` for healthy (HTTP 200 with empty body per ADR-0066 D2); `503` (or any non-`200`) triggers the gate's failure path. The probe does not parse the body — it relies on the status code. Match invariant 36's "three consecutive periods" condition; the probe loop should keep `/health/ready` returning `200` for the configured number of attempts before declaring the revision ready.
+   - For Notify.Functions: change `/api/health` to `/api/health/ready`. The Functions-host adds the `/api/` prefix to the route; ADR-0066 D11 names this as a host-imposed prefix accommodated by the per-host Functions binding. Same status-code semantics.
+3. **No auth header.** Per ADR-0066 D6, `/health/ready` is anonymous — the workflow does NOT need to pass an auth credential. Remove any auth-token handling that existed for the previous `/health` probe (which would have needed auth after Invariant `{N2}` came into effect). If the workflow currently has no auth handling (because `/health` was placeholder-only and anonymous historically), the change is just the URL path swap.
+4. **Update the workflow's documentation** (the `#`-comment header at the top of the workflow file, or an associated `docs/` file) — note that the probe target is `/health/ready` per ADR-0066, anonymous, and the gate evaluates HTTP 200 over three consecutive periods per invariant 36.
+5. **Smoke-test the change** if the Actions repo has a workflow-test scaffold. Otherwise, the operator validates by deploying a known-healthy revision and observing the deploy gate pass against `/health/ready` (this is a Human Prerequisite below).
+6. **Versioning.** If the Actions repo uses workflow versioning via `@v1`-style tags or branch refs, follow the existing convention. If reusable workflows are referenced by SHA pin from caller workflows in other repos (per the Grid's reusable-workflow discipline), confirm callers consume the updated SHA after this PR merges — the workflow change is not active in other repos until they bump the ref.
+7. **CHANGELOG.** If the Actions repo carries a `CHANGELOG.md`, add an entry. ADR-0012 sets `HoneyDrunk.Actions` as the CI/CD control plane but the changelog convention may be lighter than for code repos — match the existing pattern.
+
+## Affected Files
+- `HoneyDrunk.Actions/.github/workflows/job-deploy-container-app.yml` (and/or wherever the Container Apps readiness gate lives).
+- `HoneyDrunk.Actions/.github/workflows/release-worker.yml` (Notify Worker).
+- `HoneyDrunk.Actions/.github/workflows/` whichever Pulse.Collector release workflow exists.
+- `HoneyDrunk.Actions/.github/workflows/` whichever Notify.Functions release workflow exists.
+- `HoneyDrunk.Actions/CHANGELOG.md` (if present).
+- Inline workflow documentation (`#`-comment headers).
+
+## NuGet Dependencies
+None. This packet touches only GitHub Actions YAML; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All change is in `HoneyDrunk.Actions` — the CI/CD control plane per ADR-0012 / invariant 35-adjacent rules.
+- [x] No code change in any other repo. (The deployable Nodes already expose `/health/ready`; packets 05 and 06 ensure its body/auth semantics match the ADR-0066 contract.)
+- [x] No new dependency.
+
+## Acceptance Criteria
+- [ ] Every Container Apps deploy workflow's readiness-gate probe targets `/health/ready` (not `/health`)
+- [ ] The Notify.Functions deploy gate's probe targets `/api/health/ready` (not `/api/health`)
+- [ ] The probe expects HTTP 200 for healthy; the gate's "three consecutive periods" condition (invariant 36 / ADR-0066 D5) is preserved
+- [ ] No auth credential is passed on the readiness probe (the endpoint is anonymous per ADR-0066 D6)
+- [ ] Workflow inline documentation reflects the new probe target and the ADR-0066 reference
+- [ ] If the Actions repo carries a `CHANGELOG.md`, an entry is added
+- [ ] Caller workflows in other repos that pin to a specific SHA of the reusable workflow are NOT changed in this PR (they bump in their own repos when ready to consume) — but the PR notes which callers will need to bump
+- [ ] `pr-core.yml` tier-1 gate passes (Actions repo's own PR gate)
+
+## Human Prerequisites
+- [ ] **Validate the change against a live deployment.** After this PR merges, perform a known-good deploy of one Container App (e.g. Pulse.Collector in `dev`) and observe the deploy log to confirm the readiness-gate probe hits `/health/ready` and receives `200` over three consecutive periods. If the probe receives `503` or `401` from a still-old revision, that indicates the deploy gate is hitting the right endpoint but the revision's contract is mismatched — investigate before treating it as a workflow bug.
+- [ ] **Coordinate with packets 05 (Pulse) and 06 (Notify) deploy windows.** This packet's workflow change is environment-independent (`/health/ready` exists on every revision that maps the contract — both the old placeholder and the new Kernel-helper version expose it). But the *behaviour* of `/health/ready` (empty body vs `{ "status": "Ready" }` JSON, dependency-free vs aggregator-driven) differs by revision. Validate after each Node's amendment ships that the workflow continues to gate correctly.
+- [ ] **Caller workflows that pin to a specific SHA.** If the reusable `job-deploy-container-app.yml` is consumed by caller workflows in `HoneyDrunk.Notify`, `HoneyDrunk.Pulse`, or other Container Apps deployers via a SHA pin, those callers must bump the pin to consume this change. This packet does NOT bump the pin in other repos; that is a deliberate per-repo decision so consumers control when the gate change takes effect.
+
+## Referenced ADR Decisions
+**ADR-0066 D5 — Container-App revision health gating.** "A new revision is shifted to `100%` traffic only after `/health/ready` has returned `200` for at least three consecutive periods on the revision's direct FQDN. The probe configuration above provides the timing; the deploy workflow (`job-deploy-container-app.yml` per ADR-0015) holds the gate."
+
+**ADR-0066 D6 — Auth posture.** `/health/ready` is anonymous; the probe needs no credential.
+
+**ADR-0066 D11 / Functions-host prefix accommodation.** Notify.Functions exposes `/api/health/ready` (the `/api/` prefix is the Functions host's; the endpoint suffix is uniform).
+
+**ADR-0066 Follow-up — Deploy-workflow coordination.** "Coordinate with the deploy-workflow owner (ADR-0015's `job-deploy-container-app.yml` in `HoneyDrunk.Actions`) to confirm the readiness-gate probe target switches from `/health` to `/health/ready` for new revisions." This packet is that change.
+
+**ADR-0015 D14 — Reusable Container Apps deploy workflow.** `job-deploy-container-app.yml` is the canonical deploy gate; caller workflows compose it.
+
+**ADR-0012 — HoneyDrunk.Actions as CI/CD control plane.** This packet's edits live in the control-plane repo.
+
+**ADR-0033 — Environment-gated deploy-trigger model.** The probe gate is part of the per-environment deploy flow ADR-0033 describes; the change here applies uniformly to `dev`, `staging`, `prod`.
+
+## Constraints
+- **Invariant 36 — Container App revision-mode-Multiple with traffic splitting.** The "three consecutive periods" condition is preserved; only the probe URL changes.
+- **Invariant `{N2}` — `/health/live` and `/health/ready` anonymous; `/health` auth-required.** The reason for this change.
+- **ADR-0012 — Actions is the CI/CD control plane.** Workflow edits live here; no parallel deploy logic gets introduced in deployable repos.
+- **Do NOT bump caller workflows in other repos in this PR.** Bumping the SHA pin in `HoneyDrunk.Notify` or `HoneyDrunk.Pulse` is each consumer's decision; this packet only changes the canonical workflow.
+- **Probe consumes status code only.** ADR-0066 D2 — bodies are empty on probes; the workflow must not parse the body.
+- **No auth on the readiness probe.** Remove any historical auth-credential handling tied to the previous `/health` probe; `/health/ready` is anonymous.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci`, `adr-0066`, `wave-6`
+
+## Agent Handoff
+
+**Objective:** Switch the Container Apps deploy workflow's readiness-gate probe from `/health` to `/health/ready` so the gate continues to work after `/health` becomes auth-required.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Preserve invariant 36's revision-health gate by probing the unauthenticated `/health/ready` endpoint instead of the auth-required `/health` aggregate.
+- Feature: ADR-0066 Health, Readiness, and Liveness Endpoint Contract rollout, Wave 6.
+- ADRs: ADR-0066 D5/D6 (primary), ADR-0015 D14 (reusable Container Apps deploy workflow), ADR-0012 (Actions as CI/CD control plane), ADR-0033 (environment-gated deploys), ADR-0008.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — the Kernel runtime endpoints exist; the deploy gate probes a path the Kernel helper maps.
+
+**Constraints:**
+- Change URL path only; preserve invariant 36's "three consecutive periods" condition.
+- Remove any auth-credential handling on the readiness probe.
+- Do NOT bump caller workflows in other repos in this PR.
+- The probe consumes status code only; bodies are empty on probes per ADR-0066 D2.
+
+**Key Files:**
+- `HoneyDrunk.Actions/.github/workflows/job-deploy-container-app.yml` (and per-deployable caller workflows that hold their own probe logic, e.g. `release-worker.yml` for Notify Worker and the Pulse.Collector release workflow).
+- `HoneyDrunk.Actions/.github/workflows/` Notify.Functions deploy workflow.
+- `HoneyDrunk.Actions/CHANGELOG.md` if present.
+
+**Contracts:** None changed — workflow YAML only.

--- a/generated/issue-packets/active/adr-0066-health-endpoints/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/dispatch-plan.md
@@ -1,0 +1,189 @@
+# Dispatch Plan — ADR-0066: Health, Readiness, and Liveness Endpoint Contract
+
+**Initiative:** `adr-0066-health-endpoints`
+**ADR:** ADR-0066 (Proposed → Accepted via packet 00)
+**Sector:** Core / cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0066 commits the Grid-wide health-endpoint contract: three uniformly-named endpoints (`/health/live`, `/health/ready`, `/health`), the IETF `application/health+json` response shape on `/health`, empty-body 200/503 on the probe endpoints, `IHealthContributor` aggregation with worst-status-wins + critical-degraded escalation, Container Apps probe defaults, the `ReadinessPolicy` model (`Required` / `OptionalReported` / `NotReadinessRelevant`), an auth posture (probes anonymous, `/health` auth-required), a PII rule for contributor messages, an implementation home in `HoneyDrunk.Kernel`, and Pulse telemetry contribution per probe.
+
+This initiative delivers: ADR acceptance + three new invariants (`{N1}/{N2}/{N3}`, claimed in `invariant-reservations.md` — currently 80–82) + catalog registration + Kernel/Notify integration-points docs (Architecture); the `ReadinessPolicy` enum + IETF response DTOs in `HoneyDrunk.Kernel.Abstractions`; the `MapHoneyDrunkHealthEndpoints` extension + aggregator + IETF response writer + per-contributor timeout + Pulse telemetry in `HoneyDrunk.Kernel` runtime, plus the Functions-host helper in the new pinned optional sibling package `HoneyDrunk.Kernel.Hosting.Functions`; the `docs/Health.md` amendment in the Kernel repo; the Pulse.Collector amendment to call the Kernel helper; the Notify amendment introducing a `NotifyHealthContributorAdapter` bridge and amending `NotifyHealthEndpointsExtensions` and `HealthFunction`; the Notify follow-up that amends contributors to implement `IHealthContributor` directly and removes the Notify-private interface; per-Node Container Apps probe walkthroughs across the live deployables; the `review.md` and `security` specialist checklist updates; and the deploy-workflow readiness-gate switch from `/health` to `/health/ready` in `HoneyDrunk.Actions`.
+
+**11 packets across 6 waves**, targeting **4 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Kernel`, `HoneyDrunk.Pulse`, `HoneyDrunk.Notify`, `HoneyDrunk.Actions`). All 11 are `Actor=Agent`, 0 `Actor=Human`. Several packets carry Human Prerequisites — upstream Kernel NuGet publishing (Wave 3→4 boundary), portal-side Container App probe configuration (packet 08), deploy-workflow validation (packet 10), and an `[Obsolete]` deprecation window between packets 06 and 07 — but the *code* work in each packet is fully delegable.
+
+## Trigger
+
+ADR-0066 was authored 2026-05-23. The forcing functions from the ADR's Context:
+- **ADR-0015 committed Container Apps for every containerized deployable Node.** Container Apps probes consume the health endpoints. Without a Grid-wide contract every new containerized Node's probe configuration drifts. The revision-mode-Multiple rollback seam (invariant 36) gates on a health probe outcome — that probe needs a defined contract.
+- **Operator (ADR-0018), Agents (ADR-0020), HoneyHub (ADR-0002 / ADR-0003) are about to land.** Each is a containerized deployable Node; each will pick whatever shape exists at standup. Settling the shape before they pick prevents three more divergences from the Pulse-and-Notify drift.
+- **Notify Cloud GA carries a tenant-facing health expectation.** Per ADR-0027 tenants integrating against Notify Cloud will treat unanticipated `5xx` responses as outages; the readiness gate is what protects them from being routed to a starting-up revision before its dependencies are reachable.
+- **AI-sector standup wave (ADR-0016 through ADR-0025)** introduces nine Nodes that emit substantial telemetry to Pulse. Pulse export readiness is a credible "should I be in rotation" signal that needs a defined policy slot.
+- **Telemetry contribution.** ADR-0010 and ADR-0040 treat probe outcomes as a candidate signal source; nothing today lets Pulse observe them in a structured way.
+
+The empirical evidence is in the ADR Context audit: Pulse.Collector's three endpoints return static placeholders; Notify aggregates contributors via a Notify-private `INotifyHealthContributor` interface that does not unify with Kernel's `IHealthContributor`; the Kernel-shipped `IHealthContributor` is implemented (lifecycle contributor) but not consumed by any endpoint outside Notify's local fork. Two Nodes is enough to demonstrate the drift problem.
+
+## Scope Detection
+
+**Multi-repo, multi-Node.** The contract lands in `HoneyDrunk.Kernel.Abstractions` (the zero-dependency contract layer — same precedent as `IGridContext`, `TenantId`, the lifecycle hooks, and ADR-0042's idempotency surface), the runtime endpoints + aggregator in `HoneyDrunk.Kernel`, and amendments fan out to `HoneyDrunk.Pulse.Collector`, `HoneyDrunk.Notify.Hosting.AspNetCore`, and `HoneyDrunk.Notify.Functions`. `HoneyDrunk.Architecture` carries the governance (acceptance, three invariants, catalog, integration-points, infrastructure walkthroughs, agent-rubric update). `HoneyDrunk.Actions` carries the deploy-workflow readiness-gate switch.
+
+**Contract is additive — no forced downstream cascade.** The new contracts (`ReadinessPolicy`, `HealthCheckResponse`, `HealthCheckEntry`, `MapHoneyDrunkHealthEndpoints`, `HealthFunctionExtensions`) are *additive* to `HoneyDrunk.Kernel.Abstractions` and the `HoneyDrunk.Kernel` runtime. Per ADR-0066's Cascade-impact section and ADR-0035, this is an additive minor bump (`HoneyDrunk.Kernel` `0.7.0` → `0.8.0`), not a breaking change. Downstream Nodes that consume `HoneyDrunk.Kernel.Abstractions` are not *forced* to update — they adopt the contract when their own health-endpoint code is amended.
+
+This initiative amends only the **two existing deployable Nodes the ADR D11 names** (Pulse.Collector, Notify Worker + Functions). Notify.Cloud, Operator, Agents, HoneyHub, Audit, Communications all compose the helper at their own standup — those are deliberately **out of scope** here (see Cross-Cutting Concerns).
+
+**Cross-initiative version coordination with ADR-0042.** ADR-0042 packet 02 also bumps `HoneyDrunk.Kernel` to `0.8.0`. If both initiatives run concurrently they share the `0.8.0` line. The first-to-merge owns the bump; the second appends to the in-progress `[0.8.0]` CHANGELOG entry without re-bumping. Packet 02 of this initiative carries the explicit coordination guidance.
+
+**No new-Node scaffolding.** Every target repo is a live, scaffolded Node. No empty cataloged repo is touched; no standup ADR is needed.
+
+## Wave Diagram
+
+### Wave 1 (No Dependencies — governance + catalog)
+- [ ] **00** — Architecture: Accept ADR-0066, add the three health-endpoint invariants (`{N1}/{N2}/{N3}`, claimed in `constitution/invariant-reservations.md`; the block is currently **80, 81, 82**), insert the ADR-0066 row into `adrs/README.md`, register the initiative. `Actor=Agent`.
+- [ ] **01** — Architecture: register the health-endpoint contract surface in the Grid catalogs + integration-points docs. `Actor=Agent`. Blocked by: 00.
+
+> **Invariant numbering.** The block for ADR-0066's three new invariants (`{N1}/{N2}/{N3}`) is reserved in `constitution/invariant-reservations.md`, currently claiming **80, 81, 82**. If another ADR's packet 00 races and merges first, shift the ADR-0066 reservation row to the new contiguous triple and update every `{N1}/{N2}/{N3}` placeholder in this initiative's packets. Never reuse a claimed number.
+
+### Wave 2 (Depends on Wave 1 — contract foundation)
+- [ ] **02** — Kernel: add `ReadinessPolicy`, `HealthCheckResponse`, `HealthCheckEntry`, and the contributor-registration shape to `HoneyDrunk.Kernel.Abstractions`. `Actor=Agent`. Blocked by: 00. **Version-bumping packet for `HoneyDrunk.Kernel` (`0.7.0` → `0.8.0`)** — see Cross-Initiative Coordination with ADR-0042 below.
+
+### Wave 3 (Depends on Wave 2 — runtime + docs, parallel)
+- [ ] **03** — Kernel: add `MapHoneyDrunkHealthEndpoints` (ASP.NET Core), `HealthFunctionExtensions` (Functions host), the aggregator with worst-status-wins + critical-degraded escalation + per-contributor timeout, the IETF response writer, and the Pulse telemetry contribution to the `HoneyDrunk.Kernel` runtime. `Actor=Agent`. Blocked by: 02.
+- [ ] **04** — Kernel: amend `HoneyDrunk.Kernel/docs/Health.md` with the ADR-0066 endpoint contract, `ReadinessPolicy` model, aggregation rules, Container Apps probe defaults, telemetry, and migration notes. `Actor=Agent`. Blocked by: 03.
+
+### Wave 4 (Depends on Wave 3 — Node rollouts, parallel)
+- [ ] **05** — Pulse: amend `Pulse.Collector/Endpoints/HealthEndpoints.cs` to call `MapHoneyDrunkHealthEndpoints`; register contributors with `ReadinessPolicy`; wire host auth for `/health`. `Actor=Agent`. Blocked by: 03.
+- [ ] **06** — Notify: introduce `NotifyHealthContributorAdapter`, amend `NotifyHealthEndpointsExtensions` and `HealthFunction` to use the Kernel helpers, mark `INotifyHealthContributor` and its friends `[Obsolete]`. `Actor=Agent`. Blocked by: 03.
+
+### Wave 5 (Depends on Wave 4 — Notify reconciliation closure)
+- [ ] **07** — Notify: amend contributors to implement `IHealthContributor` directly; remove `INotifyHealthContributor`, `NotifyHealthEvaluator`, `NotifyHealthReport`, `NotifyHealthStatus`, `NotifyHealthContributorAdapter`. `Actor=Agent`. Blocked by: 06. Honour the ADR-0035 60-day `[Obsolete]` deprecation window (or document a tighter window).
+
+### Wave 6 (Infra walkthroughs + agent updates + deploy gate — parallel)
+- [ ] **08** — Architecture: per-Node Container Apps probe walkthroughs in `repos/HoneyDrunk.{Node}/` for Pulse, Notify, and the planned Notify.Cloud/Operator/Agents/HoneyHub. `Actor=Agent`. Blocked by: 00, 03.
+- [ ] **09** — Architecture: amend `.claude/agents/review.md` and (conditionally) `.claude/agents/security.md` with the ADR-0066 checklist. `Actor=Agent`. Blocked by: 00.
+- [ ] **10** — Actions: switch the Container Apps deploy workflow's readiness-gate probe from `/health` to `/health/ready` (anonymous, empty-body). `Actor=Agent`. Blocked by: 03.
+
+Packets within a wave run in parallel. **Wave-3 packets 03 and 04** share the Kernel solution: 03 is the runtime code; 04 amends the docs. Land 03 first so 04's docs reference live code. **Wave-4 packets 05 and 06** are independent — different repos. **Wave-6 packets 08, 09, 10** are independent — different docs targets / different repos.
+
+Packet 02 is the version-bumping packet for `HoneyDrunk.Kernel`; packets 03, 04 append to the in-progress `[0.8.0]` CHANGELOG. Packet 05 bumps `HoneyDrunk.Pulse` one minor version. Packet 06 bumps `HoneyDrunk.Notify` one minor version; packet 07 bumps Notify again (the removal completes the reconciliation per the ADR-0035 deprecation-window pattern).
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0066](./00-architecture-adr-0066-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [Health-endpoint contract catalog](./01-architecture-health-endpoint-catalog.md) | Architecture | Agent | 1 | 00 |
+| 02 | [Kernel `ReadinessPolicy` + IETF response shape](./02-kernel-readiness-policy-and-response-shape.md) | Kernel | Agent | 2 | 00 |
+| 03 | [Kernel health-endpoints runtime](./03-kernel-health-endpoints-runtime.md) | Kernel | Agent | 3 | 02 |
+| 04 | [Kernel `docs/Health.md` amendment](./04-kernel-docs-health-md-amendment.md) | Kernel | Agent | 3 | 03 |
+| 05 | [Pulse.Collector adopt Kernel helper](./05-pulse-collector-adopt-kernel-helper.md) | Pulse | Agent | 4 | 03 |
+| 06 | [Notify bridge adapter + adopt Kernel helper](./06-notify-bridge-adapter-and-adopt-kernel-helper.md) | Notify | Agent | 4 | 03 |
+| 07 | [Notify remove private contributor interface](./07-notify-remove-private-contributor-interface.md) | Notify | Agent | 5 | 06 |
+| 08 | [Container Apps probe walkthroughs](./08-architecture-container-apps-probe-walkthroughs.md) | Architecture | Agent | 6 | 00, 03 |
+| 09 | [Review + security specialist checklist](./09-architecture-review-agent-and-security-specialist-checklist.md) | Architecture | Agent | 6 | 00 |
+| 10 | [Deploy-workflow readiness-gate switch](./10-actions-deploy-workflow-readiness-gate-switch.md) | Actions | Agent | 6 | 03 |
+
+## Version Bumps
+
+- **`HoneyDrunk.Kernel`** — packet 02 is the first packet on the solution in this initiative; it bumps every non-test `.csproj` to the same new **minor** version `0.7.0` → `0.8.0` (new feature: the health-endpoint contract surface; additive, no break). Packets 03 and 04 append to the in-progress `[0.8.0]` CHANGELOG only (invariant 27). Per-package CHANGELOGs: `HoneyDrunk.Kernel.Abstractions` gets an entry from packet 02; `HoneyDrunk.Kernel` gets an entry from packet 03 (runtime types) and packet 04 (docs note in the repo-level CHANGELOG; the per-package CHANGELOG is unchanged by docs).
+- **`HoneyDrunk.Pulse`** — packet 05 bumps the whole solution one minor version (`0.3.0` → `0.4.0`; the wire shape changes — probes empty body, `/health` IETF, auth-required). Confirm current version at execution time.
+- **`HoneyDrunk.Notify`** — packet 06 bumps the whole solution one minor version. Packet 07 bumps again (the removal completes the reconciliation per the ADR-0035 deprecation-window pattern). Confirm current versions at execution time.
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; governance/catalog/docs edits only.
+- **`HoneyDrunk.Actions`** — not a versioned .NET solution; workflow YAML edits only. CHANGELOG entry if the Actions repo carries one.
+
+## Cross-Initiative Coordination with ADR-0042
+
+ADR-0042 (Idempotency) and ADR-0066 (Health endpoints) both add additive contracts to `HoneyDrunk.Kernel.Abstractions` and both want the `0.7.0` → `0.8.0` minor bump. Coordination rule:
+
+- **First-to-merge owns the bump.** Whichever initiative's Kernel-Abstractions packet (ADR-0042 packet 02 or ADR-0066 packet 02) merges first executes the version bump in its commit.
+- **Second-to-merge appends to the in-progress `[0.8.0]` CHANGELOG entry** without re-bumping. Per invariant 27 the solution must not partially overlap a single version line via parallel bumps — the second initiative's PR is rebased onto the first's merge and references the already-bumped `0.8.0` version.
+- **Coordinate at execution time.** The operator sequences ADR-0042 and ADR-0066 deliberately — both can ship in the same `0.8.0` line if landed in the same wave window; if separated by waves, the later initiative may target `0.9.0` instead. State the chosen sequencing in each initiative's packets at execution time.
+
+This is a soft sequencing concern, not a hard blocker. Neither ADR-0042 nor ADR-0066 depends on the other; the version-line-share is purely a CHANGELOG-and-version-bump coordination, not a contract dependency.
+
+## Cross-Cutting Concerns
+
+### Web.Rest is mentioned but has no current `/health` code
+
+ADR-0066 D11 Affected Nodes lists `HoneyDrunk.Web.Rest` as adopting the Kernel helper. A scan at packet-authoring time found **no health-endpoint code in the Web.Rest repo** — Web.Rest is a library/abstractions Node providing `Web.Rest.Abstractions` and `Web.Rest.AspNetCore` for downstream callers; it does not host a `/health` endpoint itself. The ADR's "Web.Rest amends its existing `/health` shape" framing is anticipatory — it applies when a Web.Rest consumer Node first wires its own endpoint via the Web.Rest pipeline.
+
+**No Web.Rest amendment packet exists in this initiative.** When Web.Rest's first deployable consumer (likely a future Node that uses `Web.Rest.AspNetCore`'s default pipeline) lands, that consumer's standup or feature packet will call `MapHoneyDrunkHealthEndpoints` from Kernel — same as Pulse.Collector and Notify.Worker do in this initiative. Web.Rest itself needs no code change; its existing abstractions are unaffected.
+
+If at a future point Web.Rest grows a deployable host (e.g. a Web.Rest sample API hosted in production), that host's first PR would compose the Kernel helper; the work is small and lives outside this initiative.
+
+### Audit, Communications, and the planned Nodes are out of scope
+
+ADR-0066 D11 Affected Nodes also names `HoneyDrunk.Audit`, `HoneyDrunk.Communications`, `HoneyDrunk.Notify.Cloud`, `HoneyDrunk.Operator`, `HoneyDrunk.Agents`, `HoneyHub`, and "all future containerized deployable Nodes" as composing the helper. This initiative does **not** wire them, by design:
+
+- **`HoneyDrunk.Audit`** — composes the helper at its existing standup follow-up (ADR-0031). Audit's health-endpoint code is part of its deploy-time host composition; the ADR-0066 contract is consumed there.
+- **`HoneyDrunk.Communications`** — Communications is an in-process orchestration layer above Notify (per ADR-0019 / ADR-0028 D4). It does not have its own HTTP-fronted deployable surface at v1 — it composes inside Notify.Cloud's host (ADR-0028 D4). When Notify.Cloud composes the helper at standup, it picks up Communications' contributors as well.
+- **`HoneyDrunk.Notify.Cloud`, `Operator`, `Agents`, `HoneyHub`** — standup ADRs (ADR-0027, ADR-0018, ADR-0020, ADR-0002/0003). Each composes the Kernel helper at standup time; this initiative ships the contract those standups consume. Packet 08 adds infrastructure walkthrough stubs where the `repos/{Node}/` folder exists.
+
+This initiative ships **the contract, the runtime, the docs, and conforms the two existing deployable Nodes** (Pulse.Collector, Notify Worker + Functions). Every other consumer adopts the shipped contract in its own track. This keeps the initiative bounded and consistent with the Grid's standup-gets-its-own-ADR rule.
+
+### Notify reconciliation sequencing — bridge then remove
+
+ADR-0066 D9's three-stage reconciliation:
+1. **Packet 06** introduces `NotifyHealthContributorAdapter` and marks `INotifyHealthContributor` and friends `[Obsolete]`. Existing Notify contributor implementations are wrapped in the adapter and registered as `IHealthContributor`. Notify ships in a transitional state — the Notify-private surface still exists but the endpoints go through the Kernel aggregator.
+2. **Packet 07** amends each `INotifyHealthContributor` implementation to implement `IHealthContributor` directly and removes the Notify-private surface (the interface, the evaluator, the report, the status enum, the adapter).
+
+Packets 06 and 07 are split because the removal is a public-API breaking event (`INotifyHealthContributor` is removed) and ADR-0035 mandates an `[Obsolete]` deprecation window of at least 60 days. The bridge in packet 06 keeps Notify's aggregate CHANGELOG from being a breaking event during the window — the contributors keep their existing `INotifyHealthContributor` shape and compile against an unchanged contract until packet 07's removal.
+
+The operator decides whether to honour the 60-day default or document a tighter window in packet 07's PR.
+
+### Auth scheme wiring is a per-Node concern
+
+ADR-0066 D6 makes `/health` auth-required. The mechanics of wiring an auth scheme per Node are **not** ADR-bound — each deployable Node's host composition wires the scheme it prefers (the Studios-internal token, a tenant-administrator token, an Azure Monitor scrape credential).
+
+Packets 05 and 06 ask each Node's executor to confirm the host has an auth scheme wired so `/health` resolves to `401` for unauthenticated requests. If the wiring is non-trivial in a given Node, that Node's packet flags it and proposes a follow-up — but does **not** ship the Node with `/health` anonymous on the assumption "we'll add auth later." Invariant `{N2}` is a hard rule.
+
+### Deploy-workflow change is environment-independent but sequencing matters
+
+Packet 10 changes the readiness-gate probe target from `/health` to `/health/ready` in the deploy workflow. The change is environment-independent (`/health/ready` exists on every revision — both the old placeholder and the new Kernel-helper version expose the path) and can land in any order relative to packets 05 and 06.
+
+**But:** if packet 10 lands and the workflow rolls a new revision whose code is from before packet 05/06, the probe will hit the old `/health/ready` (which returns `{ "status": "Ready" }` JSON, not empty body) — the workflow consumes the status code, not the body, so this still works. The contract drift is cosmetic during the transitional window. After packets 05/06 deploy in every environment, the contract is fully consistent.
+
+The operator should validate the deploy gate after each Node's amendment ships. Packet 10's Human Prerequisites cover this.
+
+### Container App YAML lives in HoneyDrunk.Actions, not in deployable repos
+
+ADR-0066 D5's probe configuration is a Container App YAML concern. ADR-0015 names `job-deploy-container-app.yml` (in `HoneyDrunk.Actions`) as the reusable Container Apps deploy workflow. The probe values are inputs to that workflow.
+
+**This initiative does NOT touch Container App YAML directly.** Packet 08 documents the probe defaults in each Node's infrastructure walkthrough (`repos/{Node}/`); packet 10 amends the deploy workflow's readiness-gate probe target. The actual portal-side application of the probe values to each Container App is a Human Prerequisite in packet 08.
+
+### Deferred follow-ups (explicitly out of scope)
+
+- **Web.Rest health-endpoint adoption** — Web.Rest has no deployable host today; the helper is composed by Web.Rest consumers, not Web.Rest itself.
+- **Audit Node health-endpoint composition** — handled in Audit's standup / follow-up track (ADR-0031).
+- **Communications health-endpoint composition** — composed inside Notify.Cloud's host per ADR-0028 D4; the Notify.Cloud standup track owns it.
+- **Notify.Cloud, Operator, Agents, HoneyHub** — each standup ADR cites ADR-0066 as a prerequisite for its health-endpoint canary; each composes the helper at standup time.
+- **Tenant-facing status page** — ADR-0066 D11 out-of-scope. Composes against the `/health` shape this initiative ships when it lands.
+- **Cross-Node aggregate health dashboard** — ADR-0066 D11 out-of-scope. Consumes the Pulse telemetry signals packet 03 emits; future Pulse work.
+- **Synthetic monitoring** — ADR-0066 D11 — external probes (Azure Monitor synthetic, Pingdom) hit the same endpoints with no additional plumbing.
+- **Per-tenant readiness** — ADR-0066 D11 out-of-scope. Application-layer tenant-rate-limit concern.
+- **`/api/v1/status` tenant-visible SLA signal** — ADR-0066 D11 — separate future decision.
+
+### Site sync
+
+No site-sync flag. ADR-0066 is internal Core-sector infrastructure — no public-facing Studios website content changes.
+
+## Rollback Plan
+
+- **Packets 00–01 (governance/catalog):** revert the PR. ADR returns to Proposed; the three invariants and the catalog entries are removed. No runtime impact.
+- **Packet 02 (Kernel contracts):** revert the PR; the `HoneyDrunk.Kernel` solution rolls back `0.8.0` → `0.7.0`. The contracts are additive — no consuming Node depends on them at runtime until it composes them, so the revert is contained to `HoneyDrunk.Kernel`.
+- **Packet 03 (Kernel runtime):** revert the PR; the endpoint helper / aggregator / response writer / Functions-host helper leave the `HoneyDrunk.Kernel` runtime. Additive — the revert is contained to `HoneyDrunk.Kernel`.
+- **Packet 04 (docs):** revert the PR; the docs roll back. No runtime impact.
+- **Packet 05 (Pulse.Collector):** revert the PR; Pulse.Collector's hand-rolled static endpoints return; the version rolls back. `/health/ready` returns the placeholder `200 OK { "status": "Ready" }` JSON; the deploy workflow (if packet 10 has shipped) probes `/health/ready` and still gets `200`, so the gate continues to work. If `/health` was made auth-required and an external monitoring scrape was hitting it, that scrape returns to anonymous fetch — note the temporary security regression.
+- **Packet 06 (Notify bridge):** revert the PR; Notify's hand-rolled endpoint extension and `HealthFunction` return; the Notify-private surface is no longer marked `[Obsolete]`; the version rolls back. Notify's old behaviour is restored (probe endpoints return `{ "status": "..." }` JSON; `/health/ready` aggregates via `NotifyHealthEvaluator`); the deploy workflow probes `/health/ready` and continues to work.
+- **Packet 07 (Notify removal):** revert the PR; the removed types come back as commits; the bridge adapter returns; contributors return to implementing `INotifyHealthContributor`. This revert is the most surgical of the seven — it leaves Notify in the transitional state from packet 06 rather than the closed-reconciliation state.
+- **Packet 08 (infrastructure walkthroughs):** revert the PR; the walkthroughs roll back. The portal-side Container App probe values stay where the operator applied them; no runtime impact from the revert (the docs were guidance, not enforcement).
+- **Packet 09 (review agent / security specialist):** revert the PR; the rubric checklist rolls back. PR reviews stop checking the ADR-0066 invariants explicitly until re-applied; the invariants themselves stay live in `constitution/invariants.md`.
+- **Packet 10 (deploy-workflow):** revert the PR; the deploy workflow probes `/health` again. **If `/health` has become auth-required (post-packet-05/06 deploy)**, the deploy gate will return `401` and block deploys — DO NOT revert packet 10 in isolation if packets 05/06 have already deployed in any environment. Roll back packets 05/06 first (or supply an auth credential to the deploy probe temporarily).
+
+The most coupled rollback is: if Invariant `{N2}` ships and the Pulse/Notify amendments deploy, the deploy workflow's `/health` probe stops working. The order-of-operations remedy is to land packet 10 before deploys cut over to the new `/health` behaviour — and packet 10 is in the same wave as the Node amendments precisely to keep this coordinated.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.

--- a/generated/issue-packets/active/adr-0066-health-endpoints/handoff-wave3-kernel-runtime.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/handoff-wave3-kernel-runtime.md
@@ -1,0 +1,120 @@
+# Handoff — Wave 3: Kernel Runtime
+
+**Initiative:** `adr-0066-health-endpoints`
+**Wave transition:** Wave 2 (contract foundation) → Wave 3 (Kernel runtime + docs)
+**Read once at the wave boundary. Immutable per invariant 24.**
+
+## What Wave 1 + Wave 2 landed
+
+- **Packet 00** — ADR-0066 flipped to **Accepted**. The ADR-0066 row inserted into `adrs/README.md`. Three new invariants added to `constitution/invariants.md` under a new `## Health Endpoint Invariants` section, numbered **54, 55, 56**:
+  1. **54** — Every HTTP-fronted deployable Node exposes `/health/live`, `/health/ready`, and `/health` via Kernel's `MapHoneyDrunkHealthEndpoints` (or the Functions-host equivalent), aggregating `IHealthContributor` instances per the readiness-policy model.
+  2. **55** — `/health/live` and `/health/ready` are anonymous; `/health` is auth-required.
+  3. **56** — `IHealthContributor` `output` strings must not carry secrets, connection strings, tenant identifiers, or provider opaque IDs (per ADR-0049 data-classification taxonomy). Complements (does not restate) invariant 8.
+- **Packet 01** — the health-endpoint contract surface (`ReadinessPolicy`, `HealthCheckResponse`, `HealthCheckEntry`, `MapHoneyDrunkHealthEndpoints`, `HealthFunctionExtensions`) registered in `catalogs/contracts.json` and `catalogs/relationships.json` under `honeydrunk-kernel`. `catalogs/nodes.json` was NOT modified (it has no `exposes` field). `repos/HoneyDrunk.Kernel/integration-points.md` gained a "Health endpoints (ADR-0066)" subsection; `repos/HoneyDrunk.Notify/integration-points.md` gained a "Health contributor reconciliation (ADR-0066)" subsection.
+- **Packet 02** — `HoneyDrunk.Kernel.Abstractions` now exposes the ADR-0066 contracts:
+  - `ReadinessPolicy` enum — `Required` (default; zero-value), `OptionalReported`, `NotReadinessRelevant`.
+  - `HealthCheckResponse` record — IETF `application/health+json` body root (`Status`, `Version?`, `ReleaseId?`, `Checks` dictionary).
+  - `HealthCheckEntry` record — per-contributor entry (`Status`, `Time`, optional `Output`).
+  - The contributor-registration helper shape (extension method or registration record) for declaring a contributor's `ReadinessPolicy` at composition.
+  - The `HoneyDrunk.Kernel` solution is at `0.8.0` (or the same `0.8.0` line shared with ADR-0042 if both initiatives are concurrent).
+
+ADR-0066's decisions are now live rules. Packets 03 and 04 implement the runtime endpoints + docs that consume the catalog-registered contracts.
+
+## What Wave 3 must deliver
+
+### Packet 03 — Kernel runtime endpoints
+
+Build the runtime half of ADR-0066 in **`HoneyDrunk.Kernel`**:
+
+- **`HoneyDrunk.Kernel.Hosting.AspNetCore.HealthEndpoints`** — static class with `MapHoneyDrunkHealthEndpoints(this IEndpointRouteBuilder endpoints)` that maps:
+  - `/health/live` — anonymous, returns `200` (empty body) when alive, `503` only when the lifecycle stage is `Stopping`/`Stopped`. **Does NOT consult contributors** (ADR-0066 D7 — protects against feedback-loop restarts).
+  - `/health/ready` — anonymous, returns `200`/`503` (empty body) based on the readiness aggregate (`ReadinessPolicy.Required` contributors only).
+  - `/health` — auth-required (via `RequireAuthorization()` or equivalent), returns the IETF `application/health+json` body.
+- **`HoneyDrunk.Kernel.Hosting.AspNetCore.HealthFunctionExtensions`** — static class exposing `ExecuteHealthLiveAsync`, `ExecuteHealthReadyAsync`, `ExecuteHealthAggregateAsync` for the Functions-host case. Consumers compose these inside their own `[Function]` `[HttpTrigger]`-bound functions. **Pinned: ships in the new optional `HoneyDrunk.Kernel.Hosting.Functions` package** (not in `HoneyDrunk.Kernel`) to keep `Microsoft.Azure.Functions.Worker.*` out of pure-ASP.NET-Core consumers. The new package joins the solution at `0.8.0` with its own `CHANGELOG.md` + `README.md` from the first commit (invariants 12, 27).
+- **Aggregator** with worst-status-wins + critical-degraded escalation (`Degraded` + `IsCritical == true` → `Unhealthy` per D4) + throwing-contributor handling (treated as `Unhealthy`, exception message as `output`, aggregation continues — does not short-circuit) + per-contributor timeout (1-second default, configurable per registration). Invokes contributors in `Priority` order. Exposes both a full aggregate (for `/health`) and a readiness aggregate (for `/health/ready`, filtered to `ReadinessPolicy.Required`).
+- **IETF response writer** — serializes the aggregator's output to `application/health+json` per ADR-0066 D2 sample. Status mapping: `Healthy`→`"pass"`, `Degraded`→`"warn"`, `Unhealthy`→`"fail"` (D3). Content-Type `application/health+json`.
+- **Pulse telemetry contribution per D10:**
+  - Counter `honeydrunk.health.probes` with `(node, endpoint, status_code, outcome)` dimensions.
+  - Histogram `honeydrunk.health.contributor.duration` with `(node, contributor)` dimensions.
+  - Structured log: Warning on failed probe; Error on failed critical contributor; Error on first-time-after-success `503`.
+  - Emitted via `ITelemetryActivityFactory`. **NOT** audit events (D10).
+
+### Packet 04 — Kernel docs amendment
+
+Amend `HoneyDrunk.Kernel/docs/Health.md` with new sections covering the ADR-0066 endpoint contract, `ReadinessPolicy` model, aggregation rules, Container Apps probe defaults (D5), Pulse telemetry (D10), the PII rule (D8), and migration notes for the Pulse/Notify amendments in packets 05/06/07. Keep the existing `IHealthCheck`/`HealthStatus`/`CompositeHealthCheck` narrative (the internal-primitive story stays accurate). Explicitly note that `IHealthCheck` is NOT consulted by the endpoint — only `IHealthContributor` participates.
+
+This is the **second packet on the `HoneyDrunk.Kernel` solution in this initiative** (after packet 02). Per invariant 27, packet 02 already bumped the solution to `0.8.0`; packet 03 does NOT bump again — it appends to the in-progress `[0.8.0]` repo-level `CHANGELOG.md` entry and adds a per-package `HoneyDrunk.Kernel/CHANGELOG.md` entry. Packet 04 (docs) also does NOT bump — it appends a docs note to the in-progress `[0.8.0]` repo-level CHANGELOG.
+
+## Interface signatures for downstream packets
+
+The shape packets 05/06 will compose against:
+
+```csharp
+// ASP.NET Core host:
+public static IEndpointRouteBuilder MapHoneyDrunkHealthEndpoints(this IEndpointRouteBuilder endpoints);
+
+// Functions host:
+public static class HealthFunctionExtensions
+{
+    public static Task<HttpResponseData> ExecuteHealthLiveAsync(HttpRequestData req, /* DI args */);
+    public static Task<HttpResponseData> ExecuteHealthReadyAsync(HttpRequestData req, /* DI args */);
+    public static Task<HttpResponseData> ExecuteHealthAggregateAsync(HttpRequestData req, /* DI args */);
+}
+
+// Contributor registration with ReadinessPolicy (shape per packet 02):
+services.AddHealthContributor<MyContributor>(ReadinessPolicy.Required); // or similar
+```
+
+`IHealthContributor` (already in `Kernel.Abstractions.Lifecycle`):
+```csharp
+public interface IHealthContributor
+{
+    string Name { get; }
+    int Priority { get; }
+    bool IsCritical { get; }
+    Task<(HealthStatus status, string? message)> CheckHealthAsync(CancellationToken cancellationToken = default);
+}
+```
+
+`ReadinessPolicy` (from packet 02):
+```csharp
+public enum ReadinessPolicy
+{
+    Required = 0,         // gates /health/ready (default)
+    OptionalReported,     // in /health body only
+    NotReadinessRelevant  // only in /health, not in readiness aggregation
+}
+```
+
+## Frozen / do-not-touch
+
+- **`IHealthContributor` and `IReadinessContributor` (in `Kernel.Abstractions.Lifecycle`).** These existed before ADR-0066 and remain unchanged. The endpoint aggregator consumes `IHealthContributor`. `IReadinessContributor` is a parallel surface that exists today; ADR-0066 does NOT remove it but the endpoint code only reads `IHealthContributor`. If `IReadinessContributor` becomes redundant after ADR-0066's `ReadinessPolicy` model lands, that is a follow-up concern — not packet 03's.
+- **`IHealthCheck` and `HealthStatus` (in `Kernel.Abstractions.Health`).** The simpler internal-component primitive stays as-is per ADR-0066 D4. The endpoint aggregator does NOT consult `IHealthCheck`.
+- **`CompositeHealthCheck` (in `Kernel/Health/`).** The simple internal aggregator for `IHealthCheck` stays as-is. The endpoint uses its own aggregator that consumes `IHealthContributor` only.
+- **`NodeLifecycleHealthContributor` (in `Kernel/Diagnostics/`).** The existing lifecycle contributor stays as-is. Its `IsCritical == true` means a `Degraded` from it escalates the aggregate to `Unhealthy` per D4 — confirm this works in unit tests.
+
+## Invariants binding Wave 3
+
+- **Invariant 1** — `HoneyDrunk.Kernel.Abstractions` has zero runtime dependencies on other HoneyDrunk packages. Packet 03 lives in the runtime package; it can take ASP.NET Core dependencies.
+- **Invariant 2** — runtime packages depend on Abstractions; `HoneyDrunk.Kernel` depends on `HoneyDrunk.Kernel.Abstractions`.
+- **Invariant 4** — DAG; Kernel is at the root. No `PackageReference` to other HoneyDrunk runtime packages.
+- **Invariant 13** — all public APIs have XML documentation.
+- **Invariant 27** — one version across the solution. Packet 02 set `0.8.0`; packet 03 does NOT bump again — it appends to the `[0.8.0]` CHANGELOG.
+- **Invariant 51** — no `Thread.Sleep` in tests. Timeout / duration tests drive an injected `TimeProvider` / cancellation tokens.
+- **Invariant `{N2}`** — `/health` is auth-required. The endpoint mapping wires `RequireAuthorization()` (or equivalent); host configures the scheme.
+- **Invariant `{N3}`** — contributor `output` strings carry no secrets / connection strings / tenant identifiers / provider opaque IDs. The aggregator and response writer do NOT auto-redact; the contributor is responsible at the report site. XML-doc this on `HealthCheckEntry.Output` (already done in packet 02).
+- **ADR-0066 D7** — `/health/live` does NOT consult contributors. It returns based on lifecycle stage only.
+- **ADR-0066 D10** — probe outcomes are NOT audit events. Pulse telemetry only.
+- **ADR-0066 Operational Consequences** — the per-contributor timeout default is 1 second; configurable per registration.
+
+## Cross-Initiative Coordination — ADR-0042
+
+If ADR-0042 packet 02 has already merged when this packet starts, the `HoneyDrunk.Kernel` solution is already at `0.8.0`. Packet 03 (this packet) and packet 04 (docs) of ADR-0066 both append to the in-progress `[0.8.0]` CHANGELOG without re-bumping.
+
+If ADR-0042 has not yet merged, the operator decides the sequencing — coordinate so the two initiatives share the `0.8.0` line cleanly.
+
+## Acceptance gate for the wave
+
+Packets 03 and 04's PRs pass the `pr-core.yml` tier-1 gate and the Kernel contract-shape canary. `HoneyDrunk.Kernel` exposes `MapHoneyDrunkHealthEndpoints` and `HealthFunctionExtensions` (and the docs accurately describe them). The aggregator works correctly under unit tests (worst-status-wins, criticality escalation, throwing-contributor, timeout, readiness-policy filtering). `/health/live` does not consult contributors. `/health` requires auth.
+
+**Human package release at the Wave 3→4 boundary — agents never tag.** Packets 05 and 06 (Wave 4) build against `HoneyDrunk.Kernel` / `HoneyDrunk.Kernel.Abstractions` `0.8.0` and `HoneyDrunk.Kernel.Hosting.Functions` `0.8.0` (new package, pinned in packet 03). Those artifacts reach the package feed only after a human pushes a git release tag on `HoneyDrunk.Kernel`. After packets 02, 03, and 04 have all merged (and after the ADR-0042 packet 02 if it shares the `0.8.0` line), a human tags/releases `HoneyDrunk.Kernel` `0.8.0` AND `HoneyDrunk.Kernel.Hosting.Functions` `0.8.0` so Wave 4 can compile.

--- a/generated/issue-packets/active/adr-0066-health-endpoints/handoff-wave4-node-rollouts.md
+++ b/generated/issue-packets/active/adr-0066-health-endpoints/handoff-wave4-node-rollouts.md
@@ -1,0 +1,151 @@
+# Handoff — Wave 4: Node Rollouts
+
+**Initiative:** `adr-0066-health-endpoints`
+**Wave transition:** Wave 3 (Kernel runtime + docs) → Wave 4 (Pulse + Notify amendments)
+**Read once at the wave boundary. Immutable per invariant 24.**
+
+## What Wave 3 landed
+
+- **Packet 03** — `HoneyDrunk.Kernel` runtime now ships:
+  - `HoneyDrunk.Kernel.Hosting.AspNetCore.HealthEndpoints` with `MapHoneyDrunkHealthEndpoints(this IEndpointRouteBuilder endpoints)`.
+  - `HoneyDrunk.Kernel.Hosting.AspNetCore.HealthFunctionExtensions` with `ExecuteHealthLiveAsync` / `ExecuteHealthReadyAsync` / `ExecuteHealthAggregateAsync` — pinned to ship in the new `HoneyDrunk.Kernel.Hosting.Functions` package (per packet 03's pinned split), not in `HoneyDrunk.Kernel`.
+  - The aggregator with worst-status-wins + critical-degraded escalation + per-contributor 1-second timeout (configurable per registration) + throwing-contributor handling.
+  - The IETF response writer that serializes the aggregator output to `application/health+json`.
+  - The Pulse telemetry contribution per D10: counter `honeydrunk.health.probes`, histogram `honeydrunk.health.contributor.duration`, Warning/Error structured logs on failures.
+  - `HoneyDrunk.Kernel` is at `0.8.0` (along with `HoneyDrunk.Kernel.Abstractions` `0.8.0` from packet 02).
+- **Packet 04** — `HoneyDrunk.Kernel/docs/Health.md` documents the contract end-to-end: three endpoints, IETF response shape, `ReadinessPolicy`, aggregation rules, Container Apps probe defaults (D5), Pulse telemetry, the PII rule.
+
+Packets 02 + 03 + 04 share the `[0.8.0]` line. The Kernel `[0.8.0]` CHANGELOG entry covers (a) the contract additions (packet 02), (b) the runtime endpoints + aggregator + helpers (packet 03), and (c) the docs amendment note (packet 04).
+
+**Human package release at this boundary.** Before Wave 4 packets can compile, a human tags/releases `HoneyDrunk.Kernel` `0.8.0` AND `HoneyDrunk.Kernel.Hosting.Functions` `0.8.0` (the new package pinned in packet 03) so the artifacts reach the package feed. Agents never tag.
+
+## What Wave 4 must deliver
+
+### Packet 05 — Pulse.Collector adoption
+
+Amend `HoneyDrunk.Pulse.Collector/Endpoints/HealthEndpoints.cs`:
+- Replace the three hand-rolled `MapGet` calls with `return endpoints.MapHoneyDrunkHealthEndpoints();`.
+- The method name `MapHealthEndpoints` stays (downstream callers keep their call site).
+
+Amend Pulse.Collector's host composition (`Program.cs` or equivalent):
+- Register `NodeLifecycleHealthContributor` with `ReadinessPolicy.Required` (the default).
+- Register any Pulse-specific contributor with the appropriate policy — Pulse-export-style contributors should be `ReadinessPolicy.OptionalReported` per ADR-0066 D7 (Pulse should not pull itself out of rotation on its own export's degradation).
+- Confirm the host has an auth scheme wired so `/health` is auth-gated (Invariant `{N2}`). If Pulse.Collector currently has no auth scheme, this packet must add one (a Studios-internal token, Azure Monitor scrape credential, or config flag — document the choice in the PR).
+
+Bump every non-test `.csproj` in the `HoneyDrunk.Pulse` solution one minor version (`0.3.0` → `0.4.0` or whatever the current is). Repo-level `CHANGELOG.md` new-version entry.
+
+### Packet 06 — Notify bridge adapter + adoption
+
+Amend `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthEndpointsExtensions.cs`:
+- Replace the hand-rolled `MapGet` calls with `return endpoints.MapHoneyDrunkHealthEndpoints();`.
+
+Amend `HoneyDrunk.Notify.Functions/HealthFunction.cs`:
+- Replace the body of `Run` with a call to `HealthFunctionExtensions.ExecuteHealthAggregateAsync(request, ...)` from Kernel.
+
+Introduce `HoneyDrunk.Notify.Hosting.AspNetCore/Health/NotifyHealthContributorAdapter.cs`:
+- New class `NotifyHealthContributorAdapter(INotifyHealthContributor inner, string name, int priority, bool isCritical, ReadinessPolicy policy) : IHealthContributor` that maps `NotifyHealthReport` → `(HealthStatus, string?)`.
+
+Amend Notify's host composition:
+- Wrap each registered `INotifyHealthContributor` in the adapter and register as `IHealthContributor` with an explicit `ReadinessPolicy`.
+- Confirm the host's auth scheme covers `/health` (Invariant `{N2}`). Notify already uses `HoneyDrunk.Auth` for inbound REST — confirm the same scheme is reachable on `/health`, or wire a separate scheme.
+
+Mark `INotifyHealthContributor`, `NotifyHealthEvaluator`, `NotifyHealthReport`, `NotifyHealthStatus` `[Obsolete]` with a message naming packet 07 as the removal point.
+
+Bump every non-test `.csproj` in the `HoneyDrunk.Notify` solution one minor version. The Worker and Functions hosts go to the same version together.
+
+## Wave-4 sequencing — Pulse and Notify are independent
+
+Packets 05 and 06 target different repos with no shared state — they can run in parallel.
+
+Both packets depend on packet 03 (the Kernel runtime). Both build against `HoneyDrunk.Kernel` `0.8.0` published at the Wave 3→4 boundary.
+
+## Deploy-workflow coordination — Notify is more sensitive
+
+Both Pulse.Collector and Notify.Worker have Container Apps deploy gates that currently probe `/health`. After this wave:
+- `/health` becomes auth-required (Invariant `{N2}`).
+- An unauthenticated probe from the deploy workflow returns `401`, breaking the gate.
+
+**Packet 10 (Wave 6)** switches the deploy-workflow's readiness gate from `/health` to `/health/ready` — anonymous, empty-body 200/503. Coordinate deploy windows:
+- **Best case:** packet 10's workflow change lands in the deploy environment **before** packets 05/06 deploy their `/health`-auth-required revisions. The gate continues to work.
+- **Acceptable case:** packets 05/06 deploy with a temporary credential supplied to the deploy probe, OR with a temporary fallback to `/health/live`. Packet 10 lands shortly after and the temporary accommodation is removed.
+- **Unacceptable case:** packets 05/06 deploy with no accommodation and the deploy gate gets `401`. The deploy is blocked.
+
+State the chosen deploy sequencing in the PR. The same applies to the Notify Functions deploy gate which probes `/api/health` today.
+
+## Interface signatures and constraints
+
+```csharp
+// From HoneyDrunk.Kernel.Abstractions (packet 02):
+public enum ReadinessPolicy { Required = 0, OptionalReported, NotReadinessRelevant }
+
+public interface IHealthContributor
+{
+    string Name { get; }
+    int Priority { get; }
+    bool IsCritical { get; }
+    Task<(HealthStatus status, string? message)> CheckHealthAsync(CancellationToken cancellationToken = default);
+}
+
+// From HoneyDrunk.Notify (current, marked [Obsolete] in packet 06):
+public interface INotifyHealthContributor
+{
+    Task<NotifyHealthReport> CheckAsync(CancellationToken cancellationToken = default);
+}
+
+// Bridge (introduced in packet 06):
+public sealed class NotifyHealthContributorAdapter(
+    INotifyHealthContributor inner,
+    string name,
+    int priority,
+    bool isCritical,
+    ReadinessPolicy policy) : IHealthContributor
+{
+    public string Name => name;
+    public int Priority => priority;
+    public bool IsCritical => isCritical;
+    public ReadinessPolicy Policy => policy; // recorded for the host's registration step
+    public async Task<(HealthStatus status, string? message)> CheckHealthAsync(CancellationToken ct = default)
+    {
+        var report = await inner.CheckAsync(ct);
+        var status = report.Status switch
+        {
+            NotifyHealthStatus.Healthy => HealthStatus.Healthy,
+            NotifyHealthStatus.Degraded => HealthStatus.Degraded,
+            NotifyHealthStatus.Unhealthy => HealthStatus.Unhealthy,
+            _ => HealthStatus.Unhealthy
+        };
+        return (status, report.Message);
+    }
+}
+```
+
+## Frozen / do-not-touch
+
+- **Notify hot-path contracts.** `INotificationSender`, `INotificationGateway`, the decision-log and cadence contracts (invariants 41–43). Wave 4 only touches the health-endpoint surface.
+- **`NotifyHealthEvaluator` body and `NotifyHealthReport` / `NotifyHealthStatus` shape.** Packet 06 marks them `[Obsolete]` but keeps them compileable. Packet 07 (Wave 5) does the removal.
+- **`DefaultNotifyHealthContributor` body.** Packet 06 keeps it implementing `INotifyHealthContributor` (now wrapped in the adapter at registration). Packet 07 (Wave 5) amends it to implement `IHealthContributor` directly.
+- **Container App YAML in `HoneyDrunk.Actions`.** Packet 10 owns workflow changes; packet 08 owns infrastructure walkthroughs. Wave 4 packets do not touch these.
+
+## Invariants binding Wave 4
+
+- **Invariant 4** — DAG. Pulse and Notify depend on Kernel; no inversion.
+- **Invariant 9** — Vault is the only source of secrets. Any auth credential `/health` requires resolves via `ISecretStore`.
+- **Invariants 41–43** — Notify hot-path contracts unchanged.
+- **Invariant 13** — XML documentation on new public types (the adapter is public).
+- **Invariant 27** — one version across each solution. Bump every non-test `.csproj` together; per-package CHANGELOGs only for changed packages.
+- **Invariant 51** — no `Thread.Sleep` in test code.
+- **Invariant `{N2}`** — `/health` is auth-required. Hard rule; do not ship Pulse or Notify with `/health` anonymous on the assumption "we'll add auth later."
+- **Invariant `{N3}`** — contributor `output` strings carry no secrets / connection strings / tenant identifiers / provider opaque IDs. Re-audit Notify's existing contributors' `Message` strings during the adapter wrap; audit any new Pulse contributors at registration time.
+
+## Acceptance gate for the wave
+
+Both packets 05 and 06 pass `pr-core.yml`. Endpoint contract tests prove:
+- `/health/live` returns `200` (empty body) when alive, `503` when stopping.
+- `/health/ready` returns `200`/`503` (empty body) based on `Required` contributors.
+- `/health` returns IETF body on authenticated request, `401` on unauthenticated.
+
+Both repos at their new minor versions. CHANGELOGs accurate.
+
+**Human package release at the Wave 4→5 boundary.** Packet 07 builds against `HoneyDrunk.Notify`'s post-packet-06 minor version. A human tags/releases that version after packet 06 merges so packet 07 can compile against an unchanged-as-released Notify line.
+
+After this wave, both deployable Nodes consume the Grid-wide health-endpoint contract. The Notify-private surface is `[Obsolete]` but compileable. Wave 5 closes the reconciliation.

--- a/generated/issue-packets/active/adr-0069-currency-handling/00-architecture-adr-0069-acceptance.md
+++ b/generated/issue-packets/active/adr-0069-currency-handling/00-architecture-adr-0069-acceptance.md
@@ -1,0 +1,145 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "core", "docs", "adr-0069", "wave-1"]
+dependencies: []
+adrs: ["ADR-0069"]
+accepts: ["ADR-0069"]
+wave: 1
+initiative: adr-0069-currency-handling
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0069 — flip status, register the initiative, record the four currency conventions
+
+## Summary
+Flip ADR-0069 (Currency Handling and Money Representation) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, and register the `adr-0069-currency-handling` initiative in `initiatives/active-initiatives.md`. ADR-0069 deliberately introduces **no new numbered Grid-wide invariants**; the four conventions it commits (currency code is always uppercase ISO 4217 alpha-3; no implicit FX conversion; JSON `amount` is a string, never a number; audit money fields are split into `monetary_value` + `currency_code`) are enforced by canary tests in the Kernel.Abstractions implementation packet, not by lines in `constitution/invariants.md`.
+
+## Context
+ADR-0069 was authored 2026-05-23 and commits the Grid's internal representation of monetary values: a `Money` record carrying `decimal Amount` and a validated `CurrencyCode`, arithmetic that throws on currency mismatch, banker's rounding as the default mode, multi-currency-aware-but-not-converting storage, USD as the default currency, machine-readable `ToString`, and a JSON serialization shape of `{"amount": "...", "currency": "..."}` with `amount` as a string. ADR-0026 D5 froze `BillingEvent` count-only; ADR-0069 D7 preserves that — `Money` is a separate, additive primitive in `HoneyDrunk.Kernel.Abstractions`, not a field on `BillingEvent`. ADR-0037 (Stripe) is the upstream price authority; ADR-0069 stores Stripe-derived monetary outcomes at the webhook boundary. ADR-0052's in-memory cost-rate cache is updated from implicit-`decimal` to explicit `Money(rate, CurrencyCode.Usd)` per D10. ADR-0030 audit emits adopt the D11 two-field convention.
+
+The ADR decides:
+- **D1** — `Money` is a `HoneyDrunk.Kernel.Abstractions` record carrying `decimal Amount` and a `CurrencyCode`. Naming rule: `Money` (record, no `I`); `CurrencyCode` is a `readonly record struct` validated at construction.
+- **D2** — arithmetic operators throw `CurrencyMismatchException` on mismatch; comparisons across currencies also throw; no implicit FX; `Money.Zero(CurrencyCode)` is the only construction shortcut without an amount.
+- **D3** — banker's rounding (`MidpointRounding.ToEven`) is the default for `Money.Round(int decimals, MidpointRounding mode = MidpointRounding.ToEven)`. `AwayFromZero` is supported as an explicit opt-in; truncation is deliberately *not* a `Money.Round` mode.
+- **D4** — `CurrencyCode` validates an ISO 4217 alpha-3 code (uppercase) at construction. Seed list: USD, EUR, GBP, JPY, CAD, AUD, CHF. Unknown codes throw `UnknownCurrencyCodeException`. Per-currency metadata (default decimals — 2 for fiat, 3 for JOD/BHD/KWD/OMR/TND, 0 for JPY) lives alongside the codes.
+- **D5** — multi-currency aware, not multi-currency converting; Stripe owns presentation and FX at the boundary; aggregate-revenue reporting that needs a single denomination converts at read-time and records timestamp + rate; the FX-rate service is out of scope and deferred to a future ADR.
+- **D6** — default currency is USD (Florida-registered Studio); per-product non-USD defaults are PDR-overridable.
+- **D7** — `BillingEvent` does **not** carry `Money` (ADR-0026 D5's frozen count-and-meter shape preserved). `Money` appears in invoice records, audit emits that record monetary outcomes, consumer-app price catalogs, the AI cost ledger, and Web.Rest payloads.
+- **D8** — `Money.ToString()` returns a locale-independent, machine-readable string (`"123.45 USD"`). Locale-aware formatting lives at the presentation layer, reading the user's explicit locale preference.
+- **D9** — JSON serialization shape: `{"amount": "123.45", "currency": "USD"}`. `amount` is a JSON string (precision preservation); `currency` is the ISO 4217 alpha-3 code uppercase; no `decimals` field. A System.Text.Json converter ships in `HoneyDrunk.Kernel.Abstractions`.
+- **D10** — the ADR-0052 in-memory cost-rate cache is denominated in USD at Phase 1; the cache value type is updated to `Money(rate, CurrencyCode.Usd)`.
+- **D11** — audit emits that record monetary outcomes use a two-field convention — `monetary_value` (JSON string) and `currency_code` (ISO alpha-3) — flat on the audit event, not nested. In-memory is `Money`; the emitter projects to the two fields.
+- **D12** — explicitly deferred: FX-rate service, multi-currency tax handling (Stripe Tax owns), crypto/token currencies, historical FX rate storage, per-tenant currency preference, subunit/minor-unit storage, invoice/receipt UI.
+
+ADR-0069 is a **policy / contract** ADR. The concrete code — `Money` and `CurrencyCode` in Kernel.Abstractions with arithmetic / rounding / serialization / canary suite, the AI Node cost-ledger migration to D10, the Audit emitter convention documentation, the Web.Rest converter wiring — lands in implementation packets (02–05). Catalog registration lands in packet 01. Every other packet references ADR-0069's D-decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Required ADR Amendment to D2 — `==` is NOT overridden
+
+ADR-0069 D2 reads "comparisons across currencies also throws" and explicitly cites `Money.Zero(USD) == Money.Zero(EUR)` as throwing. **The implementation in packet 02 drops the `==` throw and keeps record-default value equality.** The amendment, made at acceptance time:
+
+- **`+`, `-`, scalar `*`, scalar `/`** — throw `CurrencyMismatchException` on cross-currency operands. Unchanged.
+- **`<`, `<=`, `>`, `>=`** — throw `CurrencyMismatchException` on cross-currency operands. Unchanged.
+- **`==`, `!=`** — **NOT overridden.** Record-default value equality stands. `Money(0m, USD) == Money(0m, EUR)` returns `false` (both fields are compared; currencies differ; result is `false`).
+
+The reason for the amendment: overriding `==` on a record to throw breaks the .NET equality contract in places that should be safe. `Equals(object?)`, `GetHashCode()`, `HashSet<Money>`, `Dictionary<Money, T>`, EF Core change-tracking, and every implicit equality call in LINQ all hit `==` semantics. A throwing `==` would explode at a `Contains`, a dictionary lookup, a tracked-entity comparison — places where the caller has no way to anticipate that two values of different currencies happen to be in the same collection. The throw discipline belongs on arithmetic and ordering (where the operation is observable, intentional, and the caller is choosing to combine values), not on equality (which is silent and called everywhere).
+
+Effect on ADR-0069: when scope rolls forward, the operator amends D2's "comparisons across currencies also throws" wording to "**ordering** comparisons across currencies throws; `==`/`!=` use record-default value equality (cross-currency `==` returns `false`)." This is recorded here as a follow-up ADR edit to apply alongside (or after) the acceptance flip; the implementation in packet 02 reflects the amended discipline.
+
+## On invariants — none added; four conventions enforced by canaries
+
+ADR-0069's Consequences/Invariants section is explicit: **"No new Grid-wide invariants are introduced."** Four implicit conventions are committed:
+
+1. Currency code is always uppercase ISO 4217 alpha-3 (enforced at `CurrencyCode` construction in packet 02).
+2. No implicit FX conversion (enforced by D2's currency-mismatch throw in packet 02).
+3. JSON `amount` is a string, never a number (enforced by the `MoneyJsonConverter` shipped from `HoneyDrunk.Kernel` runtime in packet 02 — not `HoneyDrunk.Kernel.Abstractions`; the converter is runtime logic per invariant 1).
+4. Audit money fields are split into `monetary_value` + `currency_code` (enforced at the emitter projection, documented in packet 04 against `repos/HoneyDrunk.Audit/` boundaries / ADR-0030 emitter conventions).
+
+The ADR's own text reads: *"these read as conventions enforced by canary tests rather than new lines in `constitution/invariants.md`. If the scope agent judges any of them invariant-class at acceptance time, the numbering is added then; the proposed text here treats them as committed conventions."* This scope-time judgment is **no new numbered invariants** — packet 02's canary suite covers conventions 1, 2, 3 by construction; convention 4 is an Audit-emitter projection responsibility documented in packet 04 against the existing `IAuditLog` contract (which has not changed). If a later ADR or operator decides any of the four warrants a numbered invariant, it is appended then under the existing `## Audit Invariants` (for convention 4) or a new section (for conventions 1–3) — not in this packet.
+
+## Scope
+- `adrs/ADR-0069-currency-handling-and-money-representation.md` — flip `**Status:** Proposed` to `**Status:** Accepted`. **Also amend D2** to record that `==`/`!=` are NOT overridden (record-default value equality stands; the throw discipline applies to arithmetic and ordering comparisons only). See "Required ADR Amendment to D2" above. Either inline-edit D2's wording or append an "Amended at acceptance" note under the D2 paragraph — preserve the original text alongside the amendment so the audit trail is visible. Update D9's converter-placement line to read "ships in `HoneyDrunk.Kernel` (runtime)" not `HoneyDrunk.Kernel.Abstractions`, with an analogous "Amended at acceptance" note (the converter is runtime logic; invariant 1 keeps Abstractions free of it).
+- `adrs/README.md` — update the ADR-0069 row Status column to Accepted.
+- `initiatives/active-initiatives.md` — register the `adr-0069-currency-handling` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0069 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. **Amend D2** in the same ADR — record that `==`/`!=` are NOT overridden; the throw discipline applies to arithmetic (`+`/`-`) and ordering comparisons (`<`/`<=`/`>`/`>=`) only. Preserve the original wording with an "Amended at acceptance" note. Cross-reference the "Required ADR Amendment to D2" section in this packet for the rationale.
+3. **Amend D9** in the same ADR — record that `MoneyJsonConverter` ships in `HoneyDrunk.Kernel` (runtime), not `HoneyDrunk.Kernel.Abstractions`. Preserve the original wording with an "Amended at acceptance" note.
+4. Update the ADR-0069 index row in `adrs/README.md` to Accepted.
+5. Do **not** edit `constitution/invariants.md`. ADR-0069's conventions are canary-enforced (see "On invariants" above).
+6. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder.
+
+## Affected Files
+- `adrs/ADR-0069-currency-handling-and-money-representation.md`
+- `adrs/README.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0069 header reads `**Status:** Accepted`
+- [ ] ADR-0069 D2 is amended (inline or "Amended at acceptance" note) to record that `==`/`!=` are NOT overridden; throw discipline applies to arithmetic and ordering comparisons only
+- [ ] ADR-0069 D9 is amended (inline or "Amended at acceptance" note) to record that `MoneyJsonConverter` ships in `HoneyDrunk.Kernel` (runtime), not `HoneyDrunk.Kernel.Abstractions`
+- [ ] The ADR-0069 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariants.md` is **not** modified in this packet (the four ADR-0069 conventions are canary-enforced, per the ADR's own framing)
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0069-currency-handling` initiative with a packet checklist
+- [ ] No catalog schema change in this packet (catalog updates land in packet 01)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0069 D1 — `Money` placement.** A new public record `Money` lives in `HoneyDrunk.Kernel.Abstractions.Money`. Pinned shape: `public sealed record Money(decimal Amount, CurrencyCode CurrencyCode)`. `Money` is a record (drops the `I`); `CurrencyCode` is a `readonly record struct` (no `I`). Static helpers — `Money.Zero(CurrencyCode)`, `Money.Usd(decimal)`, `Money.Eur(decimal)`, etc.
+
+**ADR-0069 Consequences — Invariants.** *"No new Grid-wide invariants are introduced. Implicit conventions that the implementation must hold: currency code is always uppercase ISO 4217 alpha-3; no implicit FX conversion; JSON `amount` is a string, never a number; audit money fields are split (`monetary_value` + `currency_code`). These read as conventions enforced by canary tests rather than new lines in `constitution/invariants.md`."*
+
+**ADR-0026 D5 (referenced) — `BillingEvent` frozen shape.** The live `HoneyDrunk.Kernel.Abstractions/Tenancy/BillingEvent.cs` record carries `Units` (long) and `OperationKey` (string) as the count-and-meter fields (the ADR text says `Quantity`/`UnitOfMeasure` — the implementation diverged to `Units`/`OperationKey` and is the source of truth). No money type on the record. ADR-0069 D7 preserves the frozen shape — `Money` is a separate primitive, not a `BillingEvent` field. Acceptance of ADR-0069 does not trigger a `BillingEvent` major bump.
+
+**ADR-0035 D1 / pre-1.0 disclaimer (referenced) — additive minor bump.** New `Money` and `CurrencyCode` public types in `HoneyDrunk.Kernel.Abstractions` are net-new surface, additive, no break — a minor bump on the pre-1.0 Kernel.Abstractions package. Packet 02 owns the bump.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0069 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Do not edit `constitution/invariants.md`.** ADR-0069 deliberately adds no numbered invariants; the four committed conventions are enforced by canary tests in the Kernel.Abstractions implementation packet (02) and by the audit-emitter projection documented in packet 04.
+- **Do not modify `BillingEvent`.** ADR-0026 D5's frozen shape is preserved; ADR-0069 D7 is explicit on this. No change to `HoneyDrunk.Kernel.Abstractions.BillingEvent`.
+- **Initiative slug ≤ 39 chars.** `adr-0069-currency-handling` is 26 chars — well within the limit. Do not lengthen.
+
+## Labels
+`chore`, `tier-3`, `core`, `docs`, `adr-0069`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0069 to Accepted and register the currency-handling initiative. Do not add any numbered invariants — the ADR's four conventions are canary-enforced.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0069 so the remaining packets in this initiative can reference its decisions as live rules.
+- Feature: ADR-0069 Currency Handling and Money Representation rollout, Wave 1.
+- ADRs: ADR-0069 (primary), ADR-0026 (BillingEvent frozen shape — preserved), ADR-0035 (additive minor-bump policy — packet 02 owns the bump), ADR-0008 (initiative/packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0069 stays Proposed until this PR merges.
+- Do not edit `constitution/invariants.md`. The four conventions ADR-0069 commits are canary-enforced, not numbered invariants. If a later operator judges any of them invariant-class, it is appended then — not in this packet.
+- Do not modify `BillingEvent` or any other existing Kernel.Abstractions surface (ADR-0069 is purely additive; ADR-0026 D5 stays frozen).
+
+**Key Files:**
+- `adrs/ADR-0069-currency-handling-and-money-representation.md`
+- `adrs/README.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0069-currency-handling/01-architecture-money-contract-catalog.md
+++ b/generated/issue-packets/active/adr-0069-currency-handling/01-architecture-money-contract-catalog.md
@@ -1,0 +1,120 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "core", "docs", "adr-0069", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0069"]
+accepts: ["ADR-0069"]
+wave: 1
+initiative: adr-0069-currency-handling
+node: honeydrunk-architecture
+---
+
+# Register the Money / CurrencyCode contract surface in the Grid catalogs
+
+## Summary
+Record ADR-0069's new contract surface as catalog data: register `Money`, `CurrencyCode`, `CurrencyMismatchException`, and `UnknownCurrencyCodeException` under the `honeydrunk-kernel` Node in `catalogs/contracts.json` (appended to that node block's `interfaces` array), and append the new type names to the `honeydrunk-kernel` entry's `exposes.contracts` array in `catalogs/relationships.json`. Update the `consumes_detail` for the Nodes that gain a new dependency on the contract — at this initiative's scope, only `honeydrunk-ai` consumes it as part of packet 03 (the cost-ledger migration to D10). The Web.Rest converter wiring in packet 05 consumes the same Kernel contracts already broadcast on its existing edge, so the type names are added to its `consumes_detail` too.
+
+## Context
+ADR-0069 D1/D9 add new contract types to `HoneyDrunk.Kernel.Abstractions`: the `Money` record (carrying `decimal Amount` and a `CurrencyCode`), the `CurrencyCode` record struct (an ISO 4217 alpha-3 validated value), and two exception types (`CurrencyMismatchException` for D2's currency-mismatch arithmetic, `UnknownCurrencyCodeException` for D4's construction failure). The Grid catalogs are the discoverability surface — `catalogs/contracts.json` registers each Node's contracts in its node block's `interfaces` array, and `catalogs/relationships.json` lists each Node's contract names under `exposes.contracts`. (Note: `catalogs/nodes.json` has **no** `exposes` field — the `exposes` object lives on relationships.json entries.)
+
+The `MoneyJsonConverter` (D9's System.Text.Json converter) ships in the **`HoneyDrunk.Kernel` runtime package**, not `HoneyDrunk.Kernel.Abstractions` — invariant 1 keeps Abstractions free of runtime serialization classes (packet 02 owns this placement; the ADR-text says "ships in `HoneyDrunk.Kernel.Abstractions`" and is amended at acceptance in packet 00). As a converter, it is an implementation detail of the `Money` public type, not a separate contract surface — it is registered indirectly via the `Money` type's documented serialization shape. The `MoneyJsonConverter` class itself is **not** added as a separate `contracts.json` entry; the `consumes_detail` for `honeydrunk-web-rest` (which references the runtime package to register the converter) is captured at packet 05's wiring step, not as a new contract here.
+
+This packet keeps both catalogs accurate so the implementation packets (02–05) and any downstream Node have an accurate contract/dependency graph to read.
+
+This is a catalog/docs packet. No code, no .NET project.
+
+## Scope
+- `catalogs/contracts.json` — locate the node block whose `node` value is `honeydrunk-kernel`; append the new contract entries from ADR-0069 D1/D2/D4 to that block's `interfaces` array.
+- `catalogs/relationships.json` — append the new type names to the `honeydrunk-kernel` entry's `exposes.contracts` array; and update the `consumes_detail` for `honeydrunk-ai` (packet 03 migrates `InferenceCost.EstimatedCost` and `CostSummary.TotalCost` from `decimal` to `Money`) and `honeydrunk-web-rest` (packet 05 wires the Money converter). No new top-level Node-to-Node edge is created — both Nodes already consume `HoneyDrunk.Kernel.Abstractions`.
+- `catalogs/nodes.json` — **not edited.** nodes.json entries have no `exposes` field; the contract surface lives in relationships.json and contracts.json.
+
+## Proposed Implementation
+1. **`catalogs/contracts.json`** — locate the node block whose `node` value is `honeydrunk-kernel` (do not rely on line numbers; the file's existing entries for `IGridContext`, `TenantId`, `CorrelationId`, etc. are the precedent shape). Append entries to that block's `interfaces` array, matching the existing `{ "name", "kind", "description" }` shape:
+   - `Money` — `kind: type` — "Record. Carries `decimal Amount` and a `CurrencyCode`. Internal representation of monetary values across the Grid. Arithmetic operators throw `CurrencyMismatchException` on cross-currency operations (no implicit FX). `Money.ToString()` returns locale-independent machine-readable text (e.g. `\"123.45 USD\"`). JSON shape is `{\"amount\": \"...\", \"currency\": \"...\"}` via the System.Text.Json converter shipped in the same package."
+   - `CurrencyCode` — `kind: type` — "Readonly record struct. ISO 4217 alpha-3 currency code (uppercase). Construction validates against the seed list (USD, EUR, GBP, JPY, CAD, AUD, CHF); unknown codes throw `UnknownCurrencyCodeException`. Per-currency metadata (default decimal places — 2 for fiat, 3 for JOD/BHD/KWD/OMR/TND, 0 for JPY) lives alongside the codes."
+   - `CurrencyMismatchException` — `kind: type` — "Thrown by `Money` arithmetic and comparison operators when two `Money` operands carry different `CurrencyCode` values. No implicit FX conversion."
+   - `UnknownCurrencyCodeException` — `kind: type` — "Thrown by `CurrencyCode` construction when the input is not in the seed list of supported ISO 4217 alpha-3 codes."
+   - Drop the leading `I` from these names — `Money`, `CurrencyCode`, `CurrencyMismatchException`, `UnknownCurrencyCodeException` are records / record structs / exception classes, never interfaces.
+   - Do **not** add `MoneyJsonConverter` as a separate entry — it is an implementation detail of `Money`, not a public contract.
+2. **`catalogs/relationships.json`** — append `Money`, `CurrencyCode`, `CurrencyMismatchException`, `UnknownCurrencyCodeException` to the `honeydrunk-kernel` entry's `exposes.contracts` array. Do not touch existing entries. Then:
+   - For `honeydrunk-ai`, extend `consumes_detail["honeydrunk-kernel"]` with `Money`, `CurrencyCode` (packet 03 migrates the cost ledger).
+   - For `honeydrunk-web-rest`, extend `consumes_detail["honeydrunk-kernel"]` with `Money` (packet 05 wires the converter).
+   - Do not add a new top-level edge — `consumed_by`/`consumes` lists already include all four Nodes.
+3. **`catalogs/nodes.json`** — no edit. nodes.json has no `exposes` field; do not invent one.
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+
+## NuGet Dependencies
+None. This packet touches only catalog JSON; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] Catalog data only — the Kernel/AI/Web.Rest code lands in packets 02, 03, 05.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` registers `Money`, `CurrencyCode`, `CurrencyMismatchException`, `UnknownCurrencyCodeException` in the `honeydrunk-kernel` node block's `interfaces` array, matching the existing entry shape
+- [ ] `MoneyJsonConverter` is NOT added as a separate contracts.json entry (it is an implementation detail of `Money`, not a public contract)
+- [ ] `catalogs/relationships.json` `honeydrunk-kernel` entry lists `Money`, `CurrencyCode`, `CurrencyMismatchException`, `UnknownCurrencyCodeException` in `exposes.contracts`, with all existing entries untouched
+- [ ] `catalogs/relationships.json` `consumes_detail["honeydrunk-kernel"]` for `honeydrunk-ai` lists `Money`, `CurrencyCode`; for `honeydrunk-web-rest` lists `Money`
+- [ ] `catalogs/nodes.json` is NOT modified (it has no `exposes` field)
+- [ ] No new top-level Node-to-Node edge is created (the dependency on `HoneyDrunk.Kernel.Abstractions` already exists for both Nodes)
+- [ ] No invariant change in this packet (ADR-0069 adds no numbered invariants — see packet 00's "On invariants" section)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0069 D1 — `Money` placement.** A new public record `Money` and a `readonly record struct CurrencyCode` live in `HoneyDrunk.Kernel.Abstractions.Money` (or a similarly-named namespace settled by packet 02). Both are net-new public surface; both are records (drop the `I`).
+
+**ADR-0069 D2 — `CurrencyMismatchException`.** Arithmetic and comparison operators on `Money` throw `CurrencyMismatchException` when the two operands' `CurrencyCode` values differ. No implicit FX conversion.
+
+**ADR-0069 D4 — `UnknownCurrencyCodeException`.** `CurrencyCode` construction with a code not on the seed list throws `UnknownCurrencyCodeException` at the point of construction.
+
+**ADR-0069 D9 (amended at acceptance — see packet 00) — `MoneyJsonConverter` ships in `HoneyDrunk.Kernel` (runtime).** The ADR text says "ships in `HoneyDrunk.Kernel.Abstractions`" but the converter is runtime serialization logic and invariant 1 keeps Abstractions free of it. Packet 02 places `MoneyJsonConverter` in the runtime package; packet 00 amends D9's wording at acceptance. As an implementation detail it is **not** a separate catalog entry — its presence is documented by `Money`'s description.
+
+**ADR-0069 D10 — AI cost-ledger Money adoption.** ADR-0052's in-memory cost-rate cache is updated to `Money(rate, CurrencyCode.Usd)` — this is the `honeydrunk-ai` consumer added to `consumes_detail`.
+
+## Constraints
+- **Records drop the `I`.** `Money`, `CurrencyCode`, `CurrencyMismatchException`, `UnknownCurrencyCodeException` — no `I` prefix.
+- **Do not register `MoneyJsonConverter` separately.** It is an implementation detail of `Money`. Documenting `Money`'s JSON shape in its description is sufficient.
+- **Do not register `Money.Zero` / `Money.Usd` / etc.** They are static factory members on `Money`, not separate contract entries.
+- **No new Node-to-Node edge.** Both consuming Nodes already consume `HoneyDrunk.Kernel.Abstractions`. The contracts are additive; only `consumes_detail` is enriched.
+- **nodes.json is NOT edited** — it has no `exposes` field; do not invent one.
+
+## Labels
+`feature`, `tier-2`, `core`, `docs`, `adr-0069`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Register ADR-0069's `Money`/`CurrencyCode` contract surface in the Grid catalogs.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Keep the contract/dependency catalogs accurate so implementation packets 02–05 read a correct graph.
+- Feature: ADR-0069 Currency Handling rollout, Wave 1.
+- ADRs: ADR-0069 D1/D2/D4/D9/D10 (primary).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0069 should be Accepted before its contract surface is recorded as catalog data.
+
+**Constraints:**
+- Records drop the `I`; `Money`/`CurrencyCode` are records / record structs.
+- Do not register `MoneyJsonConverter` as a separate entry — it is an implementation detail.
+- Do not register static factory members (`Money.Zero`, `Money.Usd`) — they are not separate contracts.
+- No new top-level Node-to-Node edge — only `consumes_detail` enrichment.
+- nodes.json is NOT edited — it has no `exposes` field.
+
+**Key Files:**
+- `catalogs/contracts.json` — new entries in the `honeydrunk-kernel` block's `interfaces` array.
+- `catalogs/relationships.json` — `honeydrunk-kernel` `exposes.contracts` + `consumes_detail` enrichment for `honeydrunk-ai` and `honeydrunk-web-rest`. nodes.json is NOT touched.
+
+**Contracts:** None changed — this packet only records catalog metadata for contracts that packet 02 implements.

--- a/generated/issue-packets/active/adr-0069-currency-handling/02-kernel-money-and-currency-code.md
+++ b/generated/issue-packets/active/adr-0069-currency-handling/02-kernel-money-and-currency-code.md
@@ -1,0 +1,203 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Kernel
+labels: ["feature", "tier-2", "core", "adr-0069", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0069"]
+wave: 2
+initiative: adr-0069-currency-handling
+node: honeydrunk-kernel
+---
+
+# Add Money, CurrencyCode, and the JSON converter to HoneyDrunk.Kernel.Abstractions
+
+## Summary
+Add the ADR-0069 currency-handling surface to `HoneyDrunk.Kernel.Abstractions`: the `Money` record (carrying `decimal Amount` and a `CurrencyCode`), the `CurrencyCode` record struct with ISO 4217 alpha-3 validation and per-currency metadata, the arithmetic / comparison operators that throw on currency mismatch, the `Round` method with banker's rounding default, the machine-readable `ToString`, the `MoneyJsonConverter` (System.Text.Json), the two exception types (`CurrencyMismatchException`, `UnknownCurrencyCodeException`), and a canary test suite pinning arithmetic, rounding, serialization, currency-mismatch behavior, and validator behavior. This is the version-bumping packet for the `HoneyDrunk.Kernel` solution.
+
+## Context
+ADR-0069 commits the Grid's internal representation of monetary values: a `Money` record carrying `decimal Amount` and a validated `CurrencyCode`. The placement (per D1) is `HoneyDrunk.Kernel.Abstractions` because Kernel is the zero-dependency contract layer every Node already consumes — the same placement precedent as `TenantId`, `CorrelationId`, and `BillingEvent`. ADR-0026 D5 froze `BillingEvent` count-only; ADR-0069 D7 preserves that frozen shape — `Money` is a **separate, additive primitive** in Kernel.Abstractions, not a field on `BillingEvent`. The Stripe boundary (ADR-0037) converts to/from minor units at the Stripe adapter; the Grid's internal representation is `decimal` (D1's rationale).
+
+`HoneyDrunk.Kernel` is a live Node currently at v0.7.0 (.NET 10.0), two packages: `HoneyDrunk.Kernel.Abstractions` (zero-dependency contracts) and `HoneyDrunk.Kernel` (runtime). This packet is the **first packet on the `HoneyDrunk.Kernel` solution in this initiative** — per invariant 27 it bumps every non-test `.csproj` to the same new minor version (`0.7.0` → `0.8.0` — additive new types, no break). Confirm the current solution version at edit time — if another initiative has already bumped past `0.7.0`, take the next minor over whatever is on `main`.
+
+**Cross-initiative version-bump note (ADR-0042 race).** ADR-0042 (Idempotency Contract — `adr-0042-idempotency`) also targets the `HoneyDrunk.Kernel` solution and is sequenced as a `0.7.0` → `0.8.0` minor bump. Both ADR-0042 packet 02 and **this** packet bump the Kernel solution from `0.7.0` to `0.8.0` independently — they are racing on the same version. Coordination procedure for the executor at edit time:
+
+1. Read `HoneyDrunk.Kernel/HoneyDrunk.Kernel.csproj` to determine the live source-of-truth version.
+2. Read `repos/HoneyDrunk.Kernel/active-work.md` (in `HoneyDrunk.Architecture`) — the cross-initiative coordinator file that tracks in-progress version windows on the Kernel solution.
+3. **Case A — Kernel is still `0.7.0`:** this packet opens the `0.8.0` version entry on every `CHANGELOG.md` (repo-level and `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md` and `HoneyDrunk.Kernel/CHANGELOG.md`). Bump every non-test `.csproj` to `0.8.0`. Record "opened 0.8.0" in the PR description and update `active-work.md`.
+4. **Case B — Kernel is already `0.8.0` and unreleased (ADR-0042 landed first):** append this packet's surface (`Money`, `CurrencyCode`, `MoneyJsonConverter`, the two exception types) to the in-progress `0.8.0` CHANGELOG entries. No version-bump commit needed (already at `0.8.0`). Record "appended to in-progress 0.8.0" in the PR description.
+5. **Case C — Kernel `0.8.0` has been tagged/released:** take the next minor (`0.9.0`). Open a new version entry on every CHANGELOG, bump every non-test `.csproj` to `0.9.0`. Record "took 0.9.0" in the PR description and update `active-work.md`.
+
+The two initiatives are independent in content (idempotency contract surface vs currency primitive); the only coupling is solution-version sequencing.
+
+System.Text.Json is part of the BCL — using it in Kernel.Abstractions does not introduce a HoneyDrunk runtime dependency. Per invariant 1, only `Microsoft.Extensions.*` abstractions are permitted; System.Text.Json is fine because it is the BCL serializer (no foreign package), and `JsonConverter<T>` lives in `System.Text.Json` not `Microsoft.Extensions.*`. Read this as an intentional carve-out for serialization concerns — the converter is a contract artifact, shipped alongside the type, mirroring how `TenantId` ships its own JSON handling.
+
+## Scope
+- `HoneyDrunk.Kernel.Abstractions` — new contract types:
+  - `Money` — `public sealed record Money(decimal Amount, CurrencyCode CurrencyCode)`. Operators (`+`, `-`, scalar `*`, scalar `/`, `<`, `<=`, `>`, `>=`). **No `==`/`!=` override** — record-default value equality stands. Static factories (`Money.Zero(CurrencyCode)`, `Money.Usd(decimal)`, `Money.Eur(decimal)`, etc.). Instance methods (`Round`, `ToString`). **No `[JsonConverter]` attribute** (Abstractions stays STJ-free).
+  - `CurrencyCode` — `public readonly record struct CurrencyCode`. Construction validates ISO 4217 alpha-3 (uppercase) against the seed list (D4). Per-currency metadata: default decimals (2 for fiat, 3 for JOD/BHD/KWD/OMR/TND, 0 for JPY), display name, optional currency symbol. Static well-known values: `CurrencyCode.Usd`, `Eur`, `Gbp`, `Jpy`, `Cad`, `Aud`, `Chf`.
+  - `CurrencyMismatchException` — `public sealed class CurrencyMismatchException : InvalidOperationException`. Thrown by `Money` arithmetic and comparison operators on currency mismatch (D2).
+  - `UnknownCurrencyCodeException` — `public sealed class UnknownCurrencyCodeException : ArgumentException`. Thrown by `CurrencyCode` construction with an unknown code (D4).
+  - `MoneyJsonConverter` — `public sealed class MoneyJsonConverter : JsonConverter<Money>`. **Lives in `HoneyDrunk.Kernel` (runtime), not `HoneyDrunk.Kernel.Abstractions`** — System.Text.Json converters are serialization logic, and invariant 1 keeps Abstractions to contracts (`Microsoft.Extensions.*` + BCL types only; no runtime serialization classes). Implements the D9 shape: read/write `{"amount": "string", "currency": "USD"}`. Callers register it explicitly via `JsonSerializerOptions.Converters.Add(new MoneyJsonConverter())`. No `[JsonConverter]` attribute on `Money` (which lives in Abstractions and must stay free of STJ runtime types).
+- All non-test `.csproj` files in the solution version-bumped together (one commit, invariant 27).
+- `HoneyDrunk.Kernel.Abstractions` package `CHANGELOG.md` and `README.md` updated.
+- Repo-level `CHANGELOG.md` gets a new version entry.
+- Canary test suite (per ADR-0069's follow-up list, item 2): the canary lives wherever the existing Kernel.Abstractions canary suite lives (`HoneyDrunk.Kernel.Tests` for now; per ADR-0047 the long-term home is `*.Tests.Canaries`), pinning:
+  - `Money` arithmetic (sum/diff/scalar-mul/scalar-div preserves currency; cross-currency `+`/`-`/comparison throws `CurrencyMismatchException`)
+  - `Money.Zero(CurrencyCode)` semantics; `Money.Zero(USD) == Money.Zero(EUR)` returns `false` via record-default equality — see "Required ADR Amendment to D2" in packet 00; the ADR's "throws on cross-currency `==`" wording is dropped because overriding the record `==` operator to throw breaks `HashSet<Money>`, `Dictionary<Money>`, and EF change-tracking equality (any consumer that hashes/compares `Money` values across currencies would explode at a `GetHashCode`/`Equals` call site that should be safe)
+  - `Round(2, MidpointRounding.ToEven)` banker's-rounding result on documented boundary cases (e.g. `12.025m → 12.02m`); `Round(2, AwayFromZero)` traditional-accounting result for the same input
+  - Per-currency default decimals via `CurrencyCode` metadata (JPY = 0, USD = 2, JOD = 3 in the test data — JOD is acceptable to test against even though it is not in the Phase-1 seed list, by adding it to the test-only validator; or restrict the test to seed-list currencies)
+  - JSON round-trip via `MoneyJsonConverter` produces `{"amount": "123.45", "currency": "USD"}` with `amount` as a **string**, deserializes back to a `Money` with the same `Amount` and `CurrencyCode` (D9)
+  - JSON deserialization where `amount` is a JSON number rejects with a deserialization exception (D9: "amount is a JSON string, not a JSON number")
+  - `CurrencyCode("usd")` and `CurrencyCode("ZZZ")` both throw `UnknownCurrencyCodeException` (case-sensitivity and unknown-code rejection per D4)
+  - `Money.ToString()` produces `"123.45 USD"`, `"1234.50 EUR"`, `"1000 JPY"` (invariant culture, currency-default decimals, single-space separator per D8)
+
+## Proposed Implementation
+1. **`CurrencyCode`** — `public readonly record struct CurrencyCode`. One field, the validated uppercase code. Constructor calls a static validator that checks the input is in the seed list (`USD`, `EUR`, `GBP`, `JPY`, `CAD`, `AUD`, `CHF`); reject input with `UnknownCurrencyCodeException` on mismatch. Per-currency metadata lives in a static table keyed by code: each entry holds default decimals, display name, optional symbol. Expose `DefaultDecimals` and `DisplayName` as read-only properties on `CurrencyCode` (lookup-on-read). Static well-known values: `CurrencyCode.Usd`, `Eur`, `Gbp`, `Jpy`, `Cad`, `Aud`, `Chf` (per D4). The validator is small and hand-maintained — no third-party currencies package (per D4's "hand-maintained list is the cheapest viable choice" and the Alternatives Considered rejection).
+
+2. **`Money`** — `public sealed record Money(decimal Amount, CurrencyCode CurrencyCode)`. Implement:
+   - **Operators** — `+`, `-` (both throw `CurrencyMismatchException` if operands' `CurrencyCode` differ); scalar `*` and `/` taking a `decimal` (preserve the operand's currency); `<`, `<=`, `>`, `>=` throw `CurrencyMismatchException` on cross-currency operands per D2. **`==` / `!=` are NOT overridden** — record-default value equality stands. `Money(0m, USD) == Money(0m, EUR)` is `false` (both fields are compared; currency differs; result is `false`). This is a deliberate departure from the ADR's "comparison across currencies throws" wording for `==`: overriding `==` to throw would break `HashSet<Money>`, `Dictionary<Money>`, EF change-tracking equality, and every implicit `Equals`/`GetHashCode` call site that should be safe (these never throw on built-in record types, and an unobservable hashing operation throwing would cascade in places impossible to predict). The throw discipline is preserved where it belongs — arithmetic and ordering comparisons (`<`/`<=`/`>`/`>=`) — and is recorded in packet 00 as a **Required ADR Amendment to D2**. XML-doc `Money` and `==` to note the deliberate choice and reference the amendment.
+   - **Static factories** — `Money.Zero(CurrencyCode)`, `Money.Usd(decimal)`, `Money.Eur(decimal)`, `Money.Gbp(decimal)`, `Money.Jpy(decimal)`, `Money.Cad(decimal)`, `Money.Aud(decimal)`, `Money.Chf(decimal)`. No `Money.Zero` without a currency (per D2 — "zero in what?").
+   - **`Round(int decimals, MidpointRounding mode = MidpointRounding.ToEven)`** — banker's rounding default per D3. The `decimals` argument is mandatory; provide a `Round()` overload that picks the currency's default-decimals from the `CurrencyCode` metadata.
+   - **`ToString()`** — return `$"{Amount.ToString($"F{CurrencyCode.DefaultDecimals}", CultureInfo.InvariantCulture)} {CurrencyCode.Code}"` per D8. Example outputs: `"123.45 USD"`, `"1234.50 EUR"`, `"1000 JPY"`.
+   - XML-doc every public member (invariant 13).
+   - **Do NOT annotate `Money` with `[JsonConverter(typeof(MoneyJsonConverter))]`.** Adding `[JsonConverter]` to a type in `HoneyDrunk.Kernel.Abstractions` would require `MoneyJsonConverter` to live in Abstractions — and a System.Text.Json converter is **runtime serialization logic**, not a contract. Per invariant 1, Abstractions is contract-only. `MoneyJsonConverter` ships in the `HoneyDrunk.Kernel` runtime package (see step 5 below); callers register it explicitly via `JsonSerializerOptions.Converters.Add(...)`. Packet 05 wires it into `HoneyDrunk.Web.Rest`'s `JsonOptionsDefaults.Configure`.
+
+3. **`CurrencyMismatchException`** — `public sealed class CurrencyMismatchException : InvalidOperationException`. Constructor takes the two mismatched `CurrencyCode` values; message reads `"Cannot operate on Money values with mismatched currencies: {left} vs {right}. No implicit FX conversion is performed (ADR-0069 D2)."`.
+
+4. **`UnknownCurrencyCodeException`** — `public sealed class UnknownCurrencyCodeException : ArgumentException`. Constructor takes the offending string code; message reads `"'{code}' is not a recognized ISO 4217 alpha-3 currency code in the Grid's seed list (ADR-0069 D4)."`.
+
+5. **`MoneyJsonConverter`** — `public sealed class MoneyJsonConverter : JsonConverter<Money>`. **Located in the `HoneyDrunk.Kernel` runtime package** (`HoneyDrunk.Kernel/Serialization/MoneyJsonConverter.cs` or the repo's existing serialization folder; create one if absent). Keeping STJ runtime classes out of `HoneyDrunk.Kernel.Abstractions` preserves invariant 1 (Abstractions has no runtime classes; STJ converters are runtime logic, even if `System.Text.Json` itself is in the BCL). Callers consume `MoneyJsonConverter` by referencing `HoneyDrunk.Kernel` (the runtime) and registering it explicitly in their `JsonSerializerOptions` — packet 05 does this in `HoneyDrunk.Web.Rest.AspNetCore.Serialization.JsonOptionsDefaults.Configure`.
+   - `Write` emits `{"amount": "{Amount as string, invariant culture, currency-default decimals}", "currency": "{Code}"}`.
+   - `Read` parses `amount` as a JSON string and rejects JSON-number `amount` values with a `JsonException`. Parse the string via `decimal.Parse(s, NumberStyles.Number, CultureInfo.InvariantCulture)`; parse `currency` via `new CurrencyCode(s)` (which throws on invalid). Field order in JSON is not significant.
+
+6. **Canary tests** — add to the existing test project (per the repo's convention). At least the cases listed in the "Scope" section above. Pin the conventions ADR-0069 commits as canaries (ISO 4217 alpha-3 uppercase, no implicit FX, JSON `amount` as string).
+
+7. **Version bump** — bump every non-test `.csproj` in `HoneyDrunk.Kernel/HoneyDrunk.Kernel.slnx` to the new minor. **At edit time, read `HoneyDrunk.Kernel/HoneyDrunk.Kernel.csproj` to determine the current source-of-truth version**; if it is still `0.7.0`, bump to `0.8.0`; if ADR-0042's packet 02 has already landed and the solution is at `0.8.0`, append this initiative's surface to the in-progress `0.8.0` CHANGELOG entry rather than opening a new version (invariant 27's "one solution-wide bump per release window"); if `0.8.0` has been tagged/released, take the next minor (`0.9.0`). Coordinate via `repos/HoneyDrunk.Kernel/active-work.md` — both ADR-0042 and ADR-0069 are racing on the same Kernel solution version, so check that coordinator before opening or appending a CHANGELOG version entry. Record which case applied in the PR description. Add a repo-level CHANGELOG entry. Add a per-package CHANGELOG entry to `HoneyDrunk.Kernel.Abstractions` (real changes — `Money`, `CurrencyCode`, the two exception types). Add a per-package CHANGELOG entry to `HoneyDrunk.Kernel` (real change — `MoneyJsonConverter` ships in the runtime package, see step 5).
+
+8. Update `HoneyDrunk.Kernel.Abstractions/README.md` — the public API surface gained the currency primitives; document them in the public-API section.
+
+## Affected Files
+- `HoneyDrunk.Kernel.Abstractions/` — new contract type files (one per type per the repo's existing file-per-type convention): `Money.cs`, `CurrencyCode.cs`, `CurrencyMismatchException.cs`, `UnknownCurrencyCodeException.cs`, plus the per-currency metadata table.
+- `HoneyDrunk.Kernel/` — new `MoneyJsonConverter.cs` (in a serialization folder); converter lives in the runtime package, not Abstractions (invariant 1).
+- `HoneyDrunk.Kernel.Abstractions/HoneyDrunk.Kernel.Abstractions.csproj` — version bump.
+- `HoneyDrunk.Kernel/HoneyDrunk.Kernel.csproj` — version bump (now a real-change bump — adds `MoneyJsonConverter`).
+- `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md`, `HoneyDrunk.Kernel.Abstractions/README.md`.
+- `HoneyDrunk.Kernel/CHANGELOG.md` — entry for `MoneyJsonConverter`.
+- Repo-level `CHANGELOG.md`.
+- `repos/HoneyDrunk.Kernel/active-work.md` (in `HoneyDrunk.Architecture` — the cross-initiative coordinator) — referenced for the ADR-0042 race; updated if the executor lands first vs. appends.
+- `HoneyDrunk.Kernel.Tests` — canary test suite for `Money`, `CurrencyCode`, arithmetic, rounding, JSON serialization, validator.
+
+## NuGet Dependencies
+- **`HoneyDrunk.Kernel.Abstractions`** — no new HoneyDrunk `PackageReference`. Per invariant 1, Abstractions takes only `Microsoft.Extensions.*` abstractions; the BCL is implicit. `Money` and `CurrencyCode` do **not** reference `System.Text.Json` at all (no `[JsonConverter]` attribute) — STJ stays out of Abstractions. `HoneyDrunk.Standards` is already referenced (`PrivateAssets: all`).
+- **`HoneyDrunk.Kernel`** — no new `PackageReference`. `System.Text.Json` is in the BCL framework reference (`net10.0`); `MoneyJsonConverter` consumes `JsonConverter<T>` from the BCL — no package added.
+- The unit-test project follows the repo's existing test stack; no new packages introduced.
+
+## Boundary Check
+- [x] `Money`, `CurrencyCode`, and the JSON converter are Kernel contracts per ADR-0069 D1/D9. The ADR's explicit placement maps here.
+- [x] No dependency on any other HoneyDrunk runtime package (invariant 4 — DAG; Kernel at the root).
+- [x] No modification of `BillingEvent` (ADR-0026 D5 frozen shape; ADR-0069 D7 explicit).
+- [x] No modification of existing Kernel public types.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Kernel.Abstractions` exposes `Money` as a `public sealed record Money(decimal Amount, CurrencyCode CurrencyCode)`
+- [ ] `HoneyDrunk.Kernel.Abstractions` exposes `CurrencyCode` as a `public readonly record struct` with construction-time ISO 4217 alpha-3 validation against the D4 seed list (USD, EUR, GBP, JPY, CAD, AUD, CHF)
+- [ ] `CurrencyCode` exposes `DefaultDecimals` and `DisplayName` from the per-currency metadata table
+- [ ] Static well-known `CurrencyCode` values (`Usd`, `Eur`, `Gbp`, `Jpy`, `Cad`, `Aud`, `Chf`) are present
+- [ ] `Money` ships arithmetic operators (`+`, `-`, scalar `*`, scalar `/`) that throw `CurrencyMismatchException` on cross-currency operands
+- [ ] `Money` ships ordering operators (`<`, `<=`, `>`, `>=`) that throw `CurrencyMismatchException` on cross-currency operands
+- [ ] `Money` does **NOT** override `==`/`!=`; record-default value equality stands (cross-currency `==` returns `false`, never throws — preserves `HashSet<Money>` / `Dictionary<Money>` / EF tracking semantics; recorded as Required ADR Amendment to D2 in packet 00)
+- [ ] `Money.Zero(CurrencyCode)` exists; `Money.Zero` without a currency does NOT exist
+- [ ] `Money.Round(int decimals, MidpointRounding mode = MidpointRounding.ToEven)` uses banker's rounding by default; the `AwayFromZero` opt-in works; `Truncate`/`Math.Floor` is NOT exposed as a `Round` mode
+- [ ] `Money.ToString()` returns locale-independent `"123.45 USD"`-style output using invariant culture and the currency's default decimal places
+- [ ] `MoneyJsonConverter` reads/writes `{"amount": "string", "currency": "USD"}`; `amount` is **always** a JSON string; `amount` as a JSON number rejects with `JsonException`
+- [ ] `MoneyJsonConverter` lives in `HoneyDrunk.Kernel` (runtime), NOT `HoneyDrunk.Kernel.Abstractions` — invariant 1 keeps Abstractions STJ-free
+- [ ] `Money` is NOT annotated with `[JsonConverter(typeof(MoneyJsonConverter))]` (would force the converter into Abstractions); callers register the converter explicitly in their `JsonSerializerOptions`
+- [ ] `CurrencyMismatchException` and `UnknownCurrencyCodeException` are public, sealed, and inherit from `InvalidOperationException` / `ArgumentException` respectively
+- [ ] `BillingEvent` is NOT modified (ADR-0026 D5 frozen shape preserved per ADR-0069 D7)
+- [ ] All new public types have XML documentation (invariant 13)
+- [ ] `HoneyDrunk.Kernel.Abstractions` has zero new runtime `PackageReference` on any HoneyDrunk package (invariant 1) and zero references to `System.Text.Json` types (no `[JsonConverter]` attribute, no converter class)
+- [ ] Every non-test `.csproj` in the solution is at the same new minor version in one commit (invariant 27). At edit time the executor checks `HoneyDrunk.Kernel.csproj`'s version and `repos/HoneyDrunk.Kernel/active-work.md` — if ADR-0042 has already opened `0.8.0`, this packet appends to that in-progress version entry rather than opening a new one
+- [ ] Repo-level `CHANGELOG.md` has a new (or appended) version entry dated to the merge, listing the currency-handling surface
+- [ ] `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md` has an entry describing `Money`, `CurrencyCode`, and the two exception types
+- [ ] `HoneyDrunk.Kernel/CHANGELOG.md` has an entry describing `MoneyJsonConverter` (real change — converter lives in the runtime package)
+- [ ] `HoneyDrunk.Kernel.Abstractions/README.md` documents the new currency-handling surface in the public-API section
+- [ ] The canary test suite pins: arithmetic & currency-mismatch throw; rounding mode behavior; `ToString` output; JSON serialization shape (amount-as-string, currency-as-ISO-uppercase); JSON deserialization rejects amount-as-number; `CurrencyCode` validation (lowercase rejected, unknown code rejected)
+- [ ] The `pr-core.yml` tier-1 gate and the Kernel contract-shape canary pass — the new contracts are additive, paired with the version bump
+
+## Human Prerequisites
+None. (Per the dispatch plan: a human releases the `HoneyDrunk.Kernel` package after this packet merges so downstream consumers — AI Node in packet 03, Web.Rest in packet 05 — can compile against the new version. That release step is captured in the Wave 2→3 handoff and in packet 03's Human Prerequisites, not here.)
+
+## Referenced ADR Decisions
+**ADR-0069 D1 — `Money` shape and placement.** `public sealed record Money(decimal Amount, CurrencyCode CurrencyCode)` in `HoneyDrunk.Kernel.Abstractions`. Static helpers — `Money.Zero(CurrencyCode)`, `Money.Usd(decimal)`, etc. `ToString()` returns `"123.45 USD"` (machine-readable, locale-independent). Records drop the `I`.
+
+**ADR-0069 D2 (with amendment) — currency-mismatch arithmetic throws.** `+`, `-` (cross-currency) throw `CurrencyMismatchException`; scalar `*`/`/` preserve currency; **ordering** comparison (`<`/`<=`/`>`/`>=`) across currencies throws; `Money.Zero(CurrencyCode)` is the only construction shortcut without an amount. **Amendment (recorded in packet 00):** the ADR's "`==` across currencies throws" wording is dropped — `==`/`!=` are NOT overridden, record-default value equality stands (cross-currency `==` returns `false`). Overriding record `==` to throw would break `HashSet<Money>`, `Dictionary<Money>`, EF tracking, and every implicit `Equals`/`GetHashCode` call; the throw discipline stays on arithmetic and ordering, where it is observable and intentional.
+
+**ADR-0069 D3 — banker's rounding default.** `Round(int decimals, MidpointRounding mode = MidpointRounding.ToEven)`. Default is banker's rounding. `AwayFromZero` is an explicit opt-in for traditional accounting rounding. Truncation is not supported as a `Round` mode — `Math.Floor` on `Amount` + reconstruct is the deliberate-awkwardness path.
+
+**ADR-0069 D4 — `CurrencyCode` validation.** ISO 4217 alpha-3, uppercase, validated against a hand-maintained seed list (USD, EUR, GBP, JPY, CAD, AUD, CHF). Per-currency metadata: default decimals (2 for fiat, 3 for JOD/BHD/KWD/OMR/TND, 0 for JPY), display name. Unknown codes throw `UnknownCurrencyCodeException`. Adding a currency is a Kernel.Abstractions minor bump (additive enum-like value per ADR-0035 D4).
+
+**ADR-0069 D8 — `ToString` is machine-readable.** Invariant culture, no thousands separators, amount formatted to the currency's default decimals, currency code uppercase, single-space separator. Round-trip parseable. Locale-aware formatting lives at the presentation layer.
+
+**ADR-0069 D9 — JSON serialization.** `{"amount": "123.45", "currency": "USD"}`. `amount` is a JSON string (precision preservation); `currency` is uppercase ISO alpha-3; no `decimals` field. `MoneyJsonConverter` ships in `HoneyDrunk.Kernel` (runtime) as the canonical converter — **not** in `HoneyDrunk.Kernel.Abstractions` (invariant 1 keeps Abstractions free of runtime classes). The ADR's "ships in `HoneyDrunk.Kernel.Abstractions`" wording is corrected here on placement; the shape and discipline are unchanged.
+
+**ADR-0069 D7 — `BillingEvent` unchanged.** `BillingEvent` carries `Quantity` and `UnitOfMeasure` only; no `Money` field added. ADR-0026 D5's frozen shape is preserved.
+
+**ADR-0026 D5 (referenced) — `BillingEvent` is count-and-meter.** Frozen shape. The live `HoneyDrunk.Kernel.Abstractions/Tenancy/BillingEvent.cs` record carries `Units` (long) and `OperationKey` (string) for the count-and-meter fields (the ADR text says `Quantity`/`UnitOfMeasure` — the implementation diverged to `Units`/`OperationKey` and is the source of truth). Do not modify.
+
+**ADR-0035 D1 / pre-1.0 disclaimer (referenced) — minor bump.** New `Money`/`CurrencyCode` public surface is additive; minor bump on the pre-1.0 Kernel.Abstractions package.
+
+## Constraints
+- **Invariant 1 — Abstractions have zero runtime dependencies AND zero runtime logic.** `HoneyDrunk.Kernel.Abstractions` carries `Money`, `CurrencyCode`, and the two exception types (contracts and value-type construction validators). It does **NOT** carry `MoneyJsonConverter` (that is runtime serialization logic) and `Money` is **NOT** annotated with `[JsonConverter]` (which would force the converter into Abstractions). `MoneyJsonConverter` ships in `HoneyDrunk.Kernel` (runtime). System.Text.Json is BCL, but the converter class is logic — invariant 1 separates the two.
+- **Invariant 4 — DAG.** Kernel is at the root. No reference to any other HoneyDrunk runtime package.
+- **Invariant 13 — XML docs on every public API.** Enforced by `HoneyDrunk.Standards` analyzers.
+- **Invariant 27 — all projects in a solution share one version.** Every non-test `.csproj` in the solution gets the same minor bump in one commit. Partial bumps are forbidden. Confirm current solution version at edit time — if another initiative (e.g. ADR-0042) has already moved past `0.7.0`, take the next minor over `main`'s actual state.
+- **Invariant 12 — per-package CHANGELOGs only for packages with functional changes.** `HoneyDrunk.Kernel.Abstractions` gets an entry (`Money`, `CurrencyCode`, exceptions); `HoneyDrunk.Kernel` gets an entry (`MoneyJsonConverter` — real change, the converter now ships from the runtime package).
+- **Records drop the `I`.** `Money`, `CurrencyCode` are records / record structs — no `I` prefix.
+- **`BillingEvent` is untouched.** ADR-0026 D5 frozen; ADR-0069 D7 explicit. Do not amend the `BillingEvent` record or its catalog entry.
+- **No `Money.Zero` (no-arg).** D2 forbids zero-without-currency. `Money.Zero(CurrencyCode)` is the only shortcut without an amount.
+- **No truncation as a `Round` mode.** D3 — callers wanting truncation use `Math.Floor` on `Amount` and reconstruct, deliberately awkward.
+- **No third-party currency package.** D4 alternatives — `NodaMoney`, `Money.NET` and similar are rejected at the Grid's scale. Hand-maintained seed list only.
+
+## Labels
+`feature`, `tier-2`, `core`, `adr-0069`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add `Money`, `CurrencyCode`, `MoneyJsonConverter`, the two exception types, the arithmetic/rounding/serialization surface, and the canary tests to `HoneyDrunk.Kernel.Abstractions`. Bump the `HoneyDrunk.Kernel` solution to the next minor version.
+
+**Target:** `HoneyDrunk.Kernel`, branch from `main`.
+
+**Context:**
+- Goal: Ship the currency-handling primitive every other packet in this initiative depends on.
+- Feature: ADR-0069 Currency Handling and Money Representation rollout, Wave 2 (the foundation).
+- ADRs: ADR-0069 D1/D2/D3/D4/D7/D8/D9 (primary), ADR-0026 D5 (BillingEvent unchanged), ADR-0035 (additive minor bump), ADR-0008 (packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0069 Accepted before its contracts are built against it.
+
+**Constraints:**
+- Abstractions stay zero-HoneyDrunk-dependency and zero-runtime-logic (invariant 1). `Money` carries no `[JsonConverter]` attribute; `MoneyJsonConverter` lives in `HoneyDrunk.Kernel` (runtime), not Abstractions.
+- Records drop the `I`; `Money` and `CurrencyCode` are records / record structs.
+- `BillingEvent` is NOT modified — ADR-0026 D5 frozen shape preserved per ADR-0069 D7.
+- Bump every non-test `.csproj` in the solution in one commit (invariant 27). At edit time, check `HoneyDrunk.Kernel.csproj`'s current version and `repos/HoneyDrunk.Kernel/active-work.md` for the ADR-0042 race (see Context section, three-case procedure). Record which case applied in the PR description.
+- Do **NOT** override `==` / `!=` on `Money`. Record-default value equality stands — cross-currency `==` returns `false`, never throws. Overriding would break `HashSet<Money>`, `Dictionary<Money>`, EF equality, every implicit `Equals`/`GetHashCode`. The throw discipline stays on arithmetic (`+`/`-`) and ordering (`<`/`<=`/`>`/`>=`). Packet 00 records this as a **Required ADR Amendment to D2**.
+- JSON `amount` is **always** a string; reject `amount` as a JSON number on deserialize (D9 precision discipline).
+- No `Money.Zero` (no-arg) — D2 forbids zero-without-currency. No truncation as a `Round` mode — D3. No third-party currency package — D4.
+
+**Key Files:**
+- `HoneyDrunk.Kernel.Abstractions/` — new files for `Money`, `CurrencyCode`, `CurrencyMismatchException`, `UnknownCurrencyCodeException`, per-currency metadata table. **No** `MoneyJsonConverter` here.
+- `HoneyDrunk.Kernel/` — new `MoneyJsonConverter.cs` (in a serialization folder).
+- `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md`, `README.md`; `HoneyDrunk.Kernel/CHANGELOG.md`; repo-level `CHANGELOG.md`.
+- `repos/HoneyDrunk.Kernel/active-work.md` (Architecture repo) — read for the ADR-0042 race coordination; update with the chosen case.
+- Every non-test `.csproj` for the version bump.
+- `HoneyDrunk.Kernel.Tests` — canary suite for `Money` arithmetic, rounding, JSON, validator.
+
+**Contracts:**
+- `Money` (new record in `HoneyDrunk.Kernel.Abstractions`) — `(decimal Amount, CurrencyCode CurrencyCode)`. Arithmetic + ordering operators / static factories / `Round` / `ToString`. No `==` override; no `[JsonConverter]` attribute.
+- `CurrencyCode` (new record struct in `HoneyDrunk.Kernel.Abstractions`) — ISO 4217 alpha-3 validated. Per-currency metadata. Static well-known values.
+- `CurrencyMismatchException`, `UnknownCurrencyCodeException` (new exception types in `HoneyDrunk.Kernel.Abstractions`).
+- `MoneyJsonConverter` (new class in `HoneyDrunk.Kernel` runtime, NOT Abstractions) — System.Text.Json converter for the D9 shape; callers register explicitly.

--- a/generated/issue-packets/active/adr-0069-currency-handling/03-ai-cost-ledger-money-adoption.md
+++ b/generated/issue-packets/active/adr-0069-currency-handling/03-ai-cost-ledger-money-adoption.md
@@ -1,0 +1,201 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.AI
+labels: ["feature", "tier-2", "ai", "adr-0069", "wave-3"]
+dependencies: ["packet:02"]
+adrs: ["ADR-0069", "ADR-0052"]
+wave: 3
+initiative: adr-0069-currency-handling
+node: honeydrunk-ai
+---
+
+# Migrate the AI cost ledger from decimal to Money (USD-explicit)
+
+## Summary
+Migrate `HoneyDrunk.AI.Abstractions`'s `InferenceCost.EstimatedCost` and `CostSummary.TotalCost` from `decimal` to `Money`, with `CurrencyCode.Usd` as the explicit denomination at Phase 1 per ADR-0069 D10. Update `DefaultCostLedger`'s aggregation to operate on `Money` (sum of same-currency values) and surface the explicit USD denomination. This is the version-bumping packet for the `HoneyDrunk.AI` solution.
+
+## Context
+ADR-0069 D10 commits the AI-sector cost-rate cache (per ADR-0052) to **explicit `Money(rate, CurrencyCode.Usd)`** denomination, rather than the implicit `decimal` representation it carries today. The discipline forecloses the "we added a EUR-billed provider and silently treated its rates as USD" class of bug. The current `HoneyDrunk.AI.Abstractions` types:
+
+- `InferenceCost(string ProviderId, string ModelId, int InputTokens, int OutputTokens, decimal EstimatedCost, string OperationCorrelationId)` — a record with a `decimal EstimatedCost` field carrying the implicit-USD inference cost.
+- `CostSummary(string Scope, DateTimeOffset Since, DateTimeOffset Until, decimal TotalCost, int TotalCalls)` — a record with a `decimal TotalCost` field carrying the implicit-USD aggregate.
+- `ICostLedger.RecordAsync(InferenceCost cost, ...)` and `ICostLedger.GetSummaryAsync(string scope, DateTimeOffset since, ...) → Task<CostSummary>` — the interface contract.
+
+`DefaultCostLedger` (in `HoneyDrunk.AI.Cost`) aggregates `entry.Cost.EstimatedCost` via LINQ `Sum`, returning a `decimal`. The aggregate must be `Money` after this packet, with the currency preserved through the summation.
+
+**Cross-Node version dependency.** This packet builds against the new `Money`/`CurrencyCode` surface shipped by packet 02 in `HoneyDrunk.Kernel`. The package reaches the NuGet feed only after a human tags/releases the `HoneyDrunk.Kernel` solution version that ships the new surface. This is the Wave 2→3 boundary's Human Prerequisite.
+
+`HoneyDrunk.AI` is a live Node currently at version `0.1.0` (from `Directory.Build.props`) using `.NET 10.0`. This packet is the first packet on the AI solution in this initiative — per invariant 27 it bumps every non-test `.csproj` to the same new minor version (likely `0.1.0` → `0.2.0`; confirm at edit time). Per-package CHANGELOG: `HoneyDrunk.AI.Abstractions` gets an entry (changed surface); `HoneyDrunk.AI` gets an entry (runtime aggregation logic changed); the provider packages and the worker get no per-package CHANGELOG entry (alignment bump only — invariant 12).
+
+**Breaking change.** Changing `InferenceCost.EstimatedCost` from `decimal` to `Money` and `CostSummary.TotalCost` from `decimal` to `Money` is a **breaking shape change** on `HoneyDrunk.AI.Abstractions`. Per ADR-0035 the pre-1.0 disclaimer applies — pre-1.0 Abstractions carry no compatibility promise — but this is still a real surface break and any internal callers must be updated in the same commit. Search `HoneyDrunk.AI` for every `InferenceCost(...)` construction and every `cost.EstimatedCost` / `summary.TotalCost` read; update each to the `Money` shape. The version bump (minor, since pre-1.0) reflects the additive-and-substitutive nature of the change.
+
+**Aggregation discipline.** `DefaultCostLedger`'s `GetSummaryAsync` sums `EstimatedCost` across entries via LINQ `Sum`. After this change, the sum is `Money` and **must** respect the currency-mismatch rule (D2: cross-currency `+` throws). At Phase 1 every recorded entry is `Money(rate, CurrencyCode.Usd)` (every current AI provider — OpenAI, Anthropic, Azure OpenAI — bills in USD). If a future provider lands with a non-USD billing currency, the LINQ `Sum` over mixed currencies will throw `CurrencyMismatchException` at the read site — that throw is the **correct, deliberate behavior** per ADR-0069 D5 (multi-currency aware, multi-currency converting deferred). It is a load-bearing failure mode: it signals that the cost ledger needs the (deferred) FX-rate service to produce a unified denomination, and prevents a silent miscount. Document this in the `DefaultCostLedger.GetSummaryAsync` XML doc explicitly.
+
+## Downstream-impact (consumers of `InferenceCost.EstimatedCost` and `CostSummary.TotalCost`)
+
+This packet is a **breaking shape change** on `HoneyDrunk.AI.Abstractions` — `decimal EstimatedCost` becomes `Money EstimatedCost`, `decimal TotalCost` becomes `Money TotalCost`. Pre-1.0 disclaimer applies (ADR-0035 D1), but every consumer that reads or constructs these fields must be updated in the same merge window.
+
+**Confirmed scope at packet-authoring time (2026-05-24) — every consumer is inside the `HoneyDrunk.AI` solution.** A Grid-wide search for `HoneyDrunk.AI.Abstractions` `PackageReference` returns only the `HoneyDrunk.AI` solution's own projects. A symbol-level search for `.EstimatedCost`, `.TotalCost`, `new InferenceCost`, and `new CostSummary` field-access / constructor-call sites across the Grid returns:
+
+- **Edited in this packet (primary shape change):**
+  - `src/HoneyDrunk.AI.Abstractions/InferenceCost.cs` — `decimal EstimatedCost` → `Money EstimatedCost`
+  - `src/HoneyDrunk.AI.Abstractions/CostSummary.cs` — `decimal TotalCost` → `Money TotalCost`
+- **Edited in this packet (consumer refactor):**
+  - `src/HoneyDrunk.AI.Abstractions/ICostLedger.cs` — interface signature unchanged (carried types change shape)
+  - `src/HoneyDrunk.AI/Cost/DefaultCostLedger.cs` — aggregation rewritten to fold `Money`
+  - `tests/HoneyDrunk.AI.Abstractions.Tests/AbstractionsSmokeTests.cs` — constructor calls + field reads updated
+  - `tests/HoneyDrunk.AI.Tests/RuntimeTests.cs` — constructor calls + field reads updated
+- **Tag/constant references (no shape change needed):**
+  - `src/HoneyDrunk.AI/Telemetry/InferenceTelemetry.cs` — carries an `EstimatedCostTag` string constant (`"honeydrunk.ai.estimated_cost"`); no field-typed read of `cost.EstimatedCost` in this file today. If telemetry emit logic is added that reads `cost.EstimatedCost.Amount` for tracing, it picks up the new shape via `.Amount`; out of scope for this packet.
+- **Verified clean (not field consumers):**
+  - `src/HoneyDrunk.AI/Routing/CostFirstRoutingPolicy.cs`, `src/HoneyDrunk.AI/Routing/DefaultModelRouter.cs`, `src/HoneyDrunk.AI/Routing/PolicyLoader.cs`, `src/HoneyDrunk.AI/ServiceCollectionExtensions.cs`, `src/HoneyDrunk.AI.Providers.*/*.cs`, `tests/HoneyDrunk.AI.Providers.InMemory.Tests/InMemoryProviderTests.cs` — none of these directly read `.EstimatedCost`/`.TotalCost` or construct `InferenceCost`/`CostSummary` today. The executor still re-greps for `EstimatedCost`/`TotalCost`/`InferenceCost`/`CostSummary` at edit time in case the surface drifts between packet authoring and execution.
+
+**No external (Capabilities / Operator / Agents / Memory / Knowledge / Evals) consumers exist today.** Those Nodes do not take a `PackageReference` on `HoneyDrunk.AI.Abstractions`; the cost ledger is consumed only inside the AI Node. This forecloses the cross-Node version-race risk for this packet — every consumer is in the same solution and is updated in the same commit.
+
+**Future-cross-Node guidance.** If a future Node (e.g., `HoneyDrunk.Capabilities`, `HoneyDrunk.Operator`, `HoneyDrunk.Agents`, `HoneyDrunk.Memory`, `HoneyDrunk.Knowledge`, `HoneyDrunk.Evals`) takes a `PackageReference` on `HoneyDrunk.AI.Abstractions` after this packet ships, that Node's first cost-ledger consumer commit must pick up the new shape from the released `HoneyDrunk.AI.Abstractions` version. The `Money` adoption is recorded in:
+
+- `HoneyDrunk.AI.Abstractions/CHANGELOG.md` under the version this packet ships — entry must read along the lines of "BREAKING: `InferenceCost.EstimatedCost` and `CostSummary.TotalCost` changed from `decimal` to `Money` (ADR-0069 D10). Consumers must reference `HoneyDrunk.Kernel.Abstractions` and update their construction / read sites."
+- `HoneyDrunk.AI/CHANGELOG.md` — the `DefaultCostLedger` aggregation update with the cross-currency throw note.
+- The repo-level `CHANGELOG.md` carries the BREAKING note at version-entry level.
+
+**Release-notes guidance for the AI Node.** When the human releases the `HoneyDrunk.AI` solution after this packet's merge, the release notes (per-Node release process) flag the `Money` adoption as a **breaking pre-1.0 shape change**, list the call-site update pattern (`new InferenceCost(..., Money.Usd(decimalCost), ...)` and `summary.TotalCost.Amount` if a `decimal` is still genuinely needed), and link back to ADR-0069 D10. This is the signal future-Node-adopters look for.
+
+## Scope
+- `src/HoneyDrunk.AI.Abstractions/InferenceCost.cs` — change `decimal EstimatedCost` to `Money EstimatedCost`. Update the XML doc.
+- `src/HoneyDrunk.AI.Abstractions/CostSummary.cs` — change `decimal TotalCost` to `Money TotalCost`. Update the XML doc.
+- `src/HoneyDrunk.AI.Abstractions/HoneyDrunk.AI.Abstractions.csproj` — add `<PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="{the version shipped by packet 02}" />` (confirm with the released version).
+- `src/HoneyDrunk.AI/Cost/DefaultCostLedger.cs` — update `GetSummaryAsync` to sum `Money` values via `Aggregate`. Seed selection (spelled out): on empty scope, seed `Money.Zero(CurrencyCode.Usd)`; on non-empty scope, seed `Money.Zero(scoped[0].Cost.EstimatedCost.CurrencyCode)` so the fold returns the same currency the entries carry. Document the cross-currency throw behavior in XML doc.
+- Every internal call site that constructs `InferenceCost(...)` or reads `cost.EstimatedCost` / `summary.TotalCost` — provider packages, runtime tests, anywhere in `HoneyDrunk.AI*` that touches the shape. Search the repo and update each.
+- All non-test `.csproj` files in the solution version-bumped together (invariant 27).
+- `HoneyDrunk.AI.Abstractions/CHANGELOG.md` (real change) and `HoneyDrunk.AI/CHANGELOG.md` (real change). Provider/worker packages: alignment bump only, no per-package CHANGELOG entry.
+- Repo-level `CHANGELOG.md` gets a new version entry.
+- `HoneyDrunk.AI.Abstractions/README.md` updated for the new public-API surface shape.
+
+## Proposed Implementation
+1. **Add the Kernel.Abstractions package reference.** In `src/HoneyDrunk.AI.Abstractions/HoneyDrunk.AI.Abstractions.csproj`, add `<PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="X.Y.Z" />` where `X.Y.Z` is the released version from packet 02. Confirm the version is published on the feed before editing (this is the Wave 2→3 Human Prerequisite).
+2. **`InferenceCost`** — change the constructor signature: `public sealed record InferenceCost(string ProviderId, string ModelId, int InputTokens, int OutputTokens, Money EstimatedCost, string OperationCorrelationId)`. Update the XML doc for `EstimatedCost` to describe `Money` semantics: "Per-currency-aware estimated cost. At Phase 1 every AI provider bills in USD; `Money` carries `CurrencyCode.Usd` explicitly per ADR-0069 D10."
+3. **`CostSummary`** — change the constructor signature: `public sealed record CostSummary(string Scope, DateTimeOffset Since, DateTimeOffset Until, Money TotalCost, int TotalCalls)`. Update the XML doc for `TotalCost`.
+4. **`DefaultCostLedger.GetSummaryAsync`** — replace `var totalCost = scoped.Sum(entry => entry.Cost.EstimatedCost);` with a `Money`-respecting aggregate. **Two seed cases, spelled out:**
+
+   - **Empty scope** — `scoped.Length == 0`: seed is `Money.Zero(CurrencyCode.Usd)`. The Phase-1 default per ADR-0069 D10 — USD is the Grid-default currency, and an empty cost summary reads naturally as zero USD.
+   - **Non-empty scope** — `scoped.Length > 0`: seed is `Money.Zero(scoped[0].Cost.EstimatedCost.CurrencyCode)`. Use the first entry's currency as the seed so the fold returns the same currency the entries denominate in. If every entry is USD (Phase 1), this is `Money.Zero(CurrencyCode.Usd)`. If a non-USD provider ever appears, the seed picks up that currency from the first entry; subsequent entries with a different currency throw `CurrencyMismatchException` via the `+` operator (D2) — which is the deliberate FX-service-gap signal per ADR-0069 D5.
+
+   Implementation sketch:
+   ```csharp
+   var seed = scoped.Length == 0
+       ? Money.Zero(CurrencyCode.Usd)
+       : Money.Zero(scoped[0].Cost.EstimatedCost.CurrencyCode);
+   var totalCost = scoped.Aggregate(seed, (acc, entry) => acc + entry.Cost.EstimatedCost);
+   ```
+   Cross-currency entries within a non-empty scope trigger `CurrencyMismatchException` at the second-entry `+` — that throw is deliberate per ADR-0069 D5 and surfaces the "deferred FX-rate service" gap rather than silently miscounting.
+5. **XML-doc the cross-currency throw.** `DefaultCostLedger.GetSummaryAsync`'s XML doc must include: "Throws `CurrencyMismatchException` if the recorded entries span multiple currencies. At Phase 1 every AI provider bills in USD; mixed-currency aggregation requires the FX-rate service (out of scope per ADR-0069 D5 / D12)."
+6. **Update every call site** in `src/HoneyDrunk.AI/`, `src/HoneyDrunk.AI.Providers.*/`, `tests/HoneyDrunk.AI.Tests/`, `tests/HoneyDrunk.AI.Abstractions.Tests/`, `tests/HoneyDrunk.AI.Providers.InMemory.Tests/`. Every `new InferenceCost(..., estimatedCost, ...)` becomes `new InferenceCost(..., Money.Usd(estimatedCost), ...)`. Every `summary.TotalCost` read that expected `decimal` extracts `.Amount` if a `decimal` is genuinely needed (e.g. for logging) — but prefer to flow `Money` through.
+7. **Bump versions.** Every non-test `.csproj` in `HoneyDrunk.AI.slnx` moves to the same new minor (invariant 27). Confirm the source-of-truth version at edit time — `Directory.Build.props` shows `0.1.0` today; if it has moved, take the next minor over `main`'s actual state. Update `HoneyDrunk.AI.Abstractions/CHANGELOG.md` (real change), `HoneyDrunk.AI/CHANGELOG.md` (real change in `DefaultCostLedger`), and the repo-level `CHANGELOG.md`. Provider packages and the worker: alignment bump only, no per-package CHANGELOG entry (invariant 12).
+8. **README.** Update `src/HoneyDrunk.AI.Abstractions/README.md` to reflect the new shape of `InferenceCost` and `CostSummary` (invariant 12 — public API surface change).
+9. **Tests.** Update unit tests that construct or read these types. Add a test asserting that the `GetSummaryAsync` aggregate's `CurrencyCode` is `Usd` when the scope contains USD entries; add a test asserting that a mixed-currency scope throws `CurrencyMismatchException` (the deliberate failure mode).
+
+## Affected Files
+- `src/HoneyDrunk.AI.Abstractions/InferenceCost.cs`
+- `src/HoneyDrunk.AI.Abstractions/CostSummary.cs`
+- `src/HoneyDrunk.AI.Abstractions/HoneyDrunk.AI.Abstractions.csproj` (Kernel.Abstractions package reference + version bump)
+- `src/HoneyDrunk.AI.Abstractions/CHANGELOG.md`, `src/HoneyDrunk.AI.Abstractions/README.md`
+- `src/HoneyDrunk.AI/Cost/DefaultCostLedger.cs` (aggregation refactor)
+- `src/HoneyDrunk.AI/CHANGELOG.md`
+- All other `.csproj` files in `HoneyDrunk.AI.slnx` (alignment version bump)
+- Every internal call site that touches `InferenceCost.EstimatedCost` or `CostSummary.TotalCost` (search across `src/HoneyDrunk.AI*/` and `tests/`)
+- Repo-level `CHANGELOG.md`
+
+## NuGet Dependencies
+- **New:** `HoneyDrunk.Kernel.Abstractions` `X.Y.Z` (the version shipped by packet 02) on `HoneyDrunk.AI.Abstractions`. The Kernel.Abstractions package is the **only** runtime HoneyDrunk dependency added — invariant 1 still holds on Kernel.Abstractions itself (no upstream HoneyDrunk runtime); invariant 1 does not bind downstream Abstractions packages.
+- No new test packages — existing test stack covers the new assertions.
+- No new packages elsewhere.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.AI`. Routing rule "AI, cost ledger, model, capability → HoneyDrunk.AI" maps exactly.
+- [x] The new HoneyDrunk dependency is `HoneyDrunk.Kernel.Abstractions` only — the canonical zero-dependency contracts package. No cross-Node runtime coupling introduced.
+- [x] No change to other Nodes; consumer-side migration is local to the AI Node.
+
+## Acceptance Criteria
+- [ ] `InferenceCost.EstimatedCost` is `Money` (was `decimal`); the XML doc reflects the Phase-1 USD-explicit denomination per ADR-0069 D10
+- [ ] `CostSummary.TotalCost` is `Money` (was `decimal`); the XML doc reflects the same
+- [ ] `HoneyDrunk.AI.Abstractions` takes a `PackageReference` on `HoneyDrunk.Kernel.Abstractions` at the version shipped by packet 02
+- [ ] `DefaultCostLedger.GetSummaryAsync` aggregates `Money` correctly when every entry is USD; throws `CurrencyMismatchException` on mixed-currency scopes (deliberate per ADR-0069 D5)
+- [ ] `DefaultCostLedger.GetSummaryAsync`'s XML doc documents the cross-currency throw as the deferred-FX-service signal
+- [ ] Every internal call site in `HoneyDrunk.AI` solution that constructs `InferenceCost` or reads `EstimatedCost` / `TotalCost` is updated; the solution builds end-to-end
+- [ ] Every non-test `.csproj` in the solution is at the same new minor version in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new version entry dated to the merge, describing the `Money` adoption
+- [ ] `HoneyDrunk.AI.Abstractions/CHANGELOG.md` has an entry describing the breaking shape change on `InferenceCost.EstimatedCost` and `CostSummary.TotalCost`
+- [ ] `HoneyDrunk.AI/CHANGELOG.md` has an entry describing the `DefaultCostLedger` aggregation update
+- [ ] Provider packages and the worker (alignment bumps only) get NO per-package CHANGELOG entry (invariant 12)
+- [ ] `HoneyDrunk.AI.Abstractions/README.md` reflects the new public-API surface shape
+- [ ] Unit tests cover the USD-only happy path and the mixed-currency `CurrencyMismatchException` path
+- [ ] No use of `Money.Zero` (no-arg) — D2 forbids zero-without-currency; all seeds are `Money.Zero(CurrencyCode.Usd)` at Phase 1
+- [ ] The `pr-core.yml` tier-1 gate passes; any HoneyDrunk.AI canary suite passes (or is updated coherently with the new shape)
+
+## Human Prerequisites
+- [ ] `HoneyDrunk.Kernel` solution at the version shipped by packet 02 must be tagged and released to the package feed before this packet's branch can compile. Agents merge code; humans tag/release. See the Wave 2→3 handoff for the release procedure.
+
+## Referenced ADR Decisions
+**ADR-0069 D10 — Cost ledger is USD-explicit.** The ADR-0052 in-memory cost-rate cache is denominated in USD at Phase 1. The cache value type is updated to `Money` (rather than raw `decimal`), with `CurrencyCode.Usd` as the implicit constructor. Records the denomination explicitly to foreclose the silent-USD-assumption bug class.
+
+**ADR-0069 D5 — Multi-currency aware, not multi-currency converting.** The Grid stores in the source currency; aggregate-revenue reporting that requires a single denomination performs FX conversion at read time against an FX-rate service (deferred per D12). At the AI cost ledger today, every recorded entry is USD; mixed-currency aggregation is not supported and the `CurrencyMismatchException` is the load-bearing signal that the deferred FX-rate service is needed.
+
+**ADR-0069 D1 — `Money` shape.** `Money(decimal Amount, CurrencyCode CurrencyCode)`. Static factories include `Money.Usd(decimal)`. `Money.Zero(CurrencyCode)` is the only zero shortcut.
+
+**ADR-0069 D2 — Cross-currency arithmetic throws.** `Money + Money` with different currencies throws `CurrencyMismatchException`. The throw is the deliberate failure mode for mixed-currency aggregation in `DefaultCostLedger.GetSummaryAsync`.
+
+**ADR-0052 (referenced) — `ICostLedger` policy.** The AI cost ledger is the operationally-live consumer ADR-0069 D10 amends.
+
+**ADR-0035 D1 / pre-1.0 disclaimer (referenced) — pre-1.0 breaking change semantics.** `HoneyDrunk.AI.Abstractions` is pre-1.0; substitutive shape changes are permitted without major bump, but a minor bump still moves the version. Every non-test `.csproj` in the solution shares the bump (invariant 27).
+
+## Constraints
+- **Invariant 27 — solution-wide version bump in one commit.** Every non-test `.csproj` moves together. Partial bumps are forbidden.
+- **Invariant 12 — per-package CHANGELOGs only for packages with functional changes.** `HoneyDrunk.AI.Abstractions` and `HoneyDrunk.AI` get entries; provider/worker packages (alignment bumps only) get none.
+- **Invariant 13 — XML docs on every public API.** Updated for the new shape.
+- **Invariant 1 (referenced) — does not bind here.** `HoneyDrunk.AI.Abstractions` is a downstream Abstractions package; taking a dependency on `HoneyDrunk.Kernel.Abstractions` is allowed (Kernel.Abstractions is the canonical zero-dependency contracts package every downstream Abstractions package is permitted to consume).
+- **No `Money.Zero` (no-arg).** D2 forbids zero-without-currency. Phase-1 aggregator seed is `Money.Zero(CurrencyCode.Usd)`.
+- **Cross-currency throw is deliberate.** D5 — do not silently convert; do not hide the exception. XML-doc it as the FX-service gap signal.
+- **No FX-rate service.** D12 — out of scope here. If a non-USD provider is added later, the FX-rate service ADR commits the provider; this packet does not pre-build it.
+
+## Labels
+`feature`, `tier-2`, `ai`, `adr-0069`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Migrate the AI cost ledger from `decimal` to `Money(amount, CurrencyCode.Usd)` per ADR-0069 D10; preserve the deliberate cross-currency throw as the deferred-FX-service signal.
+
+**Target:** `HoneyDrunk.AI`, branch from `main`.
+
+**Context:**
+- Goal: Make the cost-rate denomination explicit; foreclose the silent-USD-assumption bug class; deliver ADR-0069 D10's commitment.
+- Feature: ADR-0069 Currency Handling rollout, Wave 3 — AI cost-ledger adoption.
+- ADRs: ADR-0069 D1/D2/D5/D10/D12 (primary), ADR-0052 (cost-governance — the policy this amends), ADR-0035 (pre-1.0 versioning).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — `Money`/`CurrencyCode` must exist in `HoneyDrunk.Kernel.Abstractions` and the Kernel package must be released on the feed before this packet can compile.
+
+**Constraints:**
+- The cross-currency `CurrencyMismatchException` from `DefaultCostLedger.GetSummaryAsync` is the **deliberate** failure mode — do not catch and silently convert; do not hide. Document it in XML doc as the deferred-FX-service signal.
+- `Money.Zero(CurrencyCode.Usd)` is the Phase-1 aggregator seed. No `Money.Zero` (no-arg) — D2 forbids it.
+- Every non-test `.csproj` in the solution version-bumped in one commit (invariant 27).
+- Per-package CHANGELOGs only for `HoneyDrunk.AI.Abstractions` and `HoneyDrunk.AI` (real changes). Provider/worker packages: no per-package entry (alignment bumps only).
+- Search the entire solution for `InferenceCost` constructions and `EstimatedCost`/`TotalCost` reads; update each. The change is breaking on `HoneyDrunk.AI.Abstractions` but pre-1.0, so a minor bump is sufficient.
+
+**Key Files:**
+- `src/HoneyDrunk.AI.Abstractions/InferenceCost.cs`
+- `src/HoneyDrunk.AI.Abstractions/CostSummary.cs`
+- `src/HoneyDrunk.AI.Abstractions/HoneyDrunk.AI.Abstractions.csproj`
+- `src/HoneyDrunk.AI/Cost/DefaultCostLedger.cs`
+- All other `.csproj` files in `HoneyDrunk.AI.slnx` (alignment version bump)
+- `HoneyDrunk.AI.Abstractions/CHANGELOG.md`, `README.md`; `HoneyDrunk.AI/CHANGELOG.md`; repo-level `CHANGELOG.md`
+- Every call site that touches the migrated fields
+
+**Contracts:**
+- `InferenceCost` (existing record, breaking field type change) — `EstimatedCost` is now `Money`.
+- `CostSummary` (existing record, breaking field type change) — `TotalCost` is now `Money`.
+- `ICostLedger` (existing interface, unchanged) — the interface members' signatures don't change; the carried types do.
+- New dependency: `HoneyDrunk.Kernel.Abstractions` `X.Y.Z` (`Money`, `CurrencyCode`).

--- a/generated/issue-packets/active/adr-0069-currency-handling/04-architecture-audit-money-emitter-convention.md
+++ b/generated/issue-packets/active/adr-0069-currency-handling/04-architecture-audit-money-emitter-convention.md
@@ -1,0 +1,154 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0069", "wave-3"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0069", "ADR-0030"]
+wave: 3
+initiative: adr-0069-currency-handling
+node: honeydrunk-architecture
+---
+
+# Document the audit money-emitter two-field convention (monetary_value + currency_code)
+
+## Summary
+Document ADR-0069 D11's two-field convention for money-changing audit events — `monetary_value` (JSON string) and `currency_code` (ISO 4217 alpha-3 uppercase), flat on the audit event, not nested inside a `money` object — in `repos/HoneyDrunk.Audit/boundaries.md` (or the equivalent emitter-conventions location) and in the ADR-0030 emitter-conventions section. No code change in `HoneyDrunk.Audit`: `AuditEntry.Metadata` is already a `IReadOnlyDictionary<string, string>` map, so the two-field convention is a **projection responsibility for emitters** that record monetary outcomes — they project an in-memory `Money` into `metadata["monetary_value"]` + `metadata["currency_code"]` at emit time, with no contract change to `IAuditLog`.
+
+## Context
+ADR-0069 D11 commits the audit shape for money-changing events:
+
+```json
+{
+  "event_type": "SubscriptionRenewed",
+  "tenant_id": "01HXXX...",
+  "monetary_value": "29.99",
+  "currency_code": "USD",
+  "correlation_id": "..."
+}
+```
+
+`monetary_value` is the amount as a JSON string (matching D9's serialization discipline for precision preservation); `currency_code` is the ISO 4217 alpha-3 code, uppercase. The two fields are **top-level / flat on the audit event**, not nested inside a `money` object. The rationale (per D11):
+
+- Audit-query patterns favor flat fields — a query like "total monetary outcomes for tenant X in USD this month" reads `monetary_value` and `currency_code` as separate columns / fields. A nested object requires JSON-path queries on every audit-store backend.
+- Backend-agnostic — the audit substrate per ADR-0030 does not commit a specific backend; SQL, Cosmos, and search-index backends all favor flat fields for indexability.
+- The in-memory type held by the emitter is `Money`; the on-the-wire / on-disk shape in audit is two flat fields. The emitter is responsible for the projection.
+
+**Why no code change in `HoneyDrunk.Audit` is needed.** The current `AuditEntry` record (in `HoneyDrunk.Audit.Abstractions`) is:
+
+```csharp
+public sealed record AuditEntry(
+    AuditEntryId Id,
+    DateTimeOffset OccurredAt,
+    string Actor,
+    string EventName,
+    AuditCategory Category,
+    AuditOutcome Outcome,
+    AuditTarget Target,
+    TenantId TenantId,
+    string? CorrelationId = null,
+    AuditOperation Operation = AuditOperation.None,
+    IReadOnlyList<AuditChange>? Changes = null,
+    IReadOnlyDictionary<string, string>? Metadata = null,
+    string? Reason = null)
+```
+
+`Metadata` is already a `string → string` map. The two-field convention lands as `Metadata["monetary_value"] = money.Amount.ToString("F{decimals}", InvariantCulture)` and `Metadata["currency_code"] = money.CurrencyCode.Code`. **No change to `IAuditLog`, `AuditEntry`, or any other `HoneyDrunk.Audit.Abstractions` contract.** The Audit Node's `IAuditLog` contract-shape canary (per ADR-0031 D8 / invariant 49) stays green by construction.
+
+The convention is a **documentation deliverable**: the location where emitters look for "how do I record a money-changing audit event" — `repos/HoneyDrunk.Audit/boundaries.md` (or the equivalent emitter conventions location in the repo's Architecture-side documentation) and the corresponding section in ADR-0030 (which already exists as a reference point for Audit-emitter conventions per the ADR's own follow-up list).
+
+This is a docs/governance packet. No code, no .NET project, no catalog schema change.
+
+## Scope
+- `repos/HoneyDrunk.Audit/boundaries.md` — add a "Money-changing audit events" section documenting the D11 two-field convention. Include the JSON example, the `Money → Metadata["monetary_value"] + Metadata["currency_code"]` projection sketch, the rationale (flat-field queryability, backend-agnosticism), and the invariant that `monetary_value` is always a JSON string (precision discipline, mirroring ADR-0069 D9).
+- `repos/HoneyDrunk.Audit/overview.md` — if the overview lists "what an emitter writes" or "what fields appear on an `AuditEntry`," add a one-line note pointing at the boundaries-file section for money-changing emits.
+- `adrs/ADR-0030-grid-wide-audit-substrate.md` — if the ADR has an "Emitter Conventions" section (the ADR's "Follow-Up" list mentions emitter conventions), add a note referencing ADR-0069 D11. If no such section exists, add a brief paragraph under Consequences or as a new "Money-changing emit convention" subsection. **Do not flip ADR-0030's status; do not edit any of its decisions.** This is a referencing edit only.
+- `catalogs/contracts.json` and `relationships.json` — **not edited.** The two-field convention is an emitter projection rule, not a new contract. `IAuditLog`/`AuditEntry` are unchanged.
+
+## Proposed Implementation
+1. **`repos/HoneyDrunk.Audit/boundaries.md`** — append a new section "Money-changing audit events (ADR-0069 D11)" containing:
+   - A short rationale paragraph naming why money is split into two fields (flat-field queryability, backend-agnosticism, in-memory `Money` projection at emit time).
+   - The JSON shape example (the block from ADR-0069 D11 — `event_type`, `tenant_id`, `monetary_value`, `currency_code`, `correlation_id`).
+   - The mapping rule: emitter projects an in-memory `Money(amount, currency)` into `AuditEntry.Metadata` with two keys — `metadata["monetary_value"]` carrying `amount.ToString("F{currency-default-decimals}", InvariantCulture)` (a JSON-string-shaped value to match ADR-0069 D9 precision discipline), and `metadata["currency_code"]` carrying `currency.Code` (uppercase ISO 4217 alpha-3).
+   - The discipline rule: `monetary_value` is **always** a string-shaped metadata value (Audit's `Metadata` is `string → string` so this is automatic, but flag it as the precision-preservation invariant for any future emitter that constructs the metadata dictionary).
+   - A reference to the four currently-named example event types from ADR-0069 D7: `SubscriptionRenewed`, `RefundIssued`, `QuotaOverageBilled`, plus the generic "any audit event that records a monetary outcome." These are illustrative; the convention applies to all money-changing events.
+2. **`repos/HoneyDrunk.Audit/overview.md`** — if it already enumerates emitter conventions or `AuditEntry.Metadata` patterns, add a single line: "Money-changing emits use the two-field convention — `monetary_value` + `currency_code` — see `boundaries.md` and ADR-0069 D11." If no such enumeration exists, skip this file edit.
+3. **`adrs/ADR-0030-grid-wide-audit-substrate.md`** — add a brief paragraph noting the D11 cross-reference. Recommended location: a "Money-changing emit convention" subsection under Consequences or a paragraph appended to the existing emitter-conventions discussion. Wording should be of the form: *"Money-changing audit events use the two-field convention committed by ADR-0069 D11 — `monetary_value` (JSON string) and `currency_code` (ISO 4217 alpha-3 uppercase) — projected from the in-memory `Money` value at emit time. See ADR-0069 for the rationale and the precision-preservation discipline."* **Do not flip ADR-0030's status.** **Do not edit any of ADR-0030's decisions.** This is a cross-reference addition only.
+4. **No code change.** `HoneyDrunk.Audit.Abstractions.AuditEntry.Metadata` is already `IReadOnlyDictionary<string, string>`. `IAuditLog` is unchanged. The ADR-0031-D8 contract-shape canary stays green.
+5. **No catalog change.** `IAuditLog` and `AuditEntry` are already registered; the two-field convention is an emitter projection rule, not a new contract surface.
+
+## Affected Files
+- `repos/HoneyDrunk.Audit/boundaries.md`
+- `repos/HoneyDrunk.Audit/overview.md` (only if a relevant enumeration exists)
+- `adrs/ADR-0030-grid-wide-audit-substrate.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown documentation; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, boundary, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in `HoneyDrunk.Audit` — the two-field convention lands as `Metadata["monetary_value"]` + `Metadata["currency_code"]` against the existing `AuditEntry.Metadata : IReadOnlyDictionary<string, string>` shape.
+- [x] No edit to any `IAuditLog`-bearing contract; the ADR-0031 D8 / invariant 49 contract-shape canary stays green.
+
+## Acceptance Criteria
+- [ ] `repos/HoneyDrunk.Audit/boundaries.md` has a "Money-changing audit events" section documenting the D11 two-field convention, with: (a) the rationale, (b) the JSON shape example, (c) the `Money → Metadata["monetary_value"] + Metadata["currency_code"]` projection rule, (d) the precision-preservation invariant for `monetary_value`
+- [ ] `adrs/ADR-0030-grid-wide-audit-substrate.md` has a cross-reference paragraph noting the ADR-0069 D11 convention
+- [ ] ADR-0030's Status is **unchanged** (this packet does not flip it; only the cross-reference is added)
+- [ ] No decision in ADR-0030 is edited (only the cross-reference is added)
+- [ ] No edit to `HoneyDrunk.Audit.Abstractions`, `AuditEntry`, `IAuditLog`, or any catalog file
+- [ ] No invariant change (the convention is canary-class, not invariant-class — per packet 00's "On invariants" framing)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0069 D11 — Two-field convention.** Money-changing audit events use `monetary_value` (JSON string) + `currency_code` (ISO 4217 alpha-3 uppercase), top-level on the audit event, not nested. In-memory the emitter holds a `Money`; on-the-wire the audit substrate stores the two flat fields. The split is deliberate — query patterns and backend-agnosticism — and the in-memory-vs-on-wire mismatch mirrors the same shape-mismatch ADR-0030 already uses for tracing-vs-audit envelopes.
+
+**ADR-0069 D9 (referenced) — Amount as JSON string.** `monetary_value` matches the precision-preservation discipline of D9 — always a string-shaped value, never a JSON number.
+
+**ADR-0069 D7 (referenced) — Example money-changing events.** `SubscriptionRenewed`, `RefundIssued`, `QuotaOverageBilled` are the illustrative event types named by the ADR. The convention applies to every audit event that records a monetary outcome.
+
+**ADR-0030 (referenced) — `IAuditLog`/`AuditEntry` shape unchanged.** The two-field convention lands as `Metadata["monetary_value"]` + `Metadata["currency_code"]` against the existing `AuditEntry.Metadata : IReadOnlyDictionary<string, string>`. No `IAuditLog` contract change.
+
+**ADR-0031 D8 / invariant 49 (referenced) — Audit contract-shape canary.** "The HoneyDrunk.Audit Node CI must include a contract-shape canary for the full `HoneyDrunk.Audit.Abstractions` public surface. Shape drift on `IAuditLog`, `IAuditQuery`, `AuditEntry`, or the supporting query/category/outcome/target/change value types is a build failure unless paired with an intentional version bump." This packet does not modify any of those types, so the canary stays green.
+
+## Constraints
+- **No code change.** The convention is documentation only; the existing `AuditEntry.Metadata` map carries the two-field convention without any contract change.
+- **Do not flip ADR-0030's Status.** This is a cross-reference addition to ADR-0030, not a re-acceptance.
+- **Do not edit any ADR-0030 decision.** Add the cross-reference paragraph only.
+- **Do not edit `catalogs/contracts.json` or `relationships.json`.** `IAuditLog`/`AuditEntry` are unchanged. The Audit Node's catalog entries stay as-is.
+- **Do not add a new invariant.** Per packet 00's "On invariants" framing, ADR-0069's four conventions are canary-enforced; the audit projection convention is the emitter's responsibility, documented in the boundaries file, not numbered in `constitution/invariants.md`.
+- **Precision discipline.** The `monetary_value` projection uses `Amount.ToString("F{decimals}", InvariantCulture)` so the metadata-value string carries the full decimal precision. Document this in the boundaries-file section.
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0069`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Document ADR-0069 D11's two-field convention for money-changing audit events in the Audit boundaries file and as a cross-reference in ADR-0030. No code change; no catalog change.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the projection rule discoverable for every emitter that records a monetary outcome — Billing (future), Notify Cloud (future), Web.Rest's subscription/refund endpoints (future), and any audit emit that records `SubscriptionRenewed`, `RefundIssued`, `QuotaOverageBilled`, or similar.
+- Feature: ADR-0069 Currency Handling rollout, Wave 3 — audit-emitter convention.
+- ADRs: ADR-0069 D11 (primary), ADR-0030 (audit substrate — cross-reference), ADR-0031 D8 / invariant 49 (Audit contract-shape canary stays green by construction — no contract change).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0069 Accepted before its D11 convention is documented as a live rule.
+
+**Constraints:**
+- No code change. The convention lands as `Metadata["monetary_value"]` + `Metadata["currency_code"]` against the existing `AuditEntry.Metadata` map. Do not touch `IAuditLog`, `AuditEntry`, or any catalog file.
+- Do not flip ADR-0030's status; do not edit its decisions. Cross-reference only.
+- Do not add a numbered invariant. Per packet 00, ADR-0069's conventions are canary-enforced; convention 4 (audit two-field shape) is an emitter responsibility documented in the boundaries file.
+- `monetary_value` precision discipline: `Amount.ToString("F{decimals}", InvariantCulture)` so the metadata-value string preserves the full decimal precision — mirroring ADR-0069 D9.
+
+**Key Files:**
+- `repos/HoneyDrunk.Audit/boundaries.md`
+- `adrs/ADR-0030-grid-wide-audit-substrate.md`
+- `repos/HoneyDrunk.Audit/overview.md` (only if a relevant enumeration exists)
+
+**Contracts:** None changed. `IAuditLog` and `AuditEntry` are unchanged. The ADR-0031 D8 / invariant 49 canary stays green.

--- a/generated/issue-packets/active/adr-0069-currency-handling/05-web-rest-money-json-converter-wiring.md
+++ b/generated/issue-packets/active/adr-0069-currency-handling/05-web-rest-money-json-converter-wiring.md
@@ -1,0 +1,141 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Web.Rest
+labels: ["feature", "tier-2", "core", "adr-0069", "wave-3"]
+dependencies: ["packet:02"]
+adrs: ["ADR-0069", "ADR-0057"]
+wave: 3
+initiative: adr-0069-currency-handling
+node: honeydrunk-web-rest
+---
+
+# Wire the MoneyJsonConverter into Web.Rest default JSON options and pin a canary
+
+## Summary
+Register the `MoneyJsonConverter` (shipped by packet 02 in `HoneyDrunk.Kernel` runtime — **not** Abstractions) into `HoneyDrunk.Web.Rest`'s default JSON serializer options via the existing `HoneyDrunk.Web.Rest.AspNetCore.Serialization.JsonOptionsDefaults.Configure` seam, and add a canary that round-trips a `Money` payload to assert ADR-0069 D9's shape (`{"amount": "string", "currency": "ISO"}`). The packet is forward-compatibility wiring against `HoneyDrunk.Kernel` so every future Web.Rest endpoint surfacing a price uses the canonical shape by construction, and locks the SDK-side parsing target ADR-0057 D8/D14-equivalent commits.
+
+**Seam exists today.** `HoneyDrunk.Web.Rest.AspNetCore/Serialization/JsonOptionsDefaults.cs` already exposes `static void Configure(JsonSerializerOptions options)` that consumers call. The converter registration lands as one line inside `Configure`. No new seam needed; no "deferred" branch.
+
+## Context
+ADR-0069 D9 commits the JSON shape for `Money`: `{"amount": "123.45", "currency": "USD"}`, with `amount` as a JSON string and `currency` as uppercase ISO 4217 alpha-3. The `MoneyJsonConverter` ships in `HoneyDrunk.Kernel` (runtime package, per packet 02 — **not** `HoneyDrunk.Kernel.Abstractions`; invariant 1 keeps Abstractions free of runtime classes). `Money` carries **no** `[JsonConverter]` attribute (attribute placement would force the converter into Abstractions). Explicit registration in every consumer's `JsonSerializerOptions` is therefore **required** for `Money` payloads to serialize/deserialize via the D9 shape. Web.Rest is the first such consumer.
+
+ADR-0057 (Public HTTP API Versioning and Client SDK Strategy) D8 / D14-equivalent commits the canonical SDK-side parsing target for monetary values — the JSON shape ADR-0069 D9 commits is exactly that target. Web.Rest is the layer where the Grid serves HTTP traffic, so it is the right place to:
+
+1. Register the converter in the centralized `JsonOptionsDefaults.Configure` seam so every Web.Rest serializer call (including consumer SDK clients that use Web.Rest's defaults) picks up the D9 shape.
+2. Pin the shape with a canary (round-trip assertion).
+
+The catalog packet (01) already added `Money` to `consumes_detail["honeydrunk-kernel"]` for `honeydrunk-web-rest`, anticipating this wiring.
+
+**Cross-Node version dependency.** This packet builds against the new `Money`/`CurrencyCode` surface shipped by packet 02 in `HoneyDrunk.Kernel`. The package reaches the NuGet feed only after a human tags/releases the `HoneyDrunk.Kernel` solution version. Same Human Prerequisite as packet 03.
+
+`HoneyDrunk.Web.Rest` is at v0.5.0 (per the csproj files). This packet is the first packet on the Web.Rest solution in this initiative — per invariant 27 it bumps every non-test `.csproj` in the solution to the same new minor version. The functional change is small (one converter-registration line in `JsonOptionsDefaults.Configure` plus a canary), so the bump is minor (the safer default for any new public-API-shape commitment — every `JsonOptionsDefaults.SerializerOptions` consumer now picks up the converter).
+
+## Scope
+- `HoneyDrunk.Web.Rest.AspNetCore/Serialization/JsonOptionsDefaults.cs` — register `MoneyJsonConverter` in the existing `Configure(JsonSerializerOptions options)` method by appending `options.Converters.Add(new MoneyJsonConverter());`. This is the production seam already in use across the codebase (`JsonOptionsDefaults.SerializerOptions` is consumed by every error-response serializer, controller, and SDK client).
+- `HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj` — add `<PackageReference Include="HoneyDrunk.Kernel" Version="X.Y.Z" />` (the runtime package — the converter lives in `HoneyDrunk.Kernel`, not `HoneyDrunk.Kernel.Abstractions`) where `X.Y.Z` is the version shipped by packet 02. Web.Rest already takes a runtime dependency on the Kernel runtime is fine (Web.Rest is downstream of Kernel in the DAG).
+- `HoneyDrunk.Web.Rest.Canary/` (or equivalent canary project — confirm the canary project name at edit time) — add a canary that constructs a `Money(123.45m, CurrencyCode.Usd)`, serializes it to JSON via `JsonOptionsDefaults.SerializerOptions`, asserts the result is exactly `{"amount":"123.45","currency":"USD"}`, deserializes it back, and asserts the round-trip preserves the value. Add a negative-case canary that constructs JSON with `amount` as a number (`{"amount":123.45,"currency":"USD"}`) and asserts it fails to deserialize (D9's amount-as-string discipline).
+- All non-test `.csproj` files in the solution version-bumped together (invariant 27).
+- `HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md` gets an entry (real change — the `JsonOptionsDefaults` seam now registers `MoneyJsonConverter`). The other packages (alignment bumps only) get no per-package CHANGELOG entry (invariant 12).
+- Repo-level `CHANGELOG.md` gets a new version entry.
+
+## Proposed Implementation
+1. **Add the Kernel runtime reference** to `HoneyDrunk.Web.Rest.AspNetCore.csproj`: `<PackageReference Include="HoneyDrunk.Kernel" Version="X.Y.Z" />` at the version packet 02 shipped. (If the project already references Kernel for other reasons, just bump to the new version.) Confirm the released Kernel version is on the feed first (Human Prerequisite).
+2. **Edit `JsonOptionsDefaults.Configure`** in `HoneyDrunk.Web.Rest.AspNetCore/Serialization/JsonOptionsDefaults.cs` — append one line: `options.Converters.Add(new MoneyJsonConverter());`. Place it after the existing `JsonStringEnumConverter` line so the converter list ordering stays stable. Add the `using HoneyDrunk.Kernel.Serialization;` (or whatever namespace `MoneyJsonConverter` lives in per packet 02) at the top of the file.
+3. **Add the round-trip canary.** In the canary project, write a test that:
+   - Constructs `var money = new Money(123.45m, CurrencyCode.Usd);` (or `Money.Usd(123.45m)`).
+   - Serializes via `JsonSerializer.Serialize(money, JsonOptionsDefaults.SerializerOptions)`.
+   - Asserts the JSON output equals `{"amount":"123.45","currency":"USD"}` (modulo whitespace).
+   - Deserializes the JSON back via `JsonSerializer.Deserialize<Money>(json, JsonOptionsDefaults.SerializerOptions)` and asserts the result equals the original `money`.
+4. **Add the amount-as-number negative canary.** Construct a hand-built JSON string `{"amount":123.45,"currency":"USD"}` and assert that `JsonSerializer.Deserialize<Money>(..., JsonOptionsDefaults.SerializerOptions)` throws `JsonException` (D9: `amount` must always be a JSON string, never a number).
+5. **Bump versions.** Every non-test `.csproj` in `HoneyDrunk.Web.Rest.slnx` moves to the same new minor version (invariant 27). `HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md` describes the converter registration. Other packages: alignment bumps only, no per-package CHANGELOG (invariant 12).
+6. **README.** Update `HoneyDrunk.Web.Rest.AspNetCore/README.md` (or wherever the public-API surface is documented) to note that `Money` payloads serialize via the canonical D9 shape automatically by virtue of the `JsonOptionsDefaults` registration.
+
+## Affected Files
+- `HoneyDrunk.Web.Rest.AspNetCore/Serialization/JsonOptionsDefaults.cs` — append one converter registration line inside `Configure`; add the `using HoneyDrunk.Kernel.Serialization;` import.
+- `HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj` — `HoneyDrunk.Kernel` (runtime) `PackageReference` + version bump.
+- `HoneyDrunk.Web.Rest.Canary/` — round-trip canary + amount-as-number negative canary.
+- Every other non-test `.csproj` in `HoneyDrunk.Web.Rest.slnx` — alignment version bump.
+- `HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md`; repo-level `CHANGELOG.md`.
+- `HoneyDrunk.Web.Rest.AspNetCore/README.md` — public-API note.
+
+## NuGet Dependencies
+- **New:** `HoneyDrunk.Kernel` `X.Y.Z` (the runtime package version shipped by packet 02) on `HoneyDrunk.Web.Rest.AspNetCore` — the runtime package is the right reference because `MoneyJsonConverter` lives there (invariant 1 keeps Abstractions free of runtime classes). `HoneyDrunk.Kernel.Abstractions` will come in transitively if it was not already referenced (`Money` and `CurrencyCode` are still in Abstractions). If a Web.Rest project's public DTO directly references `Money` or `CurrencyCode`, that project additionally takes a direct `PackageReference` on `HoneyDrunk.Kernel.Abstractions` (none today — wiring-only packet).
+- No new test packages.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Web.Rest`. Routing rule "HTTP, REST, ASP.NET Core, JSON serialization → HoneyDrunk.Web.Rest" maps exactly.
+- [x] The new HoneyDrunk dependency is `HoneyDrunk.Kernel` (runtime) — Web.Rest is downstream of Kernel in the DAG; runtime-to-runtime dependency is permitted (invariant 4).
+- [x] No `Money`-bearing endpoint or DTO is added; the wiring is forward-compatible only.
+- [x] No change to other Nodes; the SDK-shape commitment per ADR-0057 is honored by the converter shape ADR-0069 D9 already pinned in packet 02.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Web.Rest.AspNetCore` takes a `PackageReference` on `HoneyDrunk.Kernel` (runtime) at the version shipped by packet 02
+- [ ] `MoneyJsonConverter` is registered in `HoneyDrunk.Web.Rest.AspNetCore/Serialization/JsonOptionsDefaults.cs`'s `Configure` method — one new `options.Converters.Add(new MoneyJsonConverter());` line, with the appropriate `using` import
+- [ ] A round-trip canary asserts `Money(123.45m, CurrencyCode.Usd)` serializes to `{"amount":"123.45","currency":"USD"}` (via `JsonOptionsDefaults.SerializerOptions`) and round-trips back to the same value
+- [ ] A negative canary asserts that `{"amount":123.45,"currency":"USD"}` (amount-as-number) fails to deserialize with `JsonException` — D9's amount-as-string discipline
+- [ ] Every non-test `.csproj` in the solution is at the same new minor version in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new version entry dated to the merge, describing the Money converter wiring + canary
+- [ ] `HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md` has an entry describing the converter registration
+- [ ] Other packages (alignment bumps only) get NO per-package CHANGELOG entry (invariant 12)
+- [ ] `HoneyDrunk.Web.Rest.AspNetCore/README.md` reflects the new JSON-options behavior
+- [ ] No `Money`-bearing endpoint or DTO is added in this packet (forward-compatibility wiring only)
+- [ ] The `pr-core.yml` tier-1 gate passes; the Web.Rest canary project's tests pass
+
+## Human Prerequisites
+- [ ] `HoneyDrunk.Kernel` solution at the version shipped by packet 02 must be tagged and released to the package feed before this packet's branch can compile. Agents merge code; humans tag/release. (Same prerequisite as packet 03.)
+
+## Referenced ADR Decisions
+**ADR-0069 D9 — JSON shape.** `{"amount": "123.45", "currency": "USD"}`. `amount` is a JSON string, never a number (precision preservation). `currency` is uppercase ISO 4217 alpha-3. The `MoneyJsonConverter` shipped by packet 02 (in `HoneyDrunk.Kernel` runtime — not Abstractions, per invariant 1) implements this shape. Because `Money` carries no `[JsonConverter]` attribute, explicit registration in every consumer's options is **required** — Web.Rest's `JsonOptionsDefaults.Configure` is the production registration site.
+
+**ADR-0069 D1 (referenced) — `Money` is NOT annotated with `[JsonConverter]`.** Attribute placement would force the converter into `HoneyDrunk.Kernel.Abstractions`, violating invariant 1. Explicit registration is the canonical wiring pattern; Web.Rest does it once in `JsonOptionsDefaults.Configure` and every Web.Rest serializer call picks the converter up automatically.
+
+**ADR-0057 D8 / D14-equivalent (referenced) — SDK-side parsing target.** The committed JSON shape per ADR-0069 D9 **is** the SDK-side parsing target for monetary values. Web.Rest's default options carry the converter so the wire-shape contract is honored end-to-end from server to SDK.
+
+**ADR-0035 D1 / pre-1.0 disclaimer (referenced) — pre-1.0 minor bump.** The Web.Rest version bump is minor (new converter behavior on the default JSON options).
+
+## Constraints
+- **Invariant 27 — solution-wide version bump.** Every non-test `.csproj` moves together.
+- **Invariant 12 — per-package CHANGELOGs only for real changes.** `HoneyDrunk.Web.Rest.AspNetCore` gets an entry; the canary project may get one if functional behavior is added; everywhere else (alignment bumps) — no per-package CHANGELOG entry.
+- **Invariant 13 — XML docs.** Any new public extension or configurator must be documented.
+- **No `Money`-bearing endpoint.** This packet does not add a new HTTP endpoint that surfaces a `Money`. It only wires the converter for forward compatibility.
+- **No `Money.Zero` (no-arg).** Per ADR-0069 D2 — the canary uses `Money.Usd(123.45m)` or `Money.Zero(CurrencyCode.Usd)`, never a `Money.Zero` without a currency.
+- **Amount as a JSON string is non-negotiable.** D9's precision discipline — the negative canary pins this; do not relax it.
+
+## Labels
+`feature`, `tier-2`, `core`, `adr-0069`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Wire the `MoneyJsonConverter` into the Web.Rest default JSON options and pin ADR-0069 D9's shape with a round-trip + amount-as-number-rejects canary. Forward-compatibility wiring only — no `Money`-bearing endpoint is added.
+
+**Target:** `HoneyDrunk.Web.Rest`, branch from `main`.
+
+**Context:**
+- Goal: Lock the SDK-side parsing target ADR-0057 D8 commits, by construction, for every future Web.Rest endpoint that surfaces a price.
+- Feature: ADR-0069 Currency Handling rollout, Wave 3 — Web.Rest converter wiring.
+- ADRs: ADR-0069 D1/D9 (primary), ADR-0057 D8/D14-equivalent (SDK shape commitment), ADR-0035 (pre-1.0 versioning).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — `MoneyJsonConverter` must exist in `HoneyDrunk.Kernel.Abstractions` and the Kernel package must be released on the feed.
+
+**Constraints:**
+- Explicit converter registration is **required** — `Money` carries no `[JsonConverter]` attribute (the converter lives in the `HoneyDrunk.Kernel` runtime to keep Abstractions STJ-free per invariant 1). `HoneyDrunk.Web.Rest.AspNetCore/Serialization/JsonOptionsDefaults.cs` already exposes the `Configure(JsonSerializerOptions)` seam used grid-wide; register the converter there. No "deferred" branch; no new seam.
+- Amount-as-string is non-negotiable (D9). The negative canary pins it.
+- Every non-test `.csproj` in the solution version-bumped in one commit (invariant 27).
+- Per-package CHANGELOG only on `HoneyDrunk.Web.Rest.AspNetCore` (real change — the JSON defaults pick up a new converter).
+- No new `Money`-bearing endpoint or DTO — wiring + canary only.
+
+**Key Files:**
+- `HoneyDrunk.Web.Rest.AspNetCore/Serialization/JsonOptionsDefaults.cs` — append the `MoneyJsonConverter` registration inside `Configure`.
+- `HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj` — `HoneyDrunk.Kernel` (runtime) `PackageReference`.
+- `HoneyDrunk.Web.Rest.Canary/` — round-trip + amount-as-number negative canary.
+- Every other non-test `.csproj` in `HoneyDrunk.Web.Rest.slnx` — alignment version bump.
+- `HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md`, `README.md`; repo-level `CHANGELOG.md`.
+
+**Contracts:**
+- `MoneyJsonConverter` (existing, from packet 02, in `HoneyDrunk.Kernel` runtime) — registered explicitly in `JsonOptionsDefaults.Configure`.
+- No new Web.Rest contract; no new endpoint.

--- a/generated/issue-packets/active/adr-0069-currency-handling/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0069-currency-handling/dispatch-plan.md
@@ -1,0 +1,129 @@
+# Dispatch Plan — ADR-0069: Currency Handling and Money Representation
+
+**Initiative:** `adr-0069-currency-handling`
+**ADR:** ADR-0069 (Proposed → Accepted via packet 00)
+**Sector:** Core (Kernel.Abstractions) · Ops (cost ledger, audit emit) · cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0069 commits the Grid's internal representation of monetary values: a `Money` record (`decimal Amount` + `CurrencyCode`) in `HoneyDrunk.Kernel.Abstractions`, arithmetic that throws on currency mismatch, banker's rounding as the default mode, ISO 4217 alpha-3 validation against a hand-maintained seed list (USD, EUR, GBP, JPY, CAD, AUD, CHF), machine-readable `ToString`, a `MoneyJsonConverter` with `{"amount": "string", "currency": "ISO"}` shape, USD as the Studio's default, multi-currency-aware-but-not-converting storage, and a two-field convention (`monetary_value` + `currency_code`) for money-changing audit emits. `BillingEvent` (ADR-0026 D5 frozen count-and-meter shape) is preserved — `Money` is a separate, additive primitive, not a `BillingEvent` field.
+
+This initiative delivers: ADR acceptance + initiative registration (no new numbered invariants — the four committed conventions are canary-enforced per the ADR's own framing); catalog registration of the `Money`/`CurrencyCode` surface under `honeydrunk-kernel`; the implementation + canary suite in `HoneyDrunk.Kernel.Abstractions`; the AI Node cost-ledger migration to `Money(rate, CurrencyCode.Usd)` per D10; documentation of the D11 two-field convention in `HoneyDrunk.Audit`'s boundaries file and as an ADR-0030 cross-reference; and a forward-compatibility wiring of the `MoneyJsonConverter` into Web.Rest's default JSON options with a D9-shape canary.
+
+**6 packets across 3 waves**, targeting **4 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Kernel`, `HoneyDrunk.AI`, `HoneyDrunk.Web.Rest`). All 6 are `Actor=Agent`, 0 `Actor=Human`. Packets 03 and 05 carry a Human Prerequisite — the human git-tag/release of the `HoneyDrunk.Kernel` solution after packet 02 merges so packets 03 and 05 can compile against the new `Money` surface.
+
+## Trigger
+
+ADR-0069 is Proposed with no scope. Forcing functions from the ADR's Context: **Notify Cloud GA** is the first commercial product that emits money-changing events; the audit shape for "subscription renewed for $X" is needed before the first paying tenant signs up. **The ADR-0052 cost-governance cache** is operationally live in `HoneyDrunk.AI` today with an implicit-USD denomination (concrete location: `InferenceCost.EstimatedCost` and `CostSummary.TotalCost` are `decimal` with implicit-USD semantics); the fix is cheap now, expensive once a non-USD provider lands. **Consumer-app PDRs** (PDR-0003 through PDR-0008) are pre-implementation, every PDR has a paid tier or subscription price, and the first scaffolded price catalog needs the `Money` type pre-staged. **ADR-0026 precedent** — the Grid's pattern is to commit cross-cutting primitives in Kernel.Abstractions once (`TenantId`, `BillingEvent`); `Money` follows the same playbook. The ADR needs decomposition into actionable packets.
+
+## Scope Detection
+
+**Multi-repo.** The contract lands in `HoneyDrunk.Kernel.Abstractions` (the zero-dependency contract layer every Node already consumes — same precedent as `TenantId` and `BillingEvent`); the cost-ledger migration is local to `HoneyDrunk.AI`; the audit-emitter convention is a documentation deliverable in `HoneyDrunk.Architecture` (no code change in `HoneyDrunk.Audit` because `AuditEntry.Metadata` is already a `string→string` map); the Web.Rest wiring is a forward-compatibility wiring in `HoneyDrunk.Web.Rest` with a D9-shape canary. `HoneyDrunk.Architecture` carries the governance (acceptance, catalog, audit-convention doc) packets.
+
+**Contract is additive — no forced downstream cascade.** `Money`, `CurrencyCode`, `MoneyJsonConverter`, and the two exception types are net-new additive surface in `HoneyDrunk.Kernel.Abstractions`. Per ADR-0035 D1 and ADR-0069's own Operational Consequences, this is an additive minor bump on the pre-1.0 Kernel.Abstractions package — not a breaking change. Downstream Nodes that consume `HoneyDrunk.Kernel.Abstractions` are not *forced* to update; they adopt `Money` when their own monetary fields are amended. **`BillingEvent` is deliberately not touched** — ADR-0026 D5's frozen shape is preserved per ADR-0069 D7.
+
+**Adopters in this initiative: AI and Web.Rest only.** ADR-0069's Affected Nodes list names HoneyDrunk.Billing (a future Node — does not exist in catalogs/nodes.json today), HoneyDrunk.Notify.Cloud (a future Node — also not in nodes.json today, ADR-0027 is its standup ADR), HoneyDrunk.Audit (code change is unnecessary because `Metadata` is already a free-form map), consumer-app Nodes per PDR-0003 through PDR-0008 (all pre-scaffolding), and HoneyDrunk.AI / HoneyDrunk.Web.Rest. This initiative wires only the **two adopters that exist today as live Nodes with concrete Money-bearing code**: HoneyDrunk.AI (the operationally-live cost ledger per D10) and HoneyDrunk.Web.Rest (the forward-compatible converter wiring per D9). Every other named consumer adopts the type in its own track — see "Out of scope" below.
+
+**No new-Node scaffolding.** Every target repo is a live, scaffolded Node. No empty cataloged repo is touched; no standup ADR is needed.
+
+## Wave Diagram
+
+### Wave 1 (governance + catalog — no dependencies)
+- [ ] **00** — Architecture: Accept ADR-0069, register the initiative. **No numbered invariants added** — ADR-0069's four conventions are canary-enforced per the ADR's own framing. `Actor=Agent`.
+- [ ] **01** — Architecture: register the `Money`/`CurrencyCode` contract surface in the Grid catalogs (`contracts.json`, `relationships.json`). `Actor=Agent`. Blocked by: 00.
+
+### Wave 2 (the foundation)
+- [ ] **02** — Kernel: add `Money`, `CurrencyCode`, `MoneyJsonConverter`, the two exception types, arithmetic / rounding / serialization / canary suite to `HoneyDrunk.Kernel.Abstractions`. **Version-bumping packet for `HoneyDrunk.Kernel`.** `Actor=Agent`. Blocked by: 00.
+
+### Wave 3 (consumers, parallel)
+- [ ] **03** — AI: migrate `InferenceCost.EstimatedCost` and `CostSummary.TotalCost` from `decimal` to `Money(amount, CurrencyCode.Usd)` per ADR-0069 D10. **Version-bumping packet for `HoneyDrunk.AI`.** `Actor=Agent`. Blocked by: 02. Human Prerequisite: Kernel package release.
+- [ ] **04** — Architecture: document the D11 two-field convention (`monetary_value` + `currency_code`) in `repos/HoneyDrunk.Audit/boundaries.md` and as an ADR-0030 cross-reference. **No code change** — `AuditEntry.Metadata` is already `string→string`. `Actor=Agent`. Blocked by: 00.
+- [ ] **05** — Web.Rest: wire `MoneyJsonConverter` into the default JSON options seam and pin the D9 shape with a round-trip + amount-as-number-rejects canary. **Version-bumping packet for `HoneyDrunk.Web.Rest`.** `Actor=Agent`. Blocked by: 02. Human Prerequisite: Kernel package release.
+
+Packets within a wave run in parallel. Wave 3 packets 03, 04, 05 are independent — different repos / different concerns. Packet 04 depends only on packet 00 and could run as early as Wave 2; it is grouped into Wave 3 for tidy filing alongside the other consumers. The `dependencies:` frontmatter is the real ordering signal — 04 unblocks as soon as 00 lands.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0069](./00-architecture-adr-0069-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [Money / CurrencyCode contract catalog](./01-architecture-money-contract-catalog.md) | Architecture | Agent | 1 | 00 |
+| 02 | [Money, CurrencyCode, JSON converter, canary suite](./02-kernel-money-and-currency-code.md) | Kernel | Agent | 2 | 00 |
+| 03 | [AI cost ledger → `Money(rate, USD)`](./03-ai-cost-ledger-money-adoption.md) | AI | Agent | 3 | 02 |
+| 04 | [Audit money-emitter two-field convention](./04-architecture-audit-money-emitter-convention.md) | Architecture | Agent | 3 | 00 |
+| 05 | [Web.Rest converter wiring + D9 canary](./05-web-rest-money-json-converter-wiring.md) | Web.Rest | Agent | 3 | 02 |
+
+## Version Bumps
+
+- **`HoneyDrunk.Kernel`** — packet 02 is the first packet on the solution in this initiative. It bumps every non-test `.csproj` to the same new minor version. The csproj files show `0.7.0` today, suggesting `0.8.0` as the next minor. The runtime package (`HoneyDrunk.Kernel`) also gains the `MoneyJsonConverter` class (real-change bump, not alignment) — `MoneyJsonConverter` lives in the runtime, not Abstractions, per invariant 1.
+  - **Cross-initiative version sequencing with ADR-0042 (race).** ADR-0042 (`adr-0042-idempotency`) also targets `HoneyDrunk.Kernel` as a `0.7.0` → `0.8.0` minor bump (packet 02 of that initiative). The two packets are racing on the same version. Three-case procedure at execution time (codified in packet 02's Context section): **Case A** — Kernel still at `0.7.0`, open `0.8.0`; **Case B** — Kernel already at unreleased `0.8.0` (ADR-0042 landed first), append surface to in-progress `0.8.0` entries, no new bump; **Case C** — `0.8.0` released, take `0.9.0`. The executor reads `HoneyDrunk.Kernel.csproj` and `repos/HoneyDrunk.Kernel/active-work.md` (in Architecture) at edit time and records the chosen case in the PR description.
+- **`HoneyDrunk.AI`** — packet 03 bumps the solution one minor version (the breaking field-type change on `InferenceCost.EstimatedCost` and `CostSummary.TotalCost` is acceptable as a minor bump under ADR-0035's pre-1.0 disclaimer; Directory.Build.props shows `0.1.0` today). Confirm the actual on-`main` version at execution time.
+- **`HoneyDrunk.Web.Rest`** — packet 05 bumps the solution one minor version (new converter behavior on the default JSON options; csproj files show `0.5.0` today). Confirm at execution time.
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; governance/catalog/docs edits only (packets 00, 01, 04).
+
+## Cross-Cutting Concerns
+
+### Invariants — none added; four conventions enforced by canaries
+
+ADR-0069's Consequences/Invariants section is explicit: **"No new Grid-wide invariants are introduced."** The four committed conventions — currency code is always uppercase ISO 4217 alpha-3; no implicit FX conversion; JSON `amount` is a string, never a number; audit money fields are split (`monetary_value` + `currency_code`) — read as "conventions enforced by canary tests rather than new lines in `constitution/invariants.md`." Packet 00 explicitly does not edit `constitution/invariants.md`. Packet 02's canary suite covers the first three conventions by construction; packet 04 documents the fourth as an emitter projection rule against the existing `AuditEntry.Metadata` map. If a later operator judges any of the four invariant-class at packet-time, the numbering is added then under the appropriate existing section (or a new section) — not in this initiative.
+
+### `BillingEvent` is unchanged — ADR-0026 D5 frozen shape preserved
+
+`HoneyDrunk.Kernel.Abstractions.BillingEvent` (the count-and-meter primitive ADR-0026 D5 froze) is **not modified** by any packet in this initiative. ADR-0069 D7 is explicit: `BillingEvent` carries `Quantity` and `UnitOfMeasure` only; `Money` is a separate, additive primitive that lives alongside, not inside, the billing-event surface. Per ADR-0035 D1 this avoids any major bump on Kernel.Abstractions. The Stripe boundary owns price computation per ADR-0037 D2; the Grid stores the Stripe-derived monetary outcome at the webhook boundary (Billing Node — a future Node, not in this initiative's scope).
+
+### Adopters explicitly out of scope (deliberate deferral)
+
+ADR-0069's Affected Nodes list and Follow-up Work section name several consumers. This initiative does **not** wire them, by design:
+
+- **HoneyDrunk.Billing** — does not exist as a Node today (not in `catalogs/nodes.json`). ADR-0037 commits Stripe as the payment processor; the Billing Node's standup is its own ADR and its own initiative (a future track). When Billing is scaffolded, its invoice-record and Stripe-webhook-derived monetary fields adopt `Money` as a first-build concern — ADR-0069 D7 already names the shape.
+- **HoneyDrunk.Notify.Cloud** — does not exist as a separate Node today (not in `catalogs/nodes.json`). ADR-0027 is its standup ADR; the standup is its own initiative. The `NotifyCloudTenantTier.MonthlyBaseFee` is `Money` when Notify Cloud scaffolds — a first-build concern in that track.
+- **Consumer-app Nodes (PDR-0003 through PDR-0008)** — all pre-implementation. Their price-catalog scaffolding adopts `Money` from the first commit. Pre-staging the type (this initiative does) is the right move; pre-building the consumer-app catalogs is not.
+- **HoneyDrunk.Audit** — no code change needed because `AuditEntry.Metadata` is already a `string → string` free-form map. The two-field convention is an emitter projection rule, documented in packet 04 against the existing contract surface. The ADR-0031 D8 / invariant 49 Audit contract-shape canary stays green by construction. If a future ADR judges the two-field shape canary-class for Audit specifically, that canary lives in `HoneyDrunk.Audit` and is added then.
+- **FX-rate service** — explicitly deferred per ADR-0069 D5 / D12. The deferred-service signal is the deliberate `CurrencyMismatchException` thrown by `DefaultCostLedger.GetSummaryAsync` when entries span multiple currencies (packet 03 documents this as the load-bearing failure mode).
+- **Per-tenant currency preference, historical FX rate storage, crypto/token support, minor-unit storage, invoice/receipt UI** — all explicitly deferred per ADR-0069 D12. Not in scope here.
+
+This initiative ships the **contract, the canary, and the two operationally-live adopters (AI cost ledger, Web.Rest converter wiring)**. Every other consumer adopts the shipped contract in its own track. This keeps the initiative bounded and consistent with the Grid's "new-Node standup gets its own ADR; don't bundle into feature packets" rule.
+
+### Human package release at the Wave 2→3 boundary — agents never tag
+
+Wave 3 packets 03 and 05 compile against `HoneyDrunk.Kernel.Abstractions`'s new `Money`/`CurrencyCode` surface (packet 02). The NuGet artifact exists on the package feed **only after a human pushes a git release tag** on `HoneyDrunk.Kernel` — agents merge code but never tag or publish. One human release step gates Wave 3:
+
+- **Wave 2→3 boundary** — after packet 02 has merged, a human tags/releases the `HoneyDrunk.Kernel` solution at the new version (the tag carries `HoneyDrunk.Kernel.Abstractions` at the new minor from packet 02). Wave 3 packets 03 and 05 cannot build against unpublished packages.
+
+This is surfaced in packets 03 and 05's Human Prerequisites and in the Wave 2→3 handoff.
+
+### Required ADR Amendment to D2 — `==` is NOT overridden
+
+ADR-0069 D2 reads "comparisons across currencies also throws" and cites `Money.Zero(USD) == Money.Zero(EUR)` as throwing. **The implementation in packet 02 drops the `==` throw and keeps record-default value equality** — overriding record `==` to throw breaks `HashSet<Money>`, `Dictionary<Money>`, EF Core change-tracking equality, and every implicit `Equals`/`GetHashCode` call site that should be safe. The throw discipline stays on **arithmetic** (`+`, `-`) and **ordering** (`<`, `<=`, `>`, `>=`) — where the operation is observable and intentional — not on equality. Cross-currency `==` returns `false`.
+
+Packet 00 records this as a Required ADR Amendment, edits ADR-0069 D2's wording inline (or as an "Amended at acceptance" note that preserves the original text), and adds an analogous D9 amendment (the `MoneyJsonConverter` ships in `HoneyDrunk.Kernel` runtime, not `HoneyDrunk.Kernel.Abstractions`, per invariant 1).
+
+### `Money.Zero` (no-arg) is deliberately absent — D2
+
+ADR-0069 D2 forbids zero-without-currency. `Money.Zero(CurrencyCode)` is the only construction shortcut without an amount. Every place a seed value is needed (notably `DefaultCostLedger.GetSummaryAsync`'s aggregator seed in packet 03) uses `Money.Zero(CurrencyCode.Usd)` at Phase 1. Packets 02, 03, 05 each restate this constraint explicitly.
+
+### Truncation is not a `Round` mode — D3
+
+Banker's rounding (`MidpointRounding.ToEven`) is the default; `AwayFromZero` is supported as an explicit opt-in; **truncation is not a supported `Round` mode**. Callers wanting truncation use `Math.Floor` on `Money.Amount` and reconstruct — the deliberate awkwardness signals that truncation is an unusual choice. Stripe Tax handles customer-facing truncation per ADR-0037; the Grid does not need it internally.
+
+### Site sync
+
+No site-sync flag. ADR-0069 is internal Core infrastructure — no public-facing Studios website content changes. (Future consumer-app PDRs that surface prices to website visitors will be their own site-sync concerns.)
+
+## Rollback Plan
+
+- **Packets 00–01 (governance/catalog):** revert the PR. ADR-0069 returns to Proposed; the `Money` catalog entries are removed. No runtime impact.
+- **Packet 02 (Kernel contracts):** revert the PR. The `HoneyDrunk.Kernel` solution version rolls back. The contracts are additive — no consuming Node depends on them at runtime until it composes them, so the revert is contained to `HoneyDrunk.Kernel`. The canary suite leaves the test project.
+- **Packet 03 (AI cost ledger):** revert the PR. The `HoneyDrunk.AI` solution version rolls back. `InferenceCost.EstimatedCost` returns to `decimal` (implicit-USD); `CostSummary.TotalCost` returns to `decimal`. `DefaultCostLedger` returns to its `decimal`-summing aggregator. No external consumer of `HoneyDrunk.AI.Abstractions` was forced to migrate; the revert is contained. The reverted-to state is the pre-D10 implicit-USD baseline — still operationally correct (every current AI provider bills in USD), just not denomination-explicit.
+- **Packet 04 (audit convention doc):** revert the PR. The boundaries-file section and the ADR-0030 cross-reference are removed. Documentation only — no runtime impact.
+- **Packet 05 (Web.Rest converter wiring):** revert the PR. The `HoneyDrunk.Web.Rest` solution version rolls back. The converter registration is removed from `JsonOptionsDefaults.Configure`; the canary tests are removed from the canary project. Because `Money` carries no `[JsonConverter]` attribute (per packet 02's invariant-1 placement of the converter in the `HoneyDrunk.Kernel` runtime), the revert means Web.Rest's default options no longer carry `MoneyJsonConverter` and any `Money` payload serialization would fall back to default record serialization (`{"Amount": 123.45, "CurrencyCode": {...}}`) — but since no Web.Rest endpoint surfaces `Money` today, there is no production impact from the revert.
+- **Cross-currency throw escape hatch:** D5's deliberate failure mode (`CurrencyMismatchException` from mixed-currency aggregation) is *not* a rollback candidate — it is the load-bearing signal that the deferred FX-rate service is needed. If the throw causes operational pain in production (which it cannot today — every AI provider is USD), the fix is the FX-rate-service ADR, not a revert.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.
+
+All `dependencies:` edges in this initiative use the `packet:NN` schema and resolve within this initiative folder — no cross-initiative `{Repo}#N` edges are needed (the ADR-0042 Kernel-version sequencing is captured as narrative in this dispatch plan and in packet 02's Context, not as a hard `dependencies:` edge — the two initiatives' Kernel packets are coordinated at execution time per invariant 27, not pre-wired at filing time).

--- a/generated/issue-packets/active/adr-0069-currency-handling/handoff-wave3-consumer-adoption.md
+++ b/generated/issue-packets/active/adr-0069-currency-handling/handoff-wave3-consumer-adoption.md
@@ -1,0 +1,107 @@
+# Handoff — Wave 2 → Wave 3: Consumer Adoption (AI cost ledger, Audit convention, Web.Rest converter)
+
+**Initiative:** `adr-0069-currency-handling`
+**Wave transition:** Wave 2 (Money in Kernel.Abstractions) → Wave 3 (consumer adoption)
+**Read once at the wave boundary. Immutable per invariant 24.**
+
+## What Wave 1 and Wave 2 landed
+
+- **Packet 00** — ADR-0069 flipped to **Accepted**. **No numbered invariants added.** ADR-0069's four committed conventions (currency code is always uppercase ISO 4217 alpha-3; no implicit FX conversion; JSON `amount` is a string, never a number; audit money fields are split into `monetary_value` + `currency_code`) are canary-enforced per the ADR's own framing — not numbered in `constitution/invariants.md`. If a later operator judges any invariant-class at execution time, it is added then, not in this initiative.
+- **Packet 01** — the `Money`/`CurrencyCode`/`CurrencyMismatchException`/`UnknownCurrencyCodeException` surface registered in `catalogs/contracts.json` and `catalogs/relationships.json` under `honeydrunk-kernel`. `consumes_detail["honeydrunk-kernel"]` extended for `honeydrunk-ai` (`Money`, `CurrencyCode`) and `honeydrunk-web-rest` (`Money`) — anticipating Wave 3.
+- **Packet 02** — `HoneyDrunk.Kernel.Abstractions` ships `Money(decimal Amount, CurrencyCode CurrencyCode)`, `CurrencyCode` (readonly record struct with ISO 4217 alpha-3 validation against the seed list USD, EUR, GBP, JPY, CAD, AUD, CHF), `CurrencyMismatchException`, `UnknownCurrencyCodeException`. `HoneyDrunk.Kernel` runtime ships `MoneyJsonConverter` (the System.Text.Json converter for the D9 shape) — **not** Abstractions; the converter is runtime logic and invariant 1 keeps Abstractions STJ-free. `Money` carries **no** `[JsonConverter]` attribute. Arithmetic operators (`+`, `-`) and ordering operators (`<`, `<=`, `>`, `>=`) throw `CurrencyMismatchException` on cross-currency operands. **`==`/`!=` are NOT overridden** — record-default value equality stands; cross-currency `==` returns `false` (recorded as Required ADR Amendment to D2 in packet 00; overriding `==` would break `HashSet<Money>`/`Dictionary<Money>`/EF tracking equality). `Round(int decimals, MidpointRounding mode = MidpointRounding.ToEven)` uses banker's rounding by default; `AwayFromZero` is supported as an explicit opt-in. `ToString()` returns `"123.45 USD"`-style invariant-culture output. The canary suite pins arithmetic + currency-mismatch throws, rounding mode, JSON shape (including the negative case — amount-as-number rejects), `CurrencyCode` validation (lowercase rejected, unknown rejected), and `ToString` output. The `HoneyDrunk.Kernel` solution is at the new minor version (likely `0.8.0`, modulo ADR-0042's race — three-case procedure in packet 02; PR description records which case applied).
+- **`BillingEvent` is unchanged.** ADR-0026 D5's frozen count-and-meter shape is preserved per ADR-0069 D7. The Audit Node's `IAuditLog`/`AuditEntry` contracts are also unchanged.
+
+ADR-0069's decisions are now live rules. The implementation is shipped. Wave 3 adopts.
+
+## What Wave 3 must deliver (packets 03, 04, 05)
+
+Three packets, runnable in parallel:
+
+- **Packet 03 (`Actor=Agent`)** — `HoneyDrunk.AI`: migrate `InferenceCost.EstimatedCost` (record field) and `CostSummary.TotalCost` (record field) from `decimal` to `Money`, with `CurrencyCode.Usd` as the Phase-1 denomination per ADR-0069 D10. Update `DefaultCostLedger.GetSummaryAsync` to aggregate `Money`. Bump the `HoneyDrunk.AI` solution one minor. **Requires the Kernel package release — see Human Prerequisite below.**
+- **Packet 04 (`Actor=Agent`)** — `HoneyDrunk.Architecture`: document the D11 two-field convention (`monetary_value` + `currency_code`) in `repos/HoneyDrunk.Audit/boundaries.md` and add a cross-reference paragraph to ADR-0030. No code change in `HoneyDrunk.Audit` — `AuditEntry.Metadata` is already `string→string`. No Kernel-package dependency; runnable as soon as packet 00 lands.
+- **Packet 05 (`Actor=Agent`)** — `HoneyDrunk.Web.Rest`: register `MoneyJsonConverter` in the default JSON options seam and add a round-trip canary plus an amount-as-number negative canary that pins ADR-0069 D9. **Requires the Kernel package release — see Human Prerequisite below.**
+
+## Human Prerequisite at the wave boundary — agents never tag
+
+Wave 3 packets 03 and 05 compile against `HoneyDrunk.Kernel.Abstractions` at the new minor version shipped by packet 02. That NuGet artifact exists on the package feed **only after a human pushes a git release tag** on `HoneyDrunk.Kernel`. Agents merge code; humans tag and publish.
+
+**Procedure (human step at the Wave 2→3 boundary):**
+
+1. Confirm packet 02's PR is merged to `main`.
+2. Confirm the `HoneyDrunk.Kernel` solution version in `main`'s csproj files matches the new minor (record which version — `0.8.0` was the expected target, but ADR-0042's parallel bump may have moved it; the actual on-`main` version is what gets tagged).
+3. Tag the release on `HoneyDrunk.Kernel` per the repo's release procedure (typically a `v{X.Y.Z}` git tag pushed to `main`, triggering the release workflow that publishes to the package feed).
+4. Confirm the package is queryable on the feed (NuGet.org or the org feed Web.Rest/AI pull from).
+5. Update packets 03 and 05's csproj `PackageReference` `Version` values to the actual published version (likely the same as the planned minor, but confirm).
+
+**Until the human release step completes, packets 03 and 05 are blocked from execution** even though they are filed as unblocked-by-packet-02-merge in the dispatch graph. The dispatch graph models PR-level blocking; the package-feed availability is a real-world blocker outside Git.
+
+Packet 04 has no Kernel-package dependency and can run as soon as packet 00 has landed — i.e. immediately at Wave 1 close, in parallel with everything else.
+
+## Critical context for Wave 3 execution
+
+### Packet 03 — AI cost ledger
+
+- **Current shape (today on `HoneyDrunk.AI` `main`):**
+  ```csharp
+  public sealed record InferenceCost(string ProviderId, string ModelId, int InputTokens, int OutputTokens, decimal EstimatedCost, string OperationCorrelationId);
+  public sealed record CostSummary(string Scope, DateTimeOffset Since, DateTimeOffset Until, decimal TotalCost, int TotalCalls);
+  ```
+- **Target shape:**
+  ```csharp
+  public sealed record InferenceCost(string ProviderId, string ModelId, int InputTokens, int OutputTokens, Money EstimatedCost, string OperationCorrelationId);
+  public sealed record CostSummary(string Scope, DateTimeOffset Since, DateTimeOffset Until, Money TotalCost, int TotalCalls);
+  ```
+- **`DefaultCostLedger.GetSummaryAsync`** currently sums `entry.Cost.EstimatedCost` via LINQ `.Sum()`. Replace with a `Money`-respecting `Aggregate`. **Seed selection (spelled out):** on empty scope, seed `Money.Zero(CurrencyCode.Usd)`; on non-empty scope, seed `Money.Zero(scoped[0].Cost.EstimatedCost.CurrencyCode)` so the fold returns the same currency the entries carry. Cross-currency aggregation within a non-empty scope **must** throw `CurrencyMismatchException` (per ADR-0069 D2/D5) — that throw is the deliberate load-bearing signal that the deferred FX-rate service is needed. XML-doc it.
+- **Every call site** in `HoneyDrunk.AI` that constructs `InferenceCost(...)` or reads `cost.EstimatedCost` / `summary.TotalCost` must be updated in the same commit. Search across `src/HoneyDrunk.AI*/` and `tests/`. The breaking shape change is acceptable under ADR-0035's pre-1.0 disclaimer; the solution-wide minor bump (invariant 27) reflects it.
+- **Downstream-impact scope confirmed at packet-authoring time (2026-05-24) — no external consumers.** A Grid-wide search confirmed every `HoneyDrunk.AI.Abstractions` `PackageReference` and every `InferenceCost`/`CostSummary`/`ICostLedger` symbol reference is inside the `HoneyDrunk.AI` solution. No external Node (Capabilities, Operator, Agents, Memory, Knowledge, Evals) consumes the cost ledger today. The breaking change is therefore self-contained to the AI solution and is updated in one commit. Packet 03 carries the full downstream-impact list in its body.
+- **Release-notes guidance.** When the human releases the `HoneyDrunk.AI` solution after packet 03 merges, the release notes flag the `Money` adoption as a breaking pre-1.0 shape change, list the call-site update pattern (`new InferenceCost(..., Money.Usd(decimalCost), ...)`), and link back to ADR-0069 D10. Future Nodes adopting `HoneyDrunk.AI.Abstractions` look for this in the release notes.
+- **Per-package CHANGELOG:** `HoneyDrunk.AI.Abstractions` and `HoneyDrunk.AI` get entries (real changes). Provider packages and the worker (alignment bumps only) get no per-package CHANGELOG entry (invariant 12).
+- **No `Money.Zero` (no-arg).** D2 forbids it. The aggregator seed is `Money.Zero(CurrencyCode.Usd)`.
+
+### Packet 04 — Audit convention doc
+
+- **No code change.** The current `AuditEntry.Metadata` shape is `IReadOnlyDictionary<string, string>?`. The two-field convention lands as `metadata["monetary_value"] = money.Amount.ToString("F{decimals}", InvariantCulture)` + `metadata["currency_code"] = money.CurrencyCode.Code`. No `IAuditLog` change, no `AuditEntry` change, no catalog change. The ADR-0031 D8 / invariant 49 Audit contract-shape canary stays green by construction.
+- **Documentation deliverables:** the `repos/HoneyDrunk.Audit/boundaries.md` "Money-changing audit events" section and a cross-reference paragraph in `adrs/ADR-0030-grid-wide-audit-substrate.md`. Do not flip ADR-0030's Status; do not edit any ADR-0030 decision. Cross-reference only.
+- **Precision discipline.** `monetary_value` is always a JSON-string-shaped metadata value (Audit's `Metadata` map already enforces this; document the rule for any future emitter that builds the metadata dictionary). Mirrors ADR-0069 D9's amount-as-string discipline.
+
+### Packet 05 — Web.Rest converter wiring
+
+- **Explicit registration is required.** `Money` carries no `[JsonConverter]` attribute (the converter lives in the `HoneyDrunk.Kernel` runtime, not Abstractions, per invariant 1). Every consumer that uses `JsonSerializerOptions` must register `MoneyJsonConverter` explicitly. Web.Rest does this once in `HoneyDrunk.Web.Rest.AspNetCore/Serialization/JsonOptionsDefaults.cs`'s `Configure(JsonSerializerOptions)` method — that seam already exists today and is consumed grid-wide via `JsonOptionsDefaults.SerializerOptions`. No "deferred" branch; no new seam.
+- **The registration is one line:** inside `JsonOptionsDefaults.Configure`, append `options.Converters.Add(new MoneyJsonConverter());` after the existing `JsonStringEnumConverter` registration. Add the `using HoneyDrunk.Kernel.Serialization;` import.
+- **Canary cases:**
+  - Round-trip: `Money(123.45m, CurrencyCode.Usd)` → JSON → back; assert the JSON is exactly `{"amount":"123.45","currency":"USD"}` (modulo whitespace) and the deserialized value equals the original. Use `JsonOptionsDefaults.SerializerOptions`.
+  - Negative — amount-as-number rejects: hand-build `{"amount":123.45,"currency":"USD"}` (no quotes around amount); assert deserialization throws `JsonException`. This pins ADR-0069 D9's amount-as-string discipline as a Web.Rest-side guarantee.
+- **No new endpoint.** This packet is forward-compatibility wiring only. The first Web.Rest endpoint to surface a price comes in its own packet, in a future track (likely a consumer-app PDR's first build).
+
+## Frozen / do-not-touch
+
+- **`BillingEvent`** (in `HoneyDrunk.Kernel.Abstractions`) — ADR-0026 D5's frozen count-and-meter shape, preserved per ADR-0069 D7. Do NOT add a `Money` field; do NOT modify the shape; do NOT trigger any major bump on Kernel.Abstractions.
+- **`IAuditLog` and `AuditEntry`** (in `HoneyDrunk.Audit.Abstractions`) — unchanged. The two-field audit convention is an emitter projection rule against the existing `Metadata` map. The Audit contract-shape canary (ADR-0031 D8 / invariant 49) stays green by construction.
+- **Existing Kernel.Abstractions surface** (`IGridContext`, `TenantId`, `CorrelationId`, `BillingEvent`, etc.) — unchanged. Packet 02 added new types; it did not modify existing ones.
+
+## Invariants binding Wave 3
+
+- **Invariant 27** — every non-test `.csproj` in a solution shares one version and moves together. Packets 03 and 05 each bump their solution one minor version in one commit. Partial bumps are forbidden.
+- **Invariant 12** — per-package CHANGELOGs only for packages with functional changes. Packet 03: `HoneyDrunk.AI.Abstractions` and `HoneyDrunk.AI` get entries; provider packages and the worker get none. Packet 05: `HoneyDrunk.Web.Rest.AspNetCore` (and the canary project if functional) gets an entry; everywhere else no per-package CHANGELOG entry.
+- **Invariant 13** — XML docs on every new or modified public API. Packet 03 updates the XML docs on `InferenceCost`/`CostSummary`/`DefaultCostLedger.GetSummaryAsync` (including the deliberate cross-currency-throw documentation). Packet 05 documents any new converter-registration extension.
+- **Invariant 1 (referenced)** — `HoneyDrunk.Kernel.Abstractions` is the canonical zero-dependency contracts package; downstream Nodes' Abstractions packages may take a `PackageReference` on it. Packet 03 does so (`HoneyDrunk.AI.Abstractions` → `HoneyDrunk.Kernel.Abstractions` for `Money` and `CurrencyCode`). Packet 05 takes a `PackageReference` on `HoneyDrunk.Kernel` (runtime, not Abstractions) because `MoneyJsonConverter` lives in the runtime — invariant 1 keeps Abstractions free of runtime classes, so the converter cannot be in `HoneyDrunk.Kernel.Abstractions`. Both directions are permitted: invariant 1 binds Kernel.Abstractions itself, not downstream packages' references.
+- **No `Money.Zero` (no-arg)** — D2. Phase-1 aggregator seeds are `Money.Zero(CurrencyCode.Usd)`.
+- **Cross-currency throw is deliberate** — D5. Do not silently convert; do not catch and swallow. The throw is the load-bearing signal for the deferred FX-rate service.
+
+## Wave 3 acceptance gate
+
+Each Wave 3 packet's PR passes the relevant gates:
+
+- **Packet 03** — `HoneyDrunk.AI`'s `pr-core.yml` tier-1 gate; any contract-shape canary on `HoneyDrunk.AI.Abstractions`; the new unit tests covering the USD-only happy path and the mixed-currency `CurrencyMismatchException` path.
+- **Packet 04** — `HoneyDrunk.Architecture`'s docs-lint or equivalent (if present); no runtime test.
+- **Packet 05** — `HoneyDrunk.Web.Rest`'s `pr-core.yml` tier-1 gate; the canary project's round-trip + amount-as-number-rejects tests pass.
+
+Once all three Wave 3 packets land, the initiative's exit criteria are met:
+
+- `Money`/`CurrencyCode` shipped in `HoneyDrunk.Kernel.Abstractions` with the canary suite green.
+- AI cost ledger explicitly USD-denominated per ADR-0069 D10.
+- Audit two-field convention documented per ADR-0069 D11 (no code change needed).
+- Web.Rest default JSON options carry the canonical D9 shape; the canary pins it.
+- ADR-0069 stays Accepted; no follow-up packets in this initiative.
+
+Subsequent consumer adoption (Billing standup, Notify Cloud standup, consumer-app PDR scaffolding) happens in each consumer's own track, consuming the contract this initiative shipped.


### PR DESCRIPTION
## Summary

- Third of 3 staged PRs from the 2026-05-23 ADR batch. Governance/planning-only — packets describe future Kernel.Abstractions additions; no Kernel code in this PR.
- Three initiatives: ADR-0063 (clock policy — `TimeProvider` + `AddSystemTimeProvider` / `AddFakeTimeProvider` DI helpers + HD0054 analyzer rule), ADR-0066 (health / readiness / liveness endpoints — `/health`, `/health/live`, `/health/ready` + `ReadinessPolicy` + IETF response shape), ADR-0069 (currency handling — `Money` record + `CurrencyCode` strong types + AI cost ledger adoption).
- ADR-0069 D2 Required Amendment recorded in packet 00: original draft required throwing equality on cross-currency comparison, which breaks `HashSet<Money>` / `Dictionary<Money, _>` / EF tracking. Packet 00 carries the amendment to ship `Money` as a standard record with value-based equality. ADR text should be amended before packet 00 flips Status.

## Validation

- Markdown + JSON only; no code changed.
- Dispatch plans render correctly.
- Kernel-version coordination narrative (`repos/HoneyDrunk.Kernel/active-work.md` callout) is legible across packets.
- `file-packets.yml` will file the 20 packet files on merge — verify in The Hive.

## Authorship

Authorship: agent-claude-code

## Notes

- This PR is `out-of-band` per ADR-0011 D9 / invariant 32 — ships packet files but doesn't execute any single packet.
- **Kernel 0.8.0 race.** ADR-0063 / ADR-0066 / ADR-0069 — plus the in-flight ADR-0042 idempotency — bump `HoneyDrunk.Kernel` from 0.7.0 to 0.8.0 in their respective packet 02. "First packet on the solution bumps; second appends" per invariant 27. `repos/HoneyDrunk.Kernel/active-work.md` is the suggested coordinator surface.
- Reservation registry (`constitution/invariant-reservations.md`) is inherited from #288. ADR-0063 claims a 5-row block, ADR-0066 claims a 3-row block, ADR-0069 commits no numbered invariants. Claims happen when respective packet 00 PRs land — not in this PR.