### PR TITLE
Scope ADR-0054/0055/0056 reliability and safety governance

### DIFF
--- a/generated/issue-packets/active/adr-0054-incident-response/00-architecture-adr-0054-acceptance.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/00-architecture-adr-0054-acceptance.md
@@ -1,0 +1,154 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "docs", "adr-0054", "wave-1"]
+dependencies: []
+adrs: ["ADR-0054"]
+accepts: ["ADR-0054"]
+wave: 1
+initiative: adr-0054-incident-response
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0054 — flip status, add the three incident-response invariants, register the initiative
+
+## Summary
+Flip ADR-0054 (Incident Response and On-Call Model for a One-Person Studio) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, add the **three** new invariants ADR-0054 commits in its Consequences/Invariants section to `constitution/invariants.md` (numbered **`{N1}, {N2}, {N3}`** — the three-wide block reserved for ADR-0054 in `constitution/invariant-reservations.md`), and register the `adr-0054-incident-response` initiative in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0054 binds the Grid's existing incident-shaped signals (App Insights alerts per ADR-0040, error captures per ADR-0045, budget alerts per ADR-0052, canary failures per ADR-0012, DR drill outcomes per ADR-0036, Audit anomalies per ADR-0030, Stripe webhook failures per ADR-0037) to a defined response process shaped by the one-person-studio constraint. The decisions are:
+
+- **D1** — Four severity levels (SEV-1/2/3/4) keyed to **customer impact**, with explicit ack and communication targets. SEV defaults map approximately to ADR-0036 DR tiers; severity can be promoted but not demoted without a recorded reason.
+- **D2** — Operator availability is **09:00–21:00 ET, 7 days a week** for tenant-impacting SEV-1/2; outside-window SEV-1/2 alerts page but acknowledgment is best-effort; SEV-3/4 never page outside coverage. The Notify Cloud SLA publishes 99.5% / 99.0% (within / overall) and the 15-min / best-effort ack split.
+- **D3** — Push-to-phone via **two redundant paths**: primary through `HoneyDrunk.Notify` Communications channel; secondary via **PagerDuty Starter** (~$21–25/month). Both required because Notify-itself-down is a credible failure mode.
+- **D4** — Single alert routing table mapping every signal source (App Insights, `IErrorReporter`, Azure Monitor budgets, canary failures, Audit, Vault, Stripe, DR drills, tenant-initiated tickets) to a default severity and routing target.
+- **D5** — Single-page rule with 1-hour fingerprint dedup; auto-resolve when condition clears for ≥5 minutes; operator manual override (ack / resolve).
+- **D6** — Seven-state incident lifecycle: Open → Acknowledged → Investigating → Mitigating → Resolved → Reviewing → Closed.
+- **D7** — Incident-record template at `generated/incidents/YYYY-MM-DD-<slug>.md` with machine-readable front-matter (incident_id, severity, status, opened/acknowledged/investigating/mitigating/resolved/reviewing/closed timestamps, mtta/mtmitigate/mttr minutes, customer impact, affected nodes/tenants, alert sources, post-mortem link).
+- **D8** — Blameless post-mortem cadence: SEV-1/2 required within **5 business days**; SEV-3 optional; SEV-4 not required. Blameless template at `generated/incidents/post-mortems/`.
+- **D9** — Communication channels: Atlassian Statuspage (Starter when first paying tenant exists; static-page v0 fallback until then); tenant emails through `HoneyDrunk.Communications`; in-product banner deferred to Notify Cloud.
+- **D10** — Per-Node runbooks at `repos/{node}/runbooks/` with minimum set (`restart.md`, `rollback.md`, `health-check.md`, `common-sev2-patterns.md`, `escalation.md` for Tier 0). Operator agent (ADR-0018) consults runbooks during incident mitigation.
+- **D11** — Quarterly game days; first within 30 days post-acceptance.
+- **D12** — Second-human-on-call hand-off is a forward-looking appendix gated on a specific trigger (second person with prod credentials + contract + PagerDuty onboarding). No infrastructure for it now.
+- **D13** — Honesty constraint: published SLAs and process commitments must reflect what one human plus AI agents can actually deliver. Tighter SLAs require ADR amendment first.
+
+The forcing functions (from the ADR's Context):
+
+- **Notify Cloud GA (PDR-0002 / ADR-0027)** is the first paying-tenant surface and cannot ship a published SLA without ADR-0054's coverage-hour and acknowledgment commitments behind it.
+- **The ADR-0034–0047 wave just landed** introducing observability, error tracking, cost alerts, and DR drills — each emits signals that need a defined receiving end.
+- **The AI-sector standup wave (ADR-0016–0025)** is about to introduce nine Nodes with operationally novel failure modes whose blast radius needs a paired response model.
+- **The one-person constraint is load-bearing** — standard SRE on-call models do not transfer; pretending otherwise produces an unworkable runbook and a credibility hit during the first real incident.
+
+ADR-0054 is a **policy / decision** ADR. The concrete code (the Notify paging integration, the Pulse synthetic probe, the Communications templates, the Actions generators, the alert-routing wiring, the runbook minimum set, the operator-agent amendment, the game-day scaffolding) lands in the implementing packets (02–12). Catalog updates land as packet 01.
+
+Every other packet in this initiative references ADR-0054's D-decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Invariant Numbering
+ADR-0054 adds **three** invariants from its Consequences/Invariants section. Invariant numbers are coordinated via `constitution/invariant-reservations.md` — read that file before editing `constitution/invariants.md` and confirm the three-wide block reserved for ADR-0054 (today: **61–63**). If the reservations file has shifted because another ADR landed first, take the new next-free block and update every `{N1}`/`{N2}`/`{N3}` placeholder below before committing. The reservations-file row stays "Proposed" until this packet merges, then moves to **Reservation History** with the merge date.
+
+The three invariants, numbered **`{N1}, {N2}, {N3}`**, taken verbatim-in-substance from ADR-0054's Consequences "Invariants" subsection:
+
+- **`{N1}` — Every paying-tenant-impacting incident (SEV-1 / SEV-2) produces a record in `generated/incidents/` with the D7 template's required front-matter.** Missing records is a CI gate failure (the gate is implemented as a `hive-sync` check that diffs PagerDuty's incident log against the directory). See ADR-0054 D6, D7.
+
+- **`{N2}` — Every SEV-1 and SEV-2 incident has a post-mortem filed within 5 business days of close.** Missing post-mortems flag in the nightly `hive-sync` report. See ADR-0054 D8.
+
+- **`{N3}` — Every deployable Node has the minimum runbook set per D10** (`restart.md`, `rollback.md`, `health-check.md`, `common-sev2-patterns.md`; `escalation.md` additionally for Tier 0 Nodes per ADR-0036). Missing runbooks block the Node's next release tag. See ADR-0054 D10.
+
+## Scope
+- `adrs/ADR-0054-incident-response-and-on-call-model-for-a-one-person-studio.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0054 row Status column to Accepted.
+- `constitution/invariants.md` — add the three new invariants (incident-record-for-SEV-1/2, 5-business-day post-mortem SLA, minimum runbook set per deployable Node), numbered **`{N1}, {N2}, {N3}`** — the three-wide block reserved for ADR-0054 in `constitution/invariant-reservations.md` (see Constraints).
+- `constitution/invariant-reservations.md` — move the ADR-0054 row from **Active Reservations** to **Reservation History** with the merge date.
+- `initiatives/active-initiatives.md` — register the `adr-0054-incident-response` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0054 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update the ADR-0054 index row in `adrs/README.md` to Accepted.
+3. Read `constitution/invariant-reservations.md` and confirm the three-wide block reserved for ADR-0054 (today: **61–63**). If the reservations file has shifted because another ADR landed first, take the new next-free block and update every `{N1}`/`{N2}`/`{N3}` placeholder in this packet body before committing.
+
+   Add the three new invariants to `constitution/invariants.md`, numbered **`{N1}, {N2}, {N3}`**, in the appropriate section (a new `## Incident Response Invariants` section placed after the existing operational-substrate invariants is acceptable). The exact texts as listed in Invariant Numbering above. Cite ADR-0054 D6/D7/D8/D10 where the invariant binds.
+4. Move the ADR-0054 row in `constitution/invariant-reservations.md` from **Active Reservations** to **Reservation History** with the merge date.
+5. Register the initiative in `initiatives/active-initiatives.md` with a "Tracking" section listing every packet in this folder (00 through 13) and an exit criterion: "ADR-0054 is Accepted; PagerDuty Starter is provisioned; Statuspage v0 (or Starter on first paying tenant) is live; Notify and Pulse paging-substrate packets have shipped; the `generated/incidents/` template and the `HoneyDrunk.Actions` generators exist; Communications tenant-email templates land; Azure Monitor → PagerDuty wiring per D4 is configured; the operator agent consults per-Node runbooks; the three `hive-sync` drift checks (incident-record/PagerDuty, post-mortem deadline, runbook freshness) are wired; the first game day has run; the Notify Cloud draft SLA reflects D2."
+
+## Affected Files
+- `adrs/ADR-0054-incident-response-and-on-call-model-for-a-one-person-studio.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0054 header reads `**Status:** Accepted`
+- [ ] The ADR-0054 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariants.md` carries the three new invariants (incident-record for every SEV-1/2 with the D7 front-matter; 5-business-day post-mortem SLA for SEV-1/2; minimum runbook set per deployable Node), each citing ADR-0054, numbered with the block claimed from `constitution/invariant-reservations.md` (today **61–63**)
+- [ ] `constitution/invariant-reservations.md` — ADR-0054 row moved from **Active Reservations** to **Reservation History** with the merge date
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0054-incident-response` initiative with a packet checklist (00 through 13) and an exit criterion
+- [ ] No catalog schema change in this packet (catalog updates land in packet 01)
+- [ ] No template file added in this packet (the D7 incident-record and D8 post-mortem templates land in packet 02)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0054 D6 — Incident lifecycle.** Open → Acknowledged → Investigating → Mitigating → Resolved → Reviewing → Closed. Each state transition is recorded in the incident record with a timestamp.
+
+**ADR-0054 D7 — Incident record template.** Every incident produces a markdown file at `generated/incidents/YYYY-MM-DD-<slug>.md` with the front-matter described in the ADR.
+
+**ADR-0054 D8 — Post-mortem cadence.** SEV-1/2 post-mortems are required within 5 business days of close; blameless template.
+
+**ADR-0054 D10 — Per-Node runbook minimum set.** `restart.md`, `rollback.md`, `health-check.md`, `common-sev2-patterns.md` for every deployable Node; `escalation.md` for Tier 0 Nodes per ADR-0036.
+
+**ADR-0054 Consequences — Invariants.** ADR-0054 adds three invariants. Final numbering claimed from `constitution/invariant-reservations.md`; the three `hive-sync` drift checks that enforce them land in packet 13.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0054 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Three invariants, reserved block.** The three invariants land at the numbers claimed in `constitution/invariant-reservations.md` (today **61–63**). If a collision shifts the block, update every `{N1}`/`{N2}`/`{N3}` placeholder in this packet body before committing. Do not renumber existing invariants.
+- **No template files here.** The D7 incident-record and D8 post-mortem template files land in packet 02. The invariant text references the templates but does not require the files to exist before this packet merges — the invariant comes online when packet 02 lands.
+- **No catalog edits here.** The `generated/incidents/` contract registration and the `repos/{node}/runbooks/` convention land in packet 01.
+- **No `hive-sync` wiring here.** The three drift checks that operationalize the new invariants (incident-record vs. PagerDuty log, post-mortem 5-business-day tracker, runbook freshness) land in packet 13.
+
+## Labels
+`chore`, `tier-3`, `ops`, `docs`, `adr-0054`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0054 to Accepted, add the three incident-response invariants to `constitution/invariants.md`, and register the incident-response initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0054 so the remaining packets in this initiative can reference its decisions as live rules.
+- Feature: ADR-0054 Incident Response rollout, Wave 1.
+- ADRs: ADR-0054 (primary), ADR-0008 (initiative/packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet on the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0054 stays Proposed until this PR merges.
+- Three invariants land at the numbers claimed in `constitution/invariant-reservations.md` (today **61–63**); update the `{N1}`/`{N2}`/`{N3}` placeholders if the reservations file has shifted. Do not renumber existing invariants.
+- Move the ADR-0054 row from **Active Reservations** to **Reservation History** in the reservations file.
+- No template files in this packet; the D7/D8 templates land in packet 02.
+- No `hive-sync` wiring here; the three drift checks land in packet 13.
+
+**Key Files:**
+- `adrs/ADR-0054-incident-response-and-on-call-model-for-a-one-person-studio.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0054-incident-response/01-architecture-incident-catalog-and-runbook-convention.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/01-architecture-incident-catalog-and-runbook-convention.md
@@ -1,0 +1,119 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0054", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0054", "ADR-0036"]
+accepts: ["ADR-0054"]
+wave: 1
+initiative: adr-0054-incident-response
+node: honeydrunk-architecture
+---
+
+# Register the incident-record contract and the per-Node runbook convention in the Grid catalogs
+
+## Summary
+Record ADR-0054's structural commitments as catalog data: formalize `generated/incidents/` as a contract with the D7 front-matter schema documented, add `repos/{node}/runbooks/` as a per-Node directory convention, and add a `runbook_compliance` field to `catalogs/contracts.json` (or the closest existing per-Node compliance surface) so the minimum-set invariant is observable from the catalog.
+
+## Context
+ADR-0054 makes two structural commitments that land in the Architecture repo as catalog/convention data:
+
+- **`generated/incidents/` formalized as a contract.** ADR-0054's Affected Nodes: "`HoneyDrunk.Architecture` — `generated/incidents/` formalized as a contract (D7 template)." The directory already exists and is referenced by `CLAUDE.md`, but no schema bound it. This packet registers the D7 template's required front-matter (incident_id, severity, status, opened_at, acknowledged_at, investigating_at, mitigating_at, resolved_at, reviewing_at, closed_at, customer_impact, affected_tenants, affected_nodes, alert_sources, mtta_minutes, mtmitigate_minutes, mttr_minutes, post_mortem_required, post_mortem_link) as the contract.
+- **`repos/{node}/runbooks/` as a per-Node convention.** ADR-0054 D10: "Per-Node runbooks live in `repos/{node}/runbooks/`. This convention is added by this ADR." The convention is added here so the catalog can observe per-Node compliance.
+- **`catalogs/contracts.json` gains a runbook-compliance field per Node.** ADR-0054's Affected Nodes: "`catalogs/contracts.json` gains a 'runbook compliance' field per Node." Match the existing per-Node convention in `contracts.json` at edit time — if the catalog tracks per-Node compliance fields, add `runbook_compliance` to each Node entry; if a separate compliance/observability surface (`grid-health.json` or similar) is the established place, add it there. Read the catalog ground truth before editing.
+
+**Catalog schema ground truth — read before editing.**
+- `catalogs/contracts.json` has the shape `{_meta, contracts:[{node, node_name, package, status, interfaces:[...]}]}` per the sibling ADR-0045 packet's notes — no compliance field currently exists. The "runbook compliance" addition must match whatever convention the catalog uses for per-Node metadata at edit time (it may be that `contracts.json` is the wrong file and `grid-health.json` or a new `runbook_compliance.json` is the right home — match the convention, do not invent a parallel structure).
+- `catalogs/grid-health.json` node entries carry `signal`/`version`/`canary_status`/`last_release`/`active_blockers`/`notes`. If the runbook-compliance field is best expressed as a node-status indicator, `grid-health.json` is the right home; record the choice in the PR.
+- `catalogs/nodes.json` has no `exposes` field; this packet does not touch it.
+
+**No new App resource.** This packet adds no Azure resource; it is pure catalog/convention work.
+
+This is a docs/catalog packet. No code, no .NET project.
+
+## Scope
+- A formal contract registration for the `generated/incidents/` directory and the D7 front-matter schema — recorded in the location the Grid uses for catalog contracts (likely a new entry in `catalogs/contracts.json` under the `honeydrunk-architecture` Node, or a separate schema doc — match the existing convention).
+- A per-Node convention note for `repos/{node}/runbooks/` — recorded where the Grid documents per-Node directory conventions (likely a new section in the Architecture repo's `repos/` README or each Node's `boundaries.md` reference; match the existing convention).
+- A `runbook_compliance` field per Node in the appropriate catalog file (`contracts.json` or `grid-health.json` — match the existing per-Node compliance/metadata convention at edit time).
+
+## Proposed Implementation
+1. **`generated/incidents/` contract registration.** Register the directory and its D7 front-matter schema as a contract. The simplest expression: add a new entry to `catalogs/contracts.json` under the `honeydrunk-architecture` Node listing `generated/incidents/` as a documented surface with the D7 front-matter as the schema. Field set per the D7 template: `incident_id`, `severity` (enum: SEV-1/SEV-2/SEV-3/SEV-4), `status` (enum matching the D6 lifecycle states), the seven lifecycle timestamps, `customer_impact` (bool), `affected_tenants` (string list), `affected_nodes` (string list), `alert_sources` (string list), `mtta_minutes` / `mtmitigate_minutes` / `mttr_minutes` (int), `post_mortem_required` (bool), `post_mortem_link` (string). Mark the contract status `planned` if the catalog tracks status; flip to `live` once packet 02 lands the template files. The contract description states: "Every paying-tenant-impacting incident (SEV-1/SEV-2) produces a record at `generated/incidents/YYYY-MM-DD-<slug>.md` with this front-matter."
+2. **`repos/{node}/runbooks/` convention.** Add a per-Node convention note. The simplest expression: a section in the Architecture repo's `repos/README.md` (or the equivalent index that documents per-Node directory conventions) naming `runbooks/` as the per-Node runbook directory, with the minimum file set from D10 (`restart.md`, `rollback.md`, `health-check.md`, `common-sev2-patterns.md`, plus `escalation.md` for Tier 0 Nodes per ADR-0036) and a one-line description of each file's purpose. Cross-reference D10's freshness rule (a runbook older than 90 days untouched is flagged in the nightly `hive-sync` report).
+3. **`runbook_compliance` field per Node.** Add a per-Node compliance field that records whether the Node carries the minimum runbook set. Match the existing convention at edit time:
+   - If `catalogs/contracts.json` tracks per-Node compliance, extend each Node's entry with `runbook_compliance: { restart: bool, rollback: bool, health_check: bool, common_sev2_patterns: bool, escalation: bool, all_present: bool }`.
+   - Else if `catalogs/grid-health.json` tracks per-Node operational metadata, add the field there.
+   - Else create a new catalog file `catalogs/runbook-compliance.json` and document why a separate file was the right choice.
+   For the initial population, mark every deployable Node as `all_present: false` until the playbook (packet 10) and per-Node fanout fills in the runbooks. Tier-0 Nodes (Vault, Audit, Notify Cloud per ADR-0036) require all five files; Tier-1 / Tier-2 deployable Nodes require the four non-escalation files; library-only Nodes (Kernel, Vault, Transport per invariant 17 / ADR-0005 — i.e., Nodes with no deployable surface) are exempt and marked `not_applicable: true`.
+4. **No D7/D8 template file creation here.** The concrete template markdown files (`generated/incidents/_templates/incident-record.md`, `generated/incidents/_templates/post-mortem.md`) land in packet 02 — this packet only registers the schema, not the files.
+5. **No runbook content created here.** Per-Node runbooks land via packet 10's playbook and subsequent per-Node fanout. This packet registers the convention only.
+
+## Affected Files
+- `catalogs/contracts.json` (or `grid-health.json` or new `runbook-compliance.json` — match convention) — the `generated/incidents/` contract entry and the per-Node `runbook_compliance` field.
+- `repos/README.md` (or the equivalent index that documents per-Node directory conventions) — the `runbooks/` convention note.
+
+## NuGet Dependencies
+None. This packet touches only catalog JSON and Markdown; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] Catalog data only — the template files land in packet 02; the runbook content lands via packet 10 and follow-on per-Node fanout.
+
+## Acceptance Criteria
+- [ ] `generated/incidents/` is registered as a contract in the appropriate catalog file (likely `catalogs/contracts.json` under the `honeydrunk-architecture` Node) with the D7 front-matter schema fully enumerated and the contract description referencing the SEV-1/2 invariant from packet 00
+- [ ] `repos/{node}/runbooks/` is documented as a per-Node directory convention with the minimum file set from D10 (`restart.md`, `rollback.md`, `health-check.md`, `common-sev2-patterns.md`; `escalation.md` additionally for Tier 0 Nodes per ADR-0036), each file's purpose described in one line
+- [ ] A `runbook_compliance` field is added per Node in the appropriate catalog file (matching existing per-Node compliance/metadata convention at edit time); the choice of file is documented in the PR
+- [ ] Every deployable Node is initially populated `all_present: false`; library-only / non-deployable Nodes are marked `not_applicable: true`
+- [ ] No template file is added in this packet (those land in packet 02)
+- [ ] No runbook content is added in this packet (those land via packet 10 and follow-on per-Node fanout)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0054 D7 — Incident record template.** Every incident produces a markdown file at `generated/incidents/YYYY-MM-DD-<slug>.md` with the full front-matter (incident_id, severity, status, the seven lifecycle timestamps, customer_impact, affected_tenants, affected_nodes, alert_sources, mtta/mtmitigate/mttr minutes, post_mortem_required, post_mortem_link). The template is the contract; the directory `generated/incidents/` is the surface. The schema is **machine-readable** because `hive-sync` consumes it for the rolling MTTA/MTTR dashboard and the incident-volume report.
+
+**ADR-0054 D10 — Per-Node runbooks at `repos/{node}/runbooks/`.** Minimum file set: `restart.md`, `rollback.md`, `health-check.md`, `common-sev2-patterns.md` for every deployable Node; `escalation.md` additionally for Tier 0 Nodes per ADR-0036. A runbook older than 90 days untouched is flagged in the nightly `hive-sync` report.
+
+**ADR-0054 Affected Nodes — Architecture commitments.** "`HoneyDrunk.Architecture` — `generated/incidents/` formalized as a contract (D7 template). `repos/{node}/runbooks/` directory added per D10. `catalogs/contracts.json` gains a 'runbook compliance' field per Node."
+
+**ADR-0036 — Tier classification.** Tier-0 Nodes (Vault, Audit, Notify Cloud tenant data) carry the additional `escalation.md` requirement per ADR-0054 D10. The packet's per-Node initial population follows the ADR-0036 tier mapping.
+
+## Constraints
+- **Match existing catalog convention.** Do not invent a parallel structure. If `contracts.json` is the established home for per-Node compliance, extend it there; if `grid-health.json` is, extend it there; if neither, create a separate file and document the choice.
+- **No template files in this packet.** The D7 incident-record and D8 post-mortem template files land in packet 02; this packet registers the schema only.
+- **No runbook content in this packet.** Per-Node runbooks land via packet 10 and follow-on per-Node fanout.
+- **Library-only Nodes are exempt.** Kernel, Vault (the abstraction package — not the deployable), Transport, Architecture, Standards are library-only and marked `not_applicable: true`. Deployable Nodes (Vault.Rotation, Notify, Communications, Pulse, Audit, Notify Cloud, etc.) carry the requirement.
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0054`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Register `generated/incidents/` as a contract with the D7 front-matter schema, document `repos/{node}/runbooks/` as a per-Node convention, and add a `runbook_compliance` field per Node in the appropriate catalog file.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the D7 schema and the D10 runbook convention catalog-observable so `hive-sync` and the per-Node compliance gates can act on them.
+- Feature: ADR-0054 Incident Response rollout, Wave 1.
+- ADRs: ADR-0054 D7/D10 (primary), ADR-0036 (tier mapping).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0054 should be Accepted before its catalog commitments land.
+
+**Constraints:**
+- Match existing catalog convention; do not invent a parallel structure.
+- No template files in this packet (packet 02 owns them).
+- No runbook content in this packet (packet 10 owns the playbook).
+- Library-only Nodes are exempt and marked `not_applicable: true`.
+
+**Key Files:**
+- `catalogs/contracts.json` (and/or `grid-health.json`, depending on which file matches the existing convention for per-Node compliance metadata)
+- `repos/README.md` (or the equivalent per-Node convention index)
+
+**Contracts:** `generated/incidents/` registered as a contract; `runbook_compliance` field added per Node.

--- a/generated/issue-packets/active/adr-0054-incident-response/02-architecture-incident-and-post-mortem-templates.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/02-architecture-incident-and-post-mortem-templates.md
@@ -1,0 +1,154 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0054", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0054"]
+accepts: ["ADR-0054"]
+wave: 1
+initiative: adr-0054-incident-response
+node: honeydrunk-architecture
+---
+
+# Author the D7 incident-record and D8 blameless post-mortem markdown templates
+
+## Summary
+Author the two concrete markdown template files ADR-0054 commits — the D7 incident-record template and the D8 blameless post-mortem template — at `generated/incidents/_templates/incident-record.md` and `generated/incidents/_templates/post-mortem.md`. These are the canonical templates the operator (and packet 08's generator) copies when filing a new incident or post-mortem.
+
+## Context
+ADR-0054 D7 specifies an incident-record template that lives at `generated/incidents/YYYY-MM-DD-<slug>.md` with structured front-matter. ADR-0054 D8 specifies a blameless post-mortem template at `generated/incidents/post-mortems/YYYY-MM-DD-<slug>.md`. The ADR embeds both templates inline as examples; this packet extracts them into concrete template files that:
+
+1. Serve as the canonical source for new incidents and post-mortems (copy-and-fill).
+2. Are consumed by packet 08's `HoneyDrunk.Actions` generator, which scaffolds a pre-filled file from the template.
+3. Are referenced by the schema registered in packet 01's `contracts.json` entry.
+
+**`generated/incidents/` already exists** as a directory in this repo, referenced by `CLAUDE.md`. No directory creation needed — but the `_templates/` subdirectory is new. The post-mortem template needs `generated/incidents/post-mortems/` to exist; create it as an empty directory with a `.gitkeep` if necessary so future post-mortems have a home.
+
+**Template content is fixed by the ADR.** The two templates' exact structure is given in ADR-0054 D7 (incident-record) and D8 (blameless post-mortem). Use the ADR's wording verbatim where the ADR specifies the structure; add comments / TODO placeholders where a section needs operator input at fill time.
+
+This is a docs/templates packet. No code, no .NET project.
+
+## Scope
+- `generated/incidents/_templates/incident-record.md` (new) — the D7 incident-record template.
+- `generated/incidents/_templates/post-mortem.md` (new) — the D8 blameless post-mortem template.
+- `generated/incidents/post-mortems/.gitkeep` (new) — ensure the post-mortems directory exists.
+- `generated/incidents/_templates/README.md` (new, optional) — a one-page note describing how the templates are used (manually copied, or scaffolded by packet 08's generator).
+
+## Proposed Implementation
+1. **`incident-record.md` template.** Author exactly the structure ADR-0054 D7 specifies. The front-matter:
+   ```yaml
+   ---
+   incident_id: INC-YYYY-NNNN
+   severity: SEV-N
+   status: Open  # Open | Acknowledged | Investigating | Mitigating | Resolved | Reviewing | Closed
+   opened_at: YYYY-MM-DDTHH:MM:SSZ
+   acknowledged_at:
+   investigating_at:
+   mitigating_at:
+   resolved_at:
+   reviewing_at:
+   closed_at:
+   customer_impact: no
+   affected_tenants: []
+   affected_nodes: []
+   alert_sources: []
+   mtta_minutes:
+   mtmitigate_minutes:
+   mttr_minutes:
+   post_mortem_required: no
+   post_mortem_link:
+   ---
+   ```
+   The body sections (from D7): `# INC-YYYY-NNNN: <title>`, `## Summary` (one-paragraph customer-facing summary), `## Timeline` (append-only during the incident, frozen at close), `## Root cause` ("unknown — investigating" is a valid root cause at incident close), `## Mitigation` (what was done to restore service), `## Customer communication` (status-page and tenant-email entries with timestamps), `## Follow-ups` (linked to issue packets or ADR amendments — an incident producing no follow-ups is itself a signal worth noting), `## Post-mortem` (link or "Not required for this SEV"). Include placeholder TODO comments on each section so the operator knows what to fill in.
+
+2. **`post-mortem.md` template.** Author exactly the structure ADR-0054 D8 specifies. The front-matter:
+   ```yaml
+   ---
+   incident_id: INC-YYYY-NNNN
+   post_mortem_id: PM-YYYY-NNNN
+   authored_at: YYYY-MM-DDTHH:MM:SSZ
+   participants: [operator]
+   related_adrs: []
+   follow_up_packets: []
+   ---
+   ```
+   The body sections (from D8): `# PM-YYYY-NNNN: <title> (YYYY-MM-DD)`, `## What happened` (factual narrative, no blame language), `## Impact` (customer impact, business impact, internal cost in operator hours), `## Root cause` (five-whys depth where useful), `## What went well`, `## What went poorly`, `## Where we got lucky` (things that worked by accident — catching these is the whole point of the blameless review), `## Action items` (concrete follow-ups, each linked to an issue packet or ADR amendment, with owner / deadline / status), `## Glossary / Links` (relevant ADRs, dashboards, related incidents). Include the **blameless principle** as a header comment in the template: "The post-mortem describes systems, processes, and tools — never individual fault. In a one-person studio, the operator IS the only individual; blameless language is doubly important because self-blame is the failure mode. The point is to fix the system, not the human."
+
+3. **`post-mortems/.gitkeep`.** Create the subdirectory so future post-mortems have a home; the `.gitkeep` is the only file in it until a real post-mortem lands.
+
+4. **`_templates/README.md` (optional).** A short note describing how the templates are used: copy manually for v0; scaffolded by `HoneyDrunk.Actions` (packet 08) for v1. Cross-reference the schema registered in packet 01.
+
+5. **Front-matter fields are machine-readable** per D7. Use YAML, not custom syntax — `hive-sync` consumes the front-matter for MTTA/MTTR dashboards and the incident-volume report.
+
+## Affected Files
+- `generated/incidents/_templates/incident-record.md` (new)
+- `generated/incidents/_templates/post-mortem.md` (new)
+- `generated/incidents/post-mortems/.gitkeep` (new)
+- `generated/incidents/_templates/README.md` (new, optional)
+
+## NuGet Dependencies
+None. This packet creates only markdown template files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All files in `HoneyDrunk.Architecture/generated/incidents/`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] The templates are the canonical source consumed by packet 08's generator; this packet does not author the generator.
+
+## Acceptance Criteria
+- [ ] `generated/incidents/_templates/incident-record.md` exists with the D7 front-matter (incident_id, severity, status, the seven lifecycle timestamps, customer_impact, affected_tenants, affected_nodes, alert_sources, mtta/mtmitigate/mttr minutes, post_mortem_required, post_mortem_link) and the D7 body sections (Summary, Timeline, Root cause, Mitigation, Customer communication, Follow-ups, Post-mortem) with TODO placeholders
+- [ ] `generated/incidents/_templates/post-mortem.md` exists with the D8 front-matter (incident_id, post_mortem_id, authored_at, participants, related_adrs, follow_up_packets) and the D8 body sections (What happened, Impact, Root cause, What went well, What went poorly, Where we got lucky, Action items, Glossary / Links) and the blameless-principle header comment
+- [ ] `generated/incidents/post-mortems/.gitkeep` exists so the subdirectory is tracked
+- [ ] The front-matter is valid YAML — `hive-sync` can parse it for MTTA/MTTR aggregation
+- [ ] The template files are referenced by the schema registered in packet 01's `contracts.json` entry
+- [ ] No code or workflow is added in this packet (the generator lands in packet 08)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0054 D7 — Incident record template.** The full template structure as embedded in the ADR. Front-matter fields are machine-readable; `mtta_minutes`, `mtmitigate_minutes`, `mttr_minutes` are computed from the timestamps. The timeline is append-only during the incident and frozen at close. "Unknown — investigating" is a valid root cause at close; the post-mortem refines it. Follow-ups link to issue packets (per ADR-0008) or ADR amendments — an incident producing no follow-ups is itself a signal worth noting.
+
+**ADR-0054 D8 — Blameless post-mortem template.** The full template structure as embedded in the ADR. **Blameless principle:** the post-mortem describes systems, processes, and tools — never individual fault. In a one-person studio, the operator IS the only individual; blameless language is doubly important because self-blame is the failure mode. Patterns across multiple post-mortems trigger ADR-level changes; a quarterly retrospective reads the last 90 days of post-mortems and produces a meta-report.
+
+**ADR-0054 D6 — Incident lifecycle (seven states).** The seven states (Open → Acknowledged → Investigating → Mitigating → Resolved → Reviewing → Closed) are referenced by the front-matter's `status` field and the seven lifecycle timestamps.
+
+## Constraints
+- **Faithful to the ADR.** Use the ADR's wording verbatim where the ADR specifies the template structure. Do not invent new sections.
+- **Valid YAML front-matter.** `hive-sync` parses the front-matter for MTTA/MTTR aggregation; broken YAML breaks the dashboard.
+- **No generator in this packet.** The `HoneyDrunk.Actions` generator that scaffolds a pre-filled file from the template lands in packet 08.
+- **No real incident in this packet.** The templates are blank canonical examples — no actual incident_id, no actual timestamps.
+- **Blameless principle inlined.** The post-mortem template's header comment carries the blameless-principle text from D8 verbatim — it is load-bearing for one-person operation.
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0054`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Author the D7 incident-record and D8 blameless post-mortem markdown templates at `generated/incidents/_templates/` so the operator (and packet 08's generator) can scaffold new incidents and post-mortems from them.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land the two canonical template files that the schema in packet 01 references and the generator in packet 08 consumes.
+- Feature: ADR-0054 Incident Response rollout, Wave 1.
+- ADRs: ADR-0054 D7/D8 (primary), ADR-0054 D6 (lifecycle state names used in the front-matter).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0054 should be Accepted before its templates land as canonical files.
+
+**Constraints:**
+- Faithful to the ADR's template structure (verbatim where the ADR specifies wording).
+- Valid YAML front-matter; broken YAML breaks `hive-sync` aggregation.
+- No generator code in this packet (packet 08 owns it).
+- Blameless principle inlined verbatim in the post-mortem template header.
+
+**Key Files:**
+- `generated/incidents/_templates/incident-record.md` (new)
+- `generated/incidents/_templates/post-mortem.md` (new)
+- `generated/incidents/post-mortems/.gitkeep` (new)
+
+**Contracts:** The two template files are the canonical artifacts the schema in packet 01 binds.

--- a/generated/issue-packets/active/adr-0054-incident-response/03-architecture-pagerduty-provisioning.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/03-architecture-pagerduty-provisioning.md
@@ -1,0 +1,173 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "infrastructure", "human-only", "adr-0054", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0054", "ADR-0052", "ADR-0005"]
+accepts: ["ADR-0054"]
+wave: 1
+initiative: adr-0054-incident-response
+node: honeydrunk-architecture
+---
+
+# Provision PagerDuty Starter — account, escalation policy, and integrations
+
+## Summary
+Provision the **PagerDuty Starter** account that serves as the secondary paging path per ADR-0054 D3, configure the one-user escalation policy with the operator's phone number as the SMS + phone-call target, create the source integrations the D4 routing table calls (Azure Monitor → PagerDuty, Stripe → PagerDuty, generic webhook → PagerDuty), and store the PagerDuty integration secrets / API key in the appropriate Key Vault. Author a walkthrough doc covering all steps so re-provisioning (e.g. environment refresh or vendor swap) is documented.
+
+## Context
+ADR-0054 D3 names PagerDuty Starter (~$21–25/month at 2026 pricing) as the secondary paging path — the redundant SMS + phone-call surface that survives a Notify-itself-down scenario. The primary path is Notify (packet 04); the two together provide the redundancy the ADR demands. D3 also names PagerDuty as **the source of truth for acknowledgment** (it has a true ack-button surface) — Notify-pushed alerts include a deep-link to the PagerDuty incident for ack.
+
+ADR-0054's Follow-up Work names the discrete portal steps:
+
+- "Implement the PagerDuty integration: account creation, escalation policy, webhook configuration."
+- "Wire App Insights alerts (ADR-0040) to PagerDuty per the D4 routing table." (Packet 09 — alert wiring, depends on this packet.)
+- "Wire `IErrorReporter` captures (ADR-0045), Azure Monitor budget alerts (ADR-0052), canary failure alerts (ADR-0012) to PagerDuty per the D4 routing table." (Packet 09.)
+
+This packet is the **substrate provisioning** — packet 09 is the per-source wiring that consumes the integrations this packet creates.
+
+Per the operator's standing preference, infra provisioning uses the vendor's portal UI, not CLI / API / Terraform — so this packet delivers a portal walkthrough. The walkthrough doc lives in `infrastructure/walkthroughs/pagerduty-provisioning.md`.
+
+**Cost.** PagerDuty Starter is ~$21–25/month for one user (2026 list pricing — confirm the exact tier name and price at execution time; the vendor renames tiers periodically). The cost is named in ADR-0052's cost-discipline envelope as an **exempt category** — paging tooling itself doesn't fire its own budget alert (it would be self-referential).
+
+**Free tier rejected.** ADR-0054 D3 explicitly rejects PagerDuty's free tier for SEV-1 use because the free tier lacks SMS reliability guarantees and phone-call escalation. Pick Starter (the lowest paid tier).
+
+**Vault placement.** Per invariant 17 (one Key Vault per deployable Node per environment) there is **no shared Vault** — `kv-hd-shared-{env}` does not exist. The PagerDuty integration secrets are stored in the Vault of the Node that consumes them:
+
+- The **PagerDuty Events API v2 key** is consumed by the Pulse synthetic probe (packet 06). It lives in `kv-hd-pulse-{env}`. Pulse is a Seed Node per the catalog; if `kv-hd-pulse-{env}` does not yet exist, this packet's walkthrough provisions it as an explicit prerequisite (see Human Prerequisites) — there is no "operator-internal Vault" or "shared Vault" fallback.
+- The **PagerDuty Azure Monitor integration URL** is consumed by Azure Monitor action groups (packet 09 wires them); it lives in `kv-hd-notify-{env}` for the cross-deep-link Notify renders in paging payloads, since the URL also flows through the Notify-delivery payload. Notify is LIVE and already has `kv-hd-notify-{env}` provisioned.
+- The **Stripe integration key** (if a separate first-party PagerDuty integration is used) is consumed by the Node that emits the Stripe webhook failure capture. If that Node is Notify-adjacent, it lives in that Node's Vault; otherwise it lives in `kv-hd-notify-{env}` alongside the Azure Monitor URL.
+
+Record the chosen path per secret in the walkthrough.
+
+**Provision-when-needed.** ADR-0054 D2's coverage window starts when the paging substrate is live. This packet provisions the PagerDuty account once, in the operator's PagerDuty account (a vendor account, not per-environment). The integration secrets are stored per-environment in Vault. Packet 09 wires the per-source alerts in `dev` (which exists per ADR-0033) and re-uses the walkthrough for `staging`/`prod` when they stand up.
+
+This is an infrastructure walkthrough + provisioning packet. No code, no .NET project. **Actor=Human** — the steps are portal clicks the agent cannot perform (account signup, payment authorization, escalation policy clicks, phone-number entry).
+
+## Scope
+- `infrastructure/walkthroughs/pagerduty-provisioning.md` (new) — the PagerDuty portal walkthrough.
+- The PagerDuty account itself — created via signup at pagerduty.com (a vendor surface, not a repo artifact).
+- The Key Vault secrets for the PagerDuty integration URLs / API key — stored in the recommended Vault, path documented in the walkthrough.
+- A note in `catalogs/grid-health.json` or the equivalent recording that the PagerDuty integration is `provisioned` in `dev` (or whichever environment the secret lands in).
+
+## Proposed Work (human-executed, vendor portal + Azure Portal)
+The walkthrough authors and the operator executes:
+
+1. **PagerDuty account signup.**
+   - Visit pagerduty.com → sign up for the **Starter** plan (confirm the current tier name and price; the free trial is acceptable for initial setup but the paid plan must be activated before SEV-1 reliance because the free tier lacks SMS guarantees per D3).
+   - Add one user (the operator).
+   - Set the operator's email, phone number (for SMS), and a second phone number (for phone-call escalation if the first phone goes silent). The phone number is **personal mobile** — never a shared studio number.
+   - Configure the user's notification rules: SMS and phone call immediately for any incident.
+2. **Escalation policy.**
+   - Create a single escalation policy: "HoneyDrunk Studios Operator." One level: the operator. No secondary. The escalation policy has no timeout target — `null` after the operator per D3 ("escalation paths terminate at the single operator").
+   - Per D12 (forward-looking) — when a second human is hired this escalation policy is amended to add a secondary level; not now.
+3. **Service definitions.**
+   - Create one PagerDuty **service** per signal source family the D4 routing table calls (alternatively, a single "HoneyDrunk Grid Production" service with integrations per source — match what's cleanest in the PagerDuty UI; one service is simpler at this scale). Recommended at this scale: one service.
+   - Bind the service to the operator escalation policy.
+4. **Integrations.**
+   - Add the **Azure Monitor** integration to the service (PagerDuty has a first-party Azure Monitor integration). Note the integration URL; this is what Azure action groups call.
+   - Add a **generic webhook (Events API v2)** integration for the sources that aren't first-party (Stripe via its own webhook, custom Notify alerts, canary failures). Note the integration key.
+   - Add the **Stripe** integration if PagerDuty offers a first-party one; otherwise route Stripe via the generic Events API v2 endpoint.
+5. **Store secrets in Vault.**
+   - Per invariant 17 (one Vault per deployable Node per environment) there is no shared Vault. Store each integration credential in the Vault of the Node that consumes it:
+     - `pagerduty-events-api-key` → `kv-hd-pulse-{env}` (consumed by Pulse synthetic probe in packet 06). If `kv-hd-pulse-{env}` does not yet exist (Pulse is a Seed Node), provision it first per the ADR-0005 Vault-creation walkthrough — this is an explicit prerequisite, not a fallback to a shared Vault.
+     - `pagerduty-azure-monitor-integration-url` → `kv-hd-notify-{env}` (consumed by Notify for the cross-deep-link in paging payloads; Notify is LIVE and already has its Vault). Azure Monitor action groups read it from this Vault.
+     - `pagerduty-stripe-integration-key` → `kv-hd-notify-{env}` (same Vault as the Azure Monitor URL).
+   - Per invariant 9 (Vault is the only source of secrets), never paste the key into a config file or workflow.
+6. **Synthetic-probe credential.**
+   - The Pulse synthetic probe (packet 06) needs to send a fake SEV-3 to PagerDuty every 5 minutes. The probe authenticates via the Events API v2 key stored at `pagerduty-events-api-key` in `kv-hd-pulse-{env}`. Confirm Pulse's managed identity has Get permission on the secret. If `kv-hd-pulse-{env}` did not exist before this packet, the walkthrough's prerequisite step (Vault creation) covers it.
+7. **Verify.**
+   - From the PagerDuty UI, trigger a test incident. Confirm SMS and phone call arrive on the operator's phone within 30 seconds (D3's latency target).
+   - Acknowledge the test incident from the phone; confirm the ack is reflected in the PagerDuty UI.
+   - Resolve the test incident; confirm the auto-resolve flow.
+8. **Update catalog readout.**
+   - Flip the PagerDuty integration entry in `catalogs/grid-health.json` (or the appropriate per-vendor catalog file added at edit time — match existing convention) to `provisioned` for `dev`.
+   - Record the chosen Vault paths in the walkthrough doc.
+9. **Cost guard.**
+   - Note the recurring monthly cost (~$21–25/month) in `business/context/` alongside the ADR-0052 cost-ceiling tracking. Mark PagerDuty as an **exempt** category — it does not fire its own budget alert.
+
+## Affected Files
+- `infrastructure/walkthroughs/pagerduty-provisioning.md` (new)
+- `catalogs/grid-health.json` (or the equivalent catalog file at edit time) — PagerDuty integration entry flipped to `provisioned`.
+- `business/context/` — PagerDuty cost entry (annotation, not a new note).
+- The PagerDuty account and its integrations (a vendor surface, not repo artifacts).
+- The Key Vault secrets `pagerduty-events-api-key`, `pagerduty-azure-monitor-integration-url`, `pagerduty-stripe-integration-key` (Azure resources, not repo artifacts).
+
+## NuGet Dependencies
+None. This packet has no .NET project.
+
+## Boundary Check
+- [x] The walkthrough doc lives in `HoneyDrunk.Architecture` — correct home for infrastructure walkthroughs per the existing `infrastructure/walkthroughs/` convention.
+- [x] No code change in any repo.
+- [x] The PagerDuty account and Azure secrets land in vendor / Azure subscriptions, not in repo.
+- [x] The recommended Vault is consistent with ADR-0005 (one Vault per deployable Node per environment); the integration secrets are stored where the Node that consumes them (Pulse for the probe; Notify for the cross-deep-link) reads from.
+
+## Acceptance Criteria
+- [ ] `infrastructure/walkthroughs/pagerduty-provisioning.md` exists and documents: signup at pagerduty.com Starter plan; one-user account with personal mobile + secondary phone; the "HoneyDrunk Studios Operator" escalation policy with one level (the operator) and no secondary; one service bound to the policy; the Azure Monitor integration, the generic Events API v2 integration, and the Stripe integration (or generic-Events fallback); the recommended Vault path for each integration secret; the verify-with-test-incident step; the catalog flip and the cost note
+- [ ] The PagerDuty account is **provisioned** on the Starter plan; the operator has SMS + phone-call notification rules; a test incident has been triggered, acked from the phone, and resolved
+- [ ] The integration secrets are stored per the per-Node Vault rule (invariant 17): `pagerduty-events-api-key` in `kv-hd-pulse-{env}`, `pagerduty-azure-monitor-integration-url` and `pagerduty-stripe-integration-key` in `kv-hd-notify-{env}`. No "shared" Vault is created.
+- [ ] `catalogs/grid-health.json` (or the equivalent catalog file) reflects PagerDuty as `provisioned` for `dev`
+- [ ] `business/context/` carries the PagerDuty recurring-cost note (~$21–25/month) annotated as ADR-0052 cost-exempt
+- [ ] The walkthrough notes the D12 future-state — when a second human is hired the escalation policy gains a secondary level
+
+## Human Prerequisites
+- [ ] **Sign up for PagerDuty at pagerduty.com on the Starter plan** — payment authorization required (recurring ~$21–25/month).
+- [ ] **Operator's personal mobile phone number** — used as the SMS + phone-call target. Confirm carrier delivers SMS reliably.
+- [ ] **Azure subscription access** to store integration secrets in the per-Node Key Vaults — the secrets cannot be created without portal/CLI access. The agent does not have this access.
+- [ ] **Provision `kv-hd-pulse-{env}` first if it does not exist.** Per invariant 17 there is no shared Vault; the Events API v2 key has nowhere else to land. Follow the ADR-0005 Vault-creation walkthrough before storing the secret. (`kv-hd-notify-{env}` already exists — Notify is LIVE.)
+- [ ] **Trigger the test incident from the PagerDuty UI** to confirm end-to-end delivery; the agent cannot click "Trigger test" in a vendor UI.
+
+## Referenced ADR Decisions
+**ADR-0054 D3 — Paging mechanism.** Push-to-phone via two redundant paths. PagerDuty Starter (~$21/user/month) is the secondary path. Both paths fire for SEV-1/2; SEV-3 fires Notify only (no PagerDuty cost burn for non-paging-worthy events); SEV-4 fires neither. PagerDuty is the source of truth for acknowledgment because it has a true ack-button surface. Latency target < 30 seconds from alert fire to phone receipt. OpsGenie was considered and rejected on continuity (PagerDuty has the larger ecosystem of integrations with Azure Monitor, GitHub, Stripe webhooks).
+
+**ADR-0054 D12 — On-call hand-off (forward-looking).** Current state: one human operator. The escalation policy has one level (the operator), no secondary. When the trigger fires (second person with prod credentials + signed on-call contract + PagerDuty onboarding), the escalation policy is amended.
+
+**ADR-0052 — Cost discipline.** PagerDuty Starter is named as an **exempt category** in the cost-discipline envelope — paging tooling itself doesn't fire its own budget alert.
+
+**ADR-0005 — One Key Vault per deployable Node per environment.** Per invariant 17 there is no shared Vault. Integration secrets are stored in the Vault of the Node that consumes them: `kv-hd-pulse-{env}` for the Events API v2 key (Pulse synthetic probe); `kv-hd-notify-{env}` for the Azure Monitor integration URL (Notify cross-deep-link rendering, Azure Monitor action group reads).
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry — or in workflow files.** The PagerDuty Events API key, Azure Monitor integration URL, and Stripe integration key are stored in Vault per invariant 9; never pasted into config files, workflow YAML, or commit history.
+
+> **Invariant 9 — Vault is the only source of secrets.** PagerDuty integration secrets are read via `ISecretStore` at runtime; never via environment variables or hardcoded constants.
+
+> **Invariant 17 — One Key Vault per deployable Node per environment.** There is **no shared Vault** (no `kv-hd-shared-{env}`). The Events API v2 key lives in `kv-hd-pulse-{env}` (consumed by Pulse); the Azure Monitor integration URL and Stripe integration key live in `kv-hd-notify-{env}` (consumed by Notify and Azure Monitor action groups). If `kv-hd-pulse-{env}` does not yet exist it is provisioned as a prerequisite — never deferred to a "shared" Vault.
+
+- **Starter, not Free.** PagerDuty's free tier lacks SMS reliability for SEV-1 (D3). Provision the paid Starter plan.
+- **One-level escalation now.** The escalation policy has one level (the operator) and no secondary. D12's amendment fires when a second human is hired — not now.
+- **Personal mobile.** The SMS / phone-call target is the operator's personal mobile, not a shared studio number. The operator carries this phone outside coverage hours.
+- **Vault-stored secrets only.** All PagerDuty integration credentials live in the recommended Key Vault. No `.env` file, no `appsettings.json` entry, no committed workflow value.
+
+## Labels
+`feature`, `tier-2`, `ops`, `infrastructure`, `human-only`, `adr-0054`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Provision PagerDuty Starter, configure the one-operator escalation policy, create the Azure Monitor / Stripe / generic-webhook integrations, store the integration secrets in the recommended Key Vault, and document the steps in an infrastructure walkthrough.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main` for the walkthrough doc; the PagerDuty account and Azure secrets land outside the repo.
+
+**Context:**
+- Goal: Stand up the secondary paging path so packet 04 (Notify primary path) and packet 06 (Pulse synthetic probe) can verify end-to-end paging, and so packet 09 can wire alert sources to PagerDuty.
+- Feature: ADR-0054 Incident Response rollout, Wave 1.
+- ADRs: ADR-0054 D3 (primary), ADR-0054 D12 (forward-looking — one level only now), ADR-0052 (cost-exempt category), ADR-0005 (Vault placement).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0054 should be Accepted before its paging infrastructure stands up.
+
+**Constraints:**
+- Starter plan, not Free.
+- One-level escalation policy now; D12 amendment when a second human is hired.
+- Personal mobile, not shared.
+- Vault-stored secrets only (invariants 8, 9, 17).
+
+**Key Files:**
+- `infrastructure/walkthroughs/pagerduty-provisioning.md` (new)
+- `catalogs/grid-health.json` (or equivalent)
+- `business/context/` (PagerDuty cost annotation)
+
+**Contracts:** None changed. The PagerDuty integration URLs / keys become available secrets consumed by packets 06 and 09.

--- a/generated/issue-packets/active/adr-0054-incident-response/04-notify-primary-paging-path.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/04-notify-primary-paging-path.md
@@ -1,0 +1,212 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Communications
+labels: ["feature", "tier-2", "ops", "adr-0054", "wave-2"]
+dependencies: ["packet:00", "packet:03"]
+adrs: ["ADR-0054", "ADR-0019"]
+accepts: ["ADR-0054"]
+wave: 2
+initiative: adr-0054-incident-response
+node: honeydrunk-communications
+---
+
+# Implement the primary paging path: Communications-owned intent, Notify delivery (companion-app push or v0 SMS fallback)
+
+## Summary
+Implement the primary paging path per ADR-0054 D3 with **paging intent owned by `HoneyDrunk.Communications`** (per invariant 41 — "Preference enforcement, cadence rules, and suppression logic for outbound messages live in HoneyDrunk.Communications, not in HoneyDrunk.Notify") and **delivery owned by `HoneyDrunk.Notify`** (the channel-agnostic delivery surface). A new `IIncidentPagingIntent` lives in `HoneyDrunk.Communications.Abstractions`; the Communications handler decides (severity, fingerprint dedup, operator-availability gating, the `Diagnostic` flag) and then composes the delivery payload that flows through Notify's existing `INotificationSender` to the operator's phone via push notification (the Studios-internal companion app) with **v0 SMS via the existing Twilio provider as the fallback** when the companion app is not yet built. Each paged alert includes a deep-link to the corresponding PagerDuty incident (per D3 — "PagerDuty is the source of truth for acknowledgment").
+
+## Context
+ADR-0054 D3 specifies two redundant paging paths. The secondary path is PagerDuty (packet 03). The **primary** path is split per the ADR-0019 / invariant-41 boundary:
+
+- **Decision / intent layer** — `HoneyDrunk.Communications`. The Communications Node owns the *decision* to page (severity, fingerprint dedup, operator-availability gating, the `Diagnostic` flag distinguishing synthetic-probe pages from real pages, the audit-of-the-page-itself emission). Per invariant 41 ("Preference enforcement, cadence rules, and suppression logic for outbound messages live in HoneyDrunk.Communications, not in HoneyDrunk.Notify"), paging *intent* is a Communications concern.
+- **Delivery layer** — `HoneyDrunk.Notify`. Notify owns the *delivery mechanics*: SMS via Twilio (v0); push via the Studios-internal companion app (v1). Notify already ships the `INotificationSender` channel-agnostic dispatch contract; this packet uses it as the existing delivery handoff — **no new `IIncidentPagingSender` on the Notify side**.
+
+ADR-0054 D3 names the primary path's delivery target as "the operator's personal phone via push notification (initially APNs/FCM through a small Studios-internal companion app, or via SMS if the companion app is not yet built)." Latency target: **< 30 seconds from alert fire to phone receipt** under healthy Grid conditions.
+
+The companion app is **future work**. ADR-0054's Operational Consequences: "The companion-app push integration (D3 primary path) is initial work. v0 may use SMS via Notify if the companion app isn't ready; the trade-off is slightly higher delivery latency for v0." This packet ships **v0 with SMS** as the delivery channel; the companion-app push integration is a follow-on that does not block this packet's acceptance criteria. v0 SMS uses Notify's existing Twilio provider via `INotificationSender`.
+
+**Communications is the target Node for this packet** because the new contract — `IIncidentPagingIntent` — and the handler that owns severity / dedup / availability / `Diagnostic` decisioning live there. Notify is unchanged at the contract surface for this packet (no new `IIncidentPagingSender` is added to `Notify.Abstractions`).
+
+**Notify is live (Notify v0.x in the catalog), and already ships:**
+- `INotificationSender` / `INotificationGateway` — the channel-agnostic dispatch surface. **The Communications paging handler calls this existing contract for delivery.**
+- Twilio provider — SMS delivery.
+- Resend / SMTP providers — email (used by tenant communications elsewhere, not for paging).
+- Queue-backed async delivery, idempotency keys (per ADR-0042), delivery status tracking.
+
+This packet adds a new **incident-paging intent path** in Communications that:
+1. Accepts a `PageOperatorRequest` (the *intent* — pre-classified severity from the caller, plus the `Diagnostic` flag, content, fingerprint, etc.).
+2. Applies Communications-owned decision logic (operator-availability window per D2; D5 dedup; the `Diagnostic`-gated final-dispatch decision — `Diagnostic: true` short-circuits the actual operator-phone SMS).
+3. Composes the final delivery payload (severity-tagged subject, summary, PagerDuty deep-link).
+4. Dispatches through Notify's existing `INotificationSender` for SMS (v0) or push (v1).
+
+The new Communications intent surface is callable from:
+
+- Packet 06's Pulse synthetic probe (the every-5-minute fake SEV-3 verification — it sets `Diagnostic: true`).
+- Packet 09's Azure Monitor → PagerDuty wiring also posts to Communications in parallel (both paths fire for SEV-1/2 per D3 — `Diagnostic: false`).
+- Future direct-from-Source paging calls (Audit, Vault, etc.).
+
+**Cross-deep-link.** Each paged delivery carries a deep-link to the PagerDuty incident — D3 says "Notify-pushed alerts include a deep-link to the PagerDuty incident for ack." The PagerDuty incident URL is supplied by the caller; the Communications handler embeds it in the dispatch payload; the SMS body / push notification body renders it.
+
+**Communications is a deployable Node** at the version its `CHANGELOG.md` records; this packet bumps the `HoneyDrunk.Communications` solution (the first ADR-0054 packet on the solution — minor bump for the new paging-intent surface). Per the dispatch plan, packet 05 (tenant-email templates) also bumps Communications; coordinate the bump so both packets land in one combined minor bump if they merge close in time.
+
+**Vault.** No new Notify-side secret class introduced here — the SMS path reuses Notify's existing Twilio credential in `kv-hd-notify-{env}`. The operator's personal mobile is read from `kv-hd-communications-{env}` (Communications' own Vault per invariant 17) as a Communications-side configuration secret (e.g., `operator-paging-phone`), or alternately stays in `kv-hd-notify-{env}` if Communications reads via Notify's delivery payload (final placement chosen at edit time based on whether Communications needs the phone number directly or only via Notify's existing routing — confirm the existing pattern). If Communications does not yet have a Vault, provision `kv-hd-communications-{env}` first per the ADR-0005 walkthrough — per invariant 17 there is no shared Vault.
+
+## Scope
+- `HoneyDrunk.Communications` solution — add the `IIncidentPagingIntent` contract in `HoneyDrunk.Communications.Abstractions` and its handler in `HoneyDrunk.Communications`. The handler owns the severity / dedup / availability / `Diagnostic` decisioning and dispatches through Notify's existing `INotificationSender`.
+- Communications test projects — tests covering the SMS-delivery handoff (with the existing Twilio fake / InMemory provider exposed by Notify) and the `Diagnostic: true` short-circuit.
+- `HoneyDrunk.Notify` is **not modified** by this packet. The Communications handler consumes the existing `INotificationSender` contract from `HoneyDrunk.Notify.Abstractions`. If a small Notify enhancement is required (e.g., a delivery-status query surface the Communications handler reads to record handoff success), record it as a deferred follow-on; the v0 SMS path through `INotificationSender` already returns delivery status.
+- Repo-level `CHANGELOG.md` and any per-package CHANGELOG that actually changes; the `README.md` if the paging surface is documented externally.
+
+## Proposed Implementation
+1. **Define the intent contract.** Add `IIncidentPagingIntent` to `HoneyDrunk.Communications.Abstractions`. The contract accepts a record:
+
+   ```csharp
+   PageOperatorRequest(
+       Severity Severity,
+       string Title,
+       string Summary,
+       string PagerDutyIncidentUrl,
+       string FingerprintKey,
+       bool Diagnostic);
+   ```
+
+   - `Severity` — pre-classified by the caller (sources of severity: D4 routing table, Pulse probe sets SEV-3 for the synthetic).
+   - `Diagnostic` — when `true`, the Communications handler **does not dispatch the final SMS/push to the operator's personal phone**. Used by Pulse's synthetic probe (packet 06) to verify the intent path is alive without flooding the operator every 5 minutes. The handler still records the intent-receipt in the delivery-status surface so the probe can verify arrival.
+
+2. **Communications handler — decision logic.** The handler in `HoneyDrunk.Communications` applies:
+   - **Operator-availability gating (D2):** within coverage (09:00–21:00 ET), all SEV-1/2 dispatch; outside coverage, SEV-3/4 do not page even if `Diagnostic: false`.
+   - **D5 dedup-window (1 hour fingerprint dedup):** repeated calls with the same `FingerprintKey` within the window are silently aggregated, not re-delivered. The dedup state lives in the Communications-side store.
+   - **`Diagnostic` gate:** if `Diagnostic: true`, record the intent in delivery-status and stop — do **not** call `INotificationSender`. The arrival-verification surface for the probe reads delivery-status.
+   - **Severity-tagged composition:** the handler composes the dispatch payload (subject prefix, summary, deep-link to PagerDuty incident URL) before handing off to Notify.
+
+3. **Delivery handoff via existing Notify contract.** The handler calls `INotificationSender.Send(...)` from `HoneyDrunk.Notify.Abstractions` with the composed payload. v0 routes through Notify's existing Twilio SMS provider; v1 will route through the future Notify push provider. **No new contract is added to `Notify.Abstractions` by this packet.**
+
+4. **Operator phone number from Vault.** The operator's personal mobile is read from `kv-hd-communications-{env}` as a secret (e.g., `operator-paging-phone`). If `kv-hd-communications-{env}` does not yet exist, provision it first per the ADR-0005 walkthrough — per invariant 17 there is no shared Vault. The Twilio sender credentials remain in `kv-hd-notify-{env}` (consumed by Notify's existing provider, not by Communications).
+
+5. **Idempotency.** Reuse the existing Notify idempotency-key mechanism (ADR-0042) at the delivery boundary (`INotificationSender` already enforces it). The Communications handler's `FingerprintKey` maps to the idempotency key passed into `INotificationSender.Send(...)`. The D5 1-hour dedup-window policy lives in the Communications handler (the decision layer), not in Notify.
+
+6. **Companion-app push placeholder.** The v1 companion-app push provider is a Notify-side concern (not a Communications concern). Do not add a placeholder in this packet's Communications surface; the future Notify push provider is added when the companion app stands up. The Communications handler's call to `INotificationSender.Send(...)` is channel-agnostic — when Notify's push provider lands, Communications dispatches push automatically.
+
+7. **Delivery status tracking.** Communications exposes a delivery-status read surface keyed by `FingerprintKey` so the synthetic probe (packet 06) can verify arrival of `Diagnostic: true` intents (those never reach `INotificationSender`). For non-diagnostic intents, the status reflects Notify's underlying delivery status flowed back through the handoff.
+
+8. **D5 dedup state.** The Communications handler holds the fingerprint-window state (in-memory cache + persisted backstop — match the existing Communications-side dedup pattern if one exists; otherwise an in-memory `IMemoryCache` with a 1-hour expiry is acceptable for v0 and documented as a v1 hardening target).
+
+9. **XML documentation** on every public member (invariant 13).
+10. **Version bump.** Per invariant 27, this is the first or second ADR-0054 packet on the `HoneyDrunk.Communications` solution (packet 05 also lands templates) — minor bump for the new paging-intent surface. If packet 05 lands first, this packet's bump is the patch increment (or a combined minor if they merge together). Every non-test `.csproj` moves to the same new version in one commit.
+11. **CHANGELOG / README.** Repo-level `CHANGELOG.md` new-version entry. Per-package `CHANGELOG.md` entries only for packages with actual changes (invariant 27). Update Communications' `README.md` if the paging surface becomes part of the documented public/operational surface.
+12. **Tests.** Unit tests cover: the SMS happy path with the existing Twilio fake / InMemory provider exposed by Notify; the `Diagnostic: true` short-circuit (intent recorded, `INotificationSender` not called); D5 fingerprint dedup; D2 operator-availability gating; deep-link rendering. Tests do not call the real Twilio provider (invariant 15); no `Thread.Sleep` (invariant 51).
+
+## Affected Files
+- `HoneyDrunk.Notify/HoneyDrunk.Notify/Paging/` (or the equivalent location for new channel-specific intake handlers — match existing Notify directory convention).
+- `HoneyDrunk.Notify.Abstractions/` — `IIncidentPagingSender` / `PageOperatorRequest` / `IPagingPushProvider` interface declarations (per invariant 1).
+- `HoneyDrunk.Notify.HostBootstrap` / `Functions` / `Worker` — DI registration of the new paging intake handler and Vault binding for `operator-paging-phone`.
+- Notify test projects — paging-intake tests.
+- Repo-level `CHANGELOG.md`; per-package `CHANGELOG.md` for changed packages; every non-test `.csproj` (version bump).
+- `HoneyDrunk.Notify/README.md` if it documents the public/operational surface.
+
+## NuGet Dependencies
+- **No new external dependency.** SMS delivery reuses the existing Twilio provider package Notify already references.
+- The new abstraction types live in `HoneyDrunk.Notify.Abstractions` — invariant 1 (Abstractions packages take only `Microsoft.Extensions.*` abstractions plus whatever HoneyDrunk abstraction package they already reference). No external runtime dependency added to Abstractions.
+- `HoneyDrunk.Standards` is already on Notify's projects — no change (invariant 26).
+- If a new project is created (e.g., a dedicated `HoneyDrunk.Notify.Paging` package), it carries the full standard reference set: `HoneyDrunk.Notify.Abstractions`, `HoneyDrunk.Notify` (or whichever is the host-composed runtime package), `HoneyDrunk.Standards` (`PrivateAssets: all`), the standard test stack on its `.Tests.Unit` project (invariant 26, ADR-0047). Document why a new project is needed rather than extending an existing one.
+
+## Boundary Check
+- [x] `HoneyDrunk.Notify` is the correct repo — ADR-0054 D3 names "the Grid's own Notify Node" as the primary paging path; routing rule "notification, email, SMS, SMTP, Resend, Twilio, notify, channel → HoneyDrunk.Notify" maps exactly.
+- [x] Per ADR-0019, Notify owns **delivery mechanics**; decision/orchestration belongs to Communications. The intake contract accepts a **pre-decided** SEV + content payload — Notify does not decide severity or operator availability.
+- [x] No code change in any other Node. The synthetic probe (packet 06) and the routing layer (packet 09) call this intake; they do not implement it.
+- [x] The abstraction stays free of external runtime dependencies (invariant 1).
+
+## Acceptance Criteria
+- [ ] `IIncidentPagingSender` (or the equivalent intake contract — match Notify's existing channel-special-purpose pattern) exists in `HoneyDrunk.Notify.Abstractions` with `PageOperatorRequest { Severity, Title, Summary, PagerDutyIncidentUrl, FingerprintKey }`
+- [ ] The handler routes the intake to the existing Twilio SMS provider in v0; the SMS body renders severity + one-line summary + the PagerDuty deep-link
+- [ ] The operator's personal mobile number is read from Vault (`operator-paging-phone` in `kv-hd-notify-{env}`) — never hardcoded (invariants 8, 9)
+- [ ] Idempotency uses the existing Notify mechanism (ADR-0042); repeated calls with the same `FingerprintKey` within the dedup window are silently aggregated
+- [ ] A `IPagingPushProvider` placeholder exists for the v1 companion-app push integration; v0 implementation is no-op or "not implemented" — the companion-app integration is a follow-on, not a blocker
+- [ ] Delivery status (success / failure / latency) is recorded per Notify's existing delivery-status pattern so the synthetic probe (packet 06) can verify arrival
+- [ ] Notify is the **delivery** layer only — severity decision, operator-availability gating, and dedup-window policy live in the source / routing layer, not in Notify
+- [ ] Unit tests cover SMS happy path, idempotency dedup, fingerprint-key handling, deep-link rendering; tests run in-process (invariant 15); no `Thread.Sleep` (invariant 51)
+- [ ] The version-state check is performed: the `HoneyDrunk.Notify` solution bumps (first ADR-0054 packet on the solution) — minor bump for the new paging-intake surface (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` carries the new version entry; per-package `CHANGELOG.md` for packages with actual changes; `README.md` updated if the paging surface is documented externally
+- [ ] The solution builds; existing unit tests pass; tier-1 gate passes (build, unit, analyzers, vuln, secret scan — invariant 31)
+
+## Human Prerequisites
+- [ ] **Provision PagerDuty (packet 03) before exercising this packet's path** — the deep-link rendered in the SMS body points at a PagerDuty incident URL, and the synthetic probe (packet 06) will verify both paths together.
+- [ ] **Seed the operator's personal mobile number into Vault** as `operator-paging-phone` in `kv-hd-notify-{env}`. The agent cannot perform the Vault secret seeding via portal — this is a portal step.
+- [ ] **Twilio sender phone number** must already exist (it does — Notify is LIVE with SMS support). Confirm carrier delivery to the operator's phone in a manual test after merge.
+- [ ] The companion-app push integration is a follow-on; no portal step is required at v0.
+
+## Referenced ADR Decisions
+**ADR-0054 D3 — Paging mechanism, primary path.** Alerts route through `HoneyDrunk.Notify` per ADR-0019 (Communications owns decision/orchestration; Notify owns intake/delivery). Delivery target: the operator's personal phone via push notification (initially APNs/FCM through a small Studios-internal companion app, or via SMS if the companion app is not yet built). Latency target < 30 seconds. Cost bundled into Notify infra already running. Notify-pushed alerts include a deep-link to the PagerDuty incident for ack. **Both paths fire for SEV-1/2.** SEV-3 fires Notify only. SEV-4 fires neither.
+
+**ADR-0054 — v0 SMS fallback.** "v0 may use SMS via Notify if the companion app isn't ready; the trade-off is slightly higher delivery latency for v0." The companion-app push integration is initial work, not a blocker.
+
+**ADR-0019 — Communications/Notify split.** Notify owns **delivery mechanics**; Communications owns **decision/orchestration**. The paging intake accepts a pre-decided SEV + content payload; Notify does not decide severity.
+
+**ADR-0042 — Idempotency.** The intake's `FingerprintKey` maps to the existing Notify idempotency key; repeated calls with the same fingerprint within the dedup window are silently aggregated, not re-delivered.
+
+**ADR-0005 — Vault placement.** Twilio credentials and the operator paging phone number live in `kv-hd-notify-{env}` per the one-Vault-per-Node-per-environment rule.
+
+## Constraints
+> **Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.** `HoneyDrunk.Notify.Abstractions` takes only `Microsoft.Extensions.*` abstractions plus whatever HoneyDrunk abstraction package it already references. No external SDK in Abstractions.
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The operator paging phone number and Twilio credentials never appear in logs, in the SMS body's diagnostic envelope, or in any captured exception.
+
+> **Invariant 9 — Vault is the only source of secrets.** The operator paging phone number is read via `ISecretStore`; never via environment variables or hardcoded constants.
+
+> **Invariant 13 — All public APIs have XML documentation.** Enforced by `HoneyDrunk.Standards`.
+
+> **Invariant 15 — Unit tests never depend on external services.** SMS path tests use the existing Twilio fake / InMemory provider.
+
+> **Invariant 17 — One Key Vault per deployable Node per environment.** Notify's Vault is `kv-hd-notify-{env}`.
+
+> **Invariant 26 — Issue packets for .NET code work include a `## NuGet Dependencies` section; `HoneyDrunk.Standards` is on every new .NET project** (analyzers, `PrivateAssets: all`).
+
+> **Invariant 27 — All projects in a solution share one version and move together.** First ADR-0054 packet on `HoneyDrunk.Notify` → version bumps.
+
+> **Invariant 31 — Every PR traverses the tier-1 gate before merge.** Build, unit tests, analyzers, vulnerability scan, secret scan are required.
+
+> **Invariant 51 — Test code contains no `Thread.Sleep`.**
+
+- **Notify is delivery, not decision.** Severity, dedup-window, and operator-availability gating live in the source / routing layer; the intake accepts pre-decided payloads.
+- **v0 SMS fallback is fine.** The companion-app push integration is a follow-on. v0 SMS ships with this packet.
+- **Deep-link required.** Every paged SMS body carries the PagerDuty incident URL — that is the operator's ack surface.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0054`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add the incident-paging intake contract and its v0 SMS-via-Twilio handler to `HoneyDrunk.Notify` so the routing layer (packet 09), the synthetic probe (packet 06), and the future direct-from-Source paging callers can deliver pages to the operator's phone with a deep-link to the PagerDuty incident.
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: Implement the primary path of the redundant paging mechanism (D3). PagerDuty (packet 03) is the secondary. Both paths fire for SEV-1/2.
+- Feature: ADR-0054 Incident Response rollout, Wave 2.
+- ADRs: ADR-0054 D3 (primary), ADR-0019 (Notify owns delivery; Communications owns decision), ADR-0042 (idempotency), ADR-0005 (Vault placement).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0054 should be Accepted before its paging substrate ships.
+- `packet:03` — hard. The PagerDuty incident URL the SMS body deep-links to is created by PagerDuty (the secondary path) — the cross-link requires the PagerDuty integration to exist. Functionally, the URL is a parameter — the code compiles without PagerDuty existing — but the end-to-end test requires it.
+
+**Constraints:**
+- Notify is delivery, not decision (ADR-0019).
+- v0 SMS via existing Twilio provider; companion-app push is a follow-on.
+- Vault-stored operator paging phone number (invariants 8, 9, 17).
+- Idempotency via the existing Notify mechanism (ADR-0042).
+- Perform the invariant-27 version-bump check on the `HoneyDrunk.Notify` solution — first ADR-0054 packet → bumps.
+
+**Key Files:**
+- `HoneyDrunk.Notify.Abstractions/` — `IIncidentPagingSender`, `PageOperatorRequest`, `IPagingPushProvider`
+- `HoneyDrunk.Notify/Paging/` — handler implementation routing to existing Twilio SMS
+- Notify host bootstrap projects — DI registration, Vault secret binding
+- Notify test projects — paging-intake tests
+- Repo-level `CHANGELOG.md`; per-package `CHANGELOG.md` for changed packages; every non-test `.csproj` (version bump)
+
+**Contracts:**
+- `IIncidentPagingSender` — the new paging intake. Consumed by packet 06 (synthetic probe) and packet 09 (routing wiring).
+- `IPagingPushProvider` — placeholder for v1 companion-app push; v0 no-op.

--- a/generated/issue-packets/active/adr-0054-incident-response/05-communications-tenant-incident-email-templates.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/05-communications-tenant-incident-email-templates.md
@@ -1,0 +1,192 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Communications
+labels: ["feature", "tier-2", "ops", "adr-0054", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0054", "ADR-0019", "ADR-0027"]
+accepts: ["ADR-0054"]
+wave: 2
+initiative: adr-0054-incident-response
+node: honeydrunk-communications
+---
+
+# Author the D9 tenant-incident-email templates (declaration, update, resolution) in HoneyDrunk.Communications
+
+## Summary
+Author the three D9 tenant-facing incident-email templates — **SEV-1/2 declaration**, **update**, and **resolution** — in the `HoneyDrunk.Communications` template catalog per ADR-0054 D9 / ADR-0019 D3. Wire a `TenantIncidentEmailIntent` (or equivalent ADR-0019-aligned intent type) that maps an incident-state change to one of the three templates. Send delegation continues to flow through `INotificationSender` to Notify — Communications does not touch SMTP / Resend / Twilio.
+
+## Context
+ADR-0054 D9 specifies the tenant-email surface for incident communication. The three templates are listed verbatim in ADR-0054 D9:
+
+**SEV-1 / SEV-2 declaration:**
+```
+Subject: [HoneyDrunk Notify] Incident in progress affecting your account
+We are currently investigating an issue affecting <tenant-name>. The impact you may see is <human description>.
+Incident ID: INC-YYYY-NNNN
+Status: <status>
+Next update: within 60 minutes
+You can follow updates at status.honeydrunkstudios.com.
+```
+
+**Update:**
+```
+Subject: [HoneyDrunk Notify] Update on INC-YYYY-NNNN
+<one paragraph update>
+Next update: within 60 minutes
+```
+
+**Resolution:**
+```
+Subject: [HoneyDrunk Notify] INC-YYYY-NNNN resolved
+The issue affecting <tenant-name> has been resolved as of <time UTC>.
+Cause: <one-line>
+A post-mortem will be published within 5 business days.
+Thank you for your patience.
+```
+
+ADR-0054 D9 says: "Templates are **versioned in Communications** so they update without an ADR amendment; the SLA they reference (within 60 min, 5 business days) is bound by this ADR and changes only via amendment."
+
+Per ADR-0019, `HoneyDrunk.Communications` owns the **decision/orchestration** layer for outbound communications — the templates live here, not in Notify. The send dispatch delegates to `INotificationSender` (the Notify-Abstractions intake) which routes to Resend/SMTP for email delivery. Communications never touches SMTP / Resend / Twilio directly (invariant 41 — preference enforcement, cadence rules, and suppression logic live in Communications, not in Notify; Notify owns delivery mechanics).
+
+**Notify Cloud in-product banner and SEV-1 ticket surface are deferred.** ADR-0054 D9 names a future in-product banner on the Notify Cloud tenant portal and an in-product SEV-1 ticket surface. Both depend on Notify Cloud (ADR-0027) which is a Seed Node — those surfaces ship with Notify Cloud, not in this packet. This packet authors **only the email templates** + intent type; in-product surfaces are a follow-on packet when Notify Cloud lands.
+
+**Communications is live** (v0.1.0 ships the public contract surface and a welcome-email runtime slice per the catalog). This packet adds three template entries to the existing template catalog and wires the matching intent type. The template catalog convention already exists from the welcome-email work.
+
+**Versioning.** Communications is live and versioned. This is the first ADR-0054 packet on the `HoneyDrunk.Communications` solution → minor bump per invariant 27 (new public intent type, new templates in the catalog).
+
+## Scope
+- `HoneyDrunk.Communications` — three new tenant-incident-email templates in the template catalog; the `TenantIncidentEmailIntent` (or equivalent) intent type wiring the templates to the orchestration surface.
+- Communications test projects — tests covering each template's rendering, the intent → template mapping, and the delegation to `INotificationSender`.
+- The decision-log entry per invariant 42 — every orchestrated send records via `ICommunicationDecisionLog`. The incident emails are orchestrated; each send records a decision.
+- Repo-level `CHANGELOG.md` and per-package `CHANGELOG.md` for the packages with actual changes.
+
+## Proposed Implementation
+1. **Three template entries in the Communications template catalog.** Match the existing catalog convention (the welcome-email work already establishes how templates are registered). Each entry carries the template body, the subject template, the placeholder variables (`<tenant-name>`, `<human description>`, `INC-YYYY-NNNN`, `<status>`, `<time UTC>`, `<one-line>` cause, `<one paragraph update>`), and the channel (email).
+2. **`TenantIncidentEmailIntent` (or extension to existing intent surface).** Match the existing intent pattern in Communications. Three variants — declaration / update / resolution — distinguished by an enum or sub-type. The intent carries the same placeholder fields plus the recipient resolution (tenant id → primary tenant email contact; resolved via the existing preference / recipient-resolution path that the welcome-email work already established).
+3. **Map intent → template.** Communications' `ICommunicationOrchestrator` (or equivalent — match existing surface) accepts the intent, evaluates preferences/cadence/suppression (D9 implies tenants opted-in to product communication receive these; cadence for incident emails is **unrestricted** within the per-incident update cadence — the ADR specifies "every 60 min" during active incident, but that cadence is enforced by the source/orchestration, not by Communications' general cadence rule), renders the template with the placeholder substitutions, and delegates to `INotificationSender`.
+4. **Cadence-rule carve-out for incident emails.** Communications' general cadence rule may rate-limit tenant emails; incident emails are explicitly **carved out** from general cadence — a tenant in a SEV-1/2 affecting them must receive every update regardless of background cadence. Implement the carve-out as a per-intent cadence override or as a documented intent-class exemption — match the existing pattern.
+5. **Suppression respect.** Tenants who have unsubscribed from *transactional* communication are an edge case — incident emails are operationally critical, not marketing. Per ADR-0019's preference model, transactional communication may not be suppressible by default; if Communications' preference store distinguishes "essential service communication" from "product news," incident emails fall in the essential category. Document the policy choice in the PR.
+6. **Decision log.** Per invariant 42 ("every orchestrated send records a decision-log entry via `ICommunicationDecisionLog`"), every send records — including suppressed ones (suppressed entries carry `reason: suppressed_essential_communication` or whatever the existing decision-log convention names).
+7. **Delegate to `INotificationSender`.** The email body and subject flow to Notify via the existing `INotificationSender` surface — Notify's email provider (Resend or SMTP) handles delivery. Communications never touches the email provider directly.
+8. **No tenant-portal in-product banner here.** ADR-0054 D9 also names a future in-product banner on the Notify Cloud tenant portal. That depends on Notify Cloud (Seed Node per ADR-0027) — it is not in this packet's scope. The banner orchestration is a follow-on packet when Notify Cloud lands.
+9. **Subject branding.** The template subjects say "[HoneyDrunk Notify]" per the ADR. Confirm this matches the brand voice for paying-tenant communication; if the tenant-facing product brand is "HoneyDrunk Notify Cloud" (or similar) at the time of execution, adjust the subject to match — ADR-0054 D9 is descriptive of the v1 brand, not normative if the product brand evolves.
+10. **XML documentation** on every public member (invariant 13).
+11. **Version bump.** First ADR-0054 packet on the `HoneyDrunk.Communications` solution → minor bump (invariant 27).
+12. **CHANGELOG / README.** Repo-level `CHANGELOG.md` new-version entry. Per-package `CHANGELOG.md` for packages with actual changes. Update the Communications `README.md` if the new template catalog surface is part of the documented public/operational surface.
+13. **Tests.** Unit tests cover: each template renders correctly with the placeholder substitutions; the intent → template mapping is correct per declaration/update/resolution; the cadence carve-out is applied; the decision-log entry is recorded; the delegation to `INotificationSender` carries the right payload. Tests run in-process (invariant 15); no `Thread.Sleep` (invariant 51).
+
+## Affected Files
+- `HoneyDrunk.Communications/` — template catalog entries + intent type wiring; match existing directory layout from the welcome-email work.
+- `HoneyDrunk.Communications.Abstractions/` — if the intent type is a new public abstraction, declared here.
+- Communications test projects — incident-email tests.
+- Repo-level `CHANGELOG.md`; per-package `CHANGELOG.md` for changed packages; every non-test `.csproj` (version bump).
+- `HoneyDrunk.Communications/README.md` if the incident-email surface is documented externally.
+
+## NuGet Dependencies
+- **No new external dependency.** Template rendering uses the existing `ITemplateRenderer` surface; intent orchestration uses the existing `ICommunicationOrchestrator` surface.
+- The new abstraction types live in `HoneyDrunk.Communications.Abstractions` — invariant 1 (Abstractions packages take only `Microsoft.Extensions.*` abstractions plus whatever HoneyDrunk abstraction package they already reference). No external runtime dependency added to Abstractions.
+- `HoneyDrunk.Standards` is already on Communications' projects — no change (invariant 26).
+
+## Boundary Check
+- [x] `HoneyDrunk.Communications` is the correct repo — ADR-0054 D9 names "Tenant email — `HoneyDrunk.Communications` (ADR-0019)" as the surface owner; routing rule "workflow, CI, GitHub Actions, pipeline, PR check, release → HoneyDrunk.Actions" does NOT match (incorrect rule); the matching routing rule is the workflow/orchestration template work in Communications, per the catalog description "Decision and orchestration layer for outbound communications. Determines why, when, and to whom messages are sent; enforces preferences and cadence; records decisions; delegates delivery mechanics to Notify."
+- [x] Communications owns decision/orchestration; delivery delegates to `INotificationSender` → Notify (invariant 41).
+- [x] No SMTP / Resend / Twilio reference in Communications (invariant 41).
+- [x] Notify Cloud in-product banner / SEV-1 ticket surface are deferred to Notify Cloud (ADR-0027).
+- [x] Every send records a decision-log entry per invariant 42.
+
+## Acceptance Criteria
+- [ ] Three tenant-incident-email templates (declaration / update / resolution) exist in the Communications template catalog with the verbatim ADR-0054 D9 wording (subject and body), parameterized on the placeholder variables
+- [ ] A `TenantIncidentEmailIntent` (or extension of the existing intent surface — match the existing pattern) maps to the three templates by sub-type / enum
+- [ ] The intent → template mapping is wired into `ICommunicationOrchestrator`; preferences/cadence/suppression are evaluated; the template is rendered with placeholder substitutions; delegation flows to `INotificationSender`
+- [ ] Cadence carve-out: incident emails bypass the general cadence rate-limit; the carve-out is implemented per the existing pattern (per-intent override or intent-class exemption — documented in the PR)
+- [ ] Suppression policy is documented in the PR: incident emails are essential service communication and (per the existing Communications preference model) are not suppressible by default; the policy decision is recorded
+- [ ] Every send records a decision-log entry via `ICommunicationDecisionLog` (invariant 42), including suppressed sends with `reason: suppressed_essential_communication` or the equivalent convention
+- [ ] Communications never references SMTP / Resend / Twilio directly (invariant 41) — all email goes through `INotificationSender`
+- [ ] In-product banner / SEV-1 ticket surface are NOT implemented in this packet — they are deferred to Notify Cloud
+- [ ] Every new public member has XML documentation stating its purpose and the ADR binding (invariant 13)
+- [ ] Unit tests cover template rendering, intent → template mapping, cadence carve-out, decision-log recording, `INotificationSender` payload — tests run in-process (invariant 15), no `Thread.Sleep` (invariant 51)
+- [ ] The version-state check is performed: the `HoneyDrunk.Communications` solution bumps (first ADR-0054 packet on the solution) — minor bump for the new template catalog (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` carries the new version entry; per-package `CHANGELOG.md` for packages with actual changes; `README.md` updated if the surface is documented externally
+- [ ] The solution builds; existing unit tests pass; tier-1 gate passes
+
+## Human Prerequisites
+- [ ] No portal step. This is pure code work in `HoneyDrunk.Communications`.
+- [ ] **Existence of tenant primary-email recipient resolution.** This packet assumes the existing welcome-email work already established a recipient-resolution path that the incident intent can reuse. If it does not, that gap surfaces during execution and may require a follow-on Communications packet — document the gap, do not block on building recipient resolution here.
+
+## Referenced ADR Decisions
+**ADR-0054 D9 — Communication channels, external paying tenants.** Tenant email through `HoneyDrunk.Communications` (per ADR-0019). SEV-1 with confirmed tenant impact: emails at declaration, hourly thereafter, at resolution. SEV-2 with confirmed tenant impact: emails at declaration if > 30 min ETA to mitigation, at resolution. Three template variants (declaration / update / resolution) with the verbatim wording given in the ADR.
+
+**ADR-0054 D9 — Versioning split.** Templates are versioned in Communications and update without an ADR amendment; the SLA the templates reference (within 60 min, 5 business days) is bound by this ADR and changes only via amendment.
+
+**ADR-0054 D9 — In-product surfaces deferred.** Banner-on-tenant-portal orchestration lands when Notify Cloud portal lands (ADR-0027). Not in this packet.
+
+**ADR-0019 — Communications/Notify split.** Communications owns decision/orchestration; Notify owns delivery mechanics. Email body and subject flow to Notify via `INotificationSender`.
+
+**ADR-0019 D3 — Template catalog.** Templates live in the Communications template catalog and are managed via the existing surface.
+
+**ADR-0027 — Notify Cloud (Seed).** The in-product tenant banner and in-product SEV-1 ticket surface depend on Notify Cloud; not in this packet's scope.
+
+## Constraints
+> **Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.** `HoneyDrunk.Communications.Abstractions` takes only `Microsoft.Extensions.*` abstractions plus whatever HoneyDrunk abstraction package it already references.
+
+> **Invariant 13 — All public APIs have XML documentation.** Enforced by `HoneyDrunk.Standards`.
+
+> **Invariant 15 — Unit tests never depend on external services.** Template-rendering and orchestration tests run in-process.
+
+> **Invariant 26 — Issue packets for .NET code work include a `## NuGet Dependencies` section; `HoneyDrunk.Standards` is on every new .NET project**.
+
+> **Invariant 27 — All projects in a solution share one version and move together.** First ADR-0054 packet on `HoneyDrunk.Communications` → version bumps.
+
+> **Invariant 31 — Every PR traverses the tier-1 gate before merge.**
+
+> **Invariant 40 — Downstream Nodes take a runtime dependency only on `HoneyDrunk.Communications.Abstractions`.** The new intent type, if a public abstraction, lives in Abstractions; runtime composition is host-time.
+
+> **Invariant 41 — Preference enforcement, cadence rules, and suppression logic for outbound messages live in `HoneyDrunk.Communications`, not in `HoneyDrunk.Notify`.** This packet's templates and intent live in Communications; Notify never knows the incident-email semantics — it only ships an email payload.
+
+> **Invariant 42 — Every orchestrated send records a decision-log entry via `ICommunicationDecisionLog`.** Each incident-email send records — including suppressed ones with the documented reason.
+
+> **Invariant 43 — Communications CI must include a contract-shape canary for the hot-path orchestration contracts.** If the new intent type is part of the hot-path orchestration contract, the canary covers it.
+
+> **Invariant 51 — Test code contains no `Thread.Sleep`.**
+
+- **Verbatim ADR wording.** The three template bodies use the exact wording in ADR-0054 D9 (subject lines included). Diverging from the wording requires an ADR amendment (D9 binds it).
+- **Cadence carve-out for incident emails.** Incident emails bypass the general cadence rule; suppression respects only the "essential service communication" carve-out documented per the existing Communications preference model.
+- **No SMTP / Resend / Twilio in Communications.** Delivery delegates to `INotificationSender` always (invariant 41).
+- **In-product surfaces are deferred** to Notify Cloud — out of scope here.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0054`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add the three D9 tenant-incident-email templates (declaration / update / resolution) and the matching intent type to `HoneyDrunk.Communications`, with delegation through `INotificationSender` to Notify for delivery.
+
+**Target:** `HoneyDrunk.Communications`, branch from `main`.
+
+**Context:**
+- Goal: Land the external tenant-facing comms surface ADR-0054 D9 specifies, so the incident-response process can communicate with paying tenants per the SLA.
+- Feature: ADR-0054 Incident Response rollout, Wave 2.
+- ADRs: ADR-0054 D9 (primary), ADR-0019 (decision/orchestration ownership), ADR-0027 (Notify Cloud surfaces deferred).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0054 should be Accepted before its communication templates land.
+
+**Constraints:**
+- Verbatim D9 wording.
+- Cadence carve-out for incident emails.
+- No SMTP/Resend/Twilio in Communications (invariant 41).
+- In-product banner / SEV-1 ticket surface are NOT in this packet.
+- Perform the invariant-27 version-bump check on `HoneyDrunk.Communications` — first ADR-0054 packet → bumps.
+
+**Key Files:**
+- `HoneyDrunk.Communications/` — template catalog entries + intent type wiring (match existing welcome-email work layout)
+- `HoneyDrunk.Communications.Abstractions/` — public intent type if needed
+- Communications test projects
+- Repo-level `CHANGELOG.md`; per-package `CHANGELOG.md`; non-test `.csproj` (version bump)
+
+**Contracts:**
+- `TenantIncidentEmailIntent` (or equivalent — match the existing intent surface) — three variants for declaration / update / resolution.

--- a/generated/issue-packets/active/adr-0054-incident-response/06-pulse-paging-path-synthetic-probe.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/06-pulse-paging-path-synthetic-probe.md
@@ -1,0 +1,190 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Pulse
+labels: ["feature", "tier-2", "ops", "adr-0054", "wave-2"]
+dependencies: ["packet:03", "packet:04"]
+adrs: ["ADR-0054", "ADR-0028", "ADR-0005"]
+accepts: ["ADR-0054"]
+wave: 2
+initiative: adr-0054-incident-response
+node: honeydrunk-pulse
+---
+
+# Add the every-5-minute synthetic paging-path probe to HoneyDrunk.Pulse
+
+## Summary
+Add the **paging-path synthetic probe** to `HoneyDrunk.Pulse` per ADR-0054 D3's "who watches the watchmen" pattern: every 5 minutes the probe fires a **fake SEV-3** alert that flows through both the Notify primary path and the PagerDuty secondary path; if either path goes silent for > 15 minutes, the **other path** fires a SEV-2 about the missing path. The probe is itself a Grid-health-monitored synthetic on the Pulse synthetic-monitoring surface ADR-0028 defines.
+
+## Context
+ADR-0054 D3 names the synthetic paging-path probe as the mechanism that detects "Notify is itself down" and "PagerDuty is itself down" — the failure modes that the redundant paging pattern exists to survive. Without the probe, the operator only discovers paging-path failure when a real incident is silenced — too late.
+
+The probe's behavior (verbatim from D3):
+
+- **Every 5 minutes**, the probe fires a synthetic SEV-3 alert.
+- The alert flows through **both** the Notify primary path (packet 04's `IIncidentPagingSender`) and the PagerDuty secondary path (packet 03's integration).
+- The probe **verifies arrival** on both paths — the Notify-side delivery-status surface (packet 04 records arrival per the existing pattern) and the PagerDuty-side ack or auto-resolve (PagerDuty's Events API v2 returns a dedup-key receipt on POST; the probe can poll the PagerDuty incident's state or rely on PagerDuty's webhook back to a probe-receipt endpoint).
+- **If either path goes silent for > 15 minutes** (three consecutive 5-min probe cycles miss arrival verification on one path), the **other path** fires a **SEV-2** about the missing path. The SEV-2 says "PagerDuty silent for 15+ min" or "Notify silent for 15+ min."
+- The fake SEV-3 itself does **not** burn a real PagerDuty incident's ack tax — D3 says "SEV-3 fires Notify only (no PagerDuty cost burn for non-paging-worthy events)." **But the probe is the exception** — it must fire PagerDuty too, otherwise it cannot verify the PagerDuty path. The probe uses a dedicated PagerDuty Events API v2 integration configured to **auto-resolve immediately** so it doesn't accumulate. The probe's special-cased behavior is documented in PagerDuty's integration (probably as a dedicated service with auto-resolve, or with the `event_action: resolve` immediately following the `event_action: trigger`).
+- The probe **does not page the operator's phone** — D3 says "SEV-3 fires Notify only." For the probe's purposes, the Notify-side verification is that Notify *received and accepted* the page-intake call, not that the SMS arrived on the operator's phone. The probe uses an internal verification endpoint, not a real SMS. Notify's intake (packet 04) records delivery status — the probe queries that status surface.
+
+**Pulse owns synthetic monitoring.** Per ADR-0028 (event-driven architecture / synthetic monitoring) and the existing Pulse surface, Pulse runs scheduled synthetic probes. The new probe lives on the Pulse synthetic-monitoring surface — match the existing convention.
+
+**Pulse is a Seed Node** per the catalog. Its solution exists and is versioned; this is the first ADR-0054 packet on the Pulse solution → minor bump per invariant 27.
+
+**Vault.** The probe authenticates to PagerDuty via the Events API v2 key stored in `kv-hd-pulse-{env}` (or wherever packet 03 placed it — the walkthrough doc names the path). The probe authenticates to Notify via the existing Notify intake surface (no new credential — Notify's intake authenticates via the Grid identity per ADR-0005's intra-Grid auth).
+
+## Scope
+- `HoneyDrunk.Pulse` solution — a new synthetic probe `PagingPathProbe` on the Pulse synthetic-monitoring surface, running every 5 minutes.
+- The probe's verification logic — confirms each fired probe arrived on Notify (via Notify's delivery-status surface) and PagerDuty (via the Events API v2 receipt or PagerDuty's webhook back to a probe-receipt endpoint).
+- The 15-min-silent SEV-2 escalation — the surviving path fires a SEV-2 alert about the missing path.
+- Pulse test projects — tests covering the happy path (both arrive), each silent-path scenario (Notify-silent, PagerDuty-silent), and the escalation behavior. Tests use the InMemory provider for both Notify and PagerDuty per invariant 15.
+- Repo-level `CHANGELOG.md` and per-package `CHANGELOG.md` for changed packages.
+
+## Proposed Implementation
+1. **Define the probe.** `PagingPathProbe` is a scheduled job on the Pulse synthetic-monitoring surface — match the existing scheduled-synthetic pattern. The schedule is **every 5 minutes**. The probe carries a unique `FingerprintKey = "pulse.paging-path-probe"` so D5 dedup does not collapse it with anything else.
+2. **Fire the probe through both paths.** Each probe cycle:
+   - Invokes `IIncidentPagingSender.PageOperator(...)` (from packet 04) with `Severity = SEV-3`, `Title = "Pulse paging-path probe"`, `Summary = "Synthetic probe, 5-min cycle"`, `PagerDutyIncidentUrl = <probe-receipt-url>`, `FingerprintKey = "pulse.paging-path-probe-<cycle-id>"`.
+   - Posts a synthetic event to the PagerDuty Events API v2 (using the dedicated probe-integration key from Vault), with `event_action: trigger` followed immediately by `event_action: resolve` so PagerDuty does not accumulate open incidents from the probe.
+3. **Verify arrival.**
+   - **Notify side:** query Notify's delivery-status surface for the probe's fingerprint key; expect `delivered: true` (or `accepted` — match the existing Notify status semantics) within the cycle's verification window (e.g., 90 seconds).
+   - **PagerDuty side:** the Events API v2 returns a dedup-key receipt on POST; the probe records the receipt. Optionally, PagerDuty's webhook back can confirm processing — the simpler v0 implementation is to treat the Events API v2 200-OK receipt as proof of arrival.
+4. **15-min silent → SEV-2.** Track the per-path consecutive miss count. If a path misses **three consecutive cycles** (5 min × 3 = 15 min), fire a SEV-2 alert about the missing path through the **surviving** path:
+   - If Notify is silent, fire the SEV-2 via PagerDuty (`event_action: trigger`, severity high, summary "Notify paging path silent for 15 min").
+   - If PagerDuty is silent, fire the SEV-2 via Notify (call `IIncidentPagingSender.PageOperator(SEV-2, "PagerDuty paging path silent for 15 min", ..., FingerprintKey = "pulse.pagerduty-path-down")`).
+   - The SEV-2 is **paged for real** — it is the warning the operator must see.
+5. **Auto-recovery.** When a previously-silent path comes back, the SEV-2 auto-resolves per the D5 auto-resolve pattern (5 minutes of continuous health). The probe sends an `event_action: resolve` to PagerDuty for the SEV-2 and / or marks the Notify-side SEV-2 resolved per the existing dedup pattern.
+6. **No real operator-phone notification from SEV-3 probe.** The Notify intake's existing channel routing must NOT deliver the SEV-3 probe SMS to the operator's personal phone — that would be a flood. Use a Notify intake variant that records arrival without actually dispatching to the SMS provider, OR have the probe call a dedicated diagnostics endpoint that exercises the intake validation/queueing without the final SMS send. **Match Notify's existing synthetic-test pattern** (Notify presumably already has a "test delivery" or "dry-run" path; if not, the probe configures the intake with an explicit `diagnostic = true` flag and Notify gates the final-channel dispatch on it). Document the choice.
+7. **PagerDuty probe-integration discipline.** The probe's PagerDuty integration is a **dedicated** service / integration in PagerDuty (per packet 03's walkthrough — the probe should have its own service, not the main "HoneyDrunk Studios Operator" service, so probe firings don't bury real incidents). Coordinate with packet 03: if the walkthrough doesn't already provision a probe-dedicated service, this packet's PR comment requests the addition (and the walkthrough is amended).
+8. **Pulse's own telemetry.** The probe emits its own metrics — probe success rate, per-path miss count, per-cycle latency. Per ADR-0040, this goes through the Pulse OTLP surface and lands in App Insights. Per ADR-0045, probe failures are *not* errors (D12 in ADR-0045 says synthetic probe failure → metric/log, not an exception) — so probe outcomes flow to metrics, not to `IErrorReporter`.
+9. **XML documentation** on every public member (invariant 13).
+10. **Version bump.** First ADR-0054 packet on the `HoneyDrunk.Pulse` solution → minor bump per invariant 27.
+11. **CHANGELOG / README.** Repo-level `CHANGELOG.md` new-version entry. Per-package `CHANGELOG.md` for packages with actual changes. Update Pulse `README.md` if the synthetic-probe surface is part of the documented public/operational surface.
+12. **Tests.** Unit / integration tests cover: happy path (both arrive), Notify-silent (probe escalates via PagerDuty), PagerDuty-silent (probe escalates via Notify), recovery / auto-resolve, the probe SMS does NOT route to the operator's personal phone. Tests use InMemory Notify and a stubbed PagerDuty Events API client (invariant 15); no `Thread.Sleep` (invariant 51) — time-based behavior uses a virtual clock or polling primitives with explicit timeouts.
+
+## Affected Files
+- `HoneyDrunk.Pulse/Synthetics/` or the existing scheduled-synthetic location — `PagingPathProbe.cs`, the probe handler.
+- `HoneyDrunk.Pulse/Synthetics/PagerDuty/` (or equivalent) — a thin PagerDuty Events API v2 client used by the probe.
+- Pulse host bootstrap projects — DI registration of the probe, Vault binding for the PagerDuty Events API key, the schedule registration.
+- Pulse test projects — probe tests.
+- Repo-level `CHANGELOG.md`; per-package `CHANGELOG.md` for changed packages; every non-test `.csproj` (version bump).
+- `HoneyDrunk.Pulse/README.md` if the probe surface is documented externally.
+
+## NuGet Dependencies
+- **PagerDuty Events API v2 client** — there is no first-party SDK; the API is a simple HTTP POST to `https://events.pagerduty.com/v2/enqueue` with a JSON payload. Use `System.Net.Http.HttpClient` from `Microsoft.Extensions.Http` (Pulse already references this) — no new external NuGet package. Document the choice in the PR.
+- **Notify intake** is consumed via the existing `HoneyDrunk.Notify.Abstractions` package reference Pulse already has (or that the Pulse host bootstrap adds — confirm at edit time).
+- The new abstraction types (if any new public abstractions are introduced) live in the appropriate Pulse-abstractions package — invariant 1.
+- `HoneyDrunk.Standards` is already on Pulse's projects — no change (invariant 26).
+
+## Boundary Check
+- [x] `HoneyDrunk.Pulse` is the correct repo — synthetic monitoring is a Pulse responsibility per ADR-0028 and the existing Pulse synthetic-monitoring surface.
+- [x] Pulse consumes `IIncidentPagingSender` (a published Notify Abstractions contract per packet 04) — it does not reach into Notify internals (invariant 3).
+- [x] Pulse consumes the PagerDuty Events API as an external HTTP surface — no Notify involvement on the secondary path.
+- [x] The probe is the **exception** that fires PagerDuty for SEV-3 — D3 says SEV-3 fires Notify only "except for the synthetic probe." Document the exception in the probe's XML docs.
+- [x] Probe failures emit metrics, not `IErrorReporter` captures (ADR-0045 D12).
+
+## Acceptance Criteria
+- [ ] `PagingPathProbe` runs every 5 minutes on the Pulse synthetic-monitoring surface
+- [ ] Each cycle fires through both the Notify intake (`IIncidentPagingSender.PageOperator` with `Severity = SEV-3` and a unique `FingerprintKey`) and the PagerDuty Events API v2 (`event_action: trigger` followed immediately by `event_action: resolve` so PagerDuty does not accumulate)
+- [ ] The probe **verifies arrival** on both paths within the cycle's verification window: Notify via the delivery-status surface; PagerDuty via the Events API receipt
+- [ ] On 3 consecutive misses on one path (15 min silent), the **surviving** path fires a real SEV-2 about the missing path; the SEV-2 actually pages the operator
+- [ ] Recovery: when a previously-silent path is back for 5 minutes, the SEV-2 auto-resolves per D5
+- [ ] The probe's SEV-3 SMS does NOT dispatch to the operator's personal phone — match Notify's existing synthetic / dry-run pattern, or add the `diagnostic = true` flag (documented)
+- [ ] The probe's PagerDuty integration is a **dedicated** service (not the main operator service) so probe firings don't bury real incidents; coordinate with packet 03's walkthrough
+- [ ] Probe outcomes emit metrics through the existing Pulse OTLP surface (per ADR-0040); probe failures are metrics, NOT `IErrorReporter` captures (ADR-0045 D12)
+- [ ] PagerDuty Events API v2 key is read from Vault via `ISecretStore` (invariants 8, 9); the documented path matches packet 03's walkthrough
+- [ ] Every new public member has XML documentation; the probe's XML docs name the D3 exception (probe fires PagerDuty for SEV-3 even though D3 says SEV-3 fires Notify only)
+- [ ] Tests cover happy path, both silent-path scenarios, recovery, and the no-personal-phone-SMS guarantee; tests run in-process (invariant 15); no `Thread.Sleep` (invariant 51); time-based behavior uses a virtual clock or polling primitives
+- [ ] The version-state check is performed: the `HoneyDrunk.Pulse` solution bumps (first ADR-0054 packet on the solution) — minor bump for the new probe (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` carries the new version entry; per-package `CHANGELOG.md` for packages with actual changes; `README.md` updated if the probe surface is documented externally
+- [ ] The solution builds; existing unit tests pass; tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **Packet 03's PagerDuty walkthrough must create a dedicated probe service / integration in PagerDuty** so probe firings have their own surface and don't bury real-incident triage. If packet 03's walkthrough did not provision this, follow-on to packet 03 to add it.
+- [ ] **Confirm Vault path for the PagerDuty Events API v2 key** — packet 03 documents the path; this packet's DI registration reads from it.
+- [ ] **Confirm Notify intake's diagnostic / synthetic pattern** at execution time. If Notify has no existing "do not actually send to the operator" path, document the gap and either add the `diagnostic = true` flag in this packet's PR (small follow-on to packet 04) or use Notify's InMemory provider in the dev/staging environment.
+
+## Referenced ADR Decisions
+**ADR-0054 D3 — Synthetic paging-path probe.** "Pulse (ADR-0028) runs a synthetic probe every 5 minutes that fires a fake SEV-3 alert and verifies arrival on both Notify and PagerDuty paths. If either path goes silent for > 15 minutes, the other path fires a SEV-2 about the missing path. This is the 'who watches the watchmen' pattern. The Pulse probe is itself a Grid-health-monitored synthetic."
+
+**ADR-0054 D3 — Exception for the probe firing PagerDuty on SEV-3.** D3 says "SEV-3 fires Notify only (no PagerDuty cost burn for non-paging-worthy events)" — the probe is the exception because it must fire PagerDuty to verify the path; the probe uses an immediate-resolve pattern so it does not accumulate.
+
+**ADR-0054 D5 — Single-page rule, fingerprint, auto-resolve.** The probe's `FingerprintKey` participates in D5 dedup; the 15-min-silent SEV-2 has its own fingerprint; auto-resolve fires when the underlying condition clears for 5 minutes.
+
+**ADR-0028 — Pulse synthetic monitoring surface.** The new probe lives on the Pulse synthetic-monitoring surface ADR-0028 defines; match the existing scheduled-synthetic pattern.
+
+**ADR-0045 D12 — Synthetic monitoring is not an error source.** Probe failures emit metrics/logs, not `IErrorReporter` captures. Probe outcomes flow to metrics through the existing Pulse OTLP surface.
+
+**ADR-0040 — Pulse is the telemetry-export boundary.** Probe metrics flow through the existing Pulse OTLP path to App Insights.
+
+**ADR-0005 — Vault placement.** Pulse's Vault is `kv-hd-pulse-{env}` (or `kv-hd-shared-{env}` if Pulse does not yet have a dedicated Vault). The PagerDuty Events API v2 key is read from the documented path.
+
+## Constraints
+> **Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.** Any new abstraction types respect this.
+
+> **Invariant 3 — Provider packages depend on their parent Node's contracts, not internals.** Pulse consumes `IIncidentPagingSender` from `HoneyDrunk.Notify.Abstractions`; never Notify internals.
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The PagerDuty Events API v2 key never appears in logs, traces, the probe's emitted metrics, or any captured exception.
+
+> **Invariant 9 — Vault is the only source of secrets.** The PagerDuty Events API v2 key is read via `ISecretStore`.
+
+> **Invariant 13 — All public APIs have XML documentation.**
+
+> **Invariant 15 — Unit tests never depend on external services.** Probe tests use InMemory Notify and a stubbed PagerDuty Events API client.
+
+> **Invariant 17 — One Key Vault per deployable Node per environment.** Pulse's secret reads from the Pulse-environment Vault.
+
+> **Invariant 26 — Issue packets for .NET code work include a `## NuGet Dependencies` section.**
+
+> **Invariant 27 — All projects in a solution share one version and move together.** First ADR-0054 packet on `HoneyDrunk.Pulse` → version bumps.
+
+> **Invariant 31 — Every PR traverses the tier-1 gate before merge.**
+
+> **Invariant 51 — Test code contains no `Thread.Sleep`.** Time-based behavior uses a virtual clock or polling primitives with explicit timeouts.
+
+- **The probe is the SEV-3-fires-PagerDuty exception.** Document this in XML docs.
+- **The probe does NOT dispatch to the operator's personal phone.** Notify-side synthetic / dry-run / diagnostic flag handles this.
+- **The probe's PagerDuty service is dedicated** (not the main operator service) so probe firings don't bury real incidents.
+- **Probe failures are metrics, not `IErrorReporter` captures** (ADR-0045 D12).
+- **PagerDuty Events API v2 trigger + immediate resolve** so PagerDuty does not accumulate open incidents from the probe.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0054`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add the every-5-minute synthetic paging-path probe to `HoneyDrunk.Pulse` so the Grid detects Notify-itself-down and PagerDuty-itself-down within 15 minutes.
+
+**Target:** `HoneyDrunk.Pulse`, branch from `main`.
+
+**Context:**
+- Goal: Implement the "who watches the watchmen" pattern from ADR-0054 D3 — the cross-path liveness probe that exercises both paging surfaces every 5 minutes and escalates if either goes silent.
+- Feature: ADR-0054 Incident Response rollout, Wave 2.
+- ADRs: ADR-0054 D3 / D5 (primary), ADR-0028 (Pulse synthetic monitoring), ADR-0045 D12 (probe failures emit metrics, not captures), ADR-0040 (Pulse OTLP boundary), ADR-0005 (Vault placement).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — hard. The PagerDuty integration (Events API v2 key, dedicated probe service) must exist before the probe can fire it.
+- `packet:04` — hard. The probe consumes `IIncidentPagingSender` from packet 04; the contract must exist.
+
+**Constraints:**
+- Probe fires PagerDuty for SEV-3 (the D3 exception); uses immediate-resolve.
+- No personal-phone SMS from the probe.
+- Dedicated PagerDuty probe service (coordinate with packet 03).
+- Probe failures are metrics, not `IErrorReporter` captures (ADR-0045 D12).
+- Vault-stored Events API v2 key (invariants 8, 9, 17).
+- No `Thread.Sleep` — virtual clock / polling primitives.
+- Perform the invariant-27 version-bump check on `HoneyDrunk.Pulse` — first ADR-0054 packet → bumps.
+
+**Key Files:**
+- `HoneyDrunk.Pulse/Synthetics/PagingPathProbe.cs` (new, location matches existing scheduled-synthetic convention)
+- `HoneyDrunk.Pulse/Synthetics/PagerDuty/PagerDutyEventsApiClient.cs` (new, thin HTTP client)
+- Pulse host bootstrap projects — DI registration, schedule registration, Vault binding
+- Pulse test projects — probe tests
+- Repo-level `CHANGELOG.md`; per-package `CHANGELOG.md`; non-test `.csproj` (version bump)
+
+**Contracts:**
+- `IIncidentPagingSender` (consumed) — from packet 04.
+- PagerDuty Events API v2 (external) — HTTP surface, no SDK.

--- a/generated/issue-packets/active/adr-0054-incident-response/06-pulse-paging-path-synthetic-probe.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/06-pulse-paging-path-synthetic-probe.md
@@ -33,7 +33,7 @@ The probe's behavior (verbatim from D3):
 
 **Pulse is a Seed Node** per the catalog. Its solution exists and is versioned; this is the first ADR-0054 packet on the Pulse solution → minor bump per invariant 27.
 
-**Vault.** The probe authenticates to PagerDuty via the Events API v2 key stored in `kv-hd-pulse-{env}` (or wherever packet 03 placed it — the walkthrough doc names the path). The probe authenticates to Notify via the existing Notify intake surface (no new credential — Notify's intake authenticates via the Grid identity per ADR-0005's intra-Grid auth).
+**Vault.** The probe authenticates to PagerDuty via the Events API v2 key stored at `pagerduty-events-api-key` in `kv-hd-pulse-{env}` per packet 03's canonical Vault placement (invariant 17 — no shared Vault). The probe authenticates to Notify via the existing Notify intake surface (no new credential — Notify's intake authenticates via the Grid identity per ADR-0005's intra-Grid auth).
 
 ## Scope
 - `HoneyDrunk.Pulse` solution — a new synthetic probe `PagingPathProbe` on the Pulse synthetic-monitoring surface, running every 5 minutes.
@@ -118,7 +118,7 @@ The probe's behavior (verbatim from D3):
 
 **ADR-0040 — Pulse is the telemetry-export boundary.** Probe metrics flow through the existing Pulse OTLP path to App Insights.
 
-**ADR-0005 — Vault placement.** Pulse's Vault is `kv-hd-pulse-{env}` (or `kv-hd-shared-{env}` if Pulse does not yet have a dedicated Vault). The PagerDuty Events API v2 key is read from the documented path.
+**ADR-0005 — Vault placement.** Pulse's Vault is `kv-hd-pulse-{env}` per invariant 17 (one Vault per deployable Node — no shared Vault fallback). The PagerDuty Events API v2 key is read from the documented path. If `kv-hd-pulse-{env}` does not exist yet, provisioning it is a Human Prerequisite for this packet — packet 03 holds the canonical Vault placement for the PagerDuty secret and matches this rule.
 
 ## Constraints
 > **Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.** Any new abstraction types respect this.

--- a/generated/issue-packets/active/adr-0054-incident-response/07-architecture-statuspage-provisioning.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/07-architecture-statuspage-provisioning.md
@@ -1,0 +1,153 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "infrastructure", "human-only", "adr-0054", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0054", "ADR-0052", "ADR-0027"]
+accepts: ["ADR-0054"]
+wave: 2
+initiative: adr-0054-incident-response
+node: honeydrunk-architecture
+---
+
+# Provision the Statuspage v0 static fallback under Studios.HoneyDrunk.com; defer Statuspage Starter until first paying tenant
+
+## Summary
+Provision the **v0 static-status-page fallback** at `status.honeydrunkstudios.com` (or the equivalent path on the existing Studios website) per ADR-0054 D9. Author the operator walkthrough for updating it during a SEV-1/2. Defer the **Atlassian Statuspage Starter ($29/month)** adoption to first paying-tenant onboarding per ADR-0054's Operational Consequences. Author the upgrade walkthrough so the Starter adoption is a documented, single-session task when the trigger fires.
+
+## Context
+ADR-0054 D9 names the tenant status page as the public-facing incident surface. The ADR commits to **two tiers**:
+
+- **v1 (when first paying tenant exists):** Atlassian Statuspage Starter at ~$29/month — gives subscriber notifications, RSS, history, proper external surface.
+- **v0 (now):** a **static page** in `Studios.HoneyDrunk.com` — free, no notification surface, but acceptable until the first paying tenant. The trade-off is explicit: "Statuspage gives proper subscriber notifications, RSS, history; static page gives nothing but is free. Choose Statuspage when first paying tenant exists; before that, static is acceptable."
+
+ADR-0054's Operational Consequences: "Atlassian Statuspage Starter ($29/month) is a recommended-but-deferred adoption. The v0 fallback (static page in Studios.HoneyDrunk.com) is acceptable until the first paying tenant exists; the Starter tier adopts at first paying-tenant onboarding."
+
+**Two artifacts in one packet:**
+
+1. **v0 static-page provisioning** — a static page at `status.honeydrunkstudios.com` (or `studios.honeydrunkstudios.com/status` if subdomains require extra DNS work). Manually updated during a SEV-1/2 via the existing Studios website edit flow. Renders the current grid status from a static JSON file or just inline content. Site sync handled by the Studios website's existing static-content pipeline.
+2. **Deferred Statuspage Starter walkthrough** — the upgrade path documented now so adoption is a single-session task at trigger time. The trigger: **first paying-tenant onboarding**.
+
+**Studios website is the surface.** ADR-0054 names "static page in `Studios.HoneyDrunk.com`" — that is the `HoneyDrunk.Studios` Next.js site. The static page lives in that site. However, this packet's `target_repo` is `HoneyDrunk.Architecture` because:
+
+- The **walkthrough** (both v0 setup and the deferred Starter adoption) lives in `infrastructure/walkthroughs/` — a Architecture-repo artifact.
+- The **actual Studios website edit** that adds a `/status` route is a small follow-on Studios PR, scoped from the walkthrough. The PR is trivial (a markdown / JSON content file plus a Next.js route) and the operator executes it directly — it does not warrant a separate packet in this initiative.
+- The Statuspage Starter adoption itself is portal work in the Atlassian Statuspage UI; no code lands then either.
+
+Per the operator's standing preference, infra provisioning uses portal UI walkthroughs, not CLI / Terraform.
+
+**Provision-when-needed.** No paying tenant exists in 2026-05; the v0 static fallback is sufficient. The Starter adoption fires when the first paying tenant is onboarded — not now. This packet **does not** provision Atlassian Statuspage Starter now; it only documents the adoption walkthrough for the trigger.
+
+**Site sync.** Adding the `/status` route to the Studios website is a Studios PR; that PR is the "site sync" for this packet. Not flagged as a separate packet because the surface change is small.
+
+This is an infrastructure walkthrough packet. No code, no .NET project. **Actor=Human** — the steps are website edits and (deferred) portal clicks.
+
+## Scope
+- `infrastructure/walkthroughs/statuspage-provisioning.md` (new) — combined walkthrough covering: (a) v0 static-page setup at `status.honeydrunkstudios.com`, (b) operator runbook for updating the page during a SEV-1/2, (c) deferred Statuspage Starter adoption when first paying tenant exists.
+- The Studios website — a `/status` route or `status.honeydrunkstudios.com` subdomain rendering a static incident-status page. Surface change executed via a small follow-on Studios PR scoped from the walkthrough.
+- `catalogs/grid-health.json` (or equivalent) — record the v0 status-page state.
+- `business/context/` — record the Starter $29/month adoption as a deferred cost item gated on first-paying-tenant trigger.
+
+## Proposed Work (human-executed, website edit + walkthrough authoring)
+The walkthrough authors and the operator executes:
+
+1. **v0 static page on Studios website.**
+   - Decide path: `status.honeydrunkstudios.com` (subdomain — requires Cloudflare DNS per ADR-0029) or `honeydrunkstudios.com/status` (path — no new DNS).
+   - **Recommendation:** subdomain `status.honeydrunkstudios.com` — it matches the convention referenced in the D9 tenant-email template ("You can follow updates at status.honeydrunkstudios.com"). Requires a Cloudflare DNS record per ADR-0029.
+   - In the `HoneyDrunk.Studios` Next.js site, add a new route or new subdomain page rendering a static incident-status JSON / markdown. The page has three components: (i) current overall status ("All systems operational" / "Incident in progress" / "Maintenance"), (ii) the incident-state line (if active), (iii) the link to the most recent post-mortem (if any).
+   - Initially: "All systems operational" — no active incident.
+   - The page is **manually updated** via a Studios website PR during a SEV-1/2 declaration / update / resolution. The operator edits a static markdown / JSON content file in the Studios repo; the website redeploys automatically.
+2. **Operator runbook for the v0 page.**
+   - Document the file path in the Studios repo to edit (e.g., `data/status.json` or `content/status.md`).
+   - Document the SEV-1/2 update cadence: 30 min after declaration, every 60 min during active incident, within 30 min of resolution (per D9). Cross-link the cadence to D9 in the runbook.
+3. **Deferred Statuspage Starter walkthrough.**
+   - Document the trigger: "first paying tenant onboarded." When this fires, the operator follows the walkthrough's Starter section.
+   - The Starter section covers: signup at statuspage.com Starter plan; DNS swap for `status.honeydrunkstudios.com` from Studios website to Statuspage's hosted page; configure components (one per Node); configure subscribers (tenant emails for incident notifications); test incident → resolution flow.
+   - Update the cadence reference: Statuspage provides the proper subscriber-notification surface, replacing the manual Studios-website edit.
+4. **Update catalog readout.**
+   - `catalogs/grid-health.json` (or equivalent) carries the status-page state: `v0-static`. Flips to `v1-statuspage-starter` when the Starter is adopted (a future follow-on packet to flip the catalog).
+5. **Cost guard.**
+   - `business/context/` carries the deferred Statuspage Starter $29/month line as a **gated** cost item — does not fire until first paying tenant. Annotated against ADR-0052's cost-discipline envelope.
+
+## Affected Files
+- `infrastructure/walkthroughs/statuspage-provisioning.md` (new)
+- `catalogs/grid-health.json` (or equivalent) — status-page state entry.
+- `business/context/` — deferred Statuspage Starter cost annotation.
+- A follow-on Studios PR (out of this packet's `target_repo` scope) — small static-content edit + new route / subdomain. Scoped from the walkthrough.
+
+## NuGet Dependencies
+None. This packet has no .NET project.
+
+## Boundary Check
+- [x] The walkthrough doc lives in `HoneyDrunk.Architecture` — correct home for infrastructure walkthroughs.
+- [x] The Studios website edit is a follow-on Studios PR, not part of this packet's commit — the walkthrough scopes the work.
+- [x] Statuspage adoption is deferred per ADR-0054's Operational Consequences.
+- [x] The DNS work, if a subdomain is chosen, follows ADR-0029's Cloudflare DNS convention.
+
+## Acceptance Criteria
+- [ ] `infrastructure/walkthroughs/statuspage-provisioning.md` exists and documents: (a) the v0 static-page provisioning at `status.honeydrunkstudios.com` (or `honeydrunkstudios.com/status` — the path choice is recorded with rationale), (b) the operator runbook for updating the page during a SEV-1/2 with the D9 cadence (30 min after declaration, every 60 min during active incident, within 30 min of resolution), (c) the deferred Statuspage Starter adoption walkthrough gated on first-paying-tenant trigger
+- [ ] The Studios website has a `/status` route or `status.honeydrunkstudios.com` subdomain rendering a static incident-status page with "All systems operational" initially; this is delivered via a follow-on Studios PR, scoped from the walkthrough
+- [ ] `catalogs/grid-health.json` (or equivalent) records the status-page state as `v0-static`
+- [ ] `business/context/` records the deferred Statuspage Starter $29/month cost as gated on first-paying-tenant trigger; annotated against ADR-0052
+- [ ] The walkthrough's deferred-Statuspage section is detailed enough that adoption is a single-session task when the trigger fires (signup, DNS swap, components, subscribers, test flow — all documented)
+- [ ] The DNS choice (subdomain vs path) follows ADR-0029's Cloudflare convention if a subdomain is selected
+- [ ] No Statuspage account is provisioned now — the Starter adoption is deferred
+
+## Human Prerequisites
+- [ ] **Decide DNS path:** subdomain `status.honeydrunkstudios.com` vs path `honeydrunkstudios.com/status`. The agent recommends the subdomain to match the D9 email-template wording, but the operator chooses.
+- [ ] **If the subdomain is chosen:** add the Cloudflare DNS record per ADR-0029. The agent does not have Cloudflare access.
+- [ ] **Execute the follow-on Studios PR** to add the `/status` route / page. Small, scoped from the walkthrough — the agent can author the PR description from the walkthrough.
+- [ ] **Atlassian Statuspage Starter adoption is deferred** — no action now. When the first paying tenant is onboarded, follow the deferred section of the walkthrough.
+
+## Referenced ADR Decisions
+**ADR-0054 D9 — Status page.** Two tiers: Atlassian Statuspage Starter ($29/month) v1 when first paying tenant exists; static page in `Studios.HoneyDrunk.com` v0 fallback before that. Cadence: within 30 min of SEV-1/2 declaration with tenant impact, every 60 min during active incident, resolution within 30 min of close. Trade-off: Statuspage gives proper subscriber notifications, RSS, history; static page gives nothing but is free.
+
+**ADR-0054 D9 — Tenant email references the status page.** The D9 tenant-email templates say "You can follow updates at status.honeydrunkstudios.com." The subdomain choice should match this to avoid template churn.
+
+**ADR-0054 Operational Consequences — Atlassian Statuspage Starter deferred.** "Atlassian Statuspage Starter ($29/month) is a recommended-but-deferred adoption. The v0 fallback (static page in `Studios.HoneyDrunk.com`) is acceptable until the first paying tenant exists."
+
+**ADR-0052 — Cost discipline.** $29/month for a status page with no audience is poor ROI. Deferred adoption fires at first paying tenant.
+
+**ADR-0027 — Notify Cloud (first paying-tenant surface).** Notify Cloud GA is the first paying-tenant event; that is the Statuspage Starter trigger.
+
+**ADR-0029 — Cloudflare DNS.** Subdomain DNS records use the Cloudflare convention.
+
+## Constraints
+- **No Statuspage Starter now.** Defer to first paying-tenant trigger. Document the walkthrough so adoption is single-session at trigger time.
+- **v0 is acceptable.** The static page gives nothing but is free; the ADR explicitly accepts this.
+- **Subdomain matches D9 template wording.** If the subdomain `status.honeydrunkstudios.com` is chosen (recommended), no D9 template edit is needed. If the path is chosen, the D9 template wording in packet 05 needs to match — coordinate.
+- **Operator runbook is part of the walkthrough.** The "how to update the static page during a SEV-1/2" runbook is the v0 operational substitute for Statuspage's UI.
+
+## Labels
+`feature`, `tier-2`, `ops`, `infrastructure`, `human-only`, `adr-0054`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Provision the v0 static status page at `status.honeydrunkstudios.com` (or `honeydrunkstudios.com/status` — operator chooses), author the operator runbook for updating it during a SEV-1/2, and author the deferred Atlassian Statuspage Starter adoption walkthrough so the Starter is a single-session task when the first paying tenant is onboarded.
+
+**Target:** `HoneyDrunk.Architecture` for the walkthrough doc. The Studios website edit is a small follow-on Studios PR, scoped from the walkthrough.
+
+**Context:**
+- Goal: Land the v0 tenant-facing incident surface so the D9 tenant-email templates have a working URL to link to, and document the upgrade path so Statuspage adoption is fast at trigger time.
+- Feature: ADR-0054 Incident Response rollout, Wave 2.
+- ADRs: ADR-0054 D9 (primary), ADR-0054 Operational Consequences (deferred), ADR-0052 (cost discipline), ADR-0027 (paying-tenant trigger), ADR-0029 (Cloudflare DNS).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0054 should be Accepted before its public-status-page surface stands up.
+
+**Constraints:**
+- No Statuspage Starter now — deferred.
+- Subdomain matches D9 template wording, or coordinate with packet 05.
+- Operator runbook for updating the static page during a SEV-1/2 is part of the walkthrough.
+
+**Key Files:**
+- `infrastructure/walkthroughs/statuspage-provisioning.md` (new)
+- `catalogs/grid-health.json` (or equivalent) — status-page state
+- `business/context/` — deferred cost annotation
+- A follow-on Studios PR (out of this packet's commit scope)
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0054-incident-response/08-actions-incident-and-post-mortem-generators.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/08-actions-incident-and-post-mortem-generators.md
@@ -1,0 +1,175 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "adr-0054", "wave-3"]
+dependencies: ["packet:02"]
+adrs: ["ADR-0054", "ADR-0012"]
+accepts: ["ADR-0054"]
+wave: 3
+initiative: adr-0054-incident-response
+node: honeydrunk-actions
+---
+
+# Author the HoneyDrunk.Actions incident-record and post-mortem generator workflows
+
+## Summary
+Author reusable `HoneyDrunk.Actions` workflows (and / or composite actions) that scaffold a pre-filled incident record at `generated/incidents/YYYY-MM-DD-<slug>.md` and a pre-filled blameless post-mortem at `generated/incidents/post-mortems/YYYY-MM-DD-<slug>.md` from the templates packet 02 ships. Each generator accepts the front-matter inputs (incident_id, severity, optional title), copies the template, substitutes the placeholders, and opens a PR against `HoneyDrunk.Architecture` with the new file ready for the operator to fill in. ADR-0054 D7 commits the template; this packet automates its scaffolding.
+
+## Context
+ADR-0054's Follow-up Work names:
+
+- "Author the D7 incident-record template as a generator in `HoneyDrunk.Actions`."
+- "Author the D8 post-mortem template as a generator in `HoneyDrunk.Actions`."
+
+ADR-0012 makes `HoneyDrunk.Actions` the Grid's CI/CD control plane. Workflow scaffolds and generators belong here. The generators consume the canonical templates packet 02 ships at `generated/incidents/_templates/` in the `HoneyDrunk.Architecture` repo.
+
+**Two generator workflows.** One for the incident record, one for the post-mortem. Each is `workflow_dispatch`-triggered (operator invokes it manually) and operates in the `HoneyDrunk.Architecture` repo (the destination):
+
+- **Incident record generator** — inputs: `severity` (SEV-1/2/3/4), `title` (short kebab-case slug), `incident_id` (optional — auto-generated as `INC-YYYY-NNNN` from the latest existing record + 1 if omitted), `customer_impact` (yes/no, defaults no), and an alert source list. Steps:
+  1. Checkout `HoneyDrunk.Architecture` `main`.
+  2. Read `generated/incidents/_templates/incident-record.md`.
+  3. Compute the filename: `generated/incidents/YYYY-MM-DD-sevN-<title>.md` (date from `date +%Y-%m-%d` UTC).
+  4. Compute `incident_id` if not supplied — scan existing `generated/incidents/*.md` for the highest `INC-YYYY-NNNN`, increment by 1.
+  5. Substitute placeholders: `incident_id`, `severity`, `opened_at` (current UTC timestamp), `customer_impact`, `alert_sources`. Leave the other timestamps blank for the operator.
+  6. Create a branch, commit the new file, open a PR titled `[INC-YYYY-NNNN] <title>` against `main`. Label `incident-record` on the PR.
+  7. Output the PR URL and the new `incident_id` so the operator (or PagerDuty integration) can cross-link.
+
+- **Post-mortem generator** — inputs: `incident_id` (required — the post-mortem's parent incident), `title` (optional — defaults to the incident's title), `participants` (defaults to `[operator]`). Steps:
+  1. Checkout `HoneyDrunk.Architecture` `main`.
+  2. Read `generated/incidents/_templates/post-mortem.md`.
+  3. Compute the filename: `generated/incidents/post-mortems/YYYY-MM-DD-<incident-id-slug>.md`.
+  4. Compute `post_mortem_id` (e.g., `PM-YYYY-NNNN` matching the incident's `INC-YYYY-NNNN`).
+  5. Substitute placeholders: `incident_id`, `post_mortem_id`, `authored_at` (current UTC timestamp), `participants`.
+  6. Read the source incident record's `affected_nodes` / `alert_sources` / `customer_impact` and pre-fill the post-mortem's references where useful.
+  7. Create a branch, commit, open a PR titled `[PM-YYYY-NNNN] post-mortem for INC-YYYY-NNNN`. Label `post-mortem`.
+  8. Update the source incident record's `post_mortem_link` to the new file's path; flip its `status` to `Reviewing` (per the D6 state transition).
+
+**No GitHub-Issue creation.** These generators emit **markdown files in a PR** to the Architecture repo. They do **not** create GitHub Issues — per the user's "no manual packet filing" feedback and the auto-filing pipeline, GitHub Issues are filed elsewhere. The post-mortem's action items (which become issue packets per ADR-0008) are filed by the existing packet-filing pipeline once the operator commits the action-item packets into `generated/issue-packets/active/`.
+
+**Branch and PR conventions.** Match the existing `HoneyDrunk.Actions` reusable-workflow convention: input names, output names, and how the workflow runs against another repo (the Architecture repo, in this case — needs a write-permission token via GitHub App or `GITHUB_TOKEN` with appropriate scope). If a GitHub App is the established cross-repo write surface, use it; if `GITHUB_TOKEN` works for cross-repo writes when the workflow runs in the Architecture repo itself, run it there. Match the existing pattern from `HoneyDrunk.Actions` workflows that write back to other repos.
+
+**Trigger surface.** Both generators are `workflow_dispatch` (operator invokes manually from the Actions UI) and **optionally** `repository_dispatch` so PagerDuty webhook can fire the incident-record generator when a real incident opens. The PagerDuty webhook configuration (per packet 09's alert-wiring work) can post a `repository_dispatch` event with the SEV and title, triggering the generator automatically.
+
+**This is a workflow/YAML packet. No .NET project.** `HoneyDrunk.Actions` is not a versioned .NET solution — no version bump, no `## NuGet Dependencies`-driven project change. The repo's `CHANGELOG.md` (if it keeps one for the workflow surface) is updated per the repo convention.
+
+## Scope
+- `.github/workflows/incident-record-generator.yml` (new) — reusable workflow scaffolding the incident record.
+- `.github/workflows/post-mortem-generator.yml` (new) — reusable workflow scaffolding the post-mortem.
+- A composite action or inline script per workflow for: reading the template, substituting placeholders, computing the next `INC-YYYY-NNNN`, creating the branch + PR. Match the existing `HoneyDrunk.Actions` script style.
+- `docs/consumer-usage.md` (or the equivalent docs the reusable workflows reference) — document the new generators and their inputs.
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface.
+
+## Proposed Implementation
+1. **`incident-record-generator.yml`.** A `workflow_dispatch` + `repository_dispatch` reusable workflow. Inputs: `severity` (SEV-1/SEV-2/SEV-3/SEV-4, required), `title` (kebab-case slug, required), `incident_id` (optional), `customer_impact` (boolean, default false), `alert_sources` (string list, default empty). Steps:
+   - Checkout `HoneyDrunk.Architecture` `main` (or run within Architecture repo's Actions; the cleaner pattern is to host the workflow in Architecture and reference Actions' reusable workflows for the heavy lifting — match the existing convention).
+   - Compute the next `INC-YYYY-NNNN` if not supplied (scan `generated/incidents/*.md` for the highest, increment).
+   - Read the template at `generated/incidents/_templates/incident-record.md`.
+   - Substitute the placeholders. Use a small Bash / Python script (whatever matches the repo convention). Note: per the CLAUDE memory about Windows Git Bash CRLF, if the script runs on Windows runners and pipes through `jq` or `gh`, insert `tr -d '\r'` after pipe outputs.
+   - Compute the filename: `generated/incidents/YYYY-MM-DD-sevN-<title>.md` (UTC date).
+   - Create a branch `incident/INC-YYYY-NNNN-<title>`, commit the new file, push, open the PR via `gh pr create` titled `[INC-YYYY-NNNN] <title>`, label `incident-record`.
+   - Output the PR URL and `incident_id`.
+2. **`post-mortem-generator.yml`.** A `workflow_dispatch` reusable workflow. Inputs: `incident_id` (required), `title` (optional, defaults to the incident record's title), `participants` (string list, default `[operator]`). Steps:
+   - Checkout `HoneyDrunk.Architecture` `main`.
+   - Read the source incident record at `generated/incidents/YYYY-MM-DD-...-<incident_id>.md` (or find by glob).
+   - Read the template at `generated/incidents/_templates/post-mortem.md`.
+   - Compute `post_mortem_id` as `PM-YYYY-NNNN` matching the incident's serial.
+   - Substitute placeholders, pre-fill `affected_nodes` / `alert_sources` / `customer_impact` from the source incident record.
+   - Compute the filename: `generated/incidents/post-mortems/YYYY-MM-DD-<incident-id>.md`.
+   - Update the source incident record's front-matter: `post_mortem_link: ./post-mortems/<new-filename>`, `status: Reviewing`, `reviewing_at: <current UTC>`.
+   - Create a branch `post-mortem/PM-YYYY-NNNN`, commit both files (the new post-mortem and the updated incident record), push, open the PR via `gh pr create` titled `[PM-YYYY-NNNN] post-mortem for INC-YYYY-NNNN`, label `post-mortem`.
+   - Output the PR URL.
+3. **Cross-repo write authentication.** Use the existing pattern `HoneyDrunk.Actions` workflows use for cross-repo PR creation — likely a GitHub App or a PAT stored in repo secrets. If no such pattern exists, run the workflow inside `HoneyDrunk.Architecture` itself (the Architecture repo invokes the reusable workflow from `HoneyDrunk.Actions` and the `GITHUB_TOKEN` writes back to the same repo). Document the choice in the PR.
+4. **PagerDuty webhook integration (optional).** Add a `repository_dispatch` trigger to the incident-record generator so packet 09's PagerDuty alert wiring can fire the generator when a real incident opens. PagerDuty's webhook posts a JSON payload; the workflow extracts `severity`, `title`, `alert_sources` from it. Document the PagerDuty webhook payload shape so packet 09 wires the right schema.
+5. **Idempotency.** If the same `incident_id` is supplied twice (e.g., PagerDuty re-fires), the generator detects an existing record and exits cleanly (no duplicate file, no duplicate PR). Log a single "incident record already exists" line.
+6. **Documentation.** Update `docs/consumer-usage.md` (or the equivalent docs the reusable workflows reference) with the two new generators, their inputs, their outputs, and a worked example. Cross-reference: the templates live in `HoneyDrunk.Architecture/generated/incidents/_templates/` (packet 02); the schema is in `catalogs/contracts.json` (packet 01).
+7. **No secret in the workflow.** Use OIDC where possible; otherwise `GITHUB_TOKEN` for same-repo writes. The PagerDuty webhook authentication uses a signed-secret header validated by the workflow — secret in repo secrets, never inline.
+8. **No `Thread.Sleep` equivalent.** Workflow waits use `gh pr ready --watch` or polling primitives, never raw `sleep` loops longer than a few seconds.
+
+## Affected Files
+- `.github/workflows/incident-record-generator.yml` (new)
+- `.github/workflows/post-mortem-generator.yml` (new)
+- A composite action or script files (location matches the existing convention)
+- `docs/consumer-usage.md` (or the equivalent referenced docs)
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface.
+
+## NuGet Dependencies
+None. `HoneyDrunk.Actions` generators are GitHub Actions YAML — no .NET project is created or modified by this packet.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo — ADR-0054 names "Reusable workflow templates for incident-record creation" in Affected Nodes; ADR-0012 makes Actions the CI/CD control plane.
+- [x] The generators consume packet 02's templates and write to packet 01's catalog-registered location.
+- [x] No code change in any other Node.
+- [x] No GitHub-Issue creation — the generators emit markdown files in PRs, not issues; the auto-filing pipeline handles issue creation downstream when action items become packets.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/incident-record-generator.yml` exists, supports `workflow_dispatch` and `repository_dispatch`, accepts inputs (severity, title, incident_id, customer_impact, alert_sources), computes the next `INC-YYYY-NNNN`, scaffolds the file from `generated/incidents/_templates/incident-record.md`, opens a PR titled `[INC-YYYY-NNNN] <title>`, labels `incident-record`, outputs the PR URL and incident_id
+- [ ] `.github/workflows/post-mortem-generator.yml` exists, supports `workflow_dispatch`, accepts inputs (incident_id, title, participants), scaffolds the file from `generated/incidents/_templates/post-mortem.md`, updates the source incident record's `post_mortem_link` + `status: Reviewing` + `reviewing_at` timestamp, opens a PR titled `[PM-YYYY-NNNN] post-mortem for INC-YYYY-NNNN`, labels `post-mortem`
+- [ ] Cross-repo write authentication matches the existing `HoneyDrunk.Actions` convention (GitHub App, PAT, or running the workflow inside `HoneyDrunk.Architecture` with `GITHUB_TOKEN`) — the choice is documented
+- [ ] `repository_dispatch` trigger on the incident-record generator accepts a PagerDuty-webhook payload shape so packet 09 can wire it; the payload schema is documented
+- [ ] Idempotency: duplicate `incident_id` invocations exit cleanly (no duplicate file, no duplicate PR), logging one "incident record already exists" line
+- [ ] No secret in the workflow file; PagerDuty webhook signed-secret header validated against a repo secret (never inline)
+- [ ] `docs/consumer-usage.md` documents the two generators, their inputs, outputs, and a worked example; cross-references packet 01's schema and packet 02's templates
+- [ ] Windows-runner CRLF guard applied if any pipe through `jq` / `gh` runs on Windows (insert `tr -d '\r'`)
+- [ ] The repo `CHANGELOG.md` is updated if the repo keeps one for the workflow surface
+- [ ] Workflows pass the repo's standard YAML lint / shell-lint gates
+
+## Human Prerequisites
+- [ ] **Confirm the cross-repo write pattern.** If `HoneyDrunk.Actions` has an existing GitHub App / PAT for cross-repo writes, use it. If not, decide: host the workflow inside `HoneyDrunk.Architecture` (simpler, same-repo `GITHUB_TOKEN`) vs add a new GitHub App (more work). The agent can author either; the operator chooses.
+- [ ] **PagerDuty webhook secret seeding (deferred to packet 09).** The `repository_dispatch` payload is signed by PagerDuty; the signing secret is stored in repo secrets. Packet 09's alert-wiring work seeds this secret — not this packet.
+
+## Referenced ADR Decisions
+**ADR-0054 D7 — Incident record template.** Every incident produces a markdown file at `generated/incidents/YYYY-MM-DD-<slug>.md`. The generator automates the file creation.
+
+**ADR-0054 D8 — Post-mortem template + cadence.** The post-mortem at `generated/incidents/post-mortems/YYYY-MM-DD-<slug>.md`. The generator automates the file creation and updates the source incident record's `post_mortem_link` and `status: Reviewing`.
+
+**ADR-0054 D6 — Incident lifecycle.** The post-mortem generator's update of `status: Reviewing` is the explicit Resolved → Reviewing state transition; `reviewing_at` timestamp records it.
+
+**ADR-0054 Follow-up Work — Generators in `HoneyDrunk.Actions`.** "Author the D7 incident-record template as a generator in `HoneyDrunk.Actions`. Author the D8 post-mortem template as a generator in `HoneyDrunk.Actions`."
+
+**ADR-0012 — Actions is the CI/CD control plane.** Workflow scaffolds and generators belong in `HoneyDrunk.Actions`.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry — or in workflow files.** PagerDuty webhook signing secret stored in repo secrets; never inline.
+
+- **The generators scaffold files in PRs — not GitHub Issues.** Per the user's "no manual packet filing" feedback and the auto-filing pipeline, the workflow does not create issues. The operator opens the resulting PR, fills in the timeline, and merges. Action items in the post-mortem become issue packets via the existing packet-filing pipeline.
+- **Idempotency:** duplicate invocations exit cleanly.
+- **Cross-repo write pattern matches existing convention** — do not invent a new auth scheme.
+- **PagerDuty `repository_dispatch` shape is documented** so packet 09 wires it.
+- **CRLF guard** if Windows runners pipe through `jq` / `gh`.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `adr-0054`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Author two `HoneyDrunk.Actions` reusable workflows that scaffold the D7 incident record and the D8 blameless post-mortem from the packet 02 templates, opening PRs against `HoneyDrunk.Architecture` with the new files ready for the operator to fill in.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Eliminate the manual copy-template-and-substitute-placeholders step during a real incident so the operator's cognitive load during a SEV-1 is on the incident, not on bookkeeping.
+- Feature: ADR-0054 Incident Response rollout, Wave 3.
+- ADRs: ADR-0054 D7/D8 (primary), ADR-0054 D6 (state transitions), ADR-0012 (Actions as CI/CD control plane).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — hard. The generators consume the templates packet 02 ships; without those templates the generators have nothing to substitute placeholders into.
+
+**Constraints:**
+- Generators emit PRs, not GitHub Issues (per "no manual packet filing").
+- Idempotency on duplicate invocations.
+- Cross-repo write authentication matches existing pattern.
+- PagerDuty `repository_dispatch` payload shape documented so packet 09 wires it.
+- Windows-runner CRLF guard for `jq` / `gh` pipes.
+- No secret in workflow (invariant 8).
+
+**Key Files:**
+- `.github/workflows/incident-record-generator.yml` (new)
+- `.github/workflows/post-mortem-generator.yml` (new)
+- A composite action or script files
+- `docs/consumer-usage.md`
+
+**Contracts:** None — workflow inputs/outputs only.

--- a/generated/issue-packets/active/adr-0054-incident-response/09-architecture-alert-routing-pagerduty-wiring.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/09-architecture-alert-routing-pagerduty-wiring.md
@@ -1,0 +1,199 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "infrastructure", "human-only", "adr-0054", "wave-3"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0054", "ADR-0040", "ADR-0045", "ADR-0052", "ADR-0012", "ADR-0030", "ADR-0005", "ADR-0037"]
+accepts: ["ADR-0054"]
+wave: 3
+initiative: adr-0054-incident-response
+node: honeydrunk-architecture
+---
+
+# Wire every D4 alert source to PagerDuty per the routing table
+
+## Summary
+Wire every alert source named in ADR-0054 D4's routing table to PagerDuty via webhook — Azure Monitor action groups for App Insights alerts (ADR-0040), `IErrorReporter` captures landing in App Insights Failures (ADR-0045), Azure Monitor budget alerts (ADR-0052), canary failure alerts (ADR-0012), Audit failure paths (ADR-0030), Vault failure paths (ADR-0005), Stripe webhook failures (ADR-0037), and the operator-internal tenant-initiated SEV-1 ticket surface (deferred to Notify Cloud). Each source's default severity comes from the D4 table; SEV-3/4 sources go Notify-only (not PagerDuty). Maintain an operational reference copy of the routing table at `repos/HoneyDrunk.Notify/runbooks/alert-routing.md` per ADR-0054 D4.
+
+## Context
+ADR-0054 D4 specifies the alert routing table — every signal source the Grid produces, with its default severity, routing target (Notify + PagerDuty / Notify-only), and routing conditions. The table lives in this ADR for the v1 commitment; the **operational reference copy** lives in `repos/HoneyDrunk.Notify/runbooks/alert-routing.md` (per D10) and stays in sync via a `hive-sync` check that diffs the two.
+
+ADR-0054's Follow-up Work names the per-source wiring:
+
+- "Wire App Insights alerts (ADR-0040) to PagerDuty per the D4 routing table."
+- "Wire `IErrorReporter` captures (ADR-0045) to PagerDuty per the D4 routing table."
+- "Wire Azure Monitor budget alerts (ADR-0052) to PagerDuty per the D4 routing table."
+- "Wire canary failure alerts (ADR-0012) to PagerDuty per the D4 routing table."
+
+Per the operator's standing preference, this is **Azure Portal work**, not CLI / Terraform / ARM. The packet authors a walkthrough doc covering each source's configuration and executes it for `dev` (staging/prod are deferred per ADR-0033 — the walkthrough covers them as a re-execution).
+
+**Mechanism — Azure Monitor → PagerDuty action group.** Most sources fire through Azure Monitor alert rules. Azure Monitor's "action group" abstraction supports a webhook action that posts to PagerDuty's Azure-Monitor integration (per packet 03's PagerDuty walkthrough). One action group per environment, named `ag-hd-pagerduty-{env}`, wired into every alert rule that should page.
+
+**Stripe webhook failures** route differently — Stripe webhook failures surface in the deployable Node that consumes the webhook (per ADR-0037). The Node fires an `IErrorReporter` capture (per ADR-0045) which lands in App Insights and fires the App-Insights Failures-blade alert rule → PagerDuty. So Stripe → App Insights → PagerDuty rather than Stripe → PagerDuty direct.
+
+**Audit / Vault failures** similarly route via App Insights — the Node's failure path emits an `IErrorReporter` capture which fires the App-Insights alert rule. The D4 table's Audit and Vault entries are App Insights alert rules with high severity tags.
+
+**Tenant-initiated SEV-1 (Notify Cloud).** D4 names "Tenant opens a SEV-1 ticket via in-product surface" — but Notify Cloud is a Seed Node per ADR-0027. That source is **deferred** to Notify Cloud GA; this packet wires every other D4 source.
+
+**Per-environment wiring.** Wire `dev` now; staging/prod are deferred per ADR-0033 (those environments do not yet exist). The walkthrough covers all three environments so wiring is a re-execution when staging/prod stand up.
+
+**hive-sync drift check (deferred).** ADR-0054 D4 names a `hive-sync` check that diffs the ADR's table against `repos/HoneyDrunk.Notify/runbooks/alert-routing.md`. The drift check is a follow-on `hive-sync` enhancement, not part of this packet — flag as a deferred item in this packet's PR. This packet creates the operational reference copy; the drift check that keeps it in sync is a future packet.
+
+This is an infrastructure walkthrough + wiring packet. No code, no .NET project. **Actor=Human** — the steps are Azure portal clicks the agent cannot perform.
+
+## Scope
+- `infrastructure/walkthroughs/alert-routing-pagerduty.md` (new) — the per-source Azure Monitor → PagerDuty wiring walkthrough.
+- `repos/HoneyDrunk.Notify/runbooks/alert-routing.md` (new, in this repo — the Architecture repo holds the master per-Node runbook scaffolds per packet 10; this is the alert-routing reference copy). Created in this repo and then copied / synced to the actual Notify repo by packet 10's per-Node fanout. The drift-check hive-sync (deferred) will keep them in sync going forward.
+- Per-source Azure portal configuration: one `ag-hd-pagerduty-dev` action group; alert rules for every D4 source pointing at it for SEV-1/2; alert rules pointing at email/log-only for SEV-3 (Notify-only routing).
+- `catalogs/grid-health.json` (or equivalent) — wiring readout per source.
+- `business/context/` — deferred items list (Stripe direct integration if needed; tenant-initiated SEV-1 deferred to Notify Cloud; hive-sync drift check).
+
+## Proposed Work (human-executed, Azure Portal + walkthrough authoring)
+The walkthrough authors and the operator executes for `dev`:
+
+1. **Action group `ag-hd-pagerduty-dev`.**
+   - In Azure Portal → Monitor → Alerts → Action groups → create `ag-hd-pagerduty-dev`.
+   - Add a Webhook action: target the PagerDuty Azure Monitor integration URL from packet 03's Vault entry (`pagerduty-azure-monitor-integration-url`).
+   - Test the action group with the "Test action group" UI — confirm PagerDuty receives a synthetic alert.
+2. **App Insights alert rules per D4.**
+   - **Failure rate > 5% over 5 min on tenant-facing endpoint (SEV-1).** Create the alert rule on App Insights, scoped by the `surface=tenant` tag. Action group: `ag-hd-pagerduty-dev`. Severity: Sev1.
+   - **Failure rate > 5% over 10 min on internal endpoint (SEV-2 within coverage; Notify-only outside).** Create the alert rule, scope by `surface=internal`. Action group within coverage: `ag-hd-pagerduty-dev`. Outside coverage: a Notify-only action group (or the same `ag-hd-pagerduty-dev` with PagerDuty integration's own time-window scheduling — match the cleanest pattern).
+   - **Latency p95 > 2x baseline on tenant-facing endpoint (SEV-2).** Alert rule, action group `ag-hd-pagerduty-dev`.
+   - **New unique problem ID with > 10 occurrences in 1h on tenant traffic (SEV-2 within coverage).** Failures-blade rule on App Insights — query on `application_Version` + `problem_id` (per ADR-0045 D2). Action group within coverage: `ag-hd-pagerduty-dev`.
+   - **Existing problem ID exceeding 100/h regression threshold (SEV-3, Notify-only).** Failures-blade rule. Action group: a Notify-only action group (no PagerDuty).
+3. **Azure Monitor budget alerts per D4.**
+   - **Spend forecast > 120% of monthly budget (SEV-2 within coverage).** Existing budget alert from ADR-0052 — add `ag-hd-pagerduty-dev` to its action group list (within coverage).
+   - **Spend actual > 80% mid-month (SEV-3).** Notify-only action group.
+4. **Canary failure alerts per D4 (cross-ref ADR-0012).**
+   - **Published-package canary fails post-publish (SEV-2 within coverage).** Source: `HoneyDrunk.Actions` workflow. The canary failure already emits to App Insights / GitHub status; configure the GitHub status-check failure → repository_dispatch → packet 08's incident-record generator OR an Azure Monitor log alert on the failure event. Match the existing canary-failure surface. Route to `ag-hd-pagerduty-dev`.
+   - **Nightly grid-health canary fails on non-published Node (SEV-3, Notify-only).** Notify-only action group.
+5. **Audit failure paths per D4 (cross-ref ADR-0030).**
+   - **Write-path failure / single event drop (SEV-1).** App Insights alert rule on the Audit Node's `IErrorReporter` captures matching the Audit-write-failure problem ID. Action group: `ag-hd-pagerduty-dev`.
+   - **Ingestion latency > 30 min (SEV-2).** App Insights metric alert. Action group: `ag-hd-pagerduty-dev`.
+6. **Vault failure paths per D4 (cross-ref ADR-0005/0006).**
+   - **Vault unreachable from any Node for > 2 min (SEV-1).** App Insights metric alert on Vault Node's connectivity probe. Action group: `ag-hd-pagerduty-dev`.
+   - **Secret-rotation failure (SEV-2).** App Insights alert on rotation-Function failure path. Action group: `ag-hd-pagerduty-dev`.
+7. **Stripe webhook failures per D4 (cross-ref ADR-0037).**
+   - **Payment webhook failure > 5 min (SEV-2 within coverage).** Source: the Node consuming Stripe webhooks emits `IErrorReporter` captures on webhook-failure; the App Insights Failures-blade rule fires. Action group: `ag-hd-pagerduty-dev`.
+8. **Tenant-initiated SEV-1 ticket (DEFERRED).** ADR-0054 D4 names "Tenant opens a SEV-1 ticket via in-product surface" but Notify Cloud is Seed. Record as a deferred item in `business/context/` — wires when Notify Cloud's tenant portal lands.
+9. **DR drill SEV declarations (D4 says "as declared").** No wiring needed — drills are operator-declared incidents using packet 08's generator. Document in the walkthrough.
+10. **Operational reference copy `repos/HoneyDrunk.Notify/runbooks/alert-routing.md`.**
+    - Create the file in the Architecture repo at `repos/HoneyDrunk.Notify/runbooks/alert-routing.md` mirroring the D4 table verbatim.
+    - Cross-link the file as the operational reference and ADR-0054 D4 as the v1 commitment source.
+    - The file will be **copied to the actual Notify repo** by packet 10's per-Node runbook fanout. For now, it lives here in the Architecture repo where the walkthrough work is happening.
+    - Flag the `hive-sync` drift-check as a deferred item — packet 12 or a follow-on hive-sync packet wires it.
+11. **Verify end-to-end.**
+    - For each configured alert rule, trigger a synthetic condition (e.g., generate a failure spike, exhaust the canary, etc.) — confirm the PagerDuty incident fires through `ag-hd-pagerduty-dev` and a real alert reaches the operator. Document each test.
+    - For Notify-only alert rules, confirm Notify intake receives the alert payload (per packet 04's intake), without PagerDuty firing.
+12. **Update catalog readout.**
+    - `catalogs/grid-health.json` (or equivalent) records the wiring state per source: `wired-dev` (all D4 sources), `deferred-notify-cloud` (tenant in-product ticket).
+    - `business/context/` lists deferred items: tenant-initiated SEV-1 (Notify Cloud), `hive-sync` drift-check.
+
+## Affected Files
+- `infrastructure/walkthroughs/alert-routing-pagerduty.md` (new)
+- `repos/HoneyDrunk.Notify/runbooks/alert-routing.md` (new — operational reference copy, hosted here in Architecture for now; packet 10's per-Node fanout copies it to the actual Notify repo)
+- `catalogs/grid-health.json` (or equivalent) — per-source wiring state
+- `business/context/` — deferred items list
+- Azure Portal: one action group `ag-hd-pagerduty-dev`; alert rules for App Insights / budget / canary / Audit / Vault / Stripe paths (Azure resources, not repo artifacts)
+
+## NuGet Dependencies
+None. This packet has no .NET project.
+
+## Boundary Check
+- [x] The walkthrough doc lives in `HoneyDrunk.Architecture` — correct home for infrastructure walkthroughs.
+- [x] The operational reference copy of the D4 table lives in `repos/HoneyDrunk.Notify/runbooks/alert-routing.md` per ADR-0054 D4 — Architecture is the master copy until packet 10's fanout.
+- [x] No code change in any repo.
+- [x] Azure resources land in the Azure subscription (a vendor surface, not a Node).
+- [x] PagerDuty webhook integration was provisioned in packet 03; this packet consumes that integration.
+
+## Acceptance Criteria
+- [ ] `infrastructure/walkthroughs/alert-routing-pagerduty.md` exists and documents the per-source Azure Monitor → PagerDuty wiring for every D4 source: App Insights failure-rate / latency / Failures-blade rules; budget alerts; canary failures; Audit / Vault / Stripe failure paths; the Notify-only SEV-3 routing; the deferred Notify Cloud tenant-initiated SEV-1
+- [ ] One action group `ag-hd-pagerduty-dev` exists in `dev` with the PagerDuty Azure Monitor integration URL webhook action; test-action-group succeeded
+- [ ] Each D4 source has an alert rule (or existing alert rule extended) in `dev` pointing at the correct action group per the D4 severity / coverage-window matrix
+- [ ] `repos/HoneyDrunk.Notify/runbooks/alert-routing.md` exists in the Architecture repo (hosted here for now; packet 10 fanouts to the actual Notify repo) mirroring the D4 table verbatim and cross-linking ADR-0054 D4 as the source of truth
+- [ ] Each configured alert rule has been triggered with a synthetic condition; PagerDuty receipt confirmed for SEV-1/2; Notify-only receipt confirmed for SEV-3 — each verification documented
+- [ ] `catalogs/grid-health.json` (or equivalent) records the per-source wiring state for `dev`; staging/prod marked deferred per ADR-0033
+- [ ] `business/context/` lists deferred items: tenant-initiated SEV-1 (Notify Cloud), `hive-sync` drift-check (D4 ↔ operational reference copy)
+- [ ] No secret in any walkthrough text or repo file; the PagerDuty integration URL is read from Vault per packet 03 (invariants 8, 9)
+
+## Human Prerequisites
+- [ ] **Packet 03 must be complete** — the PagerDuty Starter account, escalation policy, and Azure Monitor integration URL must exist and be stored in Vault.
+- [ ] **Packet 04 must be complete or in progress** — Notify intake must exist for the Notify-only SEV-3 routing (the routing layer can be wired without packet 04 if the alert paths are configured to email/log-only, but verifying end-to-end requires Notify intake).
+- [ ] **ADR-0040 packet 02 must be complete** — App Insights `dev` resource provisioned (referenced by every App Insights alert rule in this packet).
+- [ ] **ADR-0030 / Audit Node alerting surfaces** — Audit must already emit the failure-path captures that ADR-0030 commits; without those, the Audit alert rules have no data.
+- [ ] **ADR-0052 budget alerts** — must already exist in `dev`; this packet extends them to add `ag-hd-pagerduty-dev`.
+- [ ] **Trigger synthetic conditions for each alert rule** — agent cannot click "trigger test" in the Azure portal; operator executes the verification.
+- [ ] **Decide deferred-items handling** — the agent can author the deferred-items list; the operator confirms tenant-initiated SEV-1 stays deferred until Notify Cloud lands and the `hive-sync` drift-check is a follow-on packet.
+
+## Referenced ADR Decisions
+**ADR-0054 D4 — Alert sources and routing table.** Every signal source the Grid produces routes through this table. The source declares the SEV at emission; the routing layer (Notify Communications + PagerDuty) honors it. Full table reproduced in the ADR's D4 section; this packet wires every row except the deferred tenant-initiated SEV-1.
+
+**ADR-0054 D4 — Operational reference copy.** "The table lives in this ADR for the v1 commitment; the operational reference copy lives in `repos/HoneyDrunk.Notify/runbooks/alert-routing.md` (per D10) and stays in sync via a `hive-sync` check that diffs the two." The `hive-sync` check is a follow-on; this packet creates the operational reference copy.
+
+**ADR-0040 — Telemetry backend.** App Insights resources per environment; alert rules attached.
+
+**ADR-0045 — Grid-wide error tracking.** `IErrorReporter` captures land in App Insights Failures with `problem_id` + `application_Version`; the Failures-blade alert rules consume them.
+
+**ADR-0052 — Cost discipline.** Azure Monitor budget alerts at the subscription level; this packet adds `ag-hd-pagerduty-dev` to their action group lists per D4's thresholds.
+
+**ADR-0012 — Canary failures.** Canary failure surface; the SEV-2 published-package-canary-failure rule fires through Azure Monitor.
+
+**ADR-0030 — Audit failure paths.** Audit write-path failures and ingestion latency emit captures that App Insights alert rules consume; SEV-1 / SEV-2 per D4.
+
+**ADR-0005 — Vault failure paths.** Vault unreachable and rotation failures emit captures that App Insights alert rules consume; SEV-1 / SEV-2 per D4.
+
+**ADR-0037 — Stripe webhook failures.** Stripe webhook surface in the consuming Node emits captures on webhook failure; App Insights alert rule fires the SEV-2 routing.
+
+**ADR-0027 — Notify Cloud (deferred).** Tenant in-product SEV-1 ticket surface depends on Notify Cloud; deferred.
+
+**ADR-0033 — Tag → environment mapping.** Staging/prod environments are deferred; this packet wires `dev` and documents the staging/prod re-execution path.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry — or in walkthrough docs.** The PagerDuty Azure Monitor integration URL is read from Vault per packet 03; never pasted into the walkthrough text, never committed.
+
+> **Invariant 9 — Vault is the only source of secrets.** The integration URL is read via `ISecretStore` at runtime by any code that consumes it; the portal configuration references the Vault path (Azure Monitor action group webhook config supports secret values).
+
+- **One action group per environment.** `ag-hd-pagerduty-dev` for `dev`. Staging/prod are deferred per ADR-0033.
+- **SEV-3 / SEV-4 are Notify-only or unrouted.** Do not add SEV-3 sources to the PagerDuty action group — they would burn PagerDuty's ack tax for non-paging-worthy events (D3).
+- **Coverage-window scheduling for SEV-2 outside coverage.** Per D2, SEV-2 outside coverage hours pages via Notify-only (not PagerDuty). Implement via PagerDuty's time-window scheduling or via separate action groups — match the cleanest pattern.
+- **Tenant-initiated SEV-1 is deferred** — record but do not wire.
+- **`hive-sync` drift check is deferred** — record but do not implement here.
+- **Walkthrough covers all environments** so staging/prod is a re-execution.
+
+## Labels
+`feature`, `tier-2`, `ops`, `infrastructure`, `human-only`, `adr-0054`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Wire every D4 alert source to PagerDuty (or Notify-only for SEV-3) in the `dev` environment via Azure Monitor action groups, create the operational reference copy of the D4 table at `repos/HoneyDrunk.Notify/runbooks/alert-routing.md` in the Architecture repo, and verify each wiring with a synthetic trigger.
+
+**Target:** `HoneyDrunk.Architecture` for the walkthrough doc and the operational reference copy. Azure resources land in the Azure subscription.
+
+**Context:**
+- Goal: Close the loop on the alert paths the ADR-0034–0047 wave opened. Every alert source defined by ADR-0040/0045/0052/0012/0030/0005/0037 now routes through PagerDuty (for SEV-1/2) or Notify (for SEV-3) per the D4 table.
+- Feature: ADR-0054 Incident Response rollout, Wave 3.
+- ADRs: ADR-0054 D4 (primary), ADR-0040 (App Insights), ADR-0045 (Failures-blade), ADR-0052 (budgets), ADR-0012 (canaries), ADR-0030 (Audit), ADR-0005 (Vault), ADR-0037 (Stripe), ADR-0027 (deferred Notify Cloud), ADR-0033 (deferred staging/prod).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — hard. PagerDuty integration URL must exist in Vault before any action group can target it.
+
+**Constraints:**
+- One action group per environment.
+- SEV-3 / SEV-4 are Notify-only.
+- Coverage-window scheduling for SEV-2 outside coverage.
+- Tenant-initiated SEV-1 deferred to Notify Cloud.
+- `hive-sync` drift check deferred to a follow-on packet.
+- Walkthrough covers all environments for staging/prod re-execution.
+- No secret in any walkthrough text or repo file (invariants 8, 9).
+
+**Key Files:**
+- `infrastructure/walkthroughs/alert-routing-pagerduty.md` (new)
+- `repos/HoneyDrunk.Notify/runbooks/alert-routing.md` (new in Architecture repo; packet 10 fanouts to Notify repo)
+- `catalogs/grid-health.json` (or equivalent) — wiring state
+- `business/context/` — deferred items list
+
+**Contracts:** None changed. The Azure Monitor action groups and alert rules are Azure resources; the operational reference copy is a docs artifact.

--- a/generated/issue-packets/active/adr-0054-incident-response/10-architecture-per-node-runbook-playbook.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/10-architecture-per-node-runbook-playbook.md
@@ -1,0 +1,150 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0054", "wave-4"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0054", "ADR-0036"]
+accepts: ["ADR-0054"]
+wave: 4
+initiative: adr-0054-incident-response
+node: honeydrunk-architecture
+---
+
+# Author the per-Node runbook minimum-set playbook and the rollout scaffold
+
+## Summary
+Author the **per-Node runbook minimum-set rollout playbook** at `infrastructure/walkthroughs/per-node-runbook-rollout.md` per ADR-0054 D10: scaffold the canonical `restart.md` / `rollback.md` / `health-check.md` / `common-sev2-patterns.md` (and `escalation.md` for Tier 0 Nodes) templates as boilerplate, plus the fanout strategy for each deployable Node. The playbook explains how each Node owner (the operator, with agent assistance) fills in the Node-specific content from the boilerplate. Per-Node packets that actually create the runbooks in each Node's `runbooks/` directory are a fanout downstream of this packet — they are not bundled here.
+
+## Context
+ADR-0054 D10 commits the per-Node runbook convention: every deployable Node has a `runbooks/` directory with the minimum file set (`restart.md`, `rollback.md`, `health-check.md`, `common-sev2-patterns.md`); Tier 0 Nodes per ADR-0036 also have `escalation.md`. The convention was registered in packet 01; the directories and content do not yet exist.
+
+**Why a playbook, not a fanout of per-Node packets now.** Packet 10 is the **template + strategy** packet; the per-Node creation is downstream. Reasons:
+
+- The runbook content is Node-specific — `restart.md` for `HoneyDrunk.Notify` (Container App revision restart) is different from `restart.md` for `HoneyDrunk.Vault.Rotation` (Function App restart). Each Node's runbook needs domain knowledge that an Architecture-repo-only packet cannot supply.
+- The fanout is mechanical once the boilerplate is in place. Per-Node packets are filed from the playbook; they execute in their target repos.
+- The playbook decouples the **convention** (this packet) from the **content** (per-Node packets), letting the convention land cleanly without waiting for every Node's content.
+
+**This packet authors:**
+
+1. The five boilerplate templates (`restart.md`, `rollback.md`, `health-check.md`, `common-sev2-patterns.md`, `escalation.md`) as scaffolds with TODO placeholders and per-Node guidance.
+2. The playbook doc explaining: which Nodes need which files, the per-Node-packet template (so the next round of fanout packets is mechanical), and the order of rollout (Tier 0 first per ADR-0036).
+3. The per-Node-packet template for the fanout: a `_templates/per-node-runbook-packet.md` packet template that the scope agent uses to generate one packet per Node in a follow-on initiative.
+
+**What this packet does NOT do:**
+
+- Does NOT create runbook files in the actual Node repos. That is the per-Node fanout, downstream.
+- Does NOT fill in Node-specific content. That is per-Node packet work.
+
+**Tier classification per ADR-0036.** The runbook minimum set differs by tier:
+
+- **Tier 0** (Vault, Audit, Notify Cloud tenant data — the "blast-radius" Nodes): `restart.md`, `rollback.md`, `health-check.md`, `common-sev2-patterns.md`, **`escalation.md`** (e.g., "Vault unavailability with no recovery in 30 min → page Azure support").
+- **Tier 1** (Notify, Memory, Knowledge — important but lower blast radius): the four files without `escalation.md`.
+- **Tier 2** (Pulse, Flow, Evals — important but recoverable in hours): the four files without `escalation.md`.
+- **Library-only** (Kernel, Vault [the abstraction package], Transport, Architecture, Standards): **exempt** — no `runbooks/` directory, marked `not_applicable: true` per packet 01.
+
+The deployable Node list at edit time: confirm against `catalogs/nodes.json` and ADR-0036 tier mapping. Deployable Nodes today (2026-05) include: Vault.Rotation, Notify, Communications, Pulse, (future: Audit, Operator, Notify Cloud). The Tier-0/1/2 mapping comes from ADR-0036.
+
+This is a docs/templates packet. No code, no .NET project.
+
+## Scope
+- `infrastructure/walkthroughs/per-node-runbook-rollout.md` (new) — the rollout playbook explaining tiers, file set, content expectations, and the per-Node fanout strategy.
+- `_templates/runbooks/restart.md`, `_templates/runbooks/rollback.md`, `_templates/runbooks/health-check.md`, `_templates/runbooks/common-sev2-patterns.md`, `_templates/runbooks/escalation.md` (new — boilerplate scaffolds with TODO placeholders).
+- `_templates/per-node-runbook-packet.md` (new) — the packet template the scope agent uses to fanout per-Node runbook packets in a follow-on initiative.
+- The Per-Node runbook fanout (downstream, not in this packet) — a separate initiative or set of packets executes per Node.
+
+## Proposed Implementation
+1. **Boilerplate scaffold for `restart.md`.** The file template covers: pre-flight checks (is the Node currently serving?), the exact restart command per common deploy surface (Container App revision restart, Function App restart, App Service restart), verification (which endpoint to probe, expected response), rollback hint if restart doesn't recover. Each section carries TODO placeholders for the Node-specific values (resource name, port, endpoint).
+2. **Boilerplate scaffold for `rollback.md`.** Covers: identifying the previous tagged release per ADR-0033 tag → environment mapping, the rollback command per deploy surface, verification, post-rollback follow-up. TODO placeholders for the Node-specific tag scheme and revision identifiers.
+3. **Boilerplate scaffold for `health-check.md`.** Covers: which endpoints to probe (the standard `/health` / `/ready` per the Kernel convention), which Pulse dashboard to consult, expected metric ranges, common false-positive patterns. TODO placeholders for the Node's specific endpoints and dashboards.
+4. **Boilerplate scaffold for `common-sev2-patterns.md`.** Covers: a handful (3-7) of known SEV-2-class failure modes with diagnostic steps and mitigation. Examples from the ADR: "Latency spike on tenant-facing endpoint — check downstream dependency", "Queue backup — check worker process count", etc. TODO placeholders for each Node to fill in its specific patterns.
+5. **Boilerplate scaffold for `escalation.md` (Tier 0 only).** Covers: what to escalate, where, when. Examples: "Vault unavailability with no recovery in 30 min → page Azure support via portal" (D10 example); "Audit write-path failure → engage security review channel". TODO placeholders for the Node-specific escalation paths.
+6. **The rollout playbook.**
+   - Lists every deployable Node from `catalogs/nodes.json` with its tier (per ADR-0036) and required file set.
+   - Documents the rollout order: **Tier 0 Nodes first** (Vault is critical — even though "Vault" in the catalog is currently the library, the deployable Vault.Rotation and the Vault-using Nodes need their runbooks; clarify per ADR-0005 and ADR-0006 which deployables need Vault-related runbooks).
+   - Lists the per-Node-packet template (`_templates/per-node-runbook-packet.md`) to be used in a follow-on fanout initiative.
+   - Cross-references the freshness rule from D10: "A runbook older than 90 days that has not been touched is flagged in the nightly `hive-sync` report." (The `hive-sync` enforcement is a follow-on; the convention is recorded here.)
+   - Cross-references the post-mortem update rule: "After every SEV-1/2 post-mortem, the affected Node's runbooks are reviewed and updated if relevant."
+7. **Per-Node-packet template.** A `_templates/per-node-runbook-packet.md` packet template the scope agent uses to fanout. The template has frontmatter (`target_repo`, `initiative: adr-0054-per-node-runbooks`, `wave`, `node`), a Summary section ("Create the minimum runbook set for {Node}"), a Scope section listing the four / five files, and Acceptance Criteria checking each file exists with Node-specific content. The fanout initiative is **a separate initiative folder** (`adr-0054-per-node-runbooks/`) that the scope agent generates next; not this packet's commit.
+8. **`escalation.md` only for Tier-0.** The scaffold is included for all Tier classifications but Tier-1 and Tier-2 Nodes mark it `not_applicable: true` and do not create the file in their `runbooks/` directory.
+
+## Affected Files
+- `infrastructure/walkthroughs/per-node-runbook-rollout.md` (new)
+- `_templates/runbooks/restart.md` (new — boilerplate)
+- `_templates/runbooks/rollback.md` (new — boilerplate)
+- `_templates/runbooks/health-check.md` (new — boilerplate)
+- `_templates/runbooks/common-sev2-patterns.md` (new — boilerplate)
+- `_templates/runbooks/escalation.md` (new — boilerplate, Tier-0 only)
+- `_templates/per-node-runbook-packet.md` (new — packet scaffold for the fanout)
+
+## NuGet Dependencies
+None. This packet creates only markdown template / playbook files; no .NET project.
+
+## Boundary Check
+- [x] All files in `HoneyDrunk.Architecture` — correct home for cross-Node playbooks and templates.
+- [x] No code change in any other repo.
+- [x] The per-Node runbook creation is a downstream fanout, scoped from this playbook — not in this packet's commit.
+- [x] Library-only Nodes (Kernel, Vault library, Transport, Architecture, Standards) are exempt per packet 01's `not_applicable: true` marking.
+
+## Acceptance Criteria
+- [ ] `infrastructure/walkthroughs/per-node-runbook-rollout.md` exists, lists every deployable Node from `catalogs/nodes.json` with its ADR-0036 tier and required file set, documents the rollout order (Tier 0 first), and cross-references the D10 freshness rule and the post-mortem update rule
+- [ ] Five boilerplate runbook scaffolds exist at `_templates/runbooks/restart.md`, `rollback.md`, `health-check.md`, `common-sev2-patterns.md`, `escalation.md` — each with TODO placeholders for Node-specific values
+- [ ] `_templates/per-node-runbook-packet.md` exists as a packet template the scope agent can copy for the fanout — frontmatter (`target_repo`, `initiative: adr-0054-per-node-runbooks`, `wave`, `node`), Summary, Scope, Acceptance Criteria sections — ready for placeholder substitution per Node
+- [ ] The playbook documents that the per-Node fanout is a **separate follow-on initiative** (`adr-0054-per-node-runbooks/`), not part of this packet
+- [ ] Library-only Nodes (Kernel, Vault [library], Transport, Architecture, Standards) are marked exempt; deployable Nodes (Vault.Rotation, Notify, Communications, Pulse, future Audit / Operator / Notify Cloud) carry the requirement
+- [ ] `escalation.md` is required only for Tier-0 Nodes per ADR-0036; Tier-1 / Tier-2 Nodes do not create that file
+- [ ] No runbook content is created in any Node repo by this packet — that is the per-Node fanout
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0054 D10 — Per-Node runbooks at `repos/{node}/runbooks/`.** Minimum file set: `restart.md`, `rollback.md`, `health-check.md`, `common-sev2-patterns.md` for every deployable Node; `escalation.md` additionally for Tier 0 Nodes per ADR-0036. Operator agent (ADR-0018) consults the runbooks during incident mitigation — runbook content quality directly affects operator-agent suggestion quality.
+
+**ADR-0054 D10 — Runbook freshness.** A runbook older than 90 days that has not been touched is flagged in the nightly `hive-sync` report. After every SEV-1/2 post-mortem, the affected Node's runbooks are reviewed and updated. Game days (D11) exercise the runbooks; an exercise that finds a runbook gap requires a same-day patch.
+
+**ADR-0036 — Tier classification.** Tier-0 Nodes (Vault, Audit, Notify Cloud tenant data) require the additional `escalation.md`. Tier-1 / Tier-2 Nodes do not. Library-only Nodes are exempt.
+
+**ADR-0033 — Tag → environment mapping.** `rollback.md` boilerplate references the tag → environment mapping for identifying the previous tagged release.
+
+**ADR-0054 Affected Nodes — All deployable Nodes.** "Minimum runbook set required for deployable Nodes; `health-check.md` required for all Nodes." (The "all Nodes" reading is loose — library-only Nodes are exempt per packet 01's `not_applicable: true`; the cleaner reading is "all deployable Nodes, plus `health-check.md` is the minimum-of-minimums for any Node with operational presence." This packet preserves the cleaner reading.)
+
+## Constraints
+- **Playbook + templates, not per-Node content.** This packet authors the scaffold and the strategy; the per-Node fanout is a separate downstream initiative.
+- **Tier-0 gets `escalation.md`; Tier-1/2 does not.** Follow ADR-0036's tier mapping at edit time.
+- **Library-only Nodes exempt.** Kernel, Vault library, Transport, Architecture, Standards do not have `runbooks/` directories.
+- **The `hive-sync` freshness check is a follow-on**, not part of this packet. Record as a deferred item.
+- **The per-Node-packet template is ready for fanout** but the fanout itself is a separate initiative (`adr-0054-per-node-runbooks/`).
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0054`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Author the per-Node runbook minimum-set rollout playbook, the five boilerplate scaffold templates, and the per-Node-packet template for a follow-on fanout initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make D10's runbook convention concrete via boilerplate that every Node owner (with agent assistance) fills in. The per-Node creation is downstream; this packet's job is the substrate.
+- Feature: ADR-0054 Incident Response rollout, Wave 4.
+- ADRs: ADR-0054 D10 (primary), ADR-0036 (tier classification), ADR-0033 (tag → environment mapping), ADR-0054 D11 (game days exercise runbooks — referenced).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0054 should be Accepted before its runbook convention's content lands.
+
+**Constraints:**
+- Playbook + templates only; no per-Node content in this packet.
+- Tier-0 gets `escalation.md`; Tier-1/2 does not.
+- Library-only Nodes exempt.
+- The `hive-sync` freshness check is a deferred follow-on.
+
+**Key Files:**
+- `infrastructure/walkthroughs/per-node-runbook-rollout.md` (new)
+- `_templates/runbooks/` (new — five boilerplate files)
+- `_templates/per-node-runbook-packet.md` (new — fanout packet scaffold)
+
+**Contracts:** None changed. The boilerplate templates are the scaffold consumed by the future fanout initiative.

--- a/generated/issue-packets/active/adr-0054-incident-response/11-architecture-operator-agent-runbook-amendment.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/11-architecture-operator-agent-runbook-amendment.md
@@ -1,0 +1,132 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "docs", "adr-0054", "wave-4"]
+dependencies: ["packet:10"]
+adrs: ["ADR-0054", "ADR-0018"]
+accepts: ["ADR-0054"]
+wave: 4
+initiative: adr-0054-incident-response
+node: honeydrunk-architecture
+---
+
+# Amend the operator-agent prompt template to consult per-Node runbooks during incident mitigation
+
+## Summary
+Amend the operator-agent prompt template per ADR-0054 D10: include "consult `repos/{affected-node}/runbooks/` for the affected Node before suggesting mitigations" in the agent's instructions for the Investigating / Mitigating phases of an incident. The agent's prompt amendment is the integration point that turns the per-Node runbooks (packet 10's boilerplate + the per-Node fanout's content) into mitigation suggestions during a real SEV-1/2.
+
+## Context
+ADR-0054 D10 names the operator-agent integration explicitly: "The operator agent **consumes the runbooks** when generating mitigation suggestions during the Investigating / Mitigating phases of an incident. The agent's prompt template is amended (per ADR-0018) to include 'consult `repos/{affected-node}/runbooks/` for the affected Node before suggesting mitigations.' Runbook content quality directly affects operator-agent suggestion quality; runbook neglect is a feedback loop."
+
+ADR-0018 is the **operator agent** standup ADR. The operator agent's prompt template lives where ADR-0018 establishes — likely `.claude/agents/operator.md` or `agents/operator/` in the Architecture repo (the exact location was set by ADR-0018's implementation; this packet locates and amends the established file).
+
+**Two amendment scopes:**
+
+1. **Investigating-phase guidance.** When the operator agent is suggesting investigation paths for a freshly-acked incident, the prompt instructs the agent to:
+   - Identify the affected Node(s) from the incident record's `affected_nodes` field.
+   - Read `repos/{affected-node}/runbooks/health-check.md` to know which endpoints / metrics to probe.
+   - Read `repos/{affected-node}/runbooks/common-sev2-patterns.md` to know which diagnostic paths to suggest first.
+2. **Mitigating-phase guidance.** When the operator agent is suggesting mitigations, the prompt instructs the agent to:
+   - Read `repos/{affected-node}/runbooks/restart.md` for restart paths.
+   - Read `repos/{affected-node}/runbooks/rollback.md` for rollback paths.
+   - For Tier-0 Nodes (per ADR-0036), read `repos/{affected-node}/runbooks/escalation.md` if the runbooks' direct mitigations have not resolved the incident in the appropriate time.
+
+**The amendment is additive.** ADR-0018's existing operator-agent surface is not rewritten — the runbook-consult instructions extend the existing prompt template. Match the existing convention for adding capability-specific instructions to the agent.
+
+**Coordination with packet 10.** Packet 10 created the boilerplate scaffolds and the per-Node-packet template; the per-Node runbook fanout is a separate downstream initiative. Until the fanout completes, many Node `runbooks/` directories will be empty or carry only boilerplate. The agent's prompt must handle this gracefully — if the affected Node has no populated runbook, the agent says so and proceeds with generic best-practice mitigation rather than failing. The instruction text covers this.
+
+**Hive-sync coupling.** Per ADR-0011 D4 / invariant 33, the review-agent and scope-agent context-loading sets are coupled. The operator agent's context-loading set is also coupled to its prompt template — the runbook-consult instructions are visible only if the agent reads its own prompt file at execution time, which the cloud-execution surface (ADR-0018) handles. Confirm at edit time that the prompt amendment lands in the file the cloud-execution surface reads.
+
+**This is a docs/governance packet.** No code, no .NET project. The amendment lives in the operator-agent prompt file.
+
+## Scope
+- The operator-agent prompt template (likely `.claude/agents/operator.md` or the equivalent ADR-0018-established location — locate at edit time).
+- A small note in `business/context/` (or the equivalent operator-facing reference) cross-linking the amendment to D10.
+
+## Proposed Implementation
+1. **Locate the operator-agent prompt template.** Per ADR-0018, the operator-agent prompt lives in `.claude/agents/operator.md` or the equivalent. At edit time, locate the file by searching the Architecture repo for the operator-agent prompt — the file name and structure follow the ADR-0044-established review-agent convention (`.claude/agents/{agent-name}.md`). If the operator-agent file does not yet exist (ADR-0018 may be Proposed without full implementation), this packet **conditionally creates** a stub file with the D10 amendment as its incident-handling section, and notes the dependency on ADR-0018's full standup.
+2. **Add the runbook-consult instruction.** Append (or extend the existing "Incident Mitigation" / "Operator Tasks" section, if one exists) with:
+   - **Investigating phase:** "When investigating an open incident, identify the affected Node(s) from the incident record's `affected_nodes` field. For each affected Node, read `repos/{node}/runbooks/health-check.md` to know which endpoints and metrics to probe, and `repos/{node}/runbooks/common-sev2-patterns.md` to know which diagnostic paths to suggest first. If the runbook is empty (only boilerplate) or absent, note this in the suggestion and fall back to generic Grid-wide best practices."
+   - **Mitigating phase:** "When suggesting mitigations, read `repos/{node}/runbooks/restart.md` for restart procedures and `repos/{node}/runbooks/rollback.md` for rollback procedures. For Tier-0 Nodes per ADR-0036 (Vault, Audit, Notify Cloud tenant data), also read `repos/{node}/runbooks/escalation.md` if the direct mitigations do not resolve the incident within the SEV-appropriate ack/resolve window."
+   - **Graceful-empty handling:** "If a runbook file does not exist or contains only the boilerplate TODO placeholders from `_templates/runbooks/`, treat it as absent. Suggest filling it in as a post-incident follow-up per the D10 freshness rule."
+   - **Cross-link to D10 / D11.** Note the runbook-content-quality feedback loop from D10 ("runbook neglect is a feedback loop") and the game-day exercise (D11) as the discipline that keeps runbooks fresh.
+3. **Coordinate with the review-agent and scope-agent context-loading contracts.** The review agent's context-loading set is a superset of the scope agent's (invariant 33). The operator agent's prompt amendment is not part of either set — it lives in the operator-agent's own prompt file — so this packet does not need to mirror anything in the review or scope agent files. Confirm this is correct at edit time; if the operator agent shares prompt content with another agent (via include / shared template), the amendment may need to land in the shared file.
+4. **`business/context/` cross-link.** Add a short note (or extend the existing telemetry/operator note from ADR-0040/0045 packets) cross-linking to the operator-agent runbook-consult amendment. This makes the integration point discoverable from operator-facing context, not just from the agent file.
+5. **No new ADR or invariant.** ADR-0018 governs operator-agent surface; ADR-0054 D10 is the source of this amendment. Reference both.
+
+## Affected Files
+- `.claude/agents/operator.md` (or the equivalent ADR-0018-established location — located at edit time)
+- `business/context/` (small cross-link note)
+- If a shared prompt-template file exists (e.g., an `agent-instructions.md` shared across agents), it may be the right home for the amendment — match the existing convention.
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance/agent files; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture` — `.claude/agents/operator.md` (or equivalent) and `business/context/` both live here. Routing rule "architecture, ADR, agent, sector → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] The operator agent's prompt amendment extends the existing ADR-0018-established surface — does not fork it.
+- [x] No runbook content is created in any Node repo by this packet — that is the per-Node fanout from packet 10.
+
+## Acceptance Criteria
+- [ ] The operator-agent prompt template (located by searching the Architecture repo at edit time — likely `.claude/agents/operator.md`) carries the runbook-consult instruction: read `repos/{node}/runbooks/health-check.md` + `common-sev2-patterns.md` during Investigating; read `restart.md` + `rollback.md` (+ `escalation.md` for Tier-0) during Mitigating
+- [ ] The instruction handles the empty / boilerplate / absent runbook case gracefully — agent notes the gap and falls back to Grid-wide best practices, suggests filling in as a post-incident follow-up per the D10 freshness rule
+- [ ] The amendment extends the existing operator-agent surface; does not fork it
+- [ ] If the operator-agent file does not exist (ADR-0018 not yet fully implemented), a stub file is created with the D10 amendment as its incident-handling section; the dependency on ADR-0018's full standup is documented in the PR
+- [ ] `business/context/` carries a short note cross-linking to the operator-agent runbook-consult amendment, discoverable from operator-facing context
+- [ ] No runbook content created in any Node repo — that is the per-Node fanout
+- [ ] No invariant change (the runbook-set invariant lives in packet 00)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0054 D10 — Operator-agent integration.** "The operator agent consumes the runbooks when generating mitigation suggestions during the Investigating / Mitigating phases of an incident. The agent's prompt template is amended (per ADR-0018) to include 'consult `repos/{affected-node}/runbooks/` for the affected Node before suggesting mitigations.' Runbook content quality directly affects operator-agent suggestion quality; runbook neglect is a feedback loop."
+
+**ADR-0054 D6 — Incident lifecycle.** The Investigating and Mitigating phases are explicit states in the lifecycle; the operator agent is active during both.
+
+**ADR-0054 D10 — Runbook freshness.** Runbooks older than 90 days untouched are flagged in the nightly `hive-sync` report. The amendment instructs the agent to surface the freshness gap during incident handling as a post-incident follow-up.
+
+**ADR-0018 — Operator agent standup.** ADR-0018 governs the operator agent's prompt-template surface. The amendment extends, does not fork, the existing prompt.
+
+**ADR-0036 — Tier classification.** Tier-0 Nodes have `escalation.md` in their runbook set; the agent reads `escalation.md` only for Tier-0 affected Nodes.
+
+## Constraints
+- **Extend, do not fork, the operator-agent prompt.** The runbook-consult instructions join the existing operator-agent surface — match the established format. If the file does not yet exist (ADR-0018 not fully implemented), create a stub with the D10 amendment as its incident-handling section.
+- **Graceful-empty handling.** Agent must handle absent / boilerplate-only runbooks without failing.
+- **No runbook content here.** The per-Node fanout (downstream of packet 10) creates runbook content. This packet wires the agent to *read* the runbooks.
+- **No invariant change here.** The runbook-set invariant lives in packet 00.
+- **Hive-sync coupling note.** Operator-agent prompt content is not part of the review/scope agent context-loading contracts; confirm at edit time.
+
+## Labels
+`chore`, `tier-3`, `ops`, `docs`, `adr-0054`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Amend the operator-agent prompt template (per ADR-0018) to consult `repos/{affected-node}/runbooks/` during the Investigating / Mitigating phases of an incident, with graceful handling of empty / absent runbooks.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the per-Node runbook content (packet 10 + the per-Node fanout) actionable during a real SEV-1/2 — the operator agent reads the runbooks and translates them into mitigation suggestions.
+- Feature: ADR-0054 Incident Response rollout, Wave 4.
+- ADRs: ADR-0054 D10 (primary), ADR-0018 (operator agent surface), ADR-0036 (tier classification — Tier-0 reads `escalation.md`).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:10` — hard. The per-Node runbook playbook + boilerplate templates must exist before the agent can be told to read them.
+
+**Constraints:**
+- Extend, don't fork, the operator-agent prompt.
+- Graceful-empty handling for absent / boilerplate-only runbooks.
+- No runbook content in this packet.
+- No invariant change in this packet.
+
+**Key Files:**
+- `.claude/agents/operator.md` (or equivalent — locate at edit time)
+- `business/context/` (cross-link note)
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0054-incident-response/12-architecture-game-day-doc-and-sla-language.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/12-architecture-game-day-doc-and-sla-language.md
@@ -1,0 +1,173 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0054", "wave-4"]
+dependencies: ["packet:04", "packet:06", "packet:08", "packet:09"]
+adrs: ["ADR-0054", "ADR-0036", "ADR-0027", "ADR-0052", "ADR-0037"]
+accepts: ["ADR-0054"]
+wave: 4
+initiative: adr-0054-incident-response
+node: honeydrunk-architecture
+---
+
+# Author the game-day discipline doc, schedule the first exercise, and update Notify Cloud's draft SLA language
+
+## Summary
+Author three closely-related operator-facing artifacts that close ADR-0054's process loop: (1) the **game-day discipline doc** at `business/context/game-day-discipline.md` per ADR-0054 D11 covering the scenario rotation, the 1-week-advance discipline, the post-exercise review process, and the 30-day fix deadline; (2) **the first scheduled game day** dated 30 days after ADR-0054 acceptance per D11, with a chosen scenario; (3) the **Notify Cloud draft SLA language update** per D2 ensuring published SLA reflects 09:00-21:00 ET coverage / 99.5% / 99.0%, the 15-min / best-effort ack split, and the D13 honesty constraint as a sales-conversation rail.
+
+## Context
+ADR-0054 commits two operator-facing artifacts that sit at the **end** of the rollout:
+
+- **D11 — Game days.** "Quarterly chaos exercise. The operator manually triggers a known failure mode in a non-production environment (or in production within a coordinated window when the failure mode is safe to trigger) and runs through the incident process end-to-end. First game day target: 30 days after this ADR accepts."
+- **D2 — Operator availability windows and SLA implications.** "Published SLA: 99.5% monthly uptime within coverage hours; 99.0% monthly uptime overall. Acknowledgment SLA: 15 min within coverage, best-effort outside. Resolution SLA: commitment varies by severity, with explicit out-of-hours carve-outs. ADR-0027 is a blocker for any tighter SLA than this; revising the SLA upward requires revising this ADR (D13)."
+
+This packet packages both, plus the **D13 honesty-constraint sales-rail** ("Sales conversations referencing tighter SLAs flag this ADR. The operator does not commit to tighter terms verbally or in contract drafts without ADR amendment"), into a single end-of-initiative governance landing.
+
+**Game-day discipline doc.** Lives at `business/context/game-day-discipline.md` (alongside the cost-discipline and other operator-context notes). Covers:
+
+- The seven scenarios from D11 (kill a Container App revision mid-traffic; expire a Vault secret without rotation; OOM a worker process; pull the network from a downstream dependency; simulate a runaway cost incident; simulate an Audit write-path outage; simulate a Stripe webhook failure).
+- Discipline:
+  - Scenario chosen and documented 1 week in advance.
+  - Exercise runs the full D6 lifecycle (page fires → ack → investigate → mitigate → resolve → post-mortem).
+  - Post-game-day post-mortem (per D8) identifies process gaps, runbook gaps, tooling gaps.
+  - Findings either fixed within 30 days or filed as ADR amendments / issue packets.
+- Coordination with ADR-0036 DR drills: "DR drills exercise data recovery; game days exercise process. Some scenarios qualify as both."
+- The exercise calendar — quarterly, with a fixed 4-8 hour budget per quarter ("calendared as a fixed obligation, not optional" per D11's Operational Consequences).
+- First exercise: dated **30 days after ADR-0054 acceptance** per D11. Pick one of the seven scenarios. **Recommendation: "Kill a Container App revision mid-traffic"** — the lowest-friction first scenario; exercises packet 04 (Notify paging path), packet 06 (Pulse synthetic probe), packet 09 (Azure Monitor alert routing), and packet 08 (incident-record generator) end-to-end without requiring production data risk. The actual exercise is **executed by the human** at the scheduled date (this packet schedules it but does not run it — the run is the Human Prerequisite, with the post-game-day post-mortem authored after).
+
+**Notify Cloud draft SLA language.** Lives wherever the Notify Cloud SLA draft currently lives. Per ADR-0027 (Notify Cloud Standup), Notify Cloud is a Seed Node; its public SLA is being drafted. The draft must reflect ADR-0054 D2's commitments **before** Notify Cloud GA (PDR-0002). The SLA language update covers:
+
+- The 09:00–21:00 ET 7-day coverage window — published, in tenant agreements.
+- The 99.5% within-coverage / 99.0% overall monthly uptime targets.
+- The 15-min within-coverage / best-effort outside-coverage ack split.
+- The resolution SLA carve-outs per severity.
+- D13's sales-conversation rail: "Sales conversations referencing tighter SLAs flag this ADR. The operator does not commit to tighter terms verbally or in contract drafts without ADR amendment." This is a process commitment, not customer-visible language — but it lives in the same Notify Cloud SLA / commercial-terms doc as a footer note.
+- The D12 forward-looking note: "Tenants requiring 24/7 coverage are not in our addressable market in 2026; the SLA cannot honestly be offered until a second human gains prod credentials." This is a footer / commercial-context note.
+
+**Coordination — Notify Cloud is Seed.** The actual Notify Cloud SLA artifact may not yet exist (ADR-0027 is the standup ADR, which may itself still be in early phases). The packet handles both cases:
+
+- If a Notify Cloud SLA draft exists at edit time, update it.
+- If no draft exists, create one at `business/context/notify-cloud-sla-draft.md` (or the equivalent location ADR-0027 establishes) with the D2 commitments as the v1 content. The draft is **internal until Notify Cloud GA**.
+
+**This packet sits at the end of the initiative** because the game-day exercise validates the entire paging substrate built by packets 04-09. The first game day's PR (executed by the human at the scheduled date) is itself a post-mortem-style record of the exercise per D8 / D11.
+
+**This is a docs/governance + scheduling packet.** No code, no .NET project. The first game-day exercise itself is a **Human Prerequisite** (the human runs the exercise on the scheduled date and authors the post-mortem); the packet's deliverable is the doc + the scheduled date + the SLA language.
+
+## Scope
+- `business/context/game-day-discipline.md` (new) — the game-day discipline doc covering scenarios, discipline, calendar, and the first exercise.
+- The first game-day scheduled date (30 days post-ADR-0054 acceptance) + chosen scenario, recorded in the discipline doc and on the operator's calendar (human prerequisite).
+- The Notify Cloud SLA language — update the existing draft if it exists, or create `business/context/notify-cloud-sla-draft.md` if it does not.
+- A small sales-conversation rail note (per D13) in the Notify Cloud SLA / commercial-terms doc.
+
+## Proposed Implementation
+1. **`business/context/game-day-discipline.md`.** Author the doc covering:
+   - **Cadence:** quarterly, 4-8 hours per quarter, calendared as fixed obligation.
+   - **The seven scenarios** verbatim from D11.
+   - **Discipline:** 1-week-advance scenario announcement; the full D6 lifecycle (page → ack → investigate → mitigate → resolve → post-mortem); the post-game-day post-mortem; the 30-day fix deadline or file-as-amendment.
+   - **Coordination with ADR-0036 DR drills.** DR drills exercise data recovery; game days exercise process. The doc lists which scenarios overlap (e.g., "restore a Cosmos DB from backup" is both).
+   - **First exercise:** dated 30 days after ADR-0054 acceptance. Scenario: **"Kill a Container App revision mid-traffic"** (recommended — exercises Notify paging path, Pulse synthetic probe, Azure Monitor alert routing, incident-record generator). The scheduled date is computed at packet 00 acceptance time (acceptance date + 30 days) and recorded in the doc. The operator adds the date to the operator calendar (Human Prerequisite).
+   - **Subsequent exercises:** quarterly cadence, scenario rotation starting from the first.
+   - **Post-exercise post-mortem template.** Cross-link packet 02's blameless post-mortem template; the game-day post-mortem follows the same structure (D8).
+2. **Notify Cloud SLA language.** Locate the existing Notify Cloud SLA draft. If it exists, update with the D2 commitments. If it does not exist, create `business/context/notify-cloud-sla-draft.md` with the D2 content as v1:
+   - **Coverage:** 09:00–21:00 ET, 7 days a week, paying-tenant SEV-1/2.
+   - **Uptime targets:** 99.5% within coverage; 99.0% overall, monthly.
+   - **Ack SLA:** 15 min within coverage; best-effort outside coverage.
+   - **Resolution SLA:** varies by severity with explicit out-of-hours carve-outs (cross-link the D1 severity table).
+   - **D12 forward-looking note:** tenants requiring 24/7 coverage are not in the 2026 addressable market.
+   - **D13 sales-conversation rail (footer / commercial-context):** "Sales conversations referencing SLAs tighter than the published commitments flag ADR-0054. The operator does not commit to tighter terms verbally or in contract drafts without ADR amendment. The order is: amend ADR → contract human #2 (D12 trigger) → publish the tighter SLA. Not: publish the SLA → hope to backfill."
+3. **D13 honesty-constraint rail.** A small note (or appendix in the Notify Cloud SLA doc) bound to the sales-conversation process. The agent does not edit sales templates or contract templates directly (those are operator-internal commercial documents); the note exists as a reminder. Cross-link to ADR-0054 D13.
+4. **Cross-link the game-day discipline doc from the operator-agent prompt (if appropriate).** The operator agent (per packet 11) consults runbooks during incidents; the game-day discipline doc is operator-facing context, not agent-facing. No additional agent-prompt amendment needed — but cross-link the discipline doc from `business/context/`'s index / TOC if one exists.
+5. **The first game-day exercise itself is a Human Prerequisite.** This packet schedules it; the human executes it on the scheduled date, authoring the post-mortem at `generated/incidents/post-mortems/<scheduled-date>-game-day-1.md`. The post-mortem PR closes packet 12 in spirit but **not as a packet** — the post-mortem is its own artifact.
+
+## Affected Files
+- `business/context/game-day-discipline.md` (new)
+- `business/context/notify-cloud-sla-draft.md` (new, or update if existing) — Notify Cloud SLA language
+- A cross-link in `business/context/`'s index / TOC if one exists
+
+## NuGet Dependencies
+None. This packet creates only markdown governance / context files; no .NET project.
+
+## Boundary Check
+- [x] All files in `HoneyDrunk.Architecture/business/context/` — correct home for operator-facing context.
+- [x] No code change in any other repo.
+- [x] The Notify Cloud SLA draft is operator-internal until Notify Cloud GA; this packet does not edit public-facing customer documents.
+- [x] The first game-day exercise is a Human Prerequisite — this packet does not run it.
+
+## Acceptance Criteria
+- [ ] `business/context/game-day-discipline.md` exists and covers: quarterly cadence with 4-8 hour budget; the seven D11 scenarios; the discipline (1-week-advance, full D6 lifecycle, post-exercise post-mortem per D8, 30-day fix deadline); coordination with ADR-0036 DR drills; the first exercise scheduled 30 days after ADR-0054 acceptance with scenario "Kill a Container App revision mid-traffic" (recommended); the post-exercise post-mortem template cross-link to packet 02
+- [ ] The Notify Cloud SLA draft exists (updated if previously existing; created at `business/context/notify-cloud-sla-draft.md` if not) and reflects: 09:00–21:00 ET 7-day coverage; 99.5% within / 99.0% overall monthly uptime; 15-min / best-effort ack split; per-severity resolution SLA with out-of-hours carve-outs; D12 forward-looking note; D13 sales-conversation rail footer
+- [ ] The D13 honesty-constraint rail is recorded in the Notify Cloud SLA / commercial-context doc — "amend ADR → contract human #2 → publish tighter SLA; not: publish → backfill"
+- [ ] If a `business/context/` index / TOC exists, it cross-links the game-day discipline doc
+- [ ] The first game-day exercise itself is recorded as a Human Prerequisite (the human runs it on the scheduled date and authors the post-mortem); the packet does not run the exercise
+- [ ] The first game-day's scheduled date is concrete: `ADR-0054 acceptance date + 30 days`. Compute from the actual ADR acceptance date at edit time and record in the doc
+
+## Human Prerequisites
+- [ ] **Execute the first game day on the scheduled date.** ~4-8 hours total: prep, exercise (full D6 lifecycle), post-mortem authoring. The agent cannot kill a Container App revision in mid-traffic (or whatever scenario is chosen); the operator runs the exercise.
+- [ ] **Add the scheduled date to the operator calendar.** Block 4-8 hours, marked as a fixed obligation per D11.
+- [ ] **Decide whether the Notify Cloud SLA draft is updated or created from scratch.** If ADR-0027's Notify Cloud standup has produced a draft, locate it and update; otherwise create new.
+- [ ] **No live customer SLA edit.** Notify Cloud is Seed; no paying tenants yet; the SLA draft is operator-internal until Notify Cloud GA. The agent does not edit any live customer-facing legal document.
+
+## Referenced ADR Decisions
+**ADR-0054 D11 — Game days.** Quarterly chaos exercise. Seven scenarios listed verbatim. Discipline: 1-week-advance scenario announcement; exercise runs the full D6 lifecycle; post-exercise post-mortem identifies gaps; findings fixed within 30 days or filed as ADR amendments / issue packets. First game-day target: 30 days after ADR-0054 acceptance. Pairs with ADR-0036 DR drills: DR drills exercise data recovery; game days exercise process; some scenarios qualify as both.
+
+**ADR-0054 D2 — Notify Cloud SLA implications.** Published SLA: 99.5% within-coverage / 99.0% overall monthly uptime. Acknowledgment SLA: 15 min within coverage / best-effort outside. Resolution SLA: per-severity with explicit out-of-hours carve-outs. ADR-0027 is a blocker for any tighter SLA; revising upward requires revising this ADR.
+
+**ADR-0054 D12 — On-call hand-off (forward-looking).** Tenants requiring 24/7 coverage are not in the 2026 addressable market. The trigger: second human with prod credentials + signed contract + PagerDuty onboarding. SLA cannot honestly be offered until that trigger fires.
+
+**ADR-0054 D13 — Honesty about limits.** Published commitments must reflect what one human + AI agents can actually deliver. Sales conversations referencing tighter SLAs flag this ADR; operator does not commit to tighter terms without ADR amendment. The order: amend ADR → contract human #2 → publish tighter SLA. Not: publish → backfill.
+
+**ADR-0054 D6 / D8 — Lifecycle + post-mortem.** The game-day exercise runs the full D6 lifecycle and produces a D8 post-mortem at completion.
+
+**ADR-0036 — DR drills coordination.** DR drills exercise data recovery (restore from backup, fail over); game days exercise process. Some scenarios qualify as both.
+
+**ADR-0027 — Notify Cloud (Seed).** Notify Cloud SLA draft is operator-internal until Notify Cloud GA. This packet updates / creates the draft.
+
+**ADR-0052 — Cost discipline / runaway-cost scenario.** One of the seven game-day scenarios is "simulate a runaway cost incident" — burn budget rapidly to exercise the cost-alert path.
+
+**ADR-0037 — Stripe webhook failure scenario.** One of the seven scenarios — exercises the Stripe-webhook failure path wired in packet 09.
+
+## Constraints
+- **First game day scheduled, not executed.** The exercise itself is the Human Prerequisite. The packet's deliverable is the scheduled date + chosen scenario + the doc.
+- **Notify Cloud SLA is operator-internal.** No live customer SLA edit; the draft is operator-internal until Notify Cloud GA.
+- **D13 sales-conversation rail is a process commitment**, not customer-visible language. The agent does not edit sales templates or contract templates directly — those are operator-internal commercial documents.
+- **The scheduled date is concrete.** `ADR-0054 acceptance date + 30 days` — compute from the actual acceptance date.
+- **Quarterly cadence is binding.** Subsequent exercises follow at 90-day intervals from the first.
+- **30-day fix deadline.** Game-day post-mortem findings fixed within 30 days or filed as ADR amendments / issue packets — record this discipline in the doc.
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0054`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Author the game-day discipline doc, schedule the first exercise 30 days after ADR-0054 acceptance with a recommended scenario, update Notify Cloud's draft SLA language to reflect D2 commitments, and record the D13 sales-conversation rail as a commercial-context footer.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Close the ADR-0054 rollout loop by setting up the recurring exercise that validates the paging substrate, the SLA language that publishes the honest coverage commitments, and the sales-conversation rail that protects D13.
+- Feature: ADR-0054 Incident Response rollout, Wave 4 (final packet).
+- ADRs: ADR-0054 D11 / D2 / D12 / D13 (primary), ADR-0036 (DR drills coordination), ADR-0027 (Notify Cloud SLA draft), ADR-0052 / ADR-0037 (game-day scenario sources).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:04` — hard. The game-day exercise exercises the Notify paging path.
+- `packet:06` — hard. The game-day exercise exercises the Pulse synthetic probe.
+- `packet:08` — hard. The game-day exercise uses the incident-record generator.
+- `packet:09` — hard. The game-day exercise exercises the alert-routing wiring.
+
+**Constraints:**
+- First game day scheduled, not executed (Human Prerequisite).
+- Notify Cloud SLA is operator-internal until Notify Cloud GA.
+- D13 sales-conversation rail is a process commitment, not customer-visible language.
+- Scheduled date concrete: ADR-0054 acceptance + 30 days.
+- Quarterly cadence binding for subsequent exercises.
+
+**Key Files:**
+- `business/context/game-day-discipline.md` (new)
+- `business/context/notify-cloud-sla-draft.md` (new, or update if existing)
+- `business/context/` index / TOC cross-link if one exists
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0054-incident-response/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0054-incident-response/dispatch-plan.md
@@ -1,0 +1,134 @@
+# Dispatch Plan — ADR-0054: Incident Response and On-Call Model for a One-Person Studio
+
+**Initiative:** `adr-0054-incident-response`
+**ADR:** ADR-0054 (Proposed → Accepted via packet 00)
+**Sector:** Ops / cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0054 binds the scattered incident-shaped signals the Grid already emits (App Insights alerts per ADR-0040, error captures per ADR-0045, budget alerts per ADR-0052, canary failures per ADR-0012, DR drill outcomes per ADR-0036, Audit anomalies per ADR-0030, Stripe webhook failures per ADR-0037) to a defined response process shaped by the one-person-studio constraint. The decisions: four severity levels keyed to **customer impact** (D1); a 09:00–21:00 ET / 7-day coverage window honestly published in tenant SLAs (D2); redundant paging via Notify primary + PagerDuty Starter secondary (D3); a single-source routing table mapping every signal source to a severity and recipient (D4); a single-page (fingerprint-dedup) rule that prevents alert storms from drowning a single human (D5); a seven-state incident lifecycle (D6); an incident-record template at `generated/incidents/YYYY-MM-DD-<slug>.md` with machine-readable front-matter (D7); a 5-business-day post-mortem SLA for SEV-1/2 and a blameless template (D8); tenant-facing communication via Statuspage (deferred Starter until first paying tenant) and `HoneyDrunk.Communications` templates (D9); a per-Node runbook convention at `repos/{node}/runbooks/` with a minimum file set (D10); quarterly game days (D11); a forward-looking second-human hand-off appendix gated on a specific trigger (D12); and a honesty constraint binding all published SLAs to actually-deliverable reality (D13).
+
+This initiative delivers: the three new invariants (incident-record-for-every-SEV-1/2, 5-business-day post-mortem SLA, minimum runbook set), the catalog registrations of `generated/incidents/` as a contract and `repos/{node}/runbooks/` as a per-Node convention, the D7/D8 markdown templates as concrete files plus the `HoneyDrunk.Actions` generators that scaffold them, the PagerDuty Starter account + escalation policy + webhook configuration (human/portal), the Statuspage v0 static-page fallback (human, with deferred Starter), the Notify-side primary paging path (companion-app push integration, with v0 SMS fallback), the Pulse synthetic paging-path probe, the `HoneyDrunk.Communications` tenant-email templates per D9, the Azure Monitor → PagerDuty webhook wiring per the D4 routing table, the per-Node runbook minimum-set rollout playbook, the operator-agent prompt-template amendment per D10, the game-day-discipline doc and the first game-day schedule per D11, and the Notify Cloud draft-SLA language update per D2.
+
+**13 packets across 4 waves**, targeting **5 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Notify`, `HoneyDrunk.Communications`, `HoneyDrunk.Pulse`, `HoneyDrunk.Actions`). 9 `Actor=Agent`, 4 `Actor=Human` (PagerDuty provisioning, Statuspage v0 standup, Azure Monitor → PagerDuty wiring, first game-day execution).
+
+## Trigger
+
+ADR-0054 is Proposed with no scope. The forcing functions (from the ADR's Context):
+
+- **Notify Cloud GA (PDR-0002 / ADR-0027)** is the first paying-tenant surface and cannot ship a published SLA without this ADR's coverage-hour and acknowledgment commitments behind it.
+- **The ADR-0034–0047 wave just landed** introducing observability (ADR-0040), error tracking (ADR-0045), cost alerts (ADR-0052), and DR drills (ADR-0036) — each emits signals that need a defined receiving end. Without ADR-0054 every alert path is improvised.
+- **The AI-sector standup wave (ADR-0016–0025)** is about to introduce nine Nodes with operationally novel failure modes whose blast radius needs a paired response model.
+- **The one-person constraint is load-bearing.** Standard SRE on-call literature assumes multi-person rotation; pretending otherwise produces an unworkable runbook and a credibility hit at the first real incident — this is the failure mode ADR-0054 exists to prevent.
+
+## Scope Detection
+
+**Multi-repo.** ADR-0054 touches `HoneyDrunk.Architecture` (acceptance, three invariants, `generated/incidents/` formalization, `repos/{node}/runbooks/` convention, the D7/D8 templates, the D9 SLA/comms language, the D10 operator-agent amendment, the D11 game-day doc, and a number of human/portal walkthroughs), `HoneyDrunk.Notify` (the primary paging path — companion-app push integration or v0 SMS fallback through Notify), `HoneyDrunk.Communications` (the D9 tenant-email templates), `HoneyDrunk.Pulse` (the D3 synthetic paging-path probe), and `HoneyDrunk.Actions` (the D7/D8 incident-record + post-mortem generators). The D10 minimum runbook set is fanned out via a playbook (packet 10) rather than as premature per-Node packets — that is a deliberate decision to keep the rollout incremental.
+
+## Wave Diagram
+
+### Wave 1 (governance — no dependencies)
+
+- [ ] **00** — Architecture: Accept ADR-0054, add the three new invariants (every SEV-1/2 produces an incident record; every SEV-1/2 has a post-mortem filed within 5 business days; every deployable Node has the minimum runbook set), register the initiative. `Actor=Agent`.
+- [ ] **01** — Architecture: register `generated/incidents/` as a contract, add `repos/{node}/runbooks/` as a per-Node convention, add the `runbook_compliance` field to `catalogs/contracts.json` per Node. `Actor=Agent`. Blocked by: 00.
+- [ ] **02** — Architecture: author the D7 incident-record template and the D8 blameless post-mortem template as concrete markdown files at `generated/incidents/_templates/`. `Actor=Agent`. Blocked by: 00.
+- [ ] **03** — Architecture: provision the **PagerDuty Starter** account, escalation policy, and Azure Monitor / Stripe / generic-webhook integrations. `Actor=Human`. Blocked by: 00.
+
+### Wave 2 (the paging substrate and tenant comms — depend on Wave 1)
+
+- [ ] **04** — Notify: implement the primary paging path — companion-app push integration with the v0 SMS fallback. `Actor=Agent`. Blocked by: 00, 03 (the operator's phone number / Notify-side push credentials surface during PagerDuty setup).
+- [ ] **05** — Communications: author the D9 tenant-email templates (SEV-1/2 declaration, update, resolution) in the `HoneyDrunk.Communications` template catalog. `Actor=Agent`. Blocked by: 00.
+- [ ] **06** — Pulse: add the synthetic paging-path probe — every 5 minutes fires a fake SEV-3 and verifies arrival on both Notify and PagerDuty paths; either silent for > 15 minutes the other fires a SEV-2 about the missing path. `Actor=Agent`. Blocked by: 03, 04.
+- [ ] **07** — Architecture: provision **Atlassian Statuspage** — the v0 static-page fallback under `Studios.HoneyDrunk.com` now, with the Statuspage Starter ($29/month) adoption deferred to first paying tenant. `Actor=Human`. Blocked by: 00.
+
+### Wave 3 (routing wiring and the generators — depend on Wave 2)
+
+- [ ] **08** — Actions: author the incident-record and post-mortem markdown generators as a reusable workflow / CLI scaffold that drops a pre-filled file into `generated/incidents/` from the template. `Actor=Agent`. Blocked by: 02.
+- [ ] **09** — Architecture (Human): wire every alert source from the D4 routing table to PagerDuty via webhook — Azure Monitor → PagerDuty action groups for App Insights alerts (ADR-0040), `IErrorReporter` captures (ADR-0045), Azure Monitor budget alerts (ADR-0052), canary failures (ADR-0012), Audit and Vault failure paths (ADR-0030 / ADR-0005), Stripe webhook failures (ADR-0037). `Actor=Human`. Blocked by: 03.
+
+### Wave 4 (per-Node and operator surface, then exercise — depend on Wave 3)
+
+- [ ] **10** — Architecture: author the per-Node runbook minimum-set rollout playbook — the `restart.md` / `rollback.md` / `health-check.md` / `common-sev2-patterns.md` / `escalation.md` scaffold and the per-Node fanout strategy. `Actor=Agent`. Blocked by: 00.
+- [ ] **11** — Architecture: amend the operator-agent prompt template (per ADR-0018) to consult `repos/{affected-node}/runbooks/` during the Investigating / Mitigating phases. `Actor=Agent`. Blocked by: 10.
+- [ ] **12** — Architecture: author the D11 game-day discipline doc, the game-day-scaffolding scenario list, and schedule the **first game day for 30 days post-acceptance**. Update Notify Cloud's draft SLA language per D2. `Actor=Human` for the first game-day **execution**; `Actor=Agent` for authoring the doc and scheduling. Split: keep both in one packet, classify as Agent for the authoring (the human-prerequisites cover the execution). Blocked by: 04, 06, 08, 09 (the game day exercises the whole paging substrate).
+
+Packets within a wave run in parallel where their dependencies allow. Most Wave 2/3 packets depend on Wave 1 governance + PagerDuty provisioning landing first; Wave 4 sequences after the paging substrate and generators are in place because the game day exercises that substrate end-to-end.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0054](./00-architecture-adr-0054-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [Incident + runbook catalog registration](./01-architecture-incident-catalog-and-runbook-convention.md) | Architecture | Agent | 1 | 00 |
+| 02 | [D7 incident-record + D8 post-mortem templates](./02-architecture-incident-and-post-mortem-templates.md) | Architecture | Agent | 1 | 00 |
+| 03 | [PagerDuty Starter provisioning + escalation policy](./03-architecture-pagerduty-provisioning.md) | Architecture | Human | 1 | 00 |
+| 04 | [Notify primary paging path](./04-notify-primary-paging-path.md) | Notify | Agent | 2 | 00, 03 |
+| 05 | [Communications tenant-email templates](./05-communications-tenant-incident-email-templates.md) | Communications | Agent | 2 | 00 |
+| 06 | [Pulse synthetic paging-path probe](./06-pulse-paging-path-synthetic-probe.md) | Pulse | Agent | 2 | 03, 04 |
+| 07 | [Statuspage v0 static + deferred Starter](./07-architecture-statuspage-provisioning.md) | Architecture | Human | 2 | 00 |
+| 08 | [Actions incident + post-mortem generators](./08-actions-incident-and-post-mortem-generators.md) | Actions | Agent | 3 | 02 |
+| 09 | [Azure Monitor → PagerDuty wiring per D4](./09-architecture-alert-routing-pagerduty-wiring.md) | Architecture | Human | 3 | 03 |
+| 10 | [Per-Node runbook minimum-set playbook](./10-architecture-per-node-runbook-playbook.md) | Architecture | Agent | 4 | 00 |
+| 11 | [Operator-agent runbook-consult amendment](./11-architecture-operator-agent-runbook-amendment.md) | Architecture | Agent | 4 | 10 |
+| 12 | [Game-day doc + first scheduled exercise + SLA language](./12-architecture-game-day-doc-and-sla-language.md) | Architecture | Agent | 4 | 04, 06, 08, 09 |
+
+## Invariant Numbering
+
+Packet 00 adds **three** new invariants per ADR-0054's Consequences/Invariants section: every SEV-1/2 produces a record in `generated/incidents/` with the D7 front-matter; every SEV-1/2 has a post-mortem filed within 5 business days of close; every deployable Node has the D10 minimum runbook set. The verified current maximum invariant number in `constitution/invariants.md` is **53**. ADR-0054 lands in the 12-ADR batch whose numbers above 51 are pre-reserved; the three numbers used here are appended sequentially in the next available batch slot. Record the chosen numbers in packet 00. Include the batch note: "These invariants are pre-reserved as part of a 12-ADR batch; if any invariant from outside this batch lands first, shift upward, never reuse."
+
+## Cross-Cutting Concerns
+
+### Coordination with sibling ADRs
+
+ADR-0054 is the receiving end for signals defined by:
+
+- **ADR-0040 (Telemetry Backend)** — App Insights alerts and Azure Monitor alert rules are the primary signal source per the D4 routing table. Packet 09's PagerDuty wiring runs against the App Insights resource ADR-0040 packet 02 provisions.
+- **ADR-0045 (Grid-Wide Error Tracking)** — `IErrorReporter` captures into App Insights Failures are a signal source per D4. Packet 09 wires the Failures-blade alert rule.
+- **ADR-0052 (Cost Discipline)** — Azure Monitor budget alerts route to PagerDuty per D4. PagerDuty Starter itself is named in the cost-discipline envelope (~$21–25/month, exempt from its own budget alert).
+- **ADR-0036 (Disaster Recovery)** — DR drills produce incident records via this ADR; severity defaults map approximately to DR tiers.
+- **ADR-0030 (Audit)** — Audit write-path failures are SEV-1 per D4 (trust-substrate breach). Audit alerting wired in packet 09.
+- **ADR-0019 (Communications)** — D9 tenant-email templates land in the Communications catalog; the D9 surface is Communications-owned per ADR-0019's decision/orchestration ownership.
+- **ADR-0018 (Operator agent)** — packet 11's prompt-template amendment is governed by ADR-0018's agent-definition surface.
+- **ADR-0028 (Pulse synthetics)** — packet 06's paging-path probe runs on the Pulse synthetic-monitoring surface ADR-0028 defines.
+- **ADR-0027 (Notify Cloud)** — D2's published SLA is a Notify Cloud GA prerequisite. The in-product SEV-1 ticket surface and tenant in-product banner mentioned in D9 are deferred until Notify Cloud lands; their orchestration is noted in packet 05's referenced ADRs but not implemented here.
+
+### Site sync
+
+No site-sync flag for the ADR itself. The **Statuspage** v0 fallback (packet 07) is a static page rendered under `Studios.HoneyDrunk.com` — that surface change is delivered by the Studios website work, not by this initiative's `target_repo: HoneyDrunk.Studios` packet. The static-page content is a small static asset; updating `HoneyDrunk.Studios` to add the route is a follow-on Studios PR, scoped from packet 07's walkthrough — not a separate packet here.
+
+### Honesty constraint (D13)
+
+D13 is policy, not implementation. It surfaces in this initiative through:
+
+- Packet 12's Notify Cloud SLA language update (the SLA must reflect 09:00–21:00 ET coverage; tighter terms require an ADR amendment).
+- A note on every sales/tenant-agreement template that tighter SLAs flag this ADR (handled in packet 12's SLA-language work; the contract-template editing itself is a business workflow outside the scope of issue packets).
+- The D12 "second human" trigger is recorded in ADR-0054 as an appendix; no infrastructure work for it is done now. When the trigger fires, an ADR amendment packet is filed at that time.
+
+## Version Bumps
+
+- **`HoneyDrunk.Notify`** — packet 04 lands on the solution. The version-bump rule (invariant 27): this packet is the first ADR-0054 packet on the solution → minor bump (new paging integration). Per-package CHANGELOG entries only for packages with actual changes.
+- **`HoneyDrunk.Communications`** — packet 05 lands on the solution; first ADR-0054 packet on the solution → minor bump (new template catalog entries).
+- **`HoneyDrunk.Pulse`** — packet 06 lands on the solution; first ADR-0054 packet on Pulse → minor bump (new synthetic probe).
+- **`HoneyDrunk.Actions`** — not a versioned .NET solution; packet 08 is a workflow/YAML change. CHANGELOG updated per the repo convention if it keeps one.
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; catalog/doc/governance edits only.
+
+## Rollback Plan
+
+- **Packets 00–02 (governance/templates):** revert the PR. ADR returns to Proposed; the three invariants, catalog entries, and template files removed. No runtime impact.
+- **Packet 03 (PagerDuty provisioning):** the PagerDuty Starter account is cancellable from the PagerDuty UI (no contract — month-to-month). The escalation policy and integrations are configuration in the PagerDuty UI — deletable. The walkthrough doc remains for re-execution.
+- **Packet 04 (Notify paging path):** revert the PR; `HoneyDrunk.Notify` solution version rolls back. No tenant depends on the paging path — the paging surface is operator-internal.
+- **Packet 05 (Communications templates):** revert the PR; the Communications version rolls back. No active orchestration consumes the new templates until packet 09's alert wiring fires a SEV-1/2 — the revert is contained.
+- **Packet 06 (Pulse probe):** revert the PR; the synthetic probe stops running. The other paging paths remain operational.
+- **Packet 07 (Statuspage v0):** revert the Studios PR adding the static-page route. No external subscribers exist at v0 (the page is static, no notification surface).
+- **Packet 08 (Actions generators):** revert the PR. Incident records and post-mortems can be authored manually from the template files (packet 02) until the generator returns.
+- **Packet 09 (alert wiring):** delete the PagerDuty webhook integrations and the Azure Monitor action-group webhook configuration in the portal. Alerts revert to the pre-ADR state (App Insights / Azure Monitor email-only or unrouted).
+- **Packet 10–11 (runbook playbook + operator-agent amendment):** revert the PRs. Docs only.
+- **Packet 12 (game-day doc + SLA language):** revert the PR. The first scheduled game day can be cancelled by deleting the calendar entry — no runtime impact.
+- **Substrate-level escape hatch:** D13 explicitly names "amend the ADR" as the response when commitments and capacity diverge. The ADR amendment is the architectural rollback for the *commitments themselves* — D12's second-human trigger fires when capacity changes, otherwise the SLAs stay matched to the one-person reality.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.

--- a/generated/issue-packets/active/adr-0055-feature-flags/00-architecture-adr-0055-acceptance.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/00-architecture-adr-0055-acceptance.md
@@ -1,0 +1,139 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "core", "docs", "adr-0055", "wave-1"]
+dependencies: []
+adrs: ["ADR-0055"]
+accepts: ["ADR-0055"]
+wave: 1
+initiative: adr-0055-feature-flags
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0055 — flip status, add the two feature-flag invariants, register the initiative
+
+## Summary
+Flip ADR-0055 (Feature Flag and Progressive Rollout Strategy) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, add the two new feature-flag invariants ADR-0055 commits in its Consequences/Invariants section to `constitution/invariants.md`, and register the `adr-0055-feature-flags` initiative in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0055 commits the Grid's first formal feature-flag substrate, selecting **Azure App Configuration's feature-flag surface** as the v1 backend (`Microsoft.FeatureManagement.AzureAppConfiguration`) leveraging the App Configuration resource already provisioned per ADR-0005, naming three flag categories (`release`, `permission`, `operational`) with distinct lifecycle policies, placing `IFeatureGate` in `HoneyDrunk.Kernel.Abstractions`, and standing up a new Node `HoneyDrunk.FeatureFlags` for the concrete App-Configuration-backed implementation and the `TenantTargetingFilter`.
+
+The ADR decides:
+- **D1** — three flag categories: `release` (days–weeks; mandatory `expires_on`, default 90 days; expired = CI failure), `permission` (long-lived; annual review; off unless tenant entitled), `operational` (long-lived kill-switch; intentionally rarely flipped).
+- **D2** — backend: Azure App Configuration's feature-flags surface (`Microsoft.FeatureManagement.AzureAppConfiguration`); no new vendor — leverages the existing App Configuration resource per ADR-0005.
+- **D3** — targeting: built-in percentage + time-window filters plus one custom filter `TenantTargetingFilter` (reads `RequestContext.TenantId` / `Tier` per ADR-0026, falls back to a default rollout percentage).
+- **D4** — `IFeatureGate` in `HoneyDrunk.Kernel.Abstractions`; concrete implementation in the new Node `HoneyDrunk.FeatureFlags`; `InMemoryFeatureGate` in `HoneyDrunk.Kernel.Abstractions.Testing` per invariant 15.
+- **D5** — naming `{category}.{node}.{feature}` (kebab-case `feature` segment); validated at registration; regex `^(release|permission|operational)\.[a-z0-9]+\.[a-z0-9-]+$`.
+- **D6** — per-Node `featureflags.json` registry + CI validation (every used flag registered, every registered flag used or `expected_orphan: true`, expiry/review enforcement).
+- **D7** — release flags hard-expire on `expires_on`; permission/operational require annual review (warning, not gate).
+- **D8** — per-tenant policy: flags drive code paths, not UX text; flags are NOT a stand-in for `Capabilities` authorization (ADR-0051); permission flips are audited per ADR-0030.
+- **D9** — local-dev affordance: dev defaults on, staging/prod/ci default off, via per-label App Configuration values.
+- **D10** — observability: every evaluation emits a `feature_flag_evaluated` log line via `HoneyDrunk.Pulse` (per ADR-0040); hotpath flags sampled at 1% with explicit `hotpath: true` marking; permission and operational flips are audit events per ADR-0030.
+- **D11** — operator surface: `operator flags …` subcommand (list/show/enable/disable/expire/review-due).
+- **D12** — flags-vs-config boundary: boolean enablement with lifecycle = flag; typed value config = config; CI validator refuses non-boolean flags.
+- **D13** — anti-patterns enforced by the review agent: flag-checking in tight loops, flag-as-authorization-check, flag without `RequestContext` access, string-concatenation flag names, long-lived release flags, permission flags that only affect UX text.
+- **D14** — phased rollout: Phase 1 contracts + `HoneyDrunk.FeatureFlags` Node standup; Phase 2 CI validation + Notify pilot; Phase 3 Operator CLI; Phase 4 Notify.Cloud (deferred); Phase 5 PDR consumers (deferred); Phase 6 escalation evaluation (deferred).
+- **D15** — escalation triggers documented (LaunchDarkly / GrowthBook).
+- **D16** — relationship to ADR-0015 (orthogonal — Container Apps revisions split deploy traffic; flags toggle code paths within a single revision), ADR-0005 (extended — same App Configuration resource), ADR-0030 (extended — flip events are audit events), ADR-0053 (completed — trunk-based dev's flag prerequisite is now provided).
+
+ADR-0055 is a **policy / contract / new-Node** ADR. The concrete code — `IFeatureGate` in Kernel, the `HoneyDrunk.FeatureFlags` Node standup, the App Configuration walkthrough, the CI validation workflow + Roslyn analyzer, the Notify pilot, the Operator CLI, the governance docs — lands in packets 01–09 of this initiative. Every other packet references ADR-0055's D-decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0055-feature-flag-and-progressive-rollout-strategy.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0055 row Status column to Accepted.
+- `constitution/invariant-reservations.md` — claim the next free block (size 2) above the current ceiling for ADR-0055, adding a row to the **Active Reservations** table.
+- `constitution/invariants.md` — add the two new feature-flag invariants (see Proposed Implementation for exact text) at the two reserved numbers (see Constraints).
+- `initiatives/active-initiatives.md` — register the `adr-0055-feature-flags` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0055 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update the ADR-0055 index row in `adrs/README.md` to Accepted.
+3. **Read `constitution/invariant-reservations.md` at edit time.** Compute the next free invariant block above the highest claim in the **Active Reservations** table (`max + 1`). The ADR-0055 block size is **2** (the two invariants below). At scoping time the ceiling is **61** (ADR-0051 holds 54–57); confirm at edit time and use the live `max + 1`.
+4. Add a new row to the **Active Reservations** table in `constitution/invariant-reservations.md` claiming that block for ADR-0055. Row shape: `<NA>-<NB> | ADR-0055 | Proposed | Feature-flag substrate (`{N-FLAG-GATE}`, `{N-FLAG-NAMING}`). Packet 00 at `generated/issue-packets/active/adr-0055-feature-flags/00-architecture-adr-0055-acceptance.md`.`
+5. Add two new invariants to `constitution/invariants.md` at the two reserved numbers (`{N-FLAG-GATE}`, `{N-FLAG-NAMING}`) — the values claimed in step 4. Never reuse a claimed number; never collide with any other Active Reservation. The text, taken verbatim-in-substance from ADR-0055's Consequences "Invariants" section:
+   - **Feature flags are evaluated through `IFeatureGate`, never via direct SDK calls to `Microsoft.FeatureManagement` or the App Configuration client.** Preserves backend reversibility (D15 escalation), audit hookup (D10), and PII scrubbing on log emission. See ADR-0055 D4, D10, D15.
+   - **Feature-flag names follow `{category}.{node}.{feature}` and are registered in the consuming Node's `featureflags.json` before first use.** CI gate per ADR-0055 D6; regex `^(release|permission|operational)\.[a-z0-9]+\.[a-z0-9-]+$`; the category prefix makes the lifecycle policy (D1, D7) visible at every use site.
+   - Create a new `## Feature Flag Invariants` section. The file's existing sectioning convention groups invariants by topic — Dependency, Context, Secrets, Packaging, Testing, AI, Audit, etc. Feature flags is a new cross-cutting topic and warrants its own section. Place it after the `## Audit Invariants` section (or after whichever section ends the current file at edit time).
+6. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder. Use the existing initiative entry pattern (Status, Scope, Initiative slug, Board link, Description, per-wave Tracking lists, Exit criteria).
+
+## Affected Files
+- `adrs/ADR-0055-feature-flag-and-progressive-rollout-strategy.md`
+- `adrs/README.md`
+- `constitution/invariant-reservations.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0055 header reads `**Status:** Accepted`
+- [ ] The ADR-0055 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariant-reservations.md` carries a new row in the **Active Reservations** table claiming a contiguous block of size 2 for ADR-0055 at the live `max + 1` (the ceiling above any existing Active Reservation), with packet 00's path in the Notes column
+- [ ] `constitution/invariants.md` carries the two new feature-flag invariants (flags evaluated through `IFeatureGate` only; flag names follow `{category}.{node}.{feature}` and are registered in `featureflags.json`) under a new `## Feature Flag Invariants` section, each citing ADR-0055
+- [ ] The two new invariants use exactly the numbers claimed in `invariant-reservations.md` — never reuse a claimed number; never collide with any other Active Reservation
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0055-feature-flags` initiative with a packet checklist mirroring this folder's `dispatch-plan.md` wave structure
+- [ ] No catalog schema change in this packet (catalog updates land in packet 01)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0055 D4 — `IFeatureGate` in Kernel.Abstractions; backing in HoneyDrunk.FeatureFlags.** The flag-system abstraction is `IFeatureGate` in `HoneyDrunk.Kernel.Abstractions`; concrete implementation in the new Node `HoneyDrunk.FeatureFlags`; `InMemoryFeatureGate` in `HoneyDrunk.Kernel.Abstractions.Testing` per invariant 15. Folding the implementation into Kernel would couple Kernel to App Configuration and force a Kernel version bump to swap providers — the exact pattern the Abstractions split is designed to prevent.
+
+**ADR-0055 D5 — Naming `{category}.{node}.{feature}`.** Three dot-separated segments: `category` is one of `release` / `permission` / `operational`; `node` is the lowercase owning Node; `feature` is the kebab-case feature identifier. Enforced at registration by the regex `^(release|permission|operational)\.[a-z0-9]+\.[a-z0-9-]+$` (D6).
+
+**ADR-0055 D6 — Per-Node `featureflags.json` + CI validation.** Each Node consuming flags declares them in a `featureflags.json` file at `src/HoneyDrunk.<Node>/featureflags.json`. CI enforces: every flag used in code is registered (Roslyn analyzer); every registered flag is used or marked `expected_orphan: true`; naming convention; category coherence; release-flag expiry; permission/operational annual-review-due warnings.
+
+**ADR-0055 D10 — Observability.** Every evaluation emits a `feature_flag_evaluated` log line via `HoneyDrunk.Pulse` (per ADR-0040), sampled at 1% for hotpath flags. Permission and operational flips are audit events per ADR-0030.
+
+**ADR-0055 D15 — Escalation path.** App Configuration is the v1 default; the documented escalation triggers (operator workflow pain past ~100 flags, experimentation needs, multi-tenant operator delegation, cost) point to LaunchDarkly or self-hosted GrowthBook. The substrate (`IFeatureGate`, naming, lifecycle, audit hooks, operator CLI) survives the swap; only the backing changes. **Invariant 1 (the first new one) — "evaluated through `IFeatureGate`, never via direct SDK calls" — is what makes the swap possible.**
+
+**ADR-0055 Consequences — Invariants.** ADR-0055 adds exactly two invariants: (1) feature flags are evaluated through `IFeatureGate`, never via direct SDK calls; (2) feature-flag names follow `{category}.{node}.{feature}` and are registered in `featureflags.json` before first use.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0055 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbering goes through `constitution/invariant-reservations.md`.** That file is the single coordination surface for in-flight Proposed ADRs; ADR-0055 is not in any pre-reserved batch and must claim its block through `invariant-reservations.md`. At scoping the ceiling is **61** (ADR-0051 holds 54–57); recompute `max + 1` at edit time and claim a contiguous block of size 2. If a sibling ADR's packet 00 lands first, `git pull` produces a conflict on `invariant-reservations.md` — resolve by shifting upward to the new `max + 1`, updating the new invariant numbers in `constitution/invariants.md` to match, and force-pushing the rebased branch (this packet has no `{N-*}` references to update outside `invariants.md` because the two new invariants are stated by content, not by number, in the packets that consume them).
+- **New section.** The two feature-flag invariants are a new cross-cutting topic; create a `## Feature Flag Invariants` section rather than appending to an unrelated section. Place it after the `## Audit Invariants` section (or at the file end if a sibling ADR-acceptance packet has added a section there first).
+- **Initiative slug length.** `adr-0055-feature-flags` is 22 characters — well under the 39-char `initiative:` slug limit and the 50-char GitHub label cap. No truncation needed.
+
+## Labels
+`chore`, `tier-3`, `core`, `docs`, `adr-0055`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0055 to Accepted, add the two feature-flag invariants to `constitution/invariants.md`, and register the feature-flags initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0055 so the remaining packets in this initiative can reference its decisions as live rules.
+- Feature: ADR-0055 Feature Flag and Progressive Rollout Strategy rollout, Wave 1.
+- ADRs: ADR-0055 (primary), ADR-0008 (initiative/packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0055 stays Proposed until this PR merges.
+- Claim the invariant block via `constitution/invariant-reservations.md` (add a row to **Active Reservations** at the live `max + 1`, block size 2). Use those exact numbers when writing the two invariants into `constitution/invariants.md`. Never reuse a claimed number; resolve any merge conflict on `invariant-reservations.md` by shifting upward to the new ceiling.
+- Create a new `## Feature Flag Invariants` section after `## Audit Invariants`.
+
+**Key Files:**
+- `adrs/ADR-0055-feature-flag-and-progressive-rollout-strategy.md`
+- `adrs/README.md`
+- `constitution/invariant-reservations.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0055-feature-flags/01-architecture-featureflags-catalog-and-node-registration.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/01-architecture-featureflags-catalog-and-node-registration.md
@@ -1,0 +1,155 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "core", "docs", "adr-0055", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0055"]
+accepts: ["ADR-0055"]
+wave: 1
+initiative: adr-0055-feature-flags
+node: honeydrunk-architecture
+---
+
+# Register the IFeatureGate contracts and the new HoneyDrunk.FeatureFlags Node in the Grid catalogs
+
+## Summary
+Record ADR-0055's new contract surface and the new Node `HoneyDrunk.FeatureFlags` as catalog data: register `IFeatureGate`, `ITargetingContext`, and `InMemoryFeatureGate` under the `honeydrunk-kernel` Node in `catalogs/contracts.json`; add the new Node entry `honeydrunk-featureflags` to `catalogs/nodes.json` and `catalogs/grid-health.json`; add the new Node and its dependency on `HoneyDrunk.Kernel.Abstractions` to `catalogs/relationships.json` (`exposes.contracts` for the FeatureFlags Node, `consumes_detail` enrichment for downstream Notes); append the new type names to the `honeydrunk-kernel` entry's `exposes.contracts` array.
+
+## Context
+ADR-0055 D4 adds new contracts to `HoneyDrunk.Kernel.Abstractions` — `IFeatureGate`, `ITargetingContext`, and the supporting variant/feature types — and a test fixture (`InMemoryFeatureGate`) in `HoneyDrunk.Kernel.Abstractions.Testing` per invariant 15. ADR-0055 D4 also stands up a **new Node `HoneyDrunk.FeatureFlags`** for the concrete `Microsoft.FeatureManagement.AzureAppConfiguration`-backed implementation and the `TenantTargetingFilter` (D3).
+
+The Grid catalogs are the discoverability surface:
+- `catalogs/nodes.json` lists every Node with descriptive metadata; `honeydrunk-featureflags` does not yet exist there.
+- `catalogs/grid-health.json` tracks per-Node release state (`signal`, `version`, `canary_status`, `last_release`, `active_blockers`).
+- `catalogs/contracts.json` registers each Node's contracts in its node block's `interfaces` array.
+- `catalogs/relationships.json` lists each Node's contract names under `exposes.contracts` and per-Node dependency `consumes_detail`.
+
+This packet keeps all four catalogs accurate so packets 04–09 read a correct graph. The Cosmos analogue from ADR-0042 packet 01 (records the Kernel contract surface; backing-package registration lives in the backing packet) is followed here: this packet records the **contract** surface in `honeydrunk-kernel` and the **new Node entry** for `honeydrunk-featureflags`. Packet 05 (the FeatureFlags Node standup) will fill in the concrete package list under `honeydrunk-featureflags` and its `exposes.contracts` once the package names are settled.
+
+This is a catalog/docs packet. No code, no .NET project.
+
+## Scope
+- `catalogs/nodes.json` — add the new Node entry `honeydrunk-featureflags`, matching the existing Node-entry shape (id/type/name/public_name/short/description/sector/signal/cluster/energy/priority/flow/tags/links/long_description). nodes.json has **no** `exposes` field; do not invent one.
+- `catalogs/grid-health.json` — add the per-Node release-state entry for `honeydrunk-featureflags` (signal `Seed`, version `0.0.0`, canary_status `none`, last_release `null`, active_blockers `["Repo not yet scaffolded — standup in packet 05"]`).
+- `catalogs/contracts.json` — locate the node block whose `node` value is `honeydrunk-kernel`; append the new contract entries from ADR-0055 D4 to that block's `interfaces` array.
+- `catalogs/relationships.json` — append the new type names to the `honeydrunk-kernel` entry's `exposes.contracts` array; add a new top-level entry for `honeydrunk-featureflags` listing its dependency on `honeydrunk-kernel` (via `HoneyDrunk.Kernel.Abstractions`); for each Node that will consume `IFeatureGate` in this initiative (Notify per packet 07; Operator per packet 08), add `honeydrunk-featureflags` to the Node's `consumes` array and populate `consumes_detail["honeydrunk-featureflags"]`. For Operator specifically (packet 08 also consumes the Audit substrate and the App Configuration management SDK), also add `honeydrunk-audit` to the `consumes` array and populate `consumes_detail["honeydrunk-audit"]`.
+
+- **Stale `IAuditLog` on `honeydrunk-operator` (out-of-scope cleanup, noted here).** `catalogs/relationships.json` still lists `IAuditLog` under `honeydrunk-operator`'s `exposes.contracts` (line ~328 at scoping). ADR-0030 already relocated `IAuditLog` to the `honeydrunk-audit` Node (and `catalogs/contracts.json` reflects that — its `honeydrunk-operator` block carries a "RELOCATED" note). This drift is **out of scope for this packet** — fixing it would mix ADR-0030 cleanup with ADR-0055 work. File a follow-up packet against ADR-0030 (or amend the `adr-0030-audit` initiative if it is still in flight) to remove `IAuditLog` from `honeydrunk-operator`'s `exposes.contracts` array. This packet's Operator edits only add new entries to `consumes` / `consumes_detail`; do not touch `honeydrunk-operator.exposes.contracts`.
+
+## Proposed Implementation
+1. **`catalogs/nodes.json`** — append a new Node entry for `honeydrunk-featureflags`. Use the existing pattern (see `honeydrunk-vault-rotation` or `honeydrunk-audit` as the closest precedents for a small Core-sector Node):
+   - `id: "honeydrunk-featureflags"`, `type: "node"`, `name: "HoneyDrunk.FeatureFlags"`, `public_name: "HoneyDrunk.FeatureFlags"`.
+   - `short`: "Feature-flag and progressive-rollout substrate."
+   - `description`: "Grid-wide feature-flag substrate backed by Azure App Configuration's feature-flag surface. Implements `IFeatureGate` from `HoneyDrunk.Kernel.Abstractions` with the `Microsoft.FeatureManagement.AzureAppConfiguration` library and a custom `TenantTargetingFilter` for per-tenant and per-tier targeting. Backend is swappable per ADR-0055 D15 (LaunchDarkly or GrowthBook escalation triggers)."
+   - `sector: "Core"`, `signal: "Seed"`, `cluster` (pick a coherent one — likely `platform` or `governance` — match the closest precedent), `energy: 0`, `priority` (match similar-priority Core Nodes), `flow: 0`.
+   - `tags`: `["feature-flags", "progressive-rollout", "app-configuration", "release-flags", "permission-flags", "operational-flags", "targeting"]`.
+   - `links.repo`: `"https://github.com/HoneyDrunkStudios/HoneyDrunk.FeatureFlags"`.
+   - `long_description`: overview, why_it_exists ("Trunk-based dev (ADR-0053) requires application-level flags; per-tenant entitlement requires runtime targeting; operational kill-switches require runtime control — App Configuration's feature-flag surface delivers all three with no new vendor relationship."), primary_audience ("Every Node consuming `IFeatureGate`; the operator via the `operator flags …` CLI."), value_props (D1 categories, D3 targeting, D9 dev-on inversion, D15 backend reversibility).
+2. **`catalogs/grid-health.json`** — append a new entry for `honeydrunk-featureflags`:
+   ```json
+   {
+     "id": "honeydrunk-featureflags",
+     "name": "HoneyDrunk.FeatureFlags",
+     "sector": "Core",
+     "signal": "Seed",
+     "version": "0.0.0",
+     "canary_status": "none",
+     "last_release": null,
+     "active_blockers": ["Repo not yet scaffolded — standup in packet 05 of adr-0055-feature-flags initiative"],
+     "notes": "ADR-0055 Phase 1 Node. App-Configuration-backed `IFeatureGate` + `TenantTargetingFilter`. Standup landing via the adr-0055-feature-flags initiative."
+   }
+   ```
+3. **`catalogs/contracts.json`** — locate the node block whose `node` value is `honeydrunk-kernel` (do not rely on line numbers). Append entries to that block's `interfaces` array, matching the existing `{ "name", "kind", "description" }` shape:
+   - `IFeatureGate` — `kind: interface` — "Grid-wide feature-flag evaluation surface. `IsEnabledAsync(name)` for binary flags, `IsEnabledAsync(name, context)` for explicit targeting context (off-request paths), `GetVariantAsync<T>(name, default)` for named-variant evaluation. The only sanctioned surface for flag evaluation — direct SDK consumption is forbidden per ADR-0055 invariant."
+   - `ITargetingContext` — `kind: interface` — "Targeting context for `IFeatureGate` evaluation. Carries `TenantId`, `PrincipalId`, `Tier`, plus a `Tags` dictionary for future targeting filters. Populated from `RequestContext` (per ADR-0026) by the default DI registration; constructed explicitly only for off-request paths."
+   - `InMemoryFeatureGate` — `kind: type` — "In-memory `IFeatureGate` test fixture in `HoneyDrunk.Kernel.Abstractions.Testing` (per invariant 15). Lets any Node's unit tests flip flags without depending on App Configuration. Ships with `SetFlag(name, enabled: bool)` / `SetVariant(name, value)` setup methods."
+   - Drop the leading `I` from record/type names per the Grid naming rule; interfaces keep the `I`. `InMemoryFeatureGate` is a class — no `I`.
+4. **`catalogs/relationships.json`** — three edits:
+   a. Append `IFeatureGate`, `ITargetingContext`, `InMemoryFeatureGate` to the `honeydrunk-kernel` entry's `exposes.contracts` array. Do not touch existing entries.
+   b. Add a new top-level entry for `honeydrunk-featureflags`:
+      - `consumes_detail`: `{ "honeydrunk-kernel": ["IFeatureGate", "ITargetingContext"] }` (FeatureFlags implements `IFeatureGate` from Kernel.Abstractions).
+      - `exposes.contracts`: placeholder — packet 05 fills in the concrete package contract names (`TenantTargetingFilter` is a type, not a public interface; the `HoneyDrunk.FeatureFlags` package exposes `AddFeatureFlags` DI extension). Record what is known now and leave a `TODO` comment if needed; packet 05 will finalize.
+   c. For `honeydrunk-notify` and `honeydrunk-operator`, extend the `consumes_detail["honeydrunk-kernel"]` array with `IFeatureGate` and `ITargetingContext` (the contract surface they consume from Kernel).
+   d. For `honeydrunk-notify` (packet 07): add `"honeydrunk-featureflags"` to its `consumes` array; populate `consumes_detail["honeydrunk-featureflags"]` with `["HoneyDrunk.FeatureFlags", "AddFeatureFlags"]` (the composition extension that wires the App-Configuration-backed `IFeatureGate` into Notify's host).
+   e. For `honeydrunk-operator` (packet 08): add `"honeydrunk-featureflags"` and `"honeydrunk-audit"` to its `consumes` array; populate `consumes_detail["honeydrunk-featureflags"]` with `["HoneyDrunk.FeatureFlags", "AddFeatureFlags"]`; populate `consumes_detail["honeydrunk-audit"]` with `["IAuditLog", "AuditEntry", "HoneyDrunk.Audit.Abstractions"]` (permission/operational flip events flow through `IAuditLog` per ADR-0055 D10 / ADR-0030). The Operator CLI's App Configuration management SDK consumption (`Azure.Data.AppConfiguration`, `Azure.ResourceManager.AppConfiguration`) is a third-party NuGet — it does not appear in `relationships.json` (which tracks HoneyDrunk-Node-to-Node edges only); the SDK consumption is captured in packet 08's NuGet Dependencies section.
+   f. **Out-of-scope drift, do NOT fix here.** Do not edit `honeydrunk-operator.exposes.contracts` — the stale `IAuditLog` entry there is ADR-0030 cleanup, deferred to a follow-up packet (see Scope note above). This packet only adds to `consumes` / `consumes_detail` for Notify and Operator; it does not touch their `exposes` arrays.
+
+## Affected Files
+- `catalogs/nodes.json` — new Node entry.
+- `catalogs/grid-health.json` — new release-state entry.
+- `catalogs/contracts.json` — new contract entries under `honeydrunk-kernel`.
+- `catalogs/relationships.json` — new Node edge + `exposes.contracts` + `consumes_detail` enrichment.
+
+## NuGet Dependencies
+None. This packet touches only catalog JSON; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] Catalog data only — the Kernel/FeatureFlags/Actions/Notify/Operator code lands in packets 04–08.
+
+## Acceptance Criteria
+- [ ] `catalogs/nodes.json` contains a new `honeydrunk-featureflags` Node entry matching the existing Node-entry shape, sector Core, signal Seed
+- [ ] `catalogs/grid-health.json` contains a new `honeydrunk-featureflags` release-state entry, signal Seed, version `0.0.0`, blockers listing the standup as scheduled in packet 05
+- [ ] `catalogs/contracts.json` registers `IFeatureGate`, `ITargetingContext`, `InMemoryFeatureGate` in the `honeydrunk-kernel` node block's `interfaces` array, matching the existing entry shape
+- [ ] `catalogs/relationships.json` `honeydrunk-kernel` `exposes.contracts` lists the three new type names, with all existing entries untouched
+- [ ] `catalogs/relationships.json` has a new top-level entry for `honeydrunk-featureflags` with `consumes_detail["honeydrunk-kernel"]` including `IFeatureGate` and `ITargetingContext`
+- [ ] `catalogs/relationships.json` `consumes_detail["honeydrunk-kernel"]` for `honeydrunk-notify` and `honeydrunk-operator` lists the new Kernel contracts (`IFeatureGate`, `ITargetingContext`) they will consume
+- [ ] `catalogs/relationships.json` `honeydrunk-notify.consumes` contains `"honeydrunk-featureflags"`, and `consumes_detail["honeydrunk-featureflags"]` is populated with `["HoneyDrunk.FeatureFlags", "AddFeatureFlags"]`
+- [ ] `catalogs/relationships.json` `honeydrunk-operator.consumes` contains both `"honeydrunk-featureflags"` and `"honeydrunk-audit"`, and `consumes_detail["honeydrunk-featureflags"]` and `consumes_detail["honeydrunk-audit"]` are populated (the audit detail lists `IAuditLog`, `AuditEntry`, and the `HoneyDrunk.Audit.Abstractions` package)
+- [ ] `honeydrunk-operator.exposes.contracts` is NOT modified in this packet — the stale `IAuditLog` entry there is out-of-scope ADR-0030 cleanup (see Scope)
+- [ ] All four catalog JSON files parse as valid JSON (no trailing commas, no merge conflicts, no broken arrays)
+- [ ] No invariant change in this packet (invariants land in packet 00)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0055 D4 — `IFeatureGate` in Kernel.Abstractions; concrete in `HoneyDrunk.FeatureFlags`.** `IFeatureGate` and `ITargetingContext` live in `HoneyDrunk.Kernel.Abstractions`; `InMemoryFeatureGate` lives in `HoneyDrunk.Kernel.Abstractions.Testing` per invariant 15. Concrete `Microsoft.FeatureManagement.AzureAppConfiguration`-backed implementation lives in the new Node `HoneyDrunk.FeatureFlags` so the backend can be swapped (D15 escalation) without touching Kernel.
+
+**ADR-0055 D3 — `TenantTargetingFilter` ships in `HoneyDrunk.FeatureFlags`.** A custom `IFeatureFilter` reading `RequestContext.TenantId` / `RequestContext.TenantTier` (per ADR-0026), matching against the flag's `tenants:` or `tiers:` configuration, falling back to a default rollout percentage. The only custom filter the Grid commits to at v1.
+
+**ADR-0055 D14 Phase 1 — `HoneyDrunk.FeatureFlags` Node standup.** "Stand up the `HoneyDrunk.FeatureFlags` Node with the `Microsoft.FeatureManagement.AzureAppConfiguration`-backed implementation, the `TenantTargetingFilter`, and the App Configuration label conventions per D9."
+
+**ADR-0055 Consequences — Affected Nodes.** "`HoneyDrunk.FeatureFlags` — new Node, standup governed by this ADR. Holds the `Microsoft.FeatureManagement.AzureAppConfiguration`-backed `IFeatureGate` implementation and the `TenantTargetingFilter`. Sector: Core." `catalogs/nodes.json` gains the new entry; `catalogs/contracts.json` gains `IFeatureGate` under the Kernel-published contracts.
+
+## Constraints
+- **Records drop the `I`, interfaces keep it.** Grid-wide naming rule. `IFeatureGate`, `ITargetingContext` are interfaces. `InMemoryFeatureGate` is a class — no `I`. No records ship in this contract set (`Feature` and `Variant` types are deferred to packet 04 if needed for the API surface; if records ship, they drop the `I`).
+- **nodes.json has no `exposes` field.** The contract surface lives in `relationships.json` and `contracts.json`. Do not invent an `exposes` field on the new nodes.json entry.
+- **Do not register the FeatureFlags package list yet.** Packet 05 (the Node standup) ships and registers the concrete package names (`HoneyDrunk.FeatureFlags`, `HoneyDrunk.FeatureFlags.Abstractions` if it splits, etc.). This packet records only what is known: the contract surface in `honeydrunk-kernel` and the new Node entry as Seed.
+- **JSON hygiene.** All four catalog files must parse as valid JSON after the edits. Pay attention to comma placement at the tail of arrays.
+
+## Labels
+`feature`, `tier-2`, `core`, `docs`, `adr-0055`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Register ADR-0055's `IFeatureGate` contract surface and the new `HoneyDrunk.FeatureFlags` Node in the Grid catalogs.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Keep the contract/dependency catalogs accurate so implementation packets 04–08 read a correct graph.
+- Feature: ADR-0055 Feature Flag rollout, Wave 1.
+- ADRs: ADR-0055 D3/D4/D14 (primary).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0055 should be Accepted before its contract surface is recorded as catalog data.
+
+**Constraints:**
+- Records drop the `I`; interfaces keep it; `InMemoryFeatureGate` is a class.
+- nodes.json has no `exposes` field — do not invent one.
+- Do not register the FeatureFlags package list yet — packet 05 owns that.
+- All four catalog JSON files must parse as valid JSON after edits.
+
+**Key Files:**
+- `catalogs/nodes.json` — new `honeydrunk-featureflags` Node entry.
+- `catalogs/grid-health.json` — new `honeydrunk-featureflags` release-state entry.
+- `catalogs/contracts.json` — new entries in the `honeydrunk-kernel` block's `interfaces` array.
+- `catalogs/relationships.json` — `honeydrunk-kernel` `exposes.contracts`; new `honeydrunk-featureflags` entry; `honeydrunk-notify` gains `"honeydrunk-featureflags"` in `consumes` + a `consumes_detail["honeydrunk-featureflags"]` array + `IFeatureGate`/`ITargetingContext` added to `consumes_detail["honeydrunk-kernel"]`; `honeydrunk-operator` gains `"honeydrunk-featureflags"` and `"honeydrunk-audit"` in `consumes` + matching `consumes_detail` arrays + the Kernel contracts. **Do not modify `honeydrunk-operator.exposes.contracts` here — the stale `IAuditLog` is ADR-0030 cleanup, deferred.**
+
+**Contracts:** None changed — this packet only records catalog metadata for contracts that packet 04 implements.

--- a/generated/issue-packets/active/adr-0055-feature-flags/02-architecture-featureflags-schema.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/02-architecture-featureflags-schema.md
@@ -1,0 +1,162 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "core", "docs", "adr-0055", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0055"]
+accepts: ["ADR-0055"]
+wave: 1
+initiative: adr-0055-feature-flags
+node: honeydrunk-architecture
+---
+
+# Author the featureflags-v1.json schema for per-Node featureflags.json registries
+
+## Summary
+Author the JSON Schema document `featureflags-v1.json` defining the shape of every Node's `featureflags.json` registry per ADR-0055 D6. The schema lives in the Architecture repo at `schemas/featureflags-v1.json`, is published at the canonical URL `https://schemas.honeydrunkstudios.com/featureflags-v1.json` (Studios site publishes schemas/ to that hostname per the existing schema-publishing pattern), and is the single source of truth that the CI validation workflow (packet 06) and the Roslyn analyzer (packet 06) parse against.
+
+## Context
+ADR-0055 D6 commits to a per-Node `featureflags.json` registry, cited inline in the ADR as:
+```json
+{
+  "$schema": "https://schemas.honeydrunkstudios.com/featureflags-v1.json",
+  "flags": [
+    {
+      "name": "release.notify.bulk-send",
+      "category": "release",
+      "description": "Bulk-send feature for Notify; ships in 0.4.0",
+      "owner": "HoneyDrunk.Notify",
+      "created": "2026-05-22",
+      "expires_on": "2026-08-20",
+      "expected_orphan": false
+    }
+  ]
+}
+```
+
+The schema URL is **named in the ADR** but the schema document does not yet exist. Until it does, every consuming Node's `featureflags.json` carries a `$schema` reference to a 404 URL, and the CI validation workflow (packet 06) has nothing concrete to validate against. This packet fixes both by authoring the schema and pinning it for publication.
+
+The schema must cover every field ADR-0055 D6 names, including the optional/conditional ones:
+- **Required on every flag:** `name`, `category`, `description`, `owner`.
+- **Required by category:**
+  - `category: release` requires `expires_on` (a date) and `created` (a date). Per ADR-0055 D7, default expiry is 90 days from creation; the schema enforces the *presence* of `expires_on`, not the 90-day default — the default is the operator workflow at flag creation.
+  - `category: permission` requires `annual_review_due` (a date); `expires_on` must be `null` or omitted (permission flags do not expire per D7).
+  - `category: operational` requires `annual_review_due` (a date); `expires_on` must be `null` or omitted (operational flags do not expire per D7).
+- **Optional on every flag:** `expected_orphan` (boolean, default `false`), `hotpath` (boolean, default `false`; controls the D10 1% sampling), `tags` (array of strings).
+- **Variant flags:** if the flag is a variant flag (consumed via `GetVariantAsync<T>` per D4), the entry declares `variants` (an array of `{ name, value }` objects). For binary flags, `variants` is omitted.
+
+The schema also constrains the file-root shape: `$schema` is a URL pointing to this document; `flags` is a non-empty array of flag entries.
+
+Studios site publishes `schemas/` at `https://schemas.honeydrunkstudios.com/` per the existing schema-publishing pattern. Confirm at edit time that this routing is configured; if it is not, the schema is still authored at `schemas/featureflags-v1.json` in the Architecture repo and the consumers (packet 06's validation workflow and analyzer) resolve it against the file path until Studios serves it. The ADR's URL is the **intent**; the actual served URL is a deployment detail that does not block this packet's authoring.
+
+This is a docs/schema packet. No code, no .NET project.
+
+## Scope
+- `schemas/featureflags-v1.json` (new) — the JSON Schema document.
+- `docs/feature-flags-registry-format.md` (new) — a human-readable guide to authoring `featureflags.json`, with worked examples for each category (`release`, `permission`, `operational`), the variant case, and the `expected_orphan` and `hotpath` markings. This lives alongside the schema so consumers reading the schema have prose to read.
+- Optionally, a stub README entry under `schemas/README.md` if that file exists.
+
+## Proposed Implementation
+1. **`schemas/featureflags-v1.json`** — author a JSON Schema 2020-12 document (or whichever draft the existing schema files in the repo target — match at edit time). Top-level shape:
+   - `$schema`: `"https://json-schema.org/draft/2020-12/schema"`.
+   - `$id`: `"https://schemas.honeydrunkstudios.com/featureflags-v1.json"`.
+   - `title`: `"HoneyDrunk Feature-Flags Registry v1"`.
+   - `description`: A one-paragraph description citing ADR-0055 D6 as the source.
+   - `type: "object"`, required `["$schema", "flags"]`.
+   - `properties.$schema`: a URL constant pointing at this document.
+   - `properties.flags`: `type: "array"`, `minItems: 1`, `items: { $ref: "#/$defs/flag" }`.
+2. **`$defs.flag`** — the per-flag entry shape. Use `oneOf` over the three categories so the conditional required fields are enforced:
+   - **Common required fields** (in each `oneOf` branch): `name` (string, pattern `^(release|permission|operational)\.[a-z0-9]+\.[a-z0-9-]+$` per D5), `category` (enum, one of `release` / `permission` / `operational`), `description` (non-empty string), `owner` (string, matches `HoneyDrunk.<Node>`), `created` (date).
+   - **`release` branch**: requires `expires_on` (date); allows `expected_orphan`, `hotpath`, `tags`, `variants`.
+   - **`permission` branch**: requires `annual_review_due` (date); forbids non-null `expires_on` (set `expires_on` to `null` or omit); allows `expected_orphan`, `hotpath`, `tags`, `variants`.
+   - **`operational` branch**: requires `annual_review_due` (date); forbids non-null `expires_on`; allows `expected_orphan`, `hotpath`, `tags`, `variants`.
+3. **`$defs.variant`** — shape for a single variant: `{ name: string, value: string|number|boolean|object }`. Variants are optional; presence makes the flag a variant flag.
+4. **Field semantics in the schema description text** (for human/agent readers, not enforced by JSON Schema):
+   - `expected_orphan: true` documents that the flag is intentionally consumed only by configuration paths (e.g., the operator dashboard's flag-list view), so the "every registered flag is used in code" CI rule (packet 06 D6 enforcement) does not false-positive on it.
+   - `hotpath: true` opts the flag into the 1% sampling of `feature_flag_evaluated` log emission per ADR-0055 D10. Default is 100% logging.
+   - `tags` is a free-form array for additional metadata (e.g., links to PRs, ownership detail). Not validated by CI.
+5. **`docs/feature-flags-registry-format.md`** — human-readable guide. Cover:
+   - The three categories and their lifecycle policies (D1, D7).
+   - Worked example for each: a release flag (`release.notify.bulk-send`), a permission flag (`permission.lately.video-posts`), an operational flag (`operational.pulse.collector-emit-disable`).
+   - The variant case — a release flag with three variants (`baseline`, `v2`, `v3`).
+   - The `expected_orphan` escape hatch.
+   - The `hotpath` marking and its observability consequence (D10).
+   - The naming convention (D5) and how it composes with the schema regex.
+   - The CI gates packet 06 will enforce (every used flag registered; every registered flag used or `expected_orphan`; expiry on release; naming/category coherence).
+6. **Schema URL publication.** Confirm that `https://schemas.honeydrunkstudios.com/` serves the Architecture repo's `schemas/` directory. If it does, no further action — the file at `schemas/featureflags-v1.json` will be reachable. If it does not, document the gap in the doc with a note that consumers will pin against the in-repo path until publication is wired (this is a Studios-site concern, not a packet 02 concern; file as a separate task only if the publication path is not yet configured).
+
+## Affected Files
+- `schemas/featureflags-v1.json` (new)
+- `docs/feature-flags-registry-format.md` (new)
+- `schemas/README.md` (if it exists, add a one-line entry for the new schema)
+
+## NuGet Dependencies
+None. This packet authors JSON and Markdown; no .NET project is created or modified.
+
+## Boundary Check
+- [x] Schema and docs live in `HoneyDrunk.Architecture`. The schema is the cross-Node contract for `featureflags.json`; Architecture is the right home.
+- [x] No code change in any other repo.
+- [x] The schema URL is a Studios-site serving concern, not a code change in Studios.
+
+## Acceptance Criteria
+- [ ] `schemas/featureflags-v1.json` exists as a valid JSON Schema 2020-12 (or matching the existing schema draft used in the repo) document
+- [ ] The schema's `$id` is `https://schemas.honeydrunkstudios.com/featureflags-v1.json`
+- [ ] The schema enforces the flag-name regex `^(release|permission|operational)\.[a-z0-9]+\.[a-z0-9-]+$` per ADR-0055 D5
+- [ ] The schema uses `oneOf` over the three categories such that `release` requires `expires_on`, `permission` requires `annual_review_due` (and forbids non-null `expires_on`), `operational` requires `annual_review_due` (and forbids non-null `expires_on`)
+- [ ] The schema covers optional fields: `expected_orphan` (bool, default false), `hotpath` (bool, default false), `tags` (array of strings), `variants` (array of `{name, value}`)
+- [ ] The schema validates an example `featureflags.json` matching the ADR-0055 D6 inline example
+- [ ] `docs/feature-flags-registry-format.md` is a human-readable guide covering all three categories, the variant case, `expected_orphan`, `hotpath`, the naming convention, and the CI gates
+- [ ] No invariant change in this packet (invariants land in packet 00)
+- [ ] If `schemas/README.md` exists, it lists the new schema with a one-line description
+
+## Human Prerequisites
+- [ ] Confirm that `https://schemas.honeydrunkstudios.com/` serves the Architecture repo's `schemas/` directory (the existing schema-publishing routing). If it does not, file a separate Studios-site task — packet 06's CI validation workflow and analyzer can pin to the in-repo path until the public URL is live; this packet still ships the schema file. The ADR-cited URL is the *intent*, and the schema authoring is not blocked.
+
+## Referenced ADR Decisions
+**ADR-0055 D6 — Per-Node `featureflags.json` with CI validation.** Each Node declares its flags at `src/HoneyDrunk.<Node>/featureflags.json`. The file references this schema via `$schema`. CI enforces every-flag-used-is-registered, every-registered-flag-used-or-expected-orphan, naming convention, category coherence, release-flag expiry, permission/operational annual-review-due.
+
+**ADR-0055 D5 — Naming `{category}.{node}.{feature}`.** Three dot-separated segments. Schema regex: `^(release|permission|operational)\.[a-z0-9]+\.[a-z0-9-]+$`.
+
+**ADR-0055 D7 — Flag expiry.** Release flags require `expires_on`; permission/operational require `annual_review_due` (do not expire). Default at creation for release: 90 days from creation (operator workflow, not schema-enforced).
+
+**ADR-0055 D10 — `hotpath: true` marking.** Hotpath flags sample evaluation logging at 1%; the default is 100% logging. The schema carries the marking; packet 06's runtime and emit pipeline respect it.
+
+## Constraints
+- **Schema must be valid against the JSON Schema draft used by the repo.** Check the existing schemas under `schemas/` at edit time and match the draft (likely 2020-12 or 2019-09).
+- **The `$schema` field in the schema document itself** points at the JSON Schema meta-schema; the **`$id`** is the document's own canonical URL (`https://schemas.honeydrunkstudios.com/featureflags-v1.json`).
+- **Don't enforce the 90-day default in the schema.** Per ADR-0055 D7, 90 days is the *operator workflow default at creation*. The schema enforces presence of `expires_on`; the CI workflow in packet 06 checks the value against today's date. The 90-day default is the human/tooling layer.
+- **`expected_orphan` escape hatch.** Critical for operator-only flags consumed only by the dashboard's flag-list view; without it, every operator-only flag false-positives the dual-validation check. Document this clearly.
+
+## Labels
+`feature`, `tier-2`, `core`, `docs`, `adr-0055`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Author the `featureflags-v1.json` JSON Schema and the human-readable registry-format guide.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Pin the schema that every consuming Node's `featureflags.json` references, and that packet 06's CI workflow + Roslyn analyzer validate against.
+- Feature: ADR-0055 Feature Flag rollout, Wave 1.
+- ADRs: ADR-0055 D5/D6/D7/D10 (primary).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0055 should be Accepted before the schema it pins lands.
+
+**Constraints:**
+- Match the JSON Schema draft used by the repo's existing schemas.
+- `$id` is the canonical URL; `$schema` is the meta-schema.
+- The schema enforces structure, not the 90-day expiry default (operator-workflow concern).
+- `expected_orphan` is essential — escape hatch for operator-only flags.
+
+**Key Files:**
+- `schemas/featureflags-v1.json` (new)
+- `docs/feature-flags-registry-format.md` (new)
+- `schemas/README.md` (if it exists)
+
+**Contracts:** None — the schema *is* the contract for `featureflags.json` files; this packet ships it.

--- a/generated/issue-packets/active/adr-0055-feature-flags/03-architecture-appconfig-featureflag-surface-walkthrough.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/03-architecture-appconfig-featureflag-surface-walkthrough.md
@@ -1,0 +1,124 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "core", "infrastructure", "human-only", "adr-0055", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0055", "ADR-0005"]
+accepts: ["ADR-0055"]
+wave: 1
+initiative: adr-0055-feature-flags
+node: honeydrunk-architecture
+---
+
+# Extend the App Configuration walkthrough with the feature-flag surface; seed dev/staging/prod/ci labels
+
+## Summary
+Extend the existing `infrastructure/walkthroughs/app-configuration-provisioning.md` with a new section covering ADR-0055 D2's feature-flag surface and D9's label conventions (`dev` defaults on, `staging` / `prod` / `ci` default off), and apply the walkthrough's label-seeding step in the existing `dev` App Configuration resource. This is `Actor=Human` — Azure resource changes are portal work and the developer prefers UI walkthroughs over CLI per the standing convention.
+
+## Context
+ADR-0055 D2 commits to **Azure App Configuration's feature-flags surface** as the v1 backend — leveraging the App Configuration resource **already provisioned per ADR-0005**. ADR-0055 D9 inverts the production safety default for the dev environment: `dev` flags default on, `staging` / `prod` / `ci` flags default off. The mechanism is per-label `enabled` definitions in App Configuration (the `dev`-labeled flag value carries `"enabled": true`; the `staging`/`prod`/`ci`-labeled values carry `"enabled": false`). CI validation (packet 06) enforces that every flag has both a `dev` and a non-dev label defined.
+
+App Configuration's feature-flag surface is a first-class resource type inside the existing App Configuration account — no new Azure resource, no new billing line, no new secret. The portal work is small: confirm the App Configuration account exists for `dev` (it does per ADR-0005), enable/locate the Feature Manager view, seed the label conventions per D9, and document the workflow for adding new flags going forward.
+
+The existing walkthrough lives at `infrastructure/walkthroughs/app-configuration-provisioning.md`. This packet **extends** it with a feature-flag section rather than authoring a separate doc — the two surfaces (config and flags) live in the same App Configuration resource and are best documented together. ADR-0055 D12 names the flag/config boundary; documenting both in one walkthrough keeps the boundary visible.
+
+**Provision-when-needed.** ADR-0055 D14 Phase 1 says "the App Configuration label conventions per D9." `dev` is the environment that exists now. `staging` and `prod` are still in flight per ADR-0033; their feature-flag label conventions are seeded when those environments stand up. The walkthrough covers all four labels (`dev`, `staging`, `prod`, `ci`) so the future seeding is a repeat execution, not a new packet.
+
+This packet authors the walkthrough section **and** executes the `dev` label seeding. No code, no .NET project.
+
+## Scope
+- `infrastructure/walkthroughs/app-configuration-provisioning.md` — append a new section "Feature-Flag Surface (ADR-0055)" covering the Feature Manager view, the four labels (`dev`/`staging`/`prod`/`ci`), how to add a new flag, and how to set its per-label default state per D9.
+- The dev Azure App Configuration resource — apply the D9 label conventions (this is the portal work).
+- `catalogs/grid-health.json` — optionally update the `honeydrunk-featureflags` entry's notes to record that the App Configuration feature-flag surface is provisioned/seeded for `dev` (the entry itself is added by packet 01).
+
+## Proposed Work (human-executed, Azure Portal)
+Author the walkthrough section to cover, and then execute for `dev`, the following:
+
+1. **Locate the dev App Configuration resource.** From ADR-0005's existing walkthrough, the dev App Configuration resource is `appcs-hd-shared-dev` (or whatever the existing walkthrough names it — confirm at the existing walkthrough). Open the resource in the Azure Portal.
+2. **Open the Feature Manager view.** App Configuration's left nav has a Feature Manager entry. This is the feature-flag surface — distinct from Configuration Explorer, which holds typed config (the D12 boundary).
+3. **Document the four labels.** ADR-0055 D9 names four environment labels: `dev`, `staging`, `prod`, `ci`. App Configuration uses labels to scope key values per environment (the same pattern ADR-0005 commits to for config). The walkthrough documents that every flag definition lives at **four label-scoped versions** — one per environment — and that the `dev` label's value carries `"enabled": true` by default while the others carry `"enabled": false`.
+4. **Document the new-flag workflow.** Adding a new flag is a two-step:
+   - In `featureflags.json` for the consuming Node (per packet 02's schema; per ADR-0055 D6), declare the flag with all its metadata (`name`, `category`, `description`, `owner`, `created`, `expires_on` for release / `annual_review_due` for permission/operational).
+   - In the Portal Feature Manager, create the flag, then for each of the four labels (`dev`, `staging`, `prod`, `ci`) set the per-environment enabled state per D9 (dev on, others off — unless this is a permission flag, in which case all start off and tenants are added explicitly).
+   - The walkthrough should show what the JSON in App Configuration looks like for a flag with the `TenantTargeting` filter (per ADR-0055 D3 example).
+5. **Apply the label conventions for `dev` now.** No flags exist yet (packet 07's Notify pilot is the first). The seeding for `dev` is essentially: confirm the Feature Manager view loads, confirm the resource accepts label-scoped flag values, and record in the walkthrough that the resource is ready. There is no first flag to create in this packet.
+6. **Document the access pattern.** ADR-0055 D2 says App Configuration push-refresh via Event Grid. The walkthrough notes that consuming hosts subscribe to App Configuration's Sentinel + Event Grid push-refresh so flag changes propagate in seconds, no app restart. This is a runtime/composition concern (packet 05 implements it in `HoneyDrunk.FeatureFlags`) but documenting it in the walkthrough closes the loop for the operator.
+7. **Document the Managed Identity access.** ADR-0005 commits to Managed Identity access to App Configuration; no new secret rotates for the flag surface. The walkthrough confirms the dev App Configuration resource grants the appropriate Reader role to the Managed Identity of every consuming Node (Notify per packet 07, others over time). If the role assignment is not yet wired, the walkthrough documents the portal step to add it.
+
+The section is authored to cover all four environments (`dev` now, `staging` / `prod` when ADR-0033 environments stand up). The `ci` label is unusual — `ci` is not a *deployed* environment; it is a label the CI test fixture (`InMemoryFeatureGate` per packet 04) loads when tests need to assert flag-off behavior explicitly. Document this clearly: `ci` is a tooling label, not a deployed environment, and its flag values are loaded into the test fixture by the unit-test setup code.
+
+## Affected Files
+- `infrastructure/walkthroughs/app-configuration-provisioning.md` — new "Feature-Flag Surface (ADR-0055)" section appended.
+- The dev Azure App Configuration resource — portal-applied label conventions (not a repo artifact).
+- `catalogs/grid-health.json` — optional notes update on `honeydrunk-featureflags`.
+
+## NuGet Dependencies
+None. This packet has no .NET project — it is an Azure-Portal walkthrough extension plus portal seeding.
+
+## Boundary Check
+- [x] The walkthrough extension and the optional `grid-health.json` update live in `HoneyDrunk.Architecture` — correct home for infrastructure walkthroughs and catalog metadata.
+- [x] No code change in any repo.
+- [x] Portal work lands in the Azure subscription (a vendor surface, not a Node).
+
+## Acceptance Criteria
+- [ ] `infrastructure/walkthroughs/app-configuration-provisioning.md` has a new "Feature-Flag Surface (ADR-0055)" section covering: locating the Feature Manager view, the four labels (`dev`/`staging`/`prod`/`ci`), the new-flag workflow (declare in `featureflags.json` → create in portal → set per-label enabled state per D9), the `TenantTargeting` filter JSON shape, the Event Grid push-refresh pattern, and the Managed Identity access pattern
+- [ ] The section explicitly documents D9's inversion: `dev` defaults on, `staging` / `prod` / `ci` default off; permission flags are an exception (all start off, tenants added explicitly)
+- [ ] The section documents that `ci` is a tooling label loaded into `InMemoryFeatureGate` test fixtures, not a deployed environment
+- [ ] The section is authored to cover all four environments; only `dev` is seeded in this packet (staging / prod when ADR-0033 environments land — repeat execution, not a new packet)
+- [ ] The dev App Configuration resource's Feature Manager view loads in the Portal and the resource accepts label-scoped flag values
+- [ ] Managed Identity Reader access on the dev App Configuration resource is confirmed for the Managed Identities of every Node planned to consume flags in this initiative (Notify per packet 07; Operator per packet 08 once Operator stands up)
+- [ ] No secret, instrumentation key, or connection string appears in the walkthrough or anywhere in the repo (invariant 8 — Vault is the only source of secrets per invariant 9)
+
+## Human Prerequisites
+This entire packet is `Actor=Human`. The human-executed steps are the Proposed Work list above. Specifically:
+- [ ] Azure Portal access to the subscription with rights to read/write the dev App Configuration resource.
+- [ ] The dev App Configuration resource must exist per ADR-0005 (it does — confirm via the existing `app-configuration-provisioning.md` walkthrough).
+- [ ] Confirmation of Managed Identity Reader role assignments for every consuming Node's Managed Identity. If a consuming Node's Managed Identity does not exist yet (e.g., FeatureFlags' own MI when it stands up via packet 05), the assignment is deferred until that Node lands; record the dependency in the walkthrough.
+- [ ] No actual flags are created in this packet — packet 07 (Notify pilot) creates the first flag.
+
+## Referenced ADR Decisions
+**ADR-0055 D2 — Backend: Azure App Configuration's feature-flags surface.** First-class feature-flag model inside the App Configuration resource; label-based environment scoping consistent with ADR-0005; built-in targeting filters (percentage, time-window, custom); push-refresh via Event Grid; no new vendor relationship.
+
+**ADR-0055 D9 — Local-dev affordances: dev defaults on, others default off.** Encoded via per-label `enabled` values in App Configuration. The `dev` label's flag value carries `"enabled": true`; `staging` / `prod` / `ci` labels carry `"enabled": false` unless explicitly enabled. CI validation (packet 06) enforces that every flag has both a `dev` and a non-dev label defined.
+
+**ADR-0055 D3 — `TenantTargetingFilter` JSON shape.** The walkthrough documents the on-the-wire shape (the `client_filters` block with `TenantTargeting` filter parameters `tenants`, `tiers`, `default_rollout_percentage`).
+
+**ADR-0005 — App Configuration is the config backend.** Same resource holds both config (Configuration Explorer) and flags (Feature Manager). Access is Managed Identity per ADR-0005.
+
+## Constraints
+- **No new resource.** ADR-0055 D2 explicitly leverages the existing App Configuration resource — do not create a separate flags-only resource.
+- **No secret in the walkthrough or the repo.** App Configuration is Managed-Identity-accessed per ADR-0005 (invariant 9 — Vault is the only source of secrets, applied to App Configuration's authentication). No connection string is needed for the flag surface.
+- **The `ci` label is tooling, not infrastructure.** Document this clearly — the `ci` label is consumed by `InMemoryFeatureGate` test fixtures in the test process, not by a deployed `ci` environment.
+- **Permission flags exception to D9.** D9's "dev defaults on" applies to release and operational flags. Permission flags default off in *every* environment including dev — they encode tenant entitlement and "dev defaults on" would inappropriately grant entitlement to every dev-environment caller. Document this.
+
+## Labels
+`feature`, `tier-2`, `core`, `infrastructure`, `human-only`, `adr-0055`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Extend the App Configuration walkthrough with the feature-flag surface section and seed the D9 label conventions in the dev App Configuration resource.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`. (And Azure Portal — the dev App Configuration resource.)
+
+**Context:**
+- Goal: Document the feature-flag surface as part of the existing App Configuration walkthrough so the operator has one place to read for both config and flags; apply the D9 inversion to the dev resource.
+- Feature: ADR-0055 Feature Flag rollout, Wave 1.
+- ADRs: ADR-0055 D2/D3/D9/D12 (primary), ADR-0005 (App Configuration as the backend), ADR-0033 (staging/prod environments in flight — deferred).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0055 should be Accepted before its walkthrough section lands.
+
+**Constraints:**
+- No new Azure resource — extend the existing App Configuration resource per ADR-0005.
+- No secret in walkthrough or repo (invariants 8, 9).
+- `ci` label is tooling; permission flags default off in every environment including dev.
+
+**Key Files:**
+- `infrastructure/walkthroughs/app-configuration-provisioning.md` — new section appended.
+- `catalogs/grid-health.json` — optional notes update.
+
+**Contracts:** None — portal/infra work.

--- a/generated/issue-packets/active/adr-0055-feature-flags/04-kernel-ifeaturegate-and-targeting-context.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/04-kernel-ifeaturegate-and-targeting-context.md
@@ -1,0 +1,195 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Kernel
+labels: ["feature", "tier-2", "core", "adr-0055", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0055"]
+wave: 2
+initiative: adr-0055-feature-flags
+node: honeydrunk-kernel
+---
+
+# Add IFeatureGate, ITargetingContext, and InMemoryFeatureGate to HoneyDrunk.Kernel.Abstractions
+
+## Summary
+Add the ADR-0055 feature-flag contract surface to `HoneyDrunk.Kernel.Abstractions` (and its testing companion): `IFeatureGate` (the only sanctioned surface for flag evaluation, per the new ADR-0055 invariant), `ITargetingContext` (carries `TenantId` / `PrincipalId` / `Tier` / `Tags` for targeting), supporting types as needed, and `InMemoryFeatureGate` test fixture in `HoneyDrunk.Kernel.Abstractions.Testing` per invariant 15. Pure contracts and an in-memory fixture — zero HoneyDrunk runtime dependencies on `Microsoft.FeatureManagement`. This is the version-bumping packet for the `HoneyDrunk.Kernel` solution in this initiative.
+
+## Context
+ADR-0055 D4 places `IFeatureGate` in `HoneyDrunk.Kernel.Abstractions` because Kernel is the zero-dependency contract layer every Node already consumes — the same placement precedent as `IGridContext`, `TenantId`, the lifecycle hooks, and (post ADR-0042) `IIdempotencyStore`. ADR-0055 D4 also names `InMemoryFeatureGate` in `HoneyDrunk.Kernel.Abstractions.Testing` per invariant 15 — every Node's unit tests must be able to flip flags without depending on App Configuration.
+
+This packet adds **contracts only**, plus the in-memory test fixture. The concrete `Microsoft.FeatureManagement.AzureAppConfiguration`-backed implementation and the `TenantTargetingFilter` ship from the new Node `HoneyDrunk.FeatureFlags` (packet 05). Splitting contract-from-runtime keeps `HoneyDrunk.Kernel.Abstractions` honest under invariant 1 (Abstractions have zero runtime dependencies on other HoneyDrunk packages, and only `Microsoft.Extensions.*` abstractions from outside).
+
+**`Microsoft.FeatureManagement` is NOT referenced from Kernel.Abstractions.** Per the first new ADR-0055 invariant ("feature flags are evaluated through `IFeatureGate`, never via direct SDK calls to `Microsoft.FeatureManagement` or the App Configuration client"), and per invariant 1, `HoneyDrunk.Kernel.Abstractions` defines `IFeatureGate` without any reference to the `Microsoft.FeatureManagement` package. The relationship is reversed: `HoneyDrunk.FeatureFlags` (packet 05) references `Microsoft.FeatureManagement.AzureAppConfiguration` internally and implements `IFeatureGate` on top of `IFeatureManager`; consumers depend on `IFeatureGate` only.
+
+`HoneyDrunk.Kernel` is a live Node currently at v0.7.0 (.NET 10.0). This packet is the **first packet on the `HoneyDrunk.Kernel` solution in this initiative** — per invariant 27 it bumps every non-test `.csproj` to the same new minor version (additive feature; no break). **Confirm the current version at execution time:** if ADR-0042's `0.8.0` has shipped first (the `adr-0042-idempotency` initiative is in flight at the time of scoping), this packet's bump is `0.8.0` → `0.9.0` (or the next minor); if ADR-0042 has not shipped, this packet bumps `0.7.0` → `0.8.0`. The bump rule is "next available minor"; per-package CHANGELOG entries go on `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.Kernel.Abstractions.Testing` (real functional change). The `HoneyDrunk.Kernel` runtime gets no per-package entry from this packet (alignment bump only — invariant 12/27).
+
+## Scope
+- `HoneyDrunk.Kernel.Abstractions` — new contract types:
+  - `IFeatureGate` — the evaluation interface.
+  - `ITargetingContext` — explicit targeting context for off-request evaluations.
+  - Optionally: `FeatureVariant<T>` or similar (a tiny record wrapping a named-variant result, if the API surface benefits — see Proposed Implementation step 3 for the decision rule).
+- `HoneyDrunk.Kernel.Abstractions.Testing` — new test fixture:
+  - `InMemoryFeatureGate` — implements `IFeatureGate` with in-memory state; supports `SetFlag(name, enabled)` and `SetVariant(name, value)` setup methods.
+- Every non-test `.csproj` in the solution version-bumped to the next minor (invariant 27).
+- `HoneyDrunk.Kernel.Abstractions` package `CHANGELOG.md` and `README.md` updated.
+- `HoneyDrunk.Kernel.Abstractions.Testing` package `CHANGELOG.md` and `README.md` updated.
+- Repo-level `CHANGELOG.md` gets a new entry for the bumped version.
+
+## Proposed Implementation
+1. **`ITargetingContext`** — interface exposing the targeting fields ADR-0055 D4 names. Match the ADR's exact API:
+   ```csharp
+   public interface ITargetingContext
+   {
+       string? TenantId { get; }
+       string? PrincipalId { get; }
+       string? Tier { get; }
+       IReadOnlyDictionary<string, string> Tags { get; }
+   }
+   ```
+   Provide a default record implementation (e.g., `TargetingContext` — record, no `I`) that consumers can construct directly for off-request paths. The record validates that `Tags` is non-null (empty `IReadOnlyDictionary` if no tags).
+2. **`IFeatureGate`** — interface exposing the three evaluation methods ADR-0055 D4 names:
+   ```csharp
+   public interface IFeatureGate
+   {
+       ValueTask<bool> IsEnabledAsync(string flagName);
+       ValueTask<bool> IsEnabledAsync(string flagName, ITargetingContext context);
+       ValueTask<T> GetVariantAsync<T>(string flagName, T defaultValue);
+   }
+   ```
+   - `IsEnabledAsync(string)` is the on-request path — the default DI registration (packet 05) populates `ITargetingContext` from `RequestContext` (per ADR-0026) automatically.
+   - `IsEnabledAsync(string, ITargetingContext)` is the off-request path — background workers, scheduled jobs that don't have a `RequestContext` but still need tenant-targeted flag evaluation.
+   - `GetVariantAsync<T>(string, T)` is the variant-evaluation primitive — for flags that aren't binary but return one of several named variants. The `defaultValue` is returned if the flag isn't registered or the variant can't be resolved.
+   XML-doc all three methods with the ADR's intent.
+3. **Variant return type — decide at edit time.** ADR-0055 D4 says `GetVariantAsync<T>(name, default)` returns `T`. This works directly for simple value types and strings; for richer variant metadata (e.g., the operator wants the variant name *and* its value), the implementation may want a small `FeatureVariant<T>` record (`Name`, `Value`). The decision: ship the simple `T`-returning overload now (matches the ADR exactly); add `FeatureVariant<T>` later if a consumer needs it. Do not speculatively add the richer type.
+4. **`InMemoryFeatureGate`** — in `HoneyDrunk.Kernel.Abstractions.Testing`. Implements `IFeatureGate` with three internal collections: `flags: Dictionary<string, bool>`, `variants: Dictionary<string, object>`, and an optional per-flag-targeting predicate dictionary for tenant/principal-based test scenarios. Public setup methods:
+   ```csharp
+   public InMemoryFeatureGate SetFlag(string name, bool enabled);
+   public InMemoryFeatureGate SetVariant<T>(string name, T value);
+   public InMemoryFeatureGate SetTargetedFlag(string name, Func<ITargetingContext, bool> predicate);
+   ```
+   - `IsEnabledAsync(name)` returns the value from `flags` if present, otherwise `false`.
+   - `IsEnabledAsync(name, context)` evaluates the targeting predicate if present, otherwise falls back to the binary `flags` entry, otherwise `false`.
+   - `GetVariantAsync<T>(name, default)` returns the value from `variants` cast to `T` if present and assignable, otherwise `default`.
+   - The setup methods are chainable (return `this`) so test setup reads cleanly.
+   - The fixture is **synchronously-completing** despite the `ValueTask` return — use `ValueTask.FromResult(...)` or just `return new ValueTask<bool>(...)`. No actual async work; the `ValueTask` is the interface obligation.
+5. **All public types get XML documentation** (invariant 13). For `IFeatureGate`, the XML-doc explains the ADR-0055 invariant that this is the only sanctioned evaluation surface; for `InMemoryFeatureGate`, the XML-doc explains the test-fixture-only intent and references invariant 15.
+6. **Version bump.** Bump every non-test `.csproj` in the solution to the same next-minor version in one commit. The expected target at scoping time is `0.8.0` (if ADR-0042's bump hasn't merged) or `0.9.0` (if it has). Confirm at edit time. Repo-level `CHANGELOG.md` adds a new dated version entry. `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md` and `HoneyDrunk.Kernel.Abstractions.Testing/CHANGELOG.md` each get a per-package entry describing the new contracts. The `HoneyDrunk.Kernel` runtime CHANGELOG gets NO per-package entry (alignment bump only — invariant 12/27).
+7. **README updates.** `HoneyDrunk.Kernel.Abstractions/README.md` — document `IFeatureGate` and `ITargetingContext` in the public-API section, with the ADR-0055 cross-reference and the "only sanctioned evaluation surface" note. `HoneyDrunk.Kernel.Abstractions.Testing/README.md` — document `InMemoryFeatureGate` with a usage example.
+8. **Unit tests.** Add unit tests for `InMemoryFeatureGate` in the test project for `HoneyDrunk.Kernel.Abstractions.Testing` (or wherever the repo currently holds tests for the Testing fixture package): `SetFlag` round-trips; `SetVariant<T>` round-trips with the expected type; `SetTargetedFlag` predicate is called with the right `ITargetingContext`; `GetVariantAsync<T>(name, default)` returns the default for an unregistered flag. No `Thread.Sleep` (invariant 51); no external dependencies (invariant 15).
+
+## Affected Files
+- `HoneyDrunk.Kernel.Abstractions/` — new contract type files (`IFeatureGate.cs`, `ITargetingContext.cs`, `TargetingContext.cs`).
+- `HoneyDrunk.Kernel.Abstractions.Testing/` — new test fixture (`InMemoryFeatureGate.cs`).
+- Every non-test `.csproj` in the solution — version bump.
+- `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md`, `README.md`.
+- `HoneyDrunk.Kernel.Abstractions.Testing/CHANGELOG.md`, `README.md`.
+- Repo-level `CHANGELOG.md`.
+- Test project for `HoneyDrunk.Kernel.Abstractions.Testing` — new `InMemoryFeatureGate` unit tests.
+
+## NuGet Dependencies
+- **`HoneyDrunk.Kernel.Abstractions`** — no new `PackageReference`. Per invariant 1, Abstractions takes only `Microsoft.Extensions.*` abstractions; the `IFeatureGate` / `ITargetingContext` contracts use only BCL types (`ValueTask`, `string`, `IReadOnlyDictionary`). **Explicitly: do NOT add `Microsoft.FeatureManagement` here.** That package belongs in `HoneyDrunk.FeatureFlags` per the abstraction/implementation split. `HoneyDrunk.Standards` is already referenced (`PrivateAssets: all`).
+- **`HoneyDrunk.Kernel.Abstractions.Testing`** — no new `PackageReference`. `InMemoryFeatureGate` is pure-BCL. `HoneyDrunk.Standards` is already referenced.
+- **`HoneyDrunk.Kernel`** — no new `PackageReference` in this packet (runtime types do not change).
+- The unit-test project follows the repo's existing test stack; no new packages introduced by this packet beyond what the test project already references.
+
+## Boundary Check
+- [x] `IFeatureGate`, `ITargetingContext` are Kernel contracts per ADR-0055 D4. Routing rule "context, GridContext, NodeContext, ... CorrelationId → HoneyDrunk.Kernel" and the ADR's explicit placement both map here.
+- [x] `InMemoryFeatureGate` in `HoneyDrunk.Kernel.Abstractions.Testing` matches invariant 15's pattern (every Abstractions package may ship a companion Testing fixture package).
+- [x] No reference to `Microsoft.FeatureManagement` — that lives in `HoneyDrunk.FeatureFlags` per the abstraction/implementation split.
+- [x] No dependency on any other HoneyDrunk runtime package (invariants 1, 4).
+- [x] Contracts + test fixture only; the App-Configuration-backed implementation (packet 05), the CI validation (packet 06), and the Notify pilot (packet 07) are separate packets.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Kernel.Abstractions` exposes `IFeatureGate` with the three methods `IsEnabledAsync(string)`, `IsEnabledAsync(string, ITargetingContext)`, `GetVariantAsync<T>(string, T)` matching ADR-0055 D4 signatures
+- [ ] `HoneyDrunk.Kernel.Abstractions` exposes `ITargetingContext` with `TenantId`, `PrincipalId`, `Tier`, `Tags` per ADR-0055 D4
+- [ ] A default `TargetingContext` record (no `I`) implements `ITargetingContext`; consumers can construct it directly
+- [ ] `HoneyDrunk.Kernel.Abstractions.Testing` exposes `InMemoryFeatureGate` with chainable setup methods `SetFlag(name, enabled)`, `SetVariant<T>(name, value)`, `SetTargetedFlag(name, predicate)`
+- [ ] `InMemoryFeatureGate.IsEnabledAsync` returns `false` for unregistered flags (the safe-default, off-by-default semantics)
+- [ ] `InMemoryFeatureGate.GetVariantAsync<T>(name, default)` returns the default for an unregistered flag and for a registered flag whose value cannot be cast to `T`
+- [ ] All new public types have XML documentation (invariant 13); `IFeatureGate`'s XML-doc explicitly notes "only sanctioned evaluation surface — direct `Microsoft.FeatureManagement` consumption is forbidden per ADR-0055 invariant"
+- [ ] `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.Kernel.Abstractions.Testing` have zero runtime `PackageReference` on any HoneyDrunk package and no reference to `Microsoft.FeatureManagement` (invariant 1)
+- [ ] Every non-test `.csproj` in the solution is at the same new minor version in a single commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new dated version entry
+- [ ] `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md` and `HoneyDrunk.Kernel.Abstractions.Testing/CHANGELOG.md` each have new-version entries describing the feature-flag contracts
+- [ ] `HoneyDrunk.Kernel/CHANGELOG.md` gets NO entry (no functional change — alignment bump only, per invariant 12/27)
+- [ ] `HoneyDrunk.Kernel.Abstractions/README.md` and `HoneyDrunk.Kernel.Abstractions.Testing/README.md` document the new public-API surface
+- [ ] Unit tests for `InMemoryFeatureGate` cover the setup methods, the default-return behaviour, and the targeting predicate
+- [ ] No `Thread.Sleep` in test code (invariant 51); no external dependencies in tests (invariant 15)
+- [ ] The `pr-core.yml` tier-1 gate and the Kernel contract-shape canary pass — the new contracts are additive, paired with the version bump
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0055 D4 — `IFeatureGate` in Kernel.Abstractions; backing in HoneyDrunk.FeatureFlags.** The Kernel-abstraction / sibling-implementation split keeps the testing story clean: `InMemoryFeatureGate` lives in `HoneyDrunk.Kernel.Abstractions.Testing` per Invariant 15, so unit tests in any Node can flip flags without depending on App Configuration. Folding the implementation into Kernel would couple Kernel to App Configuration and force a Kernel version bump to swap providers.
+
+**ADR-0055 D4 — `IFeatureGate` interface signatures (verbatim from the ADR):**
+```csharp
+public interface IFeatureGate
+{
+    ValueTask<bool> IsEnabledAsync(string flagName);
+    ValueTask<bool> IsEnabledAsync(string flagName, ITargetingContext context);
+    ValueTask<T> GetVariantAsync<T>(string flagName, T defaultValue);
+}
+
+public interface ITargetingContext
+{
+    string? TenantId { get; }
+    string? PrincipalId { get; }
+    string? Tier { get; }
+    IReadOnlyDictionary<string, string> Tags { get; }
+}
+```
+
+**ADR-0055 Consequences — new invariants.** Two new invariants land in packet 00: (1) feature flags are evaluated through `IFeatureGate`, never via direct SDK calls; (2) feature-flag names follow `{category}.{node}.{feature}` and are registered. This packet's `IFeatureGate` is the contract that makes invariant 1 enforceable; the XML-doc on the interface explicitly notes the rule so consumers see it at the call site.
+
+**ADR-0055 Operational Consequences — additive minor bump.** `Kernel.Abstractions` gains new interfaces; per ADR-0035 this is an additive minor bump (additions on new interfaces, not on existing ones). No breaking change.
+
+## Constraints
+- **Invariant 1 — Abstractions have zero runtime dependencies on other HoneyDrunk packages.** Only `Microsoft.Extensions.*` abstractions permitted. **Specifically: no `Microsoft.FeatureManagement` package reference here.** That package belongs in `HoneyDrunk.FeatureFlags` per the abstraction/implementation split. No runtime logic (no JSON loading, no DI) in Abstractions.
+- **Invariant 4 — the dependency graph is a DAG; Kernel is at the root.** Do not reference any other HoneyDrunk runtime package.
+- **Invariant 13 — all public APIs have XML documentation.** Enforced by `HoneyDrunk.Standards` analyzers.
+- **Invariant 15 — unit tests never depend on external services.** `InMemoryFeatureGate` is the fixture that enforces this for flag-consuming code.
+- **Invariant 27 — all projects in a solution share one version and move together.** Every non-test `.csproj` goes to the same next-minor version in one commit. Partial bumps are forbidden.
+- **Invariant 12 — per-package CHANGELOGs are updated only for packages with functional changes.** `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.Kernel.Abstractions.Testing` get entries; `HoneyDrunk.Kernel` (alignment bump only) gets none.
+- **Records drop the `I`; interfaces keep it.** `IFeatureGate` / `ITargetingContext` are interfaces (keep `I`); `TargetingContext` (record implementation) drops the `I`; `InMemoryFeatureGate` is a class (no `I`).
+- **First new ADR-0055 invariant is enforceable starting now.** `IFeatureGate` is the only sanctioned evaluation surface. Document this on the interface's XML-doc.
+
+## Labels
+`feature`, `tier-2`, `core`, `adr-0055`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add the ADR-0055 feature-flag contract surface (`IFeatureGate`, `ITargetingContext`) and the `InMemoryFeatureGate` test fixture to `HoneyDrunk.Kernel.Abstractions` / `.Testing`, and bump the `HoneyDrunk.Kernel` solution by one minor version.
+
+**Target:** `HoneyDrunk.Kernel`, branch from `main`.
+
+**Context:**
+- Goal: Ship the contracts every other packet in this initiative compiles against, plus the test fixture every consuming Node's unit tests will use.
+- Feature: ADR-0055 Feature Flag rollout, Wave 2 (the foundation).
+- ADRs: ADR-0055 D4 (primary), ADR-0035 (additive minor-bump policy), ADR-0026 (RequestContext sources for ITargetingContext defaults — relevant to packet 05's DI default, noted here for context), ADR-0008 (packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0055 Accepted and its two invariants live before the contracts are built against them.
+
+**Constraints:**
+- Abstractions stay zero-HoneyDrunk-dependency (invariant 1). **No reference to `Microsoft.FeatureManagement`.**
+- Bump every non-test `.csproj` to the same next-minor version in one commit (invariant 27). Confirm the target version at edit time (0.8.0 if ADR-0042's 0.8.0 hasn't shipped; 0.9.0 if it has).
+- Records drop the `I`; interfaces keep it; `InMemoryFeatureGate` is a class.
+- `IFeatureGate`'s XML-doc declares it the only sanctioned evaluation surface per ADR-0055 invariant.
+
+**Key Files:**
+- `HoneyDrunk.Kernel.Abstractions/IFeatureGate.cs`, `ITargetingContext.cs`, `TargetingContext.cs` (new).
+- `HoneyDrunk.Kernel.Abstractions.Testing/InMemoryFeatureGate.cs` (new).
+- Every non-test `.csproj` for the version bump.
+- `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md`, `README.md`; `HoneyDrunk.Kernel.Abstractions.Testing/CHANGELOG.md`, `README.md`; repo-level `CHANGELOG.md`.
+
+**Contracts:**
+- `IFeatureGate` (new interface) — `IsEnabledAsync(string)`, `IsEnabledAsync(string, ITargetingContext)`, `GetVariantAsync<T>(string, T)`.
+- `ITargetingContext` (new interface) — `TenantId`, `PrincipalId`, `Tier`, `Tags`.
+- `TargetingContext` (new record) — default implementation of `ITargetingContext`.
+- `InMemoryFeatureGate` (new test class in Testing package) — `SetFlag`, `SetVariant`, `SetTargetedFlag` setup methods.

--- a/generated/issue-packets/active/adr-0055-feature-flags/05-featureflags-node-standup.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/05-featureflags-node-standup.md
@@ -1,0 +1,293 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.FeatureFlags
+labels: ["feature", "tier-2", "core", "scaffold", "adr-0055", "wave-3"]
+dependencies: ["packet:01", "packet:02", "packet:03", "packet:04"]
+adrs: ["ADR-0055"]
+wave: 3
+initiative: adr-0055-feature-flags
+node: honeydrunk-featureflags
+---
+
+# Stand up the HoneyDrunk.FeatureFlags Node — App-Configuration-backed IFeatureGate + TenantTargetingFilter
+
+## Summary
+Bring the empty `HoneyDrunk.FeatureFlags` repo from zero to first-shippable state per ADR-0055 D4 and Phase 1. Land the solution layout, the package families (`HoneyDrunk.FeatureFlags` runtime; an `Abstractions` package iff additional Node-owned contracts beyond `IFeatureGate` ship — see Proposed Implementation), the `Microsoft.FeatureManagement.AzureAppConfiguration`-backed `IFeatureGate` implementation, the custom `TenantTargetingFilter` per D3, the App Configuration label-aware refresh per D9, the DI registration surface (`AddFeatureFlags(...)`), the standard CI pipeline, and a `HoneyDrunk.FeatureFlags.Tests.Canaries` project verifying integration assumptions against `HoneyDrunk.Kernel.Abstractions`.
+
+This Node ships as **v0.1.0** — the standup baseline (matches the HoneyDrunk.Audit precedent).
+
+## Context
+ADR-0055 D4 says: "Concrete implementation lives in a new Node `HoneyDrunk.FeatureFlags`, with the published package `HoneyDrunk.FeatureFlags` providing the `Microsoft.FeatureManagement`-backed implementation and the `TenantTargetingFilter` from D3."
+
+Per the user's "new-Node standup gets its own ADR" rule, ADR-0055 *is* that ADR (it explicitly stands up the Node). This packet executes the standup. The boundary on what to scaffold is established by the ADR + the established Grid scaffolding pattern (see `HoneyDrunk.Audit` `0.1.0` for the closest precedent — a small Core-sector Node with a clean Abstractions/runtime/Testing split).
+
+**Abstractions split — decide at edit time.** ADR-0055 D4 names a single concrete package `HoneyDrunk.FeatureFlags` containing the App-Configuration-backed `IFeatureGate` implementation and the `TenantTargetingFilter`. The Grid pattern would normally split into `HoneyDrunk.FeatureFlags.Abstractions` + `HoneyDrunk.FeatureFlags` runtime — but here the **`IFeatureGate` abstraction lives in `HoneyDrunk.Kernel.Abstractions`** (D4), not in this Node's own Abstractions package. The question is whether this Node ships *additional* contracts beyond `IFeatureGate` that warrant an Abstractions split:
+- The **`TenantTargetingFilter`** is an `IFeatureFilter` from `Microsoft.FeatureManagement`. Consumers don't reach for it directly — DI registration (the `AddFeatureFlags(...)` extension) wires it. **Not a public abstraction.**
+- A potential **`IFeatureFilter` registration extension API** or **a host-options type** might want to live in an Abstractions package so the runtime can be swapped (D15 escalation). At v1, there is no concrete consumer that needs this.
+
+**Decision rule:** ship a single `HoneyDrunk.FeatureFlags` package for now. If a second backing (D15 escalation: `HoneyDrunk.FeatureFlags.LaunchDarkly`) is added later, refactor at that time — extract the runtime-host options into a `HoneyDrunk.FeatureFlags.Abstractions` and migrate the App-Configuration-backed runtime to `HoneyDrunk.FeatureFlags.AzureAppConfiguration`. The v1 simplification is consistent with how `HoneyDrunk.Audit` shipped (one runtime + one Abstractions) and how `HoneyDrunk.Notify` started.
+
+**Single runtime package, plus a Testing fixture if useful.** The `InMemoryFeatureGate` test fixture lives in `HoneyDrunk.Kernel.Abstractions.Testing` per packet 04 — every flag-consuming Node uses that. This Node ships an additional `HoneyDrunk.FeatureFlags.Testing` package **only if** there's a concrete need for a fixture that exercises the App-Configuration-backed runtime in process (e.g., a test that boots the real backing against an in-memory `IConfiguration`). The ADR does not require this. **Decision:** skip the `.Testing` package at v1; revisit if a real consumer needs it.
+
+So the v0.1.0 shape is **one runtime package** (`HoneyDrunk.FeatureFlags`) plus tests/canaries projects.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.FeatureFlags`
+
+## Scope
+Stand up the repo end-to-end:
+
+- `HoneyDrunk.FeatureFlags.slnx` — solution file.
+- `HoneyDrunk.FeatureFlags/HoneyDrunk.FeatureFlags.csproj` — runtime package targeting .NET 10.0; references `HoneyDrunk.Kernel.Abstractions` (the new minor — confirm version at edit time; expected `0.8.0` or `0.9.0` per packet 04), `Microsoft.FeatureManagement.AzureAppConfiguration`, `Microsoft.Extensions.Configuration.AzureAppConfiguration`, and `HoneyDrunk.Standards` (`PrivateAssets: all`).
+- `src/HoneyDrunk.FeatureFlags/AzureAppConfigurationFeatureGate.cs` — concrete `IFeatureGate` over `IFeatureManager`.
+- `src/HoneyDrunk.FeatureFlags/TenantTargetingFilter.cs` — custom `IFeatureFilter` per ADR-0055 D3.
+- `src/HoneyDrunk.FeatureFlags/Hosting/FeatureFlagsServiceCollectionExtensions.cs` — `AddFeatureFlags(this IServiceCollection, IConfiguration)` DI extension; wires `Microsoft.FeatureManagement`, the App Configuration push-refresh per D2, the `TenantTargetingFilter`, and the `IFeatureGate` registration.
+- `HoneyDrunk.FeatureFlags.Tests.Unit/` — xUnit project (per ADR-0047), unit tests for `AzureAppConfigurationFeatureGate` (using a faked `IFeatureManager`) and `TenantTargetingFilter` (using `TargetingContext` fixtures).
+- `HoneyDrunk.FeatureFlags.Tests.Canaries/` — canary project per invariant 14, verifying the contract-shape `IFeatureGate` integration against `HoneyDrunk.Kernel.Abstractions`.
+- `.github/workflows/pr-core.yml` (or the reusable workflow callsite per ADR-0012) — wires `HoneyDrunk.Actions/pr-core.yml`.
+- `.github/workflows/release.yml` — release flow (consult ADR-0033 / existing Node patterns).
+- `.github/workflows/nightly-security.yml`, `.github/workflows/nightly-deps.yml` — wire the existing Actions reusable workflows.
+- `.github/dependabot.yml` — per ADR-0009 (alerts on, grouped nightly-deps off — match the existing Node pattern).
+- `.honeydrunk-review.yaml` — per ADR-0044 (review enabled).
+- `.editorconfig` — per `HoneyDrunk.Standards`.
+- `CHANGELOG.md` (repo-level), `README.md`, `LICENSE`, `.gitignore`, `.gitattributes` — match the established Node-repo bootstrap.
+- `HoneyDrunk.FeatureFlags/CHANGELOG.md`, `HoneyDrunk.FeatureFlags/README.md` — per-package files (invariant 12).
+- `Directory.Build.props`, `Directory.Packages.props` if the Grid convention uses centralized package management — match the established pattern at edit time.
+
+The Node's first published version is **v0.1.0** (matches `HoneyDrunk.Audit` precedent).
+
+## Proposed Implementation
+
+1. **Solution + project bootstrap.**
+   - Create `HoneyDrunk.FeatureFlags.slnx` at the repo root.
+   - Create `HoneyDrunk.FeatureFlags/HoneyDrunk.FeatureFlags.csproj` targeting `net10.0`, with `HoneyDrunk.Standards` (`PrivateAssets: all`), `HoneyDrunk.Kernel.Abstractions` (latest published — confirm at edit time, expected `0.8.0` or `0.9.0` per packet 04's bump), and the Microsoft packages: `Microsoft.FeatureManagement.AzureAppConfiguration`, `Microsoft.Extensions.Configuration.AzureAppConfiguration`, `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Hosting.Abstractions` (host extension). Reference `HoneyDrunk.Vault.Abstractions` only if the runtime needs `ISecretStore` (it does not — App Configuration is Managed-Identity-accessed per ADR-0005; no SDK-level secret is consumed here). **Do not** reference `HoneyDrunk.Pulse` or any observability package — logging goes through `Microsoft.Extensions.Logging.Abstractions` and Pulse's sink composition happens at the host, not in this package.
+   - Create test projects per ADR-0047 — at minimum `HoneyDrunk.FeatureFlags.Tests.Unit` (xUnit v2 + NSubstitute + AwesomeAssertions + coverlet); also `HoneyDrunk.FeatureFlags.Tests.Canaries` for the contract-shape canary required by invariant 14 (cross-Node-boundary verification — this Node implements `IFeatureGate` from `HoneyDrunk.Kernel.Abstractions`).
+
+2. **`AzureAppConfigurationFeatureGate`** — concrete `IFeatureGate` over `Microsoft.FeatureManagement.IFeatureManagerSnapshot` (or `IFeatureManager`; the snapshot variant is preferred for request-scoped consistency — confirm with the current `Microsoft.FeatureManagement` API at edit time):
+   ```csharp
+   public sealed class AzureAppConfigurationFeatureGate : IFeatureGate
+   {
+       private readonly IFeatureManagerSnapshot _featureManager;
+       private readonly ITargetingContextAccessor _contextAccessor; // produces ITargetingContext from RequestContext
+
+       public AzureAppConfigurationFeatureGate(IFeatureManagerSnapshot fm, ITargetingContextAccessor ca)
+       {
+           _featureManager = fm;
+           _contextAccessor = ca;
+       }
+
+       public ValueTask<bool> IsEnabledAsync(string flagName)
+       {
+           var ctx = _contextAccessor.Current;
+           return ctx is null
+               ? new ValueTask<bool>(_featureManager.IsEnabledAsync(flagName))
+               : new ValueTask<bool>(_featureManager.IsEnabledAsync(flagName, ctx));
+       }
+
+       public ValueTask<bool> IsEnabledAsync(string flagName, ITargetingContext context)
+           => new ValueTask<bool>(_featureManager.IsEnabledAsync(flagName, context));
+
+       public async ValueTask<T> GetVariantAsync<T>(string flagName, T defaultValue)
+       {
+           var variant = await _featureManager.GetVariantAsync(flagName);
+           return variant is null ? defaultValue : variant.Configuration.Get<T>() ?? defaultValue;
+       }
+   }
+   ```
+   The `ITargetingContextAccessor` is a small abstraction this package introduces (internal or public — internal is fine; consumers don't construct it) that resolves an `ITargetingContext` from `HoneyDrunk.Kernel`'s `RequestContext` per ADR-0026. Default implementation reads the ambient `RequestContext` via `IRequestContextAccessor` (or whatever the existing surface is named at edit time — confirm against `HoneyDrunk.Kernel`).
+
+3. **`TenantTargetingFilter`** — custom `IFeatureFilter` per ADR-0055 D3:
+   ```csharp
+   [FilterAlias("TenantTargeting")]
+   public sealed class TenantTargetingFilter : IFeatureFilter
+   {
+       private readonly ITargetingContextAccessor _contextAccessor;
+       public ValueTask<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+       {
+           var params = context.Parameters.Get<TenantTargetingParameters>();
+           var ctx = _contextAccessor.Current;
+           if (ctx?.TenantId is { } tid && params.Tenants?.Contains(tid) == true) return new(true);
+           if (ctx?.Tier is { } tier && params.Tiers?.Contains(tier) == true) return new(true);
+           // Fallback to default_rollout_percentage — use the inbound context's principal/tenant
+           // identifier hashed to a stable 0..99 bucket (matches Microsoft.FeatureManagement's
+           // TargetingFilter percentage semantics).
+           return new(_FallbackPercentageHit(ctx, params.DefaultRolloutPercentage));
+       }
+   }
+
+   public sealed class TenantTargetingParameters
+   {
+       public IReadOnlyList<string>? Tenants { get; init; }
+       public IReadOnlyList<string>? Tiers { get; init; }
+       public int DefaultRolloutPercentage { get; init; }
+   }
+   ```
+   - The `FilterAlias("TenantTargeting")` matches the JSON shape ADR-0055 D3 cites (the `client_filters[].name` value).
+   - The percentage fallback uses the same hashing-to-100-buckets approach `Microsoft.FeatureManagement.TargetingFilter` uses — the implementation can lean on a shared helper or replicate the simple deterministic-hash scheme; confirm the current API at edit time.
+   - The filter is registered via DI in the `AddFeatureFlags` extension (step 4).
+
+4. **`AddFeatureFlags` DI extension** — `Hosting/FeatureFlagsServiceCollectionExtensions.cs`:
+   ```csharp
+   public static IServiceCollection AddFeatureFlags(this IServiceCollection services, IConfiguration config)
+   {
+       services
+           .AddAzureAppConfiguration() // refresh hook
+           .AddFeatureManagement(config)
+           .AddFeatureFilter<TenantTargetingFilter>();
+       services.AddSingleton<ITargetingContextAccessor, DefaultTargetingContextAccessor>();
+       services.AddScoped<IFeatureGate, AzureAppConfigurationFeatureGate>();
+       return services;
+   }
+   ```
+   - The extension is the single entry point for hosts to compose the flag system.
+   - Document in the README that hosts must also wire App Configuration's connection per ADR-0005's pattern (Managed Identity-based; no DSN, no key).
+   - Document the D9 label-aware refresh: hosts pass the `IConfiguration` already configured with `.AddAzureAppConfiguration(opt => opt.UseFeatureFlags(...).Select(KeyFilter.Any, label: env).Watch(...))` so the active env's label-scoped flags load.
+
+5. **`DefaultTargetingContextAccessor`** — internal class that reads the ambient `RequestContext` per ADR-0026 and returns an `ITargetingContext`. If no `RequestContext` is ambient (background worker, scheduled job not using the explicit-context overload), `Current` returns `null` and the binary `IsEnabledAsync(string)` path uses the no-context evaluation — this is the safe-default behaviour for off-request paths that aren't supplying explicit targeting context.
+
+6. **CI wiring per ADR-0012.**
+   - `.github/workflows/pr-core.yml` calls the reusable `HoneyDrunk.Actions/.github/workflows/pr-core.yml` workflow (the Grid-standard tier-1 gate per invariant 31).
+   - `.github/workflows/release.yml` per the existing Node-release pattern.
+   - `.github/workflows/nightly-security.yml`, `.github/workflows/nightly-deps.yml` — per ADR-0009 + the existing pattern.
+   - `.github/workflows/featureflags-validate.yml` — this Node's own `featureflags.json` is registered if the Node ships any internal flags (it likely does not — the Node is the flag *system*, not a flag consumer). Skip the workflow callsite at standup; add it later if/when the Node consumes its own flags.
+   - `.github/dependabot.yml` — alerts on, auto-PRs off; group nightly-deps per ADR-0009.
+
+7. **Contract-shape canary per invariant 14.** `HoneyDrunk.FeatureFlags.Tests.Canaries` includes:
+   - `IFeatureGate` shape canary — asserts `IFeatureGate` in the consumed `HoneyDrunk.Kernel.Abstractions` package has the three methods with the expected signatures. If the upstream contract drifts without a coordinated bump, this canary fails. Implementation can reuse `HoneyDrunk.Actions`'s `job-api-compatibility.yml` reusable workflow scoped to `HoneyDrunk.Kernel.Abstractions` if that workflow exists at edit time (per invariant 46 / 49 / 43 — same pattern as `IAuditLog` / `ICommunicationOrchestrator` / `IChatClient`).
+   - A second canary verifies `AzureAppConfigurationFeatureGate` composes against a fake `IFeatureManagerSnapshot` and a fake `ITargetingContextAccessor` and returns the expected results for set up flags (effectively an end-to-end smoke test against the runtime). Use `Microsoft.FeatureManagement`'s `InMemoryFeatureManager` or similar test surface if available — confirm at edit time.
+
+8. **`.honeydrunk-review.yaml`** — `enabled: true` per ADR-0044, so review agents run on the Node's PRs.
+
+9. **Repo bootstrap files.**
+   - `CHANGELOG.md` (repo-level): `[0.1.0] - YYYY-MM-DD - Initial Node standup per ADR-0055.`
+   - `README.md` (repo-level): Node overview, package descriptions, the public API (`AddFeatureFlags`, `IFeatureGate` from Kernel), composition example, App Configuration prerequisite, ADR-0055 cross-reference, license footer.
+   - `HoneyDrunk.FeatureFlags/CHANGELOG.md`: `[0.1.0]` per-package entry.
+   - `HoneyDrunk.FeatureFlags/README.md`: package-scope README with installation, public surface, usage example.
+   - `LICENSE` per ADR-0039 (whichever license the Grid uses for Core-sector public packages).
+   - `.gitignore`, `.gitattributes` matching the Grid Node pattern.
+
+10. **First release tag — human action.** Agents never tag (invariant 27). Once this packet's PR merges, a human pushes the `v0.1.0` tag, triggering the release workflow to publish `HoneyDrunk.FeatureFlags` to NuGet. Downstream packets (06 unit-tests against `HoneyDrunk.Kernel.Abstractions`; 07 Notify pilot; 08 Operator CLI) consume the published package.
+
+## Affected Files
+The entire repo content — this is a from-zero standup. Every file listed in the Scope section.
+
+## NuGet Dependencies
+- **`HoneyDrunk.FeatureFlags`** (runtime):
+  - `HoneyDrunk.Standards` (`PrivateAssets: all`)
+  - `HoneyDrunk.Kernel.Abstractions` (latest published; confirm version at edit time after packet 04 ships)
+  - `Microsoft.FeatureManagement.AzureAppConfiguration` (latest stable at edit time)
+  - `Microsoft.Extensions.Configuration.AzureAppConfiguration` (latest stable at edit time)
+  - `Microsoft.Extensions.DependencyInjection.Abstractions` (latest stable matching .NET 10)
+  - `Microsoft.Extensions.Hosting.Abstractions` (latest stable matching .NET 10)
+  - `Microsoft.Extensions.Logging.Abstractions` (latest stable matching .NET 10) — for ILogger logging only
+- **`HoneyDrunk.FeatureFlags.Tests.Unit`**:
+  - `HoneyDrunk.Standards` (`PrivateAssets: all`)
+  - `HoneyDrunk.Kernel.Abstractions.Testing` (for `InMemoryFeatureGate` — though the unit tests here exercise the *runtime*, not the Kernel fixture; reference if useful)
+  - The ADR-0047 test stack: xUnit v2, NSubstitute, AwesomeAssertions, coverlet.collector — confirm versions against `HoneyDrunk.Standards`'s shared `Directory.Build.props` if it ships one.
+  - `Microsoft.NET.Test.Sdk`
+  - `Microsoft.FeatureManagement` test helpers if available
+- **`HoneyDrunk.FeatureFlags.Tests.Canaries`**:
+  - Same test stack as Unit tests.
+  - `HoneyDrunk.Kernel.Abstractions` (the contract under canary).
+
+## Boundary Check
+- [x] All code in `HoneyDrunk.FeatureFlags`. The repo is created via this packet's Human Prerequisite step; the issue is filed against the new repo.
+- [x] Implements `IFeatureGate` from `HoneyDrunk.Kernel.Abstractions` — the abstraction/implementation split per ADR-0055 D4.
+- [x] No upward dependency — does not reference any non-Kernel-Abstractions HoneyDrunk package (no Pulse, no Audit, no Vault — App Configuration auth is via Managed Identity per ADR-0005).
+- [x] Single-package v1 (no `Abstractions` split) — matches the ADR's "the published package `HoneyDrunk.FeatureFlags`" wording and the Audit standup precedent.
+
+## Acceptance Criteria
+- [ ] The `HoneyDrunk.FeatureFlags` repo exists on GitHub (human prerequisite) and this packet's branch lands a complete solution scaffold
+- [ ] The solution builds with `dotnet build` at .NET 10.0
+- [ ] `HoneyDrunk.FeatureFlags` package exposes `AddFeatureFlags(IServiceCollection, IConfiguration)` as the single DI entry point
+- [ ] `AzureAppConfigurationFeatureGate` implements `IFeatureGate` from `HoneyDrunk.Kernel.Abstractions` and delegates to `Microsoft.FeatureManagement.IFeatureManagerSnapshot` (or `IFeatureManager` if the snapshot variant is unsuitable)
+- [ ] `TenantTargetingFilter` is registered with `[FilterAlias("TenantTargeting")]`, accepts the `TenantTargetingParameters` shape ADR-0055 D3 defines (`tenants`, `tiers`, `default_rollout_percentage`), and evaluates against the ambient `ITargetingContext`
+- [ ] The `TenantTargetingFilter` percentage fallback is deterministic — same input always produces the same bucket
+- [ ] `DefaultTargetingContextAccessor` populates `ITargetingContext` from the ambient `HoneyDrunk.Kernel` `RequestContext` per ADR-0026; returns `null` when no RequestContext is ambient (and the no-context evaluation path runs)
+- [ ] Unit tests cover: `AzureAppConfigurationFeatureGate` delegation to `IFeatureManager`, the `GetVariantAsync<T>` default-fallback path, `TenantTargetingFilter` matching on `tenants`, on `tiers`, on the default-rollout percentage, and the no-context fallback to the binary `IsEnabledAsync(string)` path
+- [ ] Canary tests verify `IFeatureGate` contract shape against the consumed `HoneyDrunk.Kernel.Abstractions` package — drift fails the build
+- [ ] CI is wired per ADR-0012: `pr-core.yml`, `release.yml`, `nightly-security.yml`, `nightly-deps.yml` callsites exist
+- [ ] `.honeydrunk-review.yaml` is `enabled: true` (ADR-0044 / invariant 52)
+- [ ] `HoneyDrunk.Standards` is referenced (`PrivateAssets: all`) on every project (invariant 26)
+- [ ] Repo-level `CHANGELOG.md` carries a `[0.1.0]` initial entry; `HoneyDrunk.FeatureFlags/CHANGELOG.md` carries the per-package `[0.1.0]` entry (invariant 12)
+- [ ] Repo-level `README.md` and `HoneyDrunk.FeatureFlags/README.md` exist and document the API/installation/composition (invariant 12)
+- [ ] Public APIs carry XML documentation (invariant 13)
+- [ ] No `Thread.Sleep` in test code (invariant 51); no external dependencies in tests (invariant 15); test projects do not bleed into runtime packages (invariant 16)
+- [ ] The `pr-core.yml` tier-1 gate passes on the standup PR
+
+## Human Prerequisites
+- [ ] **Create the empty `HoneyDrunk.FeatureFlags` GitHub repo** under `HoneyDrunkStudios` before pushing this folder to `main`. Per the standing convention "repos public by default" the repo is public. The standard `main` branch, no template, no auto-init (the standup PR adds README/LICENSE/etc.). The repo must exist on GitHub or the filing pipeline cannot file this packet's issue.
+- [ ] After this packet's PR merges, a human pushes the `v0.1.0` git tag to trigger the release workflow and publish the `HoneyDrunk.FeatureFlags` package to NuGet (agents never tag — invariant 27). The downstream packets (06 references it via NuGet; 07 Notify pilot composes it; 08 Operator CLI composes it) cannot build until v0.1.0 is on the package feed.
+- [ ] Managed Identity Reader role assignment on the dev App Configuration resource for the consuming Node's Managed Identity (Notify per packet 07; Operator per packet 08). This is a portal step done as part of packet 03's walkthrough application; if not yet done at packet 05's execution time, record as a downstream prerequisite for packets 07 and 08.
+
+## Referenced ADR Decisions
+**ADR-0055 D2 — Backend: Azure App Configuration's feature-flags surface.** The package `Microsoft.FeatureManagement.AzureAppConfiguration` provides the native feature-flag model, label-based environment scoping, built-in targeting filters, and Event-Grid push refresh. No new vendor; existing App Configuration relationship (ADR-0005).
+
+**ADR-0055 D3 — `TenantTargetingFilter`.** The only custom `IFeatureFilter` the Grid commits to at v1. Resolves the active `TenantId` from `RequestContext` per ADR-0026, matches against the flag's `tenants:` or `tiers:` configuration, falls back to `default_rollout_percentage`. JSON shape: `{ "name": "TenantTargeting", "parameters": { "tenants": [...], "tiers": [...], "default_rollout_percentage": int } }`.
+
+**ADR-0055 D4 — `IFeatureGate` interface in Kernel.Abstractions; concrete here.** This Node implements `IFeatureGate` (defined in `HoneyDrunk.Kernel.Abstractions` per packet 04) using `Microsoft.FeatureManagement` internally. Consumers see only `IFeatureGate`; the SDK is hidden.
+
+**ADR-0055 D9 — Local-dev affordances.** Label-aware refresh: hosts wire App Configuration with `.UseFeatureFlags(...).Select(label: env)` so the dev/staging/prod/ci label scope determines the active flag values. Document this in the README and in `AddFeatureFlags`'s XML-doc.
+
+**ADR-0055 D14 Phase 1 — Standup.** "Stand up the `HoneyDrunk.FeatureFlags` Node with the `Microsoft.FeatureManagement.AzureAppConfiguration`-backed implementation, the `TenantTargetingFilter`, and the App Configuration label conventions per D9." This packet executes Phase 1.
+
+## Constraints
+- **Invariant 1 — Abstractions zero-dependency.** This Node's runtime references `Microsoft.FeatureManagement.AzureAppConfiguration` — fine for a runtime package. But `HoneyDrunk.Kernel.Abstractions` (the contract source) stays zero-HoneyDrunk-dependency; do NOT push any internal type back up into `HoneyDrunk.Kernel.Abstractions`.
+- **Invariant 4 — DAG; Kernel is at the root.** This Node depends on `HoneyDrunk.Kernel.Abstractions` only. No other HoneyDrunk runtime package.
+- **First new ADR-0055 invariant — `IFeatureGate` is the only sanctioned evaluation surface.** Consumers of this Node compose `AddFeatureFlags` and depend on `IFeatureGate`; they do not (and must not) reach for `IFeatureManager` directly. Document this on `AddFeatureFlags`'s XML-doc.
+- **Invariant 11 — One repo per Node.** This Node is its own repo per ADR-0055 D4.
+- **Invariant 12 — CHANGELOG + README on every package from the first commit.** Both files ship.
+- **Invariant 13 — XML documentation on every public API.**
+- **Invariant 14 — Contract-shape canary.** The Node's CI includes a canary against `HoneyDrunk.Kernel.Abstractions` (the source of `IFeatureGate`).
+- **Invariant 15 — Unit tests no external services.** Unit tests use a faked `IFeatureManager` and a faked `ITargetingContextAccessor`. The canary may use `InMemoryFeatureManager` or similar if `Microsoft.FeatureManagement` ships such a fixture.
+- **Invariant 16 — No test code in runtime packages.**
+- **Invariant 26 — `HoneyDrunk.Standards` `PrivateAssets: all` on every new .NET project.**
+- **Invariant 27 — One version across the solution.** v0.1.0 standup baseline.
+- **Invariant 31 / 52 — pr-core tier-1 gate + cloud-wired review.** CI wires both.
+- **Invariant 51 — No `Thread.Sleep` in test code.**
+
+## Labels
+`feature`, `tier-2`, `core`, `scaffold`, `adr-0055`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Stand up the `HoneyDrunk.FeatureFlags` Node — solution, the App-Configuration-backed `IFeatureGate` implementation, the `TenantTargetingFilter`, the `AddFeatureFlags` DI extension, CI, tests, canary — and ship v0.1.0.
+
+**Target:** `HoneyDrunk.FeatureFlags`, branch from `main`.
+
+**Context:**
+- Goal: Provide the concrete flag-system implementation that every consuming Node composes; preserve backend reversibility (D15) by depending on `IFeatureGate` from Kernel.Abstractions only, hiding `Microsoft.FeatureManagement` inside this Node.
+- Feature: ADR-0055 Feature Flag rollout, Wave 3 (the substrate).
+- ADRs: ADR-0055 D2/D3/D4/D9/D14 (primary), ADR-0005 (App Configuration backing — Managed Identity), ADR-0026 (RequestContext source for `ITargetingContext`), ADR-0047 (test stack), ADR-0012 (CI workflows), ADR-0044 (review agent enablement), ADR-0039 (license), ADR-0033 (release tagging is a human step).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — catalog entry for `honeydrunk-featureflags` lands before the standup so the Node is discoverable.
+- `packet:02` — `featureflags-v1.json` schema exists so consumers (and this Node's documentation) can reference it.
+- `packet:03` — App Configuration walkthrough extension applied so the runtime backing has a live App Configuration resource and seeded labels to wire against.
+- `packet:04` — `HoneyDrunk.Kernel.Abstractions` ships `IFeatureGate` and the new minor is published; this Node compiles against the new minor.
+
+**Constraints:**
+- Single-package v1 (no `Abstractions` split — matches Audit precedent and the ADR's wording).
+- No reference to non-Kernel-Abstractions HoneyDrunk packages.
+- `IFeatureGate` is the only sanctioned consumer surface; document this on `AddFeatureFlags`.
+- `HoneyDrunk.Standards` `PrivateAssets: all` on every project.
+- v0.1.0 release baseline (per the Audit standup precedent).
+
+**Key Files:**
+- `HoneyDrunk.FeatureFlags.slnx`
+- `src/HoneyDrunk.FeatureFlags/AzureAppConfigurationFeatureGate.cs`
+- `src/HoneyDrunk.FeatureFlags/TenantTargetingFilter.cs`
+- `src/HoneyDrunk.FeatureFlags/Hosting/FeatureFlagsServiceCollectionExtensions.cs`
+- `HoneyDrunk.FeatureFlags.Tests.Unit/`, `HoneyDrunk.FeatureFlags.Tests.Canaries/`
+- `.github/workflows/pr-core.yml`, `release.yml`, `nightly-*.yml`
+- `.honeydrunk-review.yaml`
+- Repo-level + per-package `CHANGELOG.md`, `README.md`
+
+**Contracts:**
+- Implements `IFeatureGate` (from `HoneyDrunk.Kernel.Abstractions`) via `AzureAppConfigurationFeatureGate`.
+- Exposes `AddFeatureFlags(IServiceCollection, IConfiguration)` as the public DI surface.
+- `TenantTargetingFilter` is registered internally; not part of the public consumer surface.

--- a/generated/issue-packets/active/adr-0055-feature-flags/06-actions-featureflags-validate-and-analyzer.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/06-actions-featureflags-validate-and-analyzer.md
@@ -1,0 +1,175 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "adr-0055", "wave-4"]
+dependencies: ["packet:02", "packet:04"]
+adrs: ["ADR-0055", "ADR-0012"]
+wave: 4
+initiative: adr-0055-feature-flags
+node: honeydrunk-actions
+---
+
+# Author job-featureflags-validate.yml reusable workflow and the Roslyn analyzer for flag-string discovery
+
+## Summary
+Author the reusable workflow `job-featureflags-validate.yml` in `HoneyDrunk.Actions` plus a Roslyn analyzer NuGet package that statically discovers literal flag strings in `IFeatureGate.IsEnabledAsync(...)` / `GetVariantAsync<...>(...)` call sites and validates them against each consuming Node's `featureflags.json` per ADR-0055 D6. Together they make the dual-validation gate (every used flag is registered; every registered flag is used or `expected_orphan: true`) a hard CI gate, and enforce the naming convention (D5), category coherence (D6), and release-flag expiry (D7).
+
+## Context
+ADR-0055 D6 commits to per-Node `featureflags.json` files with CI validation. The validation has two halves:
+- **Static analysis** (Roslyn) — scans the assembly for literal-string calls to `IFeatureGate.IsEnabledAsync` and `GetVariantAsync<T>` and emits a diagnostic for each undeclared flag literal. Variable-fed flag names produce a separate warning (per D6: "Variable-fed flag names are flagged as a separate warning — they defeat static analysis and should be avoided").
+- **Registry inspection** (the workflow) — parses `featureflags.json`, validates the schema (against the document packet 02 ships), enforces the naming regex per D5, enforces category coherence per D6 ("declared `category` matches the prefix in `name`"), enforces release-flag expiry per D7 (today's date past `expires_on` fails CI), and warns on permission/operational `annual_review_due` past today (warning, not failure).
+
+ADR-0012 makes `HoneyDrunk.Actions` the Grid's CI/CD control plane. Reusable workflows live at `.github/workflows/job-*.yml`. Per the established pattern in ADR-0042 packet 07's canary and ADR-0040's reusable workflows, this packet adds a new reusable workflow callable from any Node's `pr-core.yml` flow.
+
+The Roslyn analyzer is a NuGet package. Where it lives — `HoneyDrunk.Actions` or `HoneyDrunk.Standards` — is a judgment call. **Default to `HoneyDrunk.Actions`** per ADR-0012's CI-control-plane framing (this is CI tooling, like the `job-api-compatibility.yml` analyzer): the analyzer ships as a workflow-consumed artifact, not as a standard-on-every-project analyzer. The executor confirms at edit time whether `HoneyDrunk.Standards` already ships StyleCop/EditorConfig-style analyzers (it does — see existing standards) and whether dropping the feature-flag analyzer into Standards fits the mental model. If Standards is the better fit at edit time, the analyzer lives there with a brief explanation in the PR; otherwise, it lives in `HoneyDrunk.Actions`.
+
+This packet ships both: the workflow YAML (in Actions) and the analyzer NuGet (in Actions or Standards). Both are CI-time artifacts; neither is a runtime package consumed by any Node's deployed code.
+
+## Scope
+- `.github/workflows/job-featureflags-validate.yml` — new reusable workflow callable from any Node's `pr-core.yml` flow.
+- A new `HoneyDrunk.Actions.FeatureFlagsAnalyzer` (or `HoneyDrunk.Standards.FeatureFlagsAnalyzer`, depending on the executor's edit-time decision) Roslyn analyzer project + NuGet package.
+- A consumer-usage doc update — `docs/consumer-usage.md` (or whichever doc the existing reusable workflows reference) documents how to call `job-featureflags-validate.yml` and how to opt the analyzer into a project.
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface.
+
+## Proposed Implementation
+1. **`job-featureflags-validate.yml`** — a reusable workflow with the following inputs:
+   - `featureflags-json-glob` (string, default `'src/**/featureflags.json'`) — glob to locate the Node's `featureflags.json` file(s). Most Nodes have one; mono-repos (none today) could have several.
+   - `schema-url` (string, default `'https://schemas.honeydrunkstudios.com/featureflags-v1.json'`) — the schema to validate against (packet 02 ships it). If Studios is not yet serving the URL, the workflow falls back to the in-repo path; the consuming Node configures this. Default points to the published URL.
+   - `today` (string, optional) — overridable "today" date for testability. Defaults to the workflow run timestamp.
+
+   The workflow does:
+   a. Locate every `featureflags.json` matching the glob.
+   b. For each file, validate it against `featureflags-v1.json` using a JSON Schema validator (the workflow ships a small validation script — pick a Node.js or Python validator that runs in GitHub Actions; consult what existing schema-validating workflows in the repo use, or use `ajv-cli` for JSON Schema).
+   c. For each flag entry: verify the `name` matches the regex `^(release|permission|operational)\.[a-z0-9]+\.[a-z0-9-]+$`; verify `category` matches the prefix in `name`.
+   d. For `category: release`: verify `expires_on` is non-null; verify today's date is on or before `expires_on` (a release flag past `expires_on` fails CI with a message naming the flag and the days-past expiry).
+   e. For `category: permission` and `operational`: verify `annual_review_due` is non-null; if today's date is past `annual_review_due`, emit a `::warning::` (does NOT fail CI per D7) with the flag name and days-past-due.
+   f. Verify `category: release` does not carry `annual_review_due`; verify `category: permission`/`operational` does not carry a non-null `expires_on`.
+   g. Emit a summary table in the workflow job summary (the GitHub Actions `$GITHUB_STEP_SUMMARY` markdown surface) listing every flag, its category, its lifecycle state (active / expires-in-N-days / review-due-in-N-days / past-due).
+   h. The workflow does NOT run the Roslyn analyzer — the analyzer runs inside the Node's `dotnet build` step (because it ships as a PackageReference); the workflow validates the registry, and the analyzer separately validates the call sites. Both halves of D6 are then enforced, in their respective phases.
+
+   The workflow is consumed by adding the following to a Node's `.github/workflows/pr-core.yml` (the per-Node tier-1 gate per invariant 31):
+   ```yaml
+   featureflags-validate:
+     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-featureflags-validate.yml@main
+     with:
+       featureflags-json-glob: 'src/**/featureflags.json'
+   ```
+
+2. **`HoneyDrunk.Actions.FeatureFlagsAnalyzer`** (or the Standards-hosted equivalent) — a Roslyn analyzer NuGet package.
+   - **Targets:** `netstandard2.0` (Roslyn analyzers run in the .NET Framework MSBuild host even when the target project is .NET 10; the analyzer must target `netstandard2.0` per the standard Roslyn pattern).
+   - **Dependencies:** `Microsoft.CodeAnalysis.CSharp.Workspaces` (latest stable supported by the .NET 10 toolchain).
+   - **Analyzer rules:**
+     - **HFF001 (Error)** — "Feature flag '{name}' is not registered in featureflags.json." Triggers on a literal-string call to `IFeatureGate.IsEnabledAsync("...")` or `GetVariantAsync<T>("...", default)` where the literal string is not present in any `featureflags.json` discovered in the consuming project's source tree (the analyzer reads `featureflags.json` from the project's directory tree at analysis time via `AdditionalFiles`).
+     - **HFF002 (Warning)** — "Feature flag argument is not a literal string; static analysis cannot verify it is registered." Triggers on variable-fed flag names. Per ADR-0055 D6: "Variable-fed flag names are flagged as a separate warning — they defeat static analysis and should be avoided."
+     - **HFF003 (Warning)** — "Feature flag name '{name}' does not match the {category}.{node}.{feature} pattern." Triggers on a literal-string flag name that doesn't match the regex. (The workflow catches this too at the registry level; the analyzer catches it at the call site if a developer somehow declared a malformed flag in `featureflags.json` and used it — defense in depth.)
+     - **HFF004 (Warning)** — "Direct `IFeatureManager` consumption is discouraged; use `IFeatureGate` (ADR-0055 invariant)." Triggers on any reference to `Microsoft.FeatureManagement.IFeatureManager` or `IFeatureManagerSnapshot` outside `HoneyDrunk.FeatureFlags` itself. (Optional — ship if the implementation is tractable; otherwise defer to a follow-up. The ADR-0055 invariant is enforced by the review agent per D13 regardless.)
+   - The analyzer reads `featureflags.json` files via the `AdditionalFiles` MSBuild item — projects opt into static analysis by adding the `featureflags.json` file with `<AdditionalFiles Include="featureflags.json" />` in their `.csproj` (the analyzer NuGet's `.targets` file does this automatically when the NuGet is referenced).
+   - **`.targets` and `.props` files** — package the analyzer with auto-wiring for `featureflags.json` discovery. Consult the existing analyzer packaging in `HoneyDrunk.Standards` (e.g., the StyleCop wiring) for the pattern.
+   - **Test project** — `HoneyDrunk.Actions.FeatureFlagsAnalyzer.Tests` (or under Standards): xUnit unit tests using `Microsoft.CodeAnalysis.Testing` for each diagnostic rule (positive + negative cases for HFF001/002/003; optional HFF004 if shipped).
+
+3. **Consumer opt-in.** Document in `docs/consumer-usage.md` (or wherever the existing reusable-workflow consumer doc lives — confirm at edit time) the two ways a Node opts in:
+   - **Workflow** — add the `featureflags-validate` job to `.github/workflows/pr-core.yml` calling `job-featureflags-validate.yml@main`.
+   - **Analyzer** — add a `PackageReference` to the analyzer NuGet (whichever name lands) with `PrivateAssets: all`; the analyzer's `.targets` auto-discovers `featureflags.json`. Document the analyzer's diagnostic IDs (HFF001/002/003/(004)) so developers know what to expect.
+
+4. **Releasing the analyzer NuGet.** Consult the existing release flow in `HoneyDrunk.Actions` (or Standards if the analyzer lands there) — analyzers are NuGet packages with their own version, released by tag like any other NuGet. The version is independent of the consuming projects. v0.1.0 baseline.
+
+5. **`docs/consumer-usage.md`** — append a section: "Feature-Flag Validation (ADR-0055)." Cover the workflow call site, the analyzer opt-in, the registry shape (point to packet 02's schema doc), the diagnostic IDs, and an example of a flag declaration + use + the resulting CI behaviour.
+
+## Affected Files
+- `.github/workflows/job-featureflags-validate.yml` (new)
+- The analyzer project tree (new) — under `HoneyDrunk.Actions/analyzers/HoneyDrunk.Actions.FeatureFlagsAnalyzer/` or under `HoneyDrunk.Standards/` if the executor places it there.
+- The analyzer test project (new).
+- `docs/consumer-usage.md` (or equivalent) — new section.
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow / analyzer surface.
+
+## NuGet Dependencies
+**The analyzer project** (new):
+- `Microsoft.CodeAnalysis.CSharp.Workspaces` (latest stable supported by .NET 10)
+- `Microsoft.CodeAnalysis.Analyzers` (latest)
+- `HoneyDrunk.Standards` (`PrivateAssets: all`) — if Standards ships and this project picks it up; confirm at edit time
+
+**The analyzer test project** (new):
+- The ADR-0047 test stack: xUnit v2, NSubstitute, AwesomeAssertions, coverlet
+- `Microsoft.CodeAnalysis.CSharp.Workspaces`
+- `Microsoft.CodeAnalysis.Testing.Verifiers.XUnit` (or the current testing helper supported by Roslyn)
+- `HoneyDrunk.Standards` (`PrivateAssets: all`)
+
+**The reusable workflow** — no .NET project; uses GitHub Actions runners.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` (or Standards) is the correct repo per ADR-0012 (CI/CD control plane) and the existing analyzer-NuGet-packaging pattern.
+- [x] No code change in any Node — the analyzer ships as a NuGet that Nodes opt into; the workflow ships as a reusable that Nodes opt into.
+- [x] No runtime dependency on any Node — Roslyn analyzers run in the MSBuild host, not in deployed code.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/job-featureflags-validate.yml` exists as a reusable workflow with the inputs `featureflags-json-glob`, `schema-url`, `today`
+- [ ] The workflow validates every located `featureflags.json` against the published JSON Schema and emits a structured failure for: schema violation; flag name not matching the regex; category prefix mismatching declared `category`; release flag past `expires_on`; release flag without `expires_on`; permission/operational flag with a non-null `expires_on`
+- [ ] The workflow emits a `::warning::` (not a failure) for permission/operational flags past `annual_review_due` per D7
+- [ ] The workflow renders a markdown summary of every flag's state in the GitHub Actions job summary
+- [ ] The Roslyn analyzer NuGet package exists, targets `netstandard2.0`, and ships diagnostics HFF001 (Error) and HFF002 (Warning) at minimum; HFF003 and HFF004 are optional v0.1 additions
+- [ ] HFF001 fires on a literal-string `IFeatureGate.IsEnabledAsync("undeclared.flag.name")` call where the literal is not in any discovered `featureflags.json`
+- [ ] HFF002 fires on a variable-fed flag-name call (e.g. `IsEnabledAsync(myFlagVar)`)
+- [ ] The analyzer reads `featureflags.json` via `AdditionalFiles`; the packaged `.targets` auto-wires this so consuming projects don't manually add the include
+- [ ] Analyzer unit tests use `Microsoft.CodeAnalysis.Testing` for positive and negative cases of each shipped diagnostic
+- [ ] `docs/consumer-usage.md` (or equivalent) documents the workflow call site, the analyzer opt-in, the diagnostic IDs, and a worked example
+- [ ] The repo `CHANGELOG.md` is updated if the repo keeps one for the workflow / analyzer surface
+- [ ] Existing consumers of the deploy/PR workflows are unaffected — the new workflow and the new analyzer are opt-in
+
+## Human Prerequisites
+- [ ] After this packet's PR merges, a human publishes the analyzer NuGet to the package feed (analyzers are NuGet packages; agents never tag — invariant 27). Until publication, downstream Nodes opting into the analyzer reference it from a local source or wait. Packet 07 (Notify pilot) needs the analyzer published before it can opt in.
+
+## Referenced ADR Decisions
+**ADR-0055 D6 — Per-Node `featureflags.json` with CI validation.** A new `job-featureflags-validate.yml` in HoneyDrunk.Actions enforces: every flag used in code is registered (Roslyn analyzer); every registered flag is used in code or marked `expected_orphan: true`; naming convention (D5); category coherence; release-flag expiry; permission/operational annual-review-due warnings.
+
+**ADR-0055 D6 — Roslyn analyzer.** "A static analyzer (custom Roslyn rule) scans the assembly for `IFeatureGate.IsEnabledAsync('...')` and `GetVariantAsync<...>('...')` calls; any literal flag string not present in `featureflags.json` fails the build. (Variable-fed flag names are flagged as a separate warning — they defeat static analysis and should be avoided.)"
+
+**ADR-0055 D7 — Release-flag expiry; permission/operational warnings.** Release flags fail CI on expiry; permission/operational past `annual_review_due` produce a warning (not blocker). The workflow respects this asymmetry.
+
+**ADR-0055 D5 — Naming regex.** `^(release|permission|operational)\.[a-z0-9]+\.[a-z0-9-]+$`. Both the workflow (registry side) and the analyzer (call-site side) check this.
+
+**ADR-0012 — Actions as the CI/CD control plane.** Reusable workflows live here; analyzers ship as part of the CI tooling surface.
+
+## Constraints
+- **Analyzers target `netstandard2.0`.** Roslyn analyzers run in the .NET Framework MSBuild host; the standard requirement.
+- **Opt-in, backward-compatible.** Both the workflow and the analyzer are opt-in. Existing Nodes are unaffected until they choose to call the workflow or reference the analyzer NuGet.
+- **Don't run the Roslyn analyzer inside the workflow.** The analyzer runs inside `dotnet build` because it ships as a PackageReference; the workflow handles the registry side. The two halves run in their respective phases (build for the analyzer, the reusable workflow for the registry).
+- **`expected_orphan` is the escape hatch for the "every registered flag is used" check.** ADR-0055 D6 names this explicitly. The workflow honors it: a registered flag with `expected_orphan: true` does NOT fail CI even if the Roslyn analyzer doesn't see a literal-string call site (e.g., the flag is consumed only by the operator dashboard reading the registry list).
+- **Don't depend on Studios serving the schema URL at workflow time.** Default to `https://schemas.honeydrunkstudios.com/featureflags-v1.json`; if it 404s, the workflow falls back to the in-repo path under `HoneyDrunk.Architecture/schemas/`. The fallback path is configurable via the `schema-url` input.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `adr-0055`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Author the `job-featureflags-validate.yml` reusable workflow and the `HoneyDrunk.Actions.FeatureFlagsAnalyzer` Roslyn analyzer NuGet so per-Node `featureflags.json` registries and literal-string flag calls in code are statically validated per ADR-0055 D6.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`. (Or `HoneyDrunk.Standards`, if the executor decides at edit time that Standards is the better fit for the analyzer NuGet — document the choice in the PR.)
+
+**Context:**
+- Goal: Make the dual validation (registry + call site) a hard CI gate, with the warning-vs-error asymmetry ADR-0055 D7 names (release expires = error; permission/operational review-due = warning).
+- Feature: ADR-0055 Feature Flag rollout, Wave 4.
+- ADRs: ADR-0055 D5/D6/D7 (primary), ADR-0012 (Actions as CI/CD control plane), ADR-0047 (test stack for the analyzer's test project).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — the `featureflags-v1.json` schema exists and is the validation target.
+- `packet:04` — `IFeatureGate` exists in `HoneyDrunk.Kernel.Abstractions` so the analyzer has a concrete contract to scan calls against.
+
+**Constraints:**
+- Analyzer targets `netstandard2.0`.
+- Workflow and analyzer are opt-in, backward-compatible.
+- `expected_orphan: true` is the escape hatch in the dual-validation; honor it.
+- Schema URL is configurable with a fallback to in-repo path.
+
+**Key Files:**
+- `.github/workflows/job-featureflags-validate.yml`
+- `analyzers/HoneyDrunk.Actions.FeatureFlagsAnalyzer/` (or under Standards)
+- The analyzer test project
+- `docs/consumer-usage.md` (or equivalent)
+
+**Contracts:**
+- The analyzer scans `IFeatureGate.IsEnabledAsync(string)` and `IFeatureGate.GetVariantAsync<T>(string, T)` call sites — confirm method signatures against packet 04's shipped `IFeatureGate` at edit time.
+- The workflow reads `featureflags.json` matching the `featureflags-v1.json` schema shipped by packet 02.

--- a/generated/issue-packets/active/adr-0055-feature-flags/07-notify-pilot-release-flag.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/07-notify-pilot-release-flag.md
@@ -1,0 +1,208 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["feature", "tier-2", "ops", "pilot", "adr-0055", "wave-4"]
+dependencies: ["packet:05", "packet:06"]
+adrs: ["ADR-0055"]
+wave: 4
+initiative: adr-0055-feature-flags
+node: honeydrunk-notify
+---
+
+# Pilot ADR-0055 — declare one release flag, gate an in-progress feature, validate the end-to-end loop
+
+## Summary
+Pilot the ADR-0055 flag system end-to-end in `HoneyDrunk.Notify` per Phase 2: declare a `release.notify.<feature>` flag in a new `src/HoneyDrunk.Notify/featureflags.json`, compose `AddFeatureFlags` in Notify's host, gate an in-progress feature behind `IFeatureGate.IsEnabledAsync` at the feature's entry point, wire `job-featureflags-validate.yml` and the Roslyn analyzer NuGet, and verify the end-to-end loop: **declare → use → CI validates → flip via App Configuration → log emitted → audit recorded for permission/operational categories** (release-flag flips are logged, not audited).
+
+## Context
+ADR-0055 D14 Phase 2 names Notify as the pilot consumer: "Pilot consumption in `HoneyDrunk.Notify` (one release flag for an in-progress bulk-send feature) to validate the end-to-end loop." The ADR's example flag is `release.notify.bulk-send`. **Use the bulk-send feature if it is in flight at execution time; otherwise pick any genuinely in-progress Notify feature and name the flag accordingly** — the value of the pilot is the end-to-end loop validation, not the specific feature chosen. The Notify launch tracker is the authority on what features are currently in flight; consult it at edit time.
+
+`HoneyDrunk.Notify` is a live Node currently at v0.3.0. This packet amends Notify to consume the flag system and ships the first real-world flag gate. The change is functional (a real feature is gated; a Notify deploy after this packet leaves the feature behind a default-off flag in staging/prod and on in dev per D9) — per invariants 12/27 it bumps the solution one minor version.
+
+The end-to-end loop has six observable steps; the acceptance criteria verify each:
+1. **Declare** — the flag is registered in `featureflags.json` per D6 (and packet 02's schema).
+2. **Use** — code calls `_featureGate.IsEnabledAsync("release.notify.<feature>")` (literal string, picked up by the Roslyn analyzer per packet 06).
+3. **CI validates** — `job-featureflags-validate.yml` passes; the Roslyn analyzer's HFF001 does not fire on the literal flag string (it is registered).
+4. **Flip via App Configuration** — a human (or the Operator CLI from packet 08 when it lands; the App Configuration portal directly until then) flips the flag's per-label value. The push-refresh propagates within seconds.
+5. **Log emitted** — `HoneyDrunk.Pulse` records a `feature_flag_evaluated` event per D10 with the structured fields (`flag.name`, `flag.category`, `flag.decision`, etc.).
+6. **Audit** — for **release-category** flags, no audit event (D10: "Release-flag flips are logged but not audited"). The audit gate runs for **permission** and **operational** flips; the pilot does not exercise the audit path. Document this explicitly in the PR description — the pilot validates the **release** loop, not the audit loop. The audit loop is validated by packet 08's Operator CLI (which emits the audit events) and by a future permission-category pilot (deferred to Notify.Cloud per Phase 4).
+
+## Scope
+- `src/HoneyDrunk.Notify/featureflags.json` (new) — register the pilot release flag.
+- Notify host composition — call `AddFeatureFlags(builder.Configuration)` in the host startup, and ensure App Configuration is wired with the feature-flag section per D2/D9 (label-aware refresh).
+- The feature's entry point — wrap the code path behind `await _featureGate.IsEnabledAsync("release.notify.<feature>")`.
+- `.github/workflows/pr-core.yml` — call `job-featureflags-validate.yml` per packet 06.
+- The Notify project that consumes flags — add a `PackageReference` to the analyzer NuGet from packet 06 (`PrivateAssets: all`) so the Roslyn analyzer runs at build time.
+- A new unit/integration test asserting flag-on and flag-off behavior using `InMemoryFeatureGate` (per invariant 15 and packet 04's testing fixture).
+- The Notify solution version bumps to the next minor (invariant 27).
+- `HoneyDrunk.Notify` per-package `CHANGELOG.md` and `README.md` updates as needed (per invariant 12, only the package with the functional change gets an entry).
+- Repo-level `CHANGELOG.md` for the new version.
+
+## Proposed Implementation
+1. **Audit at execution time.** Confirm with the Notify launch tracker which Notify feature is genuinely in flight at edit time. ADR-0055's example is `release.notify.bulk-send`; if bulk-send isn't in flight, pick a real candidate (the value here is validating the loop, not the feature choice). Record the chosen flag name in the PR description.
+2. **Declare** — `src/HoneyDrunk.Notify/featureflags.json`:
+   ```json
+   {
+     "$schema": "https://schemas.honeydrunkstudios.com/featureflags-v1.json",
+     "flags": [
+       {
+         "name": "release.notify.<feature>",
+         "category": "release",
+         "description": "<feature> in Notify; ships in <target version>. Pilot flag for ADR-0055 end-to-end validation.",
+         "owner": "HoneyDrunk.Notify",
+         "created": "<YYYY-MM-DD>",
+         "expires_on": "<created + 90 days>",
+         "expected_orphan": false
+       }
+     ]
+   }
+   ```
+   The `expires_on` is 90 days from `created` per ADR-0055 D7 default — surface it explicitly so the executor doesn't pick an arbitrary date.
+3. **Compose** — in Notify's host startup (the executable Notify project, not the abstractions/runtime packages):
+   ```csharp
+   builder.Configuration.AddAzureAppConfiguration(opt =>
+   {
+       opt.Connect(new Uri(builder.Configuration["AppConfig:Endpoint"]!),
+                  new ManagedIdentityCredential())
+          .Select(KeyFilter.Any, label: env)             // dev/staging/prod/ci per D9
+          .UseFeatureFlags(ff => ff.Label = env)         // label-scoped feature flags
+          .ConfigureRefresh(r => r.Register("FeatureManagement:Sentinel", refreshAll: true)
+                                  .SetCacheExpiration(TimeSpan.FromSeconds(30)));
+   });
+   builder.Services.AddFeatureFlags(builder.Configuration);
+   ```
+   `env` resolves from `ASPNETCORE_ENVIRONMENT` (or the equivalent) per ADR-0033's environment convention; align with the existing Notify env-resolution pattern.
+4. **Use** — at the feature's entry point (the Notify code path being gated):
+   ```csharp
+   private const string BulkSendFlag = "release.notify.bulk-send"; // const for analyzer; per D13 anti-pattern, never concatenate
+   …
+   if (!await _featureGate.IsEnabledAsync(BulkSendFlag))
+   {
+       // current behaviour — fall back to per-message sends, or return the existing pre-feature response
+       return await _existingPath.ExecuteAsync(ct);
+   }
+   // new feature behaviour, only reached when the flag is on
+   return await _bulkSendPath.ExecuteAsync(ct);
+   ```
+   The `const string` hoist is per ADR-0055 D13 anti-pattern ("String-concatenating flag names at the call site"); the analyzer in packet 06 sees the literal string and validates against `featureflags.json`. **Do not** inline the string into multiple call sites — hoist it once.
+5. **CI** — `.github/workflows/pr-core.yml` adds a `featureflags-validate` job calling `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-featureflags-validate.yml@main` with `featureflags-json-glob: 'src/**/featureflags.json'`. The Notify project that holds `featureflags.json` opts into the analyzer by adding a `PackageReference` to the analyzer NuGet (`PrivateAssets: all`).
+6. **Tests** — add a unit/integration test in the appropriate Notify test project asserting:
+   - **Flag off** — `InMemoryFeatureGate.SetFlag("release.notify.<feature>", false)` → the feature entry point invokes `_existingPath`, not `_bulkSendPath`.
+   - **Flag on** — `InMemoryFeatureGate.SetFlag("release.notify.<feature>", true)` → the feature entry point invokes `_bulkSendPath`.
+   These cover the ADR-0044/0047 "test both flag-on and flag-off states" expectation. No `Thread.Sleep` (invariant 51); no App Configuration in the test (invariant 15).
+7. **App Configuration seeding (operator-side prerequisite, captured as Human Prerequisite).** Once this packet's PR merges and Notify deploys to dev, a human creates the flag in the dev App Configuration resource per packet 03's walkthrough: create the flag named `release.notify.<feature>` with the `dev` label `enabled: true` and the `staging`/`prod`/`ci` labels `enabled: false` (per D9). The flag exists in `featureflags.json` regardless — App Configuration is the *runtime* substrate; the registry is the source of truth.
+8. **Verify the loop end-to-end (operator action, captured as Human Prerequisite).**
+   a. Deploy Notify to dev with the flag at `enabled: true` (the D9 default for dev).
+   b. Exercise the gated feature; confirm the new code path runs (validates step 2 + 4).
+   c. Confirm a `feature_flag_evaluated` event appears in Pulse / App Insights with the structured fields (validates step 5).
+   d. Flip the flag to `enabled: false` in App Configuration; within ~30 seconds, confirm the next request takes the old code path (validates the push-refresh from D2).
+   e. Confirm no audit event was emitted (D10 — release-category does not audit). This is a *negative* assertion — packet 08 (Operator CLI + audit wiring) validates the *positive* audit path for permission/operational categories.
+9. **Version bump.** Bump every non-test `.csproj` in the Notify solution to the next minor version in one commit (invariant 27). Repo-level `CHANGELOG.md` adds a new dated entry; the Notify project that holds the feature gate gets a per-package CHANGELOG entry (functional change). Other Notify packages bumped only for alignment get no per-package entry (invariant 12).
+
+## Affected Files
+- `src/HoneyDrunk.Notify/featureflags.json` (new)
+- The Notify host startup file (composition wiring)
+- The feature's entry point file (the gated code path)
+- `.github/workflows/pr-core.yml` (add the `featureflags-validate` job)
+- The Notify project that owns the feature gate — add `PackageReference` to the analyzer NuGet
+- The Notify test project — new flag-on/flag-off tests
+- Every non-test `.csproj` in the Notify solution — version bump (invariant 27)
+- Repo-level `CHANGELOG.md`; per-package `CHANGELOG.md` for the changed package
+- `README.md` if the public API surface or composition story changed
+
+## NuGet Dependencies
+- The Notify project that owns the host composition:
+  - `HoneyDrunk.FeatureFlags` — the v0.1.0 published by packet 05 (concrete `IFeatureGate` implementation + `TenantTargetingFilter`). Confirm published version at edit time.
+  - `HoneyDrunk.Kernel.Abstractions` — already referenced by Notify; ensure the version is at least packet 04's minor.
+- The Notify project that owns the feature gate (the same project, or a sibling project that already references `HoneyDrunk.Kernel.Abstractions`):
+  - `HoneyDrunk.Actions.FeatureFlagsAnalyzer` (or whichever name packet 06 ships) — `PrivateAssets: all`.
+- The Notify test project that holds the new flag tests:
+  - `HoneyDrunk.Kernel.Abstractions.Testing` — for `InMemoryFeatureGate`. Already referenced if Notify uses Kernel test fixtures; confirm at edit time.
+
+## Boundary Check
+- [x] All code change is in `HoneyDrunk.Notify` — its own host composition, the feature gate site, the new test. Routing rule "notification, email, SMS, ... notify, channel → HoneyDrunk.Notify" maps here.
+- [x] No contract change — Notify consumes `IFeatureGate` as shipped by packet 04 and the App-Configuration-backed implementation as shipped by packet 05.
+- [x] Preference/cadence/suppression decision logic is NOT touched — that is Communications' boundary (invariant 41). This packet gates one Notify delivery-mechanics feature.
+- [x] Audit wiring is NOT exercised — release-category flags are logged, not audited (D10). Packet 08 validates the audit path.
+
+## Acceptance Criteria
+- [ ] `src/HoneyDrunk.Notify/featureflags.json` exists, validates against the `featureflags-v1.json` schema (packet 02), and declares one release flag with `name` matching the regex, `category: release`, `created`, `expires_on` (90 days from created), `expected_orphan: false`
+- [ ] The Notify host wires App Configuration with the label-aware feature-flag refresh per ADR-0055 D2/D9 (Managed Identity per ADR-0005; no secret in code)
+- [ ] The Notify host calls `AddFeatureFlags(builder.Configuration)` to register the App-Configuration-backed `IFeatureGate`
+- [ ] The gated feature's entry point evaluates `await _featureGate.IsEnabledAsync(BulkSendFlag)` (or the equivalent for the chosen feature) with the flag name held as a `const string` near the call site (per ADR-0055 D13 anti-pattern)
+- [ ] The new unit/integration tests assert flag-on triggers the new path and flag-off triggers the existing path; use `InMemoryFeatureGate.SetFlag(...)` (invariant 15)
+- [ ] `.github/workflows/pr-core.yml` calls `job-featureflags-validate.yml@main` from packet 06
+- [ ] The Notify project that owns the feature gate references the analyzer NuGet from packet 06 (`PrivateAssets: all`); the build picks up the analyzer and emits no HFF001/HFF003 diagnostics on the new flag use site
+- [ ] Every non-test `.csproj` in the Notify solution is at the same new minor version in a single commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new dated version entry; the package that holds the functional change has a per-package CHANGELOG entry; other packages bumped for alignment have NO per-package entry (invariant 12)
+- [ ] No `Thread.Sleep` in test code (invariant 51); no external dependencies in tests (invariant 15)
+- [ ] The PR description records the end-to-end loop verification (which feature was gated, which six steps were observed during the operator-side validation)
+- [ ] The `pr-core.yml` tier-1 gate passes, the `featureflags-validate` job is green, and the analyzer fires no errors on the new flag use site
+
+## Human Prerequisites
+- [ ] Packet 05's `HoneyDrunk.FeatureFlags` v0.1.0 must be published to NuGet (human tag/release per invariant 27) before this packet's PR can build.
+- [ ] Packet 06's analyzer NuGet must be published (or available via a local source) before this packet's project can reference it.
+- [ ] After this PR merges and Notify deploys to dev: create the flag in the dev App Configuration resource per packet 03's walkthrough. Set `dev` label `enabled: true`, `staging`/`prod`/`ci` labels `enabled: false`. Until this happens, the flag does not exist at runtime — `IFeatureGate.IsEnabledAsync` returns the default (`false`), and the gated feature stays off.
+- [ ] Run the end-to-end loop verification (the six observable steps in the Proposed Implementation step 8) and record findings in the PR description.
+
+## Referenced ADR Decisions
+**ADR-0055 D14 Phase 2 — Notify pilot.** "Pilot consumption in `HoneyDrunk.Notify` (one release flag for an in-progress bulk-send feature) to validate the end-to-end loop: declare → use → CI validates → flip via operator CLI → log emitted → audit recorded."
+
+**ADR-0055 D9 — Local-dev affordances.** Dev label defaults the flag on; staging/prod/ci default off. The pilot exercises this — in dev, the gated feature is live by default; in higher environments, it's behind the flag.
+
+**ADR-0055 D10 — Release flips are logged but not audited.** The pilot flag is `category: release`; flips emit `feature_flag_evaluated` log events to Pulse but NOT audit events. The audit-event path is exercised by packet 08 (Operator CLI with permission/operational flips). The pilot does not exercise that path — explicitly noted in the PR description.
+
+**ADR-0055 D13 — Anti-pattern: string-concatenating flag names.** The pilot holds the flag name as a `const string` so the Roslyn analyzer can resolve it and the registry stays accurate.
+
+**ADR-0055 D6 — Per-Node `featureflags.json`.** The pilot is the first real consumer of this; the file lands at `src/HoneyDrunk.Notify/featureflags.json` per the ADR's path convention.
+
+## Constraints
+- **Pilot validates the release-flag loop, not the audit loop.** Audit is a permission/operational concern (D10); the pilot is a release flag. Packet 08 validates the audit path.
+- **Don't speculatively add a permission or operational flag.** The pilot is one release flag (per the ADR's Phase 2 wording). A permission flag for Notify.Cloud is a Phase 4 deferred item.
+- **Const-string flag name.** Per ADR-0055 D13 anti-pattern, hold the flag name in a `const string`; never interpolate or concatenate the flag name at the call site. The analyzer enforces this with HFF002.
+- **Default-off in higher environments.** Per D9, the staging/prod label values for the flag are `enabled: false`. The flag stays off in production until the feature is ready to ship — at which point the operator flips the flag, then in a follow-up the flag and its `expires_on` cleanup PR retires the flag entirely per D7.
+- **Invariant 27 — solution-wide version bump.** Every non-test `.csproj` in the Notify solution bumps in one commit.
+- **Invariant 12 — per-package CHANGELOGs only for packages with actual changes.** The package holding the feature gate gets an entry; other Notify packages bumped solely for alignment get no per-package entry.
+
+## Labels
+`feature`, `tier-2`, `ops`, `pilot`, `adr-0055`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Pilot the ADR-0055 flag system end-to-end in `HoneyDrunk.Notify` with one release flag gating an in-progress feature, validating the declare → use → CI → flip → log loop.
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: Confirm the flag substrate works end-to-end against a real consumer before the broader Grid rollout (Notify.Cloud Phase 4, consumer-app PDR adoption Phase 5).
+- Feature: ADR-0055 Feature Flag rollout, Wave 4 (the pilot).
+- ADRs: ADR-0055 D2/D9/D10/D13/D14 (primary), ADR-0026 (RequestContext source for ITargetingContext — Notify's host composition already provides this), ADR-0033 (env resolution), ADR-0005 (App Configuration backing via Managed Identity).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:05` — `HoneyDrunk.FeatureFlags` v0.1.0 published to NuGet.
+- `packet:06` — `job-featureflags-validate.yml` and the analyzer NuGet published.
+
+**Constraints:**
+- One release flag. No speculative permission/operational flags.
+- Const-string flag name; analyzer HFF002 enforces.
+- Default-on in dev; default-off elsewhere (D9).
+- Solution-wide minor bump; per-package CHANGELOG only for the package with functional changes (invariants 12, 27).
+- Audit path is NOT exercised here — release-category flips are logged, not audited (D10).
+
+**Key Files:**
+- `src/HoneyDrunk.Notify/featureflags.json` (new)
+- Notify host composition file — `AddFeatureFlags` wiring.
+- The gated feature's entry-point file — `IFeatureGate.IsEnabledAsync` call.
+- `.github/workflows/pr-core.yml` — `featureflags-validate` job.
+- Notify test project — flag-on/flag-off tests with `InMemoryFeatureGate`.
+- Every non-test `.csproj` for the solution-wide minor bump.
+- Repo-level + per-package `CHANGELOG.md`.
+
+**Contracts:**
+- Consumes `IFeatureGate` from `HoneyDrunk.Kernel.Abstractions` (packet 04's surface).
+- Consumes `HoneyDrunk.FeatureFlags`'s `AddFeatureFlags` (packet 05's host composition).
+- The flag declaration in `featureflags.json` matches `featureflags-v1.json` (packet 02's schema).

--- a/generated/issue-packets/active/adr-0055-feature-flags/08-operator-flags-cli-subcommand.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/08-operator-flags-cli-subcommand.md
@@ -1,0 +1,219 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Operator
+labels: ["feature", "tier-2", "ai", "cli", "adr-0055", "wave-5"]
+dependencies: ["packet:05"]
+adrs: ["ADR-0055", "ADR-0018", "ADR-0030"]
+wave: 5
+initiative: adr-0055-feature-flags
+node: honeydrunk-operator
+---
+
+# Add the `operator flags …` CLI subcommand and wire permission/operational flip audit events
+
+## Summary
+Add the `operator flags …` CLI subcommand to `HoneyDrunk.Operator` per ADR-0055 D11 — `list`, `show`, `enable`, `disable`, `expire`, `review-due` — backed by the Azure App Configuration management SDK for write operations and `IFeatureGate` (composed from `HoneyDrunk.FeatureFlags`) for read operations. Wire **permission and operational flip events to `HoneyDrunk.Audit`** per ADR-0055 D10 / ADR-0030; release-flag flips are logged via `HoneyDrunk.Pulse` only, not audited.
+
+## Context
+ADR-0055 D11 defines the operator surface as a `flags` subcommand on the Operator CLI:
+- `operator flags list [--node <node>] [--category <cat>]` — list flags with current state per environment.
+- `operator flags show <flag-name>` — detailed view: per-environment state, targeting rules, lifecycle metadata, last flip.
+- `operator flags enable <flag-name> [--env <env>] [--tenant <tenant-id>] [--percentage <0–100>]` — enable a flag, optionally scoped. Permission/operational flips are audited per D10.
+- `operator flags disable <flag-name> [--env <env>] [--tenant <tenant-id>]` — disable; same audit semantics.
+- `operator flags expire <flag-name>` — for release flags only; marks the flag expired (triggers CI failure on next build).
+- `operator flags review-due [--node <node>]` — list permission/operational flags past their `annual_review_due`.
+
+`HoneyDrunk.Operator` is governed by **ADR-0018** (its own standup initiative, in progress at scoping time). At time of writing, Operator is Seed/v0.0.0; its standup is delivering the solution scaffold + the eight Operator-owned contracts. The CLI **shell** — the `dotnet` console host with a verb-based command surface — is part of ADR-0018's standup. **This packet depends on Operator's CLI shell being live.**
+
+**Execution prerequisite:** before this packet can execute, ADR-0018's standup must have delivered enough of `HoneyDrunk.Operator` that a CLI shell exists with subcommand routing. If it has not, this packet is deferred. See Human Prerequisites. If the executor finds the shell exists but is only a minimal scaffold, the implementation here adds the `flags` verb cleanly alongside the existing scaffold — no contortion required.
+
+The write surface — flipping App Configuration values — uses the **App Configuration management SDK** (`Azure.ResourceManager.AppConfiguration` + `Azure.Data.AppConfiguration`), authenticated via Managed Identity. Read operations use `IFeatureGate` for evaluation against the operator's principal context (handy for `show` — "what does this flag evaluate to right now for this tenant?"). The write path is direct; the read path goes through the contract for consistency with the rest of the Grid.
+
+ADR-0055 D10 names the audit semantics precisely:
+- **Permission flag flips ARE audit events** (per ADR-0030 `IAuditLog`).
+- **Operational flag flips ARE audit events** (incident-bounded toggles are exactly what audit captures).
+- **Release flag flips are LOGGED but NOT audited** (release-flag toggling is routine dev workflow; audit-logging it adds noise without value).
+
+This packet wires the audit emission for permission/operational categories; release-category flips emit log events to Pulse only.
+
+## Scope
+- New `Flags` verb / subcommand handlers on the Operator CLI — six verbs (`list`, `show`, `enable`, `disable`, `expire`, `review-due`) under the `flags` group.
+- App Configuration management SDK integration (read + write) — backing the verbs.
+- `IFeatureGate` composition for the `show` verb's evaluate-against-context option.
+- Audit emission via `HoneyDrunk.Audit.Abstractions`'s `IAuditLog` for permission/operational flips (ADR-0055 D10 / ADR-0030).
+- Pulse log emission via the structured logger for every flip (release/permission/operational).
+- New unit tests covering the verbs (each verb against a faked App Configuration client and a faked `IAuditLog`).
+- Operator runbook documentation (a new section in the Operator README or `docs/runbook.md`) covering the flip workflow per category.
+- Version bump per the Operator solution at execution time (per invariant 27).
+
+## Proposed Implementation
+1. **Confirm Operator's CLI shell exists at execution time.** Inspect `HoneyDrunk.Operator`'s solution: is there a `HoneyDrunk.Operator.Cli` executable (or similar) with a verb-routing surface? If yes, proceed. If no, this packet stops; record the gap as a hard dependency on ADR-0018 packet that adds the CLI shell, and re-file once the shell is shipped. The Human Prerequisites section calls this out.
+
+2. **Pick the verb-routing framework.** Operator likely uses `System.CommandLine` or `Cocona` or `Spectre.Console.Cli` — match whatever the shell uses; do not introduce a new CLI framework here.
+
+3. **Implement the six verbs.** Group them under `flags`:
+   - **`operator flags list [--node <node>] [--category <cat>]`**
+     - Read every `featureflags.json` discoverable from the Operator's known-Nodes registry (the Grid catalog is the source — Operator depends on `HoneyDrunk.Architecture/catalogs/` content or a structured Operator-side mirror).
+     - For each flag, query App Configuration via the management SDK for the per-environment value (`dev`/`staging`/`prod`/`ci` labels).
+     - Filter by `--node` (lowercase node segment in the flag name) and `--category` (`release`/`permission`/`operational`) if supplied.
+     - Output a markdown table to stdout (the Operator CLI's convention — confirm against the shell's existing verbs).
+   - **`operator flags show <flag-name>`**
+     - Read the flag's `featureflags.json` entry (description, owner, created, expires_on, annual_review_due, tags, hotpath).
+     - Read the flag's per-label state from App Configuration (enabled per env, targeting filters, last-flipped timestamp).
+     - Optionally evaluate the flag against the operator's principal context using `IFeatureGate.IsEnabledAsync(name, principalContext)` to show the live decision.
+   - **`operator flags enable <flag-name> [--env <env>] [--tenant <tenant-id>] [--percentage <0–100>]`**
+     - Write the per-label App Configuration value to `enabled: true` (or with the supplied targeting filter shape).
+     - Read the flag's category from `featureflags.json` to decide whether to emit an audit event (permission/operational yes; release no).
+     - Emit an audit event via `IAuditLog` (see step 4) for permission/operational; emit a Pulse log event for every flip (release/permission/operational).
+   - **`operator flags disable <flag-name> [--env <env>] [--tenant <tenant-id>]`**
+     - Same as enable, but writes `enabled: false`. Same audit/log semantics.
+   - **`operator flags expire <flag-name>`**
+     - Read the flag from `featureflags.json`; verify `category: release` (else error — `expire` is release-only per D11).
+     - Patch the registry's `expires_on` to today's date (the file lives in the Node's repo; this is a write-against-the-repo operation, not against App Configuration — see Cross-Cutting Concerns in the dispatch plan).
+     - Optional: open a PR against the Node's repo with the patch; agent-driven, but human-reviewed.
+     - Emit a Pulse log event; no audit (release-flag flips are not audited per D10).
+   - **`operator flags review-due [--node <node>]`**
+     - Read every `featureflags.json` from the catalog.
+     - Filter to permission/operational flags whose `annual_review_due` is on or before today.
+     - Output a markdown table; this is a read-only verb (no audit, no log emission beyond a routine Pulse event).
+
+4. **Audit emission for permission/operational flips.** ADR-0055 D10 + ADR-0030:
+   ```csharp
+   await _auditLog.AppendAsync(new AuditEntry(
+       category: AuditCategory.PolicyChange,
+       action: enabled ? "feature_flag_enabled" : "feature_flag_disabled",
+       principalId: requestContext.PrincipalId,
+       targetType: "feature_flag",
+       targetId: flagName,
+       tenantId: requestContext.TenantId, // null for grid-wide flips; populated for tenant-scoped
+       outcome: AuditOutcome.Success,
+       changes: new AuditChanges {
+           Previous = new { enabled = wasEnabled },
+           Current = new { enabled = enabled, env = scope.Environment, tenant = scope.TenantId, percentage = scope.Percentage }
+       }
+   ));
+   ```
+   The exact `AuditEntry` shape is defined by `HoneyDrunk.Audit.Abstractions` v0.1.0 (already published — Audit is Live at v0.1.0). Confirm the API at edit time against the published version.
+
+5. **Pulse log emission for every flip.** ADR-0055 D10 specifies the shape:
+   ```json
+   {
+     "event": "feature_flag_flipped",
+     "flag.name": "permission.lately.video-posts",
+     "flag.category": "permission",
+     "flag.previous_state": false,
+     "flag.new_state": true,
+     "operator.id": "prn-...",
+     "scope.env": "prod",
+     "scope.tenant": "tenant-...",
+     "trace_id": "..."
+   }
+   ```
+   Use `Microsoft.Extensions.Logging.ILogger` structured logging — Pulse's sink composition at the Operator host carries the events to App Insights per ADR-0040.
+
+6. **Unit tests** — for each verb, against a faked App Configuration client (`Azure.Data.AppConfiguration.ConfigurationClient` substituted via NSubstitute), a faked `IAuditLog`, and a faked `IFeatureGate` for `show`. Assertions: the write happens with the right key/label/value; the audit event is emitted with the right category/action/target; the Pulse log event is emitted with the right structured fields; release flips emit log but NOT audit; permission/operational flips emit both.
+
+7. **Operator runbook documentation** — add a "Feature Flags Operator Workflow" section to the Operator README or to a dedicated runbook doc. Cover: the verb reference, the audit semantics per category, the App Configuration permission model (Managed Identity Reader+Writer roles needed on the App Configuration resource for the verbs to work; document the role-assignment step as a portal prerequisite).
+
+8. **Version bump.** Confirm Operator's current solution version at execution time. If Operator is at `0.0.0` (still in initial standup), this packet may be bundled with Operator's standup work. If Operator has shipped a `0.1.0` (or higher) baseline, this packet bumps the next minor. The minor-bump rule per invariant 27 applies.
+
+## Affected Files
+- The Operator CLI's `Flags` verb files (new, under whatever the shell's command-tree convention is — likely `src/HoneyDrunk.Operator.Cli/Commands/Flags/`).
+- The Operator host composition — DI registration for the App Configuration management client, `IFeatureGate`, `IAuditLog`.
+- The Operator runbook doc — new "Feature Flags Operator Workflow" section.
+- The Operator test project — new unit tests for each verb.
+- Every non-test `.csproj` in the Operator solution — version bump.
+- Repo-level `CHANGELOG.md`; per-package `CHANGELOG.md` for the packages with functional changes.
+
+## NuGet Dependencies
+- The Operator CLI / host project (whichever owns command composition):
+  - `HoneyDrunk.Kernel.Abstractions` — for `IFeatureGate` (the read path).
+  - `HoneyDrunk.FeatureFlags` — packet 05's published v0.1.0 (concrete `IFeatureGate` + composition).
+  - `HoneyDrunk.Audit.Abstractions` — for `IAuditLog` (already a known dependency for Operator per ADR-0018; confirm version at edit time).
+  - `Azure.Data.AppConfiguration` — App Configuration management SDK (write path).
+  - `Azure.ResourceManager.AppConfiguration` — for higher-level management operations if needed (read flag state across labels; the higher-level SDK simplifies cross-label reads).
+  - `Azure.Identity` — for `ManagedIdentityCredential` (the auth surface per ADR-0005).
+
+## Boundary Check
+- [x] `HoneyDrunk.Operator` is the correct repo per ADR-0055 D11.
+- [x] Permission/operational flip audit events flow through `IAuditLog` (ADR-0030) — the right boundary.
+- [x] Release flag flip events flow through Pulse logs only, not audit (ADR-0055 D10).
+- [x] No new contract is added to `HoneyDrunk.Kernel.Abstractions` — the verbs consume existing contracts (`IFeatureGate`, `IAuditLog`).
+
+## Acceptance Criteria
+- [ ] Operator's CLI exposes six verbs under `operator flags`: `list`, `show`, `enable`, `disable`, `expire`, `review-due`, matching ADR-0055 D11 signatures
+- [ ] `enable` and `disable` accept `--env`, `--tenant`, `--percentage` per D11; the targeting filter JSON written to App Configuration matches ADR-0055 D3's `TenantTargeting` filter shape when `--tenant` or tier filtering is used
+- [ ] `expire` operates only on `category: release` flags; emits an error for permission/operational flags
+- [ ] `review-due` reads every discoverable `featureflags.json` and lists permission/operational flags with `annual_review_due` on or before today
+- [ ] **Permission and operational flips emit an audit event** via `IAuditLog` with category `PolicyChange`, action `feature_flag_enabled` / `feature_flag_disabled`, the principal/operator id, the flag name as the target, and the previous/new state in `changes`
+- [ ] **Release flips do NOT emit audit events** — the audit pipeline is bypassed for release-category flags per ADR-0055 D10
+- [ ] Every flip emits a Pulse log event (`feature_flag_flipped`) with the structured fields per ADR-0055 D10
+- [ ] App Configuration writes use the management SDK with Managed Identity auth per ADR-0005 (no secret in code or config; invariants 8, 9)
+- [ ] Unit tests cover each verb against faked App Configuration client + faked `IAuditLog`; the tests assert audit is emitted for permission/operational and NOT emitted for release (the negative assertion is critical)
+- [ ] Operator runbook documents the verb reference, the audit semantics per category, and the Managed Identity role-assignment portal step
+- [ ] Every non-test `.csproj` in the Operator solution is at the same new minor version in a single commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new dated version entry; per-package CHANGELOGs only for packages with actual changes (invariant 12)
+- [ ] No `Thread.Sleep` in tests (invariant 51); no external dependencies in tests (invariant 15)
+- [ ] The `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **Operator's CLI shell must be live before this packet can execute.** ADR-0018's Operator-standup track delivers the shell. If the shell does not yet exist at this packet's execution time, this packet is deferred — close the issue with `wontfix-deferred` and a comment naming the ADR-0018 prerequisite, then re-file once the shell ships. The packet body assumes the shell exists.
+- [ ] Packet 05's `HoneyDrunk.FeatureFlags` v0.1.0 must be published to NuGet before this packet's CLI host project can build.
+- [ ] **Managed Identity role assignments on App Configuration** — the Operator Node's Managed Identity needs Reader (for `list`, `show`, `review-due`) and Data Contributor / Owner (for `enable`, `disable`) on the App Configuration resource(s) per environment. This is a portal step done as part of (or alongside) packet 03's walkthrough. Document the role assignment in this packet's runbook section and confirm it before the verbs are exercised in any environment.
+
+## Referenced ADR Decisions
+**ADR-0055 D11 — Operator surface: `operator flags …` CLI subcommand.** Six verbs (`list`, `show`, `enable`, `disable`, `expire`, `review-due`) with the signatures named in the ADR. The Operator Node reads and writes via the App Configuration SDK directly; the dependency is `HoneyDrunk.FeatureFlags.Abstractions` (or `HoneyDrunk.Kernel.Abstractions` for the contract surface per packet 04 — pick the one that's actually published) plus the App Configuration management SDK. All write operations capture `RequestContext.PrincipalId` for the audit record.
+
+**ADR-0055 D10 — Permission-flag flips are audit events; operational-flag flips are also audited; release-flag flips are logged but not audited.** "These are quasi-authorization decisions (D8) and the audit substrate is the right surface for them. The audit record captures operator identity, tenant scope, previous/new state, and timestamp. Operational-flag flips are also audited (kill-switch usage during incidents is exactly the kind of event the post-mortem needs visibility into). Release-flag flips are logged but not audited — release-flag toggling is routine dev workflow and audit-logging it adds noise without value."
+
+**ADR-0030 — Audit substrate.** Permission and operational flip events are emitted via `IAuditLog` from `HoneyDrunk.Audit.Abstractions`. The Audit record carries operator id, target type (`feature_flag`), target id (flag name), previous/new state, and timestamp.
+
+**ADR-0018 — Operator standup.** This packet depends on Operator's CLI shell being live, which is delivered by the ADR-0018 standup track. If the shell is not yet shipped, this packet is deferred.
+
+## Constraints
+- **Operator's CLI shell is a hard prerequisite.** If absent, defer; do not author a parallel shell.
+- **Audit asymmetry is hard.** Release-category flips MUST NOT emit audit events. The asymmetry is not subtle and not a runtime configuration — it is a code-path branch based on the flag's category. Unit tests assert both halves of the asymmetry (audit emitted for permission/operational; audit NOT emitted for release).
+- **Managed Identity for write operations.** No connection string, no SAS key, no shared secret. Invariants 8, 9 apply.
+- **`expire` is release-only.** Permission/operational don't expire (D7); calling `expire` on one is an error.
+- **Tag/release is human.** Invariant 27. After this PR merges, a human tags the new Operator version; agents never tag.
+- **Invariant 27 — solution-wide version bump.** Standard.
+
+## Labels
+`feature`, `tier-2`, `ai`, `cli`, `adr-0055`, `wave-5`
+
+## Agent Handoff
+
+**Objective:** Add the `operator flags …` CLI subcommand to `HoneyDrunk.Operator` with six verbs (list/show/enable/disable/expire/review-due), wire permission/operational flip audit events via `IAuditLog`, and emit Pulse log events for every flip.
+
+**Target:** `HoneyDrunk.Operator`, branch from `main`. **Conditional on Operator's CLI shell being live — see Human Prerequisites.**
+
+**Context:**
+- Goal: Give the operator a low-friction surface for the daily-driver flag operations (listing, enabling, disabling, expiring, review-due) with the correct audit/log semantics per category.
+- Feature: ADR-0055 Feature Flag rollout, Wave 5 (the operator surface).
+- ADRs: ADR-0055 D10/D11 (primary), ADR-0030 (`IAuditLog`), ADR-0018 (Operator scaffold provides the CLI shell), ADR-0005 (App Configuration via Managed Identity), ADR-0026 (RequestContext for principal id in audit records).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:05` — `HoneyDrunk.FeatureFlags` v0.1.0 published; `IFeatureGate` composition available.
+
+**Constraints:**
+- Operator's CLI shell is a hard prerequisite (ADR-0018 standup).
+- Audit asymmetry per category is hard: release no, permission/operational yes. Unit tests assert both halves.
+- Managed Identity for write operations; no secret in code or config.
+- `expire` is release-only.
+
+**Key Files:**
+- `src/HoneyDrunk.Operator.Cli/Commands/Flags/*.cs` (new) — the six verb handlers.
+- Operator host composition — DI registration for `IFeatureGate`, `IAuditLog`, the App Configuration management client.
+- Operator runbook — new "Feature Flags Operator Workflow" section.
+- The test project — new unit tests for each verb.
+- Every non-test `.csproj` in the solution — version bump (invariant 27).
+
+**Contracts:**
+- Consumes `IFeatureGate` from `HoneyDrunk.Kernel.Abstractions` (read path for `show`).
+- Consumes `IAuditLog` from `HoneyDrunk.Audit.Abstractions` (permission/operational flips).
+- Consumes the App Configuration management SDK (write path).
+- Consumes `ILogger` for structured Pulse log emission.

--- a/generated/issue-packets/active/adr-0055-feature-flags/09-architecture-review-flow-and-escalation.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/09-architecture-review-flow-and-escalation.md
@@ -1,0 +1,146 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "core", "docs", "adr-0055", "wave-5"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0055"]
+wave: 5
+initiative: adr-0055-feature-flags
+node: honeydrunk-architecture
+---
+
+# Roll ADR-0055 governance into review.md, feature-flow-catalog, and the escalation-triggers doc
+
+## Summary
+Land the three governance / discovery / operator artifacts the ADR's Follow-up Work names: roll the D13 anti-pattern checklist into `.claude/agents/review.md`, add a new "feature-flag evaluation" flow to `constitution/feature-flow-catalog.md`, and document the D15 escalation triggers in `business/context/` so the operator can recognize them when they fire. None of these is a code change; together they close the loop on the ADR's discipline + observability + escalation surface.
+
+## Context
+ADR-0055 names three docs/governance follow-ups beyond the catalogs/invariants/schema landed in earlier packets:
+- **`.claude/agents/review.md`** — the `review` agent's checklist gains the D13 anti-pattern rules so every PR review sees them.
+- **`constitution/feature-flow-catalog.md`** — the Grid's canonical "how a feature flows through the system" catalog gains a new entry for feature-flag evaluation, end-to-end from `IFeatureGate.IsEnabledAsync(...)` → App Configuration lookup → targeting filter evaluation → log emission → audit (for permission/operational).
+- **`business/context/`** — the D15 escalation triggers are operator-readable signals; documenting them where the operator looks for grid-wide context makes them findable when they fire.
+
+These three are independent of every other packet (they only depend on packet 00's acceptance to ground the citations). They are grouped into Wave 5 for tidy filing, but their `dependencies:` frontmatter is the real signal — they unblock as soon as 00 lands.
+
+This is a docs-only packet. No code, no .NET project, no workflow change.
+
+## Scope
+- `.claude/agents/review.md` — append a new section "ADR-0055 Anti-Patterns (Feature Flags)" with the six D13 anti-patterns.
+- `constitution/feature-flow-catalog.md` — append a new flow entry "Feature-Flag Evaluation."
+- `business/context/feature-flag-escalation-triggers.md` (new) — the four D15 triggers documented for the operator.
+
+## Proposed Implementation
+1. **`.claude/agents/review.md`** — append a new section. The review agent's rubric (per ADR-0044 D3) is already a 20-category checklist; this packet adds the D13 anti-patterns as items the agent watches for. Section title: "ADR-0055 Anti-Patterns (Feature Flags)." Each anti-pattern from D13 gets a checklist line:
+   - **Flag-checking inside a tight loop.** Hoist the evaluation outside the loop or rely on per-request scoped caching. Flag the PR if a `IsEnabledAsync` call appears inside a loop body (the review agent uses the diff and the changed-files context to detect this — name the pattern explicitly so the agent has a target to recognize).
+   - **Flag as a stand-in for authorization.** Authorization decisions belong in `HoneyDrunk.Capabilities` per ADR-0051. A permission flag gates *availability* of a feature to a tenant; a Capabilities check authorizes the principal's invocation. Flag any PR that uses `IFeatureGate.IsEnabledAsync` as the only gate on a sensitive action.
+   - **Flag-checking without `RequestContext` access.** Tenant-targeted flags need the context to flow through; flag any PR that introduces a hardcoded tenant id, a constructed-fake targeting context, or a bypass for a flag in a code path that should have plumbed the context.
+   - **String-concatenating flag names.** `IsEnabledAsync($"release.{node}.{feature}")` defeats the Roslyn analyzer. Flag any PR with a non-literal flag-name argument; suggest the `const string` hoist pattern.
+   - **Long-lived release flags.** A release flag with an `expires_on` extended more than once signals work-pattern issues — the right response is shipping in smaller increments, not extending the flag indefinitely. Flag any PR that extends an `expires_on` past the second time.
+   - **Permission flags whose only effect is UX text.** UX-only changes belong in i18n, not the flag system. Flag any PR that uses `IFeatureGate` to toggle a label or a text snippet.
+   Each line follows the existing rubric format (terse trigger + the recommended remediation), matching the style of the other categories in `review.md`.
+
+2. **`constitution/feature-flow-catalog.md`** — append a new entry. The catalog already documents flows like "a message from intake to delivery" or "a webhook from receipt to normalization." A new flow:
+   > **Feature-Flag Evaluation (ADR-0055)**
+   > A flag-gated code path executes the following flow at every evaluation:
+   >
+   > 1. **Caller invokes `IFeatureGate.IsEnabledAsync(flagName)`** in `HoneyDrunk.<Node>`. The flag name is a `const string` matching the regex `{category}.{node}.{feature}`.
+   > 2. **`AzureAppConfigurationFeatureGate`** (`HoneyDrunk.FeatureFlags`) resolves the ambient `ITargetingContext` from `RequestContext` (per ADR-0026); on off-request paths, the caller supplies it explicitly via the second overload.
+   > 3. **`Microsoft.FeatureManagement.IFeatureManagerSnapshot`** reads the flag definition from App Configuration's feature-flag surface. Per ADR-0055 D9, the per-environment label scopes the read.
+   > 4. **Targeting filters evaluate**: built-in `PercentageFilter` and `TimeWindowFilter`, plus the custom `TenantTargetingFilter` from `HoneyDrunk.FeatureFlags`. The filter chain composes per the JSON shape (D3 example).
+   > 5. **Decision returns** as `ValueTask<bool>` (or `ValueTask<T>` for variants).
+   > 6. **`feature_flag_evaluated` log event** emits via `HoneyDrunk.Pulse`'s `ILogger` per D10; hotpath flags sample at 1%.
+   > 7. **No audit event for evaluation.** Evaluations are too high-volume for audit; the audit surface is *flip* events (D10), which is the operator-CLI path (packet 08) and ride the separate `IAuditLog` substrate.
+   >
+   > Cross-references: ADR-0055 D2 (backend), D3 (targeting), D4 (abstraction), D9 (label inversion), D10 (observability), ADR-0040 (Pulse → App Insights backing), ADR-0026 (RequestContext).
+   Match the section style and depth of existing entries in the catalog.
+
+3. **`business/context/feature-flag-escalation-triggers.md`** (new) — the four D15 escalation triggers documented for the operator. Each trigger gets:
+   - **Symptom** — what the operator observes.
+   - **Threshold** — when the trigger fires (active flag count, flip frequency, operator complaint, etc.).
+   - **Action** — what the operator does (evaluate LaunchDarkly, GrowthBook, etc.).
+
+   The four triggers, from ADR-0055 D15:
+   - **Operator workflow pain** — active flag count exceeds ~100 and App Configuration's UI / SDK becomes the operator bottleneck. Symptom: time spent on routine flag operations exceeds a working-day's worth per month; the operator reaches for spreadsheets to track flags. Action: evaluate LaunchDarkly (rich dashboard, targeting UX) and GrowthBook (self-hosted, similar UX).
+   - **Experimentation needs** — A/B testing with statistical significance, conversion tracking, automated decision rollouts become a requirement. Symptom: a product or experimentation track explicitly requests these capabilities. Action: LaunchDarkly's experimentation surface or a dedicated experimentation platform; App Configuration is not built for this.
+   - **Multi-tenant operator delegation** — tenant-scoped operator personas need to flip flags within their tenant boundary; App Configuration's RBAC is workspace-level, not flag-level. Symptom: a Notify.Cloud tenant operator needs to flip their own flags without grid-wide write access. Action: LaunchDarkly's project/environment model, or build a thin authorization layer on top of App Configuration.
+   - **Cost escalation** — App Configuration's flag-evaluation API cost becomes meaningful (extremely unlikely at v1 Grid scale). Symptom: App Configuration's monthly bill traceable to the feature-flag surface exceeds a noticeable share of the ops budget. Action: re-evaluate per-flag pricing of LaunchDarkly vs hosting GrowthBook.
+
+   Cross-reference the doc from `business/context/README.md` (or whatever the index file is named — confirm at edit time).
+
+4. **No code change. No invariant change.** All three artifacts are governance/discovery surfaces.
+
+## Affected Files
+- `.claude/agents/review.md` — new "ADR-0055 Anti-Patterns (Feature Flags)" section appended.
+- `constitution/feature-flow-catalog.md` — new "Feature-Flag Evaluation" flow entry appended.
+- `business/context/feature-flag-escalation-triggers.md` (new) — the four D15 triggers.
+- `business/context/README.md` (or the index file) — one-line entry for the new escalation-triggers doc.
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] `.claude/agents/review.md` is the canonical review-agent prompt; per the agent context-loading contract (invariant 33), updates here must mirror scope.md's context-loading where relevant — but this packet only adds anti-pattern rubric items, not context-loading changes, so the coupling rule is not triggered.
+- [x] No code change in any repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/review.md` has a new "ADR-0055 Anti-Patterns (Feature Flags)" section appended, listing the six D13 anti-patterns each as a terse-trigger + remediation rubric item matching the existing review-rubric style
+- [ ] `constitution/feature-flow-catalog.md` has a new "Feature-Flag Evaluation" flow entry covering the seven-step evaluation flow (caller → context → SDK → filters → decision → log → no-audit-on-evaluation) with cross-references to ADR-0055 D2/D3/D4/D9/D10, ADR-0040, ADR-0026
+- [ ] `business/context/feature-flag-escalation-triggers.md` exists and documents the four D15 triggers with Symptom / Threshold / Action for each
+- [ ] `business/context/README.md` (or equivalent index) lists the new escalation-triggers doc
+- [ ] No invariant change in this packet (invariants land in packet 00)
+- [ ] No code change; no .NET project modified
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0055 D13 — Anti-patterns explicitly forbidden.** Six anti-patterns: tight-loop flag-checking; flag-as-authorization; flag-without-RequestContext; string-concatenated flag names; long-lived release flags; permission flags whose only effect is UX text. The review agent enforces these per ADR-0044 D3.
+
+**ADR-0055 D10 — Observability split.** Evaluations log; flips audit (permission/operational only). The feature-flow-catalog entry documents this end-to-end so the discoverability surface matches the runtime reality.
+
+**ADR-0055 D15 — Escalation triggers.** Four operator-recognizable triggers: workflow pain past ~100 flags, experimentation needs, multi-tenant operator delegation, cost escalation. Each carries a Symptom / Threshold / Action triple in `business/context/`.
+
+**ADR-0055 Follow-up Work.** Explicitly names: "Update `.claude/agents/review.md` with the D13 anti-pattern checklist," "Add a new 'feature-flag evaluation' flow to `constitution/feature-flow-catalog.md`," "Document the D15 escalation triggers in `business/context/` so the operator can recognize them."
+
+## Constraints
+- **Match existing doc style.** `review.md`'s rubric format, `feature-flow-catalog.md`'s flow-entry shape, and `business/context/`'s entry pattern are conventions; match them rather than authoring fresh structure.
+- **Cross-references are inline.** Every ADR reference is a full-text cross-reference (`ADR-0055 D13`, `ADR-0040`, etc.) so the docs are useful without the reader knowing the ADR catalog by heart.
+- **Don't restate invariants.** The two new ADR-0055 invariants live in `constitution/invariants.md` (packet 00). The review.md anti-patterns are D13's call-site checklist; they reinforce the invariants without duplicating them.
+- **Coupling with scope.md.** Invariant 33: `review.md`'s context-loading section must be a superset of `scope.md`'s. This packet only adds rubric items, not context-loading; the coupling rule is not triggered. If the executor finds the rubric edit *does* require new context loading (e.g., the agent now needs to read `featureflags.json` files when reviewing PRs), mirror the addition in `scope.md` as well — but at scoping time the rubric is judgment-driven, not context-loaded.
+
+## Labels
+`feature`, `tier-2`, `core`, `docs`, `adr-0055`, `wave-5`
+
+## Agent Handoff
+
+**Objective:** Land the three governance / discovery / operator docs the ADR's Follow-up Work names: D13 anti-patterns into `review.md`, feature-flag evaluation flow into `feature-flow-catalog.md`, D15 escalation triggers into `business/context/`.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Close the loop on ADR-0055's discipline (review.md), discoverability (flow catalog), and escalation-readiness (operator-readable triggers).
+- Feature: ADR-0055 Feature Flag rollout, Wave 5.
+- ADRs: ADR-0055 D10/D13/D15 (primary), ADR-0044 D3 (review-agent rubric structure).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0055 should be Accepted before its anti-patterns and escalation triggers are documented as governance.
+
+**Constraints:**
+- Match existing doc style for each surface.
+- Inline cross-references; don't assume the reader knows the ADR catalog by heart.
+- Don't duplicate invariants; the rubric items reinforce, not restate.
+- Coupling with scope.md (invariant 33) — not triggered by this packet (no context-loading change), but watch for it if the rubric grows to need new context.
+
+**Key Files:**
+- `.claude/agents/review.md` — new section appended.
+- `constitution/feature-flow-catalog.md` — new flow entry appended.
+- `business/context/feature-flag-escalation-triggers.md` (new).
+- `business/context/README.md` — index entry.
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0055-feature-flags/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/dispatch-plan.md
@@ -1,0 +1,156 @@
+# Dispatch Plan — ADR-0055: Feature Flag and Progressive Rollout Strategy
+
+**Initiative:** `adr-0055-feature-flags`
+**ADR:** ADR-0055 (Proposed — flipped to Accepted via packet 00)
+**Sector:** Core / cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0055 commits the Grid's first formal feature-flag substrate. It selects **Azure App Configuration's feature-flags surface** as the v1 backend (`Microsoft.FeatureManagement.AzureAppConfiguration`) — leveraging the App Configuration resource already provisioned per ADR-0005 — and names three flag categories with distinct lifecycle policies (`release`, `permission`, `operational`). The abstraction is `IFeatureGate` in `HoneyDrunk.Kernel.Abstractions`; the concrete implementation and the `TenantTargetingFilter` ship from a **new Node `HoneyDrunk.FeatureFlags`**. CI registration is enforced via per-Node `featureflags.json` + a Roslyn analyzer + a new reusable workflow `job-featureflags-validate.yml` in `HoneyDrunk.Actions`. Observability emits a structured `feature_flag_evaluated` event per evaluation via `HoneyDrunk.Pulse`/`HoneyDrunk.Observe`; permission and operational flips are audited via `HoneyDrunk.Audit`. The operator surface is a new `operator flags …` subcommand on the Operator Node CLI.
+
+This initiative delivers the v1 substrate: the `IFeatureGate` contract + `InMemoryFeatureGate` in Kernel, the `HoneyDrunk.FeatureFlags` Node scaffold + App-Configuration-backed implementation + `TenantTargetingFilter`, the App Configuration feature-flag-surface walkthrough extension (label conventions per D9), the `job-featureflags-validate.yml` reusable workflow + the Roslyn analyzer NuGet, the Notify pilot release flag (Phase 2 end-to-end-loop validation), the `operator flags …` CLI subcommand, and the docs/governance (D13 anti-patterns into `review.md`, feature-flag-evaluation flow into `feature-flow-catalog.md`, D15 escalation triggers into `business/context/`, the `featureflags-v1.json` schema doc).
+
+**Deliberately out of scope (deferred per the ADR's phasing):**
+
+- **Phase 4 — Notify.Cloud per-tenant permission flag.** Notify.Cloud is **PDR-0002** — not yet a standup Node. The first permission flag for Cloud-only features wires when Notify.Cloud reaches standup; the substrate this initiative ships is the prerequisite.
+- **Phase 5 — Consumer-app PDR consumers (Lately, Hearth, Currents, Arcadia, Curiosities).** Those Nodes adopt `IFeatureGate` from day one of their own standup, on the substrate this initiative ships.
+- **Phase 6 — Escalation evaluation.** A Phase-6 review is a future operator action against observed flag count + flip frequency; not a packet here.
+
+**10 packets across 5 waves**, targeting **5 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Kernel`, `HoneyDrunk.FeatureFlags`, `HoneyDrunk.Actions`, `HoneyDrunk.Notify`, `HoneyDrunk.Operator`). 9 `Actor=Agent`, 1 `Actor=Human` (the App Configuration feature-flag-surface walkthrough — portal work). Several `Actor=Agent` packets carry Human Prerequisites (creation of the `HoneyDrunk.FeatureFlags` GitHub repo, git-tag/release of the Kernel/FeatureFlags packages at wave boundaries, App Configuration label seeding).
+
+## Trigger
+
+ADR-0055 is Proposed with no scope. The forcing functions from the ADR's Context:
+
+- **ADR-0053 trunk-based development** explicitly defers the flag-system commitment to a future ADR (this one). Trunk-based dev's "decouple deploy from release" property requires application-level flags — without them, in-progress work either blocks the trunk or ships visible-but-broken.
+- **Notify.Cloud (PDR-0002)** introduces per-tenant feature enablement; ADR-0015's Container Apps multi-revision traffic splitting cannot express "tenant A on, tenant B off" within a single revision.
+- **The AI-sector standup wave (ADR-0016–0025)** introduces experimental code paths (alternative agent routing, eval-time-only capabilities, model swaps) that flags excel at.
+- **Consumer-app PDRs (0003/0005/0006/0007/0008)** anticipate trunk-based development from day one of their standup.
+- **ADR-0044 D3 category 11 and ADR-0047** assume a mechanism for testing flag-on and flag-off states; this ADR names it (`InMemoryFeatureGate` in `HoneyDrunk.Kernel.Abstractions.Testing` per invariant 15).
+
+## Scope Detection
+
+**Multi-repo, multi-Node, with new-Node standup.** ADR-0055 ships:
+
+- A new contract (`IFeatureGate`, `ITargetingContext`) in `HoneyDrunk.Kernel.Abstractions` and a test fixture (`InMemoryFeatureGate`) in `HoneyDrunk.Kernel.Abstractions.Testing` per invariant 15.
+- A **new Node `HoneyDrunk.FeatureFlags`** — standup governed by this ADR (D4 names it). Per the user's standing convention "new-Node standup gets its own ADR," ADR-0055 *is* that ADR.
+- An extension to `HoneyDrunk.Actions` (new reusable workflow `job-featureflags-validate.yml` plus a Roslyn analyzer NuGet package).
+- A pilot consumer change to `HoneyDrunk.Notify` (one release flag).
+- A new subcommand on the `HoneyDrunk.Operator` CLI (depends on Operator's CLI shell being live — see Cross-Cutting Concerns).
+- Catalog/governance edits in `HoneyDrunk.Architecture`.
+
+**Contract is additive — no forced downstream cascade.** `IFeatureGate` and `ITargetingContext` are additive to `HoneyDrunk.Kernel.Abstractions`. Per ADR-0035 (additive minor bump) and ADR-0055 D14 Phase 1, this bumps `HoneyDrunk.Kernel` `0.7.0` → `0.8.0` (or the current state at execution time — see Version Bumps). Downstream Nodes that consume `HoneyDrunk.Kernel.Abstractions` are not forced to update; they adopt `IFeatureGate` when their own flagged code paths are written. The only consumer this initiative amends is `HoneyDrunk.Notify` (Phase 2 pilot, one release flag).
+
+## Wave Diagram
+
+### Wave 1 (No Dependencies — governance + catalog + schema + walkthrough)
+- [ ] **00** — Architecture: Accept ADR-0055, add the two feature-flag invariants (pre-reserved numbers — see Invariant Numbering), register the initiative. `Actor=Agent`.
+- [ ] **01** — Architecture: register the `IFeatureGate` / `ITargetingContext` contracts and the new `honeydrunk-featureflags` Node in the Grid catalogs. `Actor=Agent`. Blocked by: 00.
+- [ ] **02** — Architecture: author the `featureflags-v1.json` schema doc, the per-Node `featureflags.json` shape, and pin it for `https://schemas.honeydrunkstudios.com/featureflags-v1.json`. `Actor=Agent`. Blocked by: 00.
+- [ ] **03** — Architecture: extend the App Configuration provisioning walkthrough with the feature-flag-surface section (D2 backend, D9 label conventions `dev`/`staging`/`prod`/`ci`); apply the label-default-state policy in the `dev` App Configuration resource. `Actor=Human`. Blocked by: 00.
+
+### Wave 2 (Depends on Wave 1 — the contract foundation)
+- [ ] **04** — Kernel: add `IFeatureGate`, `ITargetingContext`, and `InMemoryFeatureGate` to `HoneyDrunk.Kernel.Abstractions` / `HoneyDrunk.Kernel.Abstractions.Testing`. `Actor=Agent`. Blocked by: 00. **Version-bumping packet for `HoneyDrunk.Kernel`.**
+
+### Wave 3 (Depends on Wave 2 — the FeatureFlags Node standup)
+- [ ] **05** — FeatureFlags: stand up the `HoneyDrunk.FeatureFlags` Node — solution, packages, App-Configuration-backed `IFeatureGate` implementation, `TenantTargetingFilter`, in-memory test fixture, CI. `Actor=Agent`. Blocked by: 01, 02, 03, 04.
+
+### Wave 4 (Depends on Wave 3 — CI validation + pilot — parallel)
+- [ ] **06** — Actions: author `job-featureflags-validate.yml` reusable workflow and the Roslyn analyzer NuGet package for static flag-string discovery. `Actor=Agent`. Blocked by: 02 (schema), 04 (contract surface analyzed). Independent of 05 — the analyzer parses calls to `IFeatureGate.IsEnabledAsync` and reads `featureflags.json`; it does not require the App-Configuration backing to exist.
+- [ ] **07** — Notify: pilot consumer — declare one release flag in `featureflags.json`, gate an in-progress feature behind `IFeatureGate.IsEnabledAsync`, verify the end-to-end loop (declare → use → CI validates → flip via App Configuration → log emitted). `Actor=Agent`. Blocked by: 05 (FeatureFlags package published), 06 (CI validation workflow).
+
+### Wave 5 (Depends on Wave 4 — operator CLI + governance docs — parallel)
+- [ ] **08** — Operator: add the `operator flags …` CLI subcommand per D11; wire permission/operational flip events to `HoneyDrunk.Audit` per D10. `Actor=Agent`. Blocked by: 05. **Conditional on Operator's CLI shell being live — see Human Prerequisites.**
+- [ ] **09** — Architecture: roll the D13 anti-pattern checklist into `.claude/agents/review.md`, add the feature-flag-evaluation flow to `constitution/feature-flow-catalog.md`, document the D15 escalation triggers in `business/context/`. `Actor=Agent`. Blocked by: 00. (Independent of 04–08 — could run as early as Wave 2; grouped here for tidy filing.)
+
+Packets within a wave run in parallel except where listed. Wave 4 packets 06 and 07 are independent — different repos — but 07 (Notify) hard-depends on 05 (the FeatureFlags package), so it cannot start until 05 ships. Wave 5 packet 09 is technically only blocked by 00 — its `dependencies:` frontmatter expresses that.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0055](./00-architecture-adr-0055-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [Catalog: IFeatureGate + FeatureFlags Node](./01-architecture-featureflags-catalog-and-node-registration.md) | Architecture | Agent | 1 | 00 |
+| 02 | [featureflags-v1.json schema doc](./02-architecture-featureflags-schema.md) | Architecture | Agent | 1 | 00 |
+| 03 | [App Configuration feature-flag surface walkthrough](./03-architecture-appconfig-featureflag-surface-walkthrough.md) | Architecture | Human | 1 | 00 |
+| 04 | [Kernel: IFeatureGate + ITargetingContext + InMemoryFeatureGate](./04-kernel-ifeaturegate-and-targeting-context.md) | Kernel | Agent | 2 | 00 |
+| 05 | [HoneyDrunk.FeatureFlags Node standup](./05-featureflags-node-standup.md) | FeatureFlags | Agent | 3 | 01, 02, 03, 04 |
+| 06 | [Actions: job-featureflags-validate.yml + Roslyn analyzer](./06-actions-featureflags-validate-and-analyzer.md) | Actions | Agent | 4 | 02, 04 |
+| 07 | [Notify: pilot release flag end-to-end](./07-notify-pilot-release-flag.md) | Notify | Agent | 4 | 05, 06 |
+| 08 | [Operator: operator flags CLI + Audit wiring](./08-operator-flags-cli-subcommand.md) | Operator | Agent | 5 | 05 |
+| 09 | [Governance: review.md D13 + flow catalog + escalation doc](./09-architecture-review-flow-and-escalation.md) | Architecture | Agent | 5 | 00 |
+
+## Invariant Numbering
+
+Packet 00 adds the two invariants ADR-0055's Consequences names:
+
+1. **Feature flags are evaluated through `IFeatureGate`, never via direct SDK calls to `Microsoft.FeatureManagement` or the App Configuration client.** Preserves backend reversibility (D15 escalation), audit hookup (D10), and PII scrubbing on log emission.
+2. **Feature-flag names follow `{category}.{node}.{feature}` and are registered in the consuming Node's `featureflags.json` before first use.** CI gate per D6.
+
+ADR-0055 explicitly says: "Final invariant numbers assigned when the implementing work updates `constitution/invariants.md`; `hive-sync` reconciles per the ADR-0044 pattern." The current verified maximum in `constitution/invariants.md` is **53**. ADR-0055 is **not** in a pre-reserved batch — pick the next two free numbers at execution time (likely **54, 55**, but check at edit time against any sibling ADR-acceptance packets that landed first; never reuse a claimed number).
+
+## Version Bumps
+
+- **`HoneyDrunk.Kernel`** — packet 04 is the version-bumping packet. Confirm the current version at execution time. As of grid-health snapshot 2026-05-21, `HoneyDrunk.Kernel` is at `0.7.0`. If ADR-0042's `0.8.0` has shipped by execution time (per `adr-0042-idempotency` initiative), packet 04 here moves the next minor (e.g. `0.8.0` → `0.9.0`). If not, packet 04 bumps `0.7.0` → `0.8.0`. Per-package CHANGELOG: `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.Kernel.Abstractions.Testing` get entries (real new contracts + fixture); `HoneyDrunk.Kernel` runtime gets no per-package entry in this packet (alignment bump only — invariant 12/27).
+- **`HoneyDrunk.FeatureFlags`** — packet 05 is the first packet on the solution (it stands the solution up). Ships `0.1.0` per the standup convention (a 0.x.y baseline for new Nodes; see HoneyDrunk.Audit `0.1.0` as the precedent).
+- **`HoneyDrunk.Actions`** — not a versioned .NET solution; packet 06 ships workflow YAML + a Roslyn analyzer NuGet package. The analyzer NuGet is versioned independently per the existing Standards/analyzer release pattern; consult the repo's existing release flow at edit time.
+- **`HoneyDrunk.Notify`** — packet 07 amends Notify to consume `HoneyDrunk.FeatureFlags`. Whether it bumps depends on whether the change is functional (yes — a real flag-gated feature). Confirm at execution; the packet expects a minor bump.
+- **`HoneyDrunk.Operator`** — packet 08 adds a CLI subcommand. Whether it bumps depends on Operator's release state at execution. Operator is currently at Seed/`0.0.0`; if its standup has shipped a `0.1.0` by the time this packet runs, the CLI subcommand bumps to the next minor.
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; catalog/doc/governance edits only.
+
+## Cross-Cutting Concerns
+
+### Operator CLI dependency
+
+Packet 08 adds the `operator flags …` subcommand to the Operator CLI. Operator is governed by **ADR-0018** (its own standup initiative, in progress at the time of this scoping). For packet 08 to execute, Operator must have a CLI shell — a `dotnet` console host with a verb-based command surface — already in place. ADR-0018's scaffold packet (the `HoneyDrunk.Operator` Node standup) is the prerequisite; if Operator's CLI shell is not yet shipped at execution time, packet 08 either (a) lands the CLI shell as part of the same PR if the scope can be bounded to "the flags subcommand plus minimum shell," (b) is deferred until Operator's standup lands far enough, or (c) is split — a follow-up to ADR-0018's standup track.
+
+The recommendation, given the user's standing rule "new-Node standup gets its own ADR," is **(b)**: defer packet 08 if Operator's CLI shell does not exist when this initiative reaches Wave 5. The packet is written assuming the shell exists; its Human Prerequisites surface this gate explicitly.
+
+### Flags vs config — the boundary lives in code review
+
+ADR-0055 D12 names the flag/config boundary. The CI validator (D6) catches the obvious case (a non-boolean value declared as a flag fails registration). The judgment-call case ("this feature flag probably should be config; this config value probably should be a flag") is enforced by the `review` agent's rubric — packet 09 rolls the D13 anti-patterns into `.claude/agents/review.md` so the review agent applies them PR-by-PR.
+
+### The two-name registration — `IFeatureGate` is *the* surface; the SDK is hidden
+
+ADR-0055 D4 places `IFeatureGate` in `HoneyDrunk.Kernel.Abstractions`. The `Microsoft.FeatureManagement` SDK lives inside `HoneyDrunk.FeatureFlags` as an implementation detail — consumers depend on `HoneyDrunk.Kernel.Abstractions` (for the contract) and compose `HoneyDrunk.FeatureFlags` (for the App Configuration backing) at host startup, never reach for `IFeatureManager` directly. This is the **first new invariant** packet 00 adds. The Notify pilot (packet 07) and any future consumer must use only `IFeatureGate`; the analyzer in packet 06 may add a future rule flagging direct `IFeatureManager` consumption, but at v1 the invariant + review rubric carry the rule.
+
+### Notify.Cloud and Phase 4 — deferred
+
+ADR-0055 D14 Phase 4 wires `TenantTargetingFilter` into Notify.Cloud's tenant-tier resolution for the first **permission** flag. Notify.Cloud is **PDR-0002** — not yet a standup Node. This initiative ships the `TenantTargetingFilter` as part of packet 05 so it is *available* when Notify.Cloud reaches standup, but no packet here wires the first per-tenant permission flag — that is a Notify.Cloud-standup-track concern.
+
+### Consumer-app PDR adoption — deferred
+
+ADR-0055 D14 Phase 5 lists the consumer-app PDRs (Lately, Hearth, Currents, Arcadia, Curiosities) as adopters of `IFeatureGate` from day one of their standup. Each Node's adoption lands in its own standup initiative, on top of the substrate this initiative ships. Not in scope here.
+
+### Roslyn analyzer scope — literal flag strings only
+
+The Roslyn analyzer in packet 06 scans for `IFeatureGate.IsEnabledAsync("…")` and `GetVariantAsync<…>("…")` calls and validates the literal string is registered in the consuming Node's `featureflags.json`. ADR-0055 D6 explicitly notes "Variable-fed flag names are flagged as a separate warning — they defeat static analysis and should be avoided." The analyzer ships with both: a hard-error rule on undeclared literal flags, and a warning rule on non-literal flag-name arguments (variable, string-concat, interpolation). The analyzer is consumer-facing — it ships from `HoneyDrunk.Actions` (or `HoneyDrunk.Standards`, depending on which repo's release flow is the closer fit at execution time — packet 06's executor decides between the two; default to `HoneyDrunk.Actions` per ADR-0012's CI/CD-control-plane framing unless Standards is the better mechanical fit).
+
+### App Configuration label seeding — D9 inversion
+
+ADR-0055 D9 commits the "dev defaults on, staging/prod/ci default off" inversion. The mechanism is **not** `Microsoft.FeatureManagement`'s `RequirementType.Any/All` — it is per-label `enabled` definitions in App Configuration. Packet 03 seeds the label conventions; packet 05's `HoneyDrunk.FeatureFlags` consumes them; packet 06's CI validator enforces that every flag has both a `dev` and a non-dev label.
+
+### Site sync
+
+No site-sync flag. ADR-0055 is internal Core infrastructure — no public-facing Studios website content changes.
+
+## Rollback Plan
+
+- **Packets 00–02 (governance + catalog + schema):** revert the PR. ADR returns to Proposed; invariants and catalog entries removed. No runtime impact.
+- **Packet 03 (App Configuration walkthrough + label seeding):** revert the walkthrough doc; in the Azure Portal, delete the dev/staging/prod/ci label conventions seeded by the human run. No runtime impact until a consumer composes the flag system.
+- **Packet 04 (Kernel contracts):** revert the PR; `HoneyDrunk.Kernel` rolls back the version. Additive — no consuming Node depends on `IFeatureGate` until it composes it.
+- **Packet 05 (FeatureFlags Node):** revert the PR; the `HoneyDrunk.FeatureFlags` repo loses the scaffold + first release. No host depends on it until the Notify pilot composes it (packet 07).
+- **Packet 06 (CI workflow + analyzer):** revert the workflow YAML and the analyzer NuGet bump; consuming repos lose the validation gate but build is unaffected (the workflow is opt-in via `featureflags-validate: true` input).
+- **Packet 07 (Notify pilot):** revert the PR; the gated feature returns to "always off" (or "always on," depending on the rollout state of the feature behind the flag); the `featureflags.json` entry is removed; the Notify solution version rolls back.
+- **Packet 08 (Operator CLI):** revert the PR; the `flags` subcommand is removed; operators flip flags through the App Configuration portal directly (a documented fallback, not the supported path).
+- **Packet 09 (governance docs):** revert the PR. Docs only.
+- **Backend-level escape hatch:** ADR-0055 D15's escalation path (LaunchDarkly or self-hosted GrowthBook) is the architectural rollback for the *backend choice itself* — `IFeatureGate` stays, `HoneyDrunk.FeatureFlags.LaunchDarkly` (or `.GrowthBook`) backing comes online, consumers re-register their DI to the new backing. The migration is the cost of the new backing implementation + the export/import of the existing flag definitions to the new platform's storage shape; the contract surface and the operator CLI semantics are preserved.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.
+
+**Before pushing — `HoneyDrunk.FeatureFlags` repo creation.** Packet 05 targets `HoneyDrunkStudios/HoneyDrunk.FeatureFlags`. The repo must exist on GitHub before its issue can be filed. ADR-0055 D4 names the repo; the human-only prerequisite step is to create the empty GitHub repo (public per the user's "repos public by default" convention, with the standard `main` branch) before pushing this folder to `main`. This is recorded as a Human Prerequisite on packet 05.

--- a/generated/issue-packets/active/adr-0055-feature-flags/handoff-wave3-featureflags-standup.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/handoff-wave3-featureflags-standup.md
@@ -1,0 +1,95 @@
+# Handoff — Wave 3: HoneyDrunk.FeatureFlags Node Standup
+
+**Initiative:** `adr-0055-feature-flags`
+**Wave transition:** Wave 2 (Kernel contract) → Wave 3 (FeatureFlags Node standup)
+**Read once at the wave boundary. Immutable per invariant 24.**
+
+## What Waves 1–2 landed
+
+- **Packet 00** — ADR-0055 flipped to **Accepted**. Two new invariants added to `constitution/invariants.md` under a new `## Feature Flag Invariants` section (the executor picked the next two free numbers at edit time — verified max at scoping was 53; confirm in the file at execution time):
+  1. **Feature flags are evaluated through `IFeatureGate`, never via direct SDK calls to `Microsoft.FeatureManagement` or the App Configuration client.** Preserves backend reversibility (D15) + audit hookup + PII scrubbing on log emission.
+  2. **Feature-flag names follow `{category}.{node}.{feature}` and are registered in the consuming Node's `featureflags.json` before first use.** CI gate per D6; regex `^(release|permission|operational)\.[a-z0-9]+\.[a-z0-9-]+$`.
+- **Packet 01** — `IFeatureGate`, `ITargetingContext`, `InMemoryFeatureGate` registered under `honeydrunk-kernel` in `catalogs/contracts.json` and `catalogs/relationships.json`. New Node entry `honeydrunk-featureflags` added to `catalogs/nodes.json` and `catalogs/grid-health.json` (Seed, v0.0.0). Notify and Operator `consumes_detail` enriched with the new Kernel contracts.
+- **Packet 02** — `schemas/featureflags-v1.json` ships the JSON Schema document for per-Node `featureflags.json` registries; `docs/feature-flags-registry-format.md` is the human-readable guide. The schema is pinned to `https://schemas.honeydrunkstudios.com/featureflags-v1.json` (or the in-repo fallback path if Studios isn't yet serving it — recorded in packet 02).
+- **Packet 03** — App Configuration provisioning walkthrough extended with the "Feature-Flag Surface (ADR-0055)" section; D9 label conventions (`dev`/`staging`/`prod`/`ci`) documented and seeded in the dev App Configuration resource.
+- **Packet 04** — `HoneyDrunk.Kernel.Abstractions` ships `IFeatureGate`, `ITargetingContext`, `TargetingContext` record; `HoneyDrunk.Kernel.Abstractions.Testing` ships `InMemoryFeatureGate`. The `HoneyDrunk.Kernel` solution bumped to its new minor (confirm the version at execution time — the bump may be `0.8.0` or `0.9.0` depending on whether ADR-0042's `0.8.0` shipped first).
+
+ADR-0055's decisions are now live rules. The contract surface in Kernel.Abstractions is the foundation packets 05–08 build on.
+
+## What Wave 3 must deliver (packet 05)
+
+Stand up `HoneyDrunk.FeatureFlags` end-to-end from an empty GitHub repo. The Node is **Core sector**, ships **one runtime package** (`HoneyDrunk.FeatureFlags`) — no `Abstractions` split at v1 because the abstraction (`IFeatureGate`) lives in `HoneyDrunk.Kernel.Abstractions` per D4. The release baseline is **v0.1.0** (matches the HoneyDrunk.Audit standup precedent).
+
+The package contains:
+- **`AzureAppConfigurationFeatureGate`** — implements `IFeatureGate` over `Microsoft.FeatureManagement.IFeatureManagerSnapshot`, with the `ITargetingContextAccessor` resolving `ITargetingContext` from the ambient `HoneyDrunk.Kernel` `RequestContext` per ADR-0026.
+- **`TenantTargetingFilter`** — `[FilterAlias("TenantTargeting")]` custom `IFeatureFilter`; matches `RequestContext.TenantId` / `Tier` against the flag's `tenants` / `tiers` configuration, falls back to `default_rollout_percentage`. JSON shape per ADR-0055 D3 example.
+- **`AddFeatureFlags(IServiceCollection, IConfiguration)`** — the single public DI entry point.
+- Tests + canary (`HoneyDrunk.FeatureFlags.Tests.Unit`, `HoneyDrunk.FeatureFlags.Tests.Canaries`) verifying the `IFeatureGate` contract shape against `HoneyDrunk.Kernel.Abstractions` per invariant 14.
+- CI workflows wired per ADR-0012 (pr-core, release, nightly-security, nightly-deps); `.honeydrunk-review.yaml` enabled per ADR-0044.
+- Repo-level + per-package CHANGELOG and README (invariant 12).
+
+## Why one package and not an Abstractions split
+
+ADR-0055 D4 names a single concrete package `HoneyDrunk.FeatureFlags`. The Grid's normal Abstractions/runtime split is unnecessary here because the abstraction (`IFeatureGate`) already lives in `HoneyDrunk.Kernel.Abstractions`. No second contract surface ships from this Node at v1 — `TenantTargetingFilter` is internal/registered-via-DI, not a public consumer surface.
+
+When D15 escalation fires (e.g., LaunchDarkly becomes the backing), the split happens then: `HoneyDrunk.FeatureFlags.Abstractions` extracts host-options; `HoneyDrunk.FeatureFlags.AzureAppConfiguration` and `HoneyDrunk.FeatureFlags.LaunchDarkly` are sibling backings. v1 does not speculatively split.
+
+## Why no `.Testing` package from this Node
+
+`InMemoryFeatureGate` is the test fixture, and it lives in `HoneyDrunk.Kernel.Abstractions.Testing` (packet 04) — every flag-consuming Node uses that. There is no concrete need at v1 for a fixture that exercises the App-Configuration-backed runtime in process; if a real consumer needs one later, it's a small follow-up.
+
+## Interface signatures for Wave 4
+
+`AddFeatureFlags` — the host composition entry point packets 07 and 08 consume:
+
+```csharp
+public static IServiceCollection AddFeatureFlags(
+    this IServiceCollection services,
+    IConfiguration config);
+```
+
+Consumers compose:
+
+```csharp
+builder.Configuration.AddAzureAppConfiguration(opt =>
+{
+    opt.Connect(new Uri(builder.Configuration["AppConfig:Endpoint"]!),
+               new ManagedIdentityCredential())
+       .Select(KeyFilter.Any, label: env)
+       .UseFeatureFlags(ff => ff.Label = env)
+       .ConfigureRefresh(r => r.Register("FeatureManagement:Sentinel", refreshAll: true)
+                               .SetCacheExpiration(TimeSpan.FromSeconds(30)));
+});
+builder.Services.AddFeatureFlags(builder.Configuration);
+```
+
+The composition wires `IFeatureManagement`, the App Configuration push-refresh, the `TenantTargetingFilter`, and the `IFeatureGate` (scoped) registration in one call.
+
+## Frozen / do-not-touch
+
+- **`HoneyDrunk.Kernel.Abstractions` is at packet 04's published minor.** Do not modify it from this packet. New contracts in Kernel.Abstractions are out of scope.
+- **`Microsoft.FeatureManagement` types must not leak into the consumer's compile surface.** Per the first new ADR-0055 invariant ("evaluated through `IFeatureGate`, never via direct SDK calls"), consumers depend on `IFeatureGate`; the `IFeatureManager`, `IFeatureManagerSnapshot`, `IFeatureFilter` types stay inside this package. The public surface of `HoneyDrunk.FeatureFlags` is `AddFeatureFlags` (and the implementation classes if they need to be public for DI registration); the consumer's compile-time view is `IFeatureGate` only.
+- **No HoneyDrunk runtime dependency beyond `HoneyDrunk.Kernel.Abstractions`.** No Pulse, no Audit, no Vault, no Transport. App Configuration is Managed-Identity-accessed per ADR-0005; no `ISecretStore` consumed here. Pulse logging composition happens at the host, not in this package.
+
+## Invariants binding Wave 3
+
+- **Invariant 1** — `HoneyDrunk.Kernel.Abstractions` stays zero-HoneyDrunk-dependency; the FeatureFlags Node references it normally but does NOT push types back up into Kernel.
+- **Invariant 4** — DAG; this Node depends on `HoneyDrunk.Kernel.Abstractions` only among HoneyDrunk packages.
+- **Invariant 11** — One repo per Node. `HoneyDrunk.FeatureFlags` is its own repo.
+- **Invariant 12** — CHANGELOG + README on every package from the first commit.
+- **Invariant 13** — XML documentation on every public API; document the "only sanctioned evaluation surface" on `IFeatureGate`-consuming types.
+- **Invariant 14** — Contract-shape canary against `HoneyDrunk.Kernel.Abstractions`.
+- **Invariant 15** — Unit tests use no external services; use faked `IFeatureManager`.
+- **Invariant 16** — No test code in runtime packages.
+- **Invariant 26** — `HoneyDrunk.Standards` `PrivateAssets: all` on every project.
+- **Invariant 27** — v0.1.0 baseline; one version across the solution.
+- **Invariant 31 / 52** — `pr-core.yml` tier-1 gate + cloud-wired review.
+- **Invariant 51** — No `Thread.Sleep` in test code.
+
+## Acceptance gate for the wave
+
+Packet 05's PR passes the `pr-core.yml` tier-1 gate; the `HoneyDrunk.FeatureFlags` solution builds; unit tests + canary pass; `HoneyDrunk.FeatureFlags` is at v0.1.0 with the contract shipped. Wave 4 (packet 06 in `HoneyDrunk.Actions` for the CI workflow + analyzer, packet 07 in `HoneyDrunk.Notify` for the pilot) can then start in parallel — though packet 07 specifically waits on both 05 and 06.
+
+**Human package release at the Wave 3→4 boundary — agents never tag (invariant 27).** Packets 07 and 08 build against `HoneyDrunk.FeatureFlags` v0.1.0 from the NuGet feed; that artifact reaches the feed only after a human pushes the `v0.1.0` git tag in the new `HoneyDrunk.FeatureFlags` repo. After packet 05 merges, a human creates the GitHub release. Wave 4 cannot build against unpublished packages.
+
+**Human repo-creation prerequisite for Wave 3 itself.** Packet 05 targets `HoneyDrunkStudios/HoneyDrunk.FeatureFlags` — the empty GitHub repo must exist on GitHub before the filing pipeline can file packet 05's issue. Create the repo (public per the "repos public by default" convention, standard `main`, no template, no auto-init) before pushing this folder to `main`.

--- a/generated/issue-packets/active/adr-0055-feature-flags/handoff-wave4-ci-validation-and-pilot.md
+++ b/generated/issue-packets/active/adr-0055-feature-flags/handoff-wave4-ci-validation-and-pilot.md
@@ -1,0 +1,79 @@
+# Handoff — Wave 4: CI Validation + Notify Pilot
+
+**Initiative:** `adr-0055-feature-flags`
+**Wave transition:** Wave 3 (FeatureFlags Node standup) → Wave 4 (CI workflow + analyzer + first-consumer pilot)
+**Read once at the wave boundary. Immutable per invariant 24.**
+
+## What Wave 3 landed
+
+- **Packet 05** — `HoneyDrunk.FeatureFlags` v0.1.0 stood up with `AzureAppConfigurationFeatureGate` (implements `IFeatureGate` over `Microsoft.FeatureManagement.IFeatureManagerSnapshot`), `TenantTargetingFilter` (`[FilterAlias("TenantTargeting")]`), the `AddFeatureFlags(IServiceCollection, IConfiguration)` DI extension, CI workflows wired per ADR-0012, the contract-shape canary against `HoneyDrunk.Kernel.Abstractions`, and the repo-level + per-package CHANGELOG/README. The v0.1.0 NuGet artifact is on the feed (human tag/release post-merge per invariant 27).
+
+The substrate is complete: contract in Kernel, App Configuration backing in FeatureFlags, label conventions seeded in dev. Wave 4 wires the CI gate and the first real consumer.
+
+## What Wave 4 must deliver
+
+### Packet 06 — `HoneyDrunk.Actions`
+
+Author the reusable workflow `job-featureflags-validate.yml` and the Roslyn analyzer NuGet that together enforce ADR-0055 D6:
+
+- **Workflow** — locates `featureflags.json` files, validates against `featureflags-v1.json` (packet 02's schema), enforces the naming regex (D5), category coherence (D6), release-flag expiry (D7 — error), permission/operational `annual_review_due` past due (D7 — warning). Emits a markdown summary in the job summary.
+- **Analyzer** — Roslyn analyzer NuGet targeting `netstandard2.0`. Diagnostics:
+  - **HFF001 (Error)** — Literal-string flag in `IFeatureGate.IsEnabledAsync(...)` / `GetVariantAsync<T>(...)` not registered in `featureflags.json`.
+  - **HFF002 (Warning)** — Variable-fed flag-name argument (defeats static analysis per D6).
+  - **HFF003 (Warning)** — Literal flag name doesn't match the regex (defense in depth).
+  - **HFF004 (Warning, optional v0.1)** — Direct `IFeatureManager` consumption outside `HoneyDrunk.FeatureFlags` (the first ADR-0055 invariant; the review agent enforces it regardless).
+
+The analyzer can live in `HoneyDrunk.Actions` (default) or `HoneyDrunk.Standards` (alternative — executor decides at edit time based on which release flow is the closer fit). Either way, it ships as a `PackageReference` with `PrivateAssets: all` and auto-wires `featureflags.json` discovery via `.targets`.
+
+### Packet 07 — `HoneyDrunk.Notify`
+
+The first real-world flag consumer. Pilot the end-to-end loop:
+
+1. **Declare** — `src/HoneyDrunk.Notify/featureflags.json` registers one release flag (the ADR example is `release.notify.bulk-send`; pick the genuinely in-flight Notify feature at edit time — the value is the loop, not the feature).
+2. **Use** — gate the feature behind `IFeatureGate.IsEnabledAsync(BulkSendFlag)` with the name held as a `const string` (per D13 anti-pattern).
+3. **CI** — `pr-core.yml` adds the `featureflags-validate` job; the project owning the gate references the analyzer NuGet (`PrivateAssets: all`).
+4. **Flip** — operator (or App Configuration portal) flips the per-label state. Push-refresh per D2 propagates in ~30s.
+5. **Log** — `feature_flag_evaluated` event emits via Pulse per D10.
+6. **Audit** — NOT exercised in this packet (release-category is logged, not audited per D10). Packet 08 validates the audit path.
+
+The pilot is the dress rehearsal for every Phase-5 consumer adoption. Failures here flag a substrate problem, not a Notify problem.
+
+## Frozen / do-not-touch
+
+- **`HoneyDrunk.FeatureFlags` v0.1.0 is the consumed published version.** Do not modify FeatureFlags from packets 06 or 07. If the executor finds a bug in v0.1.0, file a follow-up issue against the FeatureFlags repo; do not patch from this wave.
+- **`HoneyDrunk.Kernel.Abstractions` is at packet 04's published minor.** Same rule.
+- **`featureflags-v1.json` schema is packet 02's surface.** If a missing schema field is discovered, file a follow-up against the schema; do not patch from this wave.
+- **The flag/config boundary lives in code review.** Per D12, the CI validator catches non-boolean flags; the judgment call ("this should have been config" / "this should have been a flag") is the review agent's rubric (packet 09 lands the D13 anti-patterns in `review.md`).
+
+## Audit path — explicitly NOT exercised in Wave 4
+
+ADR-0055 D10's audit semantics:
+- **Permission flag flips** — audit yes.
+- **Operational flag flips** — audit yes.
+- **Release flag flips** — audit NO (logged only).
+
+Packet 07's pilot is a **release** flag. No audit emission is expected; the pilot's negative-assertion is that no audit event lands when the flag flips. Packet 08 (Operator CLI in Wave 5) is where the audit emission for permission/operational flips is wired.
+
+## Sequencing within the wave
+
+- Packet 06 and packet 07 are different repos and can land in parallel. Packet 07 depends on packet 06 for the analyzer NuGet (the analyzer must exist on the package feed before Notify can opt in). Packet 06's workflow is the gate Notify's `pr-core.yml` calls — the workflow doesn't need a published artifact (it's a reusable workflow referenced by `@main`), so Notify's `pr-core.yml` can adopt it immediately on packet 06's merge.
+- The analyzer's NuGet publication is a **human tag/release** step (invariant 27). After packet 06 merges, a human pushes the analyzer's first tag to publish v0.1.0 to the package feed. Until then, packet 07 either pins to the analyzer's local source for development or waits.
+
+## Invariants binding Wave 4
+
+- **Invariant 1** — Abstractions zero-dependency. Not directly relevant (packets 06/07 don't touch Abstractions packages), but the *consumer pattern* matters: packet 07 references `HoneyDrunk.FeatureFlags` only at the host project; flag-consuming code in other Notify projects sees only `IFeatureGate` from `HoneyDrunk.Kernel.Abstractions`.
+- **Invariant 12 / 27** — Solution-wide version bump on Notify; per-package CHANGELOG only for the package with functional changes.
+- **Invariant 13** — XML documentation on any public types touched.
+- **Invariant 15** — `InMemoryFeatureGate` in tests; no App Configuration in unit tests.
+- **Invariant 26** — `HoneyDrunk.Standards` on every project the analyzer adds to.
+- **Invariant 31 / 52** — pr-core tier-1 gate + cloud-wired review; the `featureflags-validate` job adds to the gate.
+- **Invariant 51** — No `Thread.Sleep` in tests.
+- **ADR-0055 anti-patterns (D13)** — the `const string` flag-name hoist; no string concatenation; one feature, one flag.
+
+## Acceptance gate for the wave
+
+Packet 06 — `job-featureflags-validate.yml` exists and is callable; the analyzer NuGet builds and ships diagnostics HFF001/HFF002 at minimum.
+
+Packet 07 — Notify ships the pilot flag end-to-end. The PR description records the loop verification (which feature was gated, the steps observed during deploy + flip + log + no-audit-for-release).
+
+Wave 5 (packet 08 Operator CLI + audit wiring; packet 09 governance docs) can then start. Packet 09 is technically only blocked by 00 — its `dependencies:` frontmatter expresses that.

--- a/generated/issue-packets/active/adr-0056-threat-model/00-architecture-adr-0056-acceptance.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/00-architecture-adr-0056-acceptance.md
@@ -1,0 +1,142 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "security", "docs", "adr-0056", "wave-1"]
+dependencies: []
+adrs: ["ADR-0056"]
+accepts: ["ADR-0056"]
+wave: 1
+initiative: adr-0056-threat-model
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0056 — flip status, add three threat-model invariants, register the initiative
+
+## Summary
+Flip ADR-0056 (Threat Model and Security Review Cadence) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, add the three new threat-model invariants ADR-0056 commits in its Consequences/Invariants section to `constitution/invariants.md`, and register the `adr-0056-threat-model` initiative in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0056 is the integration layer for the Grid's previously-fragmented security slice ADRs (0006 secrets, 0011 review, 0030/0031 audit, 0026 multi-tenant, 0049 data classification, 0036 DR, 0051 agent authority, 0041 LLM egress, 0044 PR discipline, 0046 specialist review agents, 0050 customer comms, 0054 incident response). It commits to STRIDE-per-trust-boundary methodology with an AI-specific overlay, a 10-entry trust-boundary inventory, an asset-classification axis layered on ADR-0049 + ADR-0036, a single living artifact at `constitution/threat-model.md`, four review cadences (per-PR / quarterly / per-Node-standup / per-major-dependency-upgrade), a three-layer pentest posture (external pre-GA, annual, DIY interim), Dependabot + SBOM, GitHub secret scanning + push protection + a found-secret rotation runbook, eight named AI-specific threats with concrete mitigations, incident-response coupling, responsible disclosure via `SECURITY.md`, and an explicit-rationaled compliance posture.
+
+The ADR decides:
+
+- **D1** — STRIDE per trust boundary as the primary methodology, with an AI-specific overlay (AI-1 through AI-8) covering prompt injection, indirect prompt injection, model jailbreak, tool poisoning, training-data poisoning, hallucinated-fact downstream impact, agent-tool exfiltration, model-API-key compromise. Supporting frames: NIST AI RMF, OWASP LLM Top 10, MITRE ATLAS.
+- **D2** — 10 enumerated trust boundaries (public internet ↔ Web.Rest, Web.Rest ↔ application Nodes, application Nodes ↔ Vault/Data, tenant ↔ tenant, human ↔ agent, agent ↔ tool registry, agent ↔ external LLM, Studios-internal ↔ paying-tenant data, CI/CD ↔ production, open-source contributors ↔ Grid repos).
+- **D3** — Asset classification table crossing ADR-0049 sensitivity (Public/Internal/Customer/Sensitive/Secret) and ADR-0036 RPO/RTO, naming Auth signing keys, per-Node Key Vault creds, payment tokens, model API keys, tenant data partitions, audit substrate, recipient address book, operator creds, source repos, CI/CD secrets, LLM prompt/completion telemetry, AI agent execution state.
+- **D4** — Single living artifact at `constitution/threat-model.md` in markdown (not a tool-specific format), with ten enforced sections (header, methodology recap, boundary inventory, asset inventory, STRIDE pass per boundary, AI-specific threats, accepted risks, pentest history, open mitigations, references). Lands as a follow-up issue after this ADR is Accepted.
+- **D5** — Four review cadences: per-PR (`security` review agent), quarterly (operator-led full review), per-new-Node (standup-ADR template requires "threat model entry"), per-major-dependency-upgrade (paragraph attached to the PR description).
+- **D6** — Three pentest layers: external pre-Notify-Cloud-GA engagement ($5–15K), annual thereafter if revenue supports it, DIY interim using OWASP ZAP + Burp Community + prompt-injection corpus.
+- **D7** — Dependency / supply-chain scanning: Dependabot Grid-wide, critical-CVE → auto-issue-packet, CodeQL on public repos free / private repos cost-gated, SBOM per release (CycloneDX or SPDX; tool selection deferred).
+- **D8** — Secret scanning: GitHub-native secret scanning Grid-wide, push protection where supported, optional local `git-secrets`/`gitleaks` pre-commit hooks, found-secret runbook with 1-hour high-sensitivity / 4-hour lower-sensitivity time-to-rotation targets.
+- **D9** — AI-specific protections: `PromptEnvelope` typed-channel pattern in `HoneyDrunk.AI` (AI-1); untrusted-content wrapping with explicit tags (AI-2); provider-side moderation + output-side gates (AI-3); immutable-tool-description-per-release in `HoneyDrunk.Capabilities` (AI-4); training-data-poisoning tracked at zero (AI-5); output-side guard for hallucinated-fact downstream impact (AI-6); PR-discipline or Operator-confirmation routing for high-blast-radius actions (AI-7); usage caps + per-environment keys + 90-day rotation for model API keys (AI-8).
+- **D10** — Incident-response coupling: confirmed security incidents SEV-1 by default, tenant notification per ADR-0050 + ADR-0019, forensic-preservation hold beyond 730-day standard retention, post-mortem with threat-model amendment section.
+- **D11** — Responsible disclosure: `SECURITY.md` at org level + per-public-repo copies, `security@honeydrunkstudios.com`, 90-day disclosure window, safe-harbor language modeled on Disclose.io core terms, no bug bounty at v1.
+- **D12** — Compliance posture: not pursuing SOC 2 Type 2 or ISO 27001 at v1; substrate-now-audit-later sequencing; trigger conditions recorded (enterprise LOI conditional on SOC 2, regulated-vertical customer, ~10 paying enterprise tenants without SOC 2).
+- **D13** — Relationship to existing security-touching ADRs: this ADR preserves every slice-ADR (0006, 0011, 0030, 0046, 0026, 0049, 0036, 0051, 0041, 0044, 0050, 0019, 0054) and adds the integration substrate.
+- **D14** — Six-phase rollout: artifact v0 → artifact v1 → tooling rollout (Dependabot, secret scanning, `SECURITY.md`) → AI-protection implementation → pentest scoping → quarterly cadence steady state.
+
+ADR-0056 is a **policy / decision** ADR. The concrete artifact — `constitution/threat-model.md` v0 shell and v1 content — lands in packets 01 and 02. The governance plumbing (standup-template + hive-sync extension, `SECURITY.md` authoring, the operator runbooks for incidents, found-secret rotation, pentest scoping, DIY adversarial probing) lands in packets 03-07. The Dependabot + secret-scanning Grid-wide enablement lands in packet 08 in `HoneyDrunk.Actions`. The cross-track follow-up tracker (for AI's `PromptEnvelope`, Capabilities' immutable-tool-description and high-blast-radius routing, Vault's tighter model-key rotation, Audit's investigation-extended-retention export, ADR-0046's `security.md` artifact-loading wiring, SBOM tool selection) lands as packet 09.
+
+Every other packet in this initiative references ADR-0056's D-decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0056-threat-model-and-security-review-cadence.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0056 row Status column to Accepted.
+- `constitution/invariants.md` — add the three new threat-model invariants (see Proposed Implementation for exact text) under a new `## Security and Threat Model Invariants` section. The numbers are claimed at edit time from `constitution/invariant-reservations.md` — referred to in this packet as `{N1}/{N2}/{N3}`. See Constraints for the reservation procedure.
+- `constitution/invariant-reservations.md` — add a new row to the **Active Reservations** table claiming the `{N1}–{N3}` block for ADR-0056 in the same commit.
+- `initiatives/active-initiatives.md` — register the `adr-0056-threat-model` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0056 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update the ADR-0056 index row in `adrs/README.md` to Accepted.
+3. **Claim the invariant block.** Read `constitution/invariant-reservations.md`. Find the highest currently-reserved number across the **Active Reservations** table (do not assume the values cached in this packet body — re-verify at edit time). Pick the next contiguous block of size 3 above it; call the three numbers `{N1}`, `{N2}`, `{N3}` for the remainder of this packet. Add a row to the **Active Reservations** table in the same PR claiming `{N1}–{N3}` for ADR-0056, with this packet's path. (At packet authoring time, the highest reservation was ADR-0049 at 58–60, so the expected block is **61–63**; re-verify before editing.)
+4. Add three new invariants to `constitution/invariants.md`, numbered `{N1}`, `{N2}`, `{N3}`. The text, taken verbatim-in-substance from ADR-0056's Consequences "Invariants" section:
+   - **`{N1}` — Every Node standup ADR includes a "threat model entry" section, and the artifact is updated in the same PR that moves the standup ADR to Accepted.** The standup ADR's "threat model entry" section declares the new Node's trust boundaries (if any), new assets (if any), STRIDE pass against the boundaries the Node touches, and the AI overlay if the Node is in the AI sector. The standup ADR cannot move from Proposed to Accepted until the artifact-update commit lands in the same PR. Enforced by `hive-sync` constitution scan, which fails if a standup ADR references a Node not present in `constitution/threat-model.md`. See ADR-0056 D5.
+   - **`{N2}` — LLM calls use the `PromptEnvelope` typed-channel pattern; direct string concatenation of untrusted input into a prompt is a CI gate failure.** Every LLM call in the Grid uses structural separation of system instructions, user input, and tool output. The Grid's LLM-calling library (per ADR-0016 — `HoneyDrunk.AI`'s abstraction) enforces a `PromptEnvelope` shape where system / user / tool / assistant messages are typed channels, not concatenated strings. Direct string concatenation of untrusted input into a prompt is a CI gate failure (analyzer rule per ADR-0046's analyzer surface). Structural separation is not a complete defense against prompt injection — the residual risk is tracked in the artifact's accepted-risk log and addressed by the output-side guard in invariant `{N3}`. See ADR-0056 D9 AI-1.
+   - **`{N3}` — High-blast-radius agent actions route through PR-discipline or Operator confirmation; never direct execution.** Any agent action with high blast radius (file write outside a sandbox, external API call to a non-allowlisted endpoint, tenant data mutation, money movement, sending a message externally) routes through one of two paths: (a) the ADR-0044 PR-discipline path — the agent opens a PR rather than executing directly, and a human-or-review-agent approves the merge; or (b) explicit Operator confirmation via ADR-0051's confirmation primitives — the operator sees a structured "the agent intends to do X" prompt and approves or denies in real time. Never direct execution for high-blast-radius actions. The list of "high blast radius" actions lives in `constitution/threat-model.md` and grows over time as new capabilities land; the default for a new capability is high blast radius until proven otherwise. Enforced by capability-side wiring in `HoneyDrunk.Capabilities` (per ADR-0017 once stood up) and by the `security` review agent's per-PR check (per ADR-0046 once accepted). See ADR-0056 D9 AI-7.
+   - Create a new `## Security and Threat Model Invariants` section at the bottom of the `## AI Invariants` block (security is a cross-cutting concern adjacent to AI in the existing sectioning), or create a new top-level section if the file's convention places `Security` ahead of `AI` — match the file's current sectioning convention.
+5. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder.
+
+## Affected Files
+- `adrs/ADR-0056-threat-model-and-security-review-cadence.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0056 header reads `**Status:** Accepted`
+- [ ] The ADR-0056 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariants.md` carries the three new threat-model invariants (standup ADRs include a "threat model entry" section; LLM calls use the `PromptEnvelope` typed-channel pattern; high-blast-radius agent actions route through PR-discipline or Operator confirmation, never direct execution), numbered `{N1}/{N2}/{N3}` under a new `## Security and Threat Model Invariants` section, each citing ADR-0056
+- [ ] `{N1}/{N2}/{N3}` were claimed via `constitution/invariant-reservations.md` — a new row was added to the **Active Reservations** table in the same PR, citing ADR-0056 and this packet's path
+- [ ] The claimed block is the next free contiguous block of size 3 above the highest reservation that existed in `invariant-reservations.md` at edit time (re-verified at edit time; not assumed from cached numbers in this packet body)
+- [ ] No existing invariant is renumbered; new invariants are appended only
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0056-threat-model` initiative with a packet checklist
+- [ ] No catalog schema change in this packet (the artifact at `constitution/threat-model.md` lands in packets 01/02)
+- [ ] No artifact file is created in this packet — `constitution/threat-model.md` is packet 01's job
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0056 D5 — Review cadence (per-Node standup row).** Node standup ADRs (every standup ADR template from ADR-0014 onward) must include a "threat model entry" section that adds the Node to the artifact: new trust boundaries (if any), new assets (if any), STRIDE pass against the boundaries the Node touches, AI overlay if the Node is in the AI sector. The standup ADR cannot move from Proposed to Accepted until the artifact-update commit lands. Enforcement: the `hive-sync` constitution-scan job fails if a standup ADR references a Node not present in the artifact.
+
+**ADR-0056 D9 AI-1 — Prompt injection (direct) — structural separation.** Every LLM call in the Grid uses structural separation of system instructions, user input, and tool output via a `PromptEnvelope` shape where system / user / tool / assistant messages are typed channels, not concatenated strings. Direct string concatenation of untrusted input into a prompt is a CI gate failure (analyzer rule per ADR-0046's analyzer surface).
+
+**ADR-0056 D9 AI-7 — Data exfiltration via agent tool misuse — output-side guard.** Any agent action with high blast radius (file write outside a sandbox, external API call to a non-allowlisted endpoint, tenant data mutation, money movement, sending a message externally) routes through PR-discipline (ADR-0044) or explicit Operator confirmation (ADR-0051), never direct execution.
+
+**ADR-0056 Consequences — Invariants.** ADR-0056 adds exactly three invariants: (1) standup ADRs include a "threat model entry"; (2) LLM calls use `PromptEnvelope`; (3) high-blast-radius agent actions route through PR-discipline or Operator confirmation.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0056 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbers are claimed at edit time from `constitution/invariant-reservations.md`.** The current verified maximum accepted invariant in `constitution/invariants.md` is **53**. Reservations for in-flight Proposed ADRs live in `constitution/invariant-reservations.md` — that file is the single source of truth for collision avoidance. The executor reads it, picks the next free contiguous block of size 3 above the highest existing reservation, claims the block by adding a row to its **Active Reservations** table in the same PR, and uses the claimed numbers throughout this packet body (referred to as `{N1}/{N2}/{N3}`). Never reuse a number that already appears in `invariants.md` or as a reservation.
+- **Do not renumber existing invariants.** Append only.
+- **New section name.** The three threat-model invariants are a new cross-cutting topic; create a `## Security and Threat Model Invariants` section. Match the file's existing sectioning convention; place adjacent to `## AI Invariants` if the file groups security-adjacent concerns there, or as a new top-level section if a `Security` heading already exists.
+- **Inline the full invariant text — do NOT reference by number only.** Each of `{N1}/{N2}/{N3}` is written out in full in the invariants file (as in Proposed Implementation), so downstream agents reading the constitution at PR time can act on the rule without traversing back to this packet.
+- **No artifact creation in this packet.** `constitution/threat-model.md` is packet 01's deliverable. This packet ships only the ADR flip + the three invariants + the initiative registration.
+
+## Labels
+`chore`, `tier-3`, `meta`, `security`, `docs`, `adr-0056`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0056 to Accepted, claim a block of three invariant numbers from `constitution/invariant-reservations.md` (referred to as `{N1}/{N2}/{N3}`), add the three threat-model invariants to `constitution/invariants.md` at those numbers, and register the threat-model initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0056 so the remaining packets in this initiative can reference its decisions as live rules.
+- Feature: ADR-0056 Threat Model and Security Review Cadence rollout, Wave 1.
+- ADRs: ADR-0056 (primary), ADR-0008 (initiative/packet conventions), ADR-0046 (specialist review agents — Proposed, soft-coupled), ADR-0044 (PR discipline — Accepted, referenced by invariant `{N3}`).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0056 stays Proposed until this PR merges.
+- Claim a contiguous block of three invariant numbers from `constitution/invariant-reservations.md` (the single source of truth for in-flight reservations). The verified current max accepted in `constitution/invariants.md` is **53**; reservations beyond 53 live in `invariant-reservations.md`. At edit time: read the **Active Reservations** table, pick the next free block of size 3 above the highest existing reservation, refer to those numbers as `{N1}/{N2}/{N3}` in this packet, and add a claiming row to that table in the same commit. Do not renumber existing invariants.
+- Inline the full text of each new invariant in `constitution/invariants.md`. Do not abbreviate to "see ADR-0056."
+- Create a new `## Security and Threat Model Invariants` section adjacent to `## AI Invariants` (or as a new top-level section if the file already has a `Security`-prefixed section).
+- No artifact file in this packet — `constitution/threat-model.md` is packet 01.
+
+**Key Files:**
+- `adrs/ADR-0056-threat-model-and-security-review-cadence.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0056-threat-model/01-architecture-threat-model-artifact-v0.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/01-architecture-threat-model-artifact-v0.md
@@ -1,0 +1,221 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "security", "docs", "adr-0056", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0056"]
+accepts: ["ADR-0056"]
+wave: 2
+initiative: adr-0056-threat-model
+node: honeydrunk-architecture
+---
+
+# Author constitution/threat-model.md v0 — header, boundary inventory, asset table, stub STRIDE/AI subsections
+
+## Summary
+Create the v0 shell of `constitution/threat-model.md` per ADR-0056 D4: the ten-section structure with the header (version + last-reviewed + last-quarterly-review + next-quarterly-review dates), methodology recap pointing back at ADR-0056, the full D2 trust-boundary inventory (10 entries), the full D3 asset inventory (12 rows crossing ADR-0049 sensitivity and ADR-0036 RPO/RTO), stub STRIDE-pass subsections per TB with six bullets each (each bullet marked TBD with a target date for fill), stub AI-overlay subsections per AI-N, empty accepted-risks / pentest-history / open-mitigations sections, and a references section citing ADR-0056, ADR-0049, ADR-0036, NIST AI RMF, OWASP LLM Top 10, OWASP Top 10 web, CWE Top 25.
+
+## Context
+ADR-0056 D4 commits to a single living artifact at `constitution/threat-model.md` in markdown (not a tool-specific format), with ten enforced sections. The ADR is explicit that **it proposes the path and the shape; it does not write the file itself** — the file's first commit lands as a follow-up after acceptance. This packet is that follow-up.
+
+The split between v0 (this packet) and v1 (packet 02) is **deliberate** per ADR-0056 D14 Phase 1 / Phase 2:
+
+- **Phase 1 / v0** — structure-first. The boundary inventory and the asset table are filled (those are factual catalogs cross-referencing ADR-0049 / ADR-0036). The STRIDE-pass subsections per TB and the AI-overlay subsections per AI-N exist as stubs with "TBD — target: {Phase 2}" markers so the section structure is in place and the file is parseable by `hive-sync` (packet 03) from day one.
+- **Phase 2 / v1** — content fill. Packet 02 replaces every TBD with a real mitigation entry citing the implementing slice-ADR.
+
+Writing the structure first means the `hive-sync` extension (packet 03) can be authored against a deterministic file shape, and the standup-ADR template amendment (also packet 03) can reference real section anchors. Writing the content first would mean re-shaping the file twice; writing both at once would be a large unreviewable commit.
+
+The artifact lives at `constitution/threat-model.md` — the canonical path ADR-0056 D4 names. It joins the existing `constitution/` files (`invariants.md`, `manifesto.md`, `charter.md`, `agent-capability-matrix.md`, `sector-interaction-map.md`, `naming-conventions.md`, `terminology.md`, `ai-sector-architecture.md`, `feature-flow-catalog.md`, `sectors.md`).
+
+**This is a docs-only packet. No code, no .NET project.**
+
+## Scope
+- New file `constitution/threat-model.md` with the v0 shell structure: ten sections per ADR-0056 D4.
+
+## Proposed Implementation
+
+Author `constitution/threat-model.md` with the following sections.
+
+### Section 1 — Header
+```
+# Threat Model
+
+**Version:** v0
+**Methodology:** STRIDE per trust boundary + AI-specific overlay (per ADR-0056 D1)
+**Last reviewed:** {YYYY-MM-DD — this packet's merge date}
+**Last quarterly review:** n/a — first quarterly review calendared for {first week of next quarter}
+**Next quarterly review:** {first week of next quarter — YYYY-MM-DD}
+**Maintainer:** the operator
+**Source of truth for:** Grid attacker model + mitigation mapping + accepted-risk log
+```
+
+### Section 2 — Methodology recap
+A short paragraph stating the methodology choice (STRIDE per trust boundary + AI-specific overlay), citing ADR-0056 D1 for the rationale, and summarizing the STRIDE letters (S/T/R/I/D/E) plus the AI overlay codes (AI-1 through AI-8). Do not reproduce the rationale — point at ADR-0056.
+
+### Section 3 — Trust boundary inventory (D2)
+Reproduce the full 10-row table verbatim from ADR-0056 D2:
+
+| # | Trust boundary | Description | STRIDE pass | AI overlay |
+|---|---|---|---|---|
+| TB-1 | Public internet ↔ Web.Rest / Front Door | Untrusted public ingress to the Grid's HTTP surface. | Full | n/a |
+| TB-2 | Web.Rest ↔ application Nodes (Notify, Pulse, Communications) | Internal HTTP / gRPC / Service Bus hops behind the front door. | Full | n/a |
+| TB-3 | Application Nodes ↔ Vault / Data | Secret resolution and data persistence boundaries. | Full | n/a |
+| TB-4 | Tenant A ↔ Tenant B | Multi-tenant isolation per ADR-0026; the most consequential application-level boundary. | Full | applies (agent execution may span tenants) |
+| TB-5 | Human user ↔ agent | Delegated authority per ADR-0051; the user grants the agent rights within a scope. | Full | applies |
+| TB-6 | Agent ↔ tool registry (Capabilities per ADR-0017) | The agent's interaction with its declared tool surface. | Full | applies |
+| TB-7 | Agent ↔ external LLM provider (data egress per ADR-0041) | Outbound boundary where prompt/completion content crosses out of the Grid. | Full | applies |
+| TB-8 | Studios-internal tooling ↔ paying-tenant data | Operator-side tooling (admin consoles, support flows) crossing into customer data. The "read fence" boundary. | Full | n/a |
+| TB-9 | CI/CD ↔ production | Deploy pipeline crossing into production infrastructure (per ADR-0015 and the Actions reusable workflows). | Full | n/a |
+| TB-10 | Open-source contributors ↔ Grid repos | Untrusted external code contributions to open-source Grid repos (per ADR-0039). | Full | applies (a poisoned PR could carry adversarial prompts in docs/tests) |
+
+State the maintenance rule: the inventory is **expected to grow** (every new Node standup ADR's "threat model entry" section adds new boundaries if any) and is **not** expected to retroactively shrink (boundary removal requires its own ADR).
+
+### Section 4 — Asset inventory (D3)
+Reproduce the full asset table verbatim from ADR-0056 D3. Add a placeholder `Threat IDs` column with `TBD` entries — packet 02 fills the cross-references.
+
+| Asset | Sensitivity (ADR-0049) | RPO (ADR-0036) | RTO (ADR-0036) | Primary defenses | Threat IDs |
+|---|---|---|---|---|---|
+| Auth signing keys (JWT, Vault unseal) | Secret | 0 | < 1h | Vault, rotation per ADR-0006 | TBD |
+| Per-Node Key Vault credentials | Secret | 0 | < 1h | Managed identity, ADR-0006 bootstrap pattern | TBD |
+| Customer payment tokens (Stripe per ADR-0037) | Secret | 0 | < 1h | Token vaulted at Stripe; we hold reference IDs only | TBD |
+| Model API keys (OpenAI, Anthropic, etc. per ADR-0041) | Secret | 0 | < 1h | Key Vault; per-environment rotation; usage caps | TBD |
+| Tenant data partitions (ADR-0026) | Customer (per tenant) | < 5min (Tier 0) | < 1h (Tier 0) | Tenant-scoped partition keys, gateway-enforced; cross-tenant query fail-closed default | TBD |
+| Audit substrate (ADR-0030) | Sensitive (append-only) | 0 | < 4h | Append-only-by-interface, dedicated retention (730 days per ADR-0040 D3) | TBD |
+| Notify recipient address book | Customer | < 1h | < 4h | Per-tenant partitioning; PII-scrubbing in observability pipelines | TBD |
+| Operator credentials (GitHub, Azure, vendor consoles) | Secret | n/a | n/a | Hardware MFA, separate browser profile, no cross-account session reuse | TBD |
+| Source code repos | Internal (public repos) / Sensitive (private repos) | Git-replicated | < 1h | GitHub branch protection, signed commits where used, secret scanning per D8 | TBD |
+| CI/CD secrets (GitHub Actions secrets) | Secret | n/a | < 1h | Repo-scoped or env-scoped; least-privilege; OIDC federation where possible | TBD |
+| LLM prompt/completion telemetry (when retained per ADR-0040 D9 carve-out) | Sensitive | < 1h | < 24h | Default-forbidden retention; `evals.sensitive=true` carve-out; PII-scrubbing | TBD |
+| AI agent execution state (Memory per ADR-0022) | Customer (per tenant) | < 5min | < 1h | Per-tenant scoping; tied to TB-4 isolation guarantees | TBD |
+
+State the data-vs-system-asset split note: ADR-0049 classifies data records; this table classifies system assets (the bytes themselves plus credentials and substrates that are not data records).
+
+### Section 5 — STRIDE pass per boundary
+One subsection per TB-N, with six bullets each (S/T/R/I/D/E). Every bullet uses the format:
+
+```
+- **S — Spoofing — TBD (target: Phase 2 / packet 02).** {threat → mitigation → implementing ADR(s)/Node(s) → residual risk}
+- **T — Tampering — TBD ...**
+- **R — Repudiation — TBD ...**
+- **I — Information disclosure — TBD ...**
+- **D — Denial of service — TBD ...**
+- **E — Elevation of privilege — TBD ...**
+```
+
+Ten subsections (TB-1 through TB-10), each with six TBD bullets. State an explicit "target: Phase 2 / packet 02" marker so the placeholder is observable to `hive-sync` and to the operator.
+
+### Section 6 — AI-specific threats
+One subsection per AI-N from D1 (AI-1 through AI-8). Each subsection has the same shape (threat → mitigation → implementing ADR/Node → residual risk), marked TBD with the same "target: Phase 2 / packet 02" anchor.
+
+For AI-1 / AI-4 / AI-7 specifically, note in the TBD entry that the implementing work is deferred to owning-Node tracks (HoneyDrunk.AI for AI-1's `PromptEnvelope`; HoneyDrunk.Capabilities for AI-4's immutable-tool-description and AI-7's high-blast-radius routing) per the dispatch plan's deferral notes.
+
+### Section 7 — Accepted risks
+Empty placeholder section with a one-line note:
+
+```
+> No risks accepted yet. An empty section here is a smell once Phase 2 is complete — every honest threat model has at least a few accepted residual risks.
+```
+
+### Section 8 — Penetration-test history
+Empty placeholder section with a one-line note:
+
+```
+> No engagements yet. The pre-Notify-Cloud-GA engagement (per ADR-0056 D6) is the first; results append here as section 8.1.
+```
+
+### Section 9 — Open mitigations
+Empty placeholder section with a one-line note:
+
+```
+> Open mitigations from this artifact's STRIDE pass populate here once Phase 2 fills the subsections.
+```
+
+### Section 10 — References
+Citations:
+- **ADR-0056** (this artifact's governing decision)
+- **ADR-0049** (data classification)
+- **ADR-0036** (disaster recovery tiers)
+- **ADR-0006** (secret rotation), **ADR-0011** (code review), **ADR-0026** (multi-tenant), **ADR-0030/0031** (audit substrate), **ADR-0041** (LLM provider egress), **ADR-0044** (PR discipline), **ADR-0046** (specialist review agents — Proposed), **ADR-0050** (customer comms — Proposed), **ADR-0051** (agent authority — Proposed), **ADR-0054** (incident response — Proposed)
+- **NIST AI Risk Management Framework (AI RMF 1.0)** — https://www.nist.gov/itl/ai-risk-management-framework
+- **OWASP LLM Top 10 (2025)** — https://owasp.org/www-project-top-10-for-large-language-model-applications/
+- **OWASP Top 10 (web)** — https://owasp.org/www-project-top-ten/
+- **CWE Top 25** — https://cwe.mitre.org/top25/
+- **MITRE ATLAS** — https://atlas.mitre.org/
+
+Note: each cross-link to an ADR uses the convention from ADR-0056 D4 — `per ADR-0006 D3` style, not free-text. This makes the artifact greppable for impact-analysis.
+
+## Affected Files
+- `constitution/threat-model.md` (new)
+
+## NuGet Dependencies
+None. This packet creates a single Markdown file; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] The file lives at `constitution/threat-model.md`, the canonical path ADR-0056 D4 names.
+
+## Acceptance Criteria
+- [ ] `constitution/threat-model.md` exists with the ten sections from ADR-0056 D4 in order
+- [ ] Section 1 (header) carries version v0, the methodology line, the merge-date "last reviewed", an n/a "last quarterly review", and a calendared "next quarterly review" date (first week of the next calendar quarter)
+- [ ] Section 2 (methodology recap) summarizes STRIDE + AI overlay in a short paragraph and points at ADR-0056 D1
+- [ ] Section 3 (boundary inventory) carries all 10 TBs verbatim from ADR-0056 D2 with the maintenance rule
+- [ ] Section 4 (asset inventory) carries all 12 assets verbatim from ADR-0056 D3 with the data-vs-system-asset split note and a placeholder `Threat IDs` column
+- [ ] Section 5 (STRIDE pass per boundary) has ten subsections, one per TB-N, each with six TBD bullets carrying the "target: Phase 2 / packet 02" marker
+- [ ] Section 6 (AI-specific threats) has eight subsections, one per AI-N, each TBD with the same target marker; AI-1, AI-4, AI-7 carry the deferred-to-owning-Node-track note
+- [ ] Sections 7, 8, 9 are empty placeholder sections with the one-line notes from Proposed Implementation
+- [ ] Section 10 (references) cites ADR-0056, ADR-0049, ADR-0036, the slice-ADRs (0006, 0011, 0026, 0030, 0031, 0041, 0044, 0046, 0050, 0051, 0054), NIST AI RMF, OWASP LLM Top 10, OWASP Top 10 web, CWE Top 25, MITRE ATLAS
+- [ ] ADR cross-references use the `per ADR-NNNN DN` convention (greppable for impact-analysis)
+- [ ] No content fill in this packet — every STRIDE bullet and every AI-N entry is TBD (Phase 2 / packet 02 owns content fill)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0056 D2 — Trust boundary inventory (10 entries).** TB-1 through TB-10 as enumerated in the table; the list is expected to grow but not retroactively shrink. Every new Node standup ADR's "threat model entry" section adds new boundaries if any.
+
+**ADR-0056 D3 — Asset classification crossing ADR-0049 sensitivity and ADR-0036 RPO/RTO.** 12 assets enumerated; system-asset axis layered on data-record axis (ADR-0049) without changing the data-record axis. Each asset will get threat-ID cross-references in Phase 2.
+
+**ADR-0056 D4 — Artifact at `constitution/threat-model.md` with ten enforced sections.** Markdown, not a tool-specific format. The artifact does not duplicate ADR content — it is the mapping (threat → mitigation → implementing ADR), not the explanation of the underlying mechanism.
+
+**ADR-0056 D14 Phase 1 — Artifact v0 with stub STRIDE-pass subsections.** Six bullets per boundary even if the bullets initially say "TBD" with a target date. This packet executes Phase 1; packet 02 executes Phase 2.
+
+## Constraints
+- **Structure-first; content is packet 02.** Every STRIDE bullet and every AI-N entry is TBD in this packet. Do not pre-fill content. The deliberate split lets packet 03 (hive-sync extension) and packet 04 (`SECURITY.md`) author against a deterministic file shape.
+- **Reproduce D2 and D3 verbatim.** The boundary table and the asset table come from the ADR; do not paraphrase or reorder rows.
+- **Cross-reference convention.** ADR cross-references use `per ADR-NNNN DN` style throughout. The artifact will be grepped for impact-analysis when ADRs are amended; free-text references defeat that.
+- **No tool-specific format.** The file is markdown only. No `.tm7` (Microsoft Threat Modeling Tool), no IriusRisk project file, no ThreatDragon JSON — see ADR-0056 D4's explicit rejection.
+- **The artifact does not duplicate ADR content.** Mitigation entries (in packet 02) will say "Vault enforces per-Node Key Vaults with managed-identity bootstrap per ADR-0006 D2" — they do not re-explain how managed identity works. The artifact's job is the mapping, not the explanation.
+
+## Labels
+`feature`, `tier-2`, `meta`, `security`, `docs`, `adr-0056`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Create `constitution/threat-model.md` v0 — the ten-section shell with boundary inventory + asset table filled, STRIDE/AI subsections stubbed with TBD markers targeting Phase 2 / packet 02.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land the canonical artifact path and the deterministic file structure so packet 03 (hive-sync extension) and packet 04 (`SECURITY.md`) can author against it.
+- Feature: ADR-0056 Threat Model and Security Review Cadence rollout, Wave 2.
+- ADRs: ADR-0056 D2/D3/D4/D14 (primary); ADR-0049 (data classification — cited); ADR-0036 (DR tiers — cited); slice-ADRs 0006/0011/0026/0030/0031/0041/0044/0046/0050/0051/0054 (cited in references).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — hard. ADR-0056 must be Accepted before its artifact lands at the canonical path.
+
+**Constraints:**
+- Structure-first; content fill is packet 02 — every STRIDE/AI bullet is TBD.
+- D2 boundary table and D3 asset table reproduced verbatim from the ADR.
+- ADR cross-references use the `per ADR-NNNN DN` convention.
+- No tool-specific format — markdown only.
+- The artifact does not duplicate ADR content.
+
+**Key Files:**
+- `constitution/threat-model.md` (new)
+
+**Contracts:** None changed. The artifact is a governance document, not a code contract.

--- a/generated/issue-packets/active/adr-0056-threat-model/02-architecture-threat-model-artifact-v1.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/02-architecture-threat-model-artifact-v1.md
@@ -1,0 +1,238 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "security", "docs", "adr-0056", "wave-3"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0056"]
+accepts: ["ADR-0056"]
+wave: 3
+initiative: adr-0056-threat-model
+node: honeydrunk-architecture
+---
+
+# Fill constitution/threat-model.md v1 — real STRIDE pass per boundary, AI overlay mitigations, asset threat-IDs
+
+## Summary
+Replace every TBD in `constitution/threat-model.md` (created by packet 01 as v0 shell) with a real mitigation entry citing the implementing slice-ADR(s): 60 STRIDE bullets across TB-1 through TB-10 (six per boundary), 8 AI-overlay entries across AI-1 through AI-8, and 12 asset rows' `Threat IDs` cross-references. Bump the header to v1. The result is the first operationally useful version of the artifact — the version the operator's quarterly-review cadence and the canonical review agents read.
+
+## Context
+Packet 01 shipped the v0 shell: section structure, boundary inventory, asset table, references, with every threat-and-mitigation entry marked TBD. This packet executes ADR-0056 D14 Phase 2: **fill the STRIDE-pass subsections with real mitigation entries pointing to the existing slice-ADRs; fill the AI-overlay subsections with the protections from D9; fill the asset table's threat-ID cross-references**.
+
+After this packet lands, the artifact is **operationally useful** for the operator's quarterly review (D5) and for the canonical `review.md` rubric. The specialist `security` agent (ADR-0046, Proposed) will consume the artifact once ADR-0046's track lands; this packet does not depend on that — the artifact is useful whether or not ADR-0046 has been accepted.
+
+The fill is **deliberately concise**. Each mitigation entry is one to three lines naming the threat, the mitigation, the implementing ADR(s) or Node(s), and the residual risk. The artifact's job is the **mapping** (threat → mitigation → implementing ADR), not the **explanation** of how the underlying mechanism works — that's the implementing ADR's job. A bullet that re-explains how managed identity works is over-engineered; a bullet that says "managed identity per ADR-0006 D2; residual risk: Azure managed-identity service outage" is right-sized.
+
+**Deferred entries are explicit.** Per the dispatch plan, AI-1's `PromptEnvelope` work is deferred to `HoneyDrunk.AI`'s own track, AI-4 and AI-7's capability-side wiring to `HoneyDrunk.Capabilities` standup (ADR-0017), AI-8's tighter rotation to a Vault.Rotation follow-up, D10's investigation-extended-retention export to an Audit Phase-2 follow-up, `.claude/agents/security.md`'s artifact-loading wiring to ADR-0046's track. In the artifact, each deferred mitigation is named explicitly: "Mitigation: {concrete pattern}. Implementing: pending {ADR-NNNN / Node track}. Residual risk: {what the deferral means until the implementing track lands}." The deferrals are visible, not hidden.
+
+**This is a docs-only packet. No code, no .NET project.**
+
+## Scope
+- `constitution/threat-model.md` — fill all TBD entries from v0 with real mitigation content; bump header to v1; update last-reviewed date.
+
+## Proposed Implementation
+
+For every TBD entry in `constitution/threat-model.md`, replace with a real mitigation entry using the established format: **threat → mitigation → implementing ADR(s)/Node(s) → residual risk**.
+
+### Section 5 — STRIDE pass per boundary (60 entries)
+
+For each TB-N, write six bullets. Below are the canonical mappings the entries draw from. The agent executing this packet has discretion on phrasing; the substance is fixed by the cited ADRs.
+
+**TB-1 (Public internet ↔ Web.Rest / Front Door)** — entry-point security:
+- S/Spoofing: Front Door + Web.Rest enforce JWT Bearer validation per ADR-0010 (Auth is validator-not-issuer). Residual: token-theft via TB-5 (covered there).
+- T/Tampering: TLS-only; HSTS preload; signed request envelopes for tenant-bearing traffic where applicable.
+- R/Repudiation: every request emits an audit entry via `IAuditLog` per ADR-0030 (invariant 47); CorrelationId attached per invariant 6.
+- I/Information disclosure: response envelope per ADR-0011 patterns; error mapping does not leak internals; secret-scrubbing in observability per invariant 8.
+- D/Denial of service: rate limits at Front Door + per-tenant rate-limit policy per ADR-0026 invariant 39 (post-dispatch tails); Notify Cloud GA carries explicit DoS rate-limit thresholds.
+- E/Elevation of privilege: claims-policy mapping in Web.Rest; tenant policy enforced at intake middleware per invariant 39.
+
+**TB-2 (Web.Rest ↔ application Nodes)** — internal-network boundary:
+- S: Managed Identity + token validation between Nodes; no shared-secret schemes.
+- T: Transport-layer integrity via Service Bus message-id + (post-ADR-0042) `IdempotencyKey`; tamper requires Service Bus credential compromise (covered by TB-3).
+- R: per-message audit entries via `IAuditLog` (ADR-0030); CorrelationId propagates per invariants 5/6.
+- I: tenant scoping enforced at consumer per ADR-0026; no cross-tenant message delivery.
+- D: Service Bus dead-letter handling per ADR-0028; per-tenant rate limits at TB-1 already bound upstream load.
+- E: per-Node Managed Identity scopes RBAC narrowly; no broad service principals.
+
+**TB-3 (Application Nodes ↔ Vault / Data)** — secret + data persistence boundary:
+- S: Managed Identity for Vault and Data access; per-Node Key Vault (invariant 17); no application-resident credentials.
+- T: Vault audit logs (invariant 22 — diagnostic settings to Log Analytics); Data EF Core constraints + outbox transactional integrity.
+- R: `IAuditLog` records every privileged Vault access path; Data emits audit on record CRUD (ADR-0030).
+- I: secret values never leave Vault as plaintext into logs (invariant 8); tenant-scoped secrets per invariant 9a.
+- D: Vault throttling per Azure default; Data connection-pool exhaustion mitigated by per-Node connection limits.
+- E: RBAC enforced at Vault (invariant 17 — no access policies); EF Core role-scoped query model.
+
+**TB-4 (Tenant A ↔ Tenant B)** — multi-tenant isolation (most consequential boundary):
+- S: `TenantId` carried as ULID per ADR-0026; cross-tenant token forgery requires Auth signing-key compromise (TB-3).
+- T: Tenant-scoped partition keys enforced at the gateway per invariant 39; cross-tenant write rejected at intake.
+- R: per-tenant audit trail via `IAuditLog` with `TenantId` dimension (ADR-0030).
+- I: cross-tenant read fail-closed by default per ADR-0026; tenant-scoped secrets per invariant 9a; AI overlay applies (agent execution may span tenants — see AI-2/AI-7).
+- D: per-tenant rate limits per ADR-0026 (invariant 39); single-tenant burst cannot starve other tenants.
+- E: tenant policy escalation requires an explicit Operator action per ADR-0051 (Proposed); no in-band escalation path.
+
+**TB-5 (Human user ↔ agent)** — delegation boundary (AI overlay applies):
+- S: delegated authority scoped to specific capabilities per ADR-0051 (Proposed); session tokens tied to authenticated user.
+- T: agent cannot rewrite its own scope mid-session; scope changes require re-authorization.
+- R: per-action audit via `IAuditLog` with PrincipalId per ADR-0030.
+- I: agent context inherits user's tenant scope; cross-tenant escalation blocked at the capability layer (per TB-6).
+- D: per-user rate limits on agent dispatch; long-running agent tasks budget-capped per ADR-0052 (Proposed).
+- E: any high-blast-radius action routes through PR-discipline or Operator confirmation per invariant `{N3}` (claimed in packet 00).
+
+**TB-6 (Agent ↔ tool registry / Capabilities)** — AI overlay applies; ADR-0017 standup pending:
+- S: tool descriptors signed at registry-version-publish per ADR-0017 D9 (pending standup); agents refuse to invoke unrecognized hashes.
+- T: tool descriptions are immutable per release (AI-4 mitigation); amendments require a new registry version + deploy.
+- R: every tool dispatch emits an audit entry via `IAuditLog` (ADR-0030).
+- I: tool descriptors carry no sensitive data; tenant-scoped capability filtering at lookup.
+- D: per-capability rate limits; expensive capabilities gate behind cost-aware routing per ADR-0041 / ADR-0052.
+- E: tool-registry mutation at runtime requires explicit Operator action per ADR-0051 D11; not delegable.
+
+**TB-7 (Agent ↔ external LLM provider)** — egress boundary; ADR-0041 governs:
+- S: per-environment API keys; provider-side workspace isolation per ADR-0041.
+- T: payload integrity bounded by TLS; provider's own integrity controls assumed.
+- R: every dispatch emits audit per ADR-0041 (and ADR-0030); CostLedger entry per ADR-0016 D5.
+- I: `evals.sensitive=true` carve-out per ADR-0040 D9 governs prompt/completion retention; default is forbidden.
+- D: per-tenant model-budget cap per ADR-0041; provider rate-limit honored at `IModelRouter`.
+- E: model API key compromise (AI-8) — separate per-environment keys, 90-day rotation cadence.
+
+**TB-8 (Studios-internal tooling ↔ paying-tenant data)** — read-fence boundary:
+- S: operator MFA required for any tenant-data read path; no service-account access to tenant data outside support-flow allowlist.
+- T: support flows are read-only; mutations require explicit Operator confirmation per ADR-0051.
+- R: every operator-side tenant-data access audited via `IAuditLog` (ADR-0030) with PrincipalId.
+- I: operator-side views minimize disclosure — masked PII, no cross-tenant aggregation outside aggregated metrics.
+- D: not a meaningful threat at this boundary.
+- E: operator credentials are the most-sensitive class; hardware MFA + separate browser profile (D3 asset table).
+
+**TB-9 (CI/CD ↔ production)** — deploy-pipeline boundary:
+- S: OIDC federation for GitHub Actions → Azure per ADR-0015 (no long-lived SP keys).
+- T: signed commits where used; branch protection requires PR approval per ADR-0044.
+- R: every deploy emits an annotation (per ADR-0045 D6) + an audit entry via the deploy workflow.
+- I: workflow files never contain secrets (invariant 8); CI/CD secrets are repo-scoped/env-scoped.
+- D: pipeline backpressure via concurrency keys per ADR-0033.
+- E: deploy-time RBAC scoped to per-Node service principals; no broad subscription contributors.
+
+**TB-10 (Open-source contributors ↔ Grid repos)** — supply-chain boundary; AI overlay applies (poisoned PR carrying adversarial prompts):
+- S: GitHub signed-commit verification where committers sign; required reviewer per branch protection.
+- T: PR-author cannot self-merge per ADR-0044; review-agent runs per invariant 52.
+- R: PR history is git-historical; audit via GitHub.
+- I: secret scanning Grid-wide per ADR-0056 D8 (packet 08) catches accidental disclosure in contributions.
+- D: GitHub Actions concurrency limits bound CI cost from PR fork builds.
+- E: dependency-injection via Dependabot scoped to security alerts + auto-PR for patches per ADR-0056 D7 (packet 08); minor/major require human merge; AI overlay — poisoned doc/test files carrying adversarial prompts are caught by the review agent's PR-author-untrusted-content scan (per ADR-0044/ADR-0046).
+
+### Section 6 — AI-specific threats (8 entries)
+
+For each AI-N, write a mitigation entry. The substance from ADR-0056 D9, recapped here with the deferred-track notes:
+
+- **AI-1 Prompt injection (direct).** Mitigation: `PromptEnvelope` typed-channel pattern in `HoneyDrunk.AI`; analyzer rule fails CI on direct string concatenation of untrusted input. Implementing: `HoneyDrunk.AI` (ADR-0016, Seed) — **pending HoneyDrunk.AI track work; tracked in cross-track follow-up (packet 09).** Residual risk: structural separation raises the bar but does not close the surface — sophisticated content can be interpreted by the model as instructions despite channel typing; second line is AI-7's output-side guard.
+- **AI-2 Indirect prompt injection.** Mitigation: untrusted external content wrapped with explicit untrusted-data tags (`<untrusted_external_content source="...">...</untrusted_external_content>`); system prompt warns the model that content within these tags is not from the user and carries no instructions to follow. Implementing: `HoneyDrunk.AI` LLM-calling library pattern. Residual risk: motivated attackers craft content the model follows despite the tags — same OWASP-LLM consensus.
+- **AI-3 Model jailbreak.** Mitigation: provider-side moderation (first line) + AI-7 output-side guard (defense in depth). The Grid does not attempt to harden provider safety stacks. Implementing: provider-side (n/a Grid code) + AI-7 below. Residual risk: provider safety-stack failures are caught only by the output-side guard + the audit trail.
+- **AI-4 Tool poisoning.** Mitigation: tool descriptions in `HoneyDrunk.Capabilities` registry are immutable per release; amendments require a new tool-registry version and a deployment that observes the version change; runtime addition requires explicit Operator action per ADR-0051 D11; agents discovering a tool whose description doesn't match the registered hash refuse to invoke it. Implementing: `HoneyDrunk.Capabilities` (ADR-0017, Proposed standup) — **pending Capabilities standup; tracked in cross-track follow-up (packet 09).** Residual risk: until the immutability invariant is enforced in code, tool poisoning is a process control (registry edits require operator action) rather than a system control.
+- **AI-5 Training-data poisoning.** Mitigation: zero current exposure — the Grid does no fine-tuning today. Tracked at zero so the gap is visible if fine-tuning is ever added without the corresponding mitigation work. Implementing: n/a today; when fine-tuning is adopted, this entry gains training-data provenance + validation + separation of training and serving infrastructure. Residual risk: zero today.
+- **AI-6 Hallucinated-fact downstream impact.** Mitigation: same as AI-7 — output-side guard. A model that confidently states a false fact and routes it into downstream automation is indistinguishable, from the automation's perspective, from a model that has been adversarially manipulated. Implementing: see AI-7. Residual risk: confident-but-false output passes the channel-typing check; only the output-side guard catches it.
+- **AI-7 Data exfiltration via agent tool misuse / output-side guard.** Mitigation: high-blast-radius agent actions (file write outside a sandbox, external API call to non-allowlisted endpoint, tenant data mutation, money movement, sending a message externally) route through PR-discipline (ADR-0044) or explicit Operator confirmation (ADR-0051), never direct execution. The list of high-blast-radius actions lives in this artifact (see "Open mitigations" — section 9) and grows as new capabilities land; default for new capability is high-blast-radius until proven otherwise. Implementing: `HoneyDrunk.Capabilities` capability-side wiring (ADR-0017, Proposed standup) + `security` review agent's per-PR check (ADR-0046, Proposed) — **pending Capabilities standup + ADR-0046 acceptance; tracked in cross-track follow-up (packet 09).** Residual risk: until capability-side wiring is in code, this is a process control (review-rubric responsibility) rather than a system control.
+- **AI-8 Model API key compromise.** Mitigation: per-environment model API keys (dev/staging/prod); per-environment usage caps configured at the provider where supported (e.g., OpenAI project-level limits); 90-day rotation cadence (tighter than the general 180-day default) for the model-key class specifically. Implementing: Vault rotation defaults (ADR-0006) amended for the model-key class — **pending Vault.Rotation follow-up; tracked in cross-track follow-up (packet 09).** Residual risk: until the 90-day cadence is configured, model keys ride the general 180-day cadence, doubling the worst-case spend-burn window.
+
+### Section 4 — Asset inventory threat-ID cross-references
+
+For each of the 12 asset rows, populate the `Threat IDs` column. Examples:
+- Auth signing keys → TB-3 (S/E), TB-9 (S/E), AI-7
+- Per-Node Key Vault credentials → TB-3 (S/I/E)
+- Customer payment tokens → TB-3 (I/E), TB-8 (I)
+- Model API keys → TB-7 (S/I), AI-8
+- Tenant data partitions → TB-4 (all), AI-2 (when agent reads cross-tenant content)
+- Audit substrate → TB-3 (T/R), TB-8 (R)
+- Notify recipient address book → TB-4 (I), TB-8 (I)
+- Operator credentials → TB-8 (S/E), TB-9 (S/E)
+- Source code repos → TB-10 (T/E)
+- CI/CD secrets → TB-9 (I/E)
+- LLM prompt/completion telemetry → TB-7 (I), AI-2
+- AI agent execution state → TB-4 (I), TB-5 (R), AI-7
+
+The agent has discretion to refine these as it writes them; the substance is "which threats from sections 5/6 target this asset."
+
+### Section 1 — Header bump
+
+Update:
+- `**Version:** v0` → `**Version:** v1`
+- `**Last reviewed:** {date}` → `{this packet's merge date}`
+- Leave the quarterly-review dates as set by packet 01 (first quarterly review still calendared for the next quarter)
+
+### Sections 7, 8, 9 — leave as v0 stubs
+
+Section 7 (Accepted risks): still a placeholder, but Phase 2 may surface 1-3 residual risks the operator has explicitly accepted (e.g., "AI-1 structural separation is incomplete — accepted because no complete defense exists in 2026 state-of-the-art"). The agent decides whether to surface accepted risks from the mitigation entries; default is empty section with the v0 smell-note.
+
+Section 8 (Penetration-test history): still empty — first engagement is per ADR-0056 D6 / packet 07 scoping.
+
+Section 9 (Open mitigations): populate with the deferred items from section 6 — AI-1 `PromptEnvelope`, AI-4 immutable-tool-description, AI-7 capability-side wiring, AI-8 tighter rotation, ADR-0046's artifact-loading wiring, Audit's investigation-extended-retention. Each with a target track (the ADR or Node initiative that owns it). This section is the operator's standing TODO list for the threat model.
+
+## Affected Files
+- `constitution/threat-model.md`
+
+## NuGet Dependencies
+None. This packet modifies a single Markdown file; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. The artifact lives at `constitution/threat-model.md` per ADR-0056 D4.
+- [x] No code change in any other repo.
+- [x] No invariant change in this packet — those landed in packet 00.
+
+## Acceptance Criteria
+- [ ] Every TBD bullet in section 5 (60 STRIDE entries across TB-1 through TB-10) is replaced with a real mitigation entry citing the implementing slice-ADR(s)/Node(s) and naming the residual risk
+- [ ] Every AI-N subsection in section 6 (8 entries) carries a real mitigation entry; AI-1, AI-4, AI-7, AI-8 explicitly name the implementing track as deferred and the residual risk that flows from the deferral
+- [ ] Section 4's `Threat IDs` column is populated for all 12 assets, cross-referencing the threats from sections 5/6 that target each asset
+- [ ] Section 1's header reads `**Version:** v1` and the last-reviewed date is updated to this packet's merge date
+- [ ] Section 7 (Accepted risks) carries any residual risks the operator has explicitly accepted (default: empty with the v0 smell-note if no accepted risks surface during fill)
+- [ ] Section 9 (Open mitigations) lists the deferred items from section 6 with their target track (AI's `PromptEnvelope` → ADR-0016 / HoneyDrunk.AI; Capabilities' immutable-tool-description and high-blast-radius routing → ADR-0017; Vault model-key rotation → ADR-0006 amendment / Vault.Rotation follow-up; Audit investigation-extended-retention → Audit Phase-2; ADR-0046 `security.md` artifact-loading → ADR-0046 track)
+- [ ] Every mitigation entry uses the `per ADR-NNNN DN` cross-reference convention from packet 01
+- [ ] No section is removed; v0 structure is preserved and only TBDs are filled
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0056 D2/D3 — boundary inventory and asset classification.** The substrate this packet fills against.
+
+**ADR-0056 D9 — AI-specific protections.** AI-1 structural separation, AI-2 untrusted-content wrapping, AI-3 provider-side + AI-7 output-side, AI-4 immutable-tool-description, AI-5 zero-exposure-tracked, AI-6 = AI-7, AI-7 PR-discipline-or-Operator-confirmation routing, AI-8 per-environment keys + usage caps + 90-day rotation.
+
+**ADR-0056 D14 Phase 2 — fill the artifact with real mitigation entries.** This packet executes Phase 2.
+
+**Slice-ADRs cited:** ADR-0006 (rotation), ADR-0010 (Auth validator), ADR-0011 (review), ADR-0015 (Container Apps), ADR-0026 (multi-tenant), ADR-0028 (messaging), ADR-0030/0031 (audit), ADR-0033 (deploy gating), ADR-0040 (telemetry), ADR-0041 (LLM egress), ADR-0044 (PR discipline), ADR-0045 (errors), ADR-0046 (specialist review — Proposed), ADR-0049 (data classification — Proposed), ADR-0050 (customer comms — Proposed), ADR-0051 (agent authority — Proposed), ADR-0052 (cost — Proposed), ADR-0054 (incident — Proposed).
+
+## Constraints
+- **Concise entries — mapping not explanation.** Each STRIDE/AI entry is one to three lines: threat → mitigation → implementing ADR → residual risk. Do not re-explain how the implementing mechanism works; that's the implementing ADR's job (D4 explicit rule).
+- **Deferred items are explicit.** AI-1, AI-4, AI-7, AI-8 entries name the implementing track as deferred ("pending {ADR-NNNN / Node track}; tracked in cross-track follow-up (packet 09)") and state the residual risk that flows from the deferral. Do not hide deferrals behind soft language.
+- **Honest residual risk.** Every entry names the residual risk — even when it's "low," "covered by another mitigation," or "structural separation is incomplete by construction." An entry without a residual risk is a sign of dishonest mitigation accounting (D2 explicit rule — "a boundary listed without a residual-risk entry is dishonest").
+- **`per ADR-NNNN DN` cross-references throughout.** Greppable. ADR-NNNN must be the actual ADR; do not invent ADR numbers.
+- **Do not invent boundaries, assets, or threats not in ADR-0056.** This packet **fills** the v0 shell; it does not add new TB-N or AI-N entries. New boundaries/assets/threats are added via subsequent commits driven by standup ADRs or amendments.
+- **Header version bump.** v0 → v1. The last-reviewed date is this packet's merge date.
+
+## Labels
+`feature`, `tier-2`, `meta`, `security`, `docs`, `adr-0056`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Replace every TBD in `constitution/threat-model.md` with a real mitigation entry — 60 STRIDE bullets, 8 AI-overlay entries, 12 asset threat-ID cross-references; bump header to v1.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the artifact operationally useful for the operator's quarterly review (D5) and for the canonical review agents.
+- Feature: ADR-0056 Threat Model and Security Review Cadence rollout, Wave 3.
+- ADRs: ADR-0056 D2/D3/D9/D14 (primary); the cited slice-ADRs as mitigation references.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — hard. The v0 shell must exist (the TBD entries this packet fills are placed by packet 01).
+
+**Constraints:**
+- Mapping not explanation — entries are one to three lines, citing implementing ADRs by `per ADR-NNNN DN`, not re-explaining mechanisms.
+- Deferred items (AI-1/AI-4/AI-7/AI-8) are explicit: "pending {track}; tracked in packet 09" + residual risk of the deferral.
+- Every entry names residual risk — no entry without one.
+- Do not invent boundaries, assets, or threats — fill only.
+- Header v0 → v1; last-reviewed date set to this packet's merge date.
+
+**Key Files:**
+- `constitution/threat-model.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0056-threat-model/03-architecture-standup-template-and-hive-sync.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/03-architecture-standup-template-and-hive-sync.md
@@ -1,0 +1,151 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "security", "docs", "adr-0056", "wave-3"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0056", "ADR-0014"]
+accepts: ["ADR-0056"]
+wave: 3
+initiative: adr-0056-threat-model
+node: honeydrunk-architecture
+---
+
+# Amend the standup-ADR template + extend hive-sync to enforce threat-model entry on every standup
+
+## Summary
+Two governance-plumbing tasks from ADR-0056 D5 / Follow-up Work: (1) amend the standup-ADR authoring template (the shape every Node standup ADR follows — ADR-0014 onward) to require a "threat model entry" section, and (2) extend `hive-sync` (per ADR-0014) to fail the constitution scan if a standup ADR references a Node not present in `constitution/threat-model.md`. Together these enforce invariant `{N1}` (added by packet 00) at authoring time and at constitution-scan time.
+
+## Context
+Invariant `{N1}` (added by packet 00) commits the Grid to: every Node standup ADR includes a "threat model entry" section, and the artifact is updated in the same PR that moves the standup ADR to Accepted. ADR-0056 D5 names two enforcement points:
+
+1. **Standup-ADR template — author-time enforcement.** The template's structure carries the "threat model entry" section so authors of new standup ADRs see the requirement before they write the ADR. Without the template amendment, invariant `{N1}` is only enforced at scan-time — after the ADR is drafted — which means authors discover the gap during PR review rather than during authoring.
+2. **`hive-sync` constitution scan — merge-time enforcement.** ADR-0014's `hive-sync` agent already scans the constitution; this packet extends the scan to check that every Accepted standup ADR references a Node that appears in `constitution/threat-model.md`'s boundary inventory and asset inventory (where the Node touches new boundaries or assets). A standup ADR moved to Accepted without a corresponding artifact update fails the scan.
+
+Both enforcement points point at the **same content discipline**: when a Node is stood up, its boundaries and assets are added to the threat model in the same PR as the standup. The template makes the requirement visible; `hive-sync` makes the requirement merge-gating.
+
+**Standup-ADR template location.** Standup ADRs follow a shape established by ADR-0014 onward (ADR-0016 HoneyDrunk.AI, ADR-0017 Capabilities, ADR-0018 Operator, ADR-0019 Communications, ADR-0020 Agents, ADR-0021 Knowledge, ADR-0022 Memory, ADR-0023 Evals, ADR-0024 Flow, ADR-0025 Sim, ADR-0027 Notify Cloud, ADR-0031 Audit). There is no single template file at a known path in this repo (verified via search — `adrs/` has no `templates/` subdirectory, only the ADRs themselves). The "template" in ADR-0056 D5 is the **shape of the standup-ADR authoring guidance**. The executor of this packet identifies the canonical location for that guidance — likely a comment in a representative standup ADR, or a new doc at `adrs/standup-template.md` if no canonical location exists — and amends it.
+
+**`hive-sync` extension.** ADR-0014's `hive-sync` agent lives in `.claude/agents/hive-sync.md` and (per the existing rollout — Architecture#61 through #66, all closed) already runs a constitution scan with packet-lifecycle, board-coverage, Proposed-ADR-queue, ADR/PDR auto-acceptance, and drift-detection checks. This packet adds one more scan rule: a standup-ADR-vs-artifact Node-list consistency check. The rule's logic, in plain terms: list every standup ADR (those that match a "Stand Up the HoneyDrunk.X Node" title pattern, or carry a `standup` label in `accepts:` frontmatter); for each, find the Node it stands up; check that the Node's name appears in `constitution/threat-model.md` either in the boundary inventory (section 3) or the asset inventory (section 4) or via an explicit "Node has no new boundaries or assets — see threat-model entry in the ADR body" note in the standup ADR. If the Node is missing, emit a scan failure naming the standup ADR.
+
+**Backfill posture.** Existing Accepted standup ADRs (ADR-0019, ADR-0031, possibly others) **predate** invariant `{N1}`. The `hive-sync` extension's scan logic distinguishes pre-invariant-`{N1}` standups (Accepted before this initiative's packet 00) from post-invariant-`{N1}` standups (Accepted after). Pre-invariant-`{N1}` standups are not flagged retroactively. New Accepted standups (after packet 00 merges) must comply or fail the scan. This is the "the discipline is forward, not retroactive" posture — consistent with how ADR-0044's PR-discipline rolled out.
+
+**This is a docs + agent-config packet. No code, no .NET project.**
+
+## Scope
+- The canonical standup-ADR authoring guidance — amend to require a "threat model entry" section. If no canonical guidance file exists, create one at `adrs/standup-template.md` (or the established location for ADR-authoring guidance — match the existing convention).
+- `.claude/agents/hive-sync.md` — extend the constitution-scan section with the standup-ADR-vs-artifact Node-list consistency rule.
+
+## Proposed Implementation
+
+### 1. Standup-ADR template amendment
+
+Identify the canonical location for standup-ADR authoring guidance. Verified at scope time: no `adrs/standup-template.md` or `adrs/templates/` exists; standup ADRs are authored from prior examples (ADR-0019, ADR-0031, etc.). The executor:
+
+- **Option A** — if a canonical authoring guidance doc exists (verify in `adrs/`, `.github/`, or the `copilot/` instructions), amend it.
+- **Option B** — if no canonical doc exists, create `adrs/standup-template.md` with the standup-ADR shape distilled from the existing standup ADRs (the section structure: Status / Date / Deciders / Sector / Context / Decision / Consequences / Alternatives Considered) and add the "threat model entry" requirement.
+
+The "threat model entry" section, to be inserted in the standup-template under Decision (after the contract/interface freezes, before Consequences):
+
+```markdown
+### D_N — Threat model entry
+
+This Node introduces the following new trust boundaries (per ADR-0056 D2):
+- {TB-N: description, or "none — this Node introduces no new boundary"}
+
+This Node introduces the following new assets (per ADR-0056 D3):
+- {asset name, sensitivity class per ADR-0049, RPO/RTO per ADR-0036, primary defenses}
+- {or "none — this Node introduces no new asset"}
+
+STRIDE pass against the boundaries this Node touches:
+- TB-N (boundary name): S/T/R/I/D/E — one line per letter naming the threat-mitigation pair
+
+AI overlay (Nodes in the AI sector, or any Node executing LLM calls or invoking agent tools):
+- AI-N: {applicable threat → mitigation → residual risk}, or "n/a — Node does not execute LLM calls or invoke agent tools"
+
+The artifact `constitution/threat-model.md` is updated in this same PR to reflect the new boundaries, assets, and threat entries. The standup ADR cannot move from Proposed to Accepted until that artifact-update commit lands.
+```
+
+If a representative standup ADR is the canonical guidance (no separate template file), add a comment block at the top noting the threat-model-entry requirement and pointing at ADR-0056 D5 + invariant `{N1}`.
+
+### 2. `hive-sync` constitution-scan extension
+
+Amend `.claude/agents/hive-sync.md` to add a new sub-scan within its constitution-scan responsibility. The scan rule (in plain English — `hive-sync` documents agent behavior in prose, not code):
+
+> **Standup-ADR vs. threat-model artifact consistency.** For every standup ADR with `**Status:** Accepted` and a merge date after {packet 00's merge date — substitute at edit time}, check that the Node it stands up appears in `constitution/threat-model.md` — either in section 3 (boundary inventory), section 4 (asset inventory), or referenced by name within a STRIDE-pass entry in section 5. If the Node is named in the standup ADR but absent from the artifact, emit a scan failure naming the standup ADR and the missing Node. Pre-invariant-`{N1}` standup ADRs (Accepted before the cutoff date) are not flagged retroactively — they ride forward under the existing artifact whether or not they are explicitly named.
+
+The exact wording in `hive-sync.md` follows the existing scan-rule conventions in that file (mirror the language of the packet-lifecycle scan, the board-coverage scan, the ADR/PDR queue scan).
+
+State the failure-mode posture: a scan failure is **advisory**, not auto-blocking — `hive-sync` runs through OpenClaw scheduled/manual execution (per ADR-0014 D3 and invariant 38) and emits findings; the operator triages and closes the gap. This is consistent with the existing scan behavior; no new gating semantics are introduced.
+
+### 3. Cross-reference to invariant `{N1}`
+
+In both the template amendment and the `hive-sync` rule, include a `cf. invariant `{N1}`` cross-reference so a reader landing in either doc can trace back to the constitutional rule.
+
+## Affected Files
+- The canonical standup-ADR authoring guidance — verified location at edit time (either an existing file or a new `adrs/standup-template.md`).
+- `.claude/agents/hive-sync.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance and agent-config files; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. The standup-ADR authoring surface and `.claude/agents/hive-sync.md` both live here. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] `hive-sync` is the right enforcement surface — ADR-0014 names it as the constitution-scan agent; ADR-0056 D5 specifies the constitution scan as the enforcement point for invariant `{N1}`.
+
+## Acceptance Criteria
+- [ ] The canonical standup-ADR authoring guidance carries a "threat model entry" section requirement that names: new trust boundaries (if any) per ADR-0056 D2, new assets (if any) per ADR-0056 D3, STRIDE pass against boundaries the Node touches, AI overlay if applicable, and the requirement that `constitution/threat-model.md` is updated in the same PR
+- [ ] If no canonical guidance doc existed at scope time, `adrs/standup-template.md` was created with the standup-ADR shape distilled from existing standups + the threat-model-entry requirement
+- [ ] `.claude/agents/hive-sync.md` carries a new sub-scan rule: standup-ADR-vs-artifact Node-list consistency, with the pre-invariant-`{N1}` backfill exemption (standups Accepted before packet 00's merge date are not flagged retroactively)
+- [ ] Both edits cross-reference invariant `{N1}` (cf. invariant `{N1}`)
+- [ ] The `hive-sync` rule follows the existing scan-rule conventions in the file (advisory findings, no new auto-blocking semantics)
+- [ ] No existing Accepted standup ADR is modified retroactively to add a threat-model-entry section (backfill is explicitly forward-only)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0056 D5 — Per-new-Node review cadence.** Node standup ADRs include a "threat model entry" section that adds the Node to the artifact: new trust boundaries (if any), new assets (if any), STRIDE pass against the boundaries the Node touches, AI overlay if the Node is in the AI sector. The standup ADR cannot move from Proposed to Accepted until the artifact-update commit lands. Enforcement: the `hive-sync` constitution-scan job fails if a standup ADR references a Node not present in the artifact.
+
+**Invariant `{N1}` (added by packet 00) — Every Node standup ADR includes a "threat model entry" section, and the artifact is updated in the same PR that moves the standup ADR to Accepted.** Enforced by `hive-sync` constitution scan.
+
+**ADR-0014 — `hive-sync` agent and the constitution scan surface.** `hive-sync` runs through OpenClaw scheduled/manual execution per invariant 38; the constitution scan is its mechanism for surfacing drift. Scan findings are advisory (per the existing rollout pattern), not auto-blocking.
+
+## Constraints
+- **Inline the requirement; do not just cite invariant `{N1}`.** Both the template and the `hive-sync` rule write out the substance (boundaries, assets, STRIDE pass, AI overlay, same-PR artifact update). Number-only references defeat the author's ability to act on the rule.
+- **Forward-only backfill.** Existing Accepted standup ADRs (predate this initiative) are not modified retroactively. The `hive-sync` scan distinguishes pre/post-invariant-`{N1}` standups using a date cutoff (packet 00's merge date) — substitute that cutoff date in `hive-sync.md` at edit time.
+- **Advisory findings, not auto-blocking.** The new `hive-sync` rule follows the existing scan conventions — emit a finding, the operator triages and closes. Do not introduce new merge-blocking semantics in `hive-sync.md` for this rule (or any other — that's not `hive-sync`'s contract per ADR-0014).
+- **Standup-template location verified at edit time.** Verified at scope time: no `adrs/standup-template.md` or `adrs/templates/` exists. If a canonical guidance file is found at edit time (in `adrs/`, `.github/`, or `copilot/`), amend it; otherwise create `adrs/standup-template.md`.
+
+## Labels
+`feature`, `tier-2`, `meta`, `security`, `docs`, `adr-0056`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Amend the standup-ADR authoring template (or create one if missing) to require a "threat model entry" section; extend `hive-sync`'s constitution scan with a standup-ADR-vs-artifact Node-list consistency rule.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make invariant `{N1}` enforceable at author time (the template) and at scan time (`hive-sync`).
+- Feature: ADR-0056 Threat Model and Security Review Cadence rollout, Wave 3.
+- ADRs: ADR-0056 D5 (primary); ADR-0014 (`hive-sync` agent surface); invariant `{N1}` (added by packet 00).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — hard. `constitution/threat-model.md` must exist for both the template language and the `hive-sync` scan rule to reference it concretely.
+
+**Constraints:**
+- Inline the requirement substance in both surfaces — no number-only invariant references.
+- Forward-only backfill — existing Accepted standup ADRs are not retroactively flagged.
+- Advisory findings — follow existing `hive-sync` conventions; no new merge-blocking semantics.
+- Standup-template location verified at edit time — amend existing guidance or create `adrs/standup-template.md`.
+
+**Key Files:**
+- The canonical standup-ADR authoring guidance (verified at edit time)
+- `.claude/agents/hive-sync.md`
+
+**Contracts:** None changed. Governance + agent-config edits only.

--- a/generated/issue-packets/active/adr-0056-threat-model/04-architecture-security-md-authoring.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/04-architecture-security-md-authoring.md
@@ -1,0 +1,209 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "security", "docs", "adr-0056", "wave-3"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0056", "ADR-0039"]
+accepts: ["ADR-0056"]
+wave: 3
+initiative: adr-0056-threat-model
+node: honeydrunk-architecture
+---
+
+# Author SECURITY.md — org-level + per-public-repo copy template, 90-day disclosure window, safe-harbor
+
+## Summary
+Author the canonical `SECURITY.md` content the Grid commits to per ADR-0056 D11, in two surfaces: (1) the org-level file at `HoneyDrunkStudios/.github/SECURITY.md` (which GitHub surfaces on every repo without its own override), and (2) a per-public-repo copy template that any public Grid repo can adopt. Contents: `security@honeydrunkstudios.com` disclosure email, 90-day disclosure window commitment, explicit safe-harbor language modeled on Disclose.io core terms, out-of-scope list, no bug-bounty-at-v1 statement.
+
+## Context
+ADR-0056 D11 commits to a published responsible-disclosure surface. The two surfaces are GitHub's two surfaces for repo-level security info:
+
+- **Org-level `SECURITY.md`** at `github.com/HoneyDrunkStudios/.github/SECURITY.md`. GitHub uses this as the default for every repo in the org that does not have its own `SECURITY.md`. This is the load-bearing artifact — a single edit propagates Grid-wide.
+- **Per-public-repo `SECURITY.md`** copies. Public Grid repos may override the org-level file with a repo-specific policy. ADR-0056 D11 mentions per-public-repo copies; this packet produces the **canonical template** the public repos use, and lists which public repos should adopt it. Actual per-repo PRs are a downstream task per repo — this packet does not file PRs against every Grid repo.
+
+ADR-0056 cross-references ADR-0039 (open-source license policy — Proposed) for the open-source posture: open-source Grid projects publish the same `SECURITY.md`; the org-level file applies to closed-source repos by default and is overridden only if a repo's specific posture differs. The org-level content fits both postures.
+
+**Where the org-level file lives.** GitHub looks for the special `.github` repo at `github.com/HoneyDrunkStudios/.github` (a meta-repo, distinct from any project repo's `.github/` folder). This repo may or may not exist at scope time. The executor:
+
+- If `HoneyDrunkStudios/.github` exists, file the org-level `SECURITY.md` there.
+- If `HoneyDrunkStudios/.github` does not exist, create the repo (org-level meta-repo for shared GitHub configuration — `SECURITY.md`, organization profile README, default community health files) and seed it with `SECURITY.md`. Repo creation is a Human Prerequisite (the operator clicks through the GitHub New Repository UI per the user's portal-first preference).
+
+**Why the org-level file is sufficient at v1.** Per-repo `SECURITY.md` files are a override of the org-level file. At v1, no Grid repo has a policy that diverges from the canonical org-level commitment — same disclosure email, same 90-day window, same safe-harbor. A single org-level file is therefore both necessary and sufficient. Per-public-repo copies become useful only if a specific repo's posture differs (e.g., a future Grid repo with a stricter disclosure window or a different out-of-scope list). This packet produces the template; per-repo adoption is deferred unless a divergence emerges.
+
+**`security@honeydrunkstudios.com` mailbox provisioning.** ADR-0056 D11 names `security@honeydrunkstudios.com` as the disclosure email. This is an alias on `honeydrunkstudios.com` that needs to exist before researchers can use it. Mailbox provisioning is a Human Prerequisite — the operator configures the email-forwarding alias at the registrar/email provider (Cloudflare per ADR-0029 if DNS migration has occurred, otherwise the current DNS provider). The packet's text does not block on this — `SECURITY.md` shipping the email address before the mailbox exists is acceptable for the brief window between packet merge and operator mailbox config (a researcher would receive a bounce, which is a recoverable error and recorded as a Human Prerequisite to close).
+
+**Safe-harbor language — Disclose.io core terms.** ADR-0056 D11 specifies that the safe-harbor language follows Disclose.io's core terms (https://disclose.io/), which the operator does not author from scratch. Disclose.io publishes the core safe-harbor language under permissive licensing for adoption. The executor pulls the current Disclose.io core safe-harbor text and embeds it in `SECURITY.md`. **Do not author novel legal language** — that is explicit in the ADR.
+
+**This is a docs packet. No code, no .NET project.**
+
+## Scope
+- `HoneyDrunkStudios/.github/SECURITY.md` (the org-level surface — may require Human Prerequisite for repo creation).
+- A per-public-repo `SECURITY.md` template, placed in this repo's `templates/` location (canonical: `issues/templates/` already exists in this repo, but a `SECURITY.md` template is documentation, not an issue template — place at `templates/security-md-template.md` or the established canonical-template-collection location, whichever the executor finds at edit time).
+- `repos/HoneyDrunkStudios.github/` context folder in `HoneyDrunk.Architecture` (parallel to the existing `repos/HoneyDrunk.X/` folders) if the org-level meta-repo is created — short note recording the file inventory of `.github`.
+
+## Proposed Implementation
+
+### 1. Org-level `SECURITY.md` content
+
+Author the file at `HoneyDrunkStudios/.github/SECURITY.md`. Content (Markdown):
+
+```markdown
+# Security Policy
+
+HoneyDrunk Studios maintains a published responsible-disclosure policy for the HoneyDrunk Grid. This policy applies to every Grid repo unless that repo carries its own `SECURITY.md` that overrides this one.
+
+## Reporting a vulnerability
+
+Send vulnerability reports to `security@honeydrunkstudios.com`. Encrypt with the PGP key at {public key URL — TBD, surface as Human Prerequisite if PGP not yet set up}.
+
+When reporting, please include:
+- A clear description of the issue and which Grid repo or service is affected.
+- Steps to reproduce, where applicable.
+- Your name and a contact method for follow-up — anonymous reports are accepted; named reporters are credited unless they request otherwise.
+
+## Disclosure window
+
+HoneyDrunk Studios commits to one of the following within **90 days** of receiving a report:
+- Ship a fix.
+- Publicly acknowledge the issue with a planned remediation timeline.
+
+The 90-day window is the default expectation. Researchers reporting an issue that requires longer to remediate may negotiate an extension; researchers preferring an accelerated timeline may negotiate a shorter window. The 90 days is the floor for response, not a hard contract.
+
+## Safe harbor
+
+{Embed the current Disclose.io core safe-harbor text verbatim — pull from https://disclose.io/, see Implementation Notes.}
+
+In summary: good-faith research conducted under this disclosure policy is not pursued legally by HoneyDrunk Studios.
+
+## Out of scope
+
+The following are out of scope for this policy:
+- Testing against production tenant data without explicit prior coordination.
+- Denial-of-service testing against production infrastructure without explicit prior coordination.
+- Social engineering attacks against HoneyDrunk Studios personnel or contractors.
+- Physical attacks against HoneyDrunk Studios infrastructure.
+- Findings in third-party services HoneyDrunk Studios depends on (Stripe, Azure, GitHub, vendor consoles). Report those to the vendor directly.
+- Issues in repos archived or marked as not-receiving-updates.
+
+## Bug bounty
+
+HoneyDrunk Studios does **not** operate a paid bug-bounty program at this time. Reporters of valid vulnerabilities are credited publicly (unless they request anonymity) and may be acknowledged in the Grid's incident post-mortems. Cash bounties may be introduced when commercial revenue justifies the budget; this policy will be updated if and when that happens.
+
+## Cross-references
+
+This policy is the implementing surface for ADR-0056 D11 (Threat Model and Security Review Cadence — responsible disclosure). The substrate posture is documented in `constitution/threat-model.md` in the HoneyDrunk.Architecture repo (public).
+```
+
+### 2. Per-public-repo `SECURITY.md` template
+
+Place a template file in this repo at a path that matches the existing template-collection convention. Verified at scope time, the existing `issues/templates/` directory holds GitHub-Issue templates (not documentation templates). Two options:
+
+- **Option A:** create `templates/security-md.md` (new top-level templates directory parallel to `issues/templates/`).
+- **Option B:** create a single template doc inside an existing meta-docs location — verify at edit time whether the repo has a `templates/` or `docs/templates/` convention; match it.
+
+The template is **identical to the org-level content** with a header note:
+
+```markdown
+<!--
+This SECURITY.md was adopted from the HoneyDrunk Studios org-level template per ADR-0056 D11.
+If this repo's disclosure posture diverges from the org-level default (e.g., shorter disclosure window
+for a high-sensitivity repo, different out-of-scope list), edit this file directly. Otherwise, the
+org-level file at https://github.com/HoneyDrunkStudios/.github/SECURITY.md covers this repo by default
+and this per-repo file is redundant.
+-->
+```
+
+State explicitly in the template's header note: **at v1, no Grid repo has a policy that diverges from the org-level default.** Per-public-repo copies are not yet adopted as a Grid-wide pattern; the template exists so that a future divergence has a starting point.
+
+### 3. Context folder for the meta-repo
+
+If the `HoneyDrunkStudios/.github` meta-repo is created (Human Prerequisite), add a thin context folder at `repos/HoneyDrunkStudios.github/` in `HoneyDrunk.Architecture`:
+
+```
+repos/HoneyDrunkStudios.github/
+  overview.md       (one paragraph naming the repo's role — org-level community health files)
+  boundaries.md     (one paragraph naming what does and does not belong in .github — community
+                     health files only; not code; not per-project workflows)
+```
+
+This mirrors the pattern set by the other `repos/HoneyDrunk.X/` context folders in this repo.
+
+### 4. Disclose.io safe-harbor text
+
+Pull the current Disclose.io core safe-harbor text at edit time (https://disclose.io/), embed verbatim in `SECURITY.md`. Do not author novel legal language. If the Disclose.io site has updated the core terms since 2026-05, use the current version.
+
+## Affected Files
+- `HoneyDrunkStudios/.github/SECURITY.md` (in the meta-repo, not this repo).
+- A per-public-repo `SECURITY.md` template in the established templates location of this repo.
+- Optional: `repos/HoneyDrunkStudios.github/overview.md` + `boundaries.md` in this repo if the meta-repo is created.
+
+## NuGet Dependencies
+None. This packet is documentation only; no .NET project.
+
+## Boundary Check
+- [x] The org-level `SECURITY.md` lives in the `HoneyDrunkStudios/.github` meta-repo — a sibling org-level repo, not `HoneyDrunk.Architecture` itself. Per ADR-0056 D11's explicit path.
+- [x] The per-public-repo `SECURITY.md` template lives in this repo's templates location.
+- [x] No code change in any Grid Node repo. Adoption of the per-public-repo template by specific repos is a downstream per-repo task, not part of this packet.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunkStudios/.github/SECURITY.md` exists with: `security@honeydrunkstudios.com` disclosure email; 90-day disclosure-window commitment with the negotiate-up-or-down language; the current Disclose.io core safe-harbor text embedded verbatim; the out-of-scope list (production tenant data, DoS testing without coordination, social engineering, physical attacks, third-party-vendor findings, archived repos); explicit no-paid-bug-bounty-at-v1 statement with the revenue-justifies-bounty condition; cross-reference to ADR-0056 D11 and `constitution/threat-model.md`
+- [ ] A per-public-repo `SECURITY.md` template exists in this repo's established templates location, identical to the org-level content with the header note explaining that org-level default covers most repos
+- [ ] If `HoneyDrunkStudios/.github` was created during this packet, a `repos/HoneyDrunkStudios.github/` context folder in this repo carries a one-paragraph `overview.md` + `boundaries.md`
+- [ ] The safe-harbor text is Disclose.io core terms, embedded verbatim — no novel legal language authored by the operator or the agent
+- [ ] No per-repo `SECURITY.md` is filed against any specific Grid repo by this packet — adoption is deferred unless a divergence emerges
+
+## Human Prerequisites
+- [ ] Create the `HoneyDrunkStudios/.github` meta-repo if it does not already exist (operator clicks through the GitHub "New repository" UI; the repo is public; the repo's role is community health files). The user prefers portal-first per the memory note.
+- [ ] Configure the `security@honeydrunkstudios.com` email alias at the operator's email/DNS provider (Cloudflare per ADR-0029 if DNS migration has occurred, else the current provider). The mailbox forwards to the operator's primary inbox; researchers' reports must reach the operator's eyes within hours, not days.
+- [ ] (Optional but recommended) Set up a PGP key for `security@honeydrunkstudios.com` and publish the public key. If skipped at v1, the `SECURITY.md` mentions the key as TBD and clear-text reports remain acceptable per existing best practice.
+- [ ] Verify the embedded Disclose.io safe-harbor text against the current published version at https://disclose.io/ — re-fetch at edit time if more than a few weeks have passed since the original embedding.
+
+## Referenced ADR Decisions
+**ADR-0056 D11 — Responsible disclosure.** Published `SECURITY.md` at the org level + per-public-repo copies. Contents: `security@honeydrunkstudios.com` disclosure email, 90-day disclosure window, explicit safe-harbor language modeled on Disclose.io's core terms, out-of-scope list (no testing against production tenant data; no DoS testing without coordination), no bug bounty at v1.
+
+**ADR-0039 (Proposed) — Grid open-source license policy.** Open-source Grid projects publish the same `SECURITY.md`; the org-level file applies to closed-source Grid repos by default and is overridden only if a repo's specific posture differs.
+
+**ADR-0056 D11 "On the 90-day disclosure window."** The 90-day commitment matches the industry norm (Google Project Zero, most major vendors). Not unconditional — researchers may negotiate shorter or longer.
+
+**ADR-0056 D11 "On the safe-harbor language."** Modeled on Disclose.io's core terms; the operator does not author novel legal language.
+
+## Constraints
+- **Use Disclose.io's core terms verbatim.** Do not author novel safe-harbor legal language. The operator's legal posture is "we use the published industry-standard safe-harbor template."
+- **Org-level first; per-repo as template only.** The org-level `SECURITY.md` is the load-bearing file. The per-public-repo template is for future divergence, not for immediate Grid-wide adoption.
+- **`security@honeydrunkstudios.com` is named in the file even if the mailbox isn't yet provisioned.** The Human Prerequisite covers mailbox provisioning; a brief window between PR merge and mailbox setup is acceptable (bounce-error is recoverable).
+- **No bug bounty at v1 is explicit, not implicit.** The file states the no-bounty posture with the trigger condition (revenue-justifies-bounty). Researchers reading the file know the answer rather than assuming.
+- **No PR filed against any specific Grid repo.** Per-public-repo adoption is deferred. Filing PRs against the 10+ public Grid repos is out of scope; the template exists so that future per-repo work has a known starting point.
+
+## Labels
+`feature`, `tier-2`, `meta`, `security`, `docs`, `adr-0056`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Author the canonical responsible-disclosure surface — org-level `SECURITY.md` in `HoneyDrunkStudios/.github` + per-public-repo template — committing to `security@honeydrunkstudios.com`, 90-day disclosure, Disclose.io safe-harbor, explicit out-of-scope list, no-bug-bounty-at-v1.
+
+**Target:** `HoneyDrunk.Architecture` (template), `HoneyDrunkStudios/.github` (org-level file — see Human Prerequisites for repo creation).
+
+**Context:**
+- Goal: Land the published responsible-disclosure surface so researchers know the Grid is open to engagement, and so prospect due-diligence checklists have a citable answer.
+- Feature: ADR-0056 Threat Model and Security Review Cadence rollout, Wave 3.
+- ADRs: ADR-0056 D11 (primary); ADR-0039 (open-source posture — Proposed).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — hard. ADR-0056 must be Accepted before its published surface lands.
+
+**Constraints:**
+- Disclose.io core safe-harbor text embedded verbatim; no novel legal language.
+- Org-level file is load-bearing; per-public-repo template is for future divergence.
+- `security@honeydrunkstudios.com` named even if mailbox not yet provisioned (covered by Human Prerequisites).
+- Explicit no-bug-bounty-at-v1 statement with revenue-justifies-bounty trigger.
+- No PR filed against any specific Grid repo — adoption is deferred.
+
+**Key Files:**
+- `HoneyDrunkStudios/.github/SECURITY.md` (org-level — repo creation is a Human Prerequisite)
+- A per-public-repo `SECURITY.md` template in this repo's established templates location
+
+**Contracts:** None changed. Disclosure-surface content only.

--- a/generated/issue-packets/active/adr-0056-threat-model/05-architecture-security-incident-runbook.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/05-architecture-security-incident-runbook.md
@@ -1,0 +1,198 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "security", "docs", "adr-0056", "wave-4"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0056", "ADR-0054", "ADR-0030", "ADR-0050", "ADR-0019"]
+accepts: ["ADR-0056"]
+wave: 4
+initiative: adr-0056-threat-model
+node: honeydrunk-architecture
+---
+
+# Author the security-incident-response extensions for the incident runbook
+
+## Summary
+Author the security-specific extensions to the Grid's incident runbook per ADR-0056 D10, in `business/context/`: SEV-1-by-default posture for confirmed security incidents with the explicit downgrade-with-rationale rule; the tenant-notification path coupling ADR-0050 customer-comms cadence and ADR-0019 Communications-orchestrated outbound delivery (GDPR 72-hour alignment); the forensic-preservation hold extending audit-substrate retention beyond the 730-day standard during an active investigation; the security post-mortem's threat-model-amendment section.
+
+## Context
+ADR-0056 D10 names four security-specific extensions to the broader incident response substrate governed by ADR-0054 (Proposed):
+
+1. **SEV-1 by default** for confirmed security incidents. Downgrade to SEV-2 requires explicit operator decision with rationale recorded. The cost of treating a real security incident as SEV-2 is meaningfully larger than the cost of treating a false-alarm as SEV-1 — the asymmetry argues for SEV-1 default.
+2. **Tenant notification** when tenant data is involved. The path consumes ADR-0050's customer-comms cadence (Proposed) and ADR-0019's Communications-orchestrated delivery (Accepted). GDPR is 72 hours; US state-level breach laws vary; the artifact records the operative window per current tenant geography.
+3. **Forensic preservation hold** during an active investigation. The audit substrate's standard retention is 730 days per ADR-0040 D3; the relevant log subset is exported to a separate retention key with no expiry during an investigation, released when the investigation closes. Both the export-event and the release-event are themselves auditable.
+4. **Post-mortem threat-model-amendment section.** Every confirmed security incident produces a post-mortem per the existing template; security post-mortems carry an additional threat-model-amendment section asking three questions: did this incident reveal a threat the model didn't enumerate? a mitigation that was on paper but not actually in place? an accepted risk that turned out to be larger than estimated? The amendment commits to `constitution/threat-model.md` in the same PR as the post-mortem.
+
+The extensions live in `business/context/` — the operator-context location for operational runbooks (precedent: ADR-0040 packet 08, ADR-0045 packet 06). The exact file path is verified at edit time:
+
+- If a security-incident-runbook file already exists in `business/context/` (verify at edit time), extend it.
+- If a broader incident runbook exists (per ADR-0054), add a security-extensions subsection to it.
+- If neither exists, create `business/context/security-incident-runbook.md` and cross-reference ADR-0054's broader matrix.
+
+**Coupling with ADR-0054 (Proposed) — soft.** ADR-0054 sets the broader incident severity matrix and response cadence. This packet's extensions cite ADR-0054 as the broader substrate; if ADR-0054's severity matrix evolves, these extensions stay consistent (they reference ADR-0054's matrix rather than restating it).
+
+**Coupling with ADR-0050 (Proposed) — soft.** ADR-0050 is the tenant-comms cadence ADR (offboarding, suspension, data export). The breach-notification path consumes ADR-0050's customer-comms cadence: the channel (email per existing Communications Node), the timing alignment with regulatory windows, the content template structure. This packet's tenant-notification entry cites ADR-0050 without restating its mechanics.
+
+**Coupling with ADR-0019 (Accepted) — concrete.** Communications Node is Accepted and v0.X is in flight. The notification *delivery* is orchestrated by `ICommunicationOrchestrator` per ADR-0019 — the breach-notification path uses Communications' existing orchestration surface, not a separate breach-only delivery path. This is consistent with invariant 41 (preference enforcement, cadence rules, suppression logic live in Communications, not in Notify).
+
+**The post-mortem template extension.** The Grid has a post-mortem template at `generated/incidents/_template.md` (verified — `find` results from scope). Security post-mortems add a "Threat model amendment" section to that template. This packet either (a) edits `_template.md` to add the section as a conditional, or (b) creates a `_template-security.md` variant adjacent. The executor decides at edit time based on the template's existing structure.
+
+**This is a docs packet. No code, no .NET project.**
+
+## Scope
+- The security-incident-response extensions in `business/context/` — verified file path at edit time.
+- The post-mortem template extension for security incidents — either in-place edit of `generated/incidents/_template.md` or a new `_template-security.md` variant.
+
+## Proposed Implementation
+
+### 1. Security incident runbook content
+
+Content of the runbook (or extension to an existing runbook). Markdown, written for the operator (the audience for `business/context/`):
+
+```markdown
+# Security incident runbook extensions
+
+> Extends the broader incident-response substrate (ADR-0054, Proposed). For non-security incidents, see {existing runbook reference}. For the underlying threat surface this runbook responds to, see `constitution/threat-model.md`.
+
+## Severity default
+
+Confirmed security incidents are **SEV-1 by default** per ADR-0056 D10. Downgrade to SEV-2 requires explicit operator decision with the rationale recorded in the incident's `generated/incidents/{date}-{slug}.md` file.
+
+**Legitimate downgrade examples:**
+- A confirmed-internal-only credential leak with no external exposure window.
+- A CVE alert on a dependency the Grid does not actually use in the affected code path.
+- A reported "vulnerability" that on triage is correct-by-design behavior.
+
+**Illegitimate downgrade examples:**
+- "This looks like a false alarm and I don't want to wake up." Operator tiredness is not a threat-model variable.
+- "We can fix it Monday." Calendar friction is not a severity argument.
+
+A confirmed-real incident at SEV-1 carries the SEV-1 response time and escalation expectations from ADR-0054 (Proposed). Until ADR-0054 is Accepted, those expectations are described in `business/context/` adjacent to this runbook.
+
+## Tenant notification
+
+When tenant data is involved in a confirmed breach, the notification path:
+
+1. **Trigger.** The operator confirms tenant data involvement and starts the notification clock. The clock starts at confirmation, not at detection.
+2. **Operative window.** **GDPR — 72 hours** from confirmation for any EU-resident tenant. **US state-level — varies** (most states 30-60 days, some "without unreasonable delay"). **Default operative window: 72 hours**, the tightest applicable regulatory floor. If no EU tenants are affected and US state-level allows longer, document the rationale for the longer window — do not silently extend.
+3. **Channel.** Email via the Communications Node's `ICommunicationOrchestrator` per ADR-0019 — the breach-notification path uses the same orchestration surface as all other tenant-facing comms, with preference enforcement and decision-log entries (invariants 41, 42).
+4. **Content alignment with ADR-0050.** The content template aligns with the customer-comms cadence ADR-0050 (Proposed) defines for other tenant-facing notifications — same tone register, same opt-out / regulatory-exception handling, same signature surface.
+5. **Content substance.** What happened (in plain language), what data was involved (specific to the affected tenant), what the operator has done about it, what the tenant should do (rotate keys, watch for fraud, contact support), how to reach the operator for follow-up.
+
+**Cross-jurisdictional.** If a single incident affects tenants across jurisdictions with different windows, **the tightest window applies to all affected tenants** — running parallel windows by jurisdiction is operationally brittle and risks differential treatment that could itself become a finding.
+
+## Forensic preservation hold
+
+The audit substrate's standard retention is 730 days per ADR-0040 D3. During an active investigation:
+
+1. **Identify the relevant subset.** The relevant `IAuditLog` subset is identified by the investigation's scope — typically a time range, a tenant scope, and an action-category scope.
+2. **Export with no expiry.** The relevant subset is exported to a separate retention key that does not expire until the investigation closes. The export uses the Audit Node's read interface (per ADR-0030; the no-expiry-export-with-hold mechanism is **pending Audit Phase-2** — see the cross-track follow-up tracker, packet 09; until then, an interim mechanism is a manual export to long-retention Azure Blob with a Key Vault-stored decryption key).
+3. **The export is itself an auditable event.** The audit substrate records the export-event. Releasing the hold (investigation closes) is also an auditable event.
+4. **Hold release.** When the investigation closes, the operator explicitly releases the hold. The release-event is recorded. The exported subset returns to its origin retention (if still within 730 days) or is preserved if the investigation produced a record that needs longer retention than the standard window.
+
+The preservation hold is the **only mechanism** by which audit logs escape the 730-day standard retention. The rules are explicit so the operator and any external investigator can verify that the preservation is what it claims to be.
+
+## Post-mortem
+
+Every confirmed security incident produces a post-mortem per the existing post-mortem template (`generated/incidents/_template.md`). Security post-mortems carry an additional **Threat model amendment** section, asking three questions:
+
+1. **Did this incident reveal a threat the model didn't enumerate?** If yes, the amendment adds the threat to `constitution/threat-model.md` — likely in section 5 (STRIDE pass) or section 6 (AI overlay) — in the same PR as the post-mortem.
+2. **Was there a mitigation that was on paper but not actually in place?** If yes, the amendment moves the mitigation from "shipped" to "open" in the artifact's section 9, and adds an issue packet to actually ship it.
+3. **Did an accepted risk turn out to be larger than estimated?** If yes, the amendment revisits the accepted risk in section 7 — either accept it at a higher cost, or move it to "open mitigations" so it is no longer just-accepted.
+
+The amendment commits to `constitution/threat-model.md` in the same PR as the post-mortem, so the artifact's history reflects what the operator learned from each incident.
+
+## Cross-references
+
+- ADR-0056 D10 — this runbook's source.
+- ADR-0054 (Proposed) — broader incident severity matrix and response cadence.
+- ADR-0050 (Proposed) — customer-comms cadence the tenant-notification content aligns with.
+- ADR-0019 (Accepted) — Communications Node's orchestration surface.
+- ADR-0030 — audit substrate boundaries; the forensic-preservation export interface is **pending Audit Phase-2**.
+- ADR-0040 D3 — 730-day audit retention standard.
+- `constitution/threat-model.md` — the artifact the post-mortem's amendment section commits to.
+```
+
+### 2. Post-mortem template extension
+
+Verify at edit time which approach the executor chooses:
+
+- **Option A — in-place edit.** Edit `generated/incidents/_template.md` to add a conditional "Threat model amendment (security incidents only)" section at the bottom. The conditional approach keeps a single template; non-security incidents leave the section empty or remove the header before committing.
+- **Option B — variant.** Create `generated/incidents/_template-security.md` with the existing structure + the threat-model-amendment section appended. The variant approach creates clean separation but adds maintenance overhead.
+
+Default to **Option A** unless the existing template's structure makes the conditional unwieldy. The threat-model-amendment section content is the three-question prompt from the runbook above.
+
+## Affected Files
+- A security-incident-response runbook file in `business/context/` — verified path at edit time (extend an existing file or create new).
+- `generated/incidents/_template.md` (Option A) or `generated/incidents/_template-security.md` (Option B).
+
+## NuGet Dependencies
+None. Docs and template files only; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. `business/context/` is the established operator-context location; `generated/incidents/` is the incident-post-mortem location, both in this repo.
+- [x] No code change in any other repo.
+- [x] The runbook cross-references ADR-0019's `ICommunicationOrchestrator` but does not modify Communications Node code — actual breach-notification orchestration lives in Communications, this packet only documents the operator-facing procedure.
+
+## Acceptance Criteria
+- [ ] A security-incident-response runbook exists in `business/context/` (verified file path at edit time — either extending an existing incident-runbook file or creating `business/context/security-incident-runbook.md`) carrying all four extensions: SEV-1 default + legitimate/illegitimate downgrade examples; tenant-notification path with 72-hour GDPR / cross-jurisdictional tightest-window-applies rule; forensic-preservation hold extending 730-day standard with audit-Phase-2-pending note; post-mortem threat-model-amendment section with the three-question prompt
+- [ ] The runbook cross-references ADR-0054 (broader incident substrate), ADR-0050 (customer-comms cadence), ADR-0019 (Communications orchestration), ADR-0030 (audit substrate + Phase-2-pending export), ADR-0040 D3 (730-day retention), and `constitution/threat-model.md`
+- [ ] The post-mortem template at `generated/incidents/_template.md` carries a Threat-model-amendment section (Option A in-place edit) OR `generated/incidents/_template-security.md` exists as a variant (Option B) — executor's choice at edit time; default Option A
+- [ ] The forensic-preservation export mechanism is named as **pending Audit Phase-2** (cross-references packet 09's tracker), with an interim manual-export-to-Blob escape hatch documented
+- [ ] No code change in any Node; no PR filed against Communications, Audit, or any other Node
+
+## Human Prerequisites
+None for this packet itself. (Operator follows the runbook **when a security incident actually happens** — that's the runbook's job. The runbook's existence is what this packet ships.)
+
+## Referenced ADR Decisions
+**ADR-0056 D10 — Incident response coupling.** SEV-1 by default; downgrade requires operator rationale. Tenant notification triggers ADR-0050 customer-comms cadence + ADR-0019 Communications orchestration; timeline aligns with applicable regulations (GDPR 72h). Forensic preservation extends standard retention during active investigation. Post-mortem has additional threat-model-amendment section.
+
+**ADR-0054 (Proposed) — Incident response and on-call model.** Broader severity matrix and response cadence; this runbook's extensions sit within that framework.
+
+**ADR-0050 (Proposed) — Tenant lifecycle.** Customer-comms cadence that the tenant-notification content aligns with.
+
+**ADR-0019 (Accepted) — Communications Node.** `ICommunicationOrchestrator` is the orchestration surface for tenant-facing comms, including breach notifications. Invariants 41, 42 apply.
+
+**ADR-0030 — Audit substrate.** `IAuditLog` is the source of forensic logs; the no-expiry-export-with-hold mechanism is a Phase-2 enhancement.
+
+**ADR-0040 D3 — Audit log retention.** 730 days is the standard; the preservation hold is the only mechanism for longer retention.
+
+## Constraints
+- **Documentation only — no Node-side code change.** The runbook tells the operator what to do; the Communications-orchestrated delivery already exists per ADR-0019. The forensic-export mechanism is **pending** — the runbook names the interim manual approach.
+- **72-hour GDPR window is the operating default for cross-jurisdictional incidents.** Differential treatment by jurisdiction is operationally brittle and could itself become a finding.
+- **`business/context/` location follows established convention.** Match the precedent set by ADR-0040 packet 08 / ADR-0045 packet 06; extend an existing file if one exists, otherwise create new.
+- **Post-mortem template extension defaults to Option A in-place edit.** Choose Option B (variant template) only if the existing template's structure makes the conditional unwieldy.
+- **Forensic preservation export is named as Phase-2 pending.** Do not promise the export interface exists — it does not yet (Audit v0.1.0 shipped but the export-and-hold is a Phase-2 enhancement per the dispatch plan's cross-track deferral note).
+
+## Labels
+`feature`, `tier-2`, `meta`, `security`, `docs`, `adr-0056`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Author the security-incident-response runbook extensions (SEV-1 default, tenant notification via Communications, forensic preservation hold, post-mortem threat-model-amendment) in `business/context/`; extend the post-mortem template with a threat-model-amendment section.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Give the operator a runbook to follow when a real security incident happens, integrated with the existing Communications orchestration and the Audit substrate.
+- Feature: ADR-0056 Threat Model and Security Review Cadence rollout, Wave 4.
+- ADRs: ADR-0056 D10 (primary); ADR-0054 (broader incident substrate, Proposed); ADR-0050 (customer-comms, Proposed); ADR-0019 (Communications, Accepted); ADR-0030 (audit, Accepted); ADR-0040 D3 (retention).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0056 should be Accepted before its operator-facing runbook lands.
+
+**Constraints:**
+- Documentation only — no Node-side code; forensic-export is Phase-2 pending with an interim manual-export note.
+- 72-hour GDPR window is the cross-jurisdictional default.
+- `business/context/` location follows the established convention (extend existing or create new).
+- Post-mortem template defaults to Option A in-place edit.
+
+**Key Files:**
+- A runbook in `business/context/`
+- `generated/incidents/_template.md` (or `_template-security.md` variant)
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0056-threat-model/06-architecture-found-secret-rotation-runbook.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/06-architecture-found-secret-rotation-runbook.md
@@ -1,0 +1,244 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "security", "docs", "adr-0056", "wave-4"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0056", "ADR-0006"]
+accepts: ["ADR-0056"]
+wave: 4
+initiative: adr-0056-threat-model
+node: honeydrunk-architecture
+---
+
+# Author the found-secret rotation runbook with time-to-rotation targets and pre-staged commands
+
+## Summary
+Author the found-secret rotation runbook in `business/context/` per ADR-0056 D8: **immediate rotation, not deletion** as the response posture; 1-hour time-to-rotation for high-sensitivity secrets (model API keys, Stripe production keys, Azure subscription credentials); 4-hour target for lower-sensitivity secrets; pre-staged rotation commands per secret class so the operator can execute rather than re-derive at 3 AM; explicit "history rewriting is cosmetic, rotation is the actual remediation" framing. Cross-references ADR-0006 for rotation mechanics.
+
+## Context
+ADR-0056 D8 commits to GitHub-native secret scanning Grid-wide with push protection. The interesting part of D8 is the **found-secret runbook**, not the scanning enablement (that's packet 08 in `HoneyDrunk.Actions`). The runbook captures three load-bearing rules:
+
+1. **Immediate rotation, not deletion.** Deletion alone is insufficient — the secret may already have been scraped before detection. The response is rotation at the source (Azure / Stripe / OpenAI / etc.), then Vault + consuming-environment update, then confirm rotation is in use. Only then address git history (and history rewriting is cosmetic, not actual remediation).
+2. **Time-to-rotation targets.** 1-hour for high-sensitivity secrets (model API keys per AI-8, Stripe production keys, Azure subscription credentials). 4-hour for lower-sensitivity (third-party SaaS API keys with limited blast radius). Time starts at **detection**, not at operator-attention — detection may happen overnight; the runbook should be operable by a half-asleep operator without multi-step approvals.
+3. **Pre-staged rotation commands.** For the high-sensitivity secrets, the runbook lists the **exact** rotation command sequence per secret class. The operator executes rather than re-derives at 3 AM. The pre-staging is the difference between "I think the runbook said to rotate the Azure subscription key but I have to look up how" and "step 1: open this portal page, step 2: click 'Rotate', step 3: copy new key, step 4: paste into this Vault secret name."
+
+ADR-0006 (Accepted) governs the underlying rotation mechanics — Tier 1 Azure-native rotation, Tier 2 third-party rotation via Function, certificate auto-renewal. This runbook does not re-decide those — it **operationalizes** them for the found-secret emergency case.
+
+**The runbook lives in `business/context/`** (operator-context location, per the precedent set by ADR-0040 packet 08 / ADR-0045 packet 06 / the security-incident-runbook from packet 05). The exact file path is verified at edit time:
+- If an existing secret-management runbook lives in `business/context/`, extend it.
+- If a Vault-rotation runbook exists (per ADR-0006), extend or cross-reference it.
+- If neither exists, create `business/context/found-secret-rotation-runbook.md`.
+
+**Coupling with ADR-0006.** ADR-0006 is the source-of-truth for rotation mechanics (Tier 1 / Tier 2 / cert auto-renewal). This runbook cites ADR-0006 D3/D4/D5 by reference and embeds **only the operational pre-staged commands** — the operator runs them, the ADR explains them.
+
+**The pre-staged commands are concrete.** This is the load-bearing detail. Generic prose runbooks fail at 3 AM; the operator needs a checklist with exact portal URLs, exact `az` CLI commands, exact Vault secret names. The executor of this packet authors those concretely per secret class — listing every high-sensitivity secret the Grid currently uses and the exact rotation sequence.
+
+**Coupling with packet 08 (Dependabot + secret scanning enablement).** Packet 08 enables GitHub secret scanning + push protection Grid-wide. This packet's runbook covers what to do **when scanning finds something**. They are complementary; this packet does not depend on packet 08 (the runbook is useful even before scanning is enabled, e.g., for a researcher report or an accidental commit caught by a code review).
+
+**This is a docs packet. No code, no .NET project.**
+
+## Scope
+- A found-secret rotation runbook in `business/context/` — verified file path at edit time.
+
+## Proposed Implementation
+
+### Runbook content
+
+Author the runbook with the following sections. Markdown, written for the operator at 3 AM with a half-functioning brain:
+
+```markdown
+# Found-secret rotation runbook
+
+> When a secret is detected leaked (push-blocked, post-push-found, researcher report, code review catch), **the response is rotation, not deletion**. Deletion is cosmetic. Rotation is the remediation.
+
+## Response posture
+
+A leaked secret may have been scraped before detection (open-source repo scrapers, GitHub-search bots, malicious actors). Assume the leaked value is compromised; treat its replacement at the source as the load-bearing fix. Rewriting git history removes the value from the repo's history but cannot remove it from clones, forks, or scrapers — history rewriting is **cosmetic**, run after rotation, not before.
+
+## Time-to-rotation targets
+
+Time starts at **detection**, not at operator-attention. The runbook must be operable by a half-asleep operator without multi-step approvals.
+
+| Secret class | Target | Examples |
+|---|---|---|
+| High-sensitivity | **1 hour** | Model API keys (OpenAI, Anthropic, Azure OpenAI) per AI-8; Stripe production keys; Azure subscription credentials; Auth signing keys |
+| Lower-sensitivity | **4 hours** | Third-party SaaS API keys with limited blast radius (Resend, Twilio, GitHub PATs scoped narrowly) |
+
+## Universal rotation sequence
+
+For any class:
+
+1. **Rotate at the source.** Generate a new credential at the source service (Azure / Stripe / OpenAI / etc.) per the pre-staged commands below.
+2. **Update Vault.** Write the new value to the Vault secret using its existing name. Vault's event-driven cache invalidation (ADR-0006 D5) propagates to consumers.
+3. **Confirm the rotated credential is in use.** Verify a real call hits the new credential and the old credential rejects. Vault's audit logs (invariant 22) and the consuming Node's telemetry confirm.
+4. **Address git history (cosmetic).** Once steps 1–3 are complete, use `git filter-repo` to remove the leaked value from history if it is in a public repo. **Do not skip steps 1–3 in favor of history rewriting.** History rewriting alone leaves the leaked credential active at the source.
+5. **Log the incident.** Even when scanning auto-detects and the rotation completes in under an hour, log the incident at `generated/incidents/{date}-{slug}.md`. The audit substrate (`IAuditLog`) records the rotation event automatically per invariant 47; the human-readable incident note exists for the post-mortem (per packet 05's threat-model-amendment section).
+
+## Pre-staged commands
+
+The runbook needs **exact portal links and exact commands** per high-sensitivity secret class. The executor authors these concretely. The skeleton:
+
+### Model API keys (OpenAI, Anthropic, Azure OpenAI) — 1-hour target
+
+For each model provider, list:
+- Portal URL (the operator clicks this).
+- Exact steps in the portal UI (verified at edit time — re-verify before each rotation since provider UIs drift).
+- Vault secret name to update (per the Grid's secret naming convention — `model-{provider}-key-{env}` per ADR-0041 Proposed).
+- Per-environment scope (dev / staging / prod separately; never rotate prod and dev with the same key per ADR-0056 D9 AI-8).
+
+Example (OpenAI):
+1. Portal: https://platform.openai.com/account/api-keys
+2. Click the rotation icon next to the affected key.
+3. Copy the new key value.
+4. Update Vault secret `model-openai-key-prod` (or the env-specific name).
+5. Verify next AI dispatch in {env} succeeds at the new key.
+
+(The executor fills in the concrete steps for Anthropic, Azure OpenAI, and any other model provider currently used. If a provider lacks a rotation primitive — some smaller providers require manual key generation and deletion — document the workaround in the pre-staged commands.)
+
+### Stripe production keys — 1-hour target
+
+(Executor fills in: Stripe Dashboard URL → API keys section → Roll secret key → Vault secret name `stripe-secret-key-prod` per ADR-0037 Proposed. Note: rolling the secret key invalidates webhooks until the new key is propagated to the webhook endpoint — sequence carefully.)
+
+### Azure subscription credentials — 1-hour target
+
+(Executor fills in: Azure Portal URL → Service Principal → Reset credentials, or Managed Identity rotation if applicable. Note: Azure-native Tier 1 rotation per ADR-0006 — most Azure credentials rotate via Managed Identity assignment changes, not by replacing values in Vault.)
+
+### Auth signing keys — 1-hour target
+
+(Executor fills in: Auth Node's signing-key rotation procedure per ADR-0006 D3 + Vault's per-Node Key Vault structure per invariant 17.)
+
+## Pre-staged commands for lower-sensitivity (4-hour target)
+
+(Executor lists the third-party SaaS keys currently in use — Resend, Twilio, GitHub PATs, etc. — with the same portal-link-and-step structure.)
+
+## What "lower sensitivity" means
+
+A secret is lower-sensitivity if **all** of the following hold:
+- The blast radius of compromise is bounded to a specific tenant or a specific external service.
+- Compromise does not enable cross-tenant escalation.
+- Compromise does not enable cost-amplification beyond a known cap.
+
+A secret that fails any of these is high-sensitivity. **Default to high-sensitivity if unsure** — the asymmetric cost of mis-classifying a high-sensitivity secret as lower-sensitivity (rotation delayed 3 hours, blast radius runs unbounded) exceeds the cost of mis-classifying a lower-sensitivity secret as high-sensitivity (rotation done faster than strictly needed).
+
+## What to do with the leaked value in git history
+
+History rewriting is run **after** rotation completes. Tools:
+- `git filter-repo` (preferred) — removes the value from all refs.
+- BFG Repo-Cleaner — alternative; older but works.
+
+After rewriting, force-push to the remote. Notify any collaborators who may have pulled the affected commits. Note that **clones, forks, and scrapers** retain the value — the rotation is what makes the leaked value non-load-bearing.
+
+## When the leaked secret is in a still-active branch
+
+If the leaked secret is in a branch that has not yet merged to `main`:
+- Rotate at the source as above.
+- Force-push the branch with the value removed. No further history work needed (the value never reached `main`).
+
+## When the leaked secret was committed years ago
+
+Older leaks are no less urgent — assume the value was scraped at the time of the leak. Rotate immediately. History rewriting on years-old commits is **futile** (the value is in countless clones and forks); skip it after rotation.
+
+## Cross-references
+
+- ADR-0006 — secret rotation mechanics (Tier 1 / Tier 2 / certificate auto-renewal).
+- ADR-0056 D8 — this runbook's source.
+- ADR-0041 (Proposed) — model API key registry.
+- ADR-0037 (Proposed) — Stripe payment.
+- Invariant 8 — secret values never appear in logs, traces, exceptions, or telemetry.
+- Invariant 17 — one Key Vault per deployable Node per environment.
+- Invariant 22 — diagnostic settings route Key Vault audit to Log Analytics.
+- Invariant 47 — durable audit emission via `IAuditLog`.
+```
+
+### Operational notes for the executor
+
+The pre-staged commands are the load-bearing content. The executor:
+1. Lists every high-sensitivity secret class **currently in use** (model providers, Stripe, Azure subscription, Auth signing keys, any others — verify at edit time by reading Vault's current secret inventory and the operator's existing process docs).
+2. Authors the concrete rotation sequence per class — portal URL, exact UI steps, Vault secret name, env scope.
+3. Lists the lower-sensitivity SaaS keys (Resend, Twilio, GitHub PATs, any others) with the same concrete sequence.
+4. Validates the runbook is operable at 3 AM by reading it cold — every step has the URL, every command has the exact parameter, no "look up X in the docs" footnotes.
+
+The runbook is a **living document** — update it when the Grid adopts a new provider, when a provider's portal UI changes, when a secret class moves between sensitivity tiers. Each update is a small commit.
+
+## Affected Files
+- A found-secret rotation runbook in `business/context/` (verified file path at edit time).
+
+## NuGet Dependencies
+None. Docs only; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. `business/context/` is the established operator-context location.
+- [x] No code change in any other repo.
+- [x] The runbook operationalizes ADR-0006's rotation mechanics — it does not re-decide them.
+
+## Acceptance Criteria
+- [ ] A found-secret rotation runbook exists in `business/context/` (verified path — extend an existing file if a related runbook is there, otherwise create `business/context/found-secret-rotation-runbook.md`)
+- [ ] The runbook states the response posture: rotation, not deletion; history rewriting is cosmetic, run after rotation
+- [ ] Time-to-rotation targets are explicit: 1-hour for high-sensitivity (model API keys, Stripe production keys, Azure subscription credentials, Auth signing keys); 4-hour for lower-sensitivity (third-party SaaS keys with limited blast radius). Time starts at detection.
+- [ ] The universal rotation sequence is listed: rotate at source → update Vault → confirm in use → address git history (cosmetic) → log incident
+- [ ] Pre-staged concrete commands are authored per high-sensitivity secret class currently in use — portal URL, exact UI steps, Vault secret name, env scope. **At minimum: model API keys (OpenAI, Anthropic, Azure OpenAI as applicable), Stripe production keys, Azure subscription credentials, Auth signing keys.**
+- [ ] Pre-staged commands for lower-sensitivity SaaS keys (Resend, Twilio, GitHub PATs, others) are authored to the same level of concreteness
+- [ ] The "what 'lower sensitivity' means" criteria are listed (bounded blast radius; no cross-tenant escalation; no cost-amplification beyond a known cap; default to high-sensitivity when unsure)
+- [ ] Git-history rewriting guidance is included: post-rotation only, `git filter-repo` preferred, futile-after-years caveat
+- [ ] Cross-references to ADR-0006, ADR-0056 D8, invariants 8/17/22/47
+
+## Human Prerequisites
+- [ ] Verify the current high-sensitivity secret inventory at edit time (read Vault's current secret names; cross-reference the operator's existing process docs). The runbook is only as useful as it is current; a missing provider in the pre-staged commands is a 3-AM gap.
+- [ ] Re-verify portal URLs and UI steps for each provider at edit time. Provider UIs drift; a runbook from a year ago may have broken links. Re-verify at every quarterly review (per ADR-0056 D5).
+
+## Referenced ADR Decisions
+**ADR-0056 D8 — Secret scanning.** GitHub secret scanning + push protection. Found-secret runbook: immediate rotation, not deletion. 1-hour time-to-rotation for high-sensitivity; 4-hour for lower-sensitivity. Time starts at detection, not operator-attention. Pre-staged rotation commands for the high-sensitivity secrets so the operator can execute rather than re-derive at 3 AM.
+
+**ADR-0056 D9 AI-8 — Model API key compromise.** Per-environment keys, usage caps, 90-day rotation cadence (tighter than general 180-day default). Compromise produces cost-amplification (a leaked key can burn through a budget overnight); the asymmetric cost justifies the tighter cadence and the 1-hour found-secret target.
+
+**ADR-0006 D3/D4/D5 — Rotation mechanics.** Tier 1 Azure-native rotation, Tier 2 third-party via rotation Function, certificate auto-renewal. Event-driven cache invalidation. This runbook operationalizes those mechanics for the emergency case.
+
+**Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The runbook itself must not embed real secret values; the pre-staged commands use placeholder values + portal links + Vault secret names.
+
+**Invariant 17 — One Key Vault per deployable Node per environment.** Vault secret name = `kv-hd-{service}-{env}` scoping per ADR-0005.
+
+**Invariant 22 — Diagnostic settings route Key Vault audit to Log Analytics.** Confirming the rotated credential is in use reads from Vault's audit logs.
+
+**Invariant 47 — Audit emission via `IAuditLog`.** Rotation events are recorded automatically; the human-readable incident note exists for the post-mortem, not for the audit substrate.
+
+## Constraints
+- **Pre-staged commands are concrete, not generic.** Portal URLs, exact UI steps, Vault secret names. A runbook that says "rotate the Azure key" without naming the portal page fails at 3 AM. The executor authors the concrete sequence per secret class currently in use.
+- **Time starts at detection, not at operator-attention.** Detection may happen overnight. The runbook should be operable by a half-asleep operator without multi-step approvals.
+- **No real secret values in the runbook.** Per invariant 8. Pre-staged commands use placeholders and Vault secret names; portal links retrieve the new values.
+- **Rotation first, history rewriting last.** Reordering these is a recipe for an active leaked credential the operator believes is fixed.
+- **Default to high-sensitivity when classifying.** The asymmetric cost favors over-rotation.
+- **Re-verify portal URLs at every quarterly review.** Provider UIs drift; runbook freshness is a quarterly-review (D5) checklist item.
+
+## Labels
+`feature`, `tier-2`, `meta`, `security`, `docs`, `adr-0056`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Author the found-secret rotation runbook in `business/context/` with concrete pre-staged commands per secret class, 1-hour / 4-hour time-to-rotation targets, and the "rotation first, history rewriting cosmetic" framing.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Give the operator a runbook that is operable at 3 AM when GitHub secret scanning (packet 08), a researcher report, or a code-review catch finds a leaked credential.
+- Feature: ADR-0056 Threat Model and Security Review Cadence rollout, Wave 4.
+- ADRs: ADR-0056 D8 (primary), ADR-0006 (rotation mechanics), ADR-0056 D9 AI-8 (model-key tighter rotation).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0056 should be Accepted before its operational runbook lands.
+
+**Constraints:**
+- Pre-staged commands are concrete (portal URLs, exact UI steps, Vault secret names) — not generic prose.
+- Time starts at detection.
+- No real secret values in the runbook (invariant 8).
+- Rotation first; history rewriting cosmetic.
+- Default to high-sensitivity when unsure.
+- Re-verify portal URLs at every quarterly review.
+
+**Key Files:**
+- A runbook in `business/context/` — extend existing or create `business/context/found-secret-rotation-runbook.md`.
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0056-threat-model/07-architecture-pentest-and-diy-probe-playbook.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/07-architecture-pentest-and-diy-probe-playbook.md
@@ -1,0 +1,217 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "security", "docs", "adr-0056", "wave-4"]
+dependencies: ["packet:02"]
+adrs: ["ADR-0056", "ADR-0052"]
+accepts: ["ADR-0056"]
+wave: 4
+initiative: adr-0056-threat-model
+node: honeydrunk-architecture
+---
+
+# Author pentest-engagement scoping prep + DIY adversarial-probe playbook
+
+## Summary
+Author two paired documents in `business/context/` per ADR-0056 D6: (1) the **pentest-engagement scoping prep** — firm-selection criteria, scope-of-engagement for the pre-Notify-Cloud-GA engagement (TB-1 through TB-4 plus credential-stuffing + rate-limit probe), engagement-budget framing ($5–15K per ADR-0052), deliverable expectations; and (2) the **DIY adversarial-probe playbook** — quarterly OWASP ZAP + Burp Community + prompt-injection-corpus pass against dev deployments, with concrete tool-invocation steps and the "DIY is not a substitute for external pentest" framing. Both consume the v1 threat-model artifact (packet 02) as scoping input.
+
+## Context
+ADR-0056 D6 splits the Grid's pentest posture into three layers:
+
+1. **Before Notify.Cloud GA — external pentester engagement.** $5–15K focused scoped engagement, not a "test everything" engagement. Scope: TB-1 (public internet ↔ Web.Rest), TB-2 (Web.Rest ↔ application Nodes), TB-3 (application Nodes ↔ Vault / Data), TB-4 (tenant ↔ tenant — the most consequential boundary) plus credential-stuffing + rate-limit probe of the auth surface. Deliverable: executive summary + finding-level detail. Findings append to `constitution/threat-model.md` section 8 (pentest history) and are tracked to resolution via `scope`-authored issue packets.
+2. **Annually thereafter — if revenue supports it.** Annual external pentest cadence is the goal once Notify.Cloud produces revenue; budget approval per ADR-0052 spend-authority pattern. A skipped year is recorded as an accepted risk in the artifact, not silently skipped.
+3. **DIY interim — operator-driven adversarial probing.** Between paid engagements (and before the first one), quarterly probes with OWASP ZAP (passive + active scan against `dev`), Burp Community (manual exploration of newly-shipped surfaces), and a curated prompt-injection corpus (community-maintained collections targeting LLM-using endpoints). Results record in section 8 of the artifact even when the pass finds nothing.
+
+The three layers are **not equivalents**. External pentest is the high-trust surface; DIY probing is the low-trust supplement; annual cadence is the steady-state target.
+
+**Why two documents, not one:** the pentest scoping is operator-facing **preparation** for a specific external engagement (something the operator does once, then references later); the DIY playbook is operator-facing **recurring procedure** (quarterly cadence). They share the threat-model artifact as a substrate but differ in audience-moment and operational frequency.
+
+**Pentest-engagement scoping does NOT engage a pentester.** That is the operator's action, gated on the Notify.Cloud GA decision (per the dispatch plan's Human Prerequisites). This packet ships the **scoping prep** that the operator uses when they engage a pentester.
+
+**DIY playbook tool selection is concrete.** OWASP ZAP (https://www.zaproxy.org/) is free, well-documented, supports passive + active scans + spider modes + report export. Burp Community (https://portswigger.net/burp/communitydownload) is free for manual exploration; the Pro edition (Burp Suite Professional) requires a license. For the prompt-injection corpus, ADR-0056 D6 names community-maintained collections; this packet selects 1-2 to use: **Garak** (https://github.com/leondz/garak — an LLM vulnerability scanner from NVIDIA's NeMo team) and the **PromptInject** corpus (https://github.com/agencyenterprise/PromptInject). The selection criteria: actively maintained, openly licensed, broad attack-pattern coverage.
+
+**This is a docs packet. No code, no .NET project.**
+
+## Scope
+- A pentest-engagement scoping prep document in `business/context/`.
+- A DIY adversarial-probe playbook in `business/context/`.
+
+Both extend or live adjacent to the existing operator-context notes (e.g., the security-incident runbook from packet 05, the found-secret rotation runbook from packet 06).
+
+## Proposed Implementation
+
+### 1. Pentest-engagement scoping prep
+
+Author `business/context/pentest-scoping-prep.md` (or the established adjacent location) with:
+
+#### Firm-selection criteria
+
+Per ADR-0056 D6, the operator selects a pentest firm based on:
+
+1. **Demonstrated experience with multi-tenant SaaS architectures.** Not generic web-app pentesting — multi-tenant isolation (TB-4) is the most consequential boundary and the firm should have an established methodology for testing it.
+2. **Willingness to scope tightly.** Firms that upsell into "test everything" engagements are not the right fit at studio scale. The first engagement is exploratory in the sense that it establishes a working relationship; the operator wants a firm that asks "what specifically are you most worried about" rather than "let us scope it for $25K."
+3. **Track record of clear written deliverables.** An executive summary plus per-finding detail with severity, exploitability, and remediation guidance. Verify with the firm's references that the deliverable structure matches what the artifact (section 8) needs.
+4. **Reasonable rates for the scope.** $5–15K is the target for the pre-GA engagement. Firms quoting $30K+ for a TB-1-through-TB-4 + auth-surface engagement are out of scope.
+
+#### Scope-of-engagement for the pre-Notify-Cloud-GA engagement
+
+The scoping document the operator sends the pentest firm. Authored against the v1 threat-model artifact (packet 02 — hence this packet's dependency on packet 02 rather than packet 01):
+
+- **Boundaries in scope:** TB-1 (public internet ↔ Web.Rest / Front Door), TB-2 (Web.Rest ↔ application Nodes), TB-3 (application Nodes ↔ Vault / Data), TB-4 (tenant ↔ tenant — the most consequential).
+- **Surfaces in scope:** the staging Notify.Cloud public ingress; the staging Web.Rest API; the staging Vault and Data backings (read-only — no write tests against staging Vault); the staging Auth surface (credential-stuffing probe explicitly in scope; rate-limit probe explicitly in scope).
+- **Boundaries explicitly out of scope:** TB-5 through TB-10 are not in the pre-GA engagement (TB-5 human↔agent and TB-6 agent↔tool-registry come into scope once the AI sector is shipping production traffic; TB-7 agent↔LLM provider is delegated to the provider's own security posture; TB-8 Studios-internal-↔-tenant-data has no production surface to test pre-GA; TB-9 CI/CD↔production and TB-10 OSS-contributors↔repos are separate concerns).
+- **Surfaces explicitly out of scope:** production data (never tested without explicit coordination — per `SECURITY.md`'s out-of-scope list); third-party-vendor surfaces (Stripe, Azure, GitHub — those are the vendor's responsibility); DoS testing without explicit coordination (could affect a tenant's experience even on staging).
+- **Reference materials provided to the firm:** the v1 `constitution/threat-model.md` artifact (the firm reads it to understand the Grid's self-described threat model and tests against / beyond it); the relevant ADRs the artifact cross-references (specifically ADR-0006, ADR-0026, ADR-0030, ADR-0049).
+- **Deliverable expectations:** executive summary (5-15 pages) + finding-level detail (per finding: severity, exploitability, reproduction steps, remediation guidance). Findings carry a CWE ID where applicable. The operator commits to acknowledging findings within 14 days and closing or accepting each finding within 90 days.
+
+#### Budget framing
+
+Per ADR-0052 (Proposed) spend-authority pattern, the engagement is the operator's discretionary budget commitment. Target: $5–15K. The deliverable appends to the artifact's section 8; findings track to resolution via `scope`-authored issue packets.
+
+If a firm quotes outside the $5–15K range, the operator's decision: (a) accept the higher quote with documented rationale; (b) request a tighter scope at the lower price; (c) pursue a different firm. Do not let scope creep into "test everything" at price.
+
+#### Annual cadence — steady state
+
+Once Notify.Cloud is producing revenue, annual external pentest is the goal. Repeat-engagement with the same firm benefits from accumulated context; switching firms is cheaper per-engagement but loses context. Default: repeat engagement.
+
+If a year passes without an engagement (because revenue did not support it), the gap is recorded in the artifact's accepted-risk log with the explicit "accepted because revenue did not support the engagement" note. Not silently skipped.
+
+### 2. DIY adversarial-probe playbook
+
+Author `business/context/diy-adversarial-probe-playbook.md` (or adjacent location) with:
+
+#### Cadence
+
+Quarterly. Each pass runs the three tools below against the dev deployments (never staging or production without explicit coordination). Results record in `constitution/threat-model.md` section 8.
+
+#### Tool 1: OWASP ZAP — passive + active scan against `dev`
+
+OWASP ZAP runs against `dev` deployments of Web.Rest and Notify (the HTTP-fronted Nodes). Concrete steps:
+
+1. **Install.** ZAP is at https://www.zaproxy.org/. The operator downloads the desktop edition (or runs the Docker image — `docker pull zaproxy/zap-stable`).
+2. **Configure target.** Point ZAP at the `dev` Web.Rest URL. Authenticate with a `dev` test user (a non-production identity provisioned for testing).
+3. **Passive scan.** Browse the application through ZAP's proxy. ZAP records traffic and runs passive analyzers — non-intrusive, safe even on shared environments.
+4. **Active scan.** From ZAP's scope view, right-click the target → "Active Scan." ZAP probes for OWASP Top 10 categories. **Active scan generates real traffic and may produce errors / lockouts** — confirm `dev` is non-production-data before running.
+5. **Report export.** ZAP exports HTML and JSON reports. Save to `business/context/probe-results/{YYYY-QN}-zap-{node}.html` (or the established adjacent location).
+6. **Triage findings.** False positives are common in OWASP ZAP — review each finding against the threat model (does it correspond to a TB-N STRIDE entry?). True positives become artifact section-9 open-mitigation entries.
+
+#### Tool 2: Burp Community — manual exploration of newly-shipped surfaces
+
+Burp Community is at https://portswigger.net/burp/communitydownload. It is more manual than ZAP and complements ZAP's automated scan with operator-driven exploration:
+
+1. **Install.** Download Burp Community (free).
+2. **Configure proxy.** Set Burp as the HTTP proxy for a test browser.
+3. **Explore newly-shipped surfaces.** For any feature shipped in the previous quarter, exercise it through Burp's proxy with eyes on Repeater + Intruder for parameter tampering.
+4. **Manual probes worth running:**
+   - Tenant-ID tampering: pass a different `TenantId` in headers / paths / bodies; confirm rejection (TB-4).
+   - JWT manipulation: replay an expired token, swap claims, confirm rejection (TB-1).
+   - Rate-limit probes: send high-frequency requests with the same tenant token, confirm rate-limiting kicks in (TB-1).
+5. **Record findings.** Notes-only is acceptable for Burp; export-to-file is less natural than ZAP. Save observations to `business/context/probe-results/{YYYY-QN}-burp-notes.md`.
+
+#### Tool 3: Prompt-injection corpus — adversarial probing against LLM-using endpoints
+
+For Nodes that route LLM calls (the AI sector — when those Nodes ship production traffic), exercise the LLM-using endpoints with a community-maintained prompt-injection corpus:
+
+**Selected corpora** (per ADR-0056 D6's "community-maintained collections"):
+- **Garak** (https://github.com/leondz/garak) — NVIDIA NeMo's LLM vulnerability scanner. Configurable; supports many attack patterns (prompt injection, jailbreak, hallucination probing).
+- **PromptInject** (https://github.com/agencyenterprise/PromptInject) — focused prompt-injection corpus; smaller scope than Garak; useful for first-pass coverage.
+
+Concrete steps:
+
+1. **Install Garak.** `pip install garak`.
+2. **Configure target.** Point Garak at a Grid LLM-using endpoint (when one exists; pre-AI-sector-shipping, this section is a stub).
+3. **Run probes.** `garak --model_type {provider} --probes promptinject,jailbreak,encoding,...`. Garak runs a battery of attacks and reports successes.
+4. **Triage.** Map successes back to AI-1 / AI-2 / AI-3 in the threat-model artifact. Successes that map to existing mitigations (e.g., AI-1's `PromptEnvelope` once shipped) become regression evidence; successes that map to no mitigation become artifact section-9 open-mitigation entries.
+
+A finding-free pass against a corpus that has not been updated recently is **materially less informative** than a finding-free pass against a recently-updated corpus. Each pass records both the corpus version and the date.
+
+#### "DIY is not a substitute" framing
+
+The DIY playbook catches the known patterns at zero cost and exercises the operator's adversarial muscles between paid engagements. **It is not authoritative the way an external pentest is.** Motivated adversaries craft novel attacks; the corpora cover the known ones. A finding-free DIY pass is not the same as a finding-free pentest. The artifact's section 8 distinguishes DIY entries from pentest entries clearly.
+
+#### Recording results
+
+Every quarterly pass records:
+- Date of pass.
+- Tools used + their versions (ZAP version, Burp version, corpus version).
+- Targets (which `dev` Nodes / endpoints).
+- Findings — null findings recorded explicitly ("no findings against {target} with {tool} {version}").
+- Operator's confidence level — qualitative ("the corpus is current and covers AI-1/AI-2/AI-3 well; AI-4/AI-7 are not exercised by the corpus and rely on system-level controls").
+
+## Affected Files
+- `business/context/pentest-scoping-prep.md` (or adjacent location — verified at edit time).
+- `business/context/diy-adversarial-probe-playbook.md` (or adjacent location).
+- `business/context/probe-results/` directory (created on first DIY run; this packet creates the empty directory with a `.gitkeep` or README placeholder).
+
+## NuGet Dependencies
+None. Docs only; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. `business/context/` is the established operator-context location.
+- [x] No code change in any Node.
+- [x] The pentest scoping document is operator-facing **preparation**; the actual pentest engagement is the operator's action, gated on the Notify.Cloud GA decision.
+
+## Acceptance Criteria
+- [ ] `business/context/pentest-scoping-prep.md` (or adjacent) exists with: firm-selection criteria (multi-tenant SaaS experience, willingness to scope tightly, clear deliverables, reasonable rates); scope-of-engagement for the pre-Notify-Cloud-GA pentest (TB-1 through TB-4 + auth-surface probe, surfaces in/out of scope, deliverable expectations); budget framing ($5–15K per ADR-0052); annual cadence steady-state + skipped-year accepted-risk posture
+- [ ] `business/context/diy-adversarial-probe-playbook.md` (or adjacent) exists with: quarterly cadence; concrete OWASP ZAP install + configure + scan + export steps; Burp Community manual-exploration recipe with specific probes (tenant-ID tampering, JWT manipulation, rate-limit probes); prompt-injection-corpus tooling (Garak + PromptInject) with install + run + triage steps; the "DIY is not a substitute" framing; the result-recording template (date, tool versions, targets, findings, operator confidence)
+- [ ] `business/context/probe-results/` directory exists (created empty with `.gitkeep` or README placeholder) as the canonical location for quarterly DIY-pass output
+- [ ] Both documents cross-reference `constitution/threat-model.md` (the substrate they read), ADR-0056 D6 (their source), ADR-0052 (Proposed — budget authority for pentest engagement)
+- [ ] The pentest scoping document explicitly names the `SECURITY.md` out-of-scope rules so the operator does not commission tests that violate the published disclosure policy
+- [ ] The DIY playbook explicitly distinguishes DIY entries from pentest entries when results record in artifact section 8
+- [ ] No pentester is engaged by this packet — engagement is the operator's action (Human Prerequisite)
+
+## Human Prerequisites
+- [ ] Engaging a specific pentest firm and the actual pentest engagement is the operator's action, gated on the Notify.Cloud GA decision per ADR-0056 D6. The scoping-prep document this packet ships is the input to that conversation; it does not initiate it.
+- [ ] Installing OWASP ZAP, Burp Community, and the Garak / PromptInject Python packages is local-machine setup that happens **before the first quarterly DIY pass**. The playbook lists the install steps; the operator runs them when ready to start the cadence.
+- [ ] Provisioning a `dev`-environment test user / test tenant for adversarial probing — required so probes have a target identity that is not a real account. May or may not already exist; verify at edit time.
+- [ ] Verify Garak and PromptInject's current state at edit time — both are community projects subject to maintenance changes. If either has been abandoned by the time this packet is edited, the playbook's tool list is adjusted to current maintained alternatives.
+
+## Referenced ADR Decisions
+**ADR-0056 D6 — Penetration testing.** Three layers: pre-Notify-Cloud-GA external engagement, annual thereafter if revenue supports it, DIY interim. Pre-GA scope: TB-1 through TB-4 + auth credential-stuffing + rate-limit probe. Budget $5–15K. DIY tools: OWASP ZAP + Burp Community + prompt-injection corpus. DIY is not a substitute for external pentest.
+
+**ADR-0056 D6 "On the pentest-firm selection criteria."** Multi-tenant SaaS experience; willingness to scope tightly; clear written deliverables; reasonable rates. First engagement establishes the working relationship; subsequent annual engagements with the same firm benefit from accumulated context.
+
+**ADR-0056 D6 "On the prompt-injection corpus as a DIY tool."** Community-maintained corpora (PromptInject, LLM-Attacks, Garak). Not exhaustive but catches the known patterns at zero cost. Each pass records the corpus version.
+
+**ADR-0052 (Proposed) — Cost governance.** Pentest engagement is the operator's discretionary budget commitment per the spend-authority pattern.
+
+**`SECURITY.md` (packet 04) — Out-of-scope rules.** Production tenant data and DoS testing without coordination are out of scope per the disclosure policy; the pentest scoping respects those rules.
+
+## Constraints
+- **Two paired documents, not one combined.** Pentest scoping is operator-facing preparation (one-time-then-reference); DIY playbook is operator-facing recurring procedure (quarterly cadence). Different audience-moment.
+- **Concrete tool steps, not generic prose.** OWASP ZAP install command, Burp Community URL, Garak pip install — same standard as packet 06's pre-staged commands. A playbook that says "run a security scan" without naming the tool's command fails at execution time.
+- **Pentest scoping consumes the v1 artifact (packet 02) as the substrate.** Hence this packet's dependency on packet 02 rather than packet 01 — the scoping document references the artifact's filled-in TB-N entries, not stubs.
+- **The DIY-is-not-a-substitute framing is explicit.** ADR-0056 D6 is unusually emphatic about this; the playbook preserves the framing.
+- **No engagement of any actual pentester.** This packet ships the prep, not the engagement.
+- **Tool-current verification at edit time.** Garak and PromptInject are community projects; verify their current state and adjust if needed.
+
+## Labels
+`feature`, `tier-2`, `meta`, `security`, `docs`, `adr-0056`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Author the pentest-engagement scoping prep (firm selection, scope of pre-Notify-Cloud-GA engagement, budget framing) + the DIY adversarial-probe playbook (quarterly cadence, concrete OWASP ZAP + Burp + Garak / PromptInject steps, result-recording template).
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the pre-GA pentest engagement actionable when the operator pursues it, and make the DIY cadence operable from quarter zero.
+- Feature: ADR-0056 Threat Model and Security Review Cadence rollout, Wave 4.
+- ADRs: ADR-0056 D6 (primary), ADR-0052 (Proposed — pentest budget authority), and the `SECURITY.md` out-of-scope rules (packet 04).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — hard. The pentest scoping document references the v1 artifact's filled-in TB-N entries, not v0 stubs. The DIY playbook also benefits from the v1 artifact for the corpus-triage step.
+
+**Constraints:**
+- Two paired documents; concrete tool steps; v1-artifact-consumes-substrate; DIY-is-not-a-substitute framing explicit; no actual pentester engagement; tool-currentness verified at edit time.
+
+**Key Files:**
+- `business/context/pentest-scoping-prep.md` (or adjacent location)
+- `business/context/diy-adversarial-probe-playbook.md` (or adjacent location)
+- `business/context/probe-results/` (created empty)
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0056-threat-model/08-actions-dependabot-and-secret-scanning.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/08-actions-dependabot-and-secret-scanning.md
@@ -1,0 +1,325 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "meta", "security", "ci-cd", "adr-0056", "wave-4"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0056", "ADR-0009", "ADR-0012", "ADR-0044"]
+accepts: ["ADR-0056"]
+wave: 4
+initiative: adr-0056-threat-model
+node: honeydrunk-actions
+---
+
+# Enable Dependabot + GitHub secret scanning + push protection Grid-wide; wire critical-CVE auto-issue-packet
+
+## Summary
+Operationalize ADR-0056 D7 and D8 in `HoneyDrunk.Actions` (the CI/CD control plane per ADR-0012): (1) add a canonical `dependabot.yml` template that every Grid repo adopts, with security alerts + auto-PR for patch versions / human-merge for minor+major; (2) wire the critical-CVE → auto-issue-packet flow as a reusable workflow that consumes Dependabot alert webhooks and authors a packet via the existing issue-packet authoring path; (3) document the Grid-wide GitHub-side security feature enablement (secret scanning, push protection, Dependabot alerts) as a `business/context/`-equivalent operator playbook so the Settings-UI toggles are explicit. The actual GitHub-side enablement is a Human Prerequisite (Settings-UI clicks).
+
+## Context
+ADR-0056 D7 (dependency / supply-chain) and D8 (secret scanning) both name GitHub-native tooling as the v1 baseline. The Grid currently has **partial coverage** — per the memory note "ADR-0009 Dependabot stance: alerts yes, auto-PRs no; grouped nightly-deps replaces per-package Dependabot PRs" — so the existing posture is alerts-but-no-auto-PR. ADR-0056 D7 amends that posture: **auto-PR for patch versions is now on**, minor / major still human-merge. ADR-0056 also commits to:
+
+- **Critical-severity CVEs auto-create issue packets** via a GitHub Actions integration per ADR-0008's issue-packet authoring path. The packet carries `security` + `priority:critical` labels and routes to the operator's primary queue.
+- **GitHub Advanced Security code scanning (CodeQL)** on all public repos (free for public OSS) and on private repos when the per-committer cost is justified (recorded as a future trigger; not enabled now for private repos).
+- **GitHub secret scanning** enabled Grid-wide; **push protection** enabled where supported.
+- **SBOM generation per release** — tool selection deferred (see packet 09's tracker).
+
+This packet is the **Actions-control-plane surface** for those commitments. Per ADR-0012 (Proposed — naming Actions as the CI/CD control plane) and ADR-0044 (Accepted — review-agent / PR-discipline control plane), the right home for cross-repo CI configuration is `HoneyDrunk.Actions`, not per-Node repos. The pattern: ship the canonical config + a fan-out mechanism here; per-Node repos consume the canonical config via reusable workflow + a thin per-repo `dependabot.yml` that copies the canonical template.
+
+**ADR-0009 reconciliation.** ADR-0009 (Accepted) is the current Grid stance on package scanning: nightly grouped CVE scan + PR-time vulnerability gate, **no Dependabot auto-PRs**. ADR-0056 D7 amends this — Dependabot auto-PR for patch versions is now on (still gated by the existing PR-time vulnerability check from ADR-0009 — auto-merge is **never** introduced; minor/major still require human review per ADR-0044). The amendment lives in `HoneyDrunk.Actions`'s shared config + this packet's docs; ADR-0009 itself is not re-decided (ADR-0056 is the integrating layer per its own D13).
+
+**The Settings-UI enablement is Human-only.** GitHub's Dependabot alerts, secret scanning, and push protection are toggled per-repo (or org-wide via the org's Security Settings). These are portal-clicks, not workflow YAML. The operator follows the playbook this packet ships; the workflow side ships the configurable canonical templates the repos adopt.
+
+**Critical-CVE auto-issue-packet flow.** ADR-0008 governs issue-packet authoring (`scope` agent surface). The auto-create path on a Critical CVE:
+
+1. GitHub emits a Dependabot alert webhook on the affected repo.
+2. A reusable workflow in `HoneyDrunk.Actions` consumes the webhook (or polls Dependabot alerts on a schedule — fallback if webhook reception is not configured).
+3. The workflow filters by severity = Critical.
+4. The workflow invokes the issue-packet authoring path: drafts a packet using a security-tuned variant of the standard template (with CVE ID, affected version range, fix version if available, exploitability assessment as extra fields), labels it `security` + `priority:critical`, files it in the affected repo via `file-packets.yml`.
+5. The packet is **labeled and prioritized** but **not auto-merged**. Even patch-version Dependabot PRs require human review per ADR-0044's invariant 52.
+
+**This packet's scope is narrow.** It ships:
+- The canonical `dependabot.yml` template (one file, copy-to-per-repo pattern).
+- A reusable workflow at `.github/workflows/job-cve-to-packet.yml` (or similar) that consumes Dependabot alerts and authors a packet.
+- A `business/context/`-equivalent operator playbook documenting the Settings-UI toggles required Grid-wide (Dependabot alerts, secret scanning, push protection, CodeQL on public repos) — placed in `HoneyDrunk.Actions/docs/security-tooling-enablement.md` or the established cross-cutting-docs location.
+
+It does **not** ship:
+- Per-repo `dependabot.yml` adoption PRs (downstream task; the canonical template is the start; per-repo adoption follows the same pattern as the `pr-core.yml` fan-out).
+- The actual GitHub-side enablement (Human Prerequisite).
+- SBOM tooling selection (deferred per packet 09).
+
+**This is a workflow/YAML + docs packet. No .NET project.** `HoneyDrunk.Actions` is not a versioned .NET solution.
+
+## Scope
+- A canonical `dependabot.yml` template in `HoneyDrunk.Actions` for per-repo adoption.
+- A reusable workflow `.github/workflows/job-cve-to-packet.yml` (or equivalent) consuming Dependabot alerts and authoring packets.
+- A `docs/security-tooling-enablement.md` operator playbook documenting GitHub Settings-UI toggles.
+- The repo `CHANGELOG.md` if `HoneyDrunk.Actions` keeps one for the workflow surface.
+
+## Proposed Implementation
+
+### 1. Canonical `dependabot.yml` template
+
+Place at a canonical location in `HoneyDrunk.Actions` — verified at edit time:
+- If `HoneyDrunk.Actions/templates/dependabot.yml` exists, amend it.
+- If no template exists, create `HoneyDrunk.Actions/templates/dependabot.yml`.
+
+Content (Dependabot config — see Dependabot v2 schema):
+
+```yaml
+# Canonical dependabot.yml for HoneyDrunk Grid repos.
+# Per ADR-0056 D7 + ADR-0009 reconciliation: alerts on; auto-PR for patches; minor/major human-merge.
+# Adopt by copying to .github/dependabot.yml at the consumer repo's root.
+
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    versioning-strategy: "increase-if-necessary"
+    # Auto-PR is on for security alerts; the pr-core.yml gate (per ADR-0044 invariant 52) reviews them.
+    # Patch-version updates are auto-PR'd; minor/major are also PR'd but explicitly require human merge per ADR-0044.
+    # No auto-merge anywhere — even patch versions go through review.
+    allow:
+      - dependency-type: "all"
+    labels:
+      - "dependencies"
+      - "dependabot"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "dependabot"
+      - "ci"
+  # Add `npm`, `pip`, etc. ecosystems as repos adopt them.
+```
+
+Document the per-repo adoption recipe in `HoneyDrunk.Actions`'s consumer-usage docs (the established docs location for reusable-workflow consumer instructions): copy the template to `<repo>/.github/dependabot.yml`, customize ecosystems for the repo (a Studios repo also has `npm`; a Lore repo has none).
+
+### 2. Critical-CVE auto-issue-packet reusable workflow
+
+Place at `HoneyDrunk.Actions/.github/workflows/job-cve-to-packet.yml` (or the established reusable-workflow naming convention).
+
+The workflow:
+
+```yaml
+# Reusable workflow: consume Dependabot security alerts and author critical-severity issue packets.
+# Per ADR-0056 D7. Invoked on a schedule (cron) and/or via repository_dispatch from Dependabot alert webhooks.
+# Authors packets via the file-packets.yml issue-packet authoring path (per ADR-0008).
+# Critical-severity only; non-critical alerts ride Dependabot's standard PR flow.
+
+name: job-cve-to-packet
+
+on:
+  workflow_call:
+    inputs:
+      target-repo:
+        description: "The repo whose Dependabot alerts to scan."
+        required: true
+        type: string
+      severity-threshold:
+        description: "Severity floor — only alerts at or above this severity author packets."
+        required: false
+        type: string
+        default: "critical"
+
+permissions:
+  contents: read
+  issues: write
+  security-events: read
+
+jobs:
+  scan-and-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch active Dependabot alerts
+        run: |
+          # Use the GitHub CLI or REST API to fetch open Dependabot alerts for the target repo.
+          # gh api /repos/{owner}/{repo}/dependabot/alerts?state=open
+          # Filter by severity == critical (or the threshold input).
+          # ...
+      - name: Draft packet content per alert
+        run: |
+          # For each critical alert, prepare packet content with:
+          # - CVE ID
+          # - Affected package + version range
+          # - Fix version (if available)
+          # - Exploitability assessment (from the alert's `security_vulnerability` block)
+          # - Generated packet filename: generated/issue-packets/active/standalone/{YYYY-MM-DD}-{repo}-cve-{cve-id}.md
+          # - Frontmatter: type=bug-fix, tier=2, labels=["security", "priority:critical", "cve", "tier-2"]
+          # - dependencies: []
+          # - target_repo from input
+          # ...
+      - name: Commit packet to HoneyDrunk.Architecture
+        run: |
+          # The packet is written to HoneyDrunk.Architecture (the issue-packet substrate),
+          # which file-packets.yml then files as an issue in the target repo on push to main.
+          # Use a deploy key or PAT scoped to HoneyDrunk.Architecture.
+          # ...
+```
+
+The workflow is **scaffolded but not fully implemented** in this packet — the implementation requires Dependabot webhook plumbing or scheduled API polling, both of which require operator-side credentials decisions. This packet ships the workflow file with the documented behavior + commented-out implementation steps as a starter. The fuller implementation is a follow-up if the auto-create path becomes load-bearing.
+
+**Why scaffold-not-implement:** the load-bearing claim of D7 is that critical CVEs become issue packets. Whether that happens via webhook or via scheduled-polling is an implementation detail the operator decides based on operational preference. The workflow's surface shape (inputs, outputs, permissions, target file location) is the part that needs to be canonical; the polling-vs-webhook decision is downstream.
+
+### 3. Operator playbook for GitHub Settings-UI enablement
+
+Place at `HoneyDrunk.Actions/docs/security-tooling-enablement.md`. Operator-facing playbook:
+
+```markdown
+# GitHub security tooling enablement (Grid-wide)
+
+> Per ADR-0056 D7 + D8. This is operator-facing — the toggles are clicked in the GitHub Settings UI, not configured in YAML.
+
+## Org-level settings (HoneyDrunkStudios org)
+
+Navigate to: https://github.com/organizations/HoneyDrunkStudios/settings/security_analysis
+
+Enable Grid-wide:
+- [ ] **Dependabot alerts** — Enable for all repositories (public + private).
+- [ ] **Dependabot security updates** — Enable for all repositories (auto-PR on alert).
+- [ ] **Dependency graph** — Enable for all repositories.
+- [ ] **Secret scanning** — Enable for all repositories (free for public, GHAS-included for private — see cost note below).
+- [ ] **Push protection for secret scanning** — Enable Grid-wide. Blocks pushes containing detected secrets at the push gate.
+- [ ] **Code scanning** — Enable on all public repos (free CodeQL default setup). On private repos: deferred until per-committer cost is justified (see GHAS cost note).
+
+## GitHub Advanced Security (GHAS) — private repo cost note
+
+GHAS bundles secret scanning + push protection + code scanning for private repos. Cost: per-active-committer per month at the time of writing. At studio scale with one active committer, the cost is bounded; with N active committers the cost scales linearly.
+
+- Enable GHAS on private revenue-bearing repos (Notify Cloud, future Billing) as a Grid-wide-default-on baseline.
+- Defer GHAS on private experimental repos until they have material traffic.
+
+The cost-tier decision is the operator's at-edit-time call. The default Grid-wide answer per ADR-0056 D7 is "secret scanning on private = on (via GHAS)."
+
+## Per-repo configuration
+
+Each Grid repo carries `.github/dependabot.yml` copied from the canonical template at `HoneyDrunk.Actions/templates/dependabot.yml`. Per-repo adoption is a small PR per repo; the fan-out follows the same pattern as the `pr-core.yml` rollout. {Reference the existing fan-out doc if one exists.}
+
+## Backlog burn-down
+
+When Dependabot is enabled Grid-wide, an initial wave of CVE alerts will surface — historical accumulation across all repos. **Expect 50-200 alerts on day one**, of which 5-20 will be critical / high. The operator triages:
+
+1. Critical: rotate or update immediately (within the runbook from packet 06's time-to-rotation targets if a secret is involved; otherwise update the dependency).
+2. High: update within the standard sprint cadence.
+3. Medium / Low: triage during the next quarterly review.
+
+Schedule the backlog burn-down for the first 1-2 weeks after enablement. Steady-state volume is much lower.
+
+## Historical secret-scan triage
+
+When push protection is enabled, GitHub scans history and may flag secrets committed and rotated months/years ago. Triage per the found-secret runbook (`business/context/found-secret-rotation-runbook.md`, packet 06): even historical leaks may need re-rotation if the value is still active anywhere.
+
+## Cross-references
+
+- ADR-0056 D7 (Dependabot + supply chain).
+- ADR-0056 D8 (secret scanning).
+- ADR-0009 (existing package-scanning posture; this enablement amends to allow auto-PR for patches).
+- ADR-0012 (Proposed — Actions is the CI/CD control plane; canonical config lives here).
+- ADR-0044 invariant 52 (every non-draft PR runs the review agent — applies to Dependabot PRs).
+- Found-secret runbook (packet 06) — what to do when scanning finds something.
+```
+
+### 4. Repo `CHANGELOG.md` (if maintained)
+
+If `HoneyDrunk.Actions` keeps a `CHANGELOG.md` for the workflow surface, append an entry under the current in-progress version (or create a dated entry) noting:
+- Canonical `dependabot.yml` template added.
+- `job-cve-to-packet.yml` reusable workflow scaffolded.
+- Security-tooling-enablement playbook documented.
+
+## Affected Files
+- `HoneyDrunk.Actions/templates/dependabot.yml` (canonical template).
+- `HoneyDrunk.Actions/.github/workflows/job-cve-to-packet.yml` (scaffolded reusable workflow).
+- `HoneyDrunk.Actions/docs/security-tooling-enablement.md` (operator playbook).
+- `HoneyDrunk.Actions/CHANGELOG.md` if the repo keeps one for workflow-surface changes.
+- `HoneyDrunk.Actions/docs/consumer-usage.md` (or equivalent) extended with the dependabot.yml adoption recipe.
+
+## NuGet Dependencies
+None. `HoneyDrunk.Actions` is not a versioned .NET solution. No .NET project is created or modified.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo per the routing rule "workflow, CI, GitHub Actions, pipeline → HoneyDrunk.Actions" and per ADR-0012 (Proposed — Actions is the CI/CD control plane).
+- [x] No code change in any Node — the canonical `dependabot.yml` is copied per-repo; that fan-out is a downstream task, not in this packet.
+- [x] The org-level / repo-level Settings-UI enablement is a Human Prerequisite — explicit, not implicit.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Actions/templates/dependabot.yml` exists as the canonical Dependabot config with: weekly NuGet + github-actions ecosystem updates; auto-PR allowed; no auto-merge anywhere; appropriate labels (`dependencies`, `dependabot`, `ci` where applicable); 10 open-PR limit; explicit comment lines naming ADR-0056 D7 + ADR-0009 reconciliation + ADR-0044 invariant 52
+- [ ] `HoneyDrunk.Actions/.github/workflows/job-cve-to-packet.yml` exists as a scaffolded reusable workflow (with documented behavior + commented-out implementation steps for either webhook or scheduled-polling path) authoring critical-severity packets into `HoneyDrunk.Architecture`'s `generated/issue-packets/active/standalone/` substrate via the existing issue-packet authoring path
+- [ ] `HoneyDrunk.Actions/docs/security-tooling-enablement.md` exists as the operator playbook covering: org-level Dependabot alerts / security updates / dependency graph / secret scanning / push protection / code scanning toggles; GHAS cost-tier decision for private repos; per-repo `dependabot.yml` adoption recipe; backlog burn-down expectations (50-200 day-one alerts, 5-20 critical/high); historical secret-scan triage cross-reference to packet 06
+- [ ] Consumer-usage docs are extended with the `dependabot.yml` adoption recipe
+- [ ] `HoneyDrunk.Actions/CHANGELOG.md` is updated if the repo keeps one for the workflow surface
+- [ ] No per-repo `dependabot.yml` adoption PR is filed by this packet — that is a downstream task
+- [ ] No org-level Settings-UI toggle is clicked by the packet — that is a Human Prerequisite
+
+## Human Prerequisites
+- [ ] Enable Dependabot alerts org-wide at https://github.com/organizations/HoneyDrunkStudios/settings/security_analysis. The user prefers portal-first; this is a portal click.
+- [ ] Enable Dependabot security updates org-wide (the auto-PR-for-alerts behavior; auto-merge stays off).
+- [ ] Enable GitHub secret scanning org-wide. Free for public; included with GHAS for private — decide the private-repo cost question for revenue-bearing repos.
+- [ ] Enable push protection for secret scanning org-wide.
+- [ ] Enable CodeQL code scanning on all public repos (free default setup).
+- [ ] Decide private-repo GHAS cost-tier — default per ADR-0056 D7 is "secret scanning on private = on (via GHAS)."
+- [ ] Triage the initial CVE backlog (1-2 weeks of operator time, 50-200 alerts expected day-one with 5-20 critical/high) — per the operator playbook section.
+- [ ] Triage the initial historical secret-scan triage — push protection scans history on enablement; expect findings from rotated-long-ago secrets. Use packet 06's runbook.
+- [ ] Per-repo adoption of `.github/dependabot.yml` from the canonical template — small PR per repo, follows the existing fan-out pattern.
+
+## Referenced ADR Decisions
+**ADR-0056 D7 — Dependency / supply-chain scanning.** Dependabot Grid-wide; auto-PR for patches with human merge; critical CVEs auto-create issue packets; CodeQL on public repos free; SBOM tool deferred (packet 09 tracker).
+
+**ADR-0056 D8 — Secret scanning.** GitHub-native secret scanning Grid-wide; push protection where supported; optional local hooks (`git-secrets`, `gitleaks`) at repos with hook infrastructure; the found-secret runbook (packet 06) governs response.
+
+**ADR-0009 — Existing package-scanning posture.** Nightly grouped CVE scan + PR-time vulnerability gate. This packet's amendment: Dependabot auto-PR for patches is on; minor/major still human-merge; no auto-merge anywhere. The PR-time vulnerability gate from ADR-0009 still runs on every PR including Dependabot's.
+
+**ADR-0012 (Proposed) — Actions as CI/CD control plane.** Canonical CI configuration lives in `HoneyDrunk.Actions`, not per-Node repos. The shared templates and reusable workflows in this packet follow that posture.
+
+**ADR-0044 — PR discipline and review-agent.** Invariant 52: every non-draft PR on an enabled repo runs the cloud-wired `review` agent. Dependabot PRs are not exempt — they run through the same review surface.
+
+**ADR-0008 — Issue-packet authoring.** The critical-CVE auto-create path produces packets via the standard authoring surface; the packet template is a security-tuned variant of the standard.
+
+## Constraints
+- **No auto-merge anywhere.** Even patch-version Dependabot PRs go through review per ADR-0044 invariant 52. The dependabot.yml allows auto-PR but never auto-merge.
+- **The reusable workflow is scaffolded, not fully implemented.** The webhook-vs-polling decision is an operator-side choice; this packet ships the workflow file's surface + documented behavior + commented-out implementation steps. Full implementation is a follow-up if needed.
+- **Settings-UI enablement is Human Prerequisite, not in-PR YAML.** GitHub's Dependabot / secret scanning / push protection / CodeQL toggles are portal clicks. The operator playbook documents the clicks.
+- **No per-repo adoption PRs filed.** The canonical template exists; per-repo PRs follow the same fan-out pattern as `pr-core.yml`. Filing 11+ PRs at once is downstream work, not this packet.
+- **Critical-only auto-create.** High / Medium / Low severities ride Dependabot's standard PR flow without packet creation. Critical alone gets the packet — D7 is explicit.
+- **PR-time vulnerability gate from ADR-0009 still runs.** This packet does not remove the existing per-PR scan; it adds Dependabot alerts as a complementary surface.
+
+## Labels
+`feature`, `tier-2`, `meta`, `security`, `ci-cd`, `adr-0056`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Land the canonical `dependabot.yml` template + the scaffolded `job-cve-to-packet.yml` reusable workflow + the operator playbook for GitHub-side security tooling enablement, in `HoneyDrunk.Actions`.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Make the Grid-wide Dependabot + secret scanning + push protection + critical-CVE-auto-issue-packet posture concrete and discoverable, with the Settings-UI clicks documented for the operator and the canonical workflow/config in the CI/CD control plane.
+- Feature: ADR-0056 Threat Model and Security Review Cadence rollout, Wave 4.
+- ADRs: ADR-0056 D7 + D8 (primary), ADR-0009 (existing scanning — amended), ADR-0012 (Proposed — Actions as CI/CD control plane), ADR-0044 (review-agent on every PR including Dependabot's), ADR-0008 (issue-packet authoring path).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0056 should be Accepted before the operational tooling lands.
+
+**Constraints:**
+- No auto-merge anywhere — patch-version Dependabot PRs go through review.
+- Reusable workflow scaffolded with documented behavior + commented-out implementation steps; full implementation deferred until webhook-vs-polling decision is made.
+- Settings-UI enablement is Human Prerequisite.
+- No per-repo adoption PRs filed.
+- Critical-only auto-create; non-critical rides Dependabot's standard PR flow.
+- Existing PR-time vulnerability gate from ADR-0009 still runs.
+
+**Key Files:**
+- `HoneyDrunk.Actions/templates/dependabot.yml`
+- `HoneyDrunk.Actions/.github/workflows/job-cve-to-packet.yml`
+- `HoneyDrunk.Actions/docs/security-tooling-enablement.md`
+- Consumer-usage docs (extended)
+- `HoneyDrunk.Actions/CHANGELOG.md` if maintained
+
+**Contracts:** None — workflow + template + docs only.

--- a/generated/issue-packets/active/adr-0056-threat-model/09-architecture-cross-track-followup-tracker.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/09-architecture-cross-track-followup-tracker.md
@@ -1,0 +1,166 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "security", "docs", "adr-0056", "wave-5"]
+dependencies: ["packet:02", "packet:03"]
+adrs: ["ADR-0056", "ADR-0016", "ADR-0017", "ADR-0006", "ADR-0031", "ADR-0046", "ADR-0035"]
+accepts: ["ADR-0056"]
+wave: 5
+initiative: adr-0056-threat-model
+node: honeydrunk-architecture
+---
+
+# Register the cross-track follow-up triggers for ADR-0056 deferred work
+
+## Summary
+Register the six deferred-to-owning-track items from ADR-0056 as a tracked list so they surface at the right Node-standup or sibling-ADR moment, not lost in the dispatch plan: (1) AI's `PromptEnvelope` typed-channel pattern + analyzer (HoneyDrunk.AI / ADR-0016 track); (2) Capabilities' immutable-tool-description-per-release (HoneyDrunk.Capabilities / ADR-0017 standup); (3) Capabilities' high-blast-radius routing (same); (4) Vault's tighter model-key rotation cadence (HoneyDrunk.Vault / ADR-0006 amendment); (5) Audit's investigation-extended-retention export interface (HoneyDrunk.Audit / Phase-2); (6) ADR-0046's `security.md` agent loading the artifact on every PR (ADR-0046 track); (7) SBOM tool selection (follow-up ADR or ADR-0035 amendment). Tracked in `initiatives/active-initiatives.md` as triggers and in `constitution/threat-model.md` section 9 (open mitigations).
+
+## Context
+ADR-0056's Follow-up Work list names 15 items. This initiative ships nine packets covering substrate, governance, runbooks, and tooling enablement. Six items are explicitly deferred to owning-Node tracks per the dispatch plan's "Coupling" sections. The deferrals are right — bundling code work into not-yet-stood-up Nodes is premature decomposition (memory note: "New-Node / standup work gets its own ADR; don't bundle into feature packets") — but they need to be **tracked** so they surface at the right moment.
+
+This packet is the **bridge from ADR-0056's commitments to the tracks that ultimately ship them**. Without it, the deferrals are visible only in the dispatch plan (which moves to `completed/` when the initiative closes) and the artifact's section 9 (which the operator's quarterly review reads). Tracking the deferrals in `initiatives/active-initiatives.md` makes them visible at the **next planning moment** — when the operator or scope agent picks up ADR-0017's standup, ADR-0046's scope-out, or a Vault.Rotation follow-up.
+
+**The six (plus SBOM) deferrals:**
+
+1. **AI-1 `PromptEnvelope` typed-channel pattern + analyzer rule** in `HoneyDrunk.AI`. ADR-0016 is Accepted (the AI standup decided the seven contracts); the Node is in Seed phase. `PromptEnvelope` lands when an LLM-calling consumer needs it, and the analyzer rule lands alongside. Owning track: HoneyDrunk.AI Node track (post-Seed).
+2. **AI-4 immutable-tool-description-per-release** in `HoneyDrunk.Capabilities`. ADR-0017 is Proposed (standup ADR; Capabilities does not yet exist as shipped code). The immutability commitment lands at standup as a designed-in invariant + runtime check. Owning track: ADR-0017 standup initiative.
+3. **AI-7 high-blast-radius routing** in `HoneyDrunk.Capabilities`. Same Node, same standup. The capability-side wiring requires the capability registry to exist; pre-writing before standup is premature.
+4. **AI-8 tighter model-key rotation cadence** (90-day vs general 180-day) in `HoneyDrunk.Vault` / Vault.Rotation. ADR-0006 is Accepted; the model-key class amendment is a one-line rotation-policy change. Owning track: Vault.Rotation follow-up or an ADR-0006 amendment packet.
+5. **D10 investigation-extended-retention export interface** in `HoneyDrunk.Audit`. ADR-0031 is Accepted; Audit v0.1.0 is published. The export-and-hold mechanism is an additive read-side feature (Phase-2). Owning track: Audit Phase-2 follow-up.
+6. **ADR-0046 `security.md` artifact loading.** ADR-0046 is Proposed; `.claude/agents/security.md` does not yet exist. When ADR-0046's scope-out work lands, the `security.md` file must load `constitution/threat-model.md` on every PR as input context per ADR-0056 D5. Owning track: ADR-0046 scope-out initiative.
+7. **SBOM tool selection.** ADR-0056 D7 explicitly defers ("becomes a follow-up ADR or a hive-sync-driven amendment to ADR-0035"). Owning track: a new ADR (or ADR-0035 amendment) once the tool decision is made.
+
+**Tracking surface.** Three locations cooperate to keep the deferrals visible:
+
+- **`initiatives/active-initiatives.md`** — this packet adds the seven items to a "Deferred follow-ups" or "Triggers" subsection inside this initiative's tracking block, with the trigger condition (which event surfaces it) and the owning track.
+- **`constitution/threat-model.md` section 9 (open mitigations)** — packet 02 populates section 9 with the same items; this packet ensures the two surfaces stay consistent (the artifact is read in the operator's quarterly review; the initiatives file is read at planning moments).
+- **The owning track's standup or follow-up ADR** — when ADR-0017's standup is scoped, when ADR-0046's scope-out is scoped, when a Vault.Rotation follow-up is scoped, those scope passes consume the trigger-list and decide how to incorporate the ADR-0056 commitment.
+
+**This packet does not file PRs against any owning track.** That is each owning track's responsibility when it next plans work. The seven items are **planning inputs**, not assigned issues.
+
+**Sequencing.** This packet depends on packet 02 (the artifact's section 9 is populated) and packet 03 (the standup-template + hive-sync extension is in place — relevant because the AI-sector standups and Audit Phase-2 will read both surfaces). Wave 5 alone — runs after both Wave 3 and Wave 4 are at least partly landed.
+
+**This is a docs packet. No code, no .NET project.**
+
+## Scope
+- `initiatives/active-initiatives.md` — add a "Deferred follow-up triggers" subsection inside this initiative's tracking block.
+- Cross-check / minor-update `constitution/threat-model.md` section 9 (open mitigations) for consistency with the initiatives-file list. Packet 02 populates section 9 with the same items; this packet confirms consistency and updates phrasing where helpful — does not re-decide content.
+
+## Proposed Implementation
+
+### 1. `initiatives/active-initiatives.md` — Deferred follow-up triggers subsection
+
+Inside the `### ADR-0056 Threat Model and Security Review Cadence` initiative block (registered by packet 00), add a `**Deferred follow-up triggers:**` subsection with the seven items. Format consistent with the existing initiative-tracking convention (see the `### ADR-0044 Cloud Code Review` initiative's tracking subsections for the precedent).
+
+Content:
+
+```markdown
+**Deferred follow-up triggers (per dispatch plan / artifact section 9):**
+
+These items are owned by other Node or ADR tracks and surface when those tracks next plan work. They are not packets in this initiative.
+
+| # | Item | Trigger event | Owning track | Threat-model entry |
+|---|---|---|---|---|
+| df-1 | `PromptEnvelope` typed-channel pattern + analyzer rule | First HoneyDrunk.AI LLM-calling consumer (post-Seed) | HoneyDrunk.AI Node track (ADR-0016) | AI-1 |
+| df-2 | Immutable-tool-description-per-release | HoneyDrunk.Capabilities standup (ADR-0017) | ADR-0017 standup initiative | AI-4 |
+| df-3 | High-blast-radius capability-side routing | Same as df-2 | Same as df-2 | AI-7 |
+| df-4 | Model-API-key 90-day rotation cadence | Next Vault.Rotation follow-up or ADR-0006 amendment | HoneyDrunk.Vault / Vault.Rotation | AI-8 |
+| df-5 | Investigation-extended-retention export | HoneyDrunk.Audit Phase-2 planning | HoneyDrunk.Audit (post-v0.1.0) | D10 |
+| df-6 | `.claude/agents/security.md` loads threat-model artifact on every PR | ADR-0046 scope-out initiative | ADR-0046 track | D5 (per-PR cadence) |
+| df-7 | SBOM tool selection | When SBOM tooling becomes a binding need (v1.5 Tier 0 release) | Follow-up ADR or ADR-0035 amendment | D7 |
+
+These items are also listed in `constitution/threat-model.md` section 9 (open mitigations). The two surfaces are kept consistent at every quarterly review (per ADR-0056 D5).
+```
+
+### 2. Consistency check against `constitution/threat-model.md` section 9
+
+Read `constitution/threat-model.md` section 9 (populated by packet 02). The seven df-N items above should map to seven entries in that section. Differences to reconcile:
+
+- **Numbering.** The artifact's section 9 may use bare bullets or its own numbering; the initiatives file uses `df-N` IDs for cross-reference. Both are acceptable — verify that each item is present in both surfaces; identifier mismatch is not a defect.
+- **Phrasing.** The artifact may be terser (it is the operator's quarterly-review reading); the initiatives file may include more trigger-context. Both are acceptable — the substance is what matters.
+- **Missing entries.** If packet 02 missed an item that this packet expects (e.g., SBOM tool selection — df-7 — was framed as deferred in the dispatch plan but might not have made packet 02's section 9 if the v1-artifact-author judged it not a threat-model item), this packet **adds the missing entry to the artifact's section 9** to keep the two surfaces consistent.
+- **Extra entries.** If packet 02's section 9 lists more open mitigations than the seven this packet expects (e.g., entries surfaced during v1 content fill), this packet leaves those in place — the artifact is authoritative for what is currently open; this packet's list is the subset that ADR-0056 explicitly deferred at scope time.
+
+### 3. Optional — issue per owning track
+
+For each `df-N`, consider whether to file a placeholder issue in the owning Node's repo or the owning ADR's track to make the deferral visible there. **Default: no.** The owning track will see the deferral when it next plans work (the operator or scope agent reads `initiatives/active-initiatives.md` + `constitution/threat-model.md` section 9 at planning moments). Filing placeholder issues now would clutter The Hive with not-yet-actionable items.
+
+The exception: if a deferral has a hard external deadline (e.g., a specific regulatory date), file the issue now with the deadline. None of the seven items here has that profile — each surfaces at a track-driven moment, not a calendar moment.
+
+## Affected Files
+- `initiatives/active-initiatives.md` — extend the ADR-0056 initiative block with the Deferred-follow-up-triggers subsection.
+- Optional: `constitution/threat-model.md` — minor edits to section 9 only if consistency reconciliation finds gaps.
+
+## NuGet Dependencies
+None. Docs only; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. `initiatives/active-initiatives.md` and `constitution/threat-model.md` both live here.
+- [x] No code change in any Node — the deferrals are planning inputs to other tracks, not issued work.
+- [x] No PR filed against any owning track — owning tracks consume the trigger list when they next plan work.
+
+## Acceptance Criteria
+- [ ] `initiatives/active-initiatives.md` carries a "Deferred follow-up triggers" subsection inside the ADR-0056 initiative block, listing all seven items (df-1 through df-7) with: item description; trigger event; owning track; threat-model-entry mapping
+- [ ] The seven items match the artifact's `constitution/threat-model.md` section 9 (open mitigations) in substance — same items appear in both surfaces, phrasing differences acceptable
+- [ ] If any item is missing from the artifact's section 9, this packet **adds** it to keep the two surfaces consistent. If the artifact's section 9 has extra items, this packet leaves them in place (artifact is authoritative for currently-open mitigations).
+- [ ] No placeholder issue is filed against any owning track's repo by this packet (default; no exception triggered by any of the seven items)
+- [ ] The subsection's format matches the existing initiative-tracking convention in `active-initiatives.md` (see ADR-0044 initiative block for a precedent)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0056 D9 AI-1 — `PromptEnvelope` typed-channel pattern.** Implementing in `HoneyDrunk.AI`. Deferred to AI Node track (df-1).
+
+**ADR-0056 D9 AI-4 — Immutable-tool-description-per-release.** Implementing in `HoneyDrunk.Capabilities`. Deferred to ADR-0017 standup (df-2).
+
+**ADR-0056 D9 AI-7 — High-blast-radius capability-side routing.** Implementing in `HoneyDrunk.Capabilities`. Deferred to ADR-0017 standup (df-3).
+
+**ADR-0056 D9 AI-8 — Model-key tighter rotation cadence.** 90-day instead of general 180-day. Implementing in Vault rotation defaults. Deferred to Vault.Rotation follow-up (df-4).
+
+**ADR-0056 D10 — Investigation-extended-retention export.** Implementing in `HoneyDrunk.Audit` read interface. Deferred to Audit Phase-2 (df-5).
+
+**ADR-0056 D5 — Per-PR review-agent cadence.** `.claude/agents/security.md` loads `constitution/threat-model.md` on every PR. Implementing once ADR-0046 is Accepted and `security.md` is authored. Deferred to ADR-0046 scope-out (df-6).
+
+**ADR-0056 D7 — SBOM generation per release.** Tool selection deferred — "becomes a follow-up ADR or a hive-sync-driven amendment to ADR-0035." Deferred to a follow-up ADR (df-7).
+
+## Constraints
+- **Planning inputs, not assigned work.** Owning tracks consume the trigger list when they next plan work; this packet does not file PRs or issues against them.
+- **Two surfaces kept consistent.** `initiatives/active-initiatives.md` and `constitution/threat-model.md` section 9 list the same items; phrasing may differ.
+- **Artifact is authoritative for currently-open mitigations.** If section 9 has extra items beyond the seven, this packet leaves them in place. If section 9 is missing items the dispatch plan deferred, this packet adds them.
+- **Forward-only.** This packet does not back-fill deferrals for earlier ADRs; it covers only ADR-0056's deferrals.
+- **The format matches the existing initiative-tracking convention.** See the ADR-0044 initiative block in `active-initiatives.md` for the precedent.
+
+## Labels
+`chore`, `tier-3`, `meta`, `security`, `docs`, `adr-0056`, `wave-5`
+
+## Agent Handoff
+
+**Objective:** Register the seven deferred follow-up triggers from ADR-0056 in `initiatives/active-initiatives.md` (and reconcile with `constitution/threat-model.md` section 9), so the deferrals surface at the right Node-standup or sibling-ADR planning moment.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the dispatch plan's "Coupling with not-yet-stood-up Nodes" deferrals visible at the next planning moment, not lost in completed-initiative folders.
+- Feature: ADR-0056 Threat Model and Security Review Cadence rollout, Wave 5.
+- ADRs: ADR-0056 D9 / D10 / D7 (sources of the deferrals); ADR-0016 (AI Node track); ADR-0017 (Capabilities standup); ADR-0006 (Vault rotation); ADR-0031 (Audit Phase-2); ADR-0046 (specialist review agents); ADR-0035 (versioning / SBOM possible home).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — hard. The artifact's section 9 (open mitigations) is populated; this packet keeps the two surfaces consistent.
+- `packet:03` — soft. The standup-template + hive-sync extension is in place; future AI-sector standups and Audit Phase-2 work will be readable against both surfaces.
+
+**Constraints:**
+- Planning inputs, not assigned work — no PR filed against any owning track.
+- Two surfaces kept consistent; artifact is authoritative for currently-open mitigations.
+- Forward-only — covers only ADR-0056's deferrals.
+- Format matches existing initiative-tracking convention.
+
+**Key Files:**
+- `initiatives/active-initiatives.md`
+- Optional: `constitution/threat-model.md` (consistency reconciliation only)
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0056-threat-model/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/dispatch-plan.md
@@ -1,0 +1,143 @@
+# Dispatch Plan — ADR-0056: Threat Model and Security Review Cadence
+
+**Initiative:** `adr-0056-threat-model`
+**ADR:** ADR-0056 (Proposed → Accepted via packet 00)
+**Sector:** Meta / Security / cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0056 is the **integration layer for the Grid's security slices**: STRIDE-per-trust-boundary methodology with an AI-specific overlay (D1), a 10-entry trust-boundary inventory (D2), an asset classification crossing ADR-0049 sensitivity and ADR-0036 RPO/RTO (D3), a single living artifact at `constitution/threat-model.md` (D4), four review cadences (D5), a three-layer pentest posture (D6), Dependabot + SBOM (D7), GitHub secret scanning + a found-secret rotation runbook (D8), eight named AI threats with concrete mitigations (D9), incident-response coupling (D10), responsible disclosure via `SECURITY.md` (D11), explicit-and-rationaled compliance posture (D12), preservation of every existing slice-ADR (D13), and a six-phase rollout (D14).
+
+The ADR adds three invariants: (a) every Node standup ADR includes a "threat model entry" section; (b) LLM calls use a typed-channel `PromptEnvelope` pattern; (c) high-blast-radius agent actions route through PR-discipline or Operator confirmation, never direct execution.
+
+This initiative ships **the substrate, the governance plumbing, the security-tooling enablement, and the operator runbooks that integrate the existing slice-ADRs**. It deliberately **does not** retrofit AI-specific code into not-yet-stood-up Nodes (Capabilities, Operator, parts of AI), Audit's investigation-extended-retention export interface, or Vault's tighter model-key rotation cadence — those land in the owning Nodes' own work tracks per the Grid's "standup gets its own ADR / don't bundle into feature packets" rule. Packet 09 registers the cross-track follow-up triggers so the deferrals are tracked, not forgotten.
+
+**10 packets across 5 waves**, targeting **2 repos** (`HoneyDrunk.Architecture` x9, `HoneyDrunk.Actions` x1). 10 `Actor=Agent`, 0 `Actor=Human`. Five packets carry Human Prerequisites — the most consequential are in packets 04 (org-level `SECURITY.md` creation in `HoneyDrunkStudios/.github`, `security@honeydrunkstudios.com` mailbox provisioning), 07 (pentest-firm shortlist + DIY tooling install), and 08 (Dependabot enablement scope decision, GitHub Advanced Security cost-tier decision, initial historical-secret-scan triage).
+
+## Trigger
+
+ADR-0056 is Proposed with no scope. Forcing functions from the ADR's Context: (a) **ADR-0046's specialist `security` review agent needs a substrate** — without the artifact, the agent pattern-matches; with it, the agent runs threat-modeled review. (b) **Notify.Cloud GA (PDR-0002) is the meaningful attack-surface expansion** — first commercial product, first tenant-bearing traffic, first regulatory exposure. (c) **The AI sector introduces nine Nodes with novel threat categories** that conventional STRIDE doesn't cover by construction. (d) **Cross-ADR mitigation drift is invisible without a substrate** — ADR-0006 rotation and ADR-0030 audit-retention windows could disagree silently today. (e) **Compliance posture conversations are imminent** — enterprise prospects will ask "do you have a threat model" and "what's your security review cadence" in due diligence; an honest written answer beats improvising under sales pressure.
+
+## Scope Detection
+
+**Multi-repo, governance-heavy.** Nine packets land in `HoneyDrunk.Architecture` (acceptance/invariants, the artifact at `constitution/threat-model.md`, standup-template + hive-sync extension, `SECURITY.md` content, security-incident runbook extensions in `business/context/`, found-secret rotation runbook, pentest-and-DIY-probe playbook, the cross-track follow-up tracker). One packet lands in `HoneyDrunk.Actions` (Dependabot enablement + critical-CVE auto-issue-packet wiring + secret-scanning verification — the CI/CD-control-plane surface per ADR-0012 invariants).
+
+**Deliberate deferrals to owning-Node tracks (registered in packet 09, not scoped as packets here):**
+
+- **AI-1 `PromptEnvelope` typed-channel pattern + analyzer rule** in `HoneyDrunk.AI`. ADR-0016 is Accepted but the Node is Seed; the `PromptEnvelope` shape is `HoneyDrunk.AI`'s own work, sequenced when an LLM-calling consumer needs it. Pre-writing a packet against a Seed-phase abstraction-only Node is premature decomposition.
+- **AI-4 immutable-tool-description-per-release** in `HoneyDrunk.Capabilities`. ADR-0017 standup is Proposed — Capabilities Node does not yet exist as shipped code. The immutability commitment lands at standup as a designed-in invariant, not retrofit. Belongs to ADR-0017's track.
+- **AI-7 high-blast-radius routing** in `HoneyDrunk.Capabilities`. Same — capability-side wiring requires the capability registry to exist. Standup-time concern.
+- **AI-8 tighter model-key rotation cadence** (90-day max vs general 180-day default) in `HoneyDrunk.Vault`. Belongs in Vault's rotation-policy track / a Vault.Rotation follow-up, not in this initiative — the rotation policy is ADR-0006's mechanism, this ADR just names a tighter cadence for the specific secret class.
+- **D10 investigation-extended-retention export interface** in `HoneyDrunk.Audit`. ADR-0031 Audit standup is Accepted and v0.1.0 is published; the export interface is a Phase-2 Audit enhancement, not in this initiative's scope. Belongs to a future Audit packet driven by an actual investigation event or by Audit's own Phase-2 plan.
+- **`.claude/agents/security.md` updates** to load the artifact on every PR. ADR-0046 (specialist review agents) is Proposed — `security.md` does not yet exist in `.claude/agents/`. The artifact-as-input wiring lands when ADR-0046 is Accepted and the agent file is authored, as part of that initiative. Packet 09 registers the cross-track hook so ADR-0046's scope-out work knows to consume `constitution/threat-model.md` as input context.
+- **SBOM tooling selection and `HoneyDrunk.Actions` reusable-workflow integration.** D7 explicitly defers the tool decision ("becomes a follow-up ADR or a hive-sync-driven amendment to ADR-0035"). This initiative does not pick the tool. Packet 09 registers the follow-up.
+
+**No new-Node scaffolding.** Every target repo is live: `HoneyDrunk.Architecture` (governance) and `HoneyDrunk.Actions` (CI/CD control plane). No empty cataloged repo is touched.
+
+## Wave Diagram
+
+### Wave 1 (No Dependencies — governance + invariants)
+- [ ] **00** — Architecture: Accept ADR-0056, add the three threat-model invariants (numbers `{N1}/{N2}/{N3}` — claimed at edit time from `constitution/invariant-reservations.md`), register the initiative. `Actor=Agent`.
+
+### Wave 2 (Depends on Wave 1 — the artifact shell)
+- [ ] **01** — Architecture: Author `constitution/threat-model.md` v0 — header, methodology recap, full D2 boundary inventory, full D3 asset table, stub STRIDE-pass subsections per TB (six bullets each with "TBD" entries and target dates), stub AI-overlay subsections, empty accepted-risk + pentest-history + open-mitigations sections, references. `Actor=Agent`. Blocked by: 00.
+
+### Wave 3 (Depends on Wave 2 — fill the artifact + governance plumbing, parallel)
+- [ ] **02** — Architecture: Fill `constitution/threat-model.md` v1 — every TB-N gets a real STRIDE pass with mitigation entries cross-referencing the slice-ADRs; every AI-N gets a mitigation entry; asset-table threat-ID cross-references filled. `Actor=Agent`. Blocked by: 01.
+- [ ] **03** — Architecture: Amend the standup-ADR template to require a "threat model entry" section + extend `hive-sync` to fail on standup-ADR-vs-artifact Node-list drift. `Actor=Agent`. Blocked by: 01.
+- [ ] **04** — Architecture: Author org-level `SECURITY.md` content + per-public-repo `SECURITY.md` copy template + 90-day disclosure commitment + safe-harbor language + out-of-scope list. `Actor=Agent`. Blocked by: 00.
+
+### Wave 4 (Depends on Wave 1 — operator runbooks + tooling enablement, parallel)
+- [ ] **05** — Architecture: Author the security-incident-response extensions in `business/context/` — SEV-1 default, tenant-notification path (GDPR 72h alignment), forensic-preservation hold, security post-mortem amendment section. `Actor=Agent`. Blocked by: 00.
+- [ ] **06** — Architecture: Author the found-secret rotation runbook in `business/context/` — 1-hour high-sensitivity / 4-hour lower-sensitivity time-to-rotation targets, pre-staged rotation commands per secret class, history-rewrite-is-cosmetic posture. `Actor=Agent`. Blocked by: 00.
+- [ ] **07** — Architecture: Document the pentest-engagement scoping prep (firm-selection criteria, scope-for-pre-GA engagement) + DIY adversarial-probe playbook (OWASP ZAP, Burp Community, prompt-injection corpus). `Actor=Agent`. Blocked by: 02.
+- [ ] **08** — Actions: Enable Dependabot Grid-wide (security alerts + auto-PR for patches, human merge for minor/major) + wire the critical-CVE → auto-issue-packet flow + verify GitHub secret scanning + push protection enabled Grid-wide. `Actor=Agent`. Blocked by: 00.
+
+### Wave 5 (Depends on Wave 3 — cross-track follow-up tracker)
+- [ ] **09** — Architecture: Register the cross-track follow-up triggers — AI's `PromptEnvelope` work, Capabilities' immutable-tool-description and high-blast-radius routing, Vault's tighter model-key rotation cadence, Audit's investigation-extended-retention export, ADR-0046's `security.md` artifact-loading wiring, SBOM tool selection — as a tracked list in `initiatives/active-initiatives.md` so the deferrals surface at the right Node-standup or sibling-ADR moment. `Actor=Agent`. Blocked by: 02, 03.
+
+Packets within a wave run in parallel. Wave 4 packets 05/06/07/08 depend only on packet 00 (or packet 02 for 07's pentest-scoping which wants the boundary inventory finalized) and run fully parallel with Wave 3. They are grouped into Wave 4 for tidy filing; the `dependencies:` frontmatter is the real ordering signal.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0056](./00-architecture-adr-0056-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [Threat-model artifact v0 shell](./01-architecture-threat-model-artifact-v0.md) | Architecture | Agent | 2 | 00 |
+| 02 | [Threat-model artifact v1 content](./02-architecture-threat-model-artifact-v1.md) | Architecture | Agent | 3 | 01 |
+| 03 | [Standup-ADR template + hive-sync extension](./03-architecture-standup-template-and-hive-sync.md) | Architecture | Agent | 3 | 01 |
+| 04 | [SECURITY.md authoring](./04-architecture-security-md-authoring.md) | Architecture | Agent | 3 | 00 |
+| 05 | [Security incident runbook extensions](./05-architecture-security-incident-runbook.md) | Architecture | Agent | 4 | 00 |
+| 06 | [Found-secret rotation runbook](./06-architecture-found-secret-rotation-runbook.md) | Architecture | Agent | 4 | 00 |
+| 07 | [Pentest scoping + DIY adversarial probe playbook](./07-architecture-pentest-and-diy-probe-playbook.md) | Architecture | Agent | 4 | 02 |
+| 08 | [Dependabot + secret-scanning Grid-wide enablement](./08-actions-dependabot-and-secret-scanning.md) | Actions | Agent | 4 | 00 |
+| 09 | [Cross-track follow-up tracker](./09-architecture-cross-track-followup-tracker.md) | Architecture | Agent | 5 | 02, 03 |
+
+## Version Bumps
+
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution. Governance, doc, catalog edits only.
+- **`HoneyDrunk.Actions`** — not a versioned .NET solution. Workflow/YAML changes + GitHub repo settings. Repo `CHANGELOG.md` updated per the repo convention if it keeps one for the workflow surface.
+
+No NuGet version bumps in this initiative. No `## NuGet Dependencies` section is load-bearing on any packet.
+
+## Cross-Cutting Concerns
+
+### Coupling with ADR-0046 (`security` review agent) — soft, registered
+
+ADR-0046 is **Proposed**, not Accepted, and `.claude/agents/security.md` does not yet exist in this repo. ADR-0056 D5 says the per-PR cadence loads the threat-model artifact "as input context" — that wiring belongs to ADR-0046's scope-out work, not this initiative. Packet 09's tracker registers the hook so ADR-0046's authors know to (a) load `constitution/threat-model.md` on every PR and (b) flag novel-boundary-not-in-model and mitigation-drift-from-model — the substance D5 commits the agent to.
+
+**Why not block this initiative on ADR-0046 acceptance:** the artifact is operationally useful for the **operator** (quarterly review, per-Node standup, per-dependency-upgrade) and for the **review agents that already exist** (the canonical `review.md` rubric already has security categories; it can cross-reference the artifact even before a specialist `security.md` ships). Decoupling lets the artifact land and exercise the operator-side cadences while ADR-0046 sequences independently.
+
+### Coupling with not-yet-stood-up AI-sector Nodes
+
+D9's AI-1 / AI-4 / AI-7 protections require code in `HoneyDrunk.AI` (Seed) and `HoneyDrunk.Capabilities` (Proposed standup ADR-0017, no shipped Node). Per the Grid's New-Node-scaffold convention, retrofitting `PromptEnvelope` into AI before AI has a real consumer, or pre-writing capability-side wiring before Capabilities is stood up, is premature decomposition. The AI overlay sections in the artifact (packet 02) cite the threats and the **named mitigations**, marking them as "implementing ADR(s): ADR-0017 D… / ADR-0056 D9 — pending capability standup." When ADR-0017's standup track lands, that track inherits the threat-model entry's commitments. Packet 09 registers the trigger.
+
+### Coupling with ADR-0006 secret rotation and ADR-0031 Audit
+
+- **ADR-0006 (Accepted) — model-key tighter rotation cadence (AI-8).** Vault's rotation defaults are 180-day general / 90-day for the model-key class per D9 AI-8. This is a one-line Vault-rotation-policy amendment, not a major Vault work item. **Deferred** to a Vault-rotation follow-up packet (or a Vault.Rotation initiative the operator already owns). Packet 09 registers it.
+- **ADR-0031 (Accepted, v0.1.0 shipped) — investigation-extended-retention export.** D10 asks Audit for an export-with-no-expiry path for an active investigation. Audit v0.1.0 ships `IAuditLog`/`IAuditQuery`/`AuditEntry` and a Data-backed impl; the export-and-hold interface is an additive read-side feature. **Deferred** to an Audit follow-up packet. Packet 09 registers it. The artifact (packet 02) records the dependency in the D10 mitigation entry as "Audit: investigation-extended-retention export — pending Audit Phase-2."
+
+### Coupling with ADR-0040 (telemetry) and ADR-0050 (customer comms) — read-only
+
+D3's asset table cross-references ADR-0036 RPO/RTO and ADR-0049 sensitivity classes. ADR-0036 and ADR-0049 are Proposed. The artifact (packet 02) records the cross-references as live citations; if those ADRs are amended before this initiative completes, the artifact's quarterly review will catch the drift. ADR-0050 (Tenant lifecycle) is referenced from D10 for the tenant-notification path; same Proposed status, same posture.
+
+**No hard blocker.** This initiative's packets do not depend on ADR-0036/0049/0050 acceptance — they cross-reference whatever those ADRs ultimately decide and the artifact is the integration substrate by design.
+
+### `business/context/` — operator-context location convention
+
+Three packets (05, 06, 07) write to `business/context/`. Per the memory note on user feedback and the precedent set by ADR-0040 packet 08 / ADR-0045 packet 06, this is where operational runbooks and operator-facing context notes live. Each packet's `Proposed Implementation` specifies the file path; the precedent of "extend an existing related note if one exists, otherwise create a new file" is preserved.
+
+### Site sync
+
+No site-sync flag. ADR-0056 is internal Meta/Security governance — no public-facing Studios website content changes. The org-level `SECURITY.md` lives in `HoneyDrunkStudios/.github`, not in Studios.
+
+### Compliance posture — D12 is decision-of-record, not work
+
+ADR-0056 D12 commits to **not** pursuing SOC 2 / ISO 27001 at v1 and records the conditions under which the question is reopened. No packet in this initiative pursues certification. If a D12 trigger fires (enterprise LOI conditional on SOC 2, regulated-vertical customer, ~10 paying enterprise tenants without SOC 2), the conversation reopens via a new ADR amendment. The artifact's references section (packet 02) records the D12 rationale for prospect-due-diligence conversations.
+
+### Invariant numbering
+
+The verified current maximum accepted invariant in `constitution/invariants.md` is **53**. ADR-0056 adds **three** invariants. The numbers are **claimed at edit time** from `constitution/invariant-reservations.md`, not hardcoded in this dispatch plan — that file is the single source of truth for in-flight reservations and prevents collisions across concurrently-Proposed ADRs. Packet 00's executor reads `constitution/invariant-reservations.md`, picks the next free contiguous block of size 3 above the highest existing reservation, adds a row to that file's **Active Reservations** table in the same PR that writes the new invariants, and references the claimed numbers as `{N1}/{N2}/{N3}` throughout the packet body. As of authoring time, ADR-0051 holds 54–57 and ADR-0049 holds 58–60 in `invariant-reservations.md`, so the next free block is **61–63** — but the executor re-reads the file at edit time in case other ADRs have landed reservations since.
+
+## Rollback Plan
+
+- **Packet 00 (governance + invariants):** revert the PR. ADR-0056 returns to Proposed; the three threat-model invariants are removed; the initiative entry is removed. No runtime impact.
+- **Packet 01 (artifact v0 shell):** revert the PR. `constitution/threat-model.md` is deleted. No downstream consumer yet — review agents fall back to their pre-artifact behavior (which is the current state).
+- **Packet 02 (artifact v1 content):** revert the PR. The artifact rolls back to v0 stubs. The operator's quarterly-review cadence still has a substrate, just an emptier one.
+- **Packet 03 (standup-template + hive-sync):** revert the PR. Standup-ADR template loses the "threat model entry" requirement; `hive-sync` loses the drift-detection scan. Existing accepted standup ADRs are unaffected.
+- **Packet 04 (`SECURITY.md`):** revert the PR. The org-level `SECURITY.md` file is removed; per-repo copies are removed. Researchers fall back to no published disclosure path — recorded as a security regression in the artifact's accepted-risk log if the revert sticks.
+- **Packet 05 (incident runbook extensions):** revert the PR. The security-specific incident-response extensions leave `business/context/`. The broader incident matrix (ADR-0054 — Proposed) is unaffected.
+- **Packet 06 (found-secret runbook):** revert the PR. The pre-staged rotation commands and time-to-rotation targets leave `business/context/`. The operator falls back to ADR-0006's general rotation mechanics.
+- **Packet 07 (pentest + DIY playbook):** revert the PR. The pentest-scoping note and DIY-probe playbook leave `business/context/`. The pre-GA pentest engagement is then ungated until re-applied.
+- **Packet 08 (Dependabot + secret scanning Grid-wide):** Dependabot configuration files (`.github/dependabot.yml` per repo) can be reverted per repo; the GitHub-side Dependabot/secret-scanning *enablement* is an org-setting that the operator must toggle off in the GitHub Settings UI if revert is needed. The auto-issue-packet workflow can be disabled via its `on:` block. **Reverting is a multi-surface operation** — the runbook in packet 08 documents the exact toggle list.
+- **Packet 09 (cross-track follow-up tracker):** revert the PR. The deferred-trigger list leaves `initiatives/active-initiatives.md`. The deferrals are then carried only in the dispatch-plan / packet bodies — readable but less prominent.
+- **Operational escape hatch for the artifact:** if the artifact develops a defect that affects the review agent or operator confidence, the operator's quarterly-review process is the corrective surface — fix in place, version-bump the artifact's header date, commit. No full revert needed for normal artifact maintenance.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.
+
+The `dependencies:` array uses `packet:NN` qualified references within this folder. No cross-initiative dependencies are wired (ADR-0046 is referenced only as a soft narrative coupling).

--- a/generated/issue-packets/active/adr-0056-threat-model/handoff-wave2-artifact-bootstrap.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/handoff-wave2-artifact-bootstrap.md
@@ -1,0 +1,62 @@
+# Handoff — Wave 1 → Wave 2: artifact bootstrap
+
+**Initiative:** `adr-0056-threat-model`
+**Wave transition:** Wave 1 (governance + invariants) → Wave 2 (artifact v0 shell)
+**Read once at the wave boundary. Immutable per invariant 24.**
+
+## What Wave 1 produced
+
+- **Packet 00** — ADR-0056 flipped to **Accepted**. A block of three invariant numbers was claimed at edit time from `constitution/invariant-reservations.md` (referred to as `{N1}/{N2}/{N3}` in the packet bodies; substitute the actual claimed numbers when reading this handoff post-merge). Three new threat-model invariants were added to `constitution/invariants.md` under a new `## Security and Threat Model Invariants` section at those numbers. The verified current max accepted invariant in `invariants.md` at scope time was **53**; reservations beyond that live in `invariant-reservations.md` and are the source of truth for the actual numbers chosen.
+  1. **`{N1}`** — Every Node standup ADR includes a "threat model entry" section, and the artifact is updated in the same PR that moves the standup ADR to Accepted. Enforced by `hive-sync` constitution scan (packet 03 implements the scan).
+  2. **`{N2}`** — LLM calls use the `PromptEnvelope` typed-channel pattern; direct string concatenation of untrusted input into a prompt is a CI gate failure. Implementing in HoneyDrunk.AI (deferred — see Cross-track follow-ups below).
+  3. **`{N3}`** — High-blast-radius agent actions route through PR-discipline (ADR-0044) or Operator confirmation (ADR-0051), never direct execution. Implementing in HoneyDrunk.Capabilities (deferred — see Cross-track follow-ups below).
+
+ADR-0056's decisions are now live rules. Every packet in this initiative from Wave 2 onward references the ADR's D-decisions as live policy.
+
+## What Wave 2 must deliver (packet 01)
+
+Build the v0 shell of `constitution/threat-model.md`:
+
+- **Section 1 (Header)** — version v0, methodology line, last-reviewed = this packet's merge date, last-quarterly-review = n/a, next-quarterly-review calendared for the first week of the next quarter.
+- **Section 2 (Methodology recap)** — short paragraph; points at ADR-0056 D1 for the rationale.
+- **Section 3 (Trust boundary inventory)** — full 10-row table reproduced verbatim from ADR-0056 D2.
+- **Section 4 (Asset inventory)** — full 12-row table reproduced verbatim from ADR-0056 D3, with a placeholder `Threat IDs` column (TBD entries — packet 02 fills).
+- **Section 5 (STRIDE pass per boundary)** — ten subsections, one per TB-N, each with six TBD bullets (S/T/R/I/D/E) carrying "target: Phase 2 / packet 02" markers.
+- **Section 6 (AI-specific threats)** — eight subsections, one per AI-N, each TBD with the same target marker; AI-1, AI-4, AI-7 carry the deferred-to-owning-Node-track note.
+- **Sections 7, 8, 9** — empty placeholder sections with the v0 smell-notes per packet 01's Proposed Implementation.
+- **Section 10 (References)** — citations to ADR-0056, ADR-0049, ADR-0036, the slice-ADRs, NIST AI RMF, OWASP LLM Top 10, OWASP Top 10, CWE Top 25, MITRE ATLAS.
+
+## Critical context for Wave 2 execution
+
+- **Structure-first, content is packet 02.** Every STRIDE bullet and every AI-N entry is TBD in packet 01. Do not pre-fill content. The split lets packet 03 (hive-sync extension) author against a deterministic shape; the structure is the deliverable for packet 01.
+- **Reproduce D2 and D3 verbatim.** The 10 boundaries and 12 assets come from ADR-0056; do not paraphrase or reorder rows.
+- **Cross-reference convention.** `per ADR-NNNN DN` throughout. ADR-0056 D4 is explicit about this — the artifact will be grepped for impact-analysis when ADRs are amended.
+- **Markdown only.** No `.tm7`, no IriusRisk, no ThreatDragon JSON. ADR-0056 D4's explicit rejection.
+- **The artifact does not duplicate ADR content.** Future mitigation entries (packet 02) say "Vault enforces per-Node Key Vaults with managed-identity bootstrap per ADR-0006 D2" — they do not re-explain managed identity. Same posture in v0: stub entries reference the implementing ADR by anchor, not by retell.
+
+## Invariants binding Wave 2
+
+- **Invariant 93** — the artifact's existence is what makes invariant 93 enforceable. Packet 03 (Wave 3) implements the `hive-sync` scan; packet 01 lands the substrate.
+- **Invariant 94** — `PromptEnvelope` typed-channel pattern. Tracked at v0 in section 6 as AI-1 (deferred to HoneyDrunk.AI track). Packet 01 records the deferral; packet 02 surfaces the residual risk; packet 09 registers the trigger.
+- **Invariant 95** — High-blast-radius routing. Tracked at v0 in section 6 as AI-7 (deferred to HoneyDrunk.Capabilities standup). Same deferral pattern as 94.
+
+## Wave 2 acceptance gate
+
+Packet 01's PR passes the `pr-core.yml` tier-1 gate. `constitution/threat-model.md` exists with the v0 shell — 10 sections, boundary inventory + asset table filled, all STRIDE/AI bullets stubbed with target-markers, placeholder sections for accepted-risks / pentest-history / open-mitigations with v0 smell-notes.
+
+After Wave 2, Wave 3 starts in parallel:
+- **Packet 02** (content fill) — depends on packet 01.
+- **Packet 03** (standup-template + hive-sync extension) — depends on packet 01.
+- **Packet 04** (`SECURITY.md` authoring) — depends only on packet 00 (already landed); could start in Wave 2 in parallel with 01, but grouped into Wave 3 in the dispatch plan for tidy filing.
+
+## Cross-track follow-ups (deferred — see packet 09 for the tracker)
+
+Wave 2 does not deliver these — they are owned by other tracks. Listed here so the Wave 2 executor knows what is **not** in scope:
+
+- **df-1 `PromptEnvelope` typed-channel pattern + analyzer rule** — HoneyDrunk.AI Node track (post-Seed). Tracked at packet 01 / 02 in section 6 AI-1.
+- **df-2 Immutable-tool-description-per-release** — ADR-0017 standup initiative. Tracked in section 6 AI-4.
+- **df-3 High-blast-radius capability-side routing** — same as df-2. Tracked in section 6 AI-7.
+- **df-4 Model-key 90-day rotation cadence** — Vault.Rotation follow-up. Tracked in section 6 AI-8.
+- **df-5 Investigation-extended-retention export** — HoneyDrunk.Audit Phase-2. Tracked in section 5 TB-3 (R) + section 6 D10 reference.
+- **df-6 `.claude/agents/security.md` loads artifact** — ADR-0046 scope-out initiative. Tracked in section 2 / packet 02 references.
+- **df-7 SBOM tool selection** — follow-up ADR or ADR-0035 amendment. Tracked in section 9 (open mitigations) once packet 02 fills it.

--- a/generated/issue-packets/active/adr-0056-threat-model/handoff-wave4-operator-and-tooling.md
+++ b/generated/issue-packets/active/adr-0056-threat-model/handoff-wave4-operator-and-tooling.md
@@ -1,0 +1,94 @@
+# Handoff — Wave 3 → Wave 4: operator runbooks + Grid-wide security tooling
+
+**Initiative:** `adr-0056-threat-model`
+**Wave transition:** Wave 3 (artifact v1 + governance plumbing + `SECURITY.md`) → Wave 4 (operator runbooks + tooling enablement)
+**Read once at the wave boundary. Immutable per invariant 24.**
+
+## What Wave 3 produced
+
+- **Packet 02 — `constitution/threat-model.md` v1.** Every TBD in v0 is replaced with a real mitigation entry. 60 STRIDE bullets across TB-1 through TB-10 cite the implementing slice-ADRs (ADR-0006, ADR-0010, ADR-0011, ADR-0015, ADR-0026, ADR-0028, ADR-0030, ADR-0033, ADR-0040, ADR-0041, ADR-0044, ADR-0045, plus Proposed-status ADRs 0046/0049/0050/0051/0052/0054). 8 AI-overlay entries fill section 6, with AI-1/AI-4/AI-7/AI-8 explicitly named as deferred to owning-Node tracks and the residual risk of each deferral spelled out. The asset table's `Threat IDs` column is populated. Header bumped to v1; last-reviewed = packet 02's merge date.
+- **Packet 03 — Standup-ADR template + `hive-sync` extension.** The canonical standup-ADR authoring guidance now requires a "threat model entry" section. `hive-sync.md` has a new sub-scan: standup-ADR-vs-artifact Node-list consistency, with the pre-invariant-93 backfill exemption (Accepted standups before packet 00's merge date are not retroactively flagged). Invariant 93 is now enforceable at authoring time (the template) and at scan time (`hive-sync`).
+- **Packet 04 — `SECURITY.md` authoring.** Org-level `SECURITY.md` lands at `HoneyDrunkStudios/.github/SECURITY.md` (may have required Human Prerequisite for the `.github` meta-repo creation). Disclosure email `security@honeydrunkstudios.com`, 90-day window, Disclose.io core safe-harbor text verbatim, explicit out-of-scope list, no-bug-bounty-at-v1. Per-public-repo template is in this repo's templates location for future divergence; no per-repo PRs filed.
+
+ADR-0056's substrate is now operationally useful for the operator's quarterly review (D5) and for the canonical review agents that read `constitution/threat-model.md` from this point on.
+
+## What Wave 4 must deliver (packets 05, 06, 07, 08)
+
+**Packet 05 — Security incident response runbook extensions** in `business/context/`:
+- SEV-1 default with legitimate/illegitimate downgrade examples.
+- Tenant notification: 72-hour GDPR window as the cross-jurisdictional default, via `ICommunicationOrchestrator` per ADR-0019, content aligning with ADR-0050.
+- Forensic preservation hold: extends the 730-day audit retention during active investigation; export-and-hold mechanism is **pending Audit Phase-2** with an interim manual-export-to-Blob note.
+- Post-mortem threat-model-amendment section: three-question prompt; `generated/incidents/_template.md` extended (Option A default) or `_template-security.md` variant (Option B).
+
+**Packet 06 — Found-secret rotation runbook** in `business/context/`:
+- Response posture: rotation, not deletion; history rewriting cosmetic.
+- 1-hour high-sensitivity / 4-hour lower-sensitivity time-to-rotation targets; time starts at detection.
+- Pre-staged concrete commands per secret class (model API keys for each provider, Stripe production keys, Azure subscription credentials, Auth signing keys, then SaaS keys at lower sensitivity).
+- Universal rotation sequence: rotate at source → update Vault → confirm in use → address git history (cosmetic) → log incident.
+
+**Packet 07 — Pentest scoping prep + DIY adversarial-probe playbook** in `business/context/`:
+- Pentest scoping: firm-selection criteria; pre-Notify-Cloud-GA scope (TB-1 through TB-4 + auth probe); $5–15K budget per ADR-0052; deliverable expectations; annual cadence with skipped-year accepted-risk posture.
+- DIY playbook: quarterly cadence; concrete OWASP ZAP + Burp Community + Garak / PromptInject steps; result-recording template; "DIY is not a substitute" framing.
+
+**Packet 08 — `HoneyDrunk.Actions` Grid-wide security tooling enablement**:
+- Canonical `dependabot.yml` template at `templates/dependabot.yml` — auto-PR for patches, no auto-merge anywhere, weekly cadence, NuGet + github-actions ecosystems baseline.
+- Scaffolded `job-cve-to-packet.yml` reusable workflow consuming Dependabot alerts and authoring critical-severity packets via `file-packets.yml`.
+- Operator playbook at `docs/security-tooling-enablement.md` documenting the GitHub Settings-UI toggles (Dependabot alerts, secret scanning, push protection, CodeQL on public repos) + GHAS cost-tier note + backlog burn-down expectations.
+
+## Critical context for Wave 4 execution
+
+- **Packets 05-08 are parallel.** None depends on another within Wave 4. Packet 07 depends on packet 02 (v1 artifact); packets 05/06/08 depend only on packet 00.
+- **`business/context/` location convention.** Three packets (05, 06, 07) write to `business/context/`. The convention from ADR-0040 packet 08 / ADR-0045 packet 06 is: extend an existing related file if one exists; otherwise create new. Verify at edit time.
+- **Audit Phase-2 dependency is named, not silent.** Packet 05's forensic-preservation export is **pending Audit Phase-2** (df-5 in packet 09's tracker). The runbook names this explicitly and ships an interim manual-export workaround.
+- **Operator portal preference.** Per the memory note, the operator prefers portal-first over CLI. Packet 08's tooling-enablement playbook documents the Settings-UI clicks; packet 06's pre-staged commands include portal URLs first, CLI commands second.
+- **No real secret values in packet 06.** Per invariant 8 (referenced in packet 00's invariant 95 context). Pre-staged commands use placeholders and Vault secret names; portal links retrieve new values.
+- **Critical-only auto-create in packet 08.** High / Medium / Low severities ride Dependabot's standard PR flow without packet creation. Critical alone gets the auto-issue-packet. ADR-0056 D7 is explicit.
+- **No auto-merge anywhere.** Patch-version Dependabot PRs go through review per ADR-0044 invariant 52. The `dependabot.yml` allows auto-PR but never auto-merge.
+
+## Human Prerequisites surfaced across Wave 4
+
+Wave 4 carries the most consequential Human Prerequisites in the initiative:
+
+- **Packet 04 (already landed in Wave 3) Human Prerequisites:** `HoneyDrunkStudios/.github` meta-repo creation; `security@honeydrunkstudios.com` email alias; PGP key setup (optional); Disclose.io text re-verification.
+- **Packet 06 Human Prerequisites:** verify current high-sensitivity secret inventory; re-verify portal URLs.
+- **Packet 07 Human Prerequisites:** engaging a specific pentest firm (gated on Notify.Cloud GA decision); installing OWASP ZAP + Burp Community + Garak / PromptInject; provisioning `dev` test user / tenant; verifying Garak / PromptInject project state.
+- **Packet 08 Human Prerequisites:** **largest portal-click surface in the initiative** — enable Dependabot alerts org-wide + Dependabot security updates + dependency graph + secret scanning + push protection + CodeQL on public repos. Decide GHAS cost-tier for private repos. Triage initial 50-200 alerts and historical secret-scan results.
+
+These are operator actions. Packets 05-08 do not block on them — the runbooks/playbooks ship and the operator follows when ready. Filing of the packets as GitHub issues will create board items that surface the Human Prerequisites as checklist items on each issue.
+
+## Invariants binding Wave 4
+
+- **Invariant 8** — Secret values never appear in logs, traces, exceptions, or telemetry — **or in committed runbook files.** Packet 06 uses placeholders and Vault secret names; never real secret values.
+- **Invariant 17** — One Key Vault per deployable Node per environment. Packet 06's rotation sequence respects per-Node / per-env Vault scoping (`kv-hd-{service}-{env}`).
+- **Invariant 22** — Diagnostic settings route Key Vault audit to Log Analytics. Packet 06's "confirm rotated credential is in use" step reads from Vault's audit logs.
+- **Invariant 41** — Preference enforcement / cadence rules / suppression for outbound messages live in Communications, not in Notify. Packet 05's breach-notification path uses Communications' `ICommunicationOrchestrator`, not Notify directly.
+- **Invariant 42** — Every orchestrated send records a decision-log entry via `ICommunicationDecisionLog`. Breach notifications are no exception.
+- **Invariant 47** — Durable audit emission via `IAuditLog`. Rotation events and breach-notification events are recorded automatically.
+- **Invariant 52** — Every non-draft PR on an enabled repo runs the review agent. Dependabot PRs are not exempt — they run through the same review surface. Packet 08's `dependabot.yml` explicitly excludes auto-merge to preserve this.
+
+## Wave 4 acceptance gate
+
+Each Wave 4 packet passes the `pr-core.yml` tier-1 gate (or, for packet 08 in `HoneyDrunk.Actions`, the equivalent CI gate for that repo). After Wave 4:
+
+- The operator has runbooks for: security incidents (packet 05), found-secret rotation (packet 06), pentest scoping + DIY probes (packet 07).
+- The CI/CD control plane has: canonical `dependabot.yml`, scaffolded auto-CVE-packet workflow, security-tooling enablement playbook (packet 08).
+- The artifact's quarterly-review cadence is fully operational.
+
+Wave 5 (packet 09 — cross-track follow-up tracker) closes the initiative by registering the seven deferred items in `initiatives/active-initiatives.md` and reconciling with `constitution/threat-model.md` section 9.
+
+## What is NOT in Wave 4 (or anywhere in this initiative)
+
+These remain deferred. Wave 4 does not produce them:
+
+- AI-1 `PromptEnvelope` code in HoneyDrunk.AI (df-1; HoneyDrunk.AI track).
+- AI-4 immutable-tool-description code in HoneyDrunk.Capabilities (df-2; ADR-0017 standup).
+- AI-7 high-blast-radius routing code in HoneyDrunk.Capabilities (df-3; ADR-0017 standup).
+- AI-8 90-day model-key rotation in Vault (df-4; Vault.Rotation follow-up).
+- Audit investigation-extended-retention export interface (df-5; Audit Phase-2).
+- `.claude/agents/security.md` artifact loading (df-6; ADR-0046 scope-out).
+- SBOM tooling selection (df-7; follow-up ADR / ADR-0035 amendment).
+- Per-repo `dependabot.yml` adoption PRs (fan-out follows the `pr-core.yml` adoption pattern).
+- Engaging a specific pentest firm (operator action; gated on Notify.Cloud GA).
+- The first DIY adversarial-probe pass (operator-driven quarterly cadence; starts when the operator schedules it).
+
+Packet 09 captures the seven `df-N` deferrals as planning inputs to the right owning tracks.


### PR DESCRIPTION
## Summary

- Sixth of the staged PRs from the 2026-05-23 ADR batch. Governance-only — no code lands in any Node.
- Three reliability/safety governance initiatives: ADR-0054 (incident response — PagerDuty + Statuspage v0, paging substrate, post-mortem templates, per-Node runbook minimum set, game-day discipline), ADR-0055 (feature flags — IFeatureGate in Kernel, HoneyDrunk.FeatureFlags Node standup, App Configuration backing, Roslyn analyzer, operator CLI), ADR-0056 (threat model — STRIDE artifact, SECURITY.md + Disclose.io safe-harbor, security-incident runbook, found-secret rotation runbook, Dependabot + secret-scanning Grid-wide).

## Validation

- Markdown + JSON only; no code changed.
- file-packets.yml will file 40 packet files on merge — verify in The Hive.
- Reservation registry rules apply per packet 00 execution.

## Authorship

Authorship: agent-claude-code

## Notes

- This PR is out-of-band per ADR-0011 D9 / invariant 32 — ships packet files but doesn't execute any single packet.
- ADR-0054 packet 03 moves the PagerDuty secret into Notify's vault (kv-hd-notify-{env}) per invariant 17 — the earlier kv-hd-shared draft was fixed per refine feedback (library Nodes have no vault; one vault per deployable Node).
- ADR-0054 packet 04 adds a Diagnostic flag to PageOperatorRequest so packet 06's synthetic probe doesn't page the operator's phone every 5 min — fix applied per refine feedback.
- ADR-0055 packet 05 introduces a new HoneyDrunk.FeatureFlags Node (paired-standup pattern); packet 08 (operator flags CLI) gates on the Operator Node shell from ADR-0018, which is currently a Seed-signal repo. Both gating constraints are surfaced as Human Prerequisites.
- ADR-0056 packet 04 targets HoneyDrunkStudios/.github (the org meta-repo) for the org-level SECURITY.md; if the meta-repo doesn't exist, packet 04 creates it.
- ADR-0056 packet 08 cross-repo write pattern (job-cve-to-packet.yml writing to HoneyDrunk.Architecture from a workflow in HoneyDrunk.Actions) is currently scaffolded; the credential mechanism (GitHub App vs fine-grained PAT vs OIDC) is flagged as an explicit decision needed at execution time.