### PR TITLE
Scope ADR-0065/0068/0077 infrastructure substrate

### DIFF
--- a/generated/issue-packets/active/adr-0065-aspire-orchestration/00-architecture-adr-0065-acceptance.md
+++ b/generated/issue-packets/active/adr-0065-aspire-orchestration/00-architecture-adr-0065-acceptance.md
@@ -1,0 +1,135 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "docs", "adr-0065", "wave-1"]
+dependencies: []
+adrs: ["ADR-0065"]
+accepts: ["ADR-0065"]
+wave: 1
+initiative: adr-0065-aspire-orchestration
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0065 — flip status, add the two Aspire invariants, register the initiative
+
+## Summary
+Flip ADR-0065 (Multi-Service Local Dev Orchestration and .NET Aspire Stance) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, add the two new Aspire invariants ADR-0065 commits in its "New Invariants" section to `constitution/invariants.md` at the reserved invariant numbers `{N1}`/`{N2}` (claimed in `constitution/invariant-reservations.md`), and register the `adr-0065-aspire-orchestration` initiative in `initiatives/active-initiatives.md`.
+
+**Invariant reservation.** ADR-0065 adds two invariants. The block size is **2**. Per the reservation protocol in `constitution/invariant-reservations.md`, this packet claims the next free block above the current ceiling. At packet-authoring time the ADR-0064 reservation (74–77) sits at the top, so ADR-0065's block is **78–79** — `{N1} = 78`, `{N2} = 79`. **Verify at execution time** by reading `constitution/invariant-reservations.md` immediately before editing: if another packet 00 has merged ahead of this one and shifted the ceiling, claim the next free pair and update every `{N1}`/`{N2}` placeholder in this packet plus the corresponding row in `invariant-reservations.md` (the row for ADR-0065 was added in this same PR — shift its `Range` column to the new pair).
+
+## Context
+ADR-0065 decides the Grid's local-dev orchestrator: `.NET Aspire`, two-tier AppHost shape (per-Node + per-scenario `HoneyDrunk.Workshop`), per-Node resource modeling, opt-in Pulse dual-emit, deliberate separation of production deployment authoring (`HoneyDrunk.Standards` + curated Bicep stays the authority — Aspire's generator is never the production path), Standards-hosted template + extension methods, incremental per-Node migration (Notify first), Container Apps Jobs cross-reference, real dev Service Bus (no in-process shim), and "Aspire not in CI." It was authored 2026-05-23 as part of an Ops/cross-cutting batch of decisions and has had no scope until now.
+
+The forcing functions from ADR-0065's Context: **the Notify (Functions + Worker) + Pulse.Collector dev deploy is imminent** — the first time the user will run multiple Grid services together locally; whatever pattern ships first becomes the de-facto Grid pattern. **The AI-sector standup wave (ADR-0016 through ADR-0025) queues nine Nodes behind it** that each need a local-dev story; without a Grid-wide stance now, each of those Nodes' first feature packets re-litigates the question. **ADR-0015** commits Container Apps as production hosting and Aspire models that platform cleanly. **Pulse OTLP integration (ADR-0010, ADR-0040)** wants the Aspire dashboard and Pulse to consume the same OTLP stream where it matters.
+
+The ADR decides:
+- **D1** — adopt `.NET Aspire` as the Grid's local-dev orchestrator (local-dev only).
+- **D2** — two-tier AppHost shape: one `{Node}.AppHost` per containerized Node for solo work; one per-scenario AppHost in `HoneyDrunk.Workshop` for cross-Node integration work.
+- **D3** — resource modeling: project resources for `.NET` processes, container resources for emulators (Cosmos, Azurite, Redis), connection-string resources for non-emulated dev services (Service Bus, Key Vault, App Configuration). Aspire's built-in OTLP receiver wired by default.
+- **D4** — Pulse integration: default ships OTLP to Aspire dashboard only; opt-in `AddPulseCollector()` fan-out to a local Pulse.Collector for Pulse-iteration scenarios.
+- **D5** — production deployment is **separate** from Aspire. `HoneyDrunk.Standards` shared workflows + per-Node curated Bicep stays the production authority (per ADR-0015). Aspire-generated Bicep is never the production path.
+- **D6** — Standards alignment: AppHost project template + `HoneyDrunkAspireExtensions.AddGridTelemetry` + default emulator/dev-resource wiring extensions (`AddGridCosmosEmulator`, `AddGridAzurite`, `AddGridServiceBusDev`, `AddGridKeyVaultDev`, `AddGridAppConfigDev`). Versioned per ADR-0035.
+- **D7** — incremental per-Node migration: Notify first; Pulse second; Communications third (when its worker arrives); AI-sector seed Nodes adopt at first feature packet, not at standup; library-only Nodes (Kernel, Vault, Transport, Standards, Auth, Web.Rest, Data) get no AppHost.
+- **D8** — Container Apps Jobs cross-reference: local pattern is a project-with-timer hosted service inside the AppHost; production runs the same entry point under a Container Apps Job definition. The future Container Apps Jobs ADR is the authority.
+- **D9** — Windows-first matrix: real dev Service Bus (`sb-hd-dev`, Basic tier, one topic per Grid topic, per-session subscriptions) — no in-process broker shim. The InMemory broker's semantics differ from ASB in load-bearing ways.
+- **D10** — Aspire is not in CI. CI keeps unit tests + Tier 2b container-based integration tests + InMemory test doubles. `Aspire.Hosting.Testing` is a future follow-up for ADR-0047.
+
+ADR-0065 is a **policy / orchestration** ADR. The concrete code — the AppHost projects in Notify and Pulse, the Standards template + extension methods, the dev Service Bus namespace, the Workshop standup ADR — lands in `HoneyDrunk.Standards`, `HoneyDrunk.Notify`, `HoneyDrunk.Pulse`, and Architecture infra walkthroughs in this initiative. The Workshop Node standup is a deliberately separate follow-up ADR (memory note: new-Node scaffolding gets its own ADR). Every other packet references ADR-0065's D-decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0065-multi-service-local-dev-orchestration-aspire.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0065 row Status column to Accepted.
+- `constitution/invariants.md` — add the two new Aspire invariants (see Proposed Implementation for exact text), numbered `{N1}` and `{N2}` (the reserved pair from `constitution/invariant-reservations.md`; **78–79** at packet-authoring time — verify before edit).
+- `constitution/invariant-reservations.md` — the reservation row for ADR-0065 lands in the **same PR** as this packet (the row was added in the packet-set commit; if a collision happened in the interim, shift the range column and the body's `{N1}`/`{N2}` numbers together).
+- `initiatives/active-initiatives.md` — register the `adr-0065-aspire-orchestration` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0065 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update the ADR-0065 index row in `adrs/README.md` to Accepted.
+3. **Re-verify the invariant reservation.** Open `constitution/invariant-reservations.md` and confirm the ADR-0065 row's `Range` column. At packet-authoring time it reads `78–79`. If a parallel packet 00 has merged and consumed that pair, the row will need to shift upward — apply the same shift to every `{N1}`/`{N2}` placeholder in this packet body and in any downstream packet that hardcodes the numbers. The verified pair becomes `{N1}` and `{N2}` for the remaining steps.
+4. Add two new invariants to `constitution/invariants.md`. The text, taken verbatim-in-substance from ADR-0065's "New Invariants" section:
+   - **Invariant `{N1}` — Every multi-process containerized Node ships an Aspire AppHost project as its local-dev inner loop.** A multi-process containerized Node is a deployable Node with more than one runtime entry point. Single-process Nodes may ship an AppHost optionally; multi-process Nodes must. The AppHost is the canonical answer to "how do I run this locally." Library-only Nodes (Kernel, Vault, Transport, Standards, Auth, Web.Rest, Data) have no runtime and are exempt. See ADR-0065 D2, D7.
+   - **Invariant `{N2}` — Aspire-generated infrastructure templates (Bicep, ARM) are never used as the production deployment authority.** Production deployment authoring stays in `HoneyDrunk.Standards` shared workflows and each Node's curated Bicep per ADR-0015. Aspire's generator is allowed for sandbox experimentation but never checked into a production deployment path. See ADR-0065 D5.
+   - Place these in a new `## Local-Dev Orchestration Invariants` section after the existing topical groupings (the file's convention groups invariants by topic — Dependency, Context, Secrets, Packaging, Testing, AI, Communications, Audit, etc.; local-dev orchestration is a new cross-cutting topic and warrants its own section). The numbers are `{N1}` and `{N2}` from step 3 — do not reuse, do not gap.
+5. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder.
+
+## Affected Files
+- `adrs/ADR-0065-multi-service-local-dev-orchestration-aspire.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md` (the ADR-0065 row's `Range` column reflects the consumed pair; if a parallel packet 00 has shifted the ceiling, this row shifts too — see Proposed Implementation step 3)
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0065 header reads `**Status:** Accepted`
+- [ ] The ADR-0065 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariants.md` carries the two new Aspire invariants (every multi-process containerized Node ships an Aspire AppHost; Aspire-generated templates never used as the production deployment authority) under a new `## Local-Dev Orchestration Invariants` section, each citing ADR-0065
+- [ ] The two new invariants take the reserved pair `{N1}`/`{N2}` from `constitution/invariant-reservations.md` (78–79 at authoring; shift if collided)
+- [ ] `constitution/invariant-reservations.md` carries the ADR-0065 row with `Range` matching the consumed pair, and the file's "Current ceiling" line reflects the new next-free number
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0065-aspire-orchestration` initiative with a packet checklist
+- [ ] No catalog schema change in this packet (catalog updates land in packet 01)
+- [ ] No tech-stack.md edit in this packet (tech-stack updates land in packet 01)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0065 D1 — Adopt .NET Aspire as the Grid's local-dev orchestrator (local-dev only).** Aspire is native .NET, ships an OTLP-emitting dashboard, integrates with Pulse, models Container Apps reasonably, and carries low ceremony for a solo dev with AI agents.
+
+**ADR-0065 D2 — Two-tier AppHost shape.** Per-Node AppHost (`{Node}.AppHost`) for solo work; per-scenario AppHost in a new `HoneyDrunk.Workshop` Node for cross-Node scenarios.
+
+**ADR-0065 D5 — Production deployment is separate.** Aspire's generator is allowed for sandbox use; it is never the production deployment authority. `HoneyDrunk.Standards` + curated Bicep stays the authority.
+
+**ADR-0065 D7 — Migration is incremental, per-Node, no big-bang.** Notify first, Pulse second, Communications third (when its worker arrives); AI-sector seed Nodes adopt at first feature packet; library-only Nodes get no AppHost.
+
+**ADR-0065 New Invariants section.** Exactly two new invariants: (1) every multi-process containerized Node ships an Aspire AppHost project; (2) Aspire-generated infrastructure templates are never the production deployment authority.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0065 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbering — read the reservation registry first.** The canonical source for the next-free invariant number is `constitution/invariant-reservations.md`, not `constitution/invariants.md`. At packet-authoring time the ADR-0065 row claims the pair **78–79** (`{N1} = 78`, `{N2} = 79`). At execution time, re-read the registry: if a parallel packet 00 has merged and shifted the ceiling, the ADR-0065 row's `Range` column will need to shift up to the new next-free pair, and every `{N1}`/`{N2}` placeholder in this packet (plus any downstream packet that hardcoded the numbers) shifts with it. Never reuse a claimed number, never gap.
+- **New section.** The two Aspire invariants are a new cross-cutting topic; create a `## Local-Dev Orchestration Invariants` section rather than appending to an unrelated section.
+- **No tech-stack.md edit here.** ADR-0065's "Catalog and Reference Updates Required" lists a tech-stack.md update — that lands in packet 01, not here.
+
+## Labels
+`chore`, `tier-3`, `ops`, `docs`, `adr-0065`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0065 to Accepted, add the two Aspire invariants to `constitution/invariants.md`, and register the Aspire-orchestration initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0065 so the remaining packets in this initiative can reference its decisions as live rules.
+- Feature: ADR-0065 Multi-Service Local Dev Orchestration rollout, Wave 1.
+- ADRs: ADR-0065 (primary), ADR-0008 (initiative/packet conventions), ADR-0015 (Container Apps — referenced by the second invariant), ADR-0035 (Standards versioning — referenced by D6).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0065 stays Proposed until this PR merges.
+- Read `constitution/invariant-reservations.md` before editing `constitution/invariants.md`; use the ADR-0065 row's reserved pair `{N1}`/`{N2}` (78–79 at authoring) under a new `## Local-Dev Orchestration Invariants` section. If a collision shifted the pair, update every `{N1}`/`{N2}` placeholder here and in downstream packets together with the registry row.
+- Do not edit `infrastructure/reference/tech-stack.md` in this packet — that is packet 01's scope.
+
+**Key Files:**
+- `adrs/ADR-0065-multi-service-local-dev-orchestration-aspire.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0065-aspire-orchestration/01-architecture-tech-stack-and-agent-updates.md
+++ b/generated/issue-packets/active/adr-0065-aspire-orchestration/01-architecture-tech-stack-and-agent-updates.md
@@ -1,0 +1,148 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0065", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0065"]
+accepts: ["ADR-0065"]
+wave: 1
+initiative: adr-0065-aspire-orchestration
+node: honeydrunk-architecture
+---
+
+# Update tech-stack reference, scope agent, and review agent for the Aspire stance
+
+## Summary
+Update three documentation surfaces that ADR-0065 commits to update at acceptance: (a) `infrastructure/reference/tech-stack.md` — move the .NET Aspire row from "Planned / Future" to "Adopted" with the local-dev-only framing, and add a row noting the dev Service Bus namespace; (b) `.claude/agents/scope.md` — packets that introduce new multi-process Nodes must include an AppHost in their solution structure; (c) `.claude/agents/review.md` — new PR-review checklist items for multi-process Node PRs (must include or update the AppHost; Aspire-generated Bicep must not be checked into production deployment paths). No catalog schema change for Workshop — the `HoneyDrunk.Workshop` Node entry is deferred to the Workshop standup ADR per ADR-0065's own Follow-up Work.
+
+## Context
+ADR-0065's "Catalog and Reference Updates Required" section lists explicit doc edits to land at acceptance:
+
+- `infrastructure/reference/tech-stack.md` line 152 — currently lists `.NET Aspire` under Planned / Future, target Q2–Q3 2026. ADR-0065 D1 adopts it; the row moves to "Adopted" with the local-dev-only framing.
+- `infrastructure/reference/tech-stack.md` — add a row noting the dev Service Bus namespace runs at Basic tier (the operator-cost note from ADR-0065 D9 and the cost line in Operational Consequences).
+- `.claude/agents/scope.md` — must require an AppHost in solution structure for new multi-process Nodes.
+- `.claude/agents/review.md` — must check multi-process Node PRs for AppHost presence and check that Aspire-generated Bicep is not checked into production deployment paths.
+
+The `HoneyDrunk.Workshop` Node entry in `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/grid-health.json`, and `constitution/sectors.md` is **deferred** — per ADR-0065's Follow-up Work, the Workshop standup ADR is a separate follow-up. Memory note "New-Node scaffolding gets its own ADR; don't bundle scaffold into feature packets" applies. This packet does NOT add `honeydrunk-workshop` to any catalog and does NOT create `repos/HoneyDrunk.Workshop/` — those land when the Workshop standup ADR is filed and scoped.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `infrastructure/reference/tech-stack.md` — move the `.NET Aspire` row out of Planned / Future and into the appropriate adopted section; add a row for the dev Service Bus namespace cost note.
+- `.claude/agents/scope.md` — append a rule into the existing packet-quality guidance that new multi-process Node standups must include an AppHost project.
+- `.claude/agents/review.md` — append two new review-checklist items.
+
+NOT in scope:
+- `catalogs/nodes.json`, `relationships.json`, `grid-health.json` Workshop entries — deferred to the Workshop standup ADR (ADR-0065 Follow-up).
+- `constitution/sectors.md` Workshop row — deferred to the Workshop standup ADR.
+- `repos/HoneyDrunk.Workshop/` folder — deferred to the Workshop standup ADR.
+
+## Proposed Implementation
+
+### `infrastructure/reference/tech-stack.md`
+
+1. Locate the `.NET Aspire` row currently under "Planned / Future → Developer Experience" (line 152 at authoring time). Move it into the appropriate adopted/in-use section of the file (the file's existing convention groups adopted tech by topic — match its structure). The updated framing, per ADR-0065 D1/D5:
+
+   > **.NET Aspire** — Adopted as the Grid's local-dev orchestrator (per ADR-0065). Local-dev only: per-Node `{Node}.AppHost` for solo Node work, per-scenario AppHosts in `HoneyDrunk.Workshop` for cross-Node scenarios. Production deployment authoring stays in `HoneyDrunk.Standards` shared workflows and curated Bicep per ADR-0015 — Aspire's generator is never the production path.
+
+2. Add a row (under Azure infrastructure / messaging, wherever Service Bus is already listed; if Service Bus has no row, add one):
+
+   > **Azure Service Bus — dev namespace** — `sb-hd-dev`, Basic tier, runs continuously. One topic per Grid topic; per-developer-session subscriptions. ~$10/month known recurring cost (per ADR-0052 cost ledger). No emulator exists for Service Bus, so dev uses the real namespace per ADR-0065 D9.
+
+### `.claude/agents/scope.md`
+
+Append (or extend the existing relevant section — match the agent file's structure) a rule under the packet-quality / scope-decomposition guidance:
+
+> **AppHost requirement for new multi-process Nodes.** Packets that introduce a new multi-process containerized Node (a deployable Node with more than one runtime entry point — e.g. Functions + Worker) must include a `{Node}.AppHost` project in the proposed solution structure. Single-process Nodes may include one optionally; library-only Nodes (no runtime) do not. See ADR-0065 D2/D7 and the related invariant.
+
+### `.claude/agents/review.md`
+
+Append two review-checklist items in the appropriate rubric section (ADR-0044 D3 governs the rubric structure — match its category placement; the two items belong in the deployment / infrastructure category):
+
+> - [ ] **Multi-process Node AppHost** — If the PR touches a deployable Node with more than one runtime entry point (Functions + Worker, host + sidecar, etc.), the PR includes or updates the Node's `{Node}.AppHost` project. Missing AppHost on a multi-process Node is a finding (severity: medium). See ADR-0065 D2/D7.
+> - [ ] **No Aspire-generated Bicep in production deployment paths** — Aspire's `azd`/`AzurePublisher` outputs (Bicep, ARM, `azure.yaml`) must not be checked into the repo's production deployment surface (`infrastructure/bicep/`, `infrastructure/arm/`, or equivalent). Sandbox-only files are acceptable in a clearly-scoped `.aspire/` or `bin/` path; production authoring is `HoneyDrunk.Standards` shared workflows + curated Bicep per ADR-0015. See ADR-0065 D5 and the related invariant.
+
+Per [`scope.md`](../../../../.claude/agents/scope.md)'s coupling rule with `review.md` (ADR-0011 D4, invariant 33 — "Review-agent and scope-agent context-loading contracts are coupled"), these two surfaces are amended together in this packet.
+
+## Affected Files
+- `infrastructure/reference/tech-stack.md`
+- `.claude/agents/scope.md`
+- `.claude/agents/review.md`
+
+NOT touched by this packet:
+- `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/grid-health.json` — Workshop entries are deferred to the Workshop standup ADR.
+- `constitution/sectors.md` — Workshop row deferred to the Workshop standup ADR.
+- `repos/HoneyDrunk.Workshop/` — deferred to the Workshop standup ADR.
+
+## NuGet Dependencies
+None. This packet touches only Markdown documentation; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+- [x] Workshop standup is explicitly deferred to its own ADR; this packet does not touch nodes.json or relationships.json.
+
+## Acceptance Criteria
+- [ ] `infrastructure/reference/tech-stack.md` no longer lists `.NET Aspire` under Planned / Future; the row appears in an adopted section with the local-dev-only framing and the ADR-0015 cross-reference
+- [ ] `infrastructure/reference/tech-stack.md` carries a row for the dev Service Bus namespace (`sb-hd-dev`, Basic tier, ~$10/month, per-session subscription convention)
+- [ ] `.claude/agents/scope.md` carries the AppHost-requirement rule for new multi-process Nodes, citing ADR-0065 D2/D7
+- [ ] `.claude/agents/review.md` carries the two new review-checklist items (multi-process Node AppHost presence; no Aspire-generated Bicep in production deployment paths), citing ADR-0065 D2/D5/D7 and the related invariants
+- [ ] No edit to `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/grid-health.json`, or `constitution/sectors.md` (Workshop entry deferred)
+- [ ] No `repos/HoneyDrunk.Workshop/` folder created (deferred)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0065 D1 — Aspire is the Grid's local-dev orchestrator, local-dev only.** Native .NET, OTLP dashboard, low ceremony.
+
+**ADR-0065 D2 — Two-tier AppHost shape.** Per-Node AppHost (`{Node}.AppHost`) for solo work; per-scenario AppHost in `HoneyDrunk.Workshop` for cross-Node scenarios.
+
+**ADR-0065 D5 — Production deployment is separate from Aspire.** `HoneyDrunk.Standards` + curated Bicep is the authority. Aspire's generator is never the production path.
+
+**ADR-0065 D7 — Migration is incremental, per-Node.** Multi-process Nodes need an AppHost; library-only Nodes do not.
+
+**ADR-0065 D9 — Real dev Service Bus, no shim.** One `sb-hd-dev` namespace, Basic tier, per-session subscriptions, ~$10/month recurring cost.
+
+**ADR-0065 Catalog and Reference Updates Required.** Lists the tech-stack.md edits, the scope.md/review.md agent-file edits, and the Workshop catalog entries explicitly deferred to the Workshop standup ADR.
+
+**ADR-0065 Follow-up Work.** "File the `HoneyDrunk.Workshop` standup ADR as a separate paired follow-up."
+
+## Constraints
+- **Invariant 33 — review and scope context-loading contracts are coupled.** When `.claude/agents/scope.md` adds a new rule that the review surface should catch, the matching review-rubric item lands in the same change. Both edits are in this packet.
+- **Workshop is a deferred standup.** Do not add Workshop entries to catalogs, sectors, or `repos/` in this packet. Memory note "New-Node scaffolding gets its own ADR" applies.
+- **Match existing file structure.** `.claude/agents/scope.md` and `review.md` have established sectioning; add new items in the topically correct location rather than appending arbitrarily.
+- **No ADR-ID noise in narrative docs.** Per the memory note "No ADR numbers in docs or comments — skip ADR IDs in README sections/code comments; runtime packet-data references are fine," the new review-checklist items may reference ADR-0065 (it is governance metadata, not narrative prose), but the tech-stack.md row should *describe* the decision, with the ADR ID present as a citation tail rather than dominating the prose — match the existing tech-stack.md rows' style.
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0065`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Update tech-stack.md, scope.md, and review.md to reflect ADR-0065's Aspire adoption.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land the documentation surfaces ADR-0065 commits to update at acceptance, so downstream packets and future scope/review work read the new rules.
+- Feature: ADR-0065 Multi-Service Local Dev Orchestration rollout, Wave 1.
+- ADRs: ADR-0065 (primary), ADR-0011 / ADR-0044 (review/scope agent governance), ADR-0015 (Container Apps — referenced by the production-deployment carve-out).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0065 should be Accepted before its decisions become live narrative in scope/review/tech-stack.
+
+**Constraints:**
+- Workshop is deferred to a separate standup ADR (per ADR-0065's Follow-up Work and the user's "new-Node scaffolding gets its own ADR" preference) — do not add Workshop entries to catalogs/sectors/repos here.
+- Review and scope rule additions land together in this packet (invariant 33 — coupled context-loading contracts).
+
+**Key Files:**
+- `infrastructure/reference/tech-stack.md`
+- `.claude/agents/scope.md`
+- `.claude/agents/review.md`
+
+**Contracts:** None changed — documentation edits only.

--- a/generated/issue-packets/active/adr-0065-aspire-orchestration/02-standards-aspire-template-and-extensions.md
+++ b/generated/issue-packets/active/adr-0065-aspire-orchestration/02-standards-aspire-template-and-extensions.md
@@ -1,0 +1,194 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Standards
+labels: ["feature", "tier-2", "ops", "adr-0065", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0065"]
+wave: 2
+initiative: adr-0065-aspire-orchestration
+node: honeydrunk-standards
+---
+
+# Author the AppHost project template and Grid Aspire extension methods in HoneyDrunk.Standards
+
+## Summary
+Ship the ADR-0065 D6 Standards alignment: an AppHost project template (`HoneyDrunk.Standards.Templates/AspireAppHost`) producing a `{Node}.AppHost` scaffold with the analyzer/EditorConfig wiring and default OTLP/dashboard setup, the `HoneyDrunkAspireExtensions.AddGridTelemetry` extension implementing the D4 dual-emit pattern, and the default emulator/dev-resource wiring extensions (`AddGridCosmosEmulator`, `AddGridAzurite`, `AddGridServiceBusDev`, `AddGridKeyVaultDev`, `AddGridAppConfigDev`). This is the first packet on the `HoneyDrunk.Standards` solution in this initiative and the version-bumping packet — it ships new public surface (additive minor bump per ADR-0035).
+
+## Context
+ADR-0065 D6 commits a small set of Aspire-related shared assets in `HoneyDrunk.Standards`. The reasoning: new Nodes adopting Aspire pull the template + extensions and get a working baseline; existing Nodes pull the extensions piecemeal as they migrate (D7). The Standards extension methods absorb Aspire-version-evolution churn so per-Node AppHosts stay stable.
+
+`HoneyDrunk.Standards` is a live Node with the package family rooted in `HoneyDrunk.Standards` and `HoneyDrunk.Standards.Analyzers` (alongside test/consumer projects). It ships the Grid's analyzer/EditorConfig conventions every Node references via `PrivateAssets: all` (invariant 26). The Aspire template + extensions are net-new public surface.
+
+ADR-0065 D6 names the exact extension methods:
+- `HoneyDrunkAspireExtensions.AddGridTelemetry(IResourceBuilder<T>)` — applies the D4 dual-emit pattern. Default: ship OTLP to Aspire's dashboard only. When the AppHost composes `AddPulseCollector()`, also fan out to a local Pulse.Collector instance.
+- `AddGridCosmosEmulator` — Cosmos Emulator container resource with Grid naming + configuration conventions.
+- `AddGridAzurite` — Azurite blob/queue/table emulator container resource.
+- `AddGridServiceBusDev` — connection-string resource pointing at the dev `sb-hd-dev` namespace; resolves connection string from `dotnet user-secrets`; creates the per-session subscription on AppHost launch (per D9).
+- `AddGridKeyVaultDev` — connection-string resource for the dev Key Vault; resolves via Azure CLI / Visual Studio sign-in (no emulator).
+- `AddGridAppConfigDev` — connection-string resource for dev App Configuration; same dev-session-auth shape as Key Vault.
+
+ADR-0065 commits these extensions as **public surface subject to SemVer per ADR-0035**. This packet ships them with full XML documentation (invariant 13) and the Grid's analyzer baseline (invariant 26).
+
+> **Aspire-version pinning.** ADR-0065 Follow-up Work: "Confirm Aspire's current version (at acceptance time) and pin the Standards templates to it. Aspire breaking changes are absorbed by Standards updates per the per-Node migration ergonomics." The executor confirms Aspire's current GA version at execution time (the ADR was authored 2026-05-23 — confirm the latest stable Aspire SDK as of the merge date) and pins the template + extension projects' `PackageReference`s to that version. Future Aspire bumps land as Standards-version updates, propagating to per-Node AppHosts on the next consumer-side bump.
+
+This packet creates new `.NET` projects (the template project, and one or more extension projects) — they need `CHANGELOG.md` and `README.md` from the first commit (invariant 12).
+
+## Scope
+- New project `HoneyDrunk.Standards.Templates.AspireAppHost` (or a sub-project of an existing templates project — match the repo's existing templates structure if one exists) — a `dotnet new` template producing a `{Node}.AppHost` scaffold with:
+  - The `Microsoft.NET.Sdk` `OutputType=Exe` shape Aspire AppHosts use.
+  - `PackageReference` to `Aspire.AppHost.Sdk` and the relevant Aspire SDK at the pinned version.
+  - `PackageReference` to `HoneyDrunk.Standards` (`PrivateAssets: all`) for the analyzer baseline (invariant 26).
+  - A starter `Program.cs` that wires `IDistributedApplicationBuilder`, calls `AddGridTelemetry`, and includes commented examples of `AddGridCosmosEmulator`/`AddGridAzurite`/`AddGridServiceBusDev`/`AddGridKeyVaultDev`/`AddGridAppConfigDev`.
+  - A `.template.config/template.json` describing the template parameters (Node name, namespace, parent solution path).
+- New project `HoneyDrunk.Standards.Aspire` (the home of the public extension methods — name to match the repo's existing package-naming pattern; confirm against `HoneyDrunk.Standards`/`HoneyDrunk.Standards.Analyzers` and pick the parallel form):
+  - `HoneyDrunkAspireExtensions` static class with `AddGridTelemetry` and the dual-emit logic.
+  - `AddGridCosmosEmulator`, `AddGridAzurite` — container resource extensions.
+  - `AddGridServiceBusDev`, `AddGridKeyVaultDev`, `AddGridAppConfigDev` — connection-string resource extensions with dev-session auth + (for Service Bus) per-session subscription creation on AppHost launch.
+- Test coverage in `HoneyDrunk.Standards.Tests` (or a new sibling test project — match the repo's existing test-project shape) — unit tests for the extension methods using Aspire's testing primitives where available; no live Azure dependency.
+- `CHANGELOG.md` + `README.md` for each new project; per-package CHANGELOG entries for the packages with real changes; repo-level `CHANGELOG.md` new version entry.
+
+## Proposed Implementation
+
+1. **Confirm Aspire version pin.** At execution time, identify the current stable Aspire SDK version on NuGet. Pin all new `Aspire.*` `PackageReference`s in this packet to that version.
+
+   > **CPM state on the Standards solution.** Verified at packet-authoring time (2026-05-24): the `HoneyDrunk.Standards` solution does **not** use Central Package Management today — there is no `Directory.Packages.props` and no `Directory.Build.props` at the repo or solution root. Existing projects pin `PackageReference` `Version` attributes directly in each `.csproj` (with shared values driven by private `_StyleCopPackageVersion`/`_NetAnalyzersVersion` MSBuild properties inside `HoneyDrunk.Standards.csproj` itself, not via CPM). **This packet matches the existing convention: pin Aspire versions inline in each new `.csproj` rather than introducing CPM.** Introducing CPM is a separate scope item (a Standards-solution-wide refactor) and belongs in its own ADR/initiative — not bundled into the Aspire feature packet.
+
+2. **`HoneyDrunk.Standards.Aspire`** — new project carrying the extension methods:
+   - `static class HoneyDrunkAspireExtensions` (note: not `I`-prefixed; it's a static helper class — the records-drop-I/interfaces-keep-it naming rule does not apply to static classes).
+   - `IResourceBuilder<TResource> AddGridTelemetry<TResource>(this IResourceBuilder<TResource> builder)` — wires OTLP environment variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_SERVICE_NAME`) on the resource. The default endpoint is Aspire's dashboard's own OTLP receiver (Aspire wires this automatically when the dashboard is enabled). The dual-emit fan-out (D4) is activated by a separate composition method on the AppHost builder, e.g. `IDistributedApplicationBuilder AddPulseCollector(this IDistributedApplicationBuilder builder, bool opt = false)` that, when `opt: true`, adds Pulse.Collector as a project resource and overrides the OTLP endpoint on every other project resource to fan out to both Aspire and Pulse. The opt-in mechanism is the AppHost-level composition method; the per-resource `AddGridTelemetry` ships the OTLP wiring that follows whatever endpoint the host has set.
+   - `IResourceBuilder<CosmosResource> AddGridCosmosEmulator(this IDistributedApplicationBuilder builder, string name)` — composes Aspire's `AddAzureCosmosDB` (or `AddCosmos` per the current Aspire API) in emulator mode, applies the Grid's `hd`-prefixed naming convention, and sets the Cosmos Emulator's Linux-container mode (per D9: "the AppHost uses the Linux-container mode for cross-platform consistency").
+   - `IResourceBuilder<AzureStorageResource> AddGridAzurite(this IDistributedApplicationBuilder builder, string name)` — composes Aspire's Azurite resource with Grid naming.
+   - `IResourceBuilder<IResourceWithConnectionString> AddGridServiceBusDev(this IDistributedApplicationBuilder builder, string name)` — connection-string resource resolving from the `ConnectionStrings:ServiceBus` key (read from `dotnet user-secrets`; ASP.NET configuration convention, matching the seeding command in the packet 03 walkthrough). On AppHost launch, creates a per-session ASB subscription named by user/machine/process so concurrent dev sessions do not interfere (D9). **On AppHost shutdown, the same composition deletes the per-session subscription** so concurrent dev sessions are not stranded with orphaned subscriptions on the dev namespace. The lifecycle (create on launch, delete on shutdown) is wired by registering an Aspire lifecycle hook (`IDistributedApplicationLifecycleHook` — `BeforeStartAsync` creates, `AfterApplicationStoppedAsync` deletes) inside the extension; document the lifecycle in the extension's XML doc. Best-effort deletion: if the delete fails (network blip, namespace gone), log and continue — orphaned subscriptions on dev are tolerable but should be the exception. A manual cleanup step is documented in packet 03 as the recovery path.
+   - `IResourceBuilder<IResourceWithConnectionString> AddGridKeyVaultDev(this IDistributedApplicationBuilder builder, string name)` — connection-string resource pointing at the dev Key Vault URI; auth via Azure CLI / Visual Studio sign-in (no emulator — Key Vault is not emulated; D3).
+   - `IResourceBuilder<IResourceWithConnectionString> AddGridAppConfigDev(this IDistributedApplicationBuilder builder, string name)` — same shape as `AddGridKeyVaultDev` for dev App Configuration.
+   - Full XML documentation on every public member (invariant 13).
+3. **`HoneyDrunk.Standards.Templates.AspireAppHost`** — new template:
+   - A `dotnet new` template (package or repo-local). The template scaffold targets a `{Node}.AppHost` project layout that compiles standalone with `dotnet run --project {Node}.AppHost`.
+   - The template's starter `Program.cs` references `HoneyDrunk.Standards.Aspire`'s extensions and includes commented examples of each `AddGrid*` call.
+   - `.template.config/template.json` declares parameters: `NodeName`, `RootNamespace`, optional `SolutionPath`.
+4. **Test coverage** — unit tests in `HoneyDrunk.Standards.Tests` (or a new sibling test project) for the extension methods. Use Aspire's `Aspire.Hosting.Testing` primitives in a *non-launching syntax-check* mode (the same mode ADR-0065 names for Workshop CI in its Operational Consequences) so tests do not require Docker Desktop or a live Azure subscription. No external dependencies (invariant 15).
+5. **Versioning + CHANGELOGs + READMEs.**
+   - This is the first packet on the `HoneyDrunk.Standards` solution in this initiative — per invariant 27 it bumps every non-test `.csproj` to the same new minor version in one commit (additive new public surface — minor bump per ADR-0035).
+   - Repo-level `CHANGELOG.md` new version entry.
+   - Per-package CHANGELOG entries for the packages with real changes: `HoneyDrunk.Standards.Aspire` and `HoneyDrunk.Standards.Templates.AspireAppHost` (both new — they need `CHANGELOG.md` and `README.md` from the first commit per invariant 12). `HoneyDrunk.Standards` and `HoneyDrunk.Standards.Analyzers` get no per-package CHANGELOG entry in this packet (alignment bump only, no functional change) — invariants 12/27.
+   - Each new project's `README.md` documents its public API surface.
+
+## Affected Files
+- `HoneyDrunk.Standards/HoneyDrunk.Standards.Aspire/` (new project)
+- `HoneyDrunk.Standards/HoneyDrunk.Standards.Templates.AspireAppHost/` (new template project)
+- `HoneyDrunk.Standards/HoneyDrunk.Standards.Tests/` (new tests for the Aspire extensions, or a sibling test project — match the repo's convention)
+- Every non-test `.csproj` in the solution — version bump (invariant 27).
+- Repo-level `CHANGELOG.md`; new per-package `CHANGELOG.md` / `README.md` for the new packages.
+
+The Standards solution does not use CPM today (verified at packet-authoring time — no `Directory.Packages.props`); Aspire versions are pinned inline in the new `.csproj` files.
+
+## NuGet Dependencies
+
+`HoneyDrunk.Standards.Aspire` — new `PackageReference` set:
+- `Aspire.Hosting` (or the current top-level Aspire hosting metapackage at the confirmed pinned version) — the Aspire AppHost programming model.
+- `Aspire.Hosting.Azure.CosmosDB`, `Aspire.Hosting.Azure.Storage` (Azurite), `Aspire.Hosting.Azure.ServiceBus`, `Aspire.Hosting.Azure.KeyVault`, `Aspire.Hosting.Azure.AppConfiguration` — match the current Aspire integrations package names (confirm at execution time; Aspire's package naming has churn — the right names are whichever shipping Aspire integrations are current as of the pinned version).
+- `Microsoft.Extensions.Configuration.UserSecrets` — for `AddGridServiceBusDev`'s `dotnet user-secrets` resolution.
+- `HoneyDrunk.Standards` — `PrivateAssets: all` (invariant 26: analyzers + EditorConfig).
+
+`HoneyDrunk.Standards.Templates.AspireAppHost` — the template scaffold's `*.csproj`:
+- `Aspire.AppHost.Sdk` — the AppHost SDK target.
+- `Aspire.Hosting` (pinned version, matching above).
+- `HoneyDrunk.Standards` (`PrivateAssets: all`) and `HoneyDrunk.Standards.Aspire` (the template references the extension methods so a freshly-templated AppHost compiles).
+
+Test project — match the Standards test stack already in place (xUnit + the assertion library the existing tests use). Add only what is missing:
+- `Aspire.Hosting.Testing` — for non-launching syntax-check validation (D10's "future testing follow-up" cites `Aspire.Hosting.Testing`; ADR-0065 D6 wants the extensions test-covered; using `Aspire.Hosting.Testing` in non-launching mode is appropriate and CI-safe).
+- `HoneyDrunk.Standards` (`PrivateAssets: all`).
+- Project reference to `HoneyDrunk.Standards.Aspire`.
+
+Add only `PackageReference` entries not already present — confirm against existing `.csproj` files first. Pin `Version=` inline on each `PackageReference` (the Standards solution does not use Central Package Management; introducing CPM is out of scope for this packet).
+
+## Boundary Check
+- [x] `HoneyDrunk.Standards` is the correct repo per ADR-0065 D6 ("HoneyDrunk.Standards gains a small set of Aspire-related shared assets").
+- [x] Net-new public surface; additive minor bump per ADR-0035. No removal or rename of existing exports.
+- [x] No runtime dependency on any `HoneyDrunk.*` Node beyond `HoneyDrunk.Standards` itself — the extensions live in Standards, sit beneath every Node, and are consumed by per-Node AppHosts at compose time.
+- [x] No production-deployment surface touched (D5: Aspire is local-dev only; the production authoring stays in `HoneyDrunk.Standards`' shared workflows + curated Bicep — those are not edited here).
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Standards.Aspire` exposes `HoneyDrunkAspireExtensions` with `AddGridTelemetry`, `AddGridCosmosEmulator`, `AddGridAzurite`, `AddGridServiceBusDev`, `AddGridKeyVaultDev`, `AddGridAppConfigDev`
+- [ ] `AddGridServiceBusDev` resolves the connection string from the `ConnectionStrings:ServiceBus` user-secrets key, creates a per-session subscription on AppHost launch, **and deletes that subscription on AppHost shutdown** via an `IDistributedApplicationLifecycleHook` (best-effort delete; log on failure)
+- [ ] `AddGridCosmosEmulator` runs the Cosmos Emulator in Linux-container mode (per D9)
+- [ ] All public types/methods have XML documentation (invariant 13)
+- [ ] `HoneyDrunk.Standards.Templates.AspireAppHost` is a working `dotnet new` template producing a compileable `{Node}.AppHost` scaffold; the starter `Program.cs` calls `AddGridTelemetry` and includes commented examples of every `AddGrid*` resource extension
+- [ ] The template's project file references the pinned Aspire SDK version and references `HoneyDrunk.Standards` (`PrivateAssets: all`) and `HoneyDrunk.Standards.Aspire`
+- [ ] Aspire SDK packages are pinned to a single confirmed version across every new `.csproj` (pinned inline, matching the Standards solution's existing no-CPM convention)
+- [ ] Tests for the extension methods run in non-launching mode and do not require Docker Desktop, a live Azure subscription, or any external service (invariant 15)
+- [ ] Every non-test `.csproj` in the solution is at the same new minor version in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new version entry
+- [ ] `HoneyDrunk.Standards.Aspire/CHANGELOG.md` + `README.md` exist (new package, created in this packet)
+- [ ] `HoneyDrunk.Standards.Templates.AspireAppHost/CHANGELOG.md` + `README.md` exist (new package, created in this packet)
+- [ ] `HoneyDrunk.Standards/CHANGELOG.md` and `HoneyDrunk.Standards.Analyzers/CHANGELOG.md` get NO per-package entry (alignment bump only — invariants 12/27)
+- [ ] `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **Tag/release `HoneyDrunk.Standards` after this packet merges.** This packet's new packages (`HoneyDrunk.Standards.Aspire`, `HoneyDrunk.Standards.Templates.AspireAppHost`) reach the NuGet feed only when a human pushes the git release tag — agents never tag or publish. Wave 4 (packets 04 Notify, 05 Pulse) compiles against the new packages and cannot proceed until they are published.
+- [ ] **The dev Service Bus namespace (`sb-hd-dev`) does not need to exist for this packet to merge** — `AddGridServiceBusDev` resolves a connection string at AppHost-launch time, not at build time. The namespace must exist before any per-Node AppHost using `AddGridServiceBusDev` is run (Notify's AppHost in packet 04). Packet 03 provisions the namespace.
+
+## Referenced ADR Decisions
+**ADR-0065 D4 — Pulse integration: dual-emit, opt-in.** Default ships OTLP to Aspire's dashboard only; opt-in `AddPulseCollector` adds Pulse.Collector as a project resource and fans out OTLP to both Aspire and Pulse.
+
+**ADR-0065 D6 — Standards alignment.** Standards gains the AppHost project template + the named extension methods. Versioned per ADR-0035.
+
+**ADR-0065 D7 — Migration is opportunistic.** New Nodes pull the template; existing Nodes pull extensions piecemeal as they migrate.
+
+**ADR-0065 D9 — Real dev Service Bus, dotnet user-secrets, per-session subscriptions.** `AddGridServiceBusDev` resolves the connection string from `dotnet user-secrets`; the per-session subscription is created on AppHost launch.
+
+**ADR-0065 D10 — Aspire is not in CI.** Tests in this packet run in non-launching mode (e.g. `Aspire.Hosting.Testing`'s syntax-check shape) so CI is fast and deterministic and does not require Docker Desktop or a live Azure subscription.
+
+**ADR-0065 Operational Consequences — Aspire version evolution.** Standards absorbs Aspire churn; per-Node AppHosts stay stable. A breaking Aspire release is a coordinated Standards update.
+
+**ADR-0035 — Abstractions versioning and deprecation policy.** New public surface in Standards = additive minor bump; the Aspire extensions are subject to the same SemVer rules as every other Standards export.
+
+## Constraints
+- **Invariant 13 — public APIs carry XML documentation.** Every extension method and template-exposed type.
+- **Invariant 26 — analyzer baseline.** New projects reference `HoneyDrunk.Standards` with `PrivateAssets: all` (the package itself is *Standards* — the convention is the same: every new Standards-solution project carries the analyzer baseline).
+- **Invariant 27 — solution-wide version alignment.** This is the first packet on the solution this initiative; it bumps every non-test `.csproj` to the same new minor version in one commit. Partial bumps are forbidden.
+- **Invariant 12 — CHANGELOG/README discipline.** New packages need `CHANGELOG.md` + `README.md` from the first commit. Existing packages with no functional change get NO per-package CHANGELOG entry.
+- **Invariant 15 — tests don't depend on external services.** The Aspire extension tests run in non-launching mode; no Docker Desktop, no Azure, no Cosmos Emulator container at test time.
+- **D5 — never the production path.** Nothing in this packet wires `azd` deployment, `AzurePublisher`, or `Aspire.Hosting.Azure.Provisioning` for production-deployment authoring. The template's `Program.cs` is local-dev shape only.
+- **Aspire SDK version pinning.** Pin Aspire packages to a single confirmed version across every new `.csproj`. The Standards solution does not use CPM today (no `Directory.Packages.props`); pin inline. Introducing CPM is a separate refactor.
+- **No `I`-prefix on the static class.** `HoneyDrunkAspireExtensions` is a static class — the records-drop-I/interfaces-keep-it rule does not apply (it applies to records vs interfaces, not classes).
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0065`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Ship the AppHost template + Grid Aspire extension methods in `HoneyDrunk.Standards` so per-Node AppHosts have a working baseline.
+
+**Target:** `HoneyDrunk.Standards`, branch from `main`.
+
+**Context:**
+- Goal: Ship the shared assets every per-Node AppHost in this initiative consumes.
+- Feature: ADR-0065 Multi-Service Local Dev Orchestration rollout, Wave 2 (Standards foundation).
+- ADRs: ADR-0065 D4/D6/D7/D9/D10 (primary), ADR-0035 (additive minor-bump policy), ADR-0008 (packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0065 Accepted and its two invariants live before the Standards extensions are built against them.
+
+**Constraints:**
+- Pin Aspire SDK to a confirmed version inline across every new `.csproj` (the Standards solution does not use CPM; do not introduce CPM in this packet).
+- Tests run in non-launching mode — no Docker Desktop, no live Azure (invariant 15, D10).
+- Bump every non-test `.csproj` to the same new minor version in one commit (invariant 27). This is the bumping packet for `HoneyDrunk.Standards` in this initiative.
+- Aspire local-dev only — no production-deployment surface (D5).
+- After merge, a human must tag/release `HoneyDrunk.Standards` so the new packages reach the NuGet feed before Wave 4 starts.
+
+**Key Files:**
+- `HoneyDrunk.Standards.Aspire/` (new project)
+- `HoneyDrunk.Standards.Templates.AspireAppHost/` (new template project)
+- Tests for the Aspire extensions
+- Every non-test `.csproj` for the version bump; repo-level `CHANGELOG.md`; per-package `CHANGELOG.md` / `README.md` for the new packages
+
+**Contracts:**
+- `HoneyDrunkAspireExtensions.AddGridTelemetry` (new static method) — OTLP wiring on a resource builder.
+- `AddGridCosmosEmulator`, `AddGridAzurite` (new) — container resource extensions.
+- `AddGridServiceBusDev`, `AddGridKeyVaultDev`, `AddGridAppConfigDev` (new) — connection-string resource extensions, dev-session-auth shape, with per-session subscription on launch for Service Bus.
+- (Composition method) `AddPulseCollector(bool opt = false)` on `IDistributedApplicationBuilder` — the AppHost-level opt-in switch for the D4 dual-emit fan-out.

--- a/generated/issue-packets/active/adr-0065-aspire-orchestration/03-architecture-dev-service-bus-walkthrough.md
+++ b/generated/issue-packets/active/adr-0065-aspire-orchestration/03-architecture-dev-service-bus-walkthrough.md
@@ -1,0 +1,158 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "infrastructure", "human-only", "adr-0065", "wave-3"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0065", "ADR-0028", "ADR-0005", "ADR-0052"]
+wave: 3
+initiative: adr-0065-aspire-orchestration
+node: honeydrunk-architecture
+---
+
+# Author the dev Service Bus provisioning walkthrough and provision sb-hd-dev + dev App Configuration
+
+## Summary
+Author `infrastructure/walkthroughs/dev-service-bus-namespace-provisioning.md` — an Azure-Portal UI walkthrough for creating the `sb-hd-dev` Service Bus namespace (Basic tier, the cheapest viable starting point per the operator's standing tier preference) — and execute it: create the namespace, document the per-session-subscription convention (including manual cleanup of orphaned subscriptions), and seed the connection string into Vault for retrieval by `dotnet user-secrets` and `AddGridServiceBusDev`. **Also provision the dev App Configuration resource** that Notify's AppHost (packet 04) consumes via `AddGridAppConfigDev` — the existing `infrastructure/walkthroughs/app-configuration-provisioning.md` is the authority; this packet executes it for the `dev` environment in the same human session so Wave 4 has both prerequisites in place. This is `Actor=Human` — Azure resource creation is portal work and the developer prefers UI walkthroughs over CLI.
+
+## Context
+ADR-0065 D9 commits real dev Service Bus (no in-process broker shim — the InMemory broker's semantics differ from ASB in load-bearing ways). The decision: one dev namespace `sb-hd-dev` is provisioned at the time the first ASB-using Node needs it (per the `feedback_provision_when_needed` preference). That moment is now: Notify's AppHost (packet 04) composes `AddGridServiceBusDev`, which resolves a connection string from `dotnet user-secrets` and creates per-session subscriptions on AppHost launch. Without the namespace, Notify's local-dev inner loop has no broker.
+
+ADR-0065 D9's specifics:
+- **One namespace**: `sb-hd-dev`.
+- **Basic tier**: the operator's `feedback_default_cheapest_azure_tier` preference. Basic supports queues + topics with subscriptions (the shape ADR-0028 commits for the Grid's default broker) — Standard tier is only justified by per-message scheduling, topic-with-subscription filters, or messages larger than 256 KB, none of which are required for v1.
+- **Per-session subscriptions**: developers create one ASB subscription per dev session (named by user / machine / process), so concurrent dev sessions do not interfere. Aspire's `AddGridServiceBusDev` extension (packet 02) creates the per-session subscription on AppHost launch.
+- **Cost**: ~$10/month, recorded against the studio's Azure budget per ADR-0052.
+
+The walkthrough sits in `infrastructure/walkthroughs/` alongside the existing infra walkthroughs (`log-analytics-workspace-and-alerts.md`, `key-vault-creation.md`, etc. — see sibling walkthroughs as reference for structure and tone). It is the operator-targeted UI walkthrough for portal-only provisioning. No code, no .NET project, no Bicep.
+
+> **Topic strategy is ADR-0028's authority.** The per-Grid-topic strategy (one ASB topic per Grid topic) is ADR-0028 D5's decision; this packet's walkthrough may document the topic naming pattern but does NOT create topics — topics are created by the Nodes that publish to them (or by the AppHost on first launch, if the AppHost composes topic-creation in its `AddGridServiceBusDev` wiring). The walkthrough creates the namespace and the access keys; topics are downstream concerns.
+
+## Scope
+- `infrastructure/walkthroughs/dev-service-bus-namespace-provisioning.md` (new) — the Azure Portal UI walkthrough.
+- `catalogs/grid-health.json` (if a `dev-service-bus` resource entry is appropriate) — flip to `provisioned` once the namespace is live. If `grid-health.json` has no slot for dev infra resources, skip the catalog update and record the provisioning in the walkthrough doc instead.
+- The Azure subscription — the actual `sb-hd-dev` namespace, the per-Grid-topic stubs (deferred to consumers), and the Vault secret (not repo artifacts).
+- **Dev App Configuration resource — provisioned in this same human session** by following the existing `infrastructure/walkthroughs/app-configuration-provisioning.md` for `env=dev`. Notify's AppHost (packet 04) composes `AddGridAppConfigDev` which resolves a connection string at launch; without the resource, packet 04 launch fails. The App Configuration walkthrough already exists — this packet executes it; it does not re-author it.
+
+NOT in scope:
+- Per-Node Key Vault provisioning — covered by existing `infrastructure/walkthroughs/key-vault-creation.md`. Notify's vault provisioning, if not already done, rides with packet 04's Human Prerequisites. The dev Service Bus connection string goes into Notify's `kv-hd-notify-dev` once Notify's vault exists.
+- Dev Key Vault provisioning — D3 names dev Key Vault as a real dev resource. It is provisioned per `feedback_provision_when_needed` by the first Node that needs it; Notify's `kv-hd-notify-dev` rides with packet 04's Human Prerequisites if it does not yet exist. Not bundled into this walkthrough.
+- Re-authoring `app-configuration-provisioning.md` — it already exists. This packet **executes** it for `env=dev`, but does not edit it.
+- Production Service Bus provisioning — ADR-0028's responsibility (or a future scoped initiative). This packet provisions `dev` only.
+
+## Proposed Work (human-executed, Azure Portal)
+Author the walkthrough to cover, and then execute, the following:
+
+1. **Namespace creation** — create a Service Bus namespace in the Azure Portal:
+   - Name: `sb-hd-dev` (per `hd` convention; ≤13-char service name "sb-hd-dev" → "hd-dev" or per the existing naming pattern — confirm against invariant 19 and existing namespaces if any).
+   - Resource group: the `dev` resource group (match existing `dev` resources' group).
+   - Region: the existing `dev` region.
+   - **Pricing tier: Basic.** Show the estimated cost (~$0.05/million operations + ~$10/month base; Basic includes 13M operations/month) before the Create click — the operator's `feedback_default_cheapest_azure_tier` preference.
+   - No zone redundancy (Basic doesn't support it; this is a dev namespace).
+2. **Connection string into Vault** — copy the namespace's primary connection string (`RootManageSharedAccessKey` or a scoped policy if the operator prefers) and store it in the relevant Key Vault. The walkthrough documents two valid placements:
+   - **Per-Node Key Vault** (preferred): the connection string lives in each consuming Node's `kv-hd-{service}-dev` and is resolved at AppHost launch via the consuming Node's Key Vault.
+   - **Shared dev Key Vault** (alternative): if a single shared `kv-hd-shared-dev` exists for dev-broker-style shared resources, the secret may live there with Read RBAC granted to each consuming Node's developer principal.
+   - The walkthrough records the chosen placement and documents the rationale. **Recommendation: per-Node Key Vault**, consistent with invariant 17 (one Key Vault per deployable Node per environment). The Notify AppHost (packet 04) will pull from `kv-hd-notify-dev`.
+3. **`dotnet user-secrets` seeding** — separately, the walkthrough documents the developer's local seeding step: `dotnet user-secrets set "ConnectionStrings:ServiceBus" "<connection-string>" --project Notify.AppHost`. This is the AppHost-level seeding the developer runs once on a fresh box; `AddGridServiceBusDev` (packet 02) resolves the connection string from user-secrets at AppHost launch.
+4. **Per-session subscription convention** — the walkthrough documents the per-developer-session naming convention (`{user}-{machine}-{process-id}` or similar — the exact form to align with `AddGridServiceBusDev`'s implementation in packet 02). Subscriptions are created at AppHost launch and deleted on AppHost shutdown by Aspire's extension (lifecycle hook — see packet 02); no manual portal subscription creation is required for normal flow.
+5. **Manual cleanup of orphaned subscriptions** — the walkthrough documents how to clear orphans when the lifecycle-hook delete fails (process killed, network blip, namespace temporarily unreachable). Steps: open the Azure Portal → `sb-hd-dev` namespace → the relevant topic → Subscriptions blade → review subscriptions older than a single dev session, delete any that no longer match a running developer's `{user}-{machine}-{process-id}`. Suggested cadence: once a week or whenever a developer notices stale entries. Provide the equivalent Service Bus Explorer path as an alternative for users in that blade.
+6. **Provision the dev App Configuration resource** — follow `infrastructure/walkthroughs/app-configuration-provisioning.md` for `env=dev`. This is a separate Azure resource creation in the same human session as the Service Bus namespace. The App Configuration endpoint URI goes into `kv-hd-notify-dev` (per the App Configuration walkthrough's convention) so Notify's AppHost can resolve it via `AddGridAppConfigDev`.
+7. **Verify** — confirm the namespace shows in the Azure Portal, the Shared Access Policy keys are readable, and (optionally) a test message round-trips via the portal's "Service Bus Explorer" blade. Confirm the dev App Configuration resource exists and its endpoint URI is stored in the relevant vault.
+8. **Update `grid-health.json` or the dispatch-plan deferred list** — if `grid-health.json` carries a slot for dev infra resources, flip the `sb-hd-dev` entry to `provisioned` and (if a slot exists) the `dev-app-configuration` entry. If not, record the provisioning facts in this packet's PR description and the dispatch plan.
+
+The walkthrough is structured to be re-runnable for a future staging/prod Service Bus when those environments stand up (per ADR-0033) — same shape, different environment name. This packet executes `dev` only.
+
+## Affected Files
+- `infrastructure/walkthroughs/dev-service-bus-namespace-provisioning.md` (new)
+- `catalogs/grid-health.json` (only if it has a dev-infra slot; otherwise no edit)
+
+NOT touched by this packet:
+- Any .NET project (no code change).
+- Production Service Bus walkthroughs (ADR-0028 / future scope).
+- Notify's or Pulse's repos (those are Wave 4 packets).
+
+## NuGet Dependencies
+None. This packet has no .NET project — it is an Azure-Portal walkthrough plus an Azure resource creation.
+
+## Boundary Check
+- [x] The walkthrough doc lives in `HoneyDrunk.Architecture` — correct home for infrastructure walkthroughs.
+- [x] No code change in any repo.
+- [x] Azure resource lands in the Azure subscription (a vendor surface, not a Node).
+- [x] No production resource provisioned — `dev` only (per `feedback_provision_when_needed` and ADR-0033).
+
+## Acceptance Criteria
+- [ ] `infrastructure/walkthroughs/dev-service-bus-namespace-provisioning.md` exists as a step-by-step Azure-Portal UI walkthrough covering namespace creation, Basic tier selection (with estimated cost shown before the Create click), connection-string copy, Vault placement decision and rationale, the `dotnet user-secrets` seeding command, the per-session subscription naming convention, **and the manual cleanup steps for orphaned subscriptions when the lifecycle-hook delete fails**
+- [ ] The walkthrough is parameterised for environment so it can be re-run for staging/prod when those environments stand up (this packet executes `dev` only)
+- [ ] The `sb-hd-dev` Service Bus namespace exists in the Azure subscription, Basic tier, in the `dev` resource group
+- [ ] **The dev App Configuration resource exists** (provisioned via the existing `infrastructure/walkthroughs/app-configuration-provisioning.md` for `env=dev`) and its endpoint URI is stored in `kv-hd-notify-dev`
+- [ ] The connection string is stored as a secret in the chosen Key Vault (per-Node `kv-hd-notify-dev` recommended; shared dev vault acceptable if documented) — never in a config file, never committed (invariants 8, 9)
+- [ ] No connection string, shared-access-key value, or any secret value appears in the walkthrough or anywhere in the repo (invariant 8)
+- [ ] The user-secrets seeding command documented in the walkthrough uses the exact key `ConnectionStrings:ServiceBus` (matching `AddGridServiceBusDev`'s configuration lookup in packet 02)
+- [ ] If `catalogs/grid-health.json` carries dev-infra slots, the `sb-hd-dev` and dev App Configuration entries read `provisioned`; if not, both provisioning facts are recorded in the PR description and the dispatch plan
+- [ ] Recurring cost (~$10/month Basic for ASB) recorded against the studio's Azure budget per ADR-0052; the dev App Configuration cost (Free tier if eligible, otherwise the lowest viable tier per `feedback_default_cheapest_azure_tier`) is recorded the same way
+
+## Human Prerequisites
+This entire packet is `Actor=Human`. The human-executed steps are the Proposed Work list above. Specifically:
+- [ ] Azure Portal access to the subscription with rights to create Service Bus namespaces **and App Configuration resources** in the `dev` resource group.
+- [ ] A decision on the connection-string Vault placement (per-Node `kv-hd-notify-dev` vs shared dev vault). Recommendation: per-Node.
+- [ ] If per-Node placement is chosen and Notify's `kv-hd-notify-dev` does not yet exist, create it per [`infrastructure/walkthroughs/key-vault-creation.md`](../../../../infrastructure/walkthroughs/key-vault-creation.md) before storing the connection string. (Notify is a live Node; its dev vault may already exist — verify first.)
+- [ ] Acceptance of the ~$10/month recurring Service Bus charge (within the studio's Azure budget per ADR-0052), plus the dev App Configuration tier cost (Free or lowest viable; show the estimate before the Create click).
+- [ ] Confirmation of the namespace name against `hd` naming convention and ≤13-char service-name rule (invariant 19).
+
+## Referenced ADR Decisions
+**ADR-0065 D9 — Windows-first: real dev Service Bus.** One namespace `sb-hd-dev`, Basic tier, per-session subscriptions, dotnet user-secrets for connection-string resolution. The InMemory broker shim was considered and rejected — its semantics differ from ASB in ways that produce bugs that pass local CI and fail in production.
+
+**ADR-0028 D5 — Default shared Service Bus namespace and topic strategy.** The Grid uses one shared Service Bus namespace per environment with one topic per Grid topic; ADR-0065 D9's `sb-hd-dev` is the dev incarnation of that shape. Note ADR-0028 is still **Proposed** — soft consistency dependency.
+
+**ADR-0005 — Vault and Key Vault naming.** One Key Vault per deployable Node per environment, named `kv-hd-{service}-{env}`. The Service Bus connection string lives in the consuming Node's Vault (per-Node placement recommended).
+
+**ADR-0052 — Cost governance.** The ~$10/month recurring Basic-tier ASB cost is recorded against the studio's Azure budget.
+
+**ADR-0033 — Deploy trigger model.** `dev` is the live environment now; staging/prod stand up later. This packet provisions `dev` only; staging/prod are re-runs of this walkthrough when they exist.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The Service Bus connection string is a secret. It never enters the repo, the walkthrough, a config file, or a commit. Only the *fact* of provisioning is recorded.
+
+> **Invariant 9 — Vault is the only source of secrets.** Consuming Nodes resolve the connection string via `ISecretStore` (or via `dotnet user-secrets` at AppHost-launch time, which is the local-dev equivalent under D9).
+
+> **Invariant 17 — One Key Vault per deployable Node per environment.** Per-Node placement of the connection string in `kv-hd-notify-dev` (and any other consuming Node's vault) is the recommended path.
+
+> **Invariant 19 — Service names in Azure resource naming ≤ 13 characters.** `sb-hd-dev` is 9 chars — fits. Confirm against any existing `hd` ASB namespaces.
+
+- **Provision `dev` only.** Staging and prod are deferred. The walkthrough is parameterised for re-run.
+- **Basic tier.** The operator's standing tier preference is "default cheapest viable"; Basic is sufficient for v1. Standard only justified by per-message scheduling, subscription filters, or large messages.
+- **Portal-only, UI walkthrough.** No Bicep, no ARM, no CLI — the operator's portal-over-CLI preference. Click-by-click.
+
+## Labels
+`feature`, `tier-2`, `ops`, `infrastructure`, `human-only`, `adr-0065`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Author the dev Service Bus provisioning walkthrough and provision `sb-hd-dev` so Notify's and Pulse's AppHosts (Wave 4) can resolve a real broker. **Also provision the dev App Configuration resource in the same human session** (via the existing `infrastructure/walkthroughs/app-configuration-provisioning.md`) so Notify's AppHost can resolve `AddGridAppConfigDev` at launch.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Unblock the first multi-service local-dev composition (Notify + Pulse) by providing the only resource the AppHosts cannot fake — real Service Bus.
+- Feature: ADR-0065 Multi-Service Local Dev Orchestration rollout, Wave 3 (infra provisioning).
+- ADRs: ADR-0065 D9 (primary), ADR-0028 D5 (topic strategy), ADR-0005 (Vault/Key Vault placement), ADR-0052 (cost recording), ADR-0033 (env scope).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0065 Accepted before the dev ASB namespace is provisioned in its name.
+
+**Constraints:**
+- Provision `dev` only; staging/prod deferred (ADR-0033).
+- Basic tier (cheapest viable per the operator's tier preference) for ASB; Free or lowest-viable tier for App Configuration.
+- Connection string into Vault, never the repo (invariants 8, 9).
+- Portal-only walkthrough; no CLI or Bicep.
+- Use the existing `app-configuration-provisioning.md` walkthrough for the App Configuration step — do not re-author it.
+
+**Key Files:**
+- `infrastructure/walkthroughs/dev-service-bus-namespace-provisioning.md` (new)
+- `infrastructure/walkthroughs/app-configuration-provisioning.md` (existing — followed, not edited)
+- `catalogs/grid-health.json` (only if a dev-infra slot exists)
+
+**Contracts:** None changed — infra provisioning + walkthrough doc only.

--- a/generated/issue-packets/active/adr-0065-aspire-orchestration/04-notify-add-apphost.md
+++ b/generated/issue-packets/active/adr-0065-aspire-orchestration/04-notify-add-apphost.md
@@ -1,0 +1,227 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["feature", "tier-2", "ops", "adr-0065", "wave-4"]
+dependencies: ["packet:02", "packet:03"]
+adrs: ["ADR-0065"]
+wave: 4
+initiative: adr-0065-aspire-orchestration
+node: honeydrunk-notify
+---
+
+# Add HoneyDrunk.Notify.AppHost — Notify is the first migrant to Aspire
+
+## Summary
+Add a `HoneyDrunk.Notify.AppHost` project to the `HoneyDrunk.Notify` solution: model Notify's Functions process, Notify's Worker process, the Cosmos Emulator, Azurite (for Notify's Storage Queue intake), the dev Service Bus connection (via `AddGridServiceBusDev`), the dev Key Vault connection, the dev App Configuration connection, and Pulse.Collector (opt-in dual-emit per D4). This is Notify's local-dev inner loop and the first per-Node Aspire migration in the Grid per ADR-0065 D7.
+
+## Context
+ADR-0065 D7 names Notify as the first migrant: Notify's Functions + Worker is the first multi-process composition; Notify's AppHost lands as part of the imminent Notify dev-deploy work. ADR-0065 also commits "Aspire ships first-party support for Azure Functions project resources; Notify's Functions process composes via `AddAzureFunctionsProject<T>` — recorded so the Notify migration packet uses the supported pattern from day one." (Alternatives Considered — "Adopt Aspire's Azure Functions project resource for Notify's Functions process" — Accepted.)
+
+`HoneyDrunk.Notify` is a live Node currently at v0.2.0 with the package family `HoneyDrunk.Notify.Abstractions`, `HoneyDrunk.Notify`, `HoneyDrunk.Notify.Functions`, `HoneyDrunk.Notify.HostBootstrap`, `HoneyDrunk.Notify.Hosting.AspNetCore`, `HoneyDrunk.Notify.ProviderSupport`, `HoneyDrunk.Notify.Providers.Email.Resend`, `HoneyDrunk.Notify.Providers.Email.Smtp`, `HoneyDrunk.Notify.Providers.Sms.Twilio`, `HoneyDrunk.Notify.Queue.Abstractions`, `HoneyDrunk.Notify.Queue.AzureStorage`, `HoneyDrunk.Notify.Queue.InMemory`, `HoneyDrunk.Notify.Tools`, `HoneyDrunk.Notify.Worker` (per the existing solution layout). Notify's two runtime entry points are **Functions** (`HoneyDrunk.Notify.Functions`) and **Worker** (`HoneyDrunk.Notify.Worker`). The AppHost composes both.
+
+Per ADR-0065 D3, Notify's AppHost models:
+- **Project resources** — `HoneyDrunk.Notify.Functions` (via `AddAzureFunctionsProject<T>` per the Accepted alternative), `HoneyDrunk.Notify.Worker` (via `AddProject<T>`), and (D4 opt-in) `HoneyDrunk.Pulse.Collector` if Pulse-iteration mode is enabled.
+- **Container resources** — Cosmos Emulator (`AddGridCosmosEmulator` from packet 02), Azurite (`AddGridAzurite` for the Storage Queue intake per ADR-0028 D2/D3 Notify-internal queue).
+- **Connection-string resources** — Service Bus (`AddGridServiceBusDev`), Key Vault (`AddGridKeyVaultDev`), App Configuration (`AddGridAppConfigDev`).
+- **OTLP** — every project resource calls `AddGridTelemetry` so OTLP ships to Aspire's dashboard by default, with optional fan-out to Pulse.Collector.
+
+This packet **adds the AppHost; it does not migrate Notify's existing `launchSettings.json` away**. Per ADR-0065 D7, the AppHost is the canonical inner loop going forward, but the existing `launchSettings.json` can remain in place during the transition (the developer chooses which to run). A future cleanup packet may remove the `launchSettings.json`-based composition; this packet does not.
+
+Per invariant 27, this packet is the first packet on the `HoneyDrunk.Notify` solution in this initiative — it bumps the whole solution to a new minor version (new project added to the solution; functional change). Confirm Notify's current version at execution time and bump to the next minor.
+
+`HoneyDrunk.Notify.AppHost` is a new project — it needs `CHANGELOG.md` and `README.md` from the first commit (invariant 12).
+
+> **Notify's intake → worker hop is in-Node.** ADR-0028 D2/D3 (Notify intake → worker via `HoneyDrunk.Notify.Queue.*`, an Azure Storage Queue) is an in-Node queue, not a Service Bus hop. Notify's AppHost models that Azure Storage Queue via Azurite (`AddGridAzurite`), not Service Bus. The `AddGridServiceBusDev` connection in the AppHost is for any **cross-Node** Service Bus hops Notify produces or consumes (today: none for the in-Node queue, but the connection is wired so that future cross-Node hops have it in place). If Notify has zero current Service Bus hops, document that in the AppHost's `Program.cs` as a future-readiness composition and call out the Storage Queue as the live one.
+
+## Scope
+- New project `HoneyDrunk.Notify.AppHost` in the `HoneyDrunk.Notify.slnx` solution:
+  - SDK: `Microsoft.NET.Sdk`, `OutputType=Exe`.
+  - `PackageReference` to Aspire AppHost SDK, `HoneyDrunk.Standards` (`PrivateAssets: all`), `HoneyDrunk.Standards.Aspire` (the Grid extensions from packet 02).
+  - `ProjectReference` to `HoneyDrunk.Notify.Functions` and `HoneyDrunk.Notify.Worker` (so the AppHost can compose them as project resources).
+  - `Program.cs` composing the resources per the Proposed Implementation below.
+- `HoneyDrunk.Notify.AppHost/CHANGELOG.md` + `README.md` (new project — invariant 12).
+- Solution `.slnx` updated to include the new project.
+- Version bump across the `HoneyDrunk.Notify` solution (invariant 27); repo-level `CHANGELOG.md` new version entry.
+
+NOT in scope:
+- Removing Notify's existing `launchSettings.json` composition — keep it; AppHost is the new canonical inner loop but the old composition can coexist during the transition.
+- Production Bicep changes — D5: Aspire is local-dev only; production deployment authoring stays in `HoneyDrunk.Standards` shared workflows + curated Bicep per ADR-0015.
+- Wiring `AddPulseCollector(...)` for Pulse dual-emit. The default OTLP shape (Aspire dashboard only — D4 default) is already in effect without any call; calling the opt-in switch with `opt: false` would be dead code. The future flip lands when a Pulse.Collector container image or NuGet host package becomes available (the composition path is documented in packet 05's `HoneyDrunk.Pulse.AppHost/README.md`). This packet documents the procedure in `HoneyDrunk.Notify.AppHost/README.md` but does not pre-wire it.
+
+## Proposed Implementation
+
+1. **Scaffold from the Standards template.** Use the `HoneyDrunk.Standards.Templates.AspireAppHost` template from packet 02 to generate the AppHost project (or scaffold by hand if the template path is not yet wired into `dotnet new`). The template produces the project file, `.template.config`-free starter `Program.cs`, and the standard `HoneyDrunk.Standards` analyzer baseline.
+
+2. **`Program.cs`** — compose the Notify inner loop:
+   ```csharp
+   var builder = DistributedApplication.CreateBuilder(args);
+
+   // Backing infrastructure
+   var cosmos = builder.AddGridCosmosEmulator("notify-cosmos");
+   var azurite = builder.AddGridAzurite("notify-azurite");
+   var serviceBus = builder.AddGridServiceBusDev("grid-asb-dev");
+   var keyVault = builder.AddGridKeyVaultDev("notify-kv");
+   var appConfig = builder.AddGridAppConfigDev("notify-appconfig");
+
+   // Notify's two runtime entry points
+   var functions = builder
+       .AddAzureFunctionsProject<Projects.HoneyDrunk_Notify_Functions>("notify-functions")
+       .WithReference(azurite)
+       .WithReference(cosmos)
+       .WithReference(serviceBus)
+       .WithReference(keyVault)
+       .WithReference(appConfig)
+       .AddGridTelemetry();
+
+   var worker = builder
+       .AddProject<Projects.HoneyDrunk_Notify_Worker>("notify-worker")
+       .WithReference(azurite)
+       .WithReference(cosmos)
+       .WithReference(serviceBus)
+       .WithReference(keyVault)
+       .WithReference(appConfig)
+       .AddGridTelemetry();
+
+   // Pulse dual-emit (D4) — NOT wired in this packet. Default behavior ships OTLP to the
+   // Aspire dashboard only. When a Pulse.Collector container image (or NuGet host package)
+   // becomes available, a future packet adds the AddPulseCollector(...) composition here.
+   // See HoneyDrunk.Notify.AppHost/README.md for the flip procedure.
+
+   await builder.Build().RunAsync();
+   ```
+   The exact Aspire API surface depends on the pinned version from packet 02; match those exact extension method shapes. Use `WithReference` (or its current Aspire equivalent) to inject the connection-string environment variables Notify's Functions/Worker need (`AZURE_KEYVAULT_URI`, `AZURE_APPCONFIG_ENDPOINT`, the Storage Queue connection, the Service Bus connection, the Cosmos connection) — match the env var names Notify already consumes in its `IConfiguration`/`ISecretStore` paths so no Notify runtime code change is needed.
+
+   > **Service Bus connection-string env var name.** `AddGridServiceBusDev` reads the connection string from the `ConnectionStrings:ServiceBus` configuration key (sourced from `dotnet user-secrets`). Per Aspire's connection-string resource convention, `WithReference(serviceBus)` projects the value into the consuming process as the environment variable `ConnectionStrings__ServiceBus` (the standard ASP.NET configuration name-to-env-var mapping — double-underscore separator). Notify's existing `IConfiguration` already binds `ConnectionStrings:ServiceBus`, so no Notify runtime code change is needed. **Pin this exact key in both the user-secrets seeding step (packet 03 walkthrough) and the Notify configuration binding** so the walkthrough, the extension, and the consumer all agree on one name.
+
+   > **Why no `AddPulseCollector(opt: false)` line.** Calling the opt-in switch with `opt: false` is dead code — the default `Program.cs` already ships OTLP to the Aspire dashboard only (D4 default behavior). The future flip is documented in `HoneyDrunk.Notify.AppHost/README.md` under "Enabling Pulse dual-emit"; the actual `AddPulseCollector(...)` invocation lands as part of the packet that introduces a Pulse.Collector container image or NuGet host package (the container-resource composition path documented in packet 05's README).
+
+3. **Service Bus connection — future-readiness.** Audit Notify's actual ASB use today. If Notify has zero current ASB producers/consumers (the intake → worker hop is Storage Queue per ADR-0028 D2/D3), document in `Program.cs` and `README.md` that the ASB connection is wired in advance for future cross-Node hops; the live broker for v1 is Azurite. If Notify already has ASB hops (e.g. for a future BillingEvent emit), keep the ASB reference live.
+
+4. **`HoneyDrunk.Notify.AppHost.csproj`**:
+   - SDK: `Microsoft.NET.Sdk` with `OutputType=Exe` and the Aspire AppHost target the template establishes.
+   - `IsAspireHost=true`.
+   - `PackageReference` to Aspire AppHost SDK + Aspire integrations (Cosmos, Storage, Service Bus, Key Vault, App Configuration, Azure Functions) at the version Standards pinned in packet 02.
+   - `PackageReference` to `HoneyDrunk.Standards` (`PrivateAssets: all`) and `HoneyDrunk.Standards.Aspire` (the version released after packet 02 merges).
+   - `ProjectReference` to `HoneyDrunk.Notify.Functions` and `HoneyDrunk.Notify.Worker`.
+
+5. **Solution + version bump.**
+   - Add `HoneyDrunk.Notify.AppHost` to `HoneyDrunk.Notify.slnx`.
+   - Bump every non-test `.csproj` in the solution to the same new minor version in one commit (invariant 27). New project added to the solution counts as functional change — minor bump.
+   - Repo-level `CHANGELOG.md` new version entry describing the AppHost addition.
+   - Per-package `CHANGELOG.md`: only `HoneyDrunk.Notify.AppHost` gets a new-package entry (the package itself is new). Other Notify packages get alignment-bump only — no per-package CHANGELOG noise (invariants 12/27).
+   - `HoneyDrunk.Notify.AppHost/README.md` documents how to run the AppHost (`dotnet run --project HoneyDrunk.Notify.AppHost`), what it composes, the `dotnet user-secrets` seeding required for `AddGridServiceBusDev` (using the exact key `ConnectionStrings:ServiceBus` — same key the packet 03 walkthrough documents), and **how to enable Pulse dual-emit in the future**: when a Pulse.Collector container image (or NuGet host package) becomes available, add the `AddPulseCollector(...)` call to `Program.cs` per the container-resource composition path documented in `HoneyDrunk.Pulse.AppHost/README.md` from packet 05. Until then the AppHost ships OTLP to the Aspire dashboard only.
+
+6. **Verify the AppHost compiles and launches.** Run `dotnet build` and (locally) `dotnet run --project HoneyDrunk.Notify.AppHost` to confirm the AppHost stands up: the Aspire dashboard URL opens, the Functions + Worker projects start, the Cosmos Emulator and Azurite containers start under Docker Desktop, the Service Bus dev connection resolves from user-secrets, and OTLP traces appear in the dashboard. (This is a developer-side verification — the CI gate is `dotnet build`; full launch is not part of CI per D10.)
+
+## Affected Files
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.AppHost/HoneyDrunk.Notify.AppHost.csproj` (new)
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.AppHost/Program.cs` (new)
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.AppHost/CHANGELOG.md` (new, invariant 12)
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.AppHost/README.md` (new, invariant 12)
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.slnx` — new project entry
+- Every non-test `.csproj` in the solution — version bump (invariant 27)
+- Repo-level `CHANGELOG.md` — new minor version entry
+
+## NuGet Dependencies
+
+`HoneyDrunk.Notify.AppHost` — new `PackageReference` set:
+- The Aspire AppHost SDK + Aspire integrations packages (Cosmos, Storage, Service Bus, Key Vault, App Configuration, Azure Functions) at the version Standards pinned in packet 02.
+- `HoneyDrunk.Standards` (`PrivateAssets: all`) at the new published version from packet 02.
+- `HoneyDrunk.Standards.Aspire` at the new published version from packet 02.
+- `ProjectReference` to `HoneyDrunk.Notify.Functions`, `HoneyDrunk.Notify.Worker`.
+
+No other Notify project gains a new `PackageReference` in this packet — the AppHost composes existing projects; the existing projects' DI/config does not need to change.
+
+Confirm the exact `HoneyDrunk.Standards` / `HoneyDrunk.Standards.Aspire` versions at execution time — they are set by packet 02's bump.
+
+## Boundary Check
+- [x] All code change is in `HoneyDrunk.Notify` — the new AppHost composes Notify's existing Functions + Worker projects. Routing rule "notification, email, SMS, ... notify, channel → HoneyDrunk.Notify" maps here.
+- [x] No contract change in Notify's existing packages; the AppHost is additive.
+- [x] No reference from Notify to `HoneyDrunk.Pulse` runtime code — the Pulse.Collector composition uses Aspire's container or external-project resource mechanism, never a Pulse project reference (which would invert the dependency direction and pull Pulse into Notify's build).
+- [x] Notify decision logic stays in Communications (invariant 41) — the AppHost touches no domain logic, only orchestration metadata.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Notify.AppHost` project exists, is `OutputType=Exe`, and is included in `HoneyDrunk.Notify.slnx`
+- [ ] `Program.cs` composes Cosmos Emulator, Azurite, dev Service Bus connection, dev Key Vault connection, dev App Configuration connection, the `HoneyDrunk.Notify.Functions` project via `AddAzureFunctionsProject<T>`, and the `HoneyDrunk.Notify.Worker` project via `AddProject<T>` — all using the Grid extensions from `HoneyDrunk.Standards.Aspire`
+- [ ] Both project resources call `AddGridTelemetry` for OTLP wiring (Aspire-dashboard default, per D4)
+- [ ] No `AddPulseCollector(...)` call appears in `Program.cs`; the default-off behavior is the Aspire-dashboard-only OTLP shape, and the README documents the future flip
+- [ ] The user-secrets key for ASB is exactly `ConnectionStrings:ServiceBus` (projected by Aspire's `WithReference(serviceBus)` to the `ConnectionStrings__ServiceBus` env var) — consistent with the packet 03 walkthrough's seeding command and Notify's existing `IConfiguration` binding
+- [ ] `dotnet build HoneyDrunk.Notify.slnx` succeeds
+- [ ] `dotnet run --project HoneyDrunk.Notify.AppHost` launches the Aspire dashboard, starts Functions + Worker, and starts the Cosmos Emulator + Azurite containers under Docker Desktop (developer verification — captured in the PR description, not in CI)
+- [ ] `HoneyDrunk.Notify.AppHost/README.md` documents the run command, the composed resources, the `dotnet user-secrets` seeding for ASB with the exact `ConnectionStrings:ServiceBus` key, and the future Pulse dual-emit flip procedure
+- [ ] `HoneyDrunk.Notify.AppHost/CHANGELOG.md` exists with the initial entry
+- [ ] Every non-test `.csproj` in the solution is at the same new minor version in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new minor version entry describing the AppHost addition
+- [ ] Per-package CHANGELOGs of unchanged Notify projects get NO entry (alignment bump only, invariants 12/27)
+- [ ] No production deployment surface modified (D5 — Aspire is local-dev only)
+- [ ] `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **Publish `HoneyDrunk.Standards` (with `HoneyDrunk.Standards.Aspire` and `HoneyDrunk.Standards.Templates.AspireAppHost`) before this packet builds.** Packet 02 ships those packages; a human pushes the git release tag on `HoneyDrunk.Standards` after packet 02 merges. Agents never tag or publish. Wave 4 cannot build against unpublished Standards packages.
+- [ ] **The `sb-hd-dev` Service Bus namespace must exist.** Packet 03 provisions it (Actor=Human). The AppHost's `AddGridServiceBusDev` resolves a connection string at launch — without the namespace, launch fails (build still succeeds; runtime launch fails).
+- [ ] **Notify's dev Key Vault (`kv-hd-notify-dev`) must exist** with the Service Bus connection string and any other Notify secrets seeded. If the vault does not yet exist, create it per `infrastructure/walkthroughs/key-vault-creation.md`.
+- [ ] **The dev App Configuration resource must exist** for `AddGridAppConfigDev` to resolve. Packet 03 provisions it in the same human session as the ASB namespace (executing the existing `infrastructure/walkthroughs/app-configuration-provisioning.md` for `env=dev`). Build succeeds without it; runtime launch fails.
+- [ ] **Developer-side `dotnet user-secrets` seeding** — the developer runs `dotnet user-secrets set "ConnectionStrings:ServiceBus" "<connection-string>" --project HoneyDrunk.Notify.AppHost` once per fresh box, with the connection string read from `kv-hd-notify-dev`. The key name `ConnectionStrings:ServiceBus` is load-bearing — it is the exact key `AddGridServiceBusDev` resolves in packet 02, the key documented in the packet 03 walkthrough, and the key Notify's existing `IConfiguration` binds. (The walkthrough in packet 03 documents this; not a packet-merge prerequisite, only a launch prerequisite.)
+- [ ] **Docker Desktop running on the developer's box** for the Cosmos Emulator + Azurite containers. Not a build-time prerequisite; launch-time only.
+
+## Referenced ADR Decisions
+**ADR-0065 D2 — Per-Node AppHost.** Each containerized Node's repo includes a `{Node}.AppHost` project alongside its main solution; the default `dotnet run --project {Node}.AppHost` launches the Node's local inner loop.
+
+**ADR-0065 D3 — Resource modeling.** Project resources for `.NET` processes, container resources for emulators (Cosmos, Azurite), connection-string resources for non-emulated dev services (Service Bus, Key Vault, App Configuration).
+
+**ADR-0065 D4 — Pulse integration, opt-in dual-emit.** Default ships OTLP to Aspire's dashboard only; opt-in `AddPulseCollector` adds Pulse.Collector and fans out OTLP.
+
+**ADR-0065 D7 — Notify is the first migrant.** Notify's AppHost lands as part of the Notify-dev-deploy work.
+
+**ADR-0065 Alternatives Considered (Accepted) — Aspire's Azure Functions project resource.** Notify's Functions process composes via `AddAzureFunctionsProject<T>` (first-party Aspire support).
+
+**ADR-0065 D5 — Production deployment is separate.** Nothing in this packet wires `azd` or generates production Bicep. The AppHost is local-dev only.
+
+**ADR-0028 D2/D3 — Notify's intake → worker queue is in-Node Storage Queue.** Notify's AppHost models that Azure Storage Queue via Azurite, not Service Bus. The Service Bus connection is wired for future cross-Node hops; the live broker for v1 is Azurite.
+
+## Constraints
+- **Invariant 27 — one version across the solution.** Bump every non-test `.csproj` together. This is the bumping packet for `HoneyDrunk.Notify` in this initiative; the bump is minor (new project added — functional change).
+- **Invariant 12 — CHANGELOG/README discipline.** New `HoneyDrunk.Notify.AppHost` package gets `CHANGELOG.md` + `README.md` from this commit. Unchanged packages get NO per-package CHANGELOG entry.
+- **Invariant 26 — analyzer baseline.** The new AppHost project references `HoneyDrunk.Standards` with `PrivateAssets: all`.
+- **Invariant 41 — preference/cadence/suppression logic lives in Communications, not Notify.** The AppHost composes Notify's existing entry points; no domain logic moves.
+- **D5 — Aspire is local-dev only.** No `azd` wiring, no generated production Bicep, no production-deployment files. The Notify production deployment continues to be the existing `HoneyDrunk.Standards` shared workflow + curated Bicep per ADR-0015.
+- **No Pulse runtime dependency.** Pulse.Collector composes via Aspire container/external-project resource, never via Notify referencing the Pulse runtime project (which would invert the build dependency).
+- **No `AddPulseCollector(opt: false)` placeholder call.** The opt-in switch with `opt: false` is dead code — the Aspire-dashboard-only default already provides that behavior. The future flip is README-documented; the actual call lands when a Pulse.Collector container image or NuGet host package exists.
+- **Pin `ConnectionStrings:ServiceBus` as the canonical key.** The packet 03 walkthrough's user-secrets seeding command, packet 02's `AddGridServiceBusDev` resolution, and Notify's existing `IConfiguration` binding all use this exact key. Aspire's `WithReference(serviceBus)` projects it to the env var `ConnectionStrings__ServiceBus`.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0065`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Add `HoneyDrunk.Notify.AppHost` as Notify's local-dev inner loop — the first per-Node Aspire migration in the Grid.
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: Replace the imminent ad-hoc Notify multi-process inner loop with a structured Aspire-modeled composition.
+- Feature: ADR-0065 Multi-Service Local Dev Orchestration rollout, Wave 4 (first migrants — parallel with packet 05 Pulse).
+- ADRs: ADR-0065 D2/D3/D4/D5/D7 (primary), ADR-0028 D2/D3 (Notify queue is in-Node), ADR-0015 (production deployment authority — unchanged).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — `HoneyDrunk.Standards.Aspire` and the AppHost template ship; the AppHost references them.
+- `packet:03` — the `sb-hd-dev` namespace exists so `AddGridServiceBusDev` resolves a real broker at launch.
+
+**Constraints:**
+- The AppHost is local-dev only — no production deployment surface (D5).
+- Bump the whole solution one minor version (invariant 27).
+- Notify decision logic stays in Communications (invariant 41) — touch no domain logic.
+- Pulse dual-emit defaults to off via the Aspire-dashboard-only OTLP shape; no `AddPulseCollector(...)` call is added in this packet. The future flip is README-documented and lands when a Pulse.Collector container image or NuGet host package is available (packet 05 documents the composition path).
+
+**Key Files:**
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.AppHost/Program.cs` (new)
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.AppHost/HoneyDrunk.Notify.AppHost.csproj` (new)
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.AppHost/CHANGELOG.md` + `README.md` (new)
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.slnx` (new project entry)
+- Every non-test `.csproj` for the version bump; repo-level `CHANGELOG.md`
+
+**Contracts:** None changed — the AppHost composes Notify's existing entry points without modifying their public surface.

--- a/generated/issue-packets/active/adr-0065-aspire-orchestration/05-pulse-add-apphost.md
+++ b/generated/issue-packets/active/adr-0065-aspire-orchestration/05-pulse-add-apphost.md
@@ -1,0 +1,205 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Pulse
+labels: ["feature", "tier-2", "ops", "adr-0065", "wave-4"]
+dependencies: ["packet:02"]
+adrs: ["ADR-0065"]
+wave: 4
+initiative: adr-0065-aspire-orchestration
+node: honeydrunk-pulse
+---
+
+# Add HoneyDrunk.Pulse.AppHost — Pulse is the second migrant to Aspire
+
+## Summary
+Add a `HoneyDrunk.Pulse.AppHost` project to the `HoneyDrunk.Pulse` solution: model Pulse.Collector as a project resource exposing its OTLP receiver, the backing infrastructure Pulse needs locally (Cosmos Emulator for telemetry stores or Pulse's durable state, dev Key Vault / App Configuration), the Aspire dashboard, and a canonical entry point for the dual-emit pattern from D4 — so that any Node's AppHost composing `AddPulseCollector(opt: true)` has a working Pulse.Collector to fan OTLP out to. Per ADR-0065 D7, Pulse is the second migrant because Notify's AppHost composes Pulse.Collector and Pulse should carry the canonical Pulse.Collector composition.
+
+## Context
+ADR-0065 D7 names Pulse as the second migrant: "Pulse migrates next, because Notify's AppHost composes Pulse.Collector and the Pulse repo benefits from carrying the canonical Pulse.Collector AppHost." ADR-0065 D4 names Pulse.Collector as the opt-in dual-emit destination: when an AppHost calls `AddPulseCollector(opt: true)`, Pulse.Collector composes as a project resource alongside the consuming Node's projects and OTLP is fanned out to both Aspire's dashboard and Pulse.Collector.
+
+`HoneyDrunk.Pulse` is a live Node at version 0.3.0. Its packages include `HoneyDrunk.Telemetry.Abstractions`, `HoneyDrunk.Telemetry.OpenTelemetry`, `HoneyDrunk.Telemetry.Sink.AzureMonitor`, `HoneyDrunk.Telemetry.Sink.Loki`, `HoneyDrunk.Telemetry.Sink.Mimir`, `HoneyDrunk.Telemetry.Sink.PostHog`, `HoneyDrunk.Telemetry.Sink.Sentry`, `HoneyDrunk.Telemetry.Sink.Tempo`, `HoneyDrunk.Telemetry.Sink.Shared` (per the existing solution layout per the ADR-0040 packet 03 context note). The Pulse Node's runtime entry point is the **Pulse Collector** — the host that exposes the OTLP receiver and routes signals to its sinks. The Pulse.AppHost composes that Collector and the backing dependencies it needs locally.
+
+> **Pulse.Collector is an existing project.** Verified at packet-authoring time: `HoneyDrunk.Pulse.Collector` ships today as a `Microsoft.NET.Sdk.Web` project at `HoneyDrunk.Pulse/Pulse.Collector/HoneyDrunk.Pulse.Collector.csproj` — a Grpc.AspNetCore-hosted OTLP receiver wired to the existing `HoneyDrunk.Telemetry.*` sinks. **This packet composes the existing Collector via `AddProject<Projects.HoneyDrunk_Pulse_Collector>("pulse-collector")`; it does not introduce a new Collector executable host.** No new project, no new public surface in Pulse — only the AppHost is net-new.
+
+Per ADR-0065 D3, Pulse's AppHost models:
+- **Project resources** — Pulse.Collector (the OTLP receiver host).
+- **Container resources** — backing infrastructure Pulse needs locally for iteration (depends on what Pulse's storage/state model is locally — Cosmos Emulator, Azurite, or none if Pulse's local state is in-memory).
+- **Connection-string resources** — dev Key Vault (for Pulse's sink credentials — App Insights, Sentry DSN, Loki/Mimir/Tempo endpoints; all stored in `kv-hd-pulse-dev` per ADR-0040 packet 02's provisioning), dev App Configuration.
+- **OTLP** — Pulse.Collector calls `AddGridTelemetry` for its own self-observability; the dashboard surfaces Pulse's own traces alongside any other project resources it composes.
+
+Per invariant 27, this packet is the first packet on the `HoneyDrunk.Pulse` solution in this initiative — it bumps the whole solution to a new minor version. Confirm Pulse's current version at execution time and bump to the next minor.
+
+`HoneyDrunk.Pulse.AppHost` is a new project — it needs `CHANGELOG.md` and `README.md` from the first commit (invariant 12). The existing `HoneyDrunk.Pulse.Collector` project is unchanged by this packet (the AppHost composes it via project reference, no source edits to the Collector).
+
+> **Sequencing note.** ADR-0040's Pulse work (packets 03/04/05/07 in the `adr-0040-telemetry-backend` initiative) extends `HoneyDrunk.Telemetry.Sink.AzureMonitor`. If ADR-0040 Pulse packets are mid-flight at execution time, the Pulse-solution version-bump rule (invariant 27) applies: only the first un-released packet bumps; the rest append to the same in-progress version's CHANGELOG. The executor checks the in-progress Pulse version state at edit time and either (a) is the bumping packet if no ADR-0040 Pulse packet has bumped yet, or (b) appends to the in-progress version if ADR-0040 already bumped. Record which case applies in the PR description.
+
+## Scope
+- New project `HoneyDrunk.Pulse.AppHost` in the `HoneyDrunk.Pulse.slnx` solution:
+  - SDK: `Microsoft.NET.Sdk`, `OutputType=Exe`.
+  - `PackageReference` to Aspire AppHost SDK, `HoneyDrunk.Standards` (`PrivateAssets: all`), `HoneyDrunk.Standards.Aspire`.
+  - `ProjectReference` to the existing `HoneyDrunk.Pulse.Collector` project.
+  - `Program.cs` composing the resources per the Proposed Implementation below.
+- `HoneyDrunk.Pulse.AppHost/CHANGELOG.md` + `README.md` (new project — invariant 12).
+- Solution `.slnx` updated to include the new AppHost project.
+- Version bump across the `HoneyDrunk.Pulse` solution per invariant 27 (or CHANGELOG-append-only if ADR-0040 already bumped the in-progress version).
+
+NOT in scope:
+- Migrating Notify's AppHost (packet 04) to live-compose Pulse.Collector via project reference. Notify cannot project-reference Pulse without inverting the dependency direction. Notify composes Pulse.Collector via **container resource against a published Pulse.Collector image**, **external `AddProject<T>` against a Pulse.Collector NuGet/path resource**, or **leaves the dual-emit defaulted off** and the developer runs Pulse's AppHost separately for Pulse-iteration scenarios. This packet documents the recommended path in `HoneyDrunk.Pulse.AppHost/README.md`.
+- Production Bicep changes (D5 — Aspire is local-dev only).
+- Replacing the existing Pulse `launchSettings.json` composition — coexist during transition.
+
+## Proposed Implementation
+
+1. **Confirm the Pulse.Collector project path.** The existing `HoneyDrunk.Pulse.Collector` project lives at `HoneyDrunk.Pulse/Pulse.Collector/HoneyDrunk.Pulse.Collector.csproj` (`Microsoft.NET.Sdk.Web`, gRPC + OTLP receiver, already wired to the `HoneyDrunk.Telemetry.*` sinks). The AppHost composes it via `AddProject<Projects.HoneyDrunk_Pulse_Collector>("pulse-collector")` — no changes to the Collector itself.
+
+2. **Scaffold the AppHost from the Standards template.** Use `HoneyDrunk.Standards.Templates.AspireAppHost` (packet 02) to generate the project skeleton.
+
+3. **`Program.cs`** — compose the Pulse inner loop:
+   ```csharp
+   var builder = DistributedApplication.CreateBuilder(args);
+
+   // Backing infrastructure (only what Pulse genuinely needs locally;
+   // omit any resource Pulse's local-dev mode does not use)
+   var keyVault = builder.AddGridKeyVaultDev("pulse-kv");
+   var appConfig = builder.AddGridAppConfigDev("pulse-appconfig");
+   // If Pulse's local state uses Cosmos / Azurite, add them here.
+
+   // Pulse.Collector — the OTLP receiver
+   var collector = builder
+       .AddProject<Projects.HoneyDrunk_Pulse_Collector>("pulse-collector")
+       .WithReference(keyVault)
+       .WithReference(appConfig)
+       .AddGridTelemetry();
+
+   await builder.Build().RunAsync();
+   ```
+   The Pulse.Collector project name is fixed (`HoneyDrunk.Pulse.Collector`); the Aspire-generated `Projects.HoneyDrunk_Pulse_Collector` strong reference comes from the `ProjectReference` in the AppHost csproj.
+
+4. **Document the cross-Node Pulse.Collector composition path in `README.md`.** The AppHost's README explains, for downstream Node AppHosts (Notify, Communications, etc.) that want the D4 dual-emit:
+   - **Recommended (when Pulse.Collector publishes a container image):** the downstream AppHost composes Pulse.Collector via `AddContainer` against the published image — no project reference, no inverted dependency.
+   - **Interim (until a Pulse.Collector image is published):** the developer runs Pulse's AppHost separately for Pulse-iteration scenarios; the downstream Node's AppHost simply omits the `AddPulseCollector(...)` call (the D4 default OTLP-to-Aspire-dashboard-only shape is already in effect), and the developer points the downstream Node's OTLP endpoint at Pulse.Collector's port manually if both AppHosts are running.
+   - **Future:** when Pulse.Collector ships as a NuGet-distributed host package, the downstream AppHost can `AddProject<T>` against the package path. Track this as a follow-up; do not block on it.
+
+5. **`HoneyDrunk.Pulse.AppHost.csproj`**:
+   - SDK: `Microsoft.NET.Sdk` with `OutputType=Exe` and the Aspire AppHost target.
+   - `IsAspireHost=true`.
+   - `PackageReference` to the Aspire AppHost SDK + integrations at the version Standards pinned in packet 02.
+   - `PackageReference` to `HoneyDrunk.Standards` (`PrivateAssets: all`) and `HoneyDrunk.Standards.Aspire`.
+   - `ProjectReference` to the existing `HoneyDrunk.Pulse.Collector` project at `..\Pulse.Collector\HoneyDrunk.Pulse.Collector.csproj`.
+
+6. **Solution + version bump.**
+   - Add `HoneyDrunk.Pulse.AppHost` to `HoneyDrunk.Pulse.slnx`.
+   - Per invariant 27: bump every non-test `.csproj` in the solution to the same new minor version **if** this is the first packet to land on the solution in the current Pulse version cycle. **If ADR-0040 Pulse packets have already bumped the in-progress version**, append to that version's CHANGELOG only — do not double-bump. The PR description records which case applies.
+   - Repo-level `CHANGELOG.md` entry describing the AppHost addition (and Collector executable if introduced).
+   - Per-package `CHANGELOG.md`: only the new package(s) get an entry. Other Pulse packages get alignment-bump only — no per-package CHANGELOG noise (invariants 12/27).
+   - `HoneyDrunk.Pulse.AppHost/README.md` documents the run command, the composed resources, the OTLP port the Collector exposes, and the cross-Node dual-emit composition guidance from step 4.
+
+7. **Verify the AppHost compiles and launches.** Run `dotnet build` and (locally) `dotnet run --project HoneyDrunk.Pulse.AppHost` to confirm the AppHost stands up: the Aspire dashboard URL opens, the Pulse.Collector starts and exposes its OTLP port, and OTLP traces appear in the dashboard. Developer verification, captured in the PR description.
+
+## Affected Files
+- `HoneyDrunk.Pulse/HoneyDrunk.Pulse.AppHost/HoneyDrunk.Pulse.AppHost.csproj` (new)
+- `HoneyDrunk.Pulse/HoneyDrunk.Pulse.AppHost/Program.cs` (new)
+- `HoneyDrunk.Pulse/HoneyDrunk.Pulse.AppHost/CHANGELOG.md` (new, invariant 12)
+- `HoneyDrunk.Pulse/HoneyDrunk.Pulse.AppHost/README.md` (new, invariant 12)
+- `HoneyDrunk.Pulse/HoneyDrunk.Pulse.slnx` — new AppHost project entry
+- Every non-test `.csproj` in the solution — version bump (if first packet on the in-progress version)
+- Repo-level `CHANGELOG.md`
+
+The existing `HoneyDrunk.Pulse.Collector` project is **not modified** by this packet.
+
+## NuGet Dependencies
+
+`HoneyDrunk.Pulse.AppHost`:
+- Aspire AppHost SDK + integrations at the version pinned in packet 02.
+- `HoneyDrunk.Standards` (`PrivateAssets: all`) at the new published version from packet 02.
+- `HoneyDrunk.Standards.Aspire` at the new published version from packet 02.
+- `ProjectReference` to the existing `HoneyDrunk.Pulse.Collector` project.
+
+The existing `HoneyDrunk.Pulse.Collector` gains no new `PackageReference` in this packet — its dependencies are already in place.
+
+Confirm exact `HoneyDrunk.Standards` / `HoneyDrunk.Standards.Aspire` versions at execution time.
+
+## Boundary Check
+- [x] All code change is in `HoneyDrunk.Pulse` — the new AppHost composes Pulse's Collector. Routing rule "observability, telemetry, traces, logs, metrics ... → HoneyDrunk.Pulse" maps here.
+- [x] No contract change in Pulse's existing packages; the AppHost (and any new Collector host) is additive.
+- [x] Pulse depends on Kernel; no reference to any other Node's runtime. Container-resource composition of Pulse from Notify's AppHost (packet 04) does not invert the dependency.
+- [x] No production deployment surface modified (D5 — Aspire is local-dev only).
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Pulse.AppHost` project exists, is `OutputType=Exe`, and is included in `HoneyDrunk.Pulse.slnx`
+- [ ] `Program.cs` composes the existing `HoneyDrunk.Pulse.Collector` as a project resource via `AddProject<Projects.HoneyDrunk_Pulse_Collector>` and calls `AddGridTelemetry` for self-observability
+- [ ] The existing `HoneyDrunk.Pulse.Collector` source is unchanged by this packet (composition only — no Collector edits)
+- [ ] `dotnet build HoneyDrunk.Pulse.slnx` succeeds
+- [ ] `dotnet run --project HoneyDrunk.Pulse.AppHost` launches the Aspire dashboard and the Collector (developer verification — captured in the PR description, not in CI)
+- [ ] `HoneyDrunk.Pulse.AppHost/README.md` documents: the run command, the OTLP port the Collector exposes, the cross-Node dual-emit composition guidance (container-resource recommended, interim manual path, future NuGet-host follow-up)
+- [ ] `HoneyDrunk.Pulse.AppHost/CHANGELOG.md` exists with the initial entry
+- [ ] The PR description records whether this packet is the first one on the current Pulse version cycle (bumps) or appends to an ADR-0040-bumped in-progress version
+- [ ] If bumping: every non-test `.csproj` in the solution is at the same new minor version in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` carries the AppHost-addition entry (new version section if bumping; appended to the in-progress section if not)
+- [ ] No production deployment surface modified (D5 — Aspire is local-dev only)
+- [ ] `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **Publish `HoneyDrunk.Standards` (with `HoneyDrunk.Standards.Aspire` and `HoneyDrunk.Standards.Templates.AspireAppHost`) before this packet builds.** Packet 02 ships those packages; a human pushes the git release tag on `HoneyDrunk.Standards` after packet 02 merges. Wave 4 cannot build against unpublished Standards packages.
+- [ ] **Pulse's dev Key Vault and dev App Configuration must exist** with the relevant sink credentials seeded (App Insights connection string per ADR-0040 packet 02 — already provisioned if that initiative landed; Sentry DSN if applicable; Loki/Mimir/Tempo endpoints if those sinks are composed locally). Build succeeds without them; runtime launch fails if any required secret is missing.
+- [ ] **Docker Desktop running on the developer's box** for any container resource the AppHost composes (Cosmos Emulator if Pulse's local state uses it; not needed if the Collector is pure-memory in dev). Not a build-time prerequisite; launch-time only if container resources are composed.
+- [ ] **Tag/release `HoneyDrunk.Pulse` after this packet merges** if downstream consumers (e.g. Notify's `AddPulseCollector` container-resource path, when adopted) need the new Collector image/package on a feed. This is downstream-driven; not a strict prerequisite for the AppHost itself.
+
+## Referenced ADR Decisions
+**ADR-0065 D2 — Per-Node AppHost.** Each containerized Node's repo includes a `{Node}.AppHost` project.
+
+**ADR-0065 D3 — Resource modeling.** Pulse models its Collector as a project resource, with connection-string resources for non-emulated dev services.
+
+**ADR-0065 D4 — Pulse integration, opt-in dual-emit.** Pulse.Collector is the destination for the dual-emit fan-out. The Pulse repo carries the canonical Pulse.Collector composition so downstream AppHosts (Notify, Communications, future) can compose Pulse.Collector as a container resource against the Pulse-published image.
+
+**ADR-0065 D7 — Pulse is the second migrant.** Notify's AppHost composes Pulse.Collector and the Pulse repo benefits from carrying the canonical Pulse.Collector AppHost.
+
+**ADR-0065 D5 — Production deployment is separate.** Nothing in this packet wires `azd` or generates production Bicep.
+
+**ADR-0040 (sibling initiative) — Pulse Telemetry Sink work.** ADR-0040's Pulse packets extend `HoneyDrunk.Telemetry.Sink.AzureMonitor`. This packet does not modify that work; if ADR-0040 Pulse packets are mid-flight, the version-bump-vs-append decision applies per the Pulse note above.
+
+## Constraints
+- **Invariant 27 — one version across the solution.** This packet is the first one on the Pulse solution this initiative; bump if no ADR-0040 Pulse packet has bumped the in-progress version, otherwise append. Confirm at edit time and record in the PR description.
+- **Invariant 12 — CHANGELOG/README discipline.** New `HoneyDrunk.Pulse.AppHost` (and Collector executable if introduced) get `CHANGELOG.md` + `README.md` from this commit. Unchanged packages get NO per-package CHANGELOG entry.
+- **Invariant 26 — analyzer baseline.** New projects reference `HoneyDrunk.Standards` with `PrivateAssets: all`.
+- **D5 — Aspire is local-dev only.** No `azd` wiring, no generated production Bicep. The Pulse production deployment continues to be the existing `HoneyDrunk.Standards` shared workflow + curated Bicep per ADR-0015.
+- **No Notify dependency.** Pulse does not depend on Notify or any consumer Node. The cross-Node composition (Notify's AppHost referencing Pulse.Collector) happens at the consumer's AppHost level — never by Pulse pulling consumers in.
+- **Container-resource recommended for cross-Node composition.** Document the path in `README.md`; do not project-reference Pulse from Notify or any other Node's AppHost.
+- **Do not modify the Pulse.Collector project.** The existing Collector at `HoneyDrunk.Pulse/Pulse.Collector/` is composed by reference only. Any Collector source changes belong to a separate Pulse feature initiative.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0065`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Add `HoneyDrunk.Pulse.AppHost` so Pulse owns its canonical Collector composition, and any downstream AppHost can compose Pulse.Collector via the documented container-resource path.
+
+**Target:** `HoneyDrunk.Pulse`, branch from `main`.
+
+**Context:**
+- Goal: Give Pulse a working AppHost and a canonical Collector entry point that downstream Node AppHosts can compose for the D4 dual-emit.
+- Feature: ADR-0065 Multi-Service Local Dev Orchestration rollout, Wave 4 (first migrants — parallel with packet 04 Notify).
+- ADRs: ADR-0065 D2/D3/D4/D5/D7 (primary), ADR-0040 (sibling Pulse telemetry work — version-bump coordination), ADR-0015 (production deployment authority — unchanged).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — `HoneyDrunk.Standards.Aspire` and the AppHost template ship; the AppHost references them.
+- (Soft) ADR-0040 Pulse packets — coordinate the in-progress Pulse version with whichever ADR-0040 Pulse packets are mid-flight per invariant 27.
+
+**Constraints:**
+- The AppHost is local-dev only — no production deployment surface (D5).
+- Bump-vs-append per invariant 27: check the Pulse in-progress version state at edit time.
+- Cross-Node Pulse.Collector composition uses container-resource path, not project reference (no inverted dependency).
+- The existing `HoneyDrunk.Pulse.Collector` is composed by project reference only — no Collector source edits in this packet.
+
+**Key Files:**
+- `HoneyDrunk.Pulse/HoneyDrunk.Pulse.AppHost/Program.cs` (new)
+- `HoneyDrunk.Pulse/HoneyDrunk.Pulse.AppHost/HoneyDrunk.Pulse.AppHost.csproj` (new)
+- `HoneyDrunk.Pulse/HoneyDrunk.Pulse.AppHost/CHANGELOG.md` + `README.md` (new)
+- `HoneyDrunk.Pulse/HoneyDrunk.Pulse.slnx` (new AppHost project entry)
+- Every non-test `.csproj` for the version bump if applicable; repo-level `CHANGELOG.md`
+
+**Contracts:** None changed — the AppHost composes the existing Pulse.Collector without modifying its public surface.

--- a/generated/issue-packets/active/adr-0065-aspire-orchestration/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0065-aspire-orchestration/dispatch-plan.md
@@ -1,0 +1,131 @@
+# Dispatch Plan — ADR-0065: Multi-Service Local Dev Orchestration and .NET Aspire Stance
+
+**Initiative:** `adr-0065-aspire-orchestration`
+**ADR:** ADR-0065 (Proposed → Accepted via packet 00)
+**Sector:** Ops / cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0065 decides the Grid's local-dev orchestrator: `.NET Aspire`, two-tier AppHost shape (per-Node + per-scenario `HoneyDrunk.Workshop` in a separate standup ADR), per-Node resource modeling, opt-in Pulse dual-emit, deliberate separation from production deployment authoring (`HoneyDrunk.Standards` + curated Bicep stays the production authority), Standards-hosted template + extension methods, incremental per-Node migration (Notify first, Pulse second), Container Apps Jobs cross-reference for the future Jobs ADR, real dev Service Bus (no in-process shim), and "Aspire not in CI."
+
+This initiative delivers: ADR acceptance + the two new Aspire invariants + initiative registration (Architecture); tech-stack.md update + scope.md/review.md agent-file updates (Architecture); the AppHost project template and the Grid Aspire extension methods in `HoneyDrunk.Standards`; the `sb-hd-dev` Service Bus namespace provisioning walkthrough + execution (Architecture, Human); and the first two per-Node AppHosts — `HoneyDrunk.Notify.AppHost` (first migrant) and `HoneyDrunk.Pulse.AppHost` (second migrant, owning the canonical Pulse.Collector composition).
+
+**6 packets across 4 waves**, targeting **4 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Standards`, `HoneyDrunk.Notify`, `HoneyDrunk.Pulse`). 5 `Actor=Agent` (00, 01, 02, 04, 05), 1 `Actor=Human` (03 — Service Bus namespace provisioning, portal work).
+
+## Trigger
+
+ADR-0065 is Proposed with no scope. The forcing functions from the ADR's Context:
+
+- **Notify (Functions + Worker) + Pulse.Collector dev deploy is imminent.** The first multi-service local-dev composition in the Grid. Without a decision, whatever pattern ships first becomes the de-facto Grid pattern.
+- **The AI-sector standup wave (ADR-0016 through ADR-0025)** queues nine Nodes that each need a local-dev story. Without a Grid-wide stance now, each Node's first feature packet re-litigates the question and the Grid ends up with N inner-loop patterns.
+- **ADR-0015** commits Container Apps as production hosting; Aspire models that platform cleanly — the local model and the production model can align if the orchestrator choice lands now.
+- **Pulse OTLP integration (ADR-0010, ADR-0040)** wants the Aspire dashboard and Pulse to consume the same OTLP stream for Pulse-iteration scenarios.
+
+The ADR needs decomposition into actionable packets.
+
+## Scope Detection
+
+**Multi-repo.** ADR-0065 touches `HoneyDrunk.Standards` (the AppHost template + Grid Aspire extension methods per D6), `HoneyDrunk.Notify` (the first migrant per D7), `HoneyDrunk.Pulse` (the second migrant per D7, carrying the canonical Pulse.Collector AppHost per D4), and `HoneyDrunk.Architecture` (the governance, the two new invariants, the catalog/reference updates, the dev Service Bus walkthrough). No cascade to consuming Nodes beyond Notify/Pulse — the AppHost is per-Node and the Standards extensions are pulled piecemeal as each Node migrates (D7 opportunistic migration). Communications, Notify Cloud, Audit, the AI-sector Nodes, and Workshop are all named in the ADR but are explicitly **out of scope for this initiative** (see Cross-Cutting Concerns).
+
+## Wave Diagram
+
+### Wave 1 (governance + reference updates — parallel)
+- [ ] **00** — Architecture: Accept ADR-0065, add the two Aspire invariants, register the initiative. `Actor=Agent`.
+- [ ] **01** — Architecture: Update `tech-stack.md`, `.claude/agents/scope.md`, `.claude/agents/review.md` for the Aspire stance. `Actor=Agent`. Blocked by: 00.
+
+### Wave 2 (Standards foundation)
+- [ ] **02** — Standards: Author the AppHost project template + Grid Aspire extension methods (`AddGridTelemetry`, `AddGridCosmosEmulator`, `AddGridAzurite`, `AddGridServiceBusDev`, `AddGridKeyVaultDev`, `AddGridAppConfigDev`). `Actor=Agent`. Blocked by: 00. **Version-bumping packet for `HoneyDrunk.Standards`.**
+
+### Wave 3 (infra provisioning, Human)
+- [ ] **03** — Architecture: Author the dev Service Bus provisioning walkthrough, provision `sb-hd-dev` (Basic tier), **and provision the dev App Configuration resource** by executing the existing `app-configuration-provisioning.md` for `env=dev`. `Actor=Human`. Blocked by: 00. (Independent of packet 02 — runs in parallel with Wave 2 in practice, but lives in Wave 3 because it is the second human gate alongside the Standards human release of packet 02.)
+
+### Wave 4 (first migrants, parallel)
+- [ ] **04** — Notify: Add `HoneyDrunk.Notify.AppHost` (first migrant — Functions + Worker + Cosmos Emulator + Azurite + dev ASB + dev Key Vault + dev App Configuration; opt-in Pulse dual-emit). `Actor=Agent`. Blocked by: 02, 03. **Version-bumping packet for `HoneyDrunk.Notify`.**
+- [ ] **05** — Pulse: Add `HoneyDrunk.Pulse.AppHost` (second migrant — composes the existing `HoneyDrunk.Pulse.Collector` project + dev Key Vault + dev App Configuration). `Actor=Agent`. Blocked by: 02. **Pulse.Collector already exists** (`HoneyDrunk.Pulse/Pulse.Collector/HoneyDrunk.Pulse.Collector.csproj`, `Microsoft.NET.Sdk.Web`, OTLP receiver) — no new Collector host is introduced. **First packet on the Pulse solution in this initiative — bumps if no ADR-0040 Pulse packet has bumped the in-progress version, otherwise appends to the in-progress version (invariant 27).**
+
+Packets within a wave run in parallel. Wave-4 packets 04 and 05 are independent — different repos, no shared solution — and run in parallel. Packet 04 is `Blocked by: 02, 03` (needs both the Standards extensions and the dev ASB namespace); packet 05 is `Blocked by: 02` only (Pulse's AppHost does not consume ASB locally — Pulse.Collector receives OTLP, not ASB messages). Packet 03 (Human) can in practice run alongside packet 02 (both depend only on packet 00); they sit in nominal Wave 2 / Wave 3 for tidy filing but the `dependencies:` frontmatter is the real ordering signal.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0065](./00-architecture-adr-0065-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [tech-stack + scope/review agent updates](./01-architecture-tech-stack-and-agent-updates.md) | Architecture | Agent | 1 | 00 |
+| 02 | [Standards AppHost template + Grid Aspire extensions](./02-standards-aspire-template-and-extensions.md) | Standards | Agent | 2 | 00 |
+| 03 | [Dev Service Bus walkthrough + `sb-hd-dev` + dev App Configuration](./03-architecture-dev-service-bus-walkthrough.md) | Architecture | Human | 3 | 00 |
+| 04 | [Notify.AppHost (first migrant)](./04-notify-add-apphost.md) | Notify | Agent | 4 | 02, 03 |
+| 05 | [Pulse.AppHost (second migrant, canonical Pulse.Collector composition)](./05-pulse-add-apphost.md) | Pulse | Agent | 4 | 02 |
+
+## Version Bumps
+
+- **`HoneyDrunk.Standards`** — packet 02 is the first packet on the solution; it bumps every non-test `.csproj` to the same new minor version. New public surface (the Aspire extensions + the AppHost template) — additive minor bump per ADR-0035.
+- **`HoneyDrunk.Notify`** — packet 04 is the only Notify packet in this initiative; it bumps the whole solution one minor version (new project added — functional change). Confirm Notify's current version at execution time and bump to the next minor.
+- **`HoneyDrunk.Pulse`** — packet 05 is the first Pulse packet in this initiative. Sibling-initiative coordination: if ADR-0040 Pulse packets are mid-flight at execution time and have already bumped the in-progress Pulse version, packet 05 appends to that version's CHANGELOG rather than double-bumping. If ADR-0040 work is fully released, packet 05 is the bumping packet. The PR description records which case applies.
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; governance/catalog/doc/walkthrough edits only.
+
+## Cross-Cutting Concerns
+
+### Workshop standup is a separate ADR — deliberate deferral
+
+ADR-0065 D2 names a new lightweight `HoneyDrunk.Workshop` Node (Meta sector) that hosts per-scenario AppHosts. ADR-0065 Follow-up Work: "File the `HoneyDrunk.Workshop` standup ADR as a separate paired follow-up." The user's standing preference is "New-Node scaffolding gets its own ADR; don't bundle scaffold into feature packets" (memory note `feedback_adr_before_scaffold`). This initiative therefore **does not**:
+
+- Add `honeydrunk-workshop` to `catalogs/nodes.json`, `catalogs/relationships.json`, or `catalogs/grid-health.json`.
+- Add a Workshop row to `constitution/sectors.md`.
+- Create `repos/HoneyDrunk.Workshop/` with `overview.md`, `boundaries.md`, `invariants.md`.
+- Create the GitHub repo `HoneyDrunk.Workshop` or its initial scaffold.
+
+All of those land via the Workshop standup ADR (TBD ADR number; the operator drafts it as a follow-up). When the Workshop standup lands, its first scenario AppHost is the first useful cross-Node integration scenario at the time (likely Notify + Communications full email-orchestration loop per D2, but the standup ADR makes the concrete first-scenario choice).
+
+### Communications migration is opportunistic — out of scope here
+
+ADR-0065 D7 names Communications as the third migrant, "when its worker process arrives (probably when it gains a worker process for cadence enforcement)." Today Communications is in-process per ADR-0028 D4. Migrating Communications is a forcing-function-triggered event, not a planned packet. **This initiative ships no Communications AppHost.** When Communications gains a worker process, the migration packet is filed against that work — likely as part of a Communications feature initiative — and consumes the `HoneyDrunk.Standards.Aspire` extensions this initiative ships.
+
+### AI-sector seed Nodes adopt at first feature packet — out of scope here
+
+ADR-0065 D7 explicitly defers AI-sector AppHost adoption to the **first feature packet** of each seed Node, rather than at standup. This initiative does not pre-create AppHosts for `HoneyDrunk.AI`, `HoneyDrunk.Agents`, `HoneyDrunk.Memory`, `HoneyDrunk.Knowledge`, `HoneyDrunk.Evals`, `HoneyDrunk.Flow`, `HoneyDrunk.Sim`, `HoneyDrunk.Operator`. Each AI-sector Node's first feature packet adopts the Standards extensions when its multi-process moment arrives.
+
+### Library-only Nodes get no AppHost — out of scope here
+
+ADR-0065 D7's final rule: single-process library-only Nodes (Kernel, Vault, Transport, Standards, Auth, Web.Rest, Data) have no runtime and therefore no AppHost. This initiative does not attempt to create AppHosts for those Nodes. (Standards is the home of the *extensions and template*, not an AppHost consumer.)
+
+### Notify Cloud, Audit, Lore — out of scope here, mentioned in the ADR
+
+- **Notify Cloud (ADR-0027)** — when scaffolded, its AppHost models the wrapper + Notify + Communications + Service Bus + Cosmos + Stripe-test endpoint. Not in this initiative; rides with the Notify Cloud standup or first-feature work.
+- **Audit (ADR-0031)** — gains an AppHost at first-feature-packet time when its query API becomes runnable. Not in this initiative.
+- **Lore** — gains an AppHost if/when its ingest becomes a service (today it is a Claude Code skill). Not in this initiative.
+
+### Coordination with ADR-0040 (Telemetry Backend) — Pulse-solution version-bump
+
+ADR-0040's Pulse packets (`adr-0040-telemetry-backend` initiative, packets 03/04/05/07) extend `HoneyDrunk.Telemetry.Sink.AzureMonitor` and may be mid-flight at the time this initiative's packet 05 (Pulse.AppHost) executes. Per invariant 27 (one version across the solution), the first un-released packet on the Pulse solution bumps the version; subsequent packets append to the in-progress version's CHANGELOG. Packet 05 records at execution time which case applies and either bumps or appends accordingly. No `dependencies:` edge is wired between the two initiatives — they are siblings on the Pulse solution, and the version-bump rule self-coordinates.
+
+### Coordination with ADR-0066 (Health / Readiness / Liveness Endpoints) — soft
+
+ADR-0066 (Health / Readiness / Liveness Endpoints) is named in the recent ADR batch (2026-05-23). The Aspire dashboard surfaces health/readiness signals from project resources via standard `.NET` health-check conventions. If ADR-0066 lands and ships health-check contracts, future Aspire AppHost packets may compose those contracts; this initiative does not. No `dependencies:` edge.
+
+### `dotnet user-secrets` is the canonical dev-secrets mechanism
+
+ADR-0065 Alternatives Considered (Accepted) — `dotnet user-secrets` is the convention for any dev resource that requires authentication, used by `AddGridServiceBusDev` and similar extensions. The dev Service Bus walkthrough (packet 03) and the Notify AppHost packet (04) both document the seeding command. No separate packet codifies this convention; it is an inline convention recorded across the packets that use it.
+
+### Aspire SDK version pin — recorded at execution time
+
+ADR-0065 Follow-up Work: "Confirm Aspire's current version (at acceptance time) and pin the Standards templates to it. Aspire breaking changes are absorbed by Standards updates per the per-Node migration ergonomics." Packet 02 pins the Aspire SDK version at execution time; the PR description records the version. Future Aspire bumps land as `HoneyDrunk.Standards` minor/major releases.
+
+### Site sync
+
+No site-sync flag. ADR-0065 is internal Ops infrastructure — no public-facing Studios website content changes.
+
+## Rollback Plan
+
+- **Packets 00–01 (governance/reference):** revert the PR. ADR returns to Proposed; the two invariants are removed; tech-stack.md, scope.md, review.md revert. No runtime impact.
+- **Packet 02 (Standards extensions + template):** revert the PR; the `HoneyDrunk.Standards` solution version rolls back one minor. The new packages (`HoneyDrunk.Standards.Aspire`, `HoneyDrunk.Standards.Templates.AspireAppHost`) leave the solution. Per-Node AppHost packets (04, 05) become unbuildable until packet 02 is re-applied or replaced.
+- **Packet 03 (dev Service Bus provisioning):** the `sb-hd-dev` namespace can be deleted in the Azure Portal; the walkthrough doc can be reverted. Low cost (~$10/month while running), easily reversed. If Notify's AppHost is in production-use locally and depends on the namespace, the rollback breaks Notify's local-dev — coordinate with packet 04.
+- **Packet 04 (Notify.AppHost):** revert the PR; the new `HoneyDrunk.Notify.AppHost` project leaves the solution. Notify's existing `launchSettings.json` composition is untouched by this packet, so Notify's pre-AppHost local-dev experience is restored. The solution version rolls back.
+- **Packet 05 (Pulse.AppHost):** revert the PR; the new `HoneyDrunk.Pulse.AppHost` project leaves the solution. The existing `HoneyDrunk.Pulse.Collector` project is untouched by this packet, so a revert leaves Pulse's runtime exactly as it was. The solution version rolls back if this was the bumping packet.
+- **Operational escape hatch:** Aspire is local-dev only (D5). Production deployments are entirely unaffected by any rollback in this initiative.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.

--- a/generated/issue-packets/active/adr-0065-aspire-orchestration/handoff-wave2-standards-foundation.md
+++ b/generated/issue-packets/active/adr-0065-aspire-orchestration/handoff-wave2-standards-foundation.md
@@ -1,0 +1,56 @@
+# Handoff — Wave 2: Standards Foundation
+
+**Initiative:** `adr-0065-aspire-orchestration`
+**Wave transition:** Wave 1 (governance + reference) → Wave 2 (Standards extensions + template)
+**Read once at the wave boundary. Immutable per invariant 24.**
+
+## What Wave 1 landed
+
+- **Packet 00** — ADR-0065 flipped to **Accepted**. Two new invariants added to `constitution/invariants.md` under a new `## Local-Dev Orchestration Invariants` section. The numbers come from the ADR-0065 row in `constitution/invariant-reservations.md` (reserved pair `78–79` at authoring; shifted up at merge if a parallel packet 00 raced ahead):
+  1. Every multi-process containerized Node ships an Aspire AppHost project as its local-dev inner loop. Single-process Nodes may ship one optionally; library-only Nodes (Kernel, Vault, Transport, Standards, Auth, Web.Rest, Data) have no runtime and are exempt.
+  2. Aspire-generated infrastructure templates (Bicep, ARM) are never used as the production deployment authority. Production deployment authoring stays in `HoneyDrunk.Standards` shared workflows and each Node's curated Bicep per ADR-0015.
+- **Packet 01** — `infrastructure/reference/tech-stack.md` moved `.NET Aspire` from Planned / Future to the adopted section with the local-dev-only framing; added the dev Service Bus namespace row. `.claude/agents/scope.md` carries the AppHost-requirement rule for new multi-process Nodes. `.claude/agents/review.md` carries two new review-checklist items (multi-process Node AppHost presence; no Aspire-generated Bicep in production paths).
+
+ADR-0065's decisions are now live rules. Packet 02 implements the Standards-side foundation every per-Node AppHost in the Grid will consume.
+
+## What Wave 2 must deliver (packet 02)
+
+Build the Standards alignment per ADR-0065 D6 in **`HoneyDrunk.Standards`**:
+
+- **`HoneyDrunk.Standards.Aspire`** (new package) — `HoneyDrunkAspireExtensions` static class with:
+  - `AddGridTelemetry<T>(this IResourceBuilder<T>)` — wires OTLP env vars on a resource builder; default endpoint is Aspire's dashboard.
+  - `AddGridCosmosEmulator(IDistributedApplicationBuilder, string name)` — Cosmos Emulator container, Linux mode (per D9).
+  - `AddGridAzurite(IDistributedApplicationBuilder, string name)` — Azurite emulator container.
+  - `AddGridServiceBusDev(IDistributedApplicationBuilder, string name)` — connection-string resource from `dotnet user-secrets` key `ConnectionStrings:ServiceBus`; creates per-session subscription on AppHost launch **and deletes it on AppHost shutdown via an `IDistributedApplicationLifecycleHook`** (best-effort; orphan cleanup documented in packet 03).
+  - `AddGridKeyVaultDev(IDistributedApplicationBuilder, string name)`, `AddGridAppConfigDev(IDistributedApplicationBuilder, string name)` — connection-string resources, dev-session-auth.
+  - (AppHost-level composition method) `AddPulseCollector(this IDistributedApplicationBuilder, bool opt = false)` — the D4 dual-emit opt-in switch.
+- **`HoneyDrunk.Standards.Templates.AspireAppHost`** (new template package) — a `dotnet new` template producing a `{Node}.AppHost` scaffold with the analyzer baseline, the Aspire AppHost SDK target, and a starter `Program.cs` referencing the Grid extensions.
+- Pin the Aspire SDK version inline on each new `PackageReference`. The Standards solution does **not** use Central Package Management today (verified — no `Directory.Packages.props`); do not introduce CPM in this packet.
+- Tests use Aspire's non-launching syntax-check mode — no Docker Desktop, no live Azure (invariant 15, D10).
+- This is the **version-bumping packet**: bump every non-test `.csproj` in the `HoneyDrunk.Standards` solution to the same new minor version in one commit (invariant 27). New public surface; additive minor bump per ADR-0035.
+
+## Frozen / do-not-touch
+
+- **`HoneyDrunk.Standards` shared workflows + curated Bicep — the production deployment authority (ADR-0015, ADR-0065 D5).** Wave 2 ships local-dev assets; nothing here writes `azd` paths, generated production Bicep, or `AzurePublisher` outputs to the production deployment surface. The new packages do not change how production deploys.
+- **The existing `HoneyDrunk.Standards` analyzer + EditorConfig surface.** New projects reference `HoneyDrunk.Standards` with `PrivateAssets: all` (invariant 26) just like every other Standards-solution project; no analyzer rule changes here.
+
+## Invariants binding Wave 2
+
+- **Invariant 13** — all public APIs carry XML documentation.
+- **Invariant 15** — unit tests do not depend on external services. The Aspire extension tests run in non-launching mode; no Docker Desktop, no Azure, no Cosmos Emulator at test time.
+- **Invariant 26** — new projects reference `HoneyDrunk.Standards` with `PrivateAssets: all`.
+- **Invariant 27** — all projects in a solution share one version and move together. Packet 02 is the bumping packet: bump every non-test `.csproj` in one commit. Partial bumps are forbidden.
+- **Invariant 12** — new packages get `CHANGELOG.md` + `README.md` from the first commit. Unchanged packages get no per-package CHANGELOG entry.
+- **D5 (the second new Aspire invariant)** — Aspire-generated Bicep / ARM is never the production deployment authority. Nothing in this packet writes such files.
+
+## Aspire SDK version pin — record in the PR
+
+Confirm the current stable Aspire SDK version at execution time and pin all new `Aspire.*` `PackageReference`s in this packet to that version inline (the Standards solution has no CPM today; pin inline). Record the version in the PR description.
+
+## Acceptance gate for the wave
+
+Packet 02's PR passes the `pr-core.yml` tier-1 gate. The new packages (`HoneyDrunk.Standards.Aspire`, `HoneyDrunk.Standards.Templates.AspireAppHost`) compile, tests pass in non-launching mode, and the solution version is bumped one minor across every non-test `.csproj`.
+
+**Human package release at the Wave 2 boundary — agents never tag.** Packet 04 (Notify.AppHost) and packet 05 (Pulse.AppHost) compile against `HoneyDrunk.Standards.Aspire` and (for packet 04) `HoneyDrunk.Standards.Templates.AspireAppHost`. Those artifacts reach the NuGet feed only after a human pushes a git release tag on `HoneyDrunk.Standards`. After packet 02 merges, a human must tag/release `HoneyDrunk.Standards` so packets 04 and 05 can compile. This is a hard gate between Wave 2 and Wave 4.
+
+Wave 3 (packet 03 — dev Service Bus provisioning, Human) and Wave 4 (packets 04 + 05) start after this human release. Packet 03 can in practice start as soon as packet 00 merges (it depends only on the ADR being Accepted, not on the Standards extensions) — but its output (the `sb-hd-dev` namespace) is consumed by packet 04 at launch time, so it should be completed before packet 04's developer verification step.

--- a/generated/issue-packets/active/adr-0065-aspire-orchestration/handoff-wave4-first-migrants.md
+++ b/generated/issue-packets/active/adr-0065-aspire-orchestration/handoff-wave4-first-migrants.md
@@ -1,0 +1,102 @@
+# Handoff — Wave 4: First Migrants (Notify + Pulse)
+
+**Initiative:** `adr-0065-aspire-orchestration`
+**Wave transition:** Wave 2 (Standards) + Wave 3 (dev ASB provisioning) → Wave 4 (first per-Node AppHosts)
+**Read once at the wave boundary. Immutable per invariant 24.**
+
+## What Waves 2 + 3 landed
+
+- **Packet 02 (Standards)** — `HoneyDrunk.Standards.Aspire` ships the `HoneyDrunkAspireExtensions` static class (`AddGridTelemetry`, `AddGridCosmosEmulator`, `AddGridAzurite`, `AddGridServiceBusDev`, `AddGridKeyVaultDev`, `AddGridAppConfigDev`) plus the AppHost-level `AddPulseCollector(opt: false)` composition method. `HoneyDrunk.Standards.Templates.AspireAppHost` ships the `dotnet new` template. Aspire SDK is pinned at the version recorded in packet 02's PR description. `HoneyDrunk.Standards` is at the new minor version; the new packages have been tagged/released by a human, so the NuGet feed carries them.
+- **Packet 03 (Architecture / Human)** — `infrastructure/walkthroughs/dev-service-bus-namespace-provisioning.md` exists, parameterised for environment, and documents manual orphan-subscription cleanup; the `sb-hd-dev` Service Bus namespace exists in the Azure subscription at Basic tier in the `dev` resource group; the connection string is stored in the chosen Key Vault (per-Node `kv-hd-notify-dev` recommended, keyed `ConnectionStrings:ServiceBus`) and never in the repo (invariants 8, 9). **The dev App Configuration resource also exists**, provisioned in the same human session via the existing `infrastructure/walkthroughs/app-configuration-provisioning.md` for `env=dev`. The ~$10/month recurring cost is recorded against the studio's Azure budget per ADR-0052.
+
+Wave 4 turns these foundations into actual per-Node AppHosts.
+
+## What Wave 4 must deliver
+
+Two packets in parallel, different repos:
+
+### Packet 04 — `HoneyDrunk.Notify` (first migrant)
+
+Add a new `HoneyDrunk.Notify.AppHost` project to the `HoneyDrunk.Notify.slnx` solution. Compose:
+- **Project resources** — `HoneyDrunk.Notify.Functions` via `AddAzureFunctionsProject<T>` (per ADR-0065's Accepted alternative); `HoneyDrunk.Notify.Worker` via `AddProject<T>`. Both call `AddGridTelemetry`.
+- **Container resources** — Cosmos Emulator (`AddGridCosmosEmulator`); Azurite (`AddGridAzurite`) for the Notify intake → worker Storage Queue per ADR-0028 D2/D3.
+- **Connection-string resources** — dev Service Bus (`AddGridServiceBusDev` — wired in advance for future cross-Node hops; the live in-Node intake queue uses Azurite); dev Key Vault (`AddGridKeyVaultDev`); dev App Configuration (`AddGridAppConfigDev`).
+- **Pulse dual-emit** — **no `AddPulseCollector(...)` call** in packet 04. The Aspire-dashboard-only default (D4) is the operative behavior; calling the opt-in switch with `opt: false` would be dead code. The live wiring follows the container-resource path documented in packet 05's `HoneyDrunk.Pulse.AppHost/README.md`, and lands in a future packet when a Pulse.Collector container image or NuGet host package exists. Do not project-reference Pulse.
+- New `HoneyDrunk.Notify.AppHost/CHANGELOG.md` + `README.md` (invariant 12). README documents the run command, composed resources, the `dotnet user-secrets` seeding using the exact `ConnectionStrings:ServiceBus` key (which Aspire's `WithReference(serviceBus)` projects as the `ConnectionStrings__ServiceBus` env var), and the future Pulse dual-emit flip procedure.
+- **Version-bumping packet for `HoneyDrunk.Notify`** — every non-test `.csproj` in the solution to the same new minor version in one commit (invariant 27).
+
+### Packet 05 — `HoneyDrunk.Pulse` (second migrant)
+
+Add a new `HoneyDrunk.Pulse.AppHost` project to the `HoneyDrunk.Pulse.slnx` solution. **`HoneyDrunk.Pulse.Collector` already exists** (`HoneyDrunk.Pulse/Pulse.Collector/HoneyDrunk.Pulse.Collector.csproj`, `Microsoft.NET.Sdk.Web`, gRPC + OTLP receiver) — compose it by project reference; do not introduce a new Collector host. Compose:
+- **Project resources** — the existing `HoneyDrunk.Pulse.Collector` via `AddProject<Projects.HoneyDrunk_Pulse_Collector>`; calls `AddGridTelemetry` for self-observability.
+- **Connection-string resources** — dev Key Vault (for sink credentials — App Insights connection string per ADR-0040 packet 02's provisioning if that initiative is live; Sentry DSN if applicable; etc.); dev App Configuration.
+- New `HoneyDrunk.Pulse.AppHost/CHANGELOG.md` + `README.md` (invariant 12). README documents the run command, OTLP port the Collector exposes, and the **cross-Node dual-emit composition guidance** for downstream AppHosts (container-resource recommended; interim manual path; future NuGet-host follow-up).
+- **Version-bump-or-append per invariant 27** — first packet on the Pulse solution this initiative; check the in-progress Pulse version state at edit time (ADR-0040's Pulse packets may be mid-flight). If no in-progress bump, this packet bumps. If ADR-0040 already bumped, this packet appends to that version's CHANGELOG. Record which case applies in the PR description.
+
+## Aspire APIs to use
+
+Match the API surface of the Aspire SDK version pinned by packet 02 (recorded in packet 02's PR description). The shapes referenced in the packets:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+var cosmos = builder.AddGridCosmosEmulator("notify-cosmos");
+var azurite = builder.AddGridAzurite("notify-azurite");
+var serviceBus = builder.AddGridServiceBusDev("grid-asb-dev");
+var keyVault = builder.AddGridKeyVaultDev("notify-kv");
+var appConfig = builder.AddGridAppConfigDev("notify-appconfig");
+
+var functions = builder
+    .AddAzureFunctionsProject<Projects.HoneyDrunk_Notify_Functions>("notify-functions")
+    .WithReference(azurite).WithReference(cosmos).WithReference(serviceBus)
+    .WithReference(keyVault).WithReference(appConfig)
+    .AddGridTelemetry();
+
+var worker = builder
+    .AddProject<Projects.HoneyDrunk_Notify_Worker>("notify-worker")
+    .WithReference(azurite).WithReference(cosmos).WithReference(serviceBus)
+    .WithReference(keyVault).WithReference(appConfig)
+    .AddGridTelemetry();
+
+// No AddPulseCollector(...) call — D4 default behavior (Aspire-dashboard-only OTLP)
+// is what packet 04 ships. The flip lands when a Pulse.Collector image/host exists.
+
+await builder.Build().RunAsync();
+```
+
+The exact method names (`AddAzureFunctionsProject<T>`, `AddProject<T>`, `WithReference`) follow the pinned Aspire version's API. If the pinned version uses different names, use those — match the shipped Aspire surface, not the example above.
+
+## Cross-Node Pulse.Collector composition path — recorded for packet 04
+
+Notify's AppHost (packet 04) cannot project-reference `HoneyDrunk.Pulse` — that would invert the dependency direction (Pulse depends on Kernel; Notify depends on Kernel; neither depends on the other). The recommended cross-Node Pulse.Collector composition is:
+
+1. **Container resource against a published Pulse.Collector image** (recommended when Pulse.Collector publishes one). When Pulse.Collector publishes an image (separate follow-up — not part of this initiative), a future packet adds `AddPulseCollector(...)` to Notify's AppHost composing via `AddContainer` against that image.
+2. **Interim path** — until a published image exists, packet 04 omits the `AddPulseCollector(...)` call entirely (the D4 default OTLP-to-Aspire-dashboard-only shape is already in effect) and the developer runs Pulse's AppHost separately for Pulse-iteration scenarios. The developer points Notify's OTLP endpoint at Pulse.Collector's port manually when both AppHosts are running.
+3. **Future** — a NuGet-distributed Pulse.Collector host package allows downstream AppHosts to `AddProject<T>` against the package path. Track as a follow-up.
+
+Packet 04 ships the default-off behavior (no call); packet 05's README documents the live cross-Node path the operator chooses when an image/host exists.
+
+## Notify-side ASB audit — record in packet 04's PR
+
+Audit Notify's actual ASB hops at packet 04 execution time. The intake → worker hop is in-Node Storage Queue per ADR-0028 D2/D3 — that uses Azurite, not Service Bus. If Notify has zero current cross-Node ASB hops, document `Program.cs` and `README.md` so the executor and future readers understand the ASB connection is wired in advance for future hops; the live broker for v1 is Azurite.
+
+## Frozen / do-not-touch
+
+- **Notify's existing `launchSettings.json` composition** — keep it. The AppHost is additive; the existing local-dev path may coexist during the transition. A future cleanup packet may remove `launchSettings.json`-based composition; this initiative does not.
+- **Notify's domain logic** — invariant 41: preference/cadence/suppression logic lives in Communications, not Notify. The AppHost composes Notify's existing entry points without modifying any domain logic.
+- **Notify's production Bicep** (and Pulse's) — D5: Aspire is local-dev only. No production deployment surface is modified.
+- **`ITransportEnvelope`, ASB sink configuration, OTel exporter wiring** — Pulse's existing telemetry contracts. Packet 05 does not modify them; the existing `HoneyDrunk.Pulse.Collector` project is composed by project reference, not edited.
+
+## Invariants binding Wave 4
+
+- **Invariant 27** — one version across each solution. Notify (packet 04) bumps; Pulse (packet 05) bumps or appends per the in-progress version state.
+- **Invariant 12** — new AppHost packages get `CHANGELOG.md` + `README.md` from the first commit. Unchanged packages (including the existing `HoneyDrunk.Pulse.Collector`) get no per-package CHANGELOG entry (alignment bump only).
+- **Invariant 26** — new projects reference `HoneyDrunk.Standards` with `PrivateAssets: all`.
+- **Invariant 41** — preference/cadence/suppression logic stays in Communications, not Notify. Packet 04 touches no Notify domain logic.
+- **D5** — Aspire is local-dev only. No `azd` wiring, no generated production Bicep, no production-deployment files in either packet.
+- **D7** — multi-process Nodes must have an AppHost; single-process Nodes may; library-only Nodes do not. Notify and Pulse are the first two multi-process Nodes to land their AppHost; both are *required* by the first new invariant.
+
+## Acceptance gate for the wave
+
+Both packets pass `pr-core.yml` tier-1. Both bump (or, for Pulse, bump-or-append) per invariant 27. Both AppHosts compile (`dotnet build` succeeds) and (developer-verified, captured in PR descriptions, not in CI) launch under `dotnet run --project {Node}.AppHost`. The Aspire dashboard opens; the composed project resources start; container resources start under Docker Desktop. CI does **not** launch the AppHosts (per D10 — Aspire is not in CI).
+
+After this wave, Notify and Pulse have working local-dev inner loops aligned with the Grid's Aspire stance. The pattern is in place for Communications (when its worker arrives), the AI-sector seed Nodes (at first feature packet), Notify Cloud (at standup), Audit (at first feature packet), and any future multi-process Node.

--- a/generated/issue-packets/active/adr-0068-background-jobs/00-architecture-jobs-deferral-and-context-updates.md
+++ b/generated/issue-packets/active/adr-0068-background-jobs/00-architecture-jobs-deferral-and-context-updates.md
@@ -1,0 +1,129 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "core", "docs", "adr-0068", "wave-1"]
+dependencies: []
+adrs: ["ADR-0068", "ADR-0006", "ADR-0015"]
+wave: 1
+initiative: adr-0068-background-jobs
+node: honeydrunk-architecture
+---
+
+# Reflect the HoneyDrunk.Jobs deferral and the two pinned background-work substrates in Grid catalogs and Node context
+
+## Summary
+Update the Architecture-repo catalogs and Node-context files to reflect ADR-0068's follow-up checklist: remove `HoneyDrunk.Jobs` from the Planned Nodes section of `infrastructure/reference/tech-stack.md`; remove the `HoneyDrunk.Jobs` line from the Future section of `initiatives/roadmap.md`; record the grandfather posture for Vault.Rotation's Azure Functions timer triggers in `repos/HoneyDrunk.Vault.Rotation/boundaries.md` (D1/D7); record the Container Apps Jobs substrate for Communications cadence/drip-campaign scheduling in the `HoneyDrunk.Communications` repo context (D3); record the in-Node `BackgroundService` substrate for Notify retries in the `HoneyDrunk.Notify` repo context (D2); register the `adr-0068-background-jobs` initiative in `initiatives/active-initiatives.md`. ADR-0068 stays **Proposed** — the status flip is packet 05's job.
+
+## Context
+ADR-0068 settles workload categorization (in-Node `BackgroundService`, cross-Node Container Apps Jobs, GitHub Actions cron for CI/CD ops) and defers the `HoneyDrunk.Jobs` Node indefinitely (D4 — "Container Apps Jobs subsumes the Node"). The ADR's "If Accepted — Required Follow-Up Work" checklist names six catalog/reference updates that must land. This packet lands four of them (the catalog/reference half) plus initiative registration; the remaining two (the reusable workflow and the invariants) land in packets 02 and 01 respectively.
+
+ADR-0068 D4 + Catalog obligations: "`catalogs/nodes.json` — **no `honeydrunk-jobs` entry to add.** This ADR explicitly defers the Node." This packet must therefore **not** add a `honeydrunk-jobs` Node anywhere in the catalogs. The only Jobs-Node trace in the current catalogs is the `Jobs | Ops | Background job scheduling` row in `tech-stack.md`'s Planned Nodes table (line 204) and the `HoneyDrunk.Jobs — Background job scheduling with Grid integration` line in `roadmap.md`'s Future section (line 67). Both go.
+
+The Vault.Rotation grandfather posture (D1 + D7) is documentation-only — no code change in `HoneyDrunk.Vault.Rotation`. The context update is in `repos/HoneyDrunk.Vault.Rotation/boundaries.md` only.
+
+ADR-0068 stays **Proposed** through this packet — the ADR header is **not** flipped here. Per the ADR's Done-When list, the Status flip happens only after the deploy workflow lands (packet 02) and the first job ships under the new substrate (packets 03 and 04). That is packet 05's job.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `infrastructure/reference/tech-stack.md` — remove the `Jobs | Ops | Background job scheduling` row from the **Planned Nodes (no code yet)** table (line 204), OR move it to a new "Deferred — substrate covered by Container Apps Jobs" subsection if such a subsection makes editorial sense (the ADR's checklist allows either). Removing is cleaner; the deferral rationale is captured in ADR-0068 itself.
+- `initiatives/roadmap.md` — remove the `HoneyDrunk.Jobs — Background job scheduling with Grid integration` line from the **Future** section (line 67), OR move it to a "Deferred — substrate decided" subsection. Same editorial choice as tech-stack.md; record which was chosen in the PR description so the two files are consistent.
+- `repos/HoneyDrunk.Vault.Rotation/boundaries.md` — add a "Substrate (grandfathered)" subsection recording that Vault.Rotation stays on its Azure Functions timer triggers per ADR-0068 D1/D7 (new cross-Node recurring work goes on Container Apps Jobs; Vault.Rotation is grandfathered until a natural migration moment).
+- `repos/HoneyDrunk.Communications/boundaries.md` — record that cadence/drip-campaign scheduling uses Azure Container Apps Jobs per ADR-0068 D3, with cron strings 5-field UTC per ADR-0063 D6. (Pinned to `boundaries.md`, not `overview.md`.)
+- `repos/HoneyDrunk.Notify/boundaries.md` — record that in-Node retries use the `IHostedService` / `BackgroundService` pattern per ADR-0068 D2, with `TimeProvider` reads per ADR-0063 D1 and ISO 8601 duration strings for backoff per ADR-0063 D6. (Pinned to `boundaries.md`, not `overview.md`.)
+- `initiatives/active-initiatives.md` — register the `adr-0068-background-jobs` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. **`infrastructure/reference/tech-stack.md`** — remove (or relocate) the Jobs row in the Planned Nodes table. Record the PR-description rationale: "`HoneyDrunk.Jobs` deferred indefinitely per ADR-0068 D4 — Container Apps Jobs (D3) subsumes the role; in-Node work uses `BackgroundService` (D2)."
+2. **`initiatives/roadmap.md`** — remove (or relocate) the `HoneyDrunk.Jobs — Background job scheduling with Grid integration` line under "Future."
+3. **`repos/HoneyDrunk.Vault.Rotation/boundaries.md`** — append a "Substrate (grandfathered)" subsection (the file currently has Owns / Does NOT Own / Status sections; add Substrate after Status). The substance: "Vault.Rotation runs on Azure Functions timer triggers per ADR-0006 Tier-2 rotation. Per ADR-0068 D1/D7 this is the grandfathered substrate — new cross-Node recurring work uses Azure Container Apps Jobs (ADR-0068 D3). Vault.Rotation is not retroactively migrated; the grandfather lasts until a natural migration moment (a major Vault.Rotation rewrite, or Azure Functions plan retirement)."
+4. **`repos/HoneyDrunk.Communications/boundaries.md`** (the editorial home — boundaries.md captures "what Communications Owns") — under the "What Communications Owns" list (which already includes "Cadence decisions: send now, suppress, or defer."), append a "Substrate" subsection at the end of the file (parallel to other boundary clarifications). The substance: "Cadence and drip-campaign scheduling runs as an Azure Container Apps Job per ADR-0068 D3. Cron strings are 5-field UTC per ADR-0063 D6; `TimeProvider` is used for wall-clock reads per ADR-0063 D1; ISO 8601 duration strings for any in-job pacing per ADR-0063 D6. Idempotency is mandatory per ADR-0068 D6 using `IIdempotencyStore` (ADR-0042)."
+5. **`repos/HoneyDrunk.Notify/boundaries.md`** — append a "Substrate" subsection. The substance: "In-Node retry handling (the Notify retry pump and any future in-process recurring or batch work) runs as an `IHostedService` / `BackgroundService` in the Notify Worker process per ADR-0068 D2. `TimeProvider` is used for wall-clock reads per ADR-0063 D1; ISO 8601 duration strings for backoff configuration per ADR-0063 D6. Idempotency is mandatory per ADR-0068 D6 using `IIdempotencyStore` (ADR-0042). Notify never depends on a third-party in-process scheduler (Quartz, Hangfire) — invariant tied to ADR-0068 D2."
+6. **`initiatives/active-initiatives.md`** — register the `adr-0068-background-jobs` initiative with the wave structure and packet checklist for this folder (00, 01, 02, 03, 04, 05).
+
+## Affected Files
+- `infrastructure/reference/tech-stack.md`
+- `initiatives/roadmap.md`
+- `repos/HoneyDrunk.Vault.Rotation/boundaries.md`
+- `repos/HoneyDrunk.Communications/boundaries.md`
+- `repos/HoneyDrunk.Notify/boundaries.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance/reference files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No `honeydrunk-jobs` entry added anywhere in the catalogs (D4 + Catalog obligations are explicit on this).
+- [x] No new Node-to-Node edge — only `HoneyDrunk.Communications` and `HoneyDrunk.Notify` context get substrate-choice notes; no relationship-graph change.
+
+## Acceptance Criteria
+- [ ] `infrastructure/reference/tech-stack.md` no longer lists `Jobs | Ops | Background job scheduling` in the Planned Nodes table — either removed entirely or relocated to a "Deferred" subsection (choice recorded in the PR description)
+- [ ] `initiatives/roadmap.md` no longer lists `HoneyDrunk.Jobs — Background job scheduling with Grid integration` in the Future section — either removed or relocated to a "Deferred" subsection (consistent with tech-stack.md's choice)
+- [ ] `repos/HoneyDrunk.Vault.Rotation/boundaries.md` has a "Substrate (grandfathered)" subsection citing ADR-0068 D1/D7, naming Azure Functions timer triggers as the grandfathered substrate, and the "natural migration moment" condition for revisiting
+- [ ] `repos/HoneyDrunk.Communications/boundaries.md` has a "Substrate" subsection citing ADR-0068 D3 (Container Apps Jobs) and ADR-0063 D6 (cron format) / D1 (`TimeProvider`)
+- [ ] `repos/HoneyDrunk.Notify/boundaries.md` has a "Substrate" subsection citing ADR-0068 D2 (`BackgroundService`) and ADR-0063 D1 (`TimeProvider`) / D6 (ISO 8601 durations) — and naming Quartz/Hangfire as forbidden per the D2 invariant
+- [ ] `initiatives/active-initiatives.md` registers `adr-0068-background-jobs` with the packet checklist for this folder
+- [ ] `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/contracts.json` are **not modified** — D4 + Catalog obligations are explicit that no `honeydrunk-jobs` Node entry is added
+- [ ] ADR-0068 header is **not** modified — it stays `**Status:** Proposed` (status flip is packet 05's job)
+- [ ] `adrs/README.md` is **not** modified for ADR-0068 (also packet 05's job)
+- [ ] No new invariant added in this packet (invariants land in packet 01)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0068 D1 — Three workload categories, each with its own substrate.** CI/CD ops cron stays on GitHub Actions (out of scope for this ADR per the table). In-Node background processing uses `IHostedService` / `BackgroundService` (D2). Cross-Node recurring orchestration uses Azure Container Apps Jobs (D3).
+
+**ADR-0068 D2 — In-Node background processing uses `IHostedService` / `BackgroundService`.** "Every Node that needs in-process recurring or background work uses ASP.NET Core's built-in `IHostedService` interface (typically via the `BackgroundService` base class). No Quartz, no Hangfire, no third-party scheduler dependency." Time substrate is `TimeProvider` per ADR-0063 D1.
+
+**ADR-0068 D3 — Cross-Node recurring orchestration uses Azure Container Apps Jobs.** "Every cross-Node recurring or event-driven job runs on Azure Container Apps Jobs. This is the Jobs-shaped sibling of the Container Apps decision in ADR-0015." Cron strings are 5-field UTC per ADR-0063 D6. Naming: `caj-hd-{service}-{env}` (the Jobs-shaped sibling of invariant 34's `ca-hd-{service}-{env}`); the 13-character service-name limit (invariant 19) applies.
+
+**ADR-0068 D4 — `HoneyDrunk.Jobs` Node deferred indefinitely.** "Container Apps Jobs subsumes the Node — Azure provides the scheduling, observability, retry, and durability; the per-job business logic lives in the Node that owns the job (Communications owns its drip-campaign Job; Vault.Rotation owns its rotation Jobs)." Roadmap entry moves to "Deferred" or is removed; no `honeydrunk-jobs` catalog entry.
+
+**ADR-0068 D7 — Vault.Rotation grandfather posture.** "Vault.Rotation per ADR-0006 Tier 2 uses Azure Functions timer triggers today. The grandfather posture: stays on its existing substrate until a natural migration moment (a major rewrite of Vault.Rotation, or a Functions plan retirement). New cross-Node recurring work goes on Container Apps Jobs per D3; Vault.Rotation is not retroactively migrated."
+
+**ADR-0068 Catalog obligations.** "`catalogs/nodes.json` — **no `honeydrunk-jobs` entry to add.** This ADR explicitly defers the Node. `catalogs/contracts.json` — no entry. The contract surface (cron strings, `BackgroundService` shape, Container Apps Jobs deploy manifest) is platform/BCL types; nothing HoneyDrunk-owned to register. `constitution/invariants.md` — append the new invariants listed above with sequential numbers at acceptance. `infrastructure/reference/tech-stack.md` — update the `HoneyDrunk.Jobs` row per the follow-up checklist. `initiatives/roadmap.md` — update line 67 per the follow-up checklist."
+
+## Constraints
+- **ADR-0068 stays Proposed.** Do not flip the ADR header in this packet. Do not edit the `adrs/README.md` index row for ADR-0068. The flip is packet 05's job.
+- **No `honeydrunk-jobs` entry in any catalog.** `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/contracts.json` are not modified. The Jobs deferral is the decision; the catalogs reflect it by NOT having an entry.
+- **One Substrate subsection per repo-context file.** Don't sprinkle the substrate note across multiple files in the same repo's context — pick boundaries.md (it already structures ownership/non-ownership claims) and append once.
+- **No invariant change.** The four ADR-0068 invariants land in packet 01 as Proposed; they are promoted in packet 05. This packet adds none.
+- **Roadmap and tech-stack must be editorially consistent.** Both files reference the same Jobs Node — both remove or both relocate. The PR description names the choice.
+
+## Labels
+`feature`, `tier-2`, `core`, `docs`, `adr-0068`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Reflect ADR-0068's Jobs-deferral and substrate decisions in the Architecture-repo catalogs and Node-context files.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land the catalog/reference half of ADR-0068's follow-up checklist while the ADR stays Proposed. The flip happens in packet 05 after the first consumers ship.
+- Feature: ADR-0068 Background Job and Recurring Work Substrate rollout, Wave 1.
+- ADRs: ADR-0068 (primary), ADR-0006 (Vault.Rotation Tier-2 grandfather context), ADR-0015 (Container Apps platform parent of Container Apps Jobs).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. First packet in the initiative.
+
+**Constraints:**
+- ADR-0068 stays Proposed through this packet — do not flip the header or the `adrs/README.md` row.
+- No `honeydrunk-jobs` entry in any catalog. The Jobs deferral is the decision; the catalogs reflect it by absence.
+- Roadmap and tech-stack must be editorially consistent — both remove or both relocate.
+
+**Key Files:**
+- `infrastructure/reference/tech-stack.md` — line 204 (Jobs row in Planned Nodes table).
+- `initiatives/roadmap.md` — line 67 (HoneyDrunk.Jobs in Future section).
+- `repos/HoneyDrunk.Vault.Rotation/boundaries.md` — new "Substrate (grandfathered)" subsection.
+- `repos/HoneyDrunk.Communications/boundaries.md` — new "Substrate" subsection.
+- `repos/HoneyDrunk.Notify/boundaries.md` — new "Substrate" subsection.
+- `initiatives/active-initiatives.md` — register `adr-0068-background-jobs`.
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0068-background-jobs/01-architecture-prereserve-jobs-invariants.md
+++ b/generated/issue-packets/active/adr-0068-background-jobs/01-architecture-prereserve-jobs-invariants.md
@@ -1,0 +1,117 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "core", "docs", "adr-0068", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0068"]
+wave: 1
+initiative: adr-0068-background-jobs
+node: honeydrunk-architecture
+---
+
+# Pre-reserve the four ADR-0068 background-jobs invariants in Proposed state
+
+## Summary
+Add four new invariants (numbered `{N1}`, `{N2}`, `{N3}`, `{N4}` — the next contiguous block of four reserved from `constitution/invariant-reservations.md`) to `constitution/invariants.md` as **Proposed invariants tied to ADR-0068**. Each invariant text is final; only the lifecycle marker ("Proposed; promoted on ADR-0068 acceptance per packet 05") differs from a regular invariant. Packet 05 (the ADR-0068 acceptance flip) removes the Proposed marker and finalizes the four invariants as Accepted in the same PR that flips the ADR header.
+
+## Context
+ADR-0068's Done-When list and the "If Accepted" follow-up checklist commit four new invariants — D6 (idempotency on every job), D7 (retry policy defaults / grandfather), D2 (in-Node `BackgroundService` substrate), D3 (cross-Node Container Apps Jobs substrate + naming). Per ADR-0068's "Catalog obligations" subsection: "constitution/invariants.md — append the new invariants listed above with sequential numbers at acceptance."
+
+ADR-0068 stays **Proposed** through packets 00–04. The acceptance flip is packet 05's job. To avoid landing four already-Accepted-looking invariants while their ADR is still Proposed (a state-mismatch readers would find confusing), this packet records the four invariants in a **Proposed** state with an explicit marker — "Proposed; promoted on ADR-0068 acceptance per packet 05." Packet 05 removes the marker.
+
+**Invariant numbers are claimed from `constitution/invariant-reservations.md` at packet-authoring time.** The executor reads that file, picks the next free contiguous block of four (size 4), adds a row to **Active Reservations** for ADR-0068 in the same PR that lands this packet, and uses those four numbers as `{N1}`/`{N2}`/`{N3}`/`{N4}` throughout this packet and the downstream packets (03 — Notify retry pump; 04 — Communications cadence Job) that reference them. If a collision is detected at merge time (another in-flight ADR's packet 00 lands first and claims overlapping numbers), the executor follows the "first merge wins" rule in `invariant-reservations.md` — shift this packet's block upward to the new "next free" and update every `{N*}` placeholder in this packet plus packets 03 and 04 in a follow-up commit before pushing.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `constitution/invariants.md` — add four new invariants in a new `## Background Job Invariants` section (or under an existing topic-section if one fits — see Proposed Implementation). Each invariant is tagged "Proposed; promoted on ADR-0068 acceptance per packet 05."
+
+## Proposed Implementation
+1. **Read `constitution/invariant-reservations.md`** to determine the next free contiguous block of four (`{N1}`/`{N2}`/`{N3}`/`{N4}`). At packet-authoring time, the reservation registry's next-free pointer named ADR-0068's block as **83/84/85/86**; the executor reconfirms at execution time and uses whatever block the registry resolves to (the first-merge-wins rule may have shifted the block upward). Add an "Active Reservations" row for ADR-0068 in the same PR that lands this packet.
+2. **Create a `## Background Job Invariants` section** in `constitution/invariants.md` (place it after the most recent topic-section — likely after `## Audit Invariants`, parallel to the precedent in ADR-0042's packet 00 which created `## Idempotency Invariants`).
+3. **Add four invariants in order, numbered `{N1}`/`{N2}`/`{N3}`/`{N4}`** from the reservation block claimed in step 1:
+   - **`{N1}` — In-Node background processing uses `IHostedService` / `BackgroundService`.** Every Node that needs in-process recurring or background work uses the BCL `IHostedService` interface (typically via the `BackgroundService` base class) registered with `services.AddHostedService<T>()`. Third-party in-process schedulers (Quartz, Hangfire, and equivalents) are forbidden in Node host processes without a follow-up ADR that justifies the dependency. `BackgroundService` instances read wall-clock time via `TimeProvider` (ADR-0063 D1) and use ISO 8601 duration strings for any backoff/interval configuration (ADR-0063 D6). See ADR-0068 D2.
+   - **`{N2}` — Cross-Node recurring orchestration uses Azure Container Apps Jobs.** Every cross-Node recurring or event-triggered job (cron-scheduled or KEDA-scaler-triggered) runs on Azure Container Apps Jobs, deployed via the reusable `job-deploy-container-apps-job.yml` workflow in `HoneyDrunk.Actions`. New cross-Node recurring work on Azure Functions timer triggers is forbidden; existing Functions-based jobs (Vault.Rotation per ADR-0006 Tier 2) are grandfathered per ADR-0068 D7 until a natural migration moment. Container Apps Jobs follow the naming convention `caj-hd-{service}-{env}` — the Jobs-shaped sibling of invariant 34's `ca-hd-{service}-{env}`; the 13-character service-name limit (invariant 19) applies the same way. Cron strings are 5-field UTC per ADR-0063 D6. See ADR-0068 D3, D7.
+   - **`{N3}` — Every state-mutating job is idempotent.** Every job — in-Node `BackgroundService` or cross-Node Container Apps Job — that mutates state must be idempotent. Schedule-triggered jobs use the deterministic idempotency key `${jobName}:${scheduledInstant:yyyyMMddTHHmmssZ}` against `IIdempotencyStore` (ADR-0042); event-triggered (KEDA) jobs derive their key from the trigger event (Service Bus `MessageId` or Event Grid event ID, salted with the job name). Read-only jobs (status probes, health checks) are exempt because re-execution is harmless. The canary surface for jobs idempotency is part of ADR-0042's canary obligations — no separate canary in ADR-0068. See ADR-0068 D6.
+   - **`{N4}` — Job failure emits Audit and Pulse signals on the documented schedule.** Every job emits a Pulse `jobs.outcome` counter (tags `{job_name, outcome=success|retry|fail}`) and a Pulse `jobs.duration` histogram (tags `{job_name}`) via the existing Kernel `ITelemetryActivityFactory` plumbing. Job lifecycle (start, end, retry attempt) is a span on the Pulse trace pipeline with the job's `correlationId` propagated to every downstream call (invariant 6). Jobs running longer than 60 seconds emit progress to `IAuditLog` as a `JobProgress` audit-category entry (ADR-0030). Final-failure jobs raise an error via `IErrorReporter` (ADR-0045) carrying the final-failure stack trace, retry count, and correlation ID, and emit a `JobFailure` audit-category `AuditEntry` (ADR-0030) carrying job name, scheduled instant, retry count, and last exception summary. See ADR-0068 D8.
+4. **Tag each as Proposed.** Append to each invariant the marker: *"**Status:** Proposed (tied to ADR-0068); promoted on ADR-0068 acceptance per packet 05 of `adr-0068-background-jobs`."*
+5. **No other change** in this packet (besides the reservation-registry row in step 1). Existing invariants are untouched; their numbers are not renumbered.
+
+## Affected Files
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md` (Active Reservations row added — block of four claimed)
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule maps exactly.
+- [x] No code change in any other repo.
+- [x] No catalog file modified — D4's "no `honeydrunk-jobs` entry" stays honored.
+- [x] No existing invariant renumbered or reworded.
+
+## Acceptance Criteria
+- [ ] `constitution/invariant-reservations.md` has a new row under **Active Reservations** for ADR-0068 claiming the next free block of four (`{N1}`–`{N4}`); the registry's "Current ceiling" / next-free pointer advances accordingly
+- [ ] `constitution/invariants.md` contains four new invariants in a new `## Background Job Invariants` section (or appropriate existing section), numbered with the `{N1}`/`{N2}`/`{N3}`/`{N4}` block claimed in the reservation-registry row above
+- [ ] Each of the four invariants carries the explicit `**Status:** Proposed (tied to ADR-0068); promoted on ADR-0068 acceptance per packet 05` marker
+- [ ] Invariant `{N1}` (in-Node `BackgroundService`) names Quartz, Hangfire, and equivalents as forbidden without a follow-up ADR; cites ADR-0068 D2 and ADR-0063 D1/D6
+- [ ] Invariant `{N2}` (cross-Node Container Apps Jobs) names the Functions-timer prohibition (with the Vault.Rotation grandfather), the `caj-hd-{service}-{env}` naming convention, the 13-char service-name limit (invariant 19), and the ADR-0063 D6 cron format
+- [ ] Invariant `{N3}` (idempotency on every state-mutating job) references `IIdempotencyStore` (ADR-0042), names the deterministic schedule key and the KEDA event-derived key, and exempts read-only jobs
+- [ ] Invariant `{N4}` (job observability) names the two Pulse signals (`jobs.outcome`, `jobs.duration`), the lifecycle traces with `correlationId` (invariant 6), the long-running-progress `JobProgress` audit category (ADR-0030), and the final-failure `IErrorReporter` + `JobFailure` audit pair (ADR-0045 + ADR-0030)
+- [ ] Downstream packets 03 (Notify retry pump) and 04 (Communications cadence Job) have any `{N1}`/`{N2}`/`{N3}`/`{N4}` placeholders resolved to the same final block numbers chosen here (if numbers shifted at merge time, both packets are updated in the same follow-up commit)
+- [ ] No existing invariant is renumbered, reworded, or moved
+- [ ] No other file is modified
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0068 D2 — In-Node `BackgroundService`.** "Every Node that needs in-process recurring or background work uses ASP.NET Core's built-in `IHostedService` interface (typically via the `BackgroundService` base class). No Quartz, no Hangfire, no third-party scheduler dependency." Time substrate is `TimeProvider` per ADR-0063 D1.
+
+**ADR-0068 D3 — Cross-Node Container Apps Jobs.** "Every cross-Node recurring or event-driven job runs on Azure Container Apps Jobs." Naming: `caj-hd-{service}-{env}`. Cron 5-field UTC per ADR-0063 D6.
+
+**ADR-0068 D6 — Idempotency on every job.** "Every job (in-Node `BackgroundService` or cross-Node Container Apps Job) must be idempotent. Re-execution is a normal failure mode." Schedule key `${jobName}:${scheduledInstant:yyyyMMddTHHmmssZ}`; KEDA event-derived key from `MessageId` / event ID + job-name salt. Uses ADR-0042's `IIdempotencyStore`.
+
+**ADR-0068 D7 — Retry policy and Vault.Rotation grandfather.** Container Apps Jobs default: 3 retries, exponential 1m / 5m / 25m; per-job override allowed. Final failure emits `JobFailure` audit entry (ADR-0030) and raises error (ADR-0045). Vault.Rotation grandfathered.
+
+**ADR-0068 D8 — Observability.** Two Pulse signals (`jobs.outcome` counter, `jobs.duration` histogram); lifecycle traces with propagated `correlationId` per invariant 6; long-running (>60s) progress to Audit as `JobProgress`; final failure to `IErrorReporter` per ADR-0045.
+
+**ADR-0068 "If Accepted" follow-up — invariant promotion.** "Promote D6 (idempotency on every job), D7 (retry policy defaults), and D8 (observability) into numbered invariants once Accepted — scope agent assigns invariant numbers in the same PR that flips Status." This packet records them as Proposed; packet 05 promotes.
+
+## Constraints
+- **Numbers `{N1}`/`{N2}`/`{N3}`/`{N4}` are claimed from `constitution/invariant-reservations.md`** at packet-authoring/execution time. The reservation registry's "first merge wins" rule (per the file's own documentation) governs any collision: if another in-flight ADR's packet 00 merges first and lands on overlapping numbers, the executor shifts ADR-0068's block upward to the new "next free," updates the reservation-registry row, and updates every `{N*}` placeholder in this packet plus packets 03 (Notify retry pump) and 04 (Communications cadence Job) in a follow-up commit before pushing. Record the resolution in the PR description so packet 05 can locate the right numbers for promotion. **Do not hardcode 75/76/77/78** — the original draft of this packet used those numbers, but they collided with the ADR-0042/0045 batch and were replaced with placeholders.
+- **Proposed marker is mandatory.** Each invariant carries the explicit `**Status:** Proposed (tied to ADR-0068); promoted on ADR-0068 acceptance per packet 05 of `adr-0068-background-jobs`` marker. Without the marker a reader cannot tell whether the rule is in force.
+- **No existing invariant is renumbered or reworded.** This is an append-only edit. Existing numbering is sacrosanct.
+- **New section is preferred.** `## Background Job Invariants` is the parallel to ADR-0042 packet 00's `## Idempotency Invariants`. If editorial judgment puts the four under an existing section (e.g. Ops), record the rationale in the PR description.
+
+## Labels
+`feature`, `tier-2`, `core`, `docs`, `adr-0068`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Pre-reserve ADR-0068's four invariants in `constitution/invariants.md` as Proposed, ready to be promoted to Accepted in packet 05.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Capture the rule text now (so packets 02–04 reference real invariants), while preserving the ADR's lifecycle (ADR stays Proposed until packet 05).
+- Feature: ADR-0068 Background Job and Recurring Work Substrate rollout, Wave 1.
+- ADRs: ADR-0068 D2/D3/D6/D7/D8 (primary), ADR-0042 (`IIdempotencyStore`), ADR-0063 (cron + `TimeProvider`), ADR-0030 (Audit categories), ADR-0045 (`IErrorReporter`).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — the catalog/reference updates land first so the invariants reference an editorially-consistent context.
+
+**Constraints:**
+- Numbers `{N1}`/`{N2}`/`{N3}`/`{N4}` are claimed from `constitution/invariant-reservations.md` at execution time; first-merge-wins per the registry's documented rule. Update placeholders consistently across packets 01, 03, and 04 once the block is resolved.
+- Proposed marker is mandatory on each invariant.
+- No existing invariant is renumbered or reworded — append-only edit.
+
+**Key Files:**
+- `constitution/invariant-reservations.md` — claim the next-free block of four; add the Active Reservations row.
+- `constitution/invariants.md` — new `## Background Job Invariants` section.
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0068-background-jobs/02-actions-job-deploy-container-apps-job-workflow.md
+++ b/generated/issue-packets/active/adr-0068-background-jobs/02-actions-job-deploy-container-apps-job-workflow.md
@@ -1,0 +1,170 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "adr-0068", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0068", "ADR-0015", "ADR-0012", "ADR-0033"]
+wave: 2
+initiative: adr-0068-background-jobs
+node: honeydrunk-actions
+---
+
+# Author `job-deploy-container-apps-job.yml` reusable workflow for Azure Container Apps Jobs deploys
+
+## Summary
+Add a new reusable workflow `job-deploy-container-apps-job.yml` to `HoneyDrunk.Actions` for deploying Azure Container Apps **Jobs** (the scheduled / event-triggered Jobs surface, not the long-running Container Apps the existing `job-deploy-container-app.yml` workflow targets). The workflow follows the same OIDC-federation, ACR-build-push, Key Vault-backed runtime secrets, and validation patterns the existing container-app deploy workflow uses, with a Jobs-specific shape: schedule-or-event trigger, replica policy, retry policy, and KEDA scaler wiring.
+
+## Context
+ADR-0068 D3 pins Azure Container Apps Jobs as the substrate for cross-Node recurring orchestration. The ADR's "If Accepted" follow-up checklist names: "Add a `job-deploy-container-apps-job.yml` reusable workflow to `HoneyDrunk.Actions` — Container Apps Jobs need a deploy workflow analogous to `job-deploy-container.yml` (which deploys Container Apps, not Jobs); the new workflow handles Jobs-specific shape (schedule-or-event trigger, replica policy, retry policy)."
+
+Per ADR-0012, `HoneyDrunk.Actions` is the Grid's CI/CD control plane — reusable workflows live there. The existing deploy workflows in the repo (`.github/workflows/`):
+- `job-deploy-container-app.yml` — Azure Container Apps deploy (long-running Container Apps per ADR-0015 — Notify.Functions/Worker, Pulse.Collector, future Notify Cloud).
+- `job-deploy-container.yml` — generic container deploy (the ADR follow-up text references this one's name).
+- `job-deploy-function.yml` — Azure Function App deploy (Vault.Rotation grandfathered substrate per ADR-0068 D7).
+
+The new `job-deploy-container-apps-job.yml` is the Jobs-shaped sibling. The Container Apps Jobs Azure surface differs from Container Apps in:
+1. **Trigger** — schedule (cron) OR event (KEDA scaler), not always-on traffic.
+2. **Replica policy** — `replicaCompletionCount`, `parallelism`, `replicaTimeout` instead of HTTP ingress + scale rules.
+3. **Retry policy** — `replicaRetryLimit` at the platform level; per-job override allowed (ADR-0068 D7: default 3 retries, 1m/5m/25m exponential backoff).
+4. **No traffic shifting** — Jobs don't have revisions in the Container-App sense; each job execution is a discrete replica.
+5. **No health probe at deploy time** — the deploy succeeds when the Jobs resource is provisioned/updated; runtime health is reported per-execution by the Job, not gate-checked at deploy.
+
+The workflow **reuses** the existing OIDC federation, the existing ACR build/push step, the existing Key Vault secret-reference pattern, and the existing managed-identity wiring — same Azure surface as Container Apps proper (per ADR-0015's shared Container Apps Environment + shared ACR). The differences are in the Container Apps Jobs-specific `az containerapp job` CLI calls and the trigger/replica/retry shape.
+
+**This is a workflow/YAML packet. No .NET project.** `HoneyDrunk.Actions` is not a versioned .NET solution — no version bump.
+
+## Scope
+- `.github/workflows/job-deploy-container-apps-job.yml` — new reusable workflow.
+- `docs/consumer-usage.md` (or the equivalent docs the deploy workflows reference) — document the new workflow's inputs, the schedule-vs-event trigger choice, and the per-job retry override.
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface.
+
+## Proposed Implementation
+1. **Author `job-deploy-container-apps-job.yml`** as a `workflow_call` reusable workflow, modelled on `job-deploy-container-app.yml`'s shape. Required inputs:
+   - `runs-on` (optional, default `ubuntu-latest`) — same as the sibling workflow.
+   - `container-image` (optional) / `build-context` (optional) / `image-name` (optional) / `image-tag` (optional) / `dockerfile` (optional, default `Dockerfile`) — same build-or-supplied-image branch as the sibling.
+   - `acr-registry` (required) — same ACR convention (`acrhdshared{env}.azurecr.io`).
+   - `containerapps-job` (required) — target Container Apps Job name. Must validate against the `caj-hd-{service}-{env}` convention (ADR-0068 D3; invariant `{N2}` once promoted — the second of the four ADR-0068 invariants claimed in packet 01 from `constitution/invariant-reservations.md`).
+   - `resource-group` (required).
+   - `containerapps-environment` (required) — the Container Apps Environment (`cae-hd-{env}`) the Job lives in (shared with Container Apps per invariant 35).
+   - `azure-client-id`, `azure-tenant-id`, `azure-subscription-id` (required) — OIDC federation, same as sibling.
+   - `trigger-type` (required) — one of `Schedule`, `Event`, `Manual`. Drives whether the workflow sets `triggerType: Schedule` (with `cronExpression`) or `triggerType: Event` (with KEDA scaler config) on the Jobs resource.
+   - `cron-expression` (optional) — required iff `trigger-type == Schedule`. Validated to be **5-field** (no seconds) per ADR-0063 D6.
+   - `event-scaler-config-path` (optional) — required iff `trigger-type == Event`. Path to a YAML/JSON snippet describing the KEDA scaler (Service Bus, Event Grid, Storage Queue, custom) and `pollingInterval` / `minReplicas` / `maxReplicas`.
+   - `replica-completion-count` (optional, default `1`) — `replicaCompletionCount`.
+   - `parallelism` (optional, default `1`).
+   - `replica-timeout-seconds` (optional, default `1800`) — 30-minute default; per-job override allowed.
+   - `replica-retry-limit` (optional, default `3`) — ADR-0068 D7 default (3 retries; 1m/5m/25m exponential backoff is implicit Container Apps Jobs platform behaviour for the retry-limit case, but the default schedule can be overridden per-job).
+   - `secrets-from-keyvault` (optional) — same Key Vault-backed runtime secrets pattern as the sibling workflow.
+   - `app-insights-resource-id` (optional) — same as the sibling. If supplied, the post-deploy step calls the App Insights release annotations API per ADR-0045 D6 (the existing `job-deploy-container-app.yml` already does this — pattern is reused).
+   - `app-insights-release-annotation` (optional boolean, default `false`) — gate the release-annotation step, same as the sibling.
+2. **Steps in the workflow:**
+   - **Validate** — assert `containerapps-job` matches `^caj-hd-[a-z0-9-]{1,13}-(dev|stg|prod)$` (invariant `{N2}` + invariant 19's 13-character service-name limit; tighten the upper bound if the Container Apps Jobs platform cap proves lower at packet 02's verification prerequisite). Fail the workflow if not.
+   - **Authenticate** via OIDC (same `azure/login@v2` action and federated credential pattern as the sibling).
+   - **Build and push** to ACR (if `build-context` is set) — reuse the sibling's build/push step verbatim.
+   - **Provision or update the Job** via `az containerapp job create` / `az containerapp job update` with the right `--trigger-type`, `--cron-expression` or `--scale-rule-*` (KEDA), `--replica-completion-count`, `--parallelism`, `--replica-timeout`, `--replica-retry-limit`, `--secrets`, and `--registry-server` arguments.
+   - **No health probe step** — Jobs don't have a deploy-time health probe (they aren't running yet; they trigger on schedule/event). Document this in the workflow header comment so callers don't expect one.
+   - **Release annotation** (gated on `app-insights-release-annotation == true`) — call the App Insights release-annotation API (current supported `az monitor app-insights` / ARM path; legacy `aisvc.visualstudio.com` endpoint fallback only). Same pattern as the sibling. The annotation tags the deploy moment with the deployable name + SemVer.
+3. **No-secret-in-the-workflow** — all auth via OIDC; secrets are pulled from Key Vault into the Container Apps Job's `secrets` collection by reference. Workflow logs never carry secret values (invariant 8).
+4. **Header comment** — mirror the existing `job-deploy-container-app.yml` header: Purpose, Responsibilities, Target ("Repos with cross-Node recurring or event-triggered jobs deploying to Azure Container Apps Jobs per ADR-0068"), Usage Example (or pointer to `docs/consumer-usage.md`).
+5. **Docs** — update `docs/consumer-usage.md` with a Container-Apps-Jobs example block: schedule-triggered (e.g. Communications cadence at `*/30 * * * *`) and event-triggered (Service Bus queue depth). Cross-link from the sibling Container-App workflow docs so a reader looking at one finds the other.
+
+## Affected Files
+- `.github/workflows/job-deploy-container-apps-job.yml` (new file)
+- `docs/consumer-usage.md` (or the equivalent referenced docs)
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface.
+
+## NuGet Dependencies
+None. `HoneyDrunk.Actions` deploy workflows are GitHub Actions YAML — no .NET project is created or modified.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo — ADR-0068's follow-up checklist names "the `HoneyDrunk.Actions` reusable deploy workflows" explicitly. ADR-0012 makes Actions the CI/CD control plane.
+- [x] The reusable workflow surface is the right shape — consuming repos call it from their own release workflows; the Container Apps Jobs deploy is a shared deploy-time concern.
+- [x] No code change in any Node — per-Node job binaries land in packet 04 (Communications) and packet 03 (Notify, in-Node so no Container Apps Job deploy).
+- [x] The Vault.Rotation Functions-timer-trigger workflow is **not** modified — Vault.Rotation is grandfathered per ADR-0068 D7.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/job-deploy-container-apps-job.yml` exists as a reusable `workflow_call` workflow with all the inputs listed in Proposed Implementation
+- [ ] The workflow validates `containerapps-job` against the `caj-hd-{service}-{env}` pattern, including the 13-character service-name limit (invariant 19)
+- [ ] The workflow supports both `Schedule` (cron) and `Event` (KEDA scaler) trigger types, with `Manual` available as a `triggerType: Manual` shape; cron strings are validated as 5-field (no seconds — ADR-0063 D6)
+- [ ] Replica policy inputs (`replica-completion-count`, `parallelism`, `replica-timeout-seconds`, `replica-retry-limit`) all have safe defaults; `replica-retry-limit` defaults to **3** per ADR-0068 D7
+- [ ] OIDC federation reused from the existing pattern — no new credential or service principal
+- [ ] Key Vault-backed runtime secrets pass through to the Job's `secrets` collection by reference; no secret value appears in the workflow file or workflow logs (invariant 8)
+- [ ] Release-annotation step is included and gated on `app-insights-release-annotation == true` + non-empty `app-insights-resource-id`; uses `az monitor app-insights` / ARM as the default mechanism; legacy `aisvc` endpoint fallback only — same as the sibling `job-deploy-container-app.yml`
+- [ ] No deploy-time health probe — documented in the header comment that Jobs don't have one
+- [ ] `docs/consumer-usage.md` includes a schedule-triggered example and an event-triggered example
+- [ ] Header comment mirrors `job-deploy-container-app.yml`'s structure (Purpose / Responsibilities / Target / Usage Example) and cites ADR-0068
+- [ ] The repo `CHANGELOG.md` is updated if the repo keeps one for the workflow surface
+- [ ] Existing deploy workflows (`job-deploy-container-app.yml`, `job-deploy-container.yml`, `job-deploy-function.yml`) are **not** modified — this packet only adds a new workflow
+
+## Human Prerequisites
+- [ ] **Container Apps Jobs portal-side requires no Studio-wide one-time provisioning** — the existing `cae-hd-{env}` Container Apps Environment already supports Jobs alongside Container Apps; the shared ACR (`acrhdshared{env}`) already serves Job images. There is **no separate environment to provision**. The first consuming Job's deploy (packet 04 — Communications cadence) creates its own `caj-hd-comms-cadence-{env}` Job resource via this workflow.
+- [ ] The OIDC federated credential the existing deploy workflows use already covers the resource scope needed for `Microsoft.App/jobs/*` provisioning, because Container Apps Jobs live under the same `Microsoft.App` resource provider as Container Apps proper. **Verify** in the Azure portal at packet 02 first-use time: the deploy identity has at least `Container Apps Contributor` (or `Contributor`) on the resource group. If it does not, a one-time RBAC grant via the portal is needed before any Job deploy. This is the portal click the operator performs; the workflow itself just calls `az`.
+- [ ] **Verify the actual Azure Container Apps Jobs resource-name length limit** before locking the regex. Invariant 19 ("13-character service-name limit") was derived from Azure Container Apps proper (`ca-hd-{service}-{env}` pattern). The Azure platform enforces a per-resource-type max length on `Microsoft.App/jobs/*` that may or may not match the Container Apps limit. Confirm via the [`Microsoft.App/jobs` resource reference](https://learn.microsoft.com/en-us/azure/templates/microsoft.app/jobs) (or via an `az containerapp job create --help` smoke test that intentionally hits the limit) what the actual cap is for the **full** resource name (`caj-hd-{service}-{env}` — 7 fixed chars + service + 1 dash + env). Document the constraint in this packet's PR description with the relationship to invariant 19:
+  - If the Jobs limit ≥ the Container Apps limit: invariant 19's 13-character cap on `{service}` carries over unchanged; the workflow's regex `^caj-hd-[a-z0-9-]{1,13}-(dev|stg|prod)$` is correct.
+  - If the Jobs limit < the Container Apps limit: tighten the regex to the lower cap and flag a follow-up to record the Jobs-specific cap (either as a refinement to invariant 19 or as a new invariant tied to ADR-0068's `{N2}`). Note in the PR that the discrepancy was discovered at this verification step.
+- [ ] No App Insights resource is provisioned by this packet; the release-annotation step gates on a caller-supplied `app-insights-resource-id` (ADR-0040 provisions the resource).
+
+## Referenced ADR Decisions
+**ADR-0068 D3 — Cross-Node Container Apps Jobs.** Every cross-Node recurring or event-driven job runs on Azure Container Apps Jobs. Trigger shapes: schedule-triggered (cron, 5-field UTC) or event-triggered (KEDA scaler — Service Bus queue depth, Event Grid event arrival, Storage Queue length, custom scaler). Naming: `caj-hd-{service}-{env}` with the 13-character service-name limit (invariant 19).
+
+**ADR-0068 D7 — Retry policy defaults.** Container Apps Jobs default: 3 retries, exponential 1m/5m/25m backoff. Per-job override allowed in the manifest. Final failure emits `JobFailure` audit entry per ADR-0030 and raises error per ADR-0045.
+
+**ADR-0068 "If Accepted" follow-up.** "Add a `job-deploy-container-apps-job.yml` reusable workflow to `HoneyDrunk.Actions` — Container Apps Jobs need a deploy workflow analogous to `job-deploy-container.yml` (which deploys Container Apps, not Jobs); the new workflow handles Jobs-specific shape (schedule-or-event trigger, replica policy, retry policy)."
+
+**ADR-0015 — Container Apps shared Environment and ACR.** Per invariant 35, one shared `cae-hd-{env}` Environment and one shared `acrhdshared{env}` ACR serve every containerized resource in a given environment — Container Apps **and** Container Apps Jobs.
+
+**ADR-0012 — Actions as CI/CD control plane.** Reusable workflows live in `HoneyDrunk.Actions`. Consuming repos' release workflows call them.
+
+**ADR-0033 — Tag→environment mapping.** SemVer tags drive environment; the workflow takes the deployable's version as an input (same convention as the sibling).
+
+**ADR-0063 D6 — Cron format.** 5-field UTC. The workflow validates input.
+
+**ADR-0045 D6 — Release annotation.** App Insights release-annotation API call after a successful deploy; use the current supported mechanism (`az monitor app-insights` / ARM). Same pattern the existing container-app workflow uses (packet 04 of `adr-0045-grid-wide-error-tracking`).
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry — or in workflow files.** The annotation API call is OIDC/AAD-authenticated. No DSN, instrumentation key, connection string, or any secret value is committed to a workflow or the repo.
+
+> **Invariant 35 — Shared Container Apps Environment and ACR per environment.** Container Apps Jobs reuse the existing `cae-hd-{env}` Environment and `acrhdshared{env}` registry; the workflow does not provision new platform-level resources.
+
+- **Use the current supported `az` surface.** `az containerapp job` was GA in 2023; the workflow uses it directly. If a more recent surface (Bicep module, ARM-only path) becomes preferred during execution, the workflow's `az` calls can be swapped for an equivalent; the contract (the workflow's inputs/outputs) does not change.
+- **No deploy-time health probe.** Container Apps Jobs don't run at deploy time; there's nothing to probe until the schedule or event fires. The workflow header documents this so consumers don't expect probe-based gating.
+- **No new credential.** The existing OIDC federation covers Microsoft.App/jobs/* — if not, the portal RBAC fix is a Human Prerequisite, not a workflow change.
+- **Backward-compatible — additive workflow.** This is a new file; existing deploy workflows are untouched. Existing consumers are unaffected.
+- **Validation, not best-effort.** Inputs that drive Azure resource names (`containerapps-job`) are regex-validated at workflow start; the workflow fails fast with a clear message rather than failing on an `az` error later.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `adr-0068`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author the `job-deploy-container-apps-job.yml` reusable workflow for Container Apps Jobs deploys.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Land the deploy substrate that packet 04 (Communications cadence Job) will use; make subsequent cross-Node Container Apps Jobs deploys a near-mechanical `workflow_call`.
+- Feature: ADR-0068 Background Job and Recurring Work Substrate rollout, Wave 2.
+- ADRs: ADR-0068 D3/D7 (primary), ADR-0015 (Container Apps platform), ADR-0012 (Actions as CI/CD control plane), ADR-0033 (tag→environment mapping), ADR-0063 D6 (cron 5-field UTC), ADR-0045 D6 (release annotation reused).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft; ADR-0068's reference and catalog updates land first so consumers reading the boundary docs see the substrate decision.
+
+**Constraints:**
+- Name validation regex `^caj-hd-[a-z0-9-]{1,13}-(dev|stg|prod)$` (invariant `{N2}` + invariant 19); tighten upper bound if the Container Apps Jobs platform cap proves lower at the verification prerequisite.
+- 5-field UTC cron validated (ADR-0063 D6).
+- OIDC reused; no new credential.
+- No deploy-time health probe.
+- No secret in the workflow (invariant 8).
+- Replica retry limit defaults to 3 (ADR-0068 D7).
+- Existing deploy workflows untouched.
+
+**Key Files:**
+- `.github/workflows/job-deploy-container-apps-job.yml` (new).
+- `.github/workflows/job-deploy-container-app.yml` (sibling — read for OIDC/ACR/Key-Vault/release-annotation pattern; do NOT modify).
+- `docs/consumer-usage.md` (new examples added).
+
+**Contracts:** None — workflow inputs only.

--- a/generated/issue-packets/active/adr-0068-background-jobs/02-actions-job-deploy-container-apps-job-workflow.md
+++ b/generated/issue-packets/active/adr-0068-background-jobs/02-actions-job-deploy-container-apps-job-workflow.md
@@ -4,7 +4,7 @@ type: repo-feature
 tier: 2
 target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
 labels: ["feature", "tier-2", "ops", "ci-cd", "adr-0068", "wave-2"]
-dependencies: ["packet:00"]
+dependencies: ["packet:00", "packet:01"]
 adrs: ["ADR-0068", "ADR-0015", "ADR-0012", "ADR-0033"]
 wave: 2
 initiative: adr-0068-background-jobs

--- a/generated/issue-packets/active/adr-0068-background-jobs/03-notify-retry-pump-background-service.md
+++ b/generated/issue-packets/active/adr-0068-background-jobs/03-notify-retry-pump-background-service.md
@@ -1,0 +1,201 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["feature", "tier-2", "ops", "adr-0068", "wave-3"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0068", "ADR-0063", "ADR-0042", "ADR-0030", "ADR-0045"]
+wave: 3
+initiative: adr-0068-background-jobs
+node: honeydrunk-notify
+---
+
+# Implement the Notify retry pump as an in-Node `BackgroundService` per ADR-0068 D2
+
+## Summary
+Stand up the Notify retry pump as a `BackgroundService` inside the `HoneyDrunk.Notify` Worker host per ADR-0068 D2 — the first in-Node consumer under the ADR's D11 first-shipping list. The pump reads Notify's failed-delivery records, applies backoff windows configured in ISO 8601 duration strings (ADR-0063 D6), reads wall-clock via `TimeProvider` (ADR-0063 D1), enforces idempotency on every re-send attempt via `IIdempotencyStore` (ADR-0042 + ADR-0068 D6), and emits the four ADR-0068 D8 observability signals (Pulse `jobs.outcome` counter, `jobs.duration` histogram, lifecycle traces with `correlationId` propagation per invariant 6, and on final failure both an `IErrorReporter` raise per ADR-0045 and a `JobFailure` audit entry per ADR-0030).
+
+## Context
+ADR-0068 D11 names "Notify retries (in flight) — Pin to D2 — in-Node `BackgroundService`" as one of the workloads this ADR pins. ADR-0027 (Notify Cloud stand-up) explicitly cites retry scheduling as needing a committed substrate; D2's in-Node `BackgroundService` is the substrate. This packet is the first concrete in-Node `BackgroundService` under ADR-0068.
+
+The retry pump's responsibilities — pinned by ADR-0068 D2 + D6 + D8:
+
+1. **Polling loop** — `while(!ct.IsCancellationRequested) { ... await Task.Delay(interval, ct) }` shape, exactly as D2 describes; interval is `TimeProvider.GetUtcNow()` aware so `FakeTimeProvider` (ADR-0063 D7) can drive tests.
+2. **Backoff windows** — ISO 8601 duration strings in configuration (e.g. `PT1M`, `PT5M`, `PT25M` for the canonical 1m/5m/25m progression D7 cites for Container Apps Jobs; the BackgroundService author decides the exact retry semantics per D7's last paragraph, but the 1m/5m/25m progression is the recommended starting point and the precedent for future authors).
+3. **Idempotency** — every re-send goes through an `IIdempotencyStore` check using a deterministic key (`notify-retry:<original-message-id>:<retry-attempt-n>` or, where the original message already carries an `IdempotencyKey` per ADR-0042 D5, a derived key per ADR-0042 D3's `SHA256(inbound:relationship)` shape with `relationship="retry"`). Idempotency on retries is mandatory per ADR-0068 D6 — re-execution is a normal failure mode.
+4. **Observability** — Pulse `jobs.outcome` counter, Pulse `jobs.duration` histogram, lifecycle traces with `correlationId` propagation. Long-running pump iterations (>60s — unlikely but possible for batch retries) emit `JobProgress` to Audit per ADR-0030. On final failure (max retries exhausted on a given message), raise via `IErrorReporter` per ADR-0045 + emit `JobFailure` to Audit per ADR-0030.
+
+The pump's name as registered for observability tagging is `notify-retry-pump`.
+
+**Boundary clarification (invariant 41).** The pump is **Notify's delivery-mechanics retry** — it re-attempts a delivery that previously failed at the provider boundary (an SMTP timeout, a Twilio 5xx). Communications' cadence/preference logic is **not** re-evaluated on retry. Per invariant 41: "Preference enforcement, cadence rules, and suppression logic for outbound messages live in HoneyDrunk.Communications, not in HoneyDrunk.Notify. Notify owns delivery mechanics; Communications owns decision logic." The retry pump is in scope (delivery mechanics) — the `BackgroundService` lives in Notify.
+
+**HoneyDrunk.Notify is a live Node** (v0.3.0 most recent per the launch tracker). This packet is the only ADR-0068 packet on the `HoneyDrunk.Notify` solution; per invariant 27 it bumps the whole solution one minor version (a new feature — the retry pump). Confirm the current solution version at execution time.
+
+## Scope
+- A new `RetryPump` class deriving from `BackgroundService`, registered via `services.AddHostedService<RetryPump>()` in the Notify Worker host.
+- Configuration shape for the pump (poll interval, max retries, backoff schedule), bound via `IOptions<RetryPumpOptions>`.
+- The deterministic idempotency-key strategy on every re-send attempt.
+- The Pulse + Audit + ErrorReporter observability emissions per ADR-0068 D8.
+- Tests using `FakeTimeProvider` (ADR-0063 D7) and the InMemory `IIdempotencyStore` (ADR-0042 D2 default test seam) to verify: a duplicate retry attempt produces exactly one send; final failure emits both audit + error; the pump respects cancellation.
+- Solution version bump; CHANGELOG/README updates.
+
+## Proposed Implementation
+1. **`RetryPump : BackgroundService`** in the Notify Worker host project (likely `HoneyDrunk.Notify` or `HoneyDrunk.Notify.Worker`, depending on the existing project structure — verify at execution time).
+   - Constructor takes `TimeProvider` (ADR-0063 D1), `IOptions<RetryPumpOptions>`, `IIdempotencyStore` (ADR-0042), `ITelemetryActivityFactory` (Kernel — for the Pulse signals + traces), `IAuditLog` (ADR-0030/0031), `IErrorReporter` (ADR-0045), an `IRetryQueueReader` or equivalent Notify-internal abstraction for reading failed-delivery records, and an `INotificationSender` or the Notify-internal delivery callback.
+   - Override `ExecuteAsync(CancellationToken ct)`:
+     ```
+     while (!ct.IsCancellationRequested) {
+         var iterationStart = TimeProvider.GetUtcNow();
+         var iterationCorrelationId = $"notify-retry-pump:{iterationStart:yyyyMMddTHHmmssZ}";
+         // pull due-for-retry records
+         // for each: claim idempotency key, send, complete, update record
+         // emit jobs.outcome + jobs.duration for the iteration
+         // long-running progress -> JobProgress audit (if applicable)
+         await Task.Delay(options.Value.PollInterval, TimeProvider, ct);
+     }
+     ```
+   - Per-message retry semantics (the `try/catch` around the actual provider send) use **Polly** with the configured backoff schedule. Polly is already a transitive dependency in many Notify projects; if it isn't on the Worker host, add it (it's MIT-licensed and BCL-aligned).
+2. **`RetryPumpOptions`** record/class — `PollInterval` (`TimeSpan`, parsed from `"PT30S"` style configuration via ISO 8601 duration string per ADR-0063 D6), `MaxRetries` (default 3 — matches D7 Container Apps Jobs default for cross-Node parity), `BackoffSchedule` (`string[]` of ISO 8601 durations — default `["PT1M", "PT5M", "PT25M"]`).
+3. **Idempotency on every send attempt.**
+   - If the failed-delivery record's original message carries an `IdempotencyKey` per ADR-0042 D5: derive the retry key via `originalKey.Derive("retry")` (ADR-0042 D3 shape — `SHA256(inbound:retry)`).
+   - Otherwise (legacy records without keys): construct `notify-retry:<external-id>:<retry-attempt-n>`. Persist the key with the retry record so subsequent attempts in the same window observe the same key.
+   - Call `IIdempotencyStore.TryClaim` before each provider call; if already claimed (a prior attempt succeeded in a concurrent pump iteration or a replay), skip the send and complete the record with `IdempotencyOutcome.AlreadyClaimed`.
+   - Standard 7-day TTL (ADR-0042 D4 — Notify is not billing/audit).
+4. **Observability — D8 emissions.**
+   - `jobs.outcome` counter — tag `{job_name=notify-retry-pump, outcome=success|retry|fail}` — emitted on each per-message attempt outcome (not the per-iteration outcome — D8 reads more naturally at the message granularity for a retry pump).
+   - `jobs.duration` histogram — tag `{job_name=notify-retry-pump}` — emitted per iteration with the iteration's total wall-clock time.
+   - Lifecycle traces — start/end span per iteration; per-message child spans; `correlationId` propagated through the provider-send call so downstream observability links back (invariant 6).
+   - `JobProgress` audit (ADR-0030) — only if an iteration runs >60s. The retry pump's iterations are usually short; surface this only if it triggers.
+   - Final-failure handling — when a message exhausts `MaxRetries`, raise via `IErrorReporter` with the full exception + retry count + correlation ID **and** emit a `JobFailure` `AuditEntry` (ADR-0030 category) carrying job name (`notify-retry-pump`), the failed message's external ID, retry count, and last exception summary. Audit category strings are new (per ADR-0068 dispatch plan's cross-cutting note — forward-compatible if Audit later normalizes its category list).
+5. **DI registration.** In the Worker host composition: `services.AddOptions<RetryPumpOptions>().Bind(config.GetSection("Notify:RetryPump"));`; `services.AddHostedService<RetryPump>();`. `TimeProvider` is registered as a singleton (`services.TryAddSingleton(TimeProvider.System);`) — if it isn't already; ADR-0063 may already pin its DI registration as a Grid invariant.
+6. **Tests.** Unit tests in the Notify test project:
+   - Pump iteration with one due record → one send → `jobs.outcome=success` emitted, `jobs.duration` emitted, the message marked complete in the queue.
+   - Two concurrent pump iterations claim the same key → only one send is performed (`IIdempotencyStore` rejects the second claim).
+   - Provider throws → retry attempts increment; final failure emits `IErrorReporter` raise + `JobFailure` audit.
+   - `FakeTimeProvider.Advance(...)` to drive the polling loop without wall-clock waits — **no `Thread.Sleep`** (invariant 51).
+   - The pump respects cancellation: `cts.Cancel()` exits the loop within one poll interval.
+7. **Versioning.** Bump every non-test `.csproj` in the `HoneyDrunk.Notify` solution to the next minor version in one commit (invariant 27). Repo-level `CHANGELOG.md` new version entry naming the retry-pump feature; per-package CHANGELOG for the Notify Worker host project (the only package with a functional change). README updated if the public composition story changed.
+
+## Affected Files
+- A new `RetryPump.cs` (and `RetryPumpOptions.cs`) in the Notify Worker host project.
+- Notify host composition / DI registration source.
+- Every non-test `.csproj` in the `HoneyDrunk.Notify` solution — version bump.
+- Repo-level `CHANGELOG.md`; per-package CHANGELOG for the Worker host package.
+- `README.md` if the public composition story changes.
+- Notify test project — new retry-pump tests.
+
+## NuGet Dependencies
+- The Worker host project gains or updates:
+  - `Microsoft.Extensions.Hosting` — almost certainly already present (it's the source of `BackgroundService`). No change expected.
+  - `HoneyDrunk.Kernel.Abstractions` — version that exports `IIdempotencyStore` (ADR-0042's packet 02 ships this; `HoneyDrunk.Kernel.Abstractions` `0.8.0` per the ADR-0042 dispatch plan's expected version-bump shape). **Verify the version at execution time** — if ADR-0042's packets have not yet shipped on the NuGet feed, see Human Prerequisites for the cross-init dependency.
+  - One of the `HoneyDrunk.Data.Idempotency.*` packages — `HoneyDrunk.Data.Idempotency.Cosmos` for the deployed-environment composition, `HoneyDrunk.Data.Idempotency.InMemory` for the test project. Both ship from ADR-0042's packet 03.
+  - `Polly` — if not already a transitive dependency. MIT-licensed; safe to add.
+- `HoneyDrunk.Standards` already on every Notify project; no change.
+- Confirm exact current versions at execution time.
+
+## Boundary Check
+- [x] All code change in `HoneyDrunk.Notify` — the retry pump is delivery mechanics (invariant 41). Routing rule "notification, email, SMS, ... notify, channel → HoneyDrunk.Notify" maps here.
+- [x] No contract change in Notify — the pump consumes `IIdempotencyStore` / `IAuditLog` / `IErrorReporter` / `TimeProvider` as shipped by other Nodes / the BCL.
+- [x] Communications' preference/cadence/suppression logic is not touched (invariant 41). The retry pump re-attempts an already-decided send; it does not re-decide whether to send.
+- [x] No third-party in-process scheduler — only `BackgroundService` + Polly (Polly is a retry library, not a scheduler; it does not violate the ADR-0068 D2 invariant `{N1}` prohibition on Quartz/Hangfire).
+- [x] The pump is in-Node (D2) — not a Container Apps Job (D3). The packet 02 deploy workflow is not used here.
+
+## Acceptance Criteria
+- [ ] `RetryPump : BackgroundService` exists in the Notify Worker host, registered via `services.AddHostedService<RetryPump>()`
+- [ ] The pump reads wall-clock time via `TimeProvider` (ADR-0063 D1); polling interval is parsed from configuration as an ISO 8601 duration string (ADR-0063 D6)
+- [ ] Per-message backoff uses Polly with a configured schedule of ISO 8601 duration strings (default `["PT1M", "PT5M", "PT25M"]`); `MaxRetries` defaults to 3 (parity with ADR-0068 D7 Container Apps Jobs default)
+- [ ] Every send attempt goes through `IIdempotencyStore.TryClaim` with a deterministic retry-derived key; standard 7-day TTL (ADR-0042 D4)
+- [ ] On a duplicate claim, the send is skipped and the record is completed with `IdempotencyOutcome.AlreadyClaimed`
+- [ ] Pulse `jobs.outcome` counter is emitted per per-message attempt with tags `{job_name=notify-retry-pump, outcome=success|retry|fail}`
+- [ ] Pulse `jobs.duration` histogram is emitted per pump iteration with tag `{job_name=notify-retry-pump}`
+- [ ] Lifecycle traces are emitted (iteration start/end span + per-message child spans) with `correlationId` propagation per invariant 6
+- [ ] Final failure (exhausted retries on a message) raises via `IErrorReporter` with full exception + retry count + correlation ID, and emits a `JobFailure` `AuditEntry` (job name, external ID, retry count, last exception summary)
+- [ ] Tests use `FakeTimeProvider` (ADR-0063 D7) and the InMemory `IIdempotencyStore`; no `Thread.Sleep` (invariant 51)
+- [ ] Tests cover: single-record happy path; concurrent claim → exactly one send; provider failure → retries → final failure with audit + error; cancellation exits within one poll interval
+- [ ] Every non-test `.csproj` in the solution is at the same new minor version in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new version entry naming the retry-pump feature; per-package CHANGELOG entry on the Worker host package
+- [ ] `README.md` updated if the public composition story changed
+- [ ] The `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **HARD GATE — Do not push this packet until ADR-0042 packets 02 and 03 ship NuGet packages on the feed.** This packet's compile depends on `HoneyDrunk.Kernel.Abstractions` (with `IIdempotencyStore` — ADR-0042 packet 02 ships 0.8.0) and `HoneyDrunk.Data.Idempotency.Cosmos` / `HoneyDrunk.Data.Idempotency.InMemory` (ADR-0042 packet 03). ADR-0042 is **Proposed** at the time this packet was authored; its packets have not yet been executed or merged. Until those packages are published, the executor cannot resolve the references and the PR will not build. Cross-initiative — not encoded in `dependencies:` (which only resolves within the initiative folder). The operator confirms package availability on the feed (search `HoneyDrunk.Kernel.Abstractions` version >= 0.8.0 and the `HoneyDrunk.Data.Idempotency.*` family in the package registry) **before** branching for this packet. **Agents never tag or publish — the operator runs that ceremony.**
+- [ ] **Upstream NuGet packages must be published before this packet compiles.** This packet's projects reference `HoneyDrunk.Kernel.Abstractions` (for `IIdempotencyStore`), `HoneyDrunk.Data.Idempotency.Cosmos` (for deployed composition), and `HoneyDrunk.Data.Idempotency.InMemory` (for tests). Those artifacts exist on the package feed only after a human pushes a git release tag in `HoneyDrunk.Kernel` and `HoneyDrunk.Data` respectively — **agents never tag or publish.** If ADR-0042's packets (`adr-0042-idempotency` packets 02 + 03) have not yet shipped at this packet's execution time, hold this packet until they have. ADR-0042 packet 02 ships `HoneyDrunk.Kernel.Abstractions` 0.8.0 (the contracts) and packet 03 ships the `HoneyDrunk.Data.Idempotency.*` family. Cross-initiative — not encoded in `dependencies:` (which only resolves within the initiative folder).
+- [ ] The Cosmos dedup account (provisioned by ADR-0042 packet 03's Human Prerequisites) must exist in each environment Notify deploys to before Notify's deployed composition can resolve the Cosmos `IIdempotencyStore` at runtime. Notify's consumer-group gets the 7-day-TTL container/configuration.
+- [ ] The Cosmos connection secret must be seeded into `kv-hd-notify-{env}` so Notify's `ISecretStore` can resolve it (invariant 9).
+- [ ] Notify's Worker / Function Managed Identity needs the Cosmos data-plane RBAC role on the dedup account.
+- [ ] **The code work in this packet does not require the live Cosmos account** — tests run against the InMemory store. It does, however, require the upstream packages above to be published.
+
+## Referenced ADR Decisions
+**ADR-0068 D2 — In-Node `BackgroundService`.** "Every Node that needs in-process recurring or background work uses ASP.NET Core's built-in `IHostedService` interface (typically via the `BackgroundService` base class). No Quartz, no Hangfire, no third-party scheduler dependency." `TimeProvider` (ADR-0063 D1) for wall-clock reads; `FakeTimeProvider` (ADR-0063 D7) for tests. ADR-0068's named first consumer under D2 (D11 row): "Notify retry pump."
+
+**ADR-0068 D6 — Idempotency on every job.** Every state-mutating job is idempotent. Notify's retry pump mutates state (sends a notification) — fully bound. Uses `IIdempotencyStore` from ADR-0042.
+
+**ADR-0068 D7 — Retry policy defaults (Container Apps Jobs context).** 3 retries, exponential 1m/5m/25m. Per D7's last paragraph, in-Node `BackgroundService` retry semantics are author-decided; the pump adopts these defaults for cross-substrate parity, with `RetryPumpOptions` allowing per-deployment override.
+
+**ADR-0068 D8 — Observability.** Pulse `jobs.outcome` counter, Pulse `jobs.duration` histogram, lifecycle traces with `correlationId` propagation per invariant 6, long-running >60s progress to Audit as `JobProgress` (ADR-0030), final-failure errors via `IErrorReporter` (ADR-0045) and `JobFailure` audit (ADR-0030).
+
+**ADR-0042 D2 — `IIdempotencyStore`.** Consumer-side dedup state, per consumer-group, durable at Tier 1, default Cosmos backing. 7-day standard TTL (D4 — Notify is not billing/audit).
+
+**ADR-0042 D3 — Downstream-key derivation.** A downstream message's key is `SHA256(inbound:relationship)` of the inbound key. The retry pump's derived-key form `originalKey.Derive("retry")` follows this shape exactly.
+
+**ADR-0063 D1 — `TimeProvider` substrate.** Every wall-clock read goes through `TimeProvider`.
+
+**ADR-0063 D6 — Cron and duration format.** 5-field UTC cron; ISO 8601 duration strings for intervals.
+
+**ADR-0063 D7 — Test seam.** `FakeTimeProvider` advances time in tests.
+
+**ADR-0045 D3 — `IErrorReporter`.** Final-failure errors flow through the Pulse `IErrorReporter` facade.
+
+**ADR-0030 — Audit substrate.** `JobProgress` and `JobFailure` are new audit-category strings; ride the existing `AuditEntry` shape. Forward-compatible if Audit later normalizes its category list.
+
+## Constraints
+> **Invariant 41 — Preference enforcement, cadence rules, and suppression logic for outbound messages live in HoneyDrunk.Communications, not in HoneyDrunk.Notify.** The retry pump is delivery mechanics; it re-attempts an already-decided send. It MUST NOT re-evaluate Communications-owned decisions (no `IPreferenceStore` read, no `ICadencePolicy` check, no decision-log emit) inside the pump.
+
+> **Invariant `{N1}` (Proposed, tied to ADR-0068) — In-Node `BackgroundService`.** No Quartz, no Hangfire, no third-party in-process scheduler. Polly is a retry library, not a scheduler — its use is permitted and expected. (`{N1}` is the first of the four ADR-0068 invariant numbers claimed in packet 01 from `constitution/invariant-reservations.md`; resolve at execution time and substitute consistently with packet 01.)
+
+> **Invariant 51 — No `Thread.Sleep` in tests.** Tests use `FakeTimeProvider.Advance(...)`; the pump uses `Task.Delay(..., TimeProvider, ct)`.
+
+> **Invariant 6 — `correlationId` propagation.** The pump's iteration `correlationId` is propagated through every per-message span and through the provider-send call.
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** Audit entries and Pulse signals carry job-name, retry-count, exception-summary metadata — never message bodies, recipient addresses (PII), or provider credentials.
+
+> **Invariant 27 — Solution version bumps are atomic.** Every non-test `.csproj` in the Notify solution moves to the same new minor version in one commit.
+
+- **Idempotency on retries is mandatory** — every send goes through `IIdempotencyStore.TryClaim`; a duplicate claim short-circuits the send.
+- **The pump does NOT use packet 02's `job-deploy-container-apps-job.yml` workflow.** It is in-Node — it ships as part of the Notify Worker host's container image, deployed by the existing `job-deploy-container-app.yml` workflow (no change to that workflow needed).
+- **Audit category strings (`JobProgress`, `JobFailure`) are new.** Ride the existing `AuditEntry` shape; if Audit later normalizes its category list, this packet's emits are forward-compatible.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0068`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Ship the Notify retry pump as the first in-Node `BackgroundService` under ADR-0068 D2.
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: First concrete consumer under ADR-0068 D2. The pump becomes the pattern future in-Node background work (AI cost-ledger drain, audit batch flush) follows.
+- Feature: ADR-0068 Background Job and Recurring Work Substrate rollout, Wave 3.
+- ADRs: ADR-0068 D2/D6/D7/D8 (primary), ADR-0063 D1/D6/D7 (clock/cron/test seam), ADR-0042 D2/D3/D4 (idempotency), ADR-0030 (`JobProgress`/`JobFailure` audit categories), ADR-0045 D3 (`IErrorReporter`).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft; the substrate-choice note in `boundaries.md` lands first so the executor reads the boundary doc and sees the substrate decision.
+
+**Constraints:**
+- Polly is the per-message retry library; no third-party scheduler (invariant `{N1}` Proposed; tied to ADR-0068 D2).
+- `TimeProvider` everywhere, `FakeTimeProvider` in tests, no `Thread.Sleep` (invariants 51 + ADR-0063 D1/D7).
+- Idempotency on every send attempt (invariant `{N3}` Proposed; ADR-0068 D6 + ADR-0042 D2/D3).
+- Invariant 41 — Notify does delivery mechanics; no preference/cadence/suppression logic in the pump.
+- Solution version bump is atomic across all non-test `.csproj` (invariant 27).
+
+**Key Files:**
+- `src/HoneyDrunk.Notify/.../RetryPump.cs` (new) — exact project path TBD at execution time based on the Notify solution's current structure.
+- `src/HoneyDrunk.Notify/.../RetryPumpOptions.cs` (new).
+- Notify Worker host composition / DI registration source.
+- `tests/HoneyDrunk.Notify.Tests/.../RetryPumpTests.cs` (new).
+
+**Contracts:** None changed — consumes `IIdempotencyStore` / `IAuditLog` / `IErrorReporter` / `TimeProvider` from other Nodes / the BCL.

--- a/generated/issue-packets/active/adr-0068-background-jobs/03-notify-retry-pump-background-service.md
+++ b/generated/issue-packets/active/adr-0068-background-jobs/03-notify-retry-pump-background-service.md
@@ -4,7 +4,7 @@ type: repo-feature
 tier: 2
 target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
 labels: ["feature", "tier-2", "ops", "adr-0068", "wave-3"]
-dependencies: ["packet:00"]
+dependencies: ["packet:00", "packet:01"]
 adrs: ["ADR-0068", "ADR-0063", "ADR-0042", "ADR-0030", "ADR-0045"]
 wave: 3
 initiative: adr-0068-background-jobs

--- a/generated/issue-packets/active/adr-0068-background-jobs/04-communications-cadence-container-apps-job.md
+++ b/generated/issue-packets/active/adr-0068-background-jobs/04-communications-cadence-container-apps-job.md
@@ -1,0 +1,294 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Communications
+labels: ["feature", "tier-2", "ops", "adr-0068", "wave-3"]
+dependencies: ["packet:02"]
+adrs: ["ADR-0068", "ADR-0063", "ADR-0042", "ADR-0030", "ADR-0045", "ADR-0019", "ADR-0015"]
+wave: 3
+initiative: adr-0068-background-jobs
+node: honeydrunk-communications
+---
+
+# Stand up the Communications cadence/drip-campaign scheduler as the first cross-Node Container Apps Job per ADR-0068 D3
+
+## Summary
+Add a new schedule-triggered Azure Container Apps Job to the `HoneyDrunk.Communications` solution — the cadence/drip-campaign scheduler — as the first cross-Node Container Apps Job under ADR-0068 D3 (D11's named first consumer for the cross-Node substrate). The Job is a small console-app binary (`Program.cs` + `Main`) that wakes on schedule, walks Communications' cadence + drip-campaign data for due intents, dispatches each through `ICommunicationOrchestrator` (the existing decision-and-delivery surface from ADR-0019), and exits. Schedule is 5-field UTC cron per ADR-0063 D6 (initial cadence `*/30 * * * *` — every 30 minutes — confirmed in-PR; per-environment configurable). Idempotency per ADR-0068 D6 uses key `comms-cadence:{scheduledInstant:yyyyMMddTHHmmssZ}` against `IIdempotencyStore` (ADR-0042). Deploys via the new reusable workflow from packet 02 to `caj-hd-comms-cadence-{env}`. D7 retry defaults (3 retries, 1m/5m/25m exponential) wired in the Container Apps Jobs manifest. D8 observability emissions (Pulse `jobs.outcome` / `jobs.duration`, lifecycle traces, long-running progress to Audit, final-failure to `IErrorReporter` + `JobFailure` audit) wired into the Job body.
+
+## Context
+ADR-0068 D11 names "Communications cadence (imminent) — Pin to D3 — Container Apps Jobs" as one of the workloads this ADR pins. ADR-0019 (Communications stand-up) commits cadence/drip-campaign scheduling as a capability of Communications. Before ADR-0068, no substrate was decided; the cadence work was deferred. This packet ships the substrate and the first concrete cross-Node Job on it.
+
+The cadence scheduler's responsibilities:
+
+1. **Wake on schedule** — Container Apps Jobs cron trigger fires on the configured cadence (initial `*/30 * * * *`, 5-field UTC per ADR-0063 D6).
+2. **Read due intents** — query Communications' data for `IMessageIntent`s whose cadence/drip-campaign schedule names this `scheduledInstant` (or one within tolerance).
+3. **Dispatch via `ICommunicationOrchestrator`** — for each due intent, call `ICommunicationOrchestrator.Send(intent, ...)`. The orchestrator (ADR-0019) is the existing decision-and-delivery surface — preferences, cadence rules, suppression, decision-log emission all run inside it. The Job is **not** a delivery path bypass.
+4. **Per-intent idempotency** — every dispatch goes through `IIdempotencyStore` with key `comms-cadence:{intentId}:{scheduledInstant:yyyyMMddTHHmmssZ}` (intent-scoped so two distinct intents at the same instant don't collide). The job-level key (`comms-cadence:{scheduledInstant:yyyyMMddTHHmmssZ}`, per ADR-0068 D6's deterministic-schedule formula) guards against double-trigger of the *job itself*; the intent-scoped key guards each dispatch within the job.
+5. **Exit when done** — Container Apps Jobs replicas terminate when the entry point returns (or when `replicaTimeout` elapses). The Job is single-invocation, not long-running.
+
+**Boundary clarification.** The Job is `HoneyDrunk.Communications` because Communications owns cadence decision logic per invariant 41. It composes the orchestrator (in-process within the Job — the Job binary references `HoneyDrunk.Communications` directly), which then delegates delivery to Notify per ADR-0019. So the Job is a *Communications* job; the in-process Communications→Notify hop inside the orchestrator stays unchanged.
+
+**Local-dev story (ADR-0068 D9).** The Job binary's `Main` is invocable as `dotnet run` from the Communications solution. A timer-driven host harness (a small `HostBuilder` + a `BackgroundService` that fires the Job entry on a developer-controlled cadence) lives in the Communications test project for local cadence-shape testing without Azure.
+
+**Communications is a live Node** (v0.2.0 most recent per the overview). This packet is the only ADR-0068 packet on the `HoneyDrunk.Communications` solution; per invariant 27 it bumps the solution one minor version (new runtime artifact — the Job binary). Confirm the current solution version at execution time.
+
+**First Container Apps Job in production.** This is the studio's first Container Apps Job deploy. The deploy workflow (packet 02) is also new; expect a small amount of iteration on both — see the dispatch plan's Cross-Cutting Concerns.
+
+## Scope
+- A new project in the Communications solution (e.g. `HoneyDrunk.Communications.Jobs.Cadence` or `HoneyDrunk.Communications.Cadence`, name per the Communications repo's existing project-naming convention — verify at execution time) that produces the Job binary.
+- `Program.cs` with `Main` that:
+  - Builds a minimal `HostBuilder` (or runs without one, depending on the in-Node convention) wiring the orchestrator and dependencies.
+  - Composes `IIdempotencyStore`, `IAuditLog`, `IErrorReporter`, `TimeProvider`, `ICommunicationOrchestrator`.
+  - Calls a `Run(scheduledInstant, ct)` method that does the iteration body.
+  - Returns / `Environment.Exit(...)` cleanly on success or failure.
+- A `Dockerfile` for the Job container image (the new container image; packet 02's workflow builds + pushes it to `acrhdshared{env}`).
+- The Container Apps Jobs manifest (a Bicep file or the input parameters for packet 02's `az containerapp job create` invocation) declaring `triggerType: Schedule`, the cron expression, replica policy (`replicaCompletionCount: 1`, `parallelism: 1`, `replicaTimeout: 1800`), retry policy (`replicaRetryLimit: 3` per ADR-0068 D7).
+- The Communications consuming release workflow change that calls packet 02's `job-deploy-container-apps-job.yml` reusable workflow on tag → environment per ADR-0033.
+- A local-dev harness (test project) for `dotnet run` invocation of the Job entry with `FakeTimeProvider`.
+- Pulse + Audit + ErrorReporter observability emissions per ADR-0068 D8.
+- Tests: `FakeTimeProvider`-driven idempotency check (job-level and intent-level), happy path (two due intents → two dispatches → two `jobs.outcome=success` emits), provider failure → final-failure handling, replay (same `scheduledInstant` → no double-dispatch via job-level idempotency).
+- Solution version bump; CHANGELOG/README updates.
+
+## Proposed Implementation
+1. **New project — the Job binary.** Add `HoneyDrunk.Communications.Cadence` (or the existing-conventions-aligned name) to the Communications solution. `<OutputType>Exe</OutputType>`, `TargetFramework=net10.0`, references `HoneyDrunk.Communications` (the runtime package) for the orchestrator, `HoneyDrunk.Kernel.Abstractions` for `IIdempotencyStore`, `HoneyDrunk.Data.Idempotency.Cosmos` for the deployed backing, `HoneyDrunk.Audit.Abstractions` for `IAuditLog`, `HoneyDrunk.Telemetry.Abstractions` (or wherever `IErrorReporter` lands per ADR-0045) for the error reporter. **Verify NuGet versions at execution time** — see Human Prerequisites for the cross-init dependency on ADR-0042 / ADR-0045 release tags.
+2. **`Program.cs`.** Pseudocode:
+   ```csharp
+   public static async Task<int> Main(string[] args) {
+       using var host = Host.CreateApplicationBuilder(args)
+           .ConfigureServices(s => { /* register everything */ })
+           .Build();
+       await host.StartAsync();
+       try {
+           var runner = host.Services.GetRequiredService<CadenceJobRunner>();
+           var scheduledInstant = TimeProvider.System.GetUtcNow(); // approximate; the platform doesn't pass schedule time directly — use the current minute boundary
+           await runner.RunAsync(scheduledInstant, host.Services.GetRequiredService<IHostApplicationLifetime>().ApplicationStopping);
+           return 0;
+       } catch (Exception ex) {
+           // ErrorReporter raise + JobFailure audit; rethrow if needed for non-zero exit
+           host.Services.GetRequiredService<IErrorReporter>().Capture(ex, /* context */);
+           return 1;
+       } finally {
+           await host.StopAsync();
+       }
+   }
+   ```
+3. **`CadenceJobRunner.RunAsync(scheduledInstant, ct)`.**
+   - **Job-level idempotency.** `var jobKey = $"comms-cadence:{scheduledInstant:yyyyMMddTHHmmssZ}"; var claim = await idempotencyStore.TryClaim(jobKey, TimeSpan.FromDays(7), ct);` — if not claimed (already-ran indicator), log and return early. Per ADR-0042 D4 standard 7-day TTL (Communications is neither billing nor audit).
+   - **Read due intents.** Query the Communications data layer for intents due at or before `scheduledInstant` with cadence tolerance.
+   - **Per-intent dispatch.** Partial-batch posture: **continue-on-error** (decided in this packet — see Constraints). A per-intent orchestrator failure is captured (`IErrorReporter.Capture` + `JobFailure` audit emit) and the loop proceeds to the next intent; the batch is not aborted on the first failure. The Job's exit code is non-zero only if `RunAsync` itself throws (an infrastructural failure — idempotency-store outage, data-layer outage); per-intent failures do not bubble out of the loop.
+     ```
+     foreach (var intent in dueIntents) {
+         var intentKey = $"comms-cadence:{intent.IntentId}:{scheduledInstant:yyyyMMddTHHmmssZ}";
+         var intentClaim = await idempotencyStore.TryClaim(intentKey, TimeSpan.FromDays(7), ct);
+         if (intentClaim.Outcome == AlreadyClaimed) continue;
+         try {
+             await orchestrator.SendAsync(intent, ct);
+             jobsOutcomeCounter.Add(1, new(...) { ["outcome"] = "success" });
+             await idempotencyStore.Complete(intentClaim, IdempotencyOutcome.Succeeded);
+         } catch (Exception ex) {
+             jobsOutcomeCounter.Add(1, new(...) { ["outcome"] = "fail" });
+             await idempotencyStore.Complete(intentClaim, IdempotencyOutcome.Failed);
+             // continue-on-error: surface per-intent failure via IErrorReporter + JobFailure audit; do NOT throw — loop proceeds to next intent.
+             errorReporter.Capture(ex, new { job_name = "comms-cadence", intent_id = intent.IntentId, scheduled_instant = scheduledInstant });
+             auditLog.Append(new AuditEntry(category: "JobFailure", /* job_name, intent_id, retry_count (from env var), last_exception_summary */));
+             continue;
+         }
+     }
+     await idempotencyStore.Complete(claim, IdempotencyOutcome.Succeeded);
+     jobsDurationHistogram.Record(stopwatch.ElapsedSeconds, new(...) { ["job_name"] = "comms-cadence" });
+     ```
+   - **Long-running progress.** If `stopwatch.Elapsed > TimeSpan.FromSeconds(60)`, emit a `JobProgress` `AuditEntry` per ADR-0030 D8 with the intent index, total intent count, and elapsed time.
+4. **`Dockerfile`.** Minimal — `mcr.microsoft.com/dotnet/runtime:10.0` base, copy the published binary, `ENTRYPOINT ["dotnet", "HoneyDrunk.Communications.Cadence.dll"]`.
+5. **Container Apps Jobs manifest.** Either a Bicep file in `infrastructure/`, or as input parameters supplied to packet 02's reusable workflow from the Communications release workflow — decide at execution time based on the Communications repo's existing infrastructure conventions. The shape:
+   - `containerapps-job: caj-hd-comms-cadence-{env}` (note `comms-cadence` is 12 chars — within the 13-char invariant 19 limit).
+   - `containerapps-environment: cae-hd-{env}`.
+   - `trigger-type: Schedule`.
+   - `cron-expression: "*/30 * * * *"` (initial; per-environment overridable). 5-field UTC per ADR-0063 D6.
+   - `replica-completion-count: 1`, `parallelism: 1`, `replica-timeout-seconds: 1800`.
+   - `replica-retry-limit: 3` per ADR-0068 D7.
+   - Secrets via Key Vault references (orchestrator's data store connection, idempotency store connection, etc.) — same Key Vault-backed pattern as Container Apps proper.
+6. **Communications release workflow change.** Amend Communications' release workflow (or add a new one if none exists for the Job) so a SemVer tag triggers packet 02's `job-deploy-container-apps-job.yml` per ADR-0033's tag→environment mapping. Path-filtered to the new Job project for dev continuous deploy.
+7. **Observability emissions.**
+   - `jobs.outcome` counter — per-intent dispatch outcome. Tags `{job_name=comms-cadence, outcome=success|fail}`.
+   - `jobs.duration` histogram — recorded once at job end. Tag `{job_name=comms-cadence}`.
+   - Lifecycle traces — span over `RunAsync` with `correlationId = $"comms-cadence:{scheduledInstant:yyyyMMddTHHmmssZ}"`; child span per intent dispatch with the intent ID; `correlationId` propagated into the orchestrator call (invariant 6).
+   - `JobProgress` audit emit on long-running iterations (>60s).
+   - **Final-failure handling.** On exhausted retries (the platform exhausts `replicaRetryLimit: 3`; the Job's final replica's exit code is non-zero), the platform records the failure. The Job's own `Program.cs` `catch` raises via `IErrorReporter` (ADR-0045 D3) and emits a `JobFailure` `AuditEntry` (ADR-0030) with job name, scheduled instant, retry attempt (read from the env var the platform sets), and last exception summary — *every* exception path emits both, regardless of whether this is the final retry, because the Job binary can't directly observe "this was the last retry" — the platform decides. ADR-0045 deduplicates by `problem_id` so multiple retries don't multiply error reports.
+8. **Local-dev harness.** In the Communications test project, add a small `HostBuilder` + `BackgroundService`-driven harness that fires `CadenceJobRunner.RunAsync` on a developer-controlled cadence using `FakeTimeProvider`. `dotnet run --project HoneyDrunk.Communications.Cadence` invokes the same entry locally without the harness; the harness is for cadence-shape testing.
+9. **Tests.**
+   - Two due intents → two `jobs.outcome=success` emits → one `jobs.duration` emit → two `IIdempotencyStore` completes.
+   - Replay at the same `scheduledInstant` → job-level idempotency claim rejects → no work done → log emitted.
+   - One intent fails inside the orchestrator → `jobs.outcome=fail` emitted for that intent, `JobFailure` audit + `IErrorReporter` raise emitted, **other intents still dispatched** (continue-on-error posture per this packet — verified by asserting the second intent's `jobs.outcome=success` emit lands after the first intent's failure).
+   - Long-running scenario (the test harness drives the duration > 60s) → `JobProgress` audit emit observed.
+   - All time-driven tests use `FakeTimeProvider` (ADR-0063 D7); no `Thread.Sleep` (invariant 51).
+10. **Versioning.** Bump every non-test `.csproj` in the `HoneyDrunk.Communications` solution to the next minor version in one commit (invariant 27). Repo-level `CHANGELOG.md` new version entry naming the cadence Job; per-package CHANGELOG for the new Cadence Job project. `README.md` updated to mention the new Job deployable.
+
+## Affected Files
+- A new project under the Communications solution — `HoneyDrunk.Communications.Cadence` (or convention-aligned name): `.csproj`, `Program.cs`, `CadenceJobRunner.cs`, `CadenceJobOptions.cs`, `Dockerfile`.
+- Communications local-dev harness in the test project — a `HostBuilder` shim and tests.
+- A Container Apps Jobs manifest — either `infrastructure/comms-cadence-job.bicep` or the input parameters supplied to packet 02's reusable workflow from the Communications release workflow.
+- Communications' release workflow (`.github/workflows/release.yml` or whatever the repo uses) — add a step that calls packet 02's `job-deploy-container-apps-job.yml`.
+- Every non-test `.csproj` in the `HoneyDrunk.Communications` solution — version bump.
+- Repo-level `CHANGELOG.md`; per-package CHANGELOG for the new Cadence Job project.
+- `README.md` updated to mention the new Job deployable.
+
+## NuGet Dependencies
+- The new `HoneyDrunk.Communications.Cadence` project gains:
+  - `HoneyDrunk.Communications` (runtime — the orchestrator).
+  - `HoneyDrunk.Kernel.Abstractions` (for `IIdempotencyStore`, `IGridContext`, etc.) — version per ADR-0042's packet 02 (0.8.0).
+  - `HoneyDrunk.Data.Idempotency.Cosmos` (deployed-environment backing) — version per ADR-0042's packet 03.
+  - `HoneyDrunk.Audit.Abstractions` (for `IAuditLog`, `AuditEntry`) — current shipped version.
+  - `HoneyDrunk.Telemetry.Abstractions` (for `IErrorReporter`) — version per ADR-0045's packet 02. If ADR-0045 has not yet shipped, see Human Prerequisites.
+  - `Microsoft.Extensions.Hosting` for `Host.CreateApplicationBuilder`.
+- Communications test project gains:
+  - `HoneyDrunk.Data.Idempotency.InMemory` — version per ADR-0042's packet 03.
+  - `Microsoft.Extensions.TimeProvider.Testing` (for `FakeTimeProvider`).
+- `HoneyDrunk.Standards` already on every Communications project; no change.
+- Confirm exact current versions at execution time.
+
+## Boundary Check
+- [x] All code change in `HoneyDrunk.Communications`. Routing rule "communications, cadence, drip, preferences, suppression, decision-log → HoneyDrunk.Communications" maps here.
+- [x] The cadence Job is Communications' work (invariant 41 — Communications owns cadence decisions; Notify owns delivery mechanics). The Job composes `ICommunicationOrchestrator` from Communications and lets *it* delegate to Notify per ADR-0019.
+- [x] The Job consumes (does not redefine) `IIdempotencyStore`, `IAuditLog`, `IErrorReporter`, `TimeProvider`. No new contract surface.
+- [x] Container Apps Jobs is the substrate per ADR-0068 D3 (cross-Node recurring orchestration). Not in-Node `BackgroundService` (D2) — the cadence work spans Nodes (Communications → Notify via the orchestrator) and runs on a schedule, not inside a Node's host process.
+- [x] No Functions timer trigger (ADR-0068 D7 grandfathers Vault.Rotation only; new cross-Node work uses Container Apps Jobs per D3 + invariant `{N2}` Proposed).
+- [x] Naming `caj-hd-comms-cadence-{env}` — service name `comms-cadence` is 12 chars, within the 13-char invariant 19 limit; matches the `caj-hd-{service}-{env}` convention from invariant `{N2}` Proposed (ADR-0068 D3).
+
+## Acceptance Criteria
+- [ ] A new `HoneyDrunk.Communications.Cadence` (or convention-aligned name) project exists in the Communications solution, producing a console-app binary with `Program.cs` + `Main`
+- [ ] The Job runs as a Container Apps Job named `caj-hd-comms-cadence-{env}` (service name within the 13-char invariant 19 limit) in the shared `cae-hd-{env}` Environment, deployed via packet 02's reusable workflow
+- [ ] Trigger is `Schedule` with cron `*/30 * * * *` (initial — per-environment configurable in the manifest); 5-field UTC per ADR-0063 D6
+- [ ] Replica policy: `replicaCompletionCount: 1`, `parallelism: 1`, `replicaTimeout: 1800`; retry policy `replicaRetryLimit: 3` per ADR-0068 D7
+- [ ] Job-level idempotency uses key `comms-cadence:{scheduledInstant:yyyyMMddTHHmmssZ}` against `IIdempotencyStore` with 7-day TTL (ADR-0042 D4 standard)
+- [ ] Per-intent idempotency uses key `comms-cadence:{intentId}:{scheduledInstant:yyyyMMddTHHmmssZ}` against `IIdempotencyStore`
+- [ ] Each due intent is dispatched through `ICommunicationOrchestrator` (Communications owns the decision, per invariant 41 and ADR-0019) — the Job does not bypass the orchestrator
+- [ ] Pulse `jobs.outcome` counter emitted per-intent with tags `{job_name=comms-cadence, outcome=success|fail}`
+- [ ] Pulse `jobs.duration` histogram emitted at job end with tag `{job_name=comms-cadence}`
+- [ ] Lifecycle traces emitted with `correlationId = comms-cadence:{scheduledInstant:yyyyMMddTHHmmssZ}` propagated into the orchestrator call per invariant 6
+- [ ] Long-running (>60s) iterations emit `JobProgress` audit entries (ADR-0030)
+- [ ] Exceptions from the orchestrator emit `JobFailure` audit (ADR-0030) and raise via `IErrorReporter` (ADR-0045)
+- [ ] Partial-batch posture is **continue-on-error** (decided in this packet) — per-intent failures are captured via `IErrorReporter` + `JobFailure` audit and the loop proceeds to the next intent; `RunAsync` only propagates infrastructural failures (idempotency-store / data-layer outage). The PR description records the chosen posture.
+- [ ] Local-dev harness in the test project drives `CadenceJobRunner.RunAsync` with `FakeTimeProvider`; `dotnet run --project HoneyDrunk.Communications.Cadence` invokes the binary locally
+- [ ] Tests cover: happy path (two intents → two dispatches), replay rejection by job-level idempotency, per-intent failure handling, long-running > 60s `JobProgress`
+- [ ] No `Thread.Sleep` in tests (invariant 51); `FakeTimeProvider` drives all time-dependent assertions (ADR-0063 D7)
+- [ ] Communications release workflow calls packet 02's `job-deploy-container-apps-job.yml` for the Cadence Job per ADR-0033's tag→environment mapping
+- [ ] Dockerfile uses `mcr.microsoft.com/dotnet/runtime:10.0` (or current equivalent) and runs the `dotnet HoneyDrunk.Communications.Cadence.dll` entry
+- [ ] Every non-test `.csproj` in the solution is at the same new minor version in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new version entry naming the cadence Job; per-package CHANGELOG entry on the new Cadence Job project
+- [ ] `README.md` updated to mention the new Job deployable
+- [ ] The `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **Packet 02's `job-deploy-container-apps-job.yml` must be merged and on `main` before this packet's deploy step can call it.** Hard same-initiative dependency, encoded in `dependencies: ["packet:02"]`.
+- [ ] **HARD GATE — Do not push this packet until ADR-0042 packets 02 and 03 ship NuGet packages on the feed.** This packet's compile depends on `HoneyDrunk.Kernel.Abstractions` (with `IIdempotencyStore` — ADR-0042 packet 02 ships 0.8.0) and `HoneyDrunk.Data.Idempotency.Cosmos` / `HoneyDrunk.Data.Idempotency.InMemory` (ADR-0042 packet 03). ADR-0042 is **Proposed** at the time this packet was authored; its packets have not yet been executed or merged. Until those packages are published, the executor cannot resolve the references and the PR will not build. Cross-initiative — not encoded in `dependencies:` (which only resolves within the initiative folder). The operator confirms package availability on the feed (search `HoneyDrunk.Kernel.Abstractions` version >= 0.8.0 and the `HoneyDrunk.Data.Idempotency.*` family in the package registry) **before** branching for this packet. **Agents never tag or publish — the operator runs that ceremony.**
+- [ ] **Verify the `IErrorReporter` package home against ADR-0045's current state.** The reference text above lists `HoneyDrunk.Telemetry.Abstractions` as the package home; ADR-0045 may have settled the surface differently (e.g. `HoneyDrunk.Pulse.Abstractions`, a dedicated `HoneyDrunk.ErrorReporting.Abstractions`, or kept it under another Node's contracts package). At packet execution time, check ADR-0045's current Status and the latest packet set in `adr-0045-grid-wide-error-tracking/`:
+  - If ADR-0045's packet 02 has shipped: use the actual published package name and version; update `## NuGet Dependencies` in this packet body to match.
+  - If ADR-0045's packet 02 has NOT shipped: wire a local TODO-comment `IErrorReporter`-shaped seam in the Cadence Job binary (a private `interface IErrorReporterSeam { void Capture(Exception, object?); }` with a no-op default registration), document the seam in the Cadence Job's README and in this packet's PR description, and file a follow-up task to lift the seam to the real `IErrorReporter` once ADR-0045 lands. The seam falls back is acceptable explicitly — do NOT block this packet on ADR-0045 if the operator decides to ship the Cadence Job with a seam.
+- [ ] **Upstream NuGet packages must be published before this packet compiles.**
+  - `HoneyDrunk.Kernel.Abstractions` with `IIdempotencyStore` — ships from ADR-0042 packet 02 (0.8.0). If ADR-0042's packets have not yet shipped on the NuGet feed, hold this packet until they have.
+  - `HoneyDrunk.Data.Idempotency.Cosmos` (deployed) and `HoneyDrunk.Data.Idempotency.InMemory` (tests) — ship from ADR-0042 packet 03.
+  - `HoneyDrunk.Telemetry.Abstractions` with `IErrorReporter` — ships from ADR-0045 packet 02 (package home verified per the prerequisite above). If ADR-0045 has not yet shipped, hold this packet OR wire a TODO-comment `IErrorReporter`-shaped seam and lift it once ADR-0045 lands (per the verification prerequisite above).
+  Cross-initiative — not encoded in `dependencies:` (which only resolves within the initiative folder). The operator confirms upstream package availability before starting this packet.
+- [ ] **Container Apps Environment** — the shared `cae-hd-{env}` already exists per ADR-0015's rollout; no new Environment provisioning. Confirm at first deploy.
+- [ ] **Cosmos dedup account** — provisioned by ADR-0042 packet 03's Human Prerequisites; the Communications Job's Managed Identity needs the Cosmos data-plane RBAC role on the dedup account in each env.
+- [ ] **Cosmos connection secret** — must be seeded into `kv-hd-comms-{env}` (or whatever Communications' Key Vault naming is per invariant 17) so the Job's `ISecretStore` can resolve it (invariant 9).
+- [ ] **Container Apps Contributor (or Contributor) role** — the deploy identity needs this on the resource group to create `Microsoft.App/jobs/*` resources. Per packet 02's Human Prerequisites, **verify in the Azure portal at first deploy** that the existing OIDC deploy identity has the role; if not, a one-time RBAC grant via the portal is needed.
+- [ ] **First Container Apps Job deploy** — the operator performs the first deploy with eyes on the Azure portal to verify the Job resource is created with the expected `triggerType`, cron, replica, and retry settings. Subsequent deploys are mechanical via the workflow.
+
+## Referenced ADR Decisions
+**ADR-0068 D3 — Cross-Node Container Apps Jobs.** Every cross-Node recurring or event-driven job runs on Azure Container Apps Jobs. Communications cadence is named in D11 as the first consumer.
+
+**ADR-0068 D6 — Idempotency on every job.** Schedule-triggered jobs use the deterministic key `${jobName}:${scheduledInstant:yyyyMMddTHHmmssZ}`. Job-level and per-intent keys both use this shape, with the intent ID inserted in the per-intent variant.
+
+**ADR-0068 D7 — Retry policy defaults.** 3 retries, exponential 1m/5m/25m. Wired in the Container Apps Jobs manifest as `replicaRetryLimit: 3`; the exponential backoff is the platform's default behaviour for that limit.
+
+**ADR-0068 D8 — Observability.** Pulse `jobs.outcome` counter, Pulse `jobs.duration` histogram, lifecycle traces with `correlationId` propagation per invariant 6, long-running >60s progress to Audit as `JobProgress` (ADR-0030), final-failure errors via `IErrorReporter` (ADR-0045) and `JobFailure` audit (ADR-0030).
+
+**ADR-0068 D9 — Local-dev story.** Container Apps Jobs don't run locally. The binary runs as a console app (`dotnet run`); optionally under a timer-driven host harness for cadence-shape testing.
+
+**ADR-0068 D10 — Job code organization.** Each Node owns its own jobs. The cadence Job lives in `HoneyDrunk.Communications`.
+
+**ADR-0068 D11 — Migration path.** Communications cadence (imminent at the time of ADR drafting) is pinned to D3.
+
+**ADR-0019 — Communications stand-up.** `ICommunicationOrchestrator` is the decision-and-delivery surface; cadence is one of Communications' owned capabilities. The Job composes the orchestrator; it does not bypass the decision logic.
+
+**ADR-0042 D2/D3/D4 — Idempotency.** `IIdempotencyStore` is consumer-side dedup state, per consumer-group, durable at Tier 1, default Cosmos backing. 7-day standard TTL (Communications is not billing/audit).
+
+**ADR-0063 D1/D6/D7 — Clock, cron, test seam.** `TimeProvider` for wall-clock; 5-field UTC cron; ISO 8601 duration strings for intervals; `FakeTimeProvider` in tests.
+
+**ADR-0045 D3 — `IErrorReporter`.** Final-failure errors flow through the Pulse `IErrorReporter` facade.
+
+**ADR-0030 — Audit substrate.** `JobProgress` and `JobFailure` are new audit-category strings; ride the existing `AuditEntry` shape; forward-compatible.
+
+**ADR-0015 — Container Apps shared platform.** Shared `cae-hd-{env}` Environment and shared `acrhdshared{env}` ACR serve both Container Apps and Container Apps Jobs.
+
+**ADR-0033 — Tag→environment mapping.** SemVer tags gate staging/prod. The cadence Job follows the same model.
+
+## Constraints
+> **Invariant 41 — Preference enforcement, cadence rules, and suppression logic for outbound messages live in HoneyDrunk.Communications, not in HoneyDrunk.Notify.** The Job is Communications' work and composes `ICommunicationOrchestrator`; it does not bypass the orchestrator or duplicate its decision logic.
+
+> **Invariant `{N2}` (Proposed, tied to ADR-0068) — Cross-Node recurring orchestration uses Azure Container Apps Jobs.** Naming `caj-hd-{service}-{env}`; 13-character service-name limit (invariant 19) applies — `comms-cadence` is 12 chars and complies. (`{N2}` is the second of the four ADR-0068 invariant numbers claimed in packet 01 from `constitution/invariant-reservations.md`; resolve at execution time and substitute consistently with packets 01 and 03.)
+
+> **Invariant `{N3}` (Proposed, tied to ADR-0068) — Every state-mutating job is idempotent.** Job-level and per-intent keys are both deterministic; `IIdempotencyStore.TryClaim` is called before every state-mutating action.
+
+> **Invariant `{N4}` (Proposed, tied to ADR-0068) — Job failure emits Audit and Pulse signals on the documented schedule.** Pulse `jobs.outcome` + `jobs.duration`; lifecycle traces with `correlationId` propagation per invariant 6; long-running `JobProgress`; final-failure `IErrorReporter` + `JobFailure` audit pair.
+
+> **Invariant 19 — Service-name 13-character limit.** `comms-cadence` is 12 chars — compliant.
+
+> **Invariant 35 — Shared Container Apps Environment and ACR.** The Cadence Job reuses `cae-hd-{env}` and `acrhdshared{env}`.
+
+> **Invariant 51 — No `Thread.Sleep` in tests.** Tests use `FakeTimeProvider.Advance(...)`.
+
+> **Invariant 6 — `correlationId` propagation.** The Job's iteration `correlationId` is propagated through the orchestrator call.
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** Audit and Pulse signals carry job-name/intent-id/scheduled-instant metadata — never message bodies, recipient PII, or provider credentials.
+
+> **Invariant 27 — Solution version bumps are atomic.** Every non-test `.csproj` in the Communications solution moves to the same new minor version in one commit.
+
+> **Invariant 11 — One repo per Node.** The Cadence Job project lives **in `HoneyDrunk.Communications`**; it is not a separate Node or repo.
+
+- **`IGridContext.AgentId` / `AgentRunId` are not plumbed in this packet.** The Cadence Job runs as a Container Apps Job replica — there is no Agent identity in scope at job invocation, and `IGridContext` does not currently expose a "Job"-shaped equivalent. Where the Job's composition needs `IGridContext` for downstream calls (audit emits, orchestrator), **pass null where Agent context is null** (the Job sets `AgentId = null, AgentRunId = null` on the `IGridContext` it constructs for the run; the audit substrate accepts null per its append contract). File a follow-up task in `initiatives/backlog.md` to plumb `IGridContext` extensions for Job-shaped runs (a `JobRunId` field or a "system" actor token) once a second cross-Node Job lands and the shape clarifies. Do NOT invent a `JobId`/`JobRunId` field on `IGridContext` in this packet — it is out of scope.
+- **Idempotency is mandatory at both levels** — job-level (one execution per scheduled-instant) and per-intent (one dispatch per intent per scheduled-instant). Both keys are 7-day TTL (ADR-0042 D4 standard).
+- **Partial-batch posture — DECIDED in this packet: continue-on-error.** A per-intent orchestrator exception is captured via `IErrorReporter` + `JobFailure` audit and the loop proceeds to the next intent. Rationale: per-intent failures are routine (one bad recipient, one provider hiccup) and systemic failures appear as a clustering pattern in error tracking (`IErrorReporter` dedupes by `problem_id` per ADR-0045) — fail-fast would lose the rest of the batch on the first transient hiccup. The Job's exit code is non-zero only on infrastructural failure (idempotency-store outage, data-layer outage) inside `RunAsync` itself; the platform's `replicaRetryLimit: 3` re-runs the Job in that case, and job-level idempotency keeps the re-run safe.
+- **First Container Apps Jobs production deploy.** Expect a small amount of iteration on the manifest shape — the ADR's Negative Consequences flag this: "The deploy workflow … is the studio's first authored Jobs workflow; expect iteration." Operator pairs with the agent for the first prod deploy.
+- **Local-dev harness is test-time only.** The cadence schedule in dev/stg/prod is the Container Apps Jobs cron; the harness exists to drive `RunAsync` in `FakeTimeProvider`-aware tests without Azure.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0068`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Ship the Communications cadence/drip-campaign scheduler as the first cross-Node Container Apps Job under ADR-0068 D3.
+
+**Target:** `HoneyDrunk.Communications`, branch from `main`.
+
+**Context:**
+- Goal: First concrete cross-Node consumer under ADR-0068 D3. Becomes the pattern future cross-Node Jobs follow (future tenant-lifecycle scheduled work per ADR-0050, future billing reconciliation per ADR-0037, etc.).
+- Feature: ADR-0068 Background Job and Recurring Work Substrate rollout, Wave 3.
+- ADRs: ADR-0068 D3/D6/D7/D8/D9/D10/D11 (primary), ADR-0063 D1/D6/D7 (clock/cron/test seam), ADR-0042 D2/D3/D4 (idempotency), ADR-0030 (`JobProgress`/`JobFailure`), ADR-0045 D3 (`IErrorReporter`), ADR-0019 (orchestrator surface), ADR-0015 (shared Environment + ACR), ADR-0033 (tag→environment mapping).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — hard. The reusable workflow this packet's release wires up must exist on `main`.
+
+**Constraints:**
+- Job composes `ICommunicationOrchestrator`; does not bypass cadence/preference decision logic (invariant 41).
+- Naming `caj-hd-comms-cadence-{env}` (invariants 19, `{N2}` Proposed).
+- Both job-level and per-intent idempotency are mandatory (invariant `{N3}` Proposed; ADR-0068 D6; ADR-0042).
+- Pulse + Audit + ErrorReporter D8 emissions all four (invariant `{N4}` Proposed; ADR-0068 D8).
+- Cron is 5-field UTC (ADR-0063 D6); `TimeProvider`+`FakeTimeProvider` (ADR-0063 D1/D7); no `Thread.Sleep` (invariant 51).
+- First Container Apps Jobs production deploy — operator pairs for the first prod deploy.
+- Solution version bump is atomic across all non-test `.csproj` (invariant 27).
+
+**Key Files:**
+- `src/HoneyDrunk.Communications.Cadence/Program.cs` (new).
+- `src/HoneyDrunk.Communications.Cadence/CadenceJobRunner.cs` (new).
+- `src/HoneyDrunk.Communications.Cadence/CadenceJobOptions.cs` (new).
+- `src/HoneyDrunk.Communications.Cadence/Dockerfile` (new).
+- `infrastructure/comms-cadence-job.bicep` OR equivalent inputs to packet 02's workflow (new).
+- Communications release workflow (`.github/workflows/release.yml` or equivalent) — new step calling `job-deploy-container-apps-job.yml`.
+- `tests/HoneyDrunk.Communications.Tests/.../CadenceJobRunnerTests.cs` + the local-dev harness (new).
+
+**Contracts:** None changed — consumes `IIdempotencyStore`, `IAuditLog`, `IErrorReporter`, `TimeProvider`, `ICommunicationOrchestrator`.

--- a/generated/issue-packets/active/adr-0068-background-jobs/04-communications-cadence-container-apps-job.md
+++ b/generated/issue-packets/active/adr-0068-background-jobs/04-communications-cadence-container-apps-job.md
@@ -4,7 +4,7 @@ type: repo-feature
 tier: 2
 target_repo: HoneyDrunkStudios/HoneyDrunk.Communications
 labels: ["feature", "tier-2", "ops", "adr-0068", "wave-3"]
-dependencies: ["packet:02"]
+dependencies: ["packet:01", "packet:02"]
 adrs: ["ADR-0068", "ADR-0063", "ADR-0042", "ADR-0030", "ADR-0045", "ADR-0019", "ADR-0015"]
 wave: 3
 initiative: adr-0068-background-jobs
@@ -180,7 +180,7 @@ The cadence scheduler's responsibilities:
 - [ ] The `pr-core.yml` tier-1 gate passes
 
 ## Human Prerequisites
-- [ ] **Packet 02's `job-deploy-container-apps-job.yml` must be merged and on `main` before this packet's deploy step can call it.** Hard same-initiative dependency, encoded in `dependencies: ["packet:02"]`.
+- [ ] **Packet 02's `job-deploy-container-apps-job.yml` must be merged and on `main` before this packet's deploy step can call it.** Hard same-initiative dependency, encoded in `dependencies: ["packet:01", "packet:02"]`.
 - [ ] **HARD GATE — Do not push this packet until ADR-0042 packets 02 and 03 ship NuGet packages on the feed.** This packet's compile depends on `HoneyDrunk.Kernel.Abstractions` (with `IIdempotencyStore` — ADR-0042 packet 02 ships 0.8.0) and `HoneyDrunk.Data.Idempotency.Cosmos` / `HoneyDrunk.Data.Idempotency.InMemory` (ADR-0042 packet 03). ADR-0042 is **Proposed** at the time this packet was authored; its packets have not yet been executed or merged. Until those packages are published, the executor cannot resolve the references and the PR will not build. Cross-initiative — not encoded in `dependencies:` (which only resolves within the initiative folder). The operator confirms package availability on the feed (search `HoneyDrunk.Kernel.Abstractions` version >= 0.8.0 and the `HoneyDrunk.Data.Idempotency.*` family in the package registry) **before** branching for this packet. **Agents never tag or publish — the operator runs that ceremony.**
 - [ ] **Verify the `IErrorReporter` package home against ADR-0045's current state.** The reference text above lists `HoneyDrunk.Telemetry.Abstractions` as the package home; ADR-0045 may have settled the surface differently (e.g. `HoneyDrunk.Pulse.Abstractions`, a dedicated `HoneyDrunk.ErrorReporting.Abstractions`, or kept it under another Node's contracts package). At packet execution time, check ADR-0045's current Status and the latest packet set in `adr-0045-grid-wide-error-tracking/`:
   - If ADR-0045's packet 02 has shipped: use the actual published package name and version; update `## NuGet Dependencies` in this packet body to match.

--- a/generated/issue-packets/active/adr-0068-background-jobs/05-architecture-adr-0068-acceptance.md
+++ b/generated/issue-packets/active/adr-0068-background-jobs/05-architecture-adr-0068-acceptance.md
@@ -1,0 +1,136 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "core", "docs", "adr-0068", "wave-4"]
+dependencies: ["packet:02", "packet:03", "packet:04"]
+adrs: ["ADR-0068"]
+accepts: ["ADR-0068"]
+wave: 4
+initiative: adr-0068-background-jobs
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0068 — flip status, promote the four invariants from Proposed to Accepted, close the initiative
+
+## Summary
+Flip ADR-0068 (Background Job and Recurring Work Substrate) from Proposed to Accepted now that the Done-When list is satisfied: the `job-deploy-container-apps-job.yml` reusable workflow has landed (packet 02); the first in-Node `BackgroundService` under D2 has shipped (Notify retry pump, packet 03); the first cross-Node Container Apps Job under D3 has shipped (Communications cadence scheduler, packet 04). This packet updates the ADR header, updates the ADR index row in `adrs/README.md`, promotes the four ADR-0068 invariants in `constitution/invariants.md` from `**Status:** Proposed (tied to ADR-0068)` to fully Accepted (the Proposed marker is removed), and marks the `adr-0068-background-jobs` initiative complete in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0068's Done-When list: ADR-0063 is Accepted (paired prerequisite — operator-verified); `job-deploy-container-apps-job.yml` workflow lands (packet 02); first cross-Node Container Apps Job ships (packet 04 — Communications cadence); first in-Node `BackgroundService` under this ADR ships (packet 03 — Notify retry pump); `infrastructure/reference/tech-stack.md` reflects the Jobs deferral (packet 00); `initiatives/roadmap.md` reflects the deferral (packet 00); `repos/HoneyDrunk.Vault.Rotation/boundaries.md` records the grandfather (packet 00); Communications and Notify context reflect substrate choices (packet 00); scope agent flips Status → Accepted (this packet).
+
+This packet is the **flip-at-the-end** acceptance pattern — opposite of the more common ADR-acceptance-first model. ADR-0068's authors committed acceptance to evidence (deploy workflow + first consumers) rather than authorial intent; this packet completes the loop after the evidence is in.
+
+The four invariants — `{N1}` (in-Node `BackgroundService`), `{N2}` (cross-Node Container Apps Jobs + naming), `{N3}` (idempotency on every state-mutating job), `{N4}` (job observability) — were recorded in packet 01 with the explicit marker `**Status:** Proposed (tied to ADR-0068); promoted on ADR-0068 acceptance per packet 05 of adr-0068-background-jobs`. The actual block-of-four numbers were claimed from `constitution/invariant-reservations.md` at packet 01's execution time (the registry's next-free pointer named ADR-0068's block as 83/84/85/86 at packet-authoring time; the executor reconfirms by reading `constitution/invariants.md` and the registry's reservation-history entry for ADR-0068). This packet removes the marker, making the four invariants Accepted in the same PR that flips the ADR. **If packet 01 shifted the block upward** at merge time, this packet promotes whatever block 01 actually used — read the current state of `constitution/invariants.md` at execution time and promote those exact invariants.
+
+ADR-0063 acceptance is a **soft cross-init prerequisite** per the ADR's Done-When list. ADR-0063 (paired clock policy ADR) was Proposed alongside ADR-0068. If ADR-0063 has not yet been Accepted at this packet's filing time, the operator either (a) holds this packet until ADR-0063 is also Accepted, or (b) decides that the cron + `TimeProvider` rules are already in force in code (packets 03 and 04 inline-cite them as live rules) and that ADR-0063's text-state can lag — recording the choice in this packet's PR description. The default recommendation: hold until ADR-0063 is Accepted, since the Done-When list is explicit.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0068-background-job-and-recurring-work-substrate.md` — flip `**Status:** Proposed` → `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0068 row Status column to Accepted (the row may need to be added if it isn't yet present — verify at execution time; ADR-0068 was authored 2026-05-23 and may not yet have an index row).
+- `constitution/invariants.md` — remove the `**Status:** Proposed (tied to ADR-0068); promoted on ADR-0068 acceptance per packet 05 of adr-0068-background-jobs` marker from each of the four ADR-0068 invariants (the `{N1}`/`{N2}`/`{N3}`/`{N4}` block packet 01 claimed from the reservation registry). The invariants are now Accepted (no marker means Accepted, per the convention in the file).
+- `constitution/invariant-reservations.md` — move the ADR-0068 row from **Active Reservations** to **Reservation History** with the merge date (per the file's "When a reservation is consumed" convention).
+- `initiatives/active-initiatives.md` — mark `adr-0068-background-jobs` complete (the initiative is finished — all five preceding packets have shipped; move the entry from active to whichever section the file uses for completed initiatives, or update its status in place per the file's existing convention).
+
+## Proposed Implementation
+1. **Verify Done-When is satisfied.** Confirm in the PR description:
+   - ADR-0063 is Accepted (operator-verified — see Constraints if ADR-0063 is not yet Accepted at filing time).
+   - Packet 02 (`job-deploy-container-apps-job.yml` reusable workflow in HoneyDrunk.Actions) is merged on `main`.
+   - Packet 03 (Notify retry pump as `BackgroundService`) is merged on `main`.
+   - Packet 04 (Communications cadence Container Apps Job) is merged on `main`.
+   - Packet 00 (catalog/reference updates) is merged on `main`.
+   - Packet 01 (Proposed invariants) is merged on `main`.
+2. **Edit `adrs/ADR-0068-background-job-and-recurring-work-substrate.md` header:** `**Status:** Proposed` → `**Status:** Accepted`.
+3. **Update `adrs/README.md`** — locate or add the ADR-0068 index row; set Status to Accepted; verify Sector and Date match the ADR's frontmatter. If the index row does not yet exist (ADR-0068 may have been authored without its README row landing yet), add it following the sibling rows' format.
+4. **Promote the four invariants in `constitution/invariants.md`.** Locate the four ADR-0068 invariants (the `{N1}`/`{N2}`/`{N3}`/`{N4}` block packet 01 claimed). For each one, **remove** the `**Status:** Proposed (tied to ADR-0068); promoted on ADR-0068 acceptance per packet 05 of adr-0068-background-jobs` marker line. The invariant text itself is unchanged; only the marker line is removed. The invariant numbers stay the same. The `## Background Job Invariants` section heading (or whatever section packet 01 placed them under) stays.
+5. **Move the ADR-0068 reservation row to history.** Edit `constitution/invariant-reservations.md`: move the ADR-0068 row from **Active Reservations** to **Reservation History** with the merge date.
+6. **Update `initiatives/active-initiatives.md`** — mark `adr-0068-background-jobs` complete. Whether that is a move to a completed-initiatives section, a status field change in place, or a checkbox flip depends on the file's existing convention — match the precedent set by ADR-0042 and ADR-0045 initiatives' completion records, or by whichever initiatives have most recently been closed.
+
+## Affected Files
+- `adrs/ADR-0068-background-job-and-recurring-work-substrate.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md` (row moved from Active Reservations to Reservation History)
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule maps exactly.
+- [x] No code change in any other repo.
+- [x] No catalog change — D4's "no `honeydrunk-jobs` entry" stays honored.
+- [x] No new invariant — the four invariants were recorded in packet 01; this packet only promotes their status.
+- [x] No ADR text change beyond the Status header — the body of ADR-0068 stays as-is.
+
+## Acceptance Criteria
+- [ ] ADR-0068 header reads `**Status:** Accepted`
+- [ ] The ADR-0068 row in `adrs/README.md` reflects Accepted (or is added if it didn't previously exist)
+- [ ] Each of the four ADR-0068 invariants (the `{N1}`/`{N2}`/`{N3}`/`{N4}` block packet 01 claimed) no longer carries the `**Status:** Proposed (tied to ADR-0068); promoted on ADR-0068 acceptance per packet 05 of adr-0068-background-jobs` marker — they are now Accepted (no marker)
+- [ ] The four invariants' text itself is unchanged from packet 01 — only the marker line is removed
+- [ ] The four invariants keep their numbers (the `{N1}`/`{N2}`/`{N3}`/`{N4}` block from packet 01)
+- [ ] The `## Background Job Invariants` section heading remains
+- [ ] No other invariant is touched
+- [ ] `constitution/invariant-reservations.md` has the ADR-0068 row moved from Active Reservations to Reservation History with the merge date
+- [ ] `initiatives/active-initiatives.md` marks `adr-0068-background-jobs` complete per the file's existing convention
+- [ ] The PR description confirms ADR-0063 is Accepted (or records the operator-recorded decision to flip ADR-0068 ahead of ADR-0063 per Constraints)
+- [ ] The PR description confirms packets 00, 01, 02, 03, 04 are merged on `main` (Done-When evidence)
+- [ ] ADR-0068's body text is unchanged (only the Status header is flipped)
+
+## Human Prerequisites
+- [ ] **ADR-0063 (paired clock policy ADR) should be Accepted before this packet's PR merges**, per ADR-0068's Done-When list. If ADR-0063 has not yet been Accepted, the operator decides whether to (a) hold this packet, or (b) flip ADR-0068 ahead of ADR-0063 (recording the rationale: cron + `TimeProvider` rules are already in force in packets 03/04 code which inline-cite them). Default: hold.
+- [ ] **All five preceding packets must be merged.** The agent verifies merge status on `main` for packets 00, 01, 02, 03, 04 before opening this PR.
+- [ ] **Container Apps Job in production is healthy.** Packet 04's first prod deploy should be observed running at least one successful cron cycle (a 30-minute observation window) before this packet's acceptance flip — the Done-When list reads "the first job migrated (or stood-up) under the new substrate," which implies the Job is actually running, not just deployed. The operator confirms via the Azure portal that `caj-hd-comms-cadence-prod` has at least one successful execution recorded.
+
+## Referenced ADR Decisions
+**ADR-0068 "If Accepted" follow-up — flip is at the end.** "Scope agent flips Status → Accepted after the deploy workflow lands and the first job migrated (or stood-up) under the new substrate." This packet completes that follow-up step.
+
+**ADR-0068 "Done When" — full list.** ADR-0063 Accepted; `job-deploy-container-apps-job.yml` lands; first cross-Node Container Apps Job ships (Communications cadence per D11); first in-Node `BackgroundService` ships (Notify retry pump per D11); tech-stack/roadmap reflect the Jobs deferral; Vault.Rotation grandfather recorded; Communications/Notify context reflect substrate choices; Scope agent flips Status → Accepted.
+
+**ADR-0068 Catalog obligations — invariant promotion.** "Promote D6 (idempotency on every job), D7 (retry policy defaults), and D8 (observability) into numbered invariants once Accepted — scope agent assigns invariant numbers in the same PR that flips Status." Packet 01 pre-assigned the numbers (the `{N1}`/`{N2}`/`{N3}`/`{N4}` block claimed from `constitution/invariant-reservations.md`); this packet completes the promotion by removing the Proposed marker.
+
+## Constraints
+- **All five preceding packets must be merged before this packet's PR opens.** Hard `dependencies: ["packet:02", "packet:03", "packet:04"]` (packets 00 and 01 are transitive dependencies of those). The agent verifies merge status on `main`.
+- **ADR-0063 acceptance is a soft prerequisite.** If ADR-0063 is not yet Accepted at this packet's filing time, the default is to hold — but the operator may flip ADR-0068 ahead of ADR-0063 if the code reality already enforces ADR-0063's rules (packets 03 and 04 cite ADR-0063 D1/D6/D7 inline). Record the choice in the PR description.
+- **No invariant text change.** Only the `**Status:** Proposed ...` marker line is removed. The numbers stay; the text stays; the section heading stays.
+- **No catalog change.** D4's "no `honeydrunk-jobs` entry" remains in force; this packet does not add one. `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/contracts.json` are not modified.
+- **Body of ADR-0068 stays as-is.** Only the Status header at the top of the ADR file changes. The body — Context, Decision, Consequences, Alternatives Considered — is unchanged.
+- **README row may need to be added.** ADR-0068 may not yet have an `adrs/README.md` index row at this packet's filing time. If absent, add it following the sibling rows' format (ID / Title / Status=Accepted / Date / Sector / Impact); do not invent fields that aren't in ADR-0068's frontmatter.
+
+## Labels
+`chore`, `tier-3`, `core`, `docs`, `adr-0068`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0068 to Accepted now that the Done-When list is satisfied — workflow landed, first consumers shipped, catalog/invariants/context reflect the decisions.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Close the ADR-0068 acceptance loop. After this packet merges, the four invariants are in force and the substrate decisions are governing rules for future cross-Node and in-Node background work.
+- Feature: ADR-0068 Background Job and Recurring Work Substrate rollout, Wave 4 (closing).
+- ADRs: ADR-0068 (primary).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — hard. `job-deploy-container-apps-job.yml` must be on `main`.
+- `packet:03` — hard. Notify retry pump must be on `main`.
+- `packet:04` — hard. Communications cadence Job must be on `main`.
+- Packets 00 and 01 are transitive dependencies (02/03/04 already depend on 00 via their own `dependencies:`).
+
+**Constraints:**
+- Verify Done-When is satisfied in the PR description (all five preceding packets merged; ADR-0063 status verified).
+- Only the Status header on the ADR and the Proposed marker on the four invariants change. No invariant text change, no catalog change, no ADR body change.
+- ADR-0063 acceptance is a soft prerequisite — default hold until accepted; operator may flip ahead with recorded rationale.
+
+**Key Files:**
+- `adrs/ADR-0068-background-job-and-recurring-work-substrate.md` — Status header.
+- `adrs/README.md` — index row.
+- `constitution/invariants.md` — remove Proposed markers from the four ADR-0068 invariants.
+- `initiatives/active-initiatives.md` — mark complete.
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0068-background-jobs/05-architecture-adr-0068-acceptance.md
+++ b/generated/issue-packets/active/adr-0068-background-jobs/05-architecture-adr-0068-acceptance.md
@@ -4,7 +4,7 @@ type: architecture-decision
 tier: 3
 target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
 labels: ["chore", "tier-3", "core", "docs", "adr-0068", "wave-4"]
-dependencies: ["packet:02", "packet:03", "packet:04"]
+dependencies: ["packet:00", "packet:01", "packet:02", "packet:03", "packet:04"]
 adrs: ["ADR-0068"]
 accepts: ["ADR-0068"]
 wave: 4
@@ -93,7 +93,7 @@ None.
 **ADR-0068 Catalog obligations — invariant promotion.** "Promote D6 (idempotency on every job), D7 (retry policy defaults), and D8 (observability) into numbered invariants once Accepted — scope agent assigns invariant numbers in the same PR that flips Status." Packet 01 pre-assigned the numbers (the `{N1}`/`{N2}`/`{N3}`/`{N4}` block claimed from `constitution/invariant-reservations.md`); this packet completes the promotion by removing the Proposed marker.
 
 ## Constraints
-- **All five preceding packets must be merged before this packet's PR opens.** Hard `dependencies: ["packet:02", "packet:03", "packet:04"]` (packets 00 and 01 are transitive dependencies of those). The agent verifies merge status on `main`.
+- **All five preceding packets must be merged before this packet's PR opens.** Hard `dependencies: ["packet:00", "packet:01", "packet:02", "packet:03", "packet:04"]` (packets 00 and 01 are transitive dependencies of those). The agent verifies merge status on `main`.
 - **ADR-0063 acceptance is a soft prerequisite.** If ADR-0063 is not yet Accepted at this packet's filing time, the default is to hold — but the operator may flip ADR-0068 ahead of ADR-0063 if the code reality already enforces ADR-0063's rules (packets 03 and 04 cite ADR-0063 D1/D6/D7 inline). Record the choice in the PR description.
 - **No invariant text change.** Only the `**Status:** Proposed ...` marker line is removed. The numbers stay; the text stays; the section heading stays.
 - **No catalog change.** D4's "no `honeydrunk-jobs` entry" remains in force; this packet does not add one. `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/contracts.json` are not modified.

--- a/generated/issue-packets/active/adr-0068-background-jobs/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0068-background-jobs/dispatch-plan.md
@@ -1,0 +1,153 @@
+# Dispatch Plan — ADR-0068: Background Job and Recurring Work Substrate
+
+**Initiative:** `adr-0068-background-jobs`
+**ADR:** ADR-0068 (Proposed → Accepted via packet 05, at the end — see Acceptance Flow below)
+**Sector:** Core / Ops · cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0068 settles the Grid's response to a planned-but-never-built `HoneyDrunk.Jobs` Node and seven workloads (existing and imminent) running on three different ad-hoc substrates. The decision is three-prong: CI/CD ops cron stays on GitHub Actions (out of scope); in-Node background work uses `IHostedService` / `BackgroundService` (D2); cross-Node recurring orchestration uses Azure Container Apps Jobs (D3). The `HoneyDrunk.Jobs` Node is deferred indefinitely — Container Apps Jobs subsumes its role (D4). Vault.Rotation's Azure Functions timer triggers are grandfathered (D7). Idempotency on every state-mutating job is mandatory (D6), routing through the ADR-0042 store. Cron format and clock substrate cross-reference ADR-0063.
+
+This initiative delivers: catalog/governance updates that reflect the Jobs deferral and the two pinned substrates (Architecture); the `job-deploy-container-apps-job.yml` reusable workflow in HoneyDrunk.Actions; the **Notify retry pump** as the first in-Node `BackgroundService` under this ADR (D2's first consumer per D11); the **Communications cadence/drip-campaign scheduler** as the first cross-Node Container Apps Job under this ADR (D3's first consumer per D11); and the acceptance flip after both first-consumer packets ship.
+
+**6 packets across 4 waves**, targeting **4 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Actions`, `HoneyDrunk.Notify`, `HoneyDrunk.Communications`). All 6 are `Actor=Agent`, 0 `Actor=Human`. Several packets carry Human Prerequisites: portal-side Container Apps Jobs provisioning, KEDA scaler wiring, and the human git-tag/release of any upstream NuGet packages whose new versions ship in this initiative.
+
+## Trigger
+
+ADR-0068 is Proposed with no scope. Forcing functions from the ADR's Context: **ADR-0019 Communications cadence rules** are the next workload to land and need a scheduling substrate; **ADR-0027 Notify Cloud retries** need a retry substrate (in-Node `BackgroundService` is the strong candidate but uncommitted); **ADR-0015** pinned Container Apps as the deployable platform, and Container Apps Jobs is the Jobs-shaped sibling already on that platform; **ADR-0063** (paired, also Proposed) pins cron format and clock substrate. Without an ADR, the next consumer (Communications cadence is imminent) picks a fourth substrate unilaterally and the Grid drifts further. The ADR needs decomposition into actionable packets — and per its own Done-When list, acceptance gates on the deploy workflow landing and the first job under the new substrate shipping.
+
+## Scope Detection
+
+**Multi-repo, multi-Node.** The decisions land in `HoneyDrunk.Architecture` (acceptance, four invariants, catalog/reference updates per the ADR's follow-up checklist), `HoneyDrunk.Actions` (the new reusable workflow per the follow-up checklist and ADR-0012's CI/CD-control-plane mandate), `HoneyDrunk.Notify` (first in-Node `BackgroundService` per D2/D11 — the retry pump), and `HoneyDrunk.Communications` (first cross-Node Container Apps Job per D3/D11 — cadence/drip-campaign scheduling).
+
+**No new-Node scaffolding.** The ADR's D4 explicitly defers `HoneyDrunk.Jobs`; this initiative removes the planned-Node slot from the catalog/roadmap and does not stand up any new Node. Every target repo is a live, scaffolded Node.
+
+**No new contract surface in Kernel.Abstractions.** D2/D3 reuse BCL types (`BackgroundService`, `IHostedService`, `TimeProvider`) and platform manifests (Container Apps Jobs YAML/Bicep); ADR-0068 Catalog obligations: "no entry. The contract surface (cron strings, `BackgroundService` shape, Container Apps Jobs deploy manifest) is platform/BCL types; nothing HoneyDrunk-owned to register." This initiative therefore carries no Kernel/Abstractions packet.
+
+## Cross-Dependency with ADR-0063 (Clock Policy)
+
+ADR-0068 D5 explicitly cross-references ADR-0063 for cron format (5-field UTC), clock substrate (`TimeProvider`), test seam (`FakeTimeProvider`), and duration shape (ISO 8601 strings). ADR-0063 is **Proposed**, not Accepted, and ADR-0068's Done-When list names "ADR-0063 is Accepted" as a paired prerequisite.
+
+**Posture for this initiative:** ADR-0068 packets reference ADR-0063 decisions inline (the rule text is summarized in each packet's Constraints/Referenced ADR Decisions) so executors don't need to read ADR-0063 to act. The two ADRs were authored as a paired set; in practice ADR-0063's scoping should happen first or in parallel so its acceptance lands before ADR-0068 packet 05 (the acceptance flip).
+
+**Soft dependency, not a hard blocker for the Wave 1–3 work** — packets 00–04 land regardless of ADR-0063's exact filing order, because their cron/`TimeProvider`/ISO-8601-duration rules are reproduced from ADR-0063 inline. Packet 05 (acceptance flip) should be the final step and is gated behind ADR-0063 acceptance per the Done-When list — see Acceptance Flow.
+
+## Acceptance Flow — flip is at the END, not the start
+
+ADR-0068's "If Accepted" follow-up checklist names: "Scope agent flips Status → Accepted **after the deploy workflow lands and the first job migrated (or stood-up) under the new substrate**." This is the opposite of the more typical ADR-acceptance-first pattern (e.g. ADR-0042, ADR-0045). The packet order reflects it:
+
+- Packet **00** (Architecture — catalog/reference updates) lands the follow-up checklist items **while the ADR is still Proposed**. Status flip is *not* in packet 00.
+- Packet **01** (Architecture — pre-reserve four ADR-0068 invariants — block of four claimed from `constitution/invariant-reservations.md` as `{N1}`/`{N2}`/`{N3}`/`{N4}`) records the four invariants ADR-0068 D6/D7/D2/D3/D4 commits, with explicit "tied to ADR-0068, promoted on acceptance" notes. This separates the invariant-text recording from the flip.
+- Packet **02** ships the Actions reusable workflow.
+- Packets **03**, **04** ship the first in-Node `BackgroundService` (Notify retry pump) and the first cross-Node Container Apps Job (Communications cadence scheduler) respectively — D11's two-consumer first-shipping list.
+- Packet **05** (Architecture — Status flip) flips the ADR header to Accepted, updates the `adrs/README.md` index row, promotes the four invariants from Proposed to numbered/accepted, and registers the initiative as complete. **Hard-blocked** behind 02, 03, 04 (and the cross-init ADR-0063 acceptance per Done-When).
+
+This is deliberate: the ADR commits its acceptance to evidence (deploy workflow + first consumers), not to authorial intent.
+
+## Wave Diagram
+
+### Wave 1 (No code; governance + catalog — proposed-only state)
+- [ ] **00** — Architecture: update `infrastructure/reference/tech-stack.md`, `initiatives/roadmap.md`, `repos/HoneyDrunk.Vault.Rotation/boundaries.md`, `repos/HoneyDrunk.Communications/`, `repos/HoneyDrunk.Notify/` context per the ADR-0068 follow-up checklist; register the `adr-0068-background-jobs` initiative. ADR-0068 stays **Proposed**. `Actor=Agent`.
+- [ ] **01** — Architecture: pre-reserve the four ADR-0068 invariants (`{N1}` in-Node `BackgroundService`; `{N2}` cross-Node Container Apps Jobs + naming; `{N3}` idempotency on every job; `{N4}` job-failure observability — Pulse/Audit/`IErrorReporter` triad) as **Proposed invariants** in `constitution/invariants.md` with explicit ADR-0068-tied promotion notes — to be promoted to Accepted in packet 05. Block of four claimed from `constitution/invariant-reservations.md` at execution time. `Actor=Agent`. Blocked by: 00.
+
+### Wave 2 (Depends on Wave 1 — the reusable deploy workflow)
+- [ ] **02** — Actions: author `job-deploy-container-apps-job.yml` reusable workflow (Container Apps Jobs deploy: schedule-or-event trigger, replica policy, retry policy, KEDA scaler wiring, OIDC auth reuse from the existing `job-deploy-container-app.yml` shape). `Actor=Agent`. Blocked by: 00. (No code dependency on packet 01 — runs as early as 00 lands.)
+
+### Wave 3 (Depends on Wave 2 — first consumers, parallel)
+- [ ] **03** — Notify: implement the Notify retry pump as an in-Node `BackgroundService` per D2; backoff config in ISO 8601 duration strings per ADR-0063 D6; `TimeProvider` for wall-clock reads; idempotency per D6 via `IIdempotencyStore` (ADR-0042). `Actor=Agent`. Blocked by: 00. (Independent of packet 02 — the in-Node substrate doesn't use the Container Apps Jobs deploy workflow.)
+- [ ] **04** — Communications: stand up the cadence/drip-campaign scheduler as the first cross-Node Container Apps Job per D3; cron is 5-field UTC per ADR-0063 D6; idempotency key `${jobName}:${scheduledInstant:yyyyMMddTHHmmssZ}` per D6; D7 retry defaults (3 retries, 1m/5m/25m exponential) wired in the Container Apps Jobs manifest; D8 observability (Pulse `jobs.outcome`/`jobs.duration`, lifecycle traces, long-running progress to Audit per ADR-0030, errors to ADR-0045). `Actor=Agent`. Blocked by: 02. Deploys via packet 02's new workflow.
+
+### Wave 4 (Depends on Wave 3 — acceptance flip + invariant promotion)
+- [ ] **05** — Architecture: flip ADR-0068 Status → Accepted; update `adrs/README.md` index row; promote the four invariants from packet 01's Proposed state to Accepted with their final numbers; mark the initiative complete in `active-initiatives.md`. `Actor=Agent`. Blocked by: 02, 03, 04. (Soft cross-init dependency on ADR-0063 acceptance per Done-When — see Cross-Dependency with ADR-0063.)
+
+Packets within a wave run in parallel. **Wave 3 packets 03 and 04 are independent** — 03 lands in `HoneyDrunk.Notify` (in-Node substrate, no deploy-workflow dependency), 04 lands in `HoneyDrunk.Communications` (uses packet 02's deploy workflow). Packet 05 alone in Wave 4 ensures every D11-named first-consumer ships before the ADR is declared Accepted.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Catalog and reference updates per follow-up checklist](./00-architecture-jobs-deferral-and-context-updates.md) | Architecture | Agent | 1 | — |
+| 01 | [Pre-reserve the four ADR-0068 invariants as Proposed](./01-architecture-prereserve-jobs-invariants.md) | Architecture | Agent | 1 | 00 |
+| 02 | [`job-deploy-container-apps-job.yml` reusable workflow](./02-actions-job-deploy-container-apps-job-workflow.md) | Actions | Agent | 2 | 00 |
+| 03 | [Notify retry pump as in-Node `BackgroundService`](./03-notify-retry-pump-background-service.md) | Notify | Agent | 3 | 00 |
+| 04 | [Communications cadence scheduler as Container Apps Job](./04-communications-cadence-container-apps-job.md) | Communications | Agent | 3 | 02 |
+| 05 | [Accept ADR-0068 — flip status + promote invariants](./05-architecture-adr-0068-acceptance.md) | Architecture | Agent | 4 | 02, 03, 04 |
+
+## Version Bumps
+
+- **`HoneyDrunk.Notify`** — packet 03 lands a new `BackgroundService` in the Notify Worker host. Per invariant 27 this is a minor bump (new feature). Confirm the current solution version at execution time (the launch tracker shows v0.3.0 most recently).
+- **`HoneyDrunk.Communications`** — packet 04 adds the Container Apps Job deployable (a new `Program.cs`/binary subproject, the cadence scheduler) to the Communications solution. New runtime artifact — minor bump. Confirm the current solution version at execution time (overview shows v0.2.0).
+- **`HoneyDrunk.Actions`** — not a versioned .NET solution; packet 02 is a workflow/YAML change. CHANGELOG updated per the repo convention if it keeps one.
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; governance/catalog/doc edits only (packets 00, 01, 05).
+
+No new public Kernel/Abstractions contracts ship in this initiative — D4's Jobs-Node deferral and ADR-0068's "no entry" in `catalogs/contracts.json` are explicit.
+
+## Cross-Cutting Concerns
+
+### Invariant numbering — four invariants, batched-block pre-reservation
+
+ADR-0068 commits four new invariants (D6 idempotency, D7 retry defaults / grandfather, D2 in-Node substrate, D3 cross-Node substrate + naming). Numbers are claimed from `constitution/invariant-reservations.md` at packet 01 execution time per the registry's "first merge wins" rule — the block of four is referenced throughout packets 01/03/04 as `{N1}`/`{N2}`/`{N3}`/`{N4}`. At packet-authoring time the registry's next-free pointer named ADR-0068's block as **83/84/85/86**; the executor reconfirms at execution time and substitutes consistently across packets 01, 03, and 04 (and packet 05's promotion text once it lands). Packet 01 records them as **Proposed**; packet 05 promotes them on acceptance. **Earlier drafts of these packets hardcoded 75/76/77/78 — those numbers collided with the ADR-0042/0045 batch reservations and were replaced with placeholders during refine.**
+
+The Container Apps Jobs naming rule (D3 — `caj-hd-{service}-{env}`) is captured inside the new invariant `{N2}`, **not** as an amendment to invariant 34 (`ca-hd-{service}-{env}` for Container Apps proper). The two naming rules are parallel and complementary; D3 is the Jobs-shaped sibling and gets its own invariant text. The 13-character service-name limit (invariant 19) applies to both unchanged — but the Azure Container Apps Jobs resource-name cap may differ; packet 02's Human Prerequisites verify the actual limit before locking the regex.
+
+### `HoneyDrunk.Jobs` is deferred, not just postponed — catalog discipline
+
+Per the ADR's "Catalog obligations": "`catalogs/nodes.json` — **no `honeydrunk-jobs` entry to add.** This ADR explicitly defers the Node." Packet 00 must NOT add a `honeydrunk-jobs` Node to any catalog (`nodes.json`, `relationships.json`, `contracts.json`). The tech-stack `Jobs | Ops | Background job scheduling` row in the Planned Nodes table is the only Jobs-Node trace in the catalogs; packet 00 removes that row (or moves it to a "Deferred — substrate covered by Container Apps Jobs" subsection if such a subsection makes sense). Same for `initiatives/roadmap.md` line 67. Packet 00's PR description states the move/removal explicitly so reviewers can verify no other catalog file is missed.
+
+### Vault.Rotation grandfather posture is documentation-only
+
+Per D7, Vault.Rotation stays on Azure Functions timer triggers until a natural migration moment (a major rewrite, or Functions plan retirement). Packet 00 records this in `repos/HoneyDrunk.Vault.Rotation/boundaries.md` as a "Substrate (grandfathered)" subsection. **No code change in `HoneyDrunk.Vault.Rotation`** in this initiative. The grandfather is explicit, documented, and time-bounded but does not produce a Vault.Rotation packet.
+
+### Idempotency on jobs reuses ADR-0042 — no new contract
+
+ADR-0068 D6 binds every state-mutating job (in-Node `BackgroundService` or cross-Node Container Apps Job) to `IIdempotencyStore` from ADR-0042. The idempotency key is `${jobName}:${scheduledInstant:yyyyMMddTHHmmssZ}` for schedule-triggered jobs; for KEDA event-triggered jobs, derived from the trigger event (Service Bus `MessageId` or Event Grid event ID, salted with job name).
+
+**Hard cross-initiative dependency:** packets 03 and 04 consume `IIdempotencyStore` from `HoneyDrunk.Kernel.Abstractions` and a backing implementation (typically the Cosmos default from `HoneyDrunk.Data.Idempotency.Cosmos`) from ADR-0042's initiative. **ADR-0042's runtime packages must be on the NuGet feed before packets 03/04 can compile** — recorded in each packet's Human Prerequisites as a release-tagging step. If ADR-0042 has not yet shipped its Kernel/Data packages by the time packet 03 or 04 starts, those packets are blocked at execution time even though their `dependencies:` frontmatter does not encode the edge (because `packet:NN` only resolves within a folder and the ADR-0042 packet numbers are different issue numbers in `HoneyDrunk.Architecture`). The cleanest fix: file ADR-0042 fully *first*, then ADR-0068 packets 03/04 reference `Architecture#<n>` qualified edges to ADR-0042's packets 02/03/04. If ADR-0042 has already shipped by the time this folder is filed, drop the cross-init edge — the NuGet packages are simply present.
+
+The dispatch plan flags this as an execution-order judgment for the operator, not as an unconditional dependency. See packets 03 and 04 for the precise Human Prerequisites text.
+
+### Observability is mandatory — D8 wiring is per-packet, not a shared deliverable
+
+ADR-0068 D8 commits four observability emissions on every job: Pulse `jobs.outcome` counter, Pulse `jobs.duration` histogram, lifecycle traces with `correlationId` per invariant 6, long-running (>60s) job progress to Audit via `JobProgress`, and final-failure errors to `IErrorReporter` per ADR-0045. The wiring is per-job — packets 03 and 04 each implement their own; there is no shared "jobs observability library" packet (consistent with D4's "no shared `HoneyDrunk.Jobs.Library` package"). Per-Node wiring is a near-mechanical pattern that the executor follows; the patterns from existing Pulse/Audit consumers are referenced inline.
+
+### ADR-0042, ADR-0030, ADR-0045 cross-init relationships — soft
+
+- **ADR-0042 (idempotency)** — packets 03/04 consume `IIdempotencyStore`. See "Idempotency on jobs reuses ADR-0042" above. Soft cross-init dependency.
+- **ADR-0030 (Audit)** — packets 03/04 emit `JobProgress` and `JobFailure` audit categories per D8. Both categories are *new* audit categories implied by D8; their registration in the Audit Node's category list is **not in scope here** — it is a deferred Audit follow-up (the categories ride the existing `AuditEntry` shape; only the category-name strings are new). Flag this in packets 03/04: the audit emit uses the new category strings; if Audit later normalizes its category list, this initiative's emits are forward-compatible.
+- **ADR-0045 (error tracking)** — packets 03/04 emit final-failure errors via `IErrorReporter` per D8 + ADR-0045 D3. ADR-0045's facade must be live; if ADR-0045 has not yet shipped by the time packets 03/04 start, the executor wires a TODO-comment `IErrorReporter`-shaped seam and lifts it once ADR-0045 lands — but this is unlikely given ADR-0045's earlier filing posture.
+
+### `BackgroundService` retry semantics are author-decided, not platform-defaulted
+
+Per D7's last paragraph: "In-Node `BackgroundService` work is not subject to D7's retry policy directly — the `BackgroundService` author decides the retry semantics in code." Packet 03 (Notify retry pump) is the first in-Node case under this ADR; its retry shape (the *Notify message* retry semantics, separate from the BackgroundService loop's own try/catch) is decided in-packet using Polly per the ADR's convention. The packet's PR description names the exact retry shape chosen so future Background-Service authors have a precedent to read.
+
+### Local-dev story for Container Apps Jobs (D9) is per-packet, not a shared deliverable
+
+Per D9, Container Apps Jobs don't run locally — the binary runs as a console app or under a timer-driven host for testing. Packet 04 ships the Communications cadence-scheduler binary as a Program.cs/Main entry that the Container Apps Jobs runtime invokes in production; locally, `dotnet run` invokes the same entry. Aspire integration (provisional ADR-0065) is not in scope; the binary stands alone via `dotnet run` regardless.
+
+### Site sync
+
+No site-sync flag. ADR-0068 is internal Core/Ops infrastructure — no public-facing Studios website content changes.
+
+## Rollback Plan
+
+- **Packet 00 (catalog/reference updates):** revert the PR. `HoneyDrunk.Jobs` returns to its Planned-Nodes row in tech-stack.md and its Future-section line in roadmap.md; Vault.Rotation boundaries.md returns to pre-grandfather state; Notify/Communications context loses its substrate-choice note. No runtime impact.
+- **Packet 01 (Proposed invariants):** revert the PR; the four invariants leave the file. ADR-0068's commitments are then unrecorded as text — note this in the revert.
+- **Packet 02 (Actions workflow):** revert the PR; the new reusable workflow leaves `.github/workflows/`. No consuming repo depends on it at runtime — Communications packet 04 is the first consumer and its deploy fails until the workflow returns or until packet 04 itself is reverted.
+- **Packet 03 (Notify retry pump):** revert the PR; Notify's Worker host loses the new `BackgroundService`. Notify's pre-existing retry surface (provider-side `Message-ID` rejection, the existing in-flight queue retry handling) still tolerates duplicates — no regression below today's behaviour. The Notify solution version rolls back.
+- **Packet 04 (Communications cadence Job):** revert the PR; the cadence Container Apps Job leaves the repo and is **un-deployed in every environment** via the `az containerapp job delete` portal click (or the equivalent CLI). The Communications solution version rolls back. Per-tenant cadence work resumes its pre-ADR-0068 (uncommitted) state — note: there is no pre-existing cadence scheduler to fall back to, so a revert here leaves Communications without scheduled cadence. Production deploys of packet 04 should be co-ordinated with the operator (Human Prerequisites).
+- **Packet 05 (acceptance flip):** revert the PR; ADR-0068 returns to Proposed, the invariants return to Proposed state. The first-consumer code in Notify and Communications continues to run — the policy is just not yet Accepted as text.
+- **Operational escape hatch:** if packet 04's Container Apps Job mis-fires (cron skew, double-run, idempotency check failure), use the Container Apps Jobs portal to suspend the schedule trigger without reverting the code. A suspended schedule is a one-click change, no redeploy.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.
+
+## Notes for the Operator (the human)
+
+- **ADR-0063 (paired clock policy)** is referenced inline by every packet that touches cron strings or `TimeProvider`. The cross-init dependency is soft; packets 03/04 do not block on ADR-0063's scoping. Packet 05 (acceptance flip) is the right moment to verify ADR-0063 has also been accepted, per ADR-0068's Done-When list. If ADR-0063 has not yet been accepted at packet 05's filing time, hold packet 05 until it has.
+- **ADR-0042 release tags** — packets 03 and 04 reference `IIdempotencyStore` and its backings. If ADR-0042's NuGet packages haven't been tagged/released yet at packet 03/04 execution time, surface this in the relevant PR: the agent should not invent a substitute idempotency shape (that would create a parallel store and violate ADR-0042's contract).
+- **No standalone `HoneyDrunk.Jobs` repo to create or update** — the deferral is the decision; no scaffolding work.
+- **First Container Apps Job in production** — packet 04 is the studio's first Container Apps Job deploy. The deploy workflow (packet 02) is also new. Expect a small amount of iteration on the workflow shape — the ADR's Negative Consequences flag this explicitly: "The deploy workflow … is the studio's first authored Jobs workflow; expect iteration."

--- a/generated/issue-packets/active/adr-0077-iac-bicep/00-architecture-adr-0077-acceptance.md
+++ b/generated/issue-packets/active/adr-0077-iac-bicep/00-architecture-adr-0077-acceptance.md
@@ -1,0 +1,130 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "docs", "adr-0077", "wave-1"]
+dependencies: []
+adrs: ["ADR-0077"]
+accepts: ["ADR-0077"]
+wave: 1
+initiative: adr-0077-iac-bicep
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0077 — flip status, add the three IaC invariants, amend invariant 35, register the initiative
+
+## Summary
+Flip ADR-0077 (Infrastructure-as-Code — Bicep) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, add the three new IaC invariants ADR-0077 commits in its Consequences/Invariants section to `constitution/invariants.md` (numbered per the reservation claimed in `constitution/invariant-reservations.md`), amend invariant 35's text to carve out the Bicep-module ACR (`acrhdbicep`) so it does not collide with the shared container-image ACR (`acrhdshared{env}`), and register the `adr-0077-iac-bicep` initiative in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0077 commits **Bicep** as the canonical IaC tool for every Azure resource the Grid provisions. Today, infrastructure is provisioned via a mix of Azure Portal clicks and ad-hoc Azure CLI scripts — there is no version-controlled, declarative IaC for the Grid's overall topology. ADR-0077 decides the tool (Bicep), the modularization strategy (per-concern modules in `HoneyDrunk.Actions/bicep/modules/`, published to a shared `acrhdbicep` Bicep registry), the naming and tagging conventions (linter-enforced), the per-environment deploy model (`main.bicep` + `parameters.{env}.bicepparam`), and the migration posture (D6 — new infrastructure goes through Bicep from day one; existing manually-provisioned resources are grandfathered and imported opportunistically at their next significant touchpoint).
+
+The ADR decides:
+- **D1** — Bicep is the canonical IaC tool for all Azure infrastructure. No manual Portal provisioning for new resources. No raw ARM JSON. No CLI scripts as primary IaC. Terraform / Pulumi / Crossplane / Azure Blueprints / mixed-IaC are explicitly rejected.
+- **D2** — Modularize by concern, not by Node. Modules live in `HoneyDrunk.Actions/bicep/modules/` (Networking / Compute / Identity / Data / Secrets / Messaging / Observability) and are published to a dedicated `acrhdbicep` Azure Container Registry on tagged release. Per-Node templates consume modules via registry references (`br:acrhdbicep.azurecr.io/modules/{concern}/{name}:{semver}`).
+- **D3** — Naming and tagging conventions enforced by Bicep linter rules (`bicepconfig.json`). Required tags: `hd:node`, `hd:env`, `hd:owner`, `hd:cost-center`, `hd:dr-tier`, `hd:adr`. Required name shape: per-resource-type prefix + `hd-` Grid identifier + `{service}` or `{node}` + `{env}` suffix. CI gate fails the PR on linter violation.
+- **D4** — Per-environment deployment via `main.bicep` + `parameters.{env}.bicepparam`. The Actions reusable deploy workflow `job-deploy-bicep.yml` runs `az deployment group create` per environment.
+- **D5** — Vendor-exit posture explicitly acknowledged. The Grid is Azure-only by current design; modularization by concern is the hedge against future Terraform migration cost. The vendor-exit playbook itself is named as separate follow-up work.
+- **D6** — Migration from existing manual provisioning: new infrastructure goes through Bicep from day one; existing resources are imported opportunistically (export ARM → decompile to Bicep → reconcile drift → adopt) at their next significant touchpoint. No retroactive campaign.
+- **D7** — Bicep templates never contain secret values. Secrets reference Vault by URI; parameter files carry non-secret config only; the deploy identity has rights to provision resources, not to read secret values.
+- **D8** — Out of scope: vendor-exit playbook content, multi-region topology, Azure Policy / Blueprints, detailed cost-allocation tagging beyond D3, Bicep-generated docs, deploy-workflow specifics, subscription / resource-group topology.
+
+ADR-0077 is a **policy / substrate** ADR. The concrete code — the Actions modules library, `bicepconfig.json`, the `bicep-publish.yml` and `job-deploy-bicep.yml` workflows, the first module set, the `bicep lint` PR gate, the per-Node template-scaffold pattern, and the D6 import playbook — lands as the remaining packets in this initiative. Every other packet references ADR-0077's D-decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0077-infrastructure-as-code-bicep.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0077 row Status column to Accepted.
+- `constitution/invariant-reservations.md` — claim the next free block (size 3) and add the row. The block is `{N1}–{N3}` (claimed at file authoring time as **90–92**; if a later in-flight ADR's packet 00 lands first, rebase upward and update every `{N*}` placeholder in this packet and `constitution/invariants.md` together).
+- `constitution/invariants.md` — add the three new IaC invariants (see Proposed Implementation for exact text), numbered `{N1}/{N2}/{N3}` (the block reserved in `invariant-reservations.md`). **Amend the existing invariant 35 text in the same PR** to explicitly carve out the Bicep-module ACR.
+- `initiatives/active-initiatives.md` — register the `adr-0077-iac-bicep` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0077 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update the ADR-0077 index row in `adrs/README.md` to Accepted.
+3. **Claim the invariant block.** Read `constitution/invariant-reservations.md`. Take the next free block (size 3) — at file authoring time **90–92**. Add the row in the same PR as this packet's edits; if the file shows a higher next-free at claim time, take that instead and update every `{N1}/{N2}/{N3}` placeholder in this packet's body together with the invariant text in step 4.
+4. Add three new invariants to `constitution/invariants.md`, numbered `{N1}/{N2}/{N3}` (the block from step 3). The text, taken verbatim-in-substance from ADR-0077's Consequences "Invariants" section:
+   - **`{N1}` — New Azure infrastructure is provisioned via Bicep.** Every new Azure resource — Container Apps, Key Vault, App Configuration, Service Bus, Event Grid, Storage, Application Insights, Azure Cache for Redis, anything else — is declared in a Bicep template, version-controlled in the owning repo, and applied through the `HoneyDrunk.Actions` reusable Bicep deploy workflow. Manual Azure Portal provisioning of new resources, raw ARM JSON, and Azure CLI scripts as primary IaC are boundary violations. Existing resources manually provisioned before ADR-0077 are grandfathered and imported to Bicep at their next significant touchpoint per ADR-0077 D6 — not in a retroactive campaign. See ADR-0077 D1, D6.
+   - **`{N2}` — Bicep templates never contain secret values.** Bicep templates reference secrets via Vault URIs and `keyVaultSecret` resources; parameter files (`.bicepparam`) carry non-secret configuration only; the GitHub Actions OIDC-federated deploy identity has rights to provision resources, not to read secret values. This codifies invariant 8 (secrets never appear in logs, traces, exceptions, or telemetry) extended to IaC payloads. The linter flags hardcoded secret-shaped literals (`accountKey`, `connectionString`, `password`, `apiKey`) on a best-effort basis. See ADR-0077 D7.
+   - **`{N3}` — Bicep templates apply the Grid naming and tagging conventions enforced by linter rules.** Every Azure resource declared in Bicep carries a per-resource-type prefix (`ca-`, `kv-`, `redis-`, `sb-`, etc.), the `hd-` Grid identifier, a `{service}` or `{node}` name truncated to fit Azure's resource-name length limits (≤13 chars per invariant 19 where applicable), and an `{env}` suffix. Every resource carries the required tags `hd:node`, `hd:env`, `hd:owner`, `hd:cost-center`, `hd:dr-tier`, and `hd:adr`. `bicepconfig.json` flags missing tags and non-conformant names; `bicep lint` in `pr-core.yml` fails the PR on violation. See ADR-0077 D3.
+   - Create a new `## Infrastructure-as-Code Invariants` section. The file's existing sectioning convention groups invariants by topic (Dependency / Context / Secrets / Packaging / Testing / Infrastructure / Work Tracking / AI / Code Review / Hosting Platform / Hive Sync / Multi-Tenant Boundary / Communications / Audit). IaC is a new cross-cutting topic; place the new section after `## Audit Invariants`.
+5. **Amend invariant 35 to explicitly carve out the Bicep-module ACR.** The current invariant 35 text reads roughly "one shared ACR (`acrhdshared{env}`) per environment." Amend it to read (substantively): **"one shared container-image ACR `acrhdshared{env}` per environment; one shared Bicep-module ACR `acrhdbicep` is permitted Grid-wide per ADR-0077 D2 (environment-agnostic, modules-only, distinct purpose)."** This is a text-only amendment — invariant 35 keeps its number. Land it in the same PR as the new IaC invariants so the new `acrhdbicep` registry catalog/walkthrough work in packets 01/02 does not contradict the constitution.
+6. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder.
+
+## Affected Files
+- `adrs/ADR-0077-infrastructure-as-code-bicep.md`
+- `adrs/README.md`
+- `constitution/invariant-reservations.md` (claim the size-3 block; add the row)
+- `constitution/invariants.md` (add the three new IaC invariants; amend invariant 35 text)
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency — IaC is a substrate concern; no contract cascade.
+
+## Acceptance Criteria
+- [ ] ADR-0077 header reads `**Status:** Accepted`
+- [ ] The ADR-0077 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariant-reservations.md` carries a row reserving the `{N1}–{N3}` block for ADR-0077 (size 3), per the file's "How a packet 00 claims a block" procedure
+- [ ] `constitution/invariants.md` carries the three new IaC invariants (new Azure infrastructure is provisioned via Bicep with the D6 grandfather carve-out; Bicep templates never contain secret values; Bicep templates apply Grid naming + tagging conventions enforced by linter rules), numbered `{N1}/{N2}/{N3}` under a new `## Infrastructure-as-Code Invariants` section, each citing ADR-0077
+- [ ] `constitution/invariants.md` invariant 35 text is amended in the same PR to read (substantively) "one shared container-image ACR `acrhdshared{env}` per environment; one shared Bicep-module ACR `acrhdbicep` is permitted Grid-wide per ADR-0077 D2 (environment-agnostic, modules-only, distinct purpose)" — invariant 35 keeps its number
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0077-iac-bicep` initiative with a packet checklist
+- [ ] No catalog schema change in this packet (catalog updates land in packet 01)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0077 D1 — Bicep is the canonical IaC tool.** Every Azure resource declared in Bicep; no manual Portal provisioning for new resources; no raw ARM JSON; no CLI scripts as primary IaC. Terraform / Pulumi / Crossplane explicitly rejected (Azure-only Grid; abstraction tax not justified; state-file overhead avoided; AI-assistance gradient on Bicep is good).
+
+**ADR-0077 D3 — Naming and tagging conventions enforced by Bicep linter rules.** `bicepconfig.json` flags missing required tags and non-conformant names; CI `bicep lint` fails the PR on violation. Required tags `hd:node`, `hd:env`, `hd:owner`, `hd:cost-center`, `hd:dr-tier`, `hd:adr`.
+
+**ADR-0077 D6 — Migration from existing manual provisioning.** New infrastructure goes through Bicep from day one; existing resources are imported opportunistically (export → decompile → reconcile → adopt) at their next significant touchpoint, not in a retroactive campaign. The discipline matches the grandfather pattern from ADR-0058 D9, ADR-0074 D6, ADR-0075 D4.
+
+**ADR-0077 D7 — Secrets in Bicep.** Templates never contain secret values; secrets reference Vault by URI; parameter files carry non-secret config only; deploy identity has provisioning rights, not secret-read rights. Codifies invariant 8 extended to IaC payloads.
+
+**ADR-0077 Consequences — Invariants.** ADR-0077 adds exactly three invariants: (1) new Azure infrastructure is provisioned via Bicep with the D6 grandfather carve-out; (2) Bicep templates never contain secret values; (3) Bicep templates apply Grid naming + tagging conventions enforced by linter rules.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0077 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbers come from the reservation registry.** Read `constitution/invariant-reservations.md` and claim the next free block (size 3) in the same PR. At file authoring time the block is **90–92**; this packet uses `{N1}/{N2}/{N3}` placeholders throughout — substitute the actual numbers at PR time. If a racing ADR's packet 00 lands first, rebase upward, update the registry row, and update every `{N*}` placeholder here and in `constitution/invariants.md` together.
+- **New section.** The three IaC invariants are a new cross-cutting topic; create a `## Infrastructure-as-Code Invariants` section after `## Audit Invariants` rather than appending to an unrelated section.
+- **Invariant 35 amendment is mandatory and lands in this PR.** Invariant 35 today names `acrhdshared{env}` as "the" shared ACR — a literal collision with the new `acrhdbicep` registry that packets 01/02 catalog and provision. Amend invariant 35's text in this same PR to explicitly carve out the Bicep-module ACR per the wording in step 5 of Proposed Implementation. Do NOT defer the amendment to a follow-up packet; the constitution must not contradict the catalog/walkthrough work that lands in Waves 1–2.
+
+## Labels
+`chore`, `tier-3`, `ops`, `docs`, `adr-0077`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0077 to Accepted, claim the next free invariant block in `invariant-reservations.md`, add the three IaC invariants to `constitution/invariants.md`, amend invariant 35 to carve out `acrhdbicep`, and register the Bicep IaC initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0077 so the remaining packets in this initiative can reference its decisions as live rules.
+- Feature: ADR-0077 Infrastructure-as-Code — Bicep rollout, Wave 1.
+- ADRs: ADR-0077 (primary), ADR-0008 (initiative/packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0077 stays Proposed until this PR merges.
+- Claim the invariant block from `constitution/invariant-reservations.md` in this same PR. The reserved range at file authoring is **90–92**; substitute the live `{N1}/{N2}/{N3}` placeholders against the registry at PR time. Land the three new invariants under a new `## Infrastructure-as-Code Invariants` section; do not renumber existing invariants.
+- Amend invariant 35's text in the same PR to carve out `acrhdbicep` — the constitution must not contradict the new registry catalog/walkthrough work in packets 01/02. Invariant 35 keeps its number; only the text changes.
+
+**Key Files:**
+- `adrs/ADR-0077-infrastructure-as-code-bicep.md`
+- `adrs/README.md`
+- `constitution/invariant-reservations.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0077-iac-bicep/01-architecture-bicep-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0077-iac-bicep/01-architecture-bicep-catalog-registration.md
@@ -1,0 +1,121 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0077", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0077"]
+accepts: ["ADR-0077"]
+wave: 1
+initiative: adr-0077-iac-bicep
+node: honeydrunk-architecture
+---
+
+# Register the Bicep modules library, the acrhdbicep registry, and the deploy workflows in the Grid catalogs
+
+## Summary
+Record ADR-0077's IaC substrate as catalog data: register the Bicep modules library and its publish/deploy workflows in `catalogs/contracts.json` under `honeydrunk-actions` (the Node that owns the modules library and the workflows per ADR-0012); add the `acrhdbicep` Bicep registry as a new "not-yet-provisioned" entry in `catalogs/grid-health.json` so packet 02's portal work flips it to `provisioned`; and update the `honeydrunk-actions` entry in `catalogs/relationships.json` to expose the new module-library and workflow surface.
+
+## Context
+ADR-0077 D2 places the Bicep modules library in `HoneyDrunk.Actions/bicep/modules/` and publishes modules to a dedicated `acrhdbicep` Azure Container Registry. D4 places the `job-deploy-bicep.yml` reusable deploy workflow in `HoneyDrunk.Actions`. Per ADR-0012, Actions is the Grid's CI/CD control plane — placing both the modules library and the deploy/publish workflows here is consistent with that role.
+
+The Grid catalogs are the discoverability surface:
+- `catalogs/contracts.json` registers each Node's contracts in its node block's `interfaces` array. The Bicep modules surface (the per-concern modules, the publish workflow, the deploy workflow) is the closest thing the Actions Node has to a "contract" — it is a public consumption surface for every other Node's per-repo `infra/main.bicep`.
+- `catalogs/relationships.json` lists each Node's `exposes.contracts`; updating the `honeydrunk-actions` entry surfaces the new Bicep substrate to the dependency graph.
+- `catalogs/grid-health.json` tracks per-environment infrastructure provisioning state. The `acrhdbicep` registry is new infrastructure that does not yet exist; packet 02 provisions it and flips its grid-health entry to `provisioned`.
+
+This packet records only the **catalog** state. The actual library, workflows, modules, and registry land in subsequent packets (02–07).
+
+This is a catalog/docs packet. No code, no .NET project.
+
+## Scope
+- `catalogs/contracts.json` — locate the node block whose `node` value is `honeydrunk-actions`. If it has no `interfaces` array yet (Actions' contracts are workflows, not .NET interfaces — so the block may need to be created or extended), add an `interfaces` array with the new entries listed below. The `kind` for workflow entries is `workflow`; for the modules library it is `library`; for the registry it is `azure-resource`.
+- `catalogs/relationships.json` — append the new Bicep-substrate identifiers to the `honeydrunk-actions` entry's `exposes.contracts` (or the equivalent surface field for non-.NET Nodes — match the existing shape of the `honeydrunk-actions` entry). Do not invent a new field structure; if the existing entry exposes only workflow names, follow that pattern.
+- `catalogs/grid-health.json` — add a new entry for the `acrhdbicep` Bicep registry with state `not-provisioned` (packet 02 flips it). If `grid-health.json` already has a section for shared Azure resources (the per-environment ACR `acrhdshared{env}` for instance), follow that section's shape.
+- `catalogs/nodes.json` — **not edited.** nodes.json has no `exposes` field; the substrate surface lives in relationships.json and contracts.json.
+
+## Proposed Implementation
+1. **Inspect the existing shapes first.** Read the `honeydrunk-actions` block in `catalogs/contracts.json` and `catalogs/relationships.json` and the relevant section of `catalogs/grid-health.json`. The catalogs encode multiple Node types; match the existing shape for Actions (the CI/CD control-plane Node) rather than imposing a .NET-Node shape on it.
+2. **`catalogs/contracts.json`** — locate or create the `honeydrunk-actions` node block. Add the following entries to its `interfaces` array (the existing array name; do not rename):
+   - `bicep/modules` — `kind: library` — "The per-concern Bicep modules library shipped from `HoneyDrunk.Actions/bicep/modules/`. Published to the `acrhdbicep` Azure Container Registry on tagged release (`modules/v{N}.{N}.{N}`). Module groups: networking, compute, identity, data, secrets, messaging, observability. Consumed by per-Node `infra/main.bicep` templates via `br:acrhdbicep.azurecr.io/modules/{concern}/{name}:{semver}`."
+   - `bicep-publish.yml` — `kind: workflow` — "Reusable workflow that runs `az bicep publish` for each changed module against the `acrhdbicep` registry on tagged release. Trigger: tag push of the form `modules/v{N}.{N}.{N}`. Authenticated via the existing Actions OIDC federation."
+   - `job-deploy-bicep.yml` — `kind: workflow` — "Reusable deploy workflow that runs `az deployment group create` (or `az deployment sub create` for subscription-scoped resources) on a Node's `infra/main.bicep` with the appropriate `parameters.{env}.bicepparam` per ADR-0077 D4. Consumed by per-Node release workflows."
+   - `acrhdbicep` — `kind: azure-resource` — "The shared Azure Container Registry hosting the published Bicep modules per ADR-0077 D2. Environment-agnostic (single registry across `dev`/`staging`/`prod`). Distinct from the per-environment container-image registry `acrhdshared{env}` per invariant 35."
+   - `bicepconfig.json` — `kind: config` — "Bicep linter rules per ADR-0077 D3. Flags missing required tags (`hd:node`, `hd:env`, `hd:owner`, `hd:cost-center`, `hd:dr-tier`, `hd:adr`), non-conformant resource names, and hardcoded secret-shaped literals. Inherited by per-Node templates via Bicep's config-file resolution; enforced at PR time by the `bicep lint` step in `pr-core.yml`."
+3. **`catalogs/relationships.json`** — append the same identifiers (`bicep/modules`, `bicep-publish.yml`, `job-deploy-bicep.yml`, `acrhdbicep`, `bicepconfig.json`) to the `honeydrunk-actions` entry's `exposes.contracts` array (or whichever existing surface field is the equivalent for non-.NET Nodes). Do not create a new top-level Node-to-Node edge — every Node already depends on Actions via the existing reusable-workflow pattern; the Bicep substrate is additive on the same edge.
+4. **`catalogs/grid-health.json`** — add an entry for `acrhdbicep`. Match the shape of existing infrastructure entries: identifier, environment scope (`shared` — environment-agnostic), provisioning state (`not-provisioned` until packet 02 lands), the resource group it lives in (`rg-hd-platform-shared` recommended per the dispatch plan, or whichever RG the operator decides in packet 02 — leave it as a placeholder if unknown), the responsible ADR (`ADR-0077`).
+5. **`catalogs/nodes.json`** — no edit. nodes.json has no `exposes` field; do not invent one.
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+- `catalogs/grid-health.json`
+
+## NuGet Dependencies
+None. This packet touches only catalog JSON; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] Catalog data only — the modules library, workflows, registry, and per-Node templates land in packets 02–09.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` registers the Bicep substrate entries (`bicep/modules`, `bicep-publish.yml`, `job-deploy-bicep.yml`, `acrhdbicep`, `bicepconfig.json`) in the `honeydrunk-actions` node block, matching the existing entry shape for that block
+- [ ] `catalogs/relationships.json` `honeydrunk-actions` entry surfaces the new identifiers in its existing exposes-array shape, with all existing entries untouched
+- [ ] `catalogs/grid-health.json` has a new `acrhdbicep` entry with state `not-provisioned`, scoped `shared` (environment-agnostic), citing `ADR-0077`
+- [ ] `catalogs/nodes.json` is NOT modified (it has no `exposes` field)
+- [ ] No new top-level Node-to-Node edge is created — every Node already depends on Actions; the Bicep substrate is additive on the existing dependency
+- [ ] The `acrhdbicep` entry in grid-health.json is identifiable as distinct from `acrhdshared{env}` (the per-environment container-image registry — invariant 35) — comment or description field clarifies it
+- [ ] No invariant change in this packet (invariants land in packet 00)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0077 D2 — Modularize by concern.** Modules live in `HoneyDrunk.Actions/bicep/modules/` (Networking / Compute / Identity / Data / Secrets / Messaging / Observability). Published to `acrhdbicep` Azure Container Registry on tagged release via `bicep-publish.yml`. Per-Node templates consume modules via `br:acrhdbicep.azurecr.io/modules/{concern}/{name}:{semver}`. `acrhdbicep` is distinct from the per-environment container-image registry `acrhdshared{env}`.
+
+**ADR-0077 D3 — Linter rules in `bicepconfig.json`.** Naming and tagging conventions enforced; PR gate fails on violation.
+
+**ADR-0077 D4 — Per-environment deployment.** `main.bicep` + `parameters.{env}.bicepparam`; `job-deploy-bicep.yml` runs `az deployment group create` per environment.
+
+**ADR-0012 — Actions is the Grid CI/CD control plane.** The Bicep deploy/publish workflows and the modules library belong in `HoneyDrunk.Actions`.
+
+**Invariant 35 — One shared Container Apps Environment and one shared Azure Container Registry per environment.** `acrhdshared{env}` is the per-environment container-image registry. The Bicep modules registry `acrhdbicep` is a separate, environment-agnostic resource (D2 explicitly carves it out). Packet 00 reconciles the invariant text; this packet records the distinction in the catalog data.
+
+## Constraints
+- **Match existing catalog shapes for Actions.** Actions is not a .NET Node — its "contracts" are workflows and (now) Bicep modules. Inspect the existing `honeydrunk-actions` blocks in contracts.json and relationships.json and follow that shape rather than imposing the .NET-Node shape on it.
+- **Do not register the modules themselves.** Individual modules (`compute/containerApp`, etc.) ship in packet 05. This packet records only the **library surface** and the workflows that publish/deploy it.
+- **`acrhdbicep` is distinct from `acrhdshared{env}`.** The catalog entry must make the distinction visible — they are different resources for different purposes, despite the shared `acrhd` prefix.
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0077`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Register the Bicep modules library, the `acrhdbicep` registry, and the `bicep-publish.yml` / `job-deploy-bicep.yml` workflows in the Grid catalogs under `honeydrunk-actions`, and add `acrhdbicep` as a `not-provisioned` entry in `grid-health.json`.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Keep the catalogs accurate so subsequent implementation packets (02–09) read a correct substrate surface.
+- Feature: ADR-0077 IaC — Bicep rollout, Wave 1.
+- ADRs: ADR-0077 D2/D3/D4 (primary), ADR-0012 (Actions as CI/CD control plane), invariant 35 (per-environment container-image ACR — the Bicep registry is a carve-out).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0077 should be Accepted before its substrate is recorded as catalog data.
+
+**Constraints:**
+- Match existing catalog shapes for `honeydrunk-actions` — Actions is not a .NET Node.
+- Do not register individual modules (those ship in packet 05).
+- Distinguish `acrhdbicep` from `acrhdshared{env}` in the catalog data; they are different resources.
+- nodes.json is NOT edited — it has no `exposes` field.
+
+**Key Files:**
+- `catalogs/contracts.json` — new entries in the `honeydrunk-actions` block.
+- `catalogs/relationships.json` — `honeydrunk-actions` exposes-array enrichment.
+- `catalogs/grid-health.json` — new `acrhdbicep` entry, state `not-provisioned`.
+
+**Contracts:** None changed — this packet records catalog metadata for substrate that packets 02–07 implement.

--- a/generated/issue-packets/active/adr-0077-iac-bicep/02-architecture-bicep-registry-acr-walkthrough.md
+++ b/generated/issue-packets/active/adr-0077-iac-bicep/02-architecture-bicep-registry-acr-walkthrough.md
@@ -1,0 +1,147 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "infrastructure", "human-only", "adr-0077", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0077", "ADR-0015"]
+accepts: ["ADR-0077"]
+wave: 2
+initiative: adr-0077-iac-bicep
+node: honeydrunk-architecture
+---
+
+# Author the Bicep registry ACR walkthrough and provision acrhdbicep
+
+## Summary
+Author `infrastructure/walkthroughs/bicep-registry-acr-creation.md` — an Azure-Portal UI walkthrough for creating the shared `acrhdbicep` Azure Container Registry that hosts the Grid's published Bicep modules per ADR-0077 D2 — and execute it: provision the `acrhdbicep` registry in `rg-hd-platform-shared`, grant the Actions OIDC-federated identity `AcrPush` on it (so `bicep-publish.yml` can push modules), and grant per-environment Container App deploy identities `AcrPull` (or scope `AcrPull` more broadly to the deploy identities used by `job-deploy-bicep.yml` consumers). This is `Actor=Human` — Azure resource creation is portal work and the operator prefers UI walkthroughs over CLI.
+
+## Context
+ADR-0077 D2 commits a **dedicated** Bicep modules registry, distinct from the per-environment container-image registry `acrhdshared{env}` (invariant 35). The Bicep registry is **environment-agnostic** — a single registry across `dev`/`staging`/`prod` — because Bicep modules are environment-agnostic templates; per-environment module registries would force version-bump-and-republish per environment for no security gain.
+
+**Why a new resource group.** The container-image ACR `acrhdshared{env}` and the Container Apps environment `cae-hd-{env}` live in `rg-hd-platform-{env}` per [container-registry-creation.md](../../../../infrastructure/walkthroughs/container-registry-creation.md) and [container-apps-environment-creation.md](../../../../infrastructure/walkthroughs/container-apps-environment-creation.md) — those are per-environment platform resources. The Bicep registry is **not** per-environment, so it does not belong in `rg-hd-platform-{env}`. Recommendation: a new `rg-hd-platform-shared` resource group for non-environment-scoped shared resources (the Bicep registry, and any future shared substrate). The walkthrough records the RG decision; if the operator prefers a different RG, document the choice.
+
+**Naming.** `acrhdbicep` — alphanumeric, globally unique, 11 chars — comfortably inside the ACR name limit (5–50 chars, alphanumeric only). No environment suffix per its environment-agnostic role.
+
+**Cheapest viable tier.** **Basic SKU.** The Bicep registry's storage and bandwidth requirements are minimal (Bicep modules are small text files, not multi-GB container images). The shared container-image ACR uses Basic too per the existing walkthrough; same posture here. Show the estimated cost before the Create click — Basic is ~$0.167/day = ~$5/month. The walkthrough documents that estimate.
+
+**RBAC.** Two role assignments needed up-front:
+- The Actions OIDC-federated identity needs `AcrPush` on the registry so the `bicep-publish.yml` workflow (packet 04) can push modules on tag.
+- The Actions OIDC-federated identity (or whichever per-environment deploy identity `job-deploy-bicep.yml` uses) needs `AcrPull` so per-Node `main.bicep` templates can resolve `br:acrhdbicep.azurecr.io/modules/...` references at deploy time.
+
+In the current single-subscription posture, the same Actions OIDC identity handles both push (publish) and pull (deploy). The walkthrough records this and the per-role assignment pattern.
+
+This packet authors a walkthrough doc **and** executes it (provisioning is one-time, environment-agnostic — no `dev`/`staging`/`prod` repetition unlike the per-environment walkthroughs). No code, no .NET project.
+
+## Scope
+- `infrastructure/walkthroughs/bicep-registry-acr-creation.md` (new) — the Azure Portal UI walkthrough.
+- `catalogs/grid-health.json` — flip the `acrhdbicep` entry from `not-provisioned` to `provisioned` once the registry is live (entry added by packet 01).
+- The Azure subscription — the actual `acrhdbicep` registry, the `rg-hd-platform-shared` resource group (if it does not already exist), and the RBAC role assignments.
+
+## Proposed Work (human-executed, Azure Portal)
+Author the walkthrough to cover, and then execute, the following:
+
+1. **Platform-shared resource group.** Create `rg-hd-platform-shared` if it does not exist. Location: a single canonical region (recommended: the same region as the operator's primary `dev` deployments — record the choice). Tags `purpose=platform-shared`; do not tag `env` since this RG is environment-agnostic.
+2. **`acrhdbicep` Azure Container Registry.** Portal breadcrumb: **Container registries → + Create**. On **Basics**:
+   - Subscription: the Grid's subscription.
+   - Resource group: `rg-hd-platform-shared`.
+   - Registry name: `acrhdbicep` (alphanumeric, globally unique, 11 chars — inside the ACR limit).
+   - Location: same as `rg-hd-platform-shared`.
+   - Domain name label scope: **Unsecure** (consistent with the existing `acrhdshared{env}` walkthrough — the Grid documents the plain `acrhdbicep.azurecr.io` form across naming conventions; switching to Secure would force renaming).
+   - Pricing plan: **Basic** (show the estimated cost — ~$5/month — before the Create click).
+   - Role assignment permissions mode: **RBAC Registry Permissions** (no ABAC; consistent with the existing image ACR's posture).
+3. **Networking, Encryption, Tags.** Networking → Public access — All networks (consistent with the existing image ACR; private-link is a separate decision). Encryption → CMK disabled (Basic SKU does not support CMK). Tags: `purpose=platform-shared`, `hd:adr=ADR-0077`. Do not tag `env`.
+4. **Post-create hardening.**
+   - Open the registry → **Settings → Access keys**. Confirm **Admin user** is **Disabled**.
+   - Open **Monitoring → Diagnostic settings → + Add diagnostic setting**. Name `acrhdbicep-audit-to-loganalytics`. Categories `ContainerRegistryLoginEvents`, `ContainerRegistryRepositoryEvents`, AllMetrics. Send to `log-hd-shared-{env}` — for an environment-agnostic registry, pick the `dev` workspace (or whichever workspace the operator designates for shared-resource audit). Document the choice. Invariant 22 (Key Vaults must have diagnostic settings) does not literally apply to ACR, but the same audit-routing discipline is the right shape.
+5. **RBAC assignments.**
+   - **`AcrPush` for the Actions OIDC-federated identity.** Open the registry → **Access control (IAM) → + Add → Add role assignment**. Role `AcrPush`. Assignees: the Actions OIDC-federated service principal (the same identity used by the deploy workflows per the existing `oidc-federated-credentials.md` walkthrough). Scope: the `acrhdbicep` registry.
+   - **`AcrPull` for the deploy path.** Same `+ Add role assignment`. Role `AcrPull`. Assignees: the deploy identity used by `job-deploy-bicep.yml` consumers. If this is the same Actions OIDC identity (current single-subscription posture), assign once. If a future split deploys per-environment with per-environment identities, document the multi-assignment shape.
+6. **Update `grid-health.json`.** Flip the `acrhdbicep` entry from `not-provisioned` to `provisioned`. Record the actual resource group name if it differs from the recommended `rg-hd-platform-shared`.
+
+## Affected Files
+- `infrastructure/walkthroughs/bicep-registry-acr-creation.md` (new)
+- `catalogs/grid-health.json` — `acrhdbicep` entry flipped to `provisioned`.
+
+## NuGet Dependencies
+None. This packet has no .NET project — it is an Azure-Portal walkthrough plus a catalog update.
+
+## Boundary Check
+- [x] The walkthrough doc and `grid-health.json` update live in `HoneyDrunk.Architecture` — correct home for infrastructure walkthroughs and catalog metadata.
+- [x] No code change in any repo.
+- [x] Azure resources land in the Azure subscription (a vendor surface, not a Node).
+
+## Acceptance Criteria
+- [ ] `infrastructure/walkthroughs/bicep-registry-acr-creation.md` exists as a step-by-step Azure-Portal UI walkthrough covering the `rg-hd-platform-shared` resource group creation, the `acrhdbicep` Basic-SKU registry creation, the diagnostic-settings routing, the `AcrPush` role assignment for the Actions OIDC identity, and the `AcrPull` role assignment for the deploy path
+- [ ] The walkthrough shows the estimated cost before the Create click (~$5/month Basic SKU) and documents the resource-group decision (recommended: `rg-hd-platform-shared`)
+- [ ] The walkthrough explicitly distinguishes `acrhdbicep` from the per-environment `acrhdshared{env}` container-image registry (different purpose, different scope, separate resource)
+- [ ] The `acrhdbicep` registry exists in the Azure subscription, Basic SKU, admin user disabled
+- [ ] Diagnostic settings route ACR audit events to a Log Analytics workspace (the walkthrough records which workspace was chosen)
+- [ ] The Actions OIDC-federated identity has `AcrPush` on the registry, scoped to the registry
+- [ ] The deploy identity has `AcrPull` on the registry (in the current single-subscription posture this is the same Actions OIDC identity)
+- [ ] `catalogs/grid-health.json` `acrhdbicep` entry is flipped to `provisioned` with the actual resource group name recorded
+- [ ] No connection string, registry password, or any secret value appears in the walkthrough or anywhere in the repo (invariant 8) — the Bicep workflows authenticate via OIDC, not via stored credentials
+- [ ] The registry has no images / modules at create time — packet 05 publishes the first module set (`modules/v1.0.0`)
+
+## Human Prerequisites
+This entire packet is `Actor=Human`. The human-executed steps are the Proposed Work list above. Specifically:
+- [ ] Azure Portal access to the subscription with rights to create resource groups and Container Registries.
+- [ ] A decision on the resource-group location (recommended: same region as primary `dev` deployments).
+- [ ] A decision on which Log Analytics workspace receives the registry's audit events (for an environment-agnostic registry the `dev` workspace is a reasonable default; the walkthrough records the choice).
+- [ ] The Actions OIDC-federated service principal exists per the existing `oidc-federated-credentials.md` walkthrough — confirm before assigning `AcrPush` / `AcrPull`. If it does not yet exist for this scope, create it as part of this packet's portal work or note it as a prerequisite.
+- [ ] Acceptance of the Azure charges (~$5/month Basic SKU; within the operator's lean Azure-spend posture).
+
+## Referenced ADR Decisions
+**ADR-0077 D2 — Bicep registry on Azure Container Registry, distinct from the image ACR.** Bicep modules are environment-agnostic templates; a single shared registry across environments is the right shape. The registry is named `acrhdbicep` and is distinct from the per-environment container-image registry `acrhdshared{env}` per invariant 35.
+
+**ADR-0077 D7 — Bicep templates never contain secret values; deploy identity has provisioning rights, not secret-read rights.** The registry-side enforcement is the OIDC-federated identity scoped to `AcrPush` / `AcrPull` on the registry, not to broader secret-read scopes.
+
+**ADR-0015 — Container Apps and the container-image ACR (`acrhdshared{env}`).** The per-environment image ACR is the precedent for the ACR-creation walkthrough; the Bicep registry walkthrough mirrors its shape with the key differences noted (environment-agnostic, different RG, different name).
+
+**Invariant 35 — One shared Container Apps Environment and one shared Azure Container Registry per environment.** The per-environment image ACR is `acrhdshared{env}`. The Bicep registry `acrhdbicep` is a separate, environment-agnostic resource. Packet 00's invariant 35 reconciliation clarifies the distinction; this packet operationalizes it.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The registry's access keys are not used — the Bicep workflows authenticate via the OIDC-federated identity, not via stored credentials. Admin user disabled, no access-key copy-paste into config files.
+
+> **Invariant 17 — One Key Vault per deployable Node per environment.** Not directly applicable (the Bicep registry is not a Vault), but the same discipline — no shared identities across Nodes, no Node references another Node's Vault. The Actions OIDC identity is the Actions Node's deploy identity; it has scoped access to `acrhdbicep` for push / pull, nothing more.
+
+> **Invariant 22 — Every Key Vault must have diagnostic settings routed to the shared Log Analytics workspace.** Literally applies to Key Vaults, not ACR — but the same diagnostic-routing discipline is the right shape for the Bicep registry.
+
+- **Provision once, environment-agnostic.** No `dev`/`staging`/`prod` repetition — a single shared registry.
+- **Basic SKU.** Cheapest viable tier (per the lean-Azure-spend posture); show cost before Create.
+- **Portal-only, UI walkthrough.** No Bicep, no ARM, no CLI — the operator's portal-over-CLI preference. (The irony of using portal to provision the Bicep registry is acknowledged — D6's grandfather pattern explicitly anticipates this: the substrate has to bootstrap somewhere, and that bootstrap is operator-executed portal work.)
+- **Distinct from `acrhdshared{env}`.** The walkthrough explicitly clarifies this so a future executor does not conflate the two.
+
+## Labels
+`feature`, `tier-2`, `ops`, `infrastructure`, `human-only`, `adr-0077`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author the `bicep-registry-acr-creation.md` walkthrough and provision `acrhdbicep` in the Azure subscription with the necessary RBAC assignments for push (publish workflow) and pull (deploy workflow).
+
+**Target:** Tracked against `HoneyDrunk.Architecture`; the Azure work is human-executed in the Azure Portal. `Actor=Human` — `human-only` label set. The walkthrough doc lands in `infrastructure/walkthroughs/`.
+
+**Context:**
+- Goal: Stand up the Bicep modules registry so packet 04's `bicep-publish.yml` workflow has a target to push to and packet 05's first module set has a registry to land in.
+- Feature: ADR-0077 IaC — Bicep rollout, Wave 2.
+- ADRs: ADR-0077 D2/D7 (primary), ADR-0015 (image ACR — the analogous walkthrough), invariant 35 (per-environment image ACR — the Bicep registry is a carve-out).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0077 should be Accepted (and invariant 35 reconciled) before its registry is provisioned.
+
+**Constraints:**
+- Environment-agnostic — provision once, not per-environment.
+- Basic SKU — cheapest viable; show cost before Create.
+- Portal-only UI walkthrough — no Bicep/ARM/CLI.
+- Distinct from `acrhdshared{env}` — the walkthrough explicitly clarifies this.
+- Admin user disabled; OIDC-federated identity is the only authenticated principal (invariant 8).
+- Diagnostic settings route to Log Analytics — same discipline as Key Vaults per invariant 22 (literally applies to Vaults, but the routing pattern carries).
+
+**Key Files:**
+- `infrastructure/walkthroughs/bicep-registry-acr-creation.md` (new)
+- `catalogs/grid-health.json`
+
+**Contracts:** None — Azure resources, no code.

--- a/generated/issue-packets/active/adr-0077-iac-bicep/03-actions-bicep-modules-library-scaffold.md
+++ b/generated/issue-packets/active/adr-0077-iac-bicep/03-actions-bicep-modules-library-scaffold.md
@@ -1,0 +1,146 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "infrastructure", "adr-0077", "wave-3"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0077", "ADR-0012"]
+wave: 3
+initiative: adr-0077-iac-bicep
+node: honeydrunk-actions
+---
+
+# Scaffold the bicep/modules library layout and bicepconfig.json linter rules
+
+## Summary
+Scaffold the Bicep modules library structure in `HoneyDrunk.Actions/bicep/` per ADR-0077 D2 — create the seven per-concern subdirectories (`networking/`, `compute/`, `identity/`, `data/`, `secrets/`, `messaging/`, `observability/`), an empty-state `README.md` documenting the library's conventions and the registry-publish flow, and `bicepconfig.json` carrying the linter rules that enforce ADR-0077 D3 (required tags, name conventions, secret-shaped-literal detection). Do not author actual modules yet — those land in packet 05.
+
+## Context
+ADR-0077 D2 places the canonical Bicep modules library in `HoneyDrunk.Actions/bicep/modules/`, organized by **concern** (not by Node):
+
+| Module group | Owns |
+|---|---|
+| **Networking** | Virtual networks, subnets, private endpoints, NSGs, public IPs, DNS zones |
+| **Compute** | Container Apps environment, Container Apps, Container Apps Jobs, Function Apps |
+| **Identity** | Managed identities, role assignments, RBAC scopes |
+| **Data** | SQL servers, SQL databases, Postgres servers, Cosmos accounts, Storage accounts, Redis |
+| **Secrets** | Key Vault, Key Vault secrets-as-resources, App Configuration stores |
+| **Messaging** | Service Bus namespaces, topics, subscriptions, queues, Event Grid topics |
+| **Observability** | Application Insights, Log Analytics, Action Groups, Alerts |
+
+ADR-0077 D3 commits the linter rules in `bicepconfig.json`. The rules enforce:
+- Required tags on every resource: `hd:node`, `hd:env`, `hd:owner`, `hd:cost-center`, `hd:dr-tier`, `hd:adr`.
+- Resource-name conventions: per-resource-type prefix (`ca-`, `redis-`, `kv-`, `sb-`, `acr`, `cae-`, `log-`, etc.), `hd-` Grid identifier, `{service}` or `{node}` name within the ≤13-char service-name length limit per invariant 19, `{env}` suffix.
+- Best-effort secret-shaped-literal detection (`accountKey`, `connectionString`, `password`, `apiKey` literals) to enforce ADR-0077 D7 / invariant 85.
+
+Bicep's `bicepconfig.json` supports custom analyzer rules via its `analyzers.core.rules` block and pluggable conventions. The first cut of rules uses Bicep's built-in linter rule set with project-specific severity tuning; pure-custom rules (Bicep does not yet support fully arbitrary user-defined rules) for tag and name enforcement land as required-input checks expressed via module-parameter `@allowed` / `@minLength` / `@description` decorators inside each module rather than via the global linter. **Document this clearly in the library README and the `bicepconfig.json` comments** — the linter handles what Bicep's analyzer surface supports; the module structure itself enforces the rest at module-author time.
+
+This packet **does not** author actual modules — packet 05 does that. This packet ships the scaffold and the rules so packet 04 (the publish workflow) and packet 05 (the modules) have a stable surface to land on.
+
+`HoneyDrunk.Actions` is the Grid's CI/CD control plane per ADR-0012. The repo is not a versioned .NET solution — no version bump, no `## NuGet Dependencies`. The repo `CHANGELOG.md` (if it keeps one for the workflow surface) is updated per the repo convention.
+
+## Scope
+- `bicep/` (new top-level directory in `HoneyDrunk.Actions`).
+- `bicep/README.md` (new) — documents the library's conventions, the seven per-concern subdirectories, the registry-publish flow (`bicep-publish.yml` — packet 04), the module reference pattern (`br:acrhdbicep.azurecr.io/modules/{concern}/{name}:{semver}`), and the linter rule set.
+- `bicep/modules/networking/.gitkeep` — placeholder so the empty directory tracks in git.
+- `bicep/modules/compute/.gitkeep`
+- `bicep/modules/identity/.gitkeep`
+- `bicep/modules/data/.gitkeep`
+- `bicep/modules/secrets/.gitkeep`
+- `bicep/modules/messaging/.gitkeep`
+- `bicep/modules/observability/.gitkeep`
+- `bicep/bicepconfig.json` (new) — the linter configuration. Placed at `bicep/` (not `bicep/modules/`) so it applies to the modules **and** to any future per-repo `infra/main.bicep` examples or test templates that might land in the repo. Bicep resolves `bicepconfig.json` by file-system search from the template directory upward.
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface — a new entry for the `bicep/` substrate.
+
+## Proposed Implementation
+1. **Create the directory tree.** `bicep/`, `bicep/modules/`, and the seven per-concern subdirectories. Each per-concern subdirectory gets a `.gitkeep` for git tracking. The repo's existing `actions/`, `docs/`, `examples/`, `scripts/` top-level dirs are the precedent for a new top-level `bicep/`.
+2. **`bicep/README.md`** — author it with these sections:
+   - **Library purpose** — quote ADR-0077 D2 verbatim on per-concern modularization and registry publishing.
+   - **Per-concern subdirectories** — the table from ADR-0077 D2 (the seven concerns and what each owns).
+   - **Module file convention** — one Bicep file per module, named `{name}.bicep` (e.g. `compute/containerApp.bicep`). Tests, if added later, in a sibling `{name}.tests.bicep`. Per-concern subdir may carry a small `README.md` listing its modules and their parameters once modules land.
+   - **Publish flow** — `bicep-publish.yml` (packet 04) runs `az bicep publish` for each changed module against `acrhdbicep` on tagged release of the form `modules/v{N}.{N}.{N}`. The publish flow is per-tag, not per-PR — modules are version-pinned at consumer time, never overwritten.
+   - **Module reference pattern** — consumers reference the registry path with an immutable version: `br:acrhdbicep.azurecr.io/modules/{concern}/{name}:{semver}`. Local-path references (`./modules/...`) are forbidden in per-Node templates — only registry references.
+   - **Linter rules** — what `bicepconfig.json` enforces and what is enforced by module-parameter convention instead.
+3. **`bicep/bicepconfig.json`** — author with these settings:
+   - The Bicep schema reference (`$schema: https://aka.ms/bicep/bicepconfig-schema.json`).
+   - `analyzers.core.enabled: true`.
+   - `analyzers.core.rules` block enabling the built-in rules that align with ADR-0077: `no-hardcoded-env-urls`, `no-unused-params`, `no-unused-vars`, `secure-parameter-default`, `secure-params-in-nested-deploy`, `outputs-should-not-contain-secrets`, `simplify-interpolation`, `prefer-interpolation`, `protect-commandtoexecute-secrets`, `use-resource-id-functions`, `use-stable-resource-identifiers`, `use-stable-vm-image`. Set severity `error` on the security-shaped rules (`secure-parameter-default`, `outputs-should-not-contain-secrets`, `protect-commandtoexecute-secrets`, `secure-params-in-nested-deploy`); `warning` on the others.
+   - Include a `// ` JSON-comment block (Bicep's `bicepconfig.json` supports JSON-with-comments) explaining what the file does NOT enforce (per-Node tag presence, name convention) and why (Bicep's analyzer surface does not yet support fully custom rules; tag/name enforcement is module-author convention via `@allowed` parameters and the module README).
+4. **Update the repo `CHANGELOG.md`** if the repo keeps one for the workflow surface — note the new `bicep/` substrate and the ADR-0077 reference.
+
+## Affected Files
+- `bicep/` (new directory tree)
+- `bicep/README.md` (new)
+- `bicep/bicepconfig.json` (new)
+- `bicep/modules/{networking,compute,identity,data,secrets,messaging,observability}/.gitkeep` (new)
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface
+
+## NuGet Dependencies
+None. `HoneyDrunk.Actions` ships GitHub Actions YAML and (now) Bicep — no .NET project is created or modified by this packet.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo — ADR-0077 D2 names "`HoneyDrunk.Actions/bicep/modules/`" as the canonical home; ADR-0012 makes Actions the CI/CD control plane.
+- [x] The seven per-concern subdirectory structure matches ADR-0077 D2's table exactly.
+- [x] No code change in any Node — this is repo scaffolding.
+
+## Acceptance Criteria
+- [ ] `bicep/` directory exists at the repo root with seven per-concern subdirectories (`networking`, `compute`, `identity`, `data`, `secrets`, `messaging`, `observability`) each holding a `.gitkeep` so empty dirs track in git
+- [ ] `bicep/README.md` documents the library purpose (verbatim quote of ADR-0077 D2's modularization rationale), the per-concern subdirectory table, the file convention (`{name}.bicep`), the publish flow (`bicep-publish.yml` on `modules/v{N}.{N}.{N}` tag), and the module-reference pattern (`br:acrhdbicep.azurecr.io/modules/{concern}/{name}:{semver}`)
+- [ ] `bicep/bicepconfig.json` carries the Bicep linter rules enabling the security-shaped rules at `error` severity (`secure-parameter-default`, `outputs-should-not-contain-secrets`, `protect-commandtoexecute-secrets`, `secure-params-in-nested-deploy`) and the convention rules at `warning` severity
+- [ ] `bicep/bicepconfig.json` carries a comment block explicitly stating what the file does NOT enforce (per-Node tag presence, full name convention) and why — so a future executor reading the rules understands the scope
+- [ ] `bicep/README.md` documents that tag and name enforcement is module-author convention (via `@allowed` / `@minLength` / `@description` decorators and the module README) until Bicep's analyzer surface supports custom rules
+- [ ] No `.bicep` file exists in `bicep/modules/` yet — module authoring lives in packet 05
+- [ ] No workflow file is added or modified by this packet — `bicep-publish.yml` is packet 04; the `bicep lint` PR gate is packet 07
+- [ ] The repo `CHANGELOG.md` is updated if the repo keeps one for the workflow surface
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0077 D2 — Modularize by concern.** Modules live in `HoneyDrunk.Actions/bicep/modules/`, organized by the seven per-concern subdirectories. Published to `acrhdbicep` on tagged release (`modules/v{N}.{N}.{N}`). Per-Node templates consume via registry references; local-path references forbidden in per-Node templates.
+
+**ADR-0077 D3 — Linter rules in `bicepconfig.json`.** Required tags, naming conventions, secret-shaped-literal detection. CI gate (packet 07) fails the PR on violation. `bicepconfig.json` enforces what Bicep's analyzer surface supports; the rest is module-author convention until Bicep's analyzer surface evolves.
+
+**ADR-0012 — Actions is the Grid CI/CD control plane.** The Bicep modules library and the publish/deploy workflows belong in `HoneyDrunk.Actions`.
+
+**Invariant 19 — Service names in Azure resource naming must be ≤ 13 characters.** Modules accepting a `service` or `node` name parameter should `@maxLength(13)` that parameter to enforce the invariant at module-author time.
+
+## Constraints
+- **Module structure mirrors ADR-0077 D2's table exactly.** Seven subdirectories, the concerns named verbatim. Do not add or rename; if a future need arises, that is a follow-up packet.
+- **No actual modules in this packet.** `.gitkeep` placeholders only. Module authoring is packet 05.
+- **`bicepconfig.json` enables built-in rules; custom rules deferred.** Bicep does not yet support fully custom analyzer rules. The README documents this clearly.
+- **Local-path module references are forbidden in per-Node templates.** Document this in the README; modules-in-this-repo reference siblings by relative path during local development, but per-Node `infra/main.bicep` references use registry paths only.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `infrastructure`, `adr-0077`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Scaffold the Bicep modules library tree (`bicep/modules/{networking,compute,identity,data,secrets,messaging,observability}/`), author the library README, and commit the `bicepconfig.json` linter rules. Do not author actual modules.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Land the library substrate so packet 04 (publish workflow) and packet 05 (first module set) can build on a stable scaffold.
+- Feature: ADR-0077 IaC — Bicep rollout, Wave 3.
+- ADRs: ADR-0077 D2/D3 (primary), ADR-0012 (Actions as CI/CD control plane), invariant 19 (≤13-char service names).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0077 should be Accepted before its substrate scaffold lands.
+
+**Constraints:**
+- Module structure exactly matches ADR-0077 D2's seven concerns — verbatim names.
+- No actual modules in this packet — `.gitkeep` only.
+- `bicepconfig.json` enables Bicep's built-in security-shaped rules at `error` severity; convention rules at `warning`.
+- Document what the linter does NOT enforce, and why — so a future executor understands the scope.
+- Local-path module references are forbidden in per-Node templates — registry references only.
+
+**Key Files:**
+- `bicep/README.md`
+- `bicep/bicepconfig.json`
+- `bicep/modules/{networking,compute,identity,data,secrets,messaging,observability}/.gitkeep`
+
+**Contracts:** None — repo scaffolding only.

--- a/generated/issue-packets/active/adr-0077-iac-bicep/04-actions-bicep-publish-workflow.md
+++ b/generated/issue-packets/active/adr-0077-iac-bicep/04-actions-bicep-publish-workflow.md
@@ -1,0 +1,167 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "infrastructure", "adr-0077", "wave-3"]
+dependencies: ["packet:02", "packet:03"]
+adrs: ["ADR-0077", "ADR-0012"]
+wave: 3
+initiative: adr-0077-iac-bicep
+node: honeydrunk-actions
+---
+
+# Author bicep-publish.yml — the reusable workflow that publishes modules to acrhdbicep on tagged release
+
+## Summary
+Author `.github/workflows/bicep-publish.yml` in `HoneyDrunk.Actions` — the reusable workflow that runs `az bicep publish` for each Bicep module under `bicep/modules/` against the `acrhdbicep` Azure Container Registry on tagged release per ADR-0077 D2. Trigger: tag push of the form `modules/v{N}.{N}.{N}` (or `workflow_dispatch` for manual republish). Authenticated via the existing Actions OIDC federation. Publishes only modules whose files changed since the previous tag (best-effort) or all modules if change detection is not feasible.
+
+## Context
+ADR-0077 D2 commits the publish flow:
+
+> Module authors edit `HoneyDrunk.Actions/bicep/modules/` and tag a semantic-version release (`modules/v1.2.0` style). A reusable `bicep-publish` workflow in `HoneyDrunk.Actions` runs `az bicep publish` for each changed module against the target registry on tag.
+
+The workflow runs against `acrhdbicep` (provisioned by packet 02). It authenticates via the existing Actions OIDC-federated service principal (which has `AcrPush` per packet 02). It iterates over the modules under `bicep/modules/` and publishes each with the tag's SemVer as the immutable tag.
+
+**Tag shape.** `modules/v{N}.{N}.{N}` (e.g. `modules/v1.0.0`, `modules/v1.1.0`). The `modules/` prefix distinguishes module tags from any future repo-level tags (the repo itself is not versioned today; this leaves room).
+
+**Module versioning.** All modules in a tag receive the same SemVer. This is a simplification — if a single module changes, the tag bumps all modules' published versions. Consumers can either pin per-module (`br:acrhdbicep.azurecr.io/modules/compute/containerApp:1.0.0`) or to the most recent tag at consumption time. The simplification is intentional — per-module SemVer tracking with selective publish is a small library-management problem the Grid does not need to solve at v1. Document this in the workflow's comments and in the library README (packet 03).
+
+**Trigger.** Push of a tag matching `modules/v*.*.*`. Plus `workflow_dispatch` for manual republish (useful for re-running against a failed publish).
+
+**OIDC authentication.** Reuse the existing Actions OIDC federation pattern (per `oidc-federated-credentials.md`). The workflow needs `id-token: write` and `contents: read` permissions; it does not need `packages: write` (we are pushing to ACR, not GHCR).
+
+**`az bicep publish` invocation.** For each `bicep/modules/{concern}/{name}.bicep`:
+```
+az bicep publish \
+  --file bicep/modules/{concern}/{name}.bicep \
+  --target br:acrhdbicep.azurecr.io/modules/{concern}/{name}:{semver} \
+  --documentation-uri https://github.com/HoneyDrunkStudios/HoneyDrunk.Actions/blob/main/bicep/modules/{concern}/{name}.bicep \
+  --with-source
+```
+The `--with-source` flag embeds the original Bicep source in the published artifact — useful for `az bicep restore`'s decompile-on-demand. Cost: a few KB per module; negligible.
+
+**Change detection.** v1: publish every module on every tag. v2 (deferred): detect changed files via `git diff` between the current tag and the previous `modules/v*` tag and publish only changed modules. The v1 simplification is cheap (publishing ~6 small Bicep files takes seconds) and avoids the change-detection complexity.
+
+`HoneyDrunk.Actions` is the CI/CD control plane per ADR-0012; reusable workflows live in `.github/workflows/`. This is a workflow/YAML packet — no .NET project. The repo `CHANGELOG.md` (if it keeps one for the workflow surface) is updated per the repo convention.
+
+## Scope
+- `.github/workflows/bicep-publish.yml` (new) — the reusable workflow.
+- `docs/` — if the repo keeps a consumer-usage doc for reusable workflows, add a section documenting `bicep-publish.yml`.
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface.
+
+## Proposed Implementation
+1. **Workflow header.**
+   ```yaml
+   name: Bicep modules publish
+
+   on:
+     push:
+       tags:
+         - 'modules/v*.*.*'
+     workflow_dispatch:
+       inputs:
+         version:
+           description: 'SemVer to republish as (e.g., 1.0.1). Required for workflow_dispatch.'
+           required: true
+           type: string
+
+   permissions:
+     id-token: write
+     contents: read
+   ```
+2. **Single job: `publish`.**
+   - Runs on `ubuntu-latest`.
+   - Steps:
+     1. `actions/checkout@v4` — `ref` = the tag for push, the branch for dispatch.
+     2. **Derive the SemVer.** For tag push: strip the `modules/v` prefix from `${{ github.ref_name }}` (`modules/v1.0.0` → `1.0.0`). For dispatch: use `${{ inputs.version }}`.
+     3. **Azure login via OIDC.** Use `azure/login@v2` with `client-id`, `tenant-id`, `subscription-id` sourced from the existing repo secrets / variables that the other deploy workflows already use (the Actions OIDC-federated identity per `oidc-federated-credentials.md`).
+     4. **Enumerate modules.** Use `find bicep/modules -type f -name '*.bicep'` (or a `bash` loop) to discover modules. Skip `*.tests.bicep` files.
+     5. **Publish each module.** For each discovered `.bicep` file, derive the target path (`modules/{concern}/{name}` from the file path) and run the `az bicep publish` invocation documented above with `--with-source`.
+     6. **Summary.** Print a final summary listing each module → its target registry path → the SemVer published. Write the summary to `$GITHUB_STEP_SUMMARY` so consumers see it on the workflow run page.
+3. **Reusability shape.** The workflow is consumed via `workflow_call` so other repos (in principle) could publish modules to `acrhdbicep`. v1 only the Actions repo publishes — but the `workflow_call` shape keeps the door open. Reference the existing reusable workflows (`job-deploy-container-app.yml`, etc.) for the input shape.
+4. **Failure modes.**
+   - **Tag already published.** `az bicep publish` against an immutable tag in ACR fails by design — the workflow surfaces the error cleanly and exits non-zero. Republishing requires a SemVer bump.
+   - **No modules found.** If `bicep/modules/` has no `.bicep` files (this initiative's state at packet 03 merge — module files land in packet 05), the workflow logs "no modules to publish" and exits 0. This makes the workflow safe to wire before modules exist.
+   - **OIDC auth failure.** Surface the Azure error; do not retry. Operator intervention (re-check role assignments per packet 02) is the right response.
+5. **Docs.** If `docs/` has a reusable-workflow consumer guide, add a section documenting `bicep-publish.yml`: the trigger shape, the SemVer derivation, the secret/variable references, and the workflow_dispatch fallback path.
+
+## Affected Files
+- `.github/workflows/bicep-publish.yml` (new)
+- `docs/` — if a consumer-usage doc exists for reusable workflows, extend it
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface
+
+## NuGet Dependencies
+None. `HoneyDrunk.Actions` ships GitHub Actions YAML — no .NET project is created or modified.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo — ADR-0077 D2 names this exact workflow location; ADR-0012 makes Actions the CI/CD control plane.
+- [x] The workflow consumes the `acrhdbicep` registry (provisioned by packet 02) and the OIDC federation (existing).
+- [x] No code change in any Node — workflow YAML only.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/bicep-publish.yml` exists, triggers on `push.tags: modules/v*.*.*` and on `workflow_dispatch` (with a `version` input), and uses `permissions: { id-token: write, contents: read }`
+- [ ] The workflow authenticates to Azure via `azure/login@v2` using the existing OIDC-federated identity — no static secrets in the workflow or repo (invariant 8)
+- [ ] The workflow derives the SemVer from the tag (strip `modules/v` prefix) on tag push, or from the `version` input on dispatch
+- [ ] The workflow enumerates `bicep/modules/**/*.bicep` (skipping `*.tests.bicep`) and runs `az bicep publish --file {path} --target br:acrhdbicep.azurecr.io/modules/{concern}/{name}:{semver} --with-source --documentation-uri {github-blob-url}` for each
+- [ ] The workflow writes a summary of published modules to `$GITHUB_STEP_SUMMARY`
+- [ ] If `bicep/modules/` has no `.bicep` files, the workflow logs "no modules to publish" and exits 0 — safe to wire before modules exist
+- [ ] Republishing an existing tag fails cleanly (`az bicep publish` against an immutable tag returns non-zero) and the workflow surfaces the error
+- [ ] The workflow shape is `workflow_call`-callable (i.e., the trigger surface and the input shape do not preclude future reuse from another repo)
+- [ ] `docs/` consumer-usage doc (if it exists) documents `bicep-publish.yml`: trigger, SemVer derivation, OIDC requirement, dispatch fallback
+- [ ] The repo `CHANGELOG.md` is updated if the repo keeps one for the workflow surface
+- [ ] No actual module is published by this packet — packet 05 ships and tags the first module set (`modules/v1.0.0`)
+
+## Human Prerequisites
+- [ ] `acrhdbicep` exists and the Actions OIDC identity has `AcrPush` on it — both delivered by packet 02. The workflow does not need any portal click to land, but it will not produce a successful publish until packet 02 has provisioned the registry and assigned the role. Until then the workflow can be merged safely — it will only execute on a `modules/v*` tag, and packet 05 is what files the first tag.
+
+## Referenced ADR Decisions
+**ADR-0077 D2 — Publish flow.** "Module authors edit `HoneyDrunk.Actions/bicep/modules/` and tag a semantic-version release (`modules/v1.2.0` style). A reusable `bicep-publish` workflow in `HoneyDrunk.Actions` runs `az bicep publish` for each changed module against the target registry on tag. Module consumers reference the registry path with an immutable version: `br:acrhdbicep.azurecr.io/modules/{concern}/{name}:{semver}`."
+
+**ADR-0077 D7 — Deploy / publish identity has provisioning rights, not secret-read rights.** The OIDC-federated identity has `AcrPush` on `acrhdbicep`, scoped to the registry. It cannot read Vault secrets; it cannot push to `acrhdshared{env}` (the image registry).
+
+**ADR-0012 — Actions is the Grid CI/CD control plane.** Reusable workflows in `.github/workflows/` are the Grid's CI/CD surface.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry — or in workflow files.** OIDC authentication is the only credential path. No `AZURE_CREDENTIALS` JSON blob, no ACR access key, no registry password in the workflow or repo.
+
+- **OIDC-only.** The workflow uses the existing Actions OIDC federation — do not introduce a new service principal or a stored credential.
+- **Immutable tags.** ACR enforces tag immutability. Republishing requires a SemVer bump; the workflow surfaces the error cleanly.
+- **Safe to wire before modules exist.** A run on an empty `bicep/modules/` tree logs "no modules to publish" and exits 0. The workflow merge does not depend on packet 05's module set being authored.
+- **All modules share the tag's SemVer.** Per-module SemVer tracking with selective publish is deferred (small library-management problem, deferred to v2). Document this in the workflow comments.
+- **`workflow_call` reusability shape.** The workflow shape does not preclude future reuse from another repo, even if v1 only the Actions repo publishes.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `infrastructure`, `adr-0077`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Author `.github/workflows/bicep-publish.yml` — the reusable workflow that publishes Bicep modules under `bicep/modules/` to `acrhdbicep` on `modules/v*.*.*` tag push.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Make the Bicep modules library publishable on tag, so packet 05's first module set has a path to the registry.
+- Feature: ADR-0077 IaC — Bicep rollout, Wave 3.
+- ADRs: ADR-0077 D2/D7 (primary), ADR-0012 (Actions as CI/CD control plane).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — `acrhdbicep` exists with the Actions OIDC identity granted `AcrPush`. The workflow can merge before packet 02 is executed (it will only run on a `modules/v*` tag, and that tag is filed by packet 05); but the first successful execution requires packet 02 to be done.
+- `packet:03` — `bicep/modules/` directory tree exists. The workflow safely no-ops on an empty tree, so the strict need is only "the directory exists" — `packet:03` delivers that.
+
+**Constraints:**
+- OIDC-only — no stored credential in the workflow or repo (invariant 8).
+- ACR tags are immutable — republish requires a SemVer bump.
+- Safe to wire before modules exist — `bicep/modules/` empty → exit 0.
+- All modules in a tag share the tag's SemVer — per-module SemVer deferred to v2.
+- `workflow_call` reusability shape preserved.
+
+**Key Files:**
+- `.github/workflows/bicep-publish.yml` (new)
+- `docs/` consumer-usage doc (if it exists)
+
+**Contracts:**
+- Workflow trigger: `push.tags: modules/v*.*.*`, `workflow_dispatch.inputs.version`.
+- Workflow contract for consumers: tag a `modules/v{N}.{N}.{N}` → modules under `bicep/modules/` are published to `br:acrhdbicep.azurecr.io/modules/{concern}/{name}:{semver}` with `--with-source`.

--- a/generated/issue-packets/active/adr-0077-iac-bicep/05-actions-bicep-first-module-set.md
+++ b/generated/issue-packets/active/adr-0077-iac-bicep/05-actions-bicep-first-module-set.md
@@ -1,0 +1,215 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "infrastructure", "adr-0077", "wave-4"]
+dependencies: ["packet:02", "packet:03", "packet:04"]
+adrs: ["ADR-0077", "ADR-0015", "ADR-0005", "ADR-0028", "ADR-0040"]
+wave: 4
+initiative: adr-0077-iac-bicep
+node: honeydrunk-actions
+---
+
+# Author the first per-concern Bicep module set and tag modules/v1.0.0
+
+## Summary
+Author the first per-concern Bicep module set in `HoneyDrunk.Actions/bicep/modules/` per ADR-0077 D2's Follow-up Work — covering the six concerns named in the ADR: `compute/containerApp.bicep`, `secrets/keyVault.bicep`, `secrets/appConfigurationStore.bicep`, `data/storageAccount.bicep`, `messaging/serviceBusNamespace.bicep`, and `observability/applicationInsights.bicep`. Each module accepts the parameters needed to provision its resource per Grid naming and tagging conventions (D3) and references Vault for any secret-shaped input (D7). Tag `modules/v1.0.0` after merge so `bicep-publish.yml` (packet 04) publishes the set to `acrhdbicep`.
+
+## Context
+ADR-0077 D2's Follow-up Work names "a first set of modules covering Container Apps, Key Vault, App Configuration, Storage, Service Bus, and Application Insights." These six concerns map to the resource families the Grid already provisions today (or is about to provision per ADR-0059/0060/0061):
+
+| Module | Resource | Naming (D3) | Source ADR(s) |
+|---|---|---|---|
+| `compute/containerApp` | Azure Container App + system-assigned MI | `ca-hd-{service}-{env}` (≤13-char service) | ADR-0015 D2, invariant 34 |
+| `secrets/keyVault` | Azure Key Vault with Azure RBAC | `kv-hd-{node}-{env}` | ADR-0005 D3, invariant 17 |
+| `secrets/appConfigurationStore` | Azure App Configuration | `appcs-hd-{env}` (shared) | ADR-0005 |
+| `data/storageAccount` | Azure Storage Account | `sthd{node}{env}` (alphanumeric, ≤24 chars) | ADR-0036 (DR), ADR-0061 |
+| `messaging/serviceBusNamespace` | Azure Service Bus namespace | `sbns-hd-shared-{env}` or `sbns-hd-{node}-{env}` | ADR-0028 D5 |
+| `observability/applicationInsights` | Workspace-based App Insights | `appi-hd-{service}-{env}` | ADR-0040 D1 |
+
+Each module:
+- Accepts strongly-typed parameters with `@description`, `@minLength` / `@maxLength` (especially `@maxLength(13)` on `{service}` / `{node}` names per invariant 19), and `@allowed` for enumerations like `env`.
+- Applies the required tags from D3 (`hd:node`, `hd:env`, `hd:owner`, `hd:cost-center`, `hd:dr-tier`, `hd:adr`) — passed as a single `tags` object parameter so the consumer composes them once at the per-Node template level.
+- References secrets via Key Vault URI parameters, never as raw string parameters (D7 / invariant 85). For example, the `containerApp` module accepts an array of `secretRef: { name: 'X', keyVaultUrl: '...', identity: '...' }` rather than a `password: string` parameter.
+- Outputs the canonical resource id and any consumer-facing properties (FQDN, registry login server, namespace endpoint).
+- Has a sibling `README.md` or top-of-file comment block documenting the module's purpose, parameters, outputs, and example usage.
+
+**Parameter convention enforces what bicepconfig.json cannot.** Per packet 03, the linter does not yet support fully custom rules for tag and name conventions. The module-author convention — `@maxLength(13)` on service names, the `tags` parameter shape, the `secretRef` shape for secrets — is what enforces ADR-0077 D3 at module-author time. Consumers of the modules inherit the discipline automatically.
+
+**Module scope at v1.** This packet ships **only the six modules ADR-0077 D2 explicitly names**. Other modules (e.g. `data/redisCache` for ADR-0076 Cache, `data/postgresServer` for ADR-0060 Identity, `compute/containerAppJob`, `compute/functionApp`, `identity/userAssignedIdentity` + `identity/roleAssignment`, `networking/*`, `messaging/serviceBusTopic`, `observability/logAnalyticsWorkspace`, `observability/actionGroup`) are deferred to follow-up packets when their consuming Nodes scope their infrastructure work. The v1 set is the minimum that lets the Notify/Pulse existing deployables and the upcoming Cache/Identity/Files standups consume Bicep-from-day-one for the most common resources.
+
+**Tagging the publish.** After merge, the operator (or a follow-up automation) tags `modules/v1.0.0` to fire `bicep-publish.yml` and land the modules in `acrhdbicep`. The packet's acceptance criteria include the post-merge tag step.
+
+`HoneyDrunk.Actions` is the CI/CD control plane per ADR-0012. This is a Bicep authoring packet — no .NET project, no NuGet dependencies. The repo `CHANGELOG.md` is updated per the repo convention if it tracks Bicep modules.
+
+## Scope
+- `bicep/modules/compute/containerApp.bicep` (new)
+- `bicep/modules/secrets/keyVault.bicep` (new)
+- `bicep/modules/secrets/appConfigurationStore.bicep` (new)
+- `bicep/modules/data/storageAccount.bicep` (new)
+- `bicep/modules/messaging/serviceBusNamespace.bicep` (new)
+- `bicep/modules/observability/applicationInsights.bicep` (new)
+- Per-concern `README.md` files in each of `bicep/modules/{compute,secrets,data,messaging,observability}/` listing the modules and their parameter signatures
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow / Bicep surface
+
+## Proposed Implementation
+1. **Pattern, applied to each module.** Each `.bicep` file:
+   - Opens with a top-of-file comment block: purpose, ADR reference, parameter table, outputs, example usage.
+   - Declares strongly-typed parameters with decorators. Required tags go through a single `tags object` parameter; service / node names through `@maxLength(13)` `string` parameters; environment through `@allowed(['dev', 'staging', 'prod']) string env`.
+   - Declares the Azure resource with the conformant name shape (composed from the parameters).
+   - Applies the `tags` parameter to the resource.
+   - Outputs `id`, the resource's canonical name, and any consumer-relevant property (login server, FQDN, endpoint, namespace).
+2. **`compute/containerApp.bicep`.**
+   - Parameters: `service` (`@maxLength(13)` string), `env`, `tags`, `containerAppEnvironmentId`, `imageRef` (e.g. `acrhdshareddev.azurecr.io/honeydrunk/notify-functions:0.2.0`), `cpu` (default `0.25`), `memory` (default `0.5Gi`), `minReplicas` (default `0`), `maxReplicas` (default `1`), `revisionMode` (default `Multiple` per invariant 36), `secretRefs` (array of `{ name, keyVaultUrl, identity }`), `envVars` (array of `{ name, value }` or `{ name, secretRef }`), `ingress` (object with `external`, `targetPort`).
+   - Resource name: `'ca-hd-${service}-${env}'`.
+   - System-assigned managed identity enabled (invariant 34).
+   - Revision mode `Multiple` (invariant 36).
+   - Outputs: `id`, `name`, `fqdn`, `principalId` (the MI's principal id, for downstream role assignments).
+3. **`secrets/keyVault.bicep`.**
+   - Parameters: `node` (`@maxLength(13)` string), `env`, `tags`, `location`, `enableRbacAuthorization` (default `true` per ADR-0005), `enableSoftDelete` (default `true`, retention `90`), `enablePurgeProtection` (default `true`).
+   - Resource name: `'kv-hd-${node}-${env}'`.
+   - Azure RBAC enabled (invariant 17).
+   - Diagnostic settings parameter (`logAnalyticsWorkspaceId`) — when provided, configures diagnostic settings routing per invariant 22.
+   - Outputs: `id`, `name`, `vaultUri`.
+4. **`secrets/appConfigurationStore.bicep`.**
+   - Parameters: `name` (e.g. `appcs-hd-${env}`), `env`, `tags`, `location`, `sku` (default `standard`), `softDeleteRetentionInDays` (default `7`).
+   - Resource name composed from `name` parameter.
+   - Outputs: `id`, `endpoint`.
+5. **`data/storageAccount.bicep`.**
+   - Parameters: `node` (`@maxLength(13)` — storage account names are ≤24 chars total, alphanumeric only; `sthd` prefix is 4 chars and the longest `env` value `staging` is 7 chars, leaving 13 chars for `node`), `env`, `tags`, `location`, `sku` (default `Standard_LRS`), `kind` (default `StorageV2`), `accessTier` (default `Hot`), `minimumTlsVersion` (default `TLS1_2`), `publicNetworkAccess` (default `Enabled`).
+   - Resource name: `'sthd${node}${env}'` — note no hyphens (Azure storage account name restriction).
+   - Outputs: `id`, `name`, `primaryBlobEndpoint`.
+   - Math: `len('sthd') + maxLength(node) + len('staging') = 4 + 13 + 7 = 24` — fits the 24-char ceiling exactly for the longest `env`. `dev` / `prod` leave headroom.
+6. **`messaging/serviceBusNamespace.bicep`.**
+   - Parameters: `scope` (`@allowed(['shared', 'node'])`), `node` (`@maxLength(13)` string, used only when `scope == 'node'`), `env`, `tags`, `location`, `sku` (default `Standard`), `zoneRedundant` (default `false`).
+   - Resource name: `scope == 'shared' ? 'sbns-hd-shared-${env}' : 'sbns-hd-${node}-${env}'`.
+   - Outputs: `id`, `name`, `endpoint`.
+7. **`observability/applicationInsights.bicep`.**
+   - Parameters: `service` (`@maxLength(13)` string), `env`, `tags`, `location`, `workspaceResourceId` (the backing Log Analytics workspace per ADR-0040 D1's workspace-based App Insights), `applicationType` (default `web`).
+   - Resource name: `'appi-hd-${service}-${env}'`.
+   - Resource is workspace-based (ADR-0040 D1 — non-workspace mode is retired by Azure).
+   - Outputs: `id`, `name`. **Does NOT output `connectionString` as a plain string** — the connection string contains the instrumentation key and is itself the secret per ADR-0040 packet 02. Bicep outputs surface in `az deployment` JSON and flow through to workflow outputs (`deployment-outputs` in `job-deploy-bicep.yml`), where they are visible in the calling workflow's run logs — a critical leak path. Instead the module outputs a Vault-reference shape consumers use to read the connection string at runtime: `outputs.connectionStringRef object = { kind: 'keyVaultSecret', id: <appi-resource-id>, listKeysExpression: 'listKeys(\'<resource-id>\', \'<api-version>\').connectionString' }` (or equivalent shape — the operational pattern is that consumers call `listKeys` against the App Insights resource at runtime via Managed Identity, never via a `string` output). Document this in the module README: callers wire the connection string into Vault via a Vault `keyVaultSecret` resource at the per-Node template level (or via a runtime `listKeys` call from the deployed app), never log it. **Acceptance criterion:** no `output ... string` or `@secure() output` of the connection string itself.
+8. **Per-concern `README.md` files.** Each per-concern subdir gets a small `README.md` listing the modules it contains and their parameter signatures at-a-glance. The library-level `bicep/README.md` (packet 03) cross-references these.
+9. **Update the repo `CHANGELOG.md`** if the repo keeps one for the workflow / Bicep surface.
+10. **Post-merge tag step.** After merge, the operator tags `modules/v1.0.0` to fire `bicep-publish.yml` and publish the set. This is the **post-merge action** that completes the packet — call it out in the Human Prerequisites.
+
+## Affected Files
+- `bicep/modules/compute/containerApp.bicep` (new)
+- `bicep/modules/secrets/keyVault.bicep` (new)
+- `bicep/modules/secrets/appConfigurationStore.bicep` (new)
+- `bicep/modules/data/storageAccount.bicep` (new)
+- `bicep/modules/messaging/serviceBusNamespace.bicep` (new)
+- `bicep/modules/observability/applicationInsights.bicep` (new)
+- `bicep/modules/compute/README.md`, `secrets/README.md`, `data/README.md`, `messaging/README.md`, `observability/README.md` (new)
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow / Bicep surface
+- (post-merge) `modules/v1.0.0` git tag — fires `bicep-publish.yml`
+
+## NuGet Dependencies
+None. Bicep authoring — no .NET project.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo — ADR-0077 D2 names the canonical home; ADR-0012 confirms Actions as the CI/CD control plane.
+- [x] The six modules match the ADR's Follow-up Work list exactly.
+- [x] No code change in any Node — Bicep modules only.
+
+## Acceptance Criteria
+- [ ] All six modules (`compute/containerApp.bicep`, `secrets/keyVault.bicep`, `secrets/appConfigurationStore.bicep`, `data/storageAccount.bicep`, `messaging/serviceBusNamespace.bicep`, `observability/applicationInsights.bicep`) exist under `bicep/modules/`
+- [ ] Each module has a top-of-file comment block documenting purpose, ADR reference, parameter table, outputs, and example usage
+- [ ] Each module's resource name composes to the Grid naming convention for that resource type (`ca-hd-{service}-{env}`, `kv-hd-{node}-{env}`, `appcs-hd-{env}`, `sthd{node}{env}`, `sbns-hd-shared-{env}` or `sbns-hd-{node}-{env}`, `appi-hd-{service}-{env}`)
+- [ ] Each module's service / node name parameter has `@maxLength(13)` enforcing invariant 19; the storage account module's `node` parameter is `@maxLength(13)` because `len('sthd') + 13 + len('staging') = 24` exactly hits the storage-account 24-char ceiling for the longest `env`
+- [ ] Each module accepts a `tags object` parameter and applies it to the resource — no per-tag scalar parameters
+- [ ] No module accepts a secret as a raw string parameter — secret-shaped inputs use a `secretRef`-style `{ name, keyVaultUrl, identity }` shape, or the consumer wires the Vault reference at the resource level (invariant 8, invariant 85, ADR-0077 D7)
+- [ ] The `containerApp` module enables system-assigned managed identity (invariant 34) and sets revision mode `Multiple` (invariant 36) by default
+- [ ] The `keyVault` module enables Azure RBAC by default (invariant 17 / ADR-0005 D3) and accepts an optional `logAnalyticsWorkspaceId` for invariant-22 diagnostic settings routing
+- [ ] The `applicationInsights` module is workspace-based (consumes a `workspaceResourceId` parameter)
+- [ ] The `applicationInsights` module does NOT output the App Insights `connectionString` as a `string` (or as any output that surfaces into `az deployment` JSON / workflow logs). Instead it outputs a Vault-reference shape (`{ kind: 'keyVaultSecret', id, listKeysExpression }`) consumers use to read the secret at runtime via Managed Identity. The module README documents the runtime-resolution pattern.
+- [ ] Per-concern `README.md` files in `compute/`, `secrets/`, `data/`, `messaging/`, `observability/` list the modules and their parameter signatures
+- [ ] Running `bicep build` on each module produces a clean ARM JSON output (no compile errors)
+- [ ] Running `bicep lint` against each module with the `bicepconfig.json` from packet 03 produces no `error`-severity violations (warnings are acceptable for v1; future packets tighten)
+- [ ] The repo `CHANGELOG.md` is updated if the repo keeps one for the workflow / Bicep surface
+- [ ] **(post-merge)** A git tag `modules/v1.0.0` is pushed and `bicep-publish.yml` succeeds, publishing all six modules to `acrhdbicep` — recorded as a closing comment on the issue
+
+## Human Prerequisites
+- [ ] Packet 02 must be done — `acrhdbicep` registry exists and OIDC `AcrPush` is granted. If packet 02 is not yet executed, the modules can still be merged; the post-merge `modules/v1.0.0` tag step waits.
+- [ ] **Post-merge:** push the `modules/v1.0.0` git tag to fire `bicep-publish.yml` (packet 04). This is a one-line operator action: `git tag modules/v1.0.0 && git push origin modules/v1.0.0`. The packet is not fully closed until the tag is pushed and the publish workflow succeeds.
+
+## Referenced ADR Decisions
+**ADR-0077 D2 — First module set.** The ADR's Follow-up Work names "a first set of modules covering Container Apps, Key Vault, App Configuration, Storage, Service Bus, and Application Insights." This packet ships that set. Other modules (Redis, Postgres, networking, identity, observability/logAnalytics, etc.) are deferred to follow-up packets driven by their consuming Nodes' infrastructure work.
+
+**ADR-0077 D3 — Naming and tagging conventions.** Resource name shape (per-resource-type prefix + `hd-` + `{service}/{node}` + `{env}`) and required tags (`hd:node`, `hd:env`, `hd:owner`, `hd:cost-center`, `hd:dr-tier`, `hd:adr`). Enforced by module-author convention (parameter decorators, `tags` parameter shape) where the linter cannot.
+
+**ADR-0077 D7 — Secrets in Bicep.** Modules never accept secrets as raw string parameters. Secret-shaped inputs use a `secretRef` shape that references Vault by URI. Codifies invariant 8 / invariant 85.
+
+**ADR-0015 / invariant 34 — Containerized deployable Nodes run on Azure Container Apps, named `ca-hd-{service}-{env}`, one per Node per environment, with system-assigned Managed Identity.**
+
+**Invariant 36 — Container App revision mode is `Multiple` with explicit traffic splitting on deploy.**
+
+**ADR-0005 / invariant 17 — One Key Vault per deployable Node per environment, named `kv-hd-{service}-{env}` (`{service}` ≤ 13 chars per invariant 19), Azure RBAC enabled.**
+
+**Invariant 19 — Service names in Azure resource naming must be ≤ 13 characters.**
+
+**Invariant 22 — Every Key Vault must have diagnostic settings routed to the shared Log Analytics workspace.** The `keyVault` module's optional `logAnalyticsWorkspaceId` parameter and the consumer-side wiring satisfy this.
+
+**ADR-0028 D5 — `sbns-hd-shared-{env}` shared Service Bus namespace.** The `serviceBusNamespace` module's `scope` parameter supports both shared and per-Node shapes.
+
+**ADR-0040 D1 — Workspace-based Application Insights.** The `applicationInsights` module is workspace-based; non-workspace mode is retired by Azure.
+
+## Constraints
+> **Invariant 8 / Invariant 85 — Bicep templates never contain secret values.** No module accepts a secret as a raw string parameter. Secret-shaped inputs use the `secretRef` shape ({ name, keyVaultUrl, identity }) that references Vault by URI. The `applicationInsights` module's `connectionString` output is documented as a secret that must be wired into Vault by the caller.
+
+> **Invariant 19 — Service names in Azure resource naming must be ≤ 13 characters.** Modules enforce this with `@maxLength(13)` parameter decorators. The storage account module also uses `@maxLength(13)` — the storage-account 24-char total budget is exhausted by `sthd` (4) + 13 + `staging` (7) = 24 for the longest `env`.
+
+> **Invariant 34, 36 — Container Apps shape.** The `containerApp` module enables system-assigned MI by default and sets revision mode `Multiple` by default.
+
+> **Invariant 17 — Per-Node Key Vault, Azure RBAC.** The `keyVault` module enables Azure RBAC by default.
+
+> **Invariant 22 — Diagnostic settings for Key Vaults.** The `keyVault` module exposes an optional `logAnalyticsWorkspaceId` parameter; consumers wire it.
+
+- **Six modules in v1.** Match ADR-0077 D2's Follow-up Work list exactly. Do not add Redis, Postgres, networking, or other resources — those are follow-up packets driven by consuming Nodes.
+- **One module per resource family.** Each module declares one Azure resource (or one resource plus its tightly-coupled children like Container App secrets). No mega-modules.
+- **Outputs limited to what consumers need.** `id`, canonical name, and consumer-facing endpoints / FQDNs / principalIds. Do not leak full resource configs.
+- **No local-path consumption in test code.** If a module test ever lands, it consumes the registry path, not the local file path — same discipline as per-Node templates.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `infrastructure`, `adr-0077`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Author the six Bicep modules ADR-0077 D2's Follow-up Work names, with parameter / tag / name conventions enforced at module-author time, and tag `modules/v1.0.0` after merge.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Ship the first reusable Bicep modules so upcoming Node infrastructure work (ADR-0059 Cache, ADR-0060 Identity, ADR-0061 Files) consumes the registry path from day one.
+- Feature: ADR-0077 IaC — Bicep rollout, Wave 4.
+- ADRs: ADR-0077 D2/D3/D7 (primary), ADR-0015 (Container Apps shape), ADR-0005 (Key Vault shape), ADR-0028 (Service Bus shape), ADR-0040 (App Insights shape).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — `acrhdbicep` registry exists and OIDC `AcrPush` is granted; required for the post-merge `modules/v1.0.0` publish to land somewhere.
+- `packet:03` — `bicep/modules/` directory tree and `bicepconfig.json` exist.
+- `packet:04` — `bicep-publish.yml` workflow exists, so the post-merge `modules/v1.0.0` tag fires the publish.
+
+**Constraints:**
+- Six modules in v1 — match D2's Follow-up Work list exactly.
+- One Azure resource per module — no mega-modules.
+- Tags via single `tags object` parameter; names via `@maxLength`-decorated `service`/`node` parameters; secrets via `secretRef` shape — never raw string secrets.
+- `containerApp` defaults: system-assigned MI, revision mode `Multiple`.
+- `keyVault` defaults: Azure RBAC enabled; soft-delete + purge protection on.
+- `applicationInsights` is workspace-based; its `connectionString` output is a secret — document this in the module README.
+- `bicep lint` against `bicepconfig.json` produces zero `error`-severity violations.
+
+**Key Files:**
+- `bicep/modules/compute/containerApp.bicep`
+- `bicep/modules/secrets/keyVault.bicep`
+- `bicep/modules/secrets/appConfigurationStore.bicep`
+- `bicep/modules/data/storageAccount.bicep`
+- `bicep/modules/messaging/serviceBusNamespace.bicep`
+- `bicep/modules/observability/applicationInsights.bicep`
+- Per-concern `README.md` files
+- (post-merge) git tag `modules/v1.0.0`
+
+**Contracts:**
+- Each module exposes a contract (its parameter list + outputs) for per-Node `infra/main.bicep` consumers. The contract is documented in the module's top-of-file comment block and the per-concern README. Breaking changes require a SemVer major bump on the next `modules/v*` tag.

--- a/generated/issue-packets/active/adr-0077-iac-bicep/06-actions-job-deploy-bicep-workflow.md
+++ b/generated/issue-packets/active/adr-0077-iac-bicep/06-actions-job-deploy-bicep-workflow.md
@@ -1,0 +1,213 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "infrastructure", "adr-0077", "wave-5"]
+dependencies: ["packet:05"]
+adrs: ["ADR-0077", "ADR-0012", "ADR-0033"]
+wave: 5
+initiative: adr-0077-iac-bicep
+node: honeydrunk-actions
+---
+
+# Author job-deploy-bicep.yml — the reusable workflow that applies a Node's main.bicep per environment
+
+## Summary
+Author `.github/workflows/job-deploy-bicep.yml` in `HoneyDrunk.Actions` — the reusable deploy workflow that runs `az deployment group create` (or `az deployment sub create` for subscription-scoped resources) on a Node's `infra/main.bicep` with the appropriate `parameters.{env}.bicepparam` per ADR-0077 D4. Consumed via `workflow_call` by per-Node release workflows. Authenticates via the existing Actions OIDC federation. Runs `bicep lint` and `bicep build` as preflight steps, then applies the deployment.
+
+## Context
+ADR-0077 D4 commits the deploy shape:
+
+> **`main.bicep`** — the entry-point template per Node (composes module references). **`parameters.{env}.bicepparam`** — per-environment parameter values (sizing, naming, regional pinning). **CI per-environment job** runs `az deployment group create` (or `az deployment sub create` for subscription-scoped resources) with the appropriate parameter file.
+
+The workflow is the per-Node infrastructure deploy artifact. Consuming repos (per-Node release workflows) call it like:
+```yaml
+jobs:
+  deploy-infra:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-deploy-bicep.yml@main
+    with:
+      env: dev
+      template-path: infra/main.bicep
+      parameters-path: infra/parameters.dev.bicepparam
+      deployment-scope: resourceGroup
+      resource-group: rg-hd-{node}-dev
+    permissions:
+      id-token: write
+      contents: read
+```
+
+**Deployment scope.** Two scopes are needed v1:
+- `resourceGroup` — the most common scope; `az deployment group create`. Requires a `resource-group` input.
+- `subscription` — for subscription-scoped resources (resource group creation itself, subscription-level role assignments); `az deployment sub create`. Requires a `location` input. The `resource-group` input is ignored in this mode.
+
+Other scopes (`management-group`, `tenant`) are deferred — the Grid does not provision at those scopes today.
+
+**Preflight: lint + build.** Before the deploy, run `bicep lint` against the template (using the inherited `bicepconfig.json`) and `bicep build` to surface any compile errors. Failing either step fails the deploy without touching Azure.
+
+**Idempotent What-If preview.** ADR-0077 D4 does not require a What-If gate, but it is cheap and prevents surprises. Run `az deployment {scope} what-if` as a non-blocking step that prints to the job summary. Operator can review the What-If output on the workflow run page before approving the actual apply (if the consuming workflow uses an `environment` requirement for approval gates, which is the recommended pattern for staging/prod).
+
+**Approval gates are the consumer's concern.** This workflow does not impose an approval gate; the consuming per-Node release workflow uses GitHub `environment:` to gate `staging` and `prod` per ADR-0033. The deploy-bicep workflow runs whatever scope+template it is called with; the safety rails are at the trigger surface (only release tags trigger; only the per-environment Action's `environment` lets it actually apply).
+
+**Outputs.** The workflow surfaces the Azure deployment's outputs (resource IDs, FQDNs, etc. — whatever the consumer's `main.bicep` outputs) as workflow outputs, so a downstream job in the consumer workflow can wire them. Use the `azure/cli` action's stdout JSON capture pattern.
+
+**Outputs are scrubbed of `secureString` / `secureObject` typed entries before being surfaced.** Bicep's `output` JSON carries each output's declared type. The workflow filters out any output whose `type` is `secureString` or `secureObject` before assigning the remainder to `deployment-outputs`. Modules and per-Node templates that need to surface a secret value MUST do so by writing the secret into Vault inside the template (via a `keyVaultSecret` resource) and outputting the Vault secret URI / id only — never the secret value itself. This is defense-in-depth on top of invariant 85; even if a module author mistakenly declares a `@secure() output`, the workflow does not relay it to the calling workflow's run logs.
+
+**Safe-to-call shape.** The workflow is `workflow_call`-callable from any HoneyDrunk repo; existing patterns (`job-deploy-container-app.yml`) are the precedent for shape, inputs, secrets passthrough, and outputs.
+
+`HoneyDrunk.Actions` is the CI/CD control plane per ADR-0012. This is a workflow/YAML packet — no .NET project, no NuGet. The repo `CHANGELOG.md` is updated per the repo convention.
+
+## Scope
+- `.github/workflows/job-deploy-bicep.yml` (new) — the reusable deploy workflow.
+- `docs/` — if the repo keeps a consumer-usage doc for reusable workflows, add a section documenting `job-deploy-bicep.yml` with the input shape and an example consumer invocation.
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface.
+
+## Proposed Implementation
+1. **Workflow header.**
+   ```yaml
+   name: Deploy Bicep template
+
+   on:
+     workflow_call:
+       inputs:
+         env:
+           type: string
+           required: true
+           description: 'Target environment (dev|staging|prod).'
+         template-path:
+           type: string
+           required: true
+           description: 'Path (relative to the consumer repo root) of the entry Bicep template (typically infra/main.bicep).'
+         parameters-path:
+           type: string
+           required: true
+           description: 'Path of the .bicepparam file (typically infra/parameters.{env}.bicepparam).'
+         deployment-scope:
+           type: string
+           required: true
+           description: 'resourceGroup or subscription. Other scopes are not supported v1.'
+         resource-group:
+           type: string
+           required: false
+           description: 'Required when deployment-scope=resourceGroup. Ignored otherwise.'
+         location:
+           type: string
+           required: false
+           description: 'Required when deployment-scope=subscription. The Azure region for the deployment metadata.'
+         what-if:
+           type: boolean
+           default: true
+           description: 'Run az deployment what-if as a preflight; print to job summary; non-blocking.'
+       outputs:
+         deployment-outputs:
+           description: 'JSON object of the Azure deployment outputs.'
+           value: ${{ jobs.deploy.outputs.outputs }}
+
+   permissions:
+     id-token: write
+     contents: read
+   ```
+2. **Single job: `deploy`.** Runs on `ubuntu-latest`. Steps:
+   1. `actions/checkout@v4` — the consumer repo's checkout (the calling workflow's `${{ github.workspace }}` is what `template-path` and `parameters-path` resolve against).
+   2. **Validate inputs.** If `deployment-scope=resourceGroup` and `resource-group` is empty, fail fast with a clear message. Same for `subscription` / `location`.
+   3. **Azure OIDC login.** `azure/login@v2` with `client-id`, `tenant-id`, `subscription-id` sourced from the existing repo secrets pattern. (The consumer repo passes these via `secrets: inherit`; document this in the consumer-usage doc.)
+   4. **`bicep lint`.** Run `az bicep lint --file ${{ inputs.template-path }}`. Fail on any `error`-severity finding (the `bicepconfig.json` resolution picks up the consumer repo's config; if the consumer has none, Bicep falls back to defaults — which is acceptable since per-Node templates do not duplicate the Actions repo's `bicepconfig.json`).
+   5. **`bicep build`.** Run `az bicep build --file ${{ inputs.template-path }}`. Fail on compile error.
+   6. **What-If preflight** (gated on `inputs.what-if == true`). Run `az deployment {scope} what-if` with the appropriate args; capture the output and write it to `$GITHUB_STEP_SUMMARY`. Non-blocking.
+   7. **Deploy.** Run `az deployment group create` (for `resourceGroup`) or `az deployment sub create` (for `subscription`) with `--template-file`, `--parameters @{parameters-path}`. Use `--name "${{ github.run_id }}-${{ inputs.env }}"` so the deployment name is unique and traceable. Capture stdout JSON.
+   8. **Capture outputs (scrub secureString / secureObject).** Parse the deployment's outputs from the captured JSON. Filter the outputs object to exclude any entry whose `type` is `secureString` or `secureObject` — those are dropped silently with a single summary line in `$GITHUB_STEP_SUMMARY` listing the dropped output names (without their values). Assign the filtered object to the job output `outputs` for the workflow output `deployment-outputs`. Implementation: `jq` filter like `. | with_entries(select(.value.type | ascii_downcase | IN(\"securestring\", \"secureobject\") | not))` against the `properties.outputs` object.
+   9. **Summary.** Write a final summary (template path, env, deployment name, key outputs) to `$GITHUB_STEP_SUMMARY`.
+3. **Reusability shape.** `workflow_call` only — no direct push / PR / tag trigger on this workflow. It is called by per-Node release workflows after the build/test stages succeed.
+4. **Failure modes.**
+   - **Bicep lint error-severity.** Fail before touching Azure.
+   - **Bicep build error.** Fail before touching Azure.
+   - **What-If preflight error.** Surface, do not fail (What-If can fail for valid templates if the target resource group does not exist yet; the actual deploy will create it).
+   - **Azure deployment error.** Surface the Azure error JSON cleanly; exit non-zero. Operator intervention required.
+   - **Missing inputs.** Fail fast at step 2 with a clear message.
+5. **Docs.** Author or extend `docs/consumer-usage.md` with a section: how to call `job-deploy-bicep.yml` from a per-Node release workflow, the recommended job structure (build → test → deploy-infra → deploy-app), and the environment-approval pattern per ADR-0033.
+
+## Affected Files
+- `.github/workflows/job-deploy-bicep.yml` (new)
+- `docs/consumer-usage.md` (or equivalent) — consumer-usage section
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface
+
+## NuGet Dependencies
+None. Workflow YAML — no .NET project.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo — ADR-0077 D1 names the Actions reusable deploy workflow; ADR-0012 confirms Actions as the CI/CD control plane.
+- [x] No code change in any Node — workflow YAML only.
+- [x] Consumer repos own their `infra/main.bicep` + `parameters.{env}.bicepparam` — this workflow is the deploy artifact only.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/job-deploy-bicep.yml` exists, is `workflow_call`-only, and takes the documented inputs (`env`, `template-path`, `parameters-path`, `deployment-scope`, optional `resource-group` / `location`, optional `what-if`)
+- [ ] The workflow exposes a `deployment-outputs` output containing the Azure deployment's JSON outputs, **scrubbed of any entry whose `type` is `secureString` or `secureObject`** — those entries are dropped silently (a summary line in `$GITHUB_STEP_SUMMARY` lists the dropped output names without their values). A test deployment with a `@secure() output` MUST NOT surface that output's value in `deployment-outputs` or in the workflow run log.
+- [ ] The workflow authenticates via `azure/login@v2` and the existing OIDC-federated identity — no static secrets in the workflow or repo (invariant 8)
+- [ ] Pre-flight: `bicep lint` runs on the template; `error`-severity findings fail the workflow before Azure is touched
+- [ ] Pre-flight: `bicep build` runs on the template; compile errors fail the workflow before Azure is touched
+- [ ] When `what-if=true`, `az deployment {scope} what-if` runs and writes its output to `$GITHUB_STEP_SUMMARY` (non-blocking)
+- [ ] When `deployment-scope=resourceGroup` and `resource-group` is empty, the workflow fails fast with a clear message; same for `subscription` and `location`
+- [ ] The deployment name is `${{ github.run_id }}-${{ inputs.env }}` (or equivalent unique-and-traceable shape) so the deployment is identifiable in the Azure activity log
+- [ ] The workflow writes a deploy summary (template, env, deployment name, key outputs) to `$GITHUB_STEP_SUMMARY`
+- [ ] Approval / environment gates are NOT imposed by this workflow — the consuming per-Node workflow uses GitHub `environment:` per ADR-0033 for staging / prod
+- [ ] `docs/consumer-usage.md` (or equivalent) has a section documenting how to call the workflow, the recommended consumer job structure, and the environment-approval pattern
+- [ ] The repo `CHANGELOG.md` is updated if the repo keeps one for the workflow surface
+- [ ] No per-Node `infra/main.bicep` exists in the Actions repo as a result of this packet — this packet is the deploy artifact; per-Node templates land in the consuming Nodes
+
+## Human Prerequisites
+- [ ] The first **consuming** use of this workflow waits on the per-Node `infra/main.bicep` + `parameters.{env}.bicepparam` existing in a Node's repo. That per-Node work happens at each Node's next significant infrastructure touchpoint per D6 — not here. The workflow can merge and stand idle until the first consumer wires it.
+
+## Referenced ADR Decisions
+**ADR-0077 D4 — Per-environment deployment.** "`main.bicep` entry point per Node. `parameters.{env}.bicepparam` per-environment values. CI per-environment job runs `az deployment group create` (or `az deployment sub create`) with the parameter file." This packet is the reusable workflow that does that.
+
+**ADR-0077 D7 — Deploy identity has provisioning rights, not secret-read rights.** The OIDC-federated identity has resource-provisioning RBAC on the target subscription / resource groups; it does not have `Key Vault Secrets User`. Bicep templates resolve secrets at runtime via Vault references; the deploy identity never sees the secret value.
+
+**ADR-0033 — Environment-gated deploy trigger model.** The consuming per-Node release workflow uses `environment:` to gate staging / prod approvals. This workflow stays scope-pure: deploy what you are given, where you are told to.
+
+**ADR-0012 — Actions is the Grid CI/CD control plane.** Reusable deploy workflows in `.github/workflows/` are the Grid's CI/CD surface.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry — or in workflow files.** OIDC-only authentication. The deploy identity has `Contributor` (or scoped equivalents) on the target subscription / RG, not `Key Vault Secrets User` — so even if a template accidentally tried to read a secret, AAD denies it.
+
+- **`workflow_call` only.** No direct push / PR / tag trigger on this workflow. Called by per-Node release workflows.
+- **Preflight before Azure.** `bicep lint` + `bicep build` first; failing either does not touch Azure.
+- **Approval gates are the consumer's concern.** Do not impose an `environment:` requirement here; the consumer uses `environment:` per ADR-0033.
+- **What-If is non-blocking.** It surfaces the diff to the summary; it does not gate the apply.
+- **Two scopes only v1.** `resourceGroup` and `subscription`. `management-group` and `tenant` deferred.
+- **Outputs scrubbed of `secureString` / `secureObject` before surfacing.** Defense-in-depth on top of invariant 85; the workflow drops secret-typed outputs even if a module mistakenly declares one.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `infrastructure`, `adr-0077`, `wave-5`
+
+## Agent Handoff
+
+**Objective:** Author `.github/workflows/job-deploy-bicep.yml` — the reusable deploy workflow that applies a Node's `infra/main.bicep` + `parameters.{env}.bicepparam` per environment via `az deployment {scope} create`, with `bicep lint` and `bicep build` preflights.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Ship the per-Node deploy artifact so consuming Node release workflows can apply Bicep templates per environment.
+- Feature: ADR-0077 IaC — Bicep rollout, Wave 5.
+- ADRs: ADR-0077 D4/D7 (primary), ADR-0033 (environment-gated deploys — consumer's concern), ADR-0012 (Actions as CI/CD control plane).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:05` — the first module set exists and is published to `acrhdbicep`, so per-Node `main.bicep` templates the workflow deploys can resolve module references. Strictly the workflow can land before any module is published (it deploys whatever template it is given), but the dependency keeps the wave sequencing honest — packet 05 is the realistic precursor to a meaningful first consumer.
+
+**Constraints:**
+- `workflow_call` only.
+- OIDC-only authentication (invariant 8).
+- `bicep lint` + `bicep build` preflight before any Azure call.
+- What-If is non-blocking.
+- Approval gates are the consumer's concern (ADR-0033).
+- Two scopes v1: `resourceGroup`, `subscription`.
+
+**Key Files:**
+- `.github/workflows/job-deploy-bicep.yml` (new)
+- `docs/consumer-usage.md` (or equivalent)
+
+**Contracts:**
+- Workflow inputs: `env`, `template-path`, `parameters-path`, `deployment-scope`, optional `resource-group` / `location`, optional `what-if`.
+- Workflow outputs: `deployment-outputs` (JSON object of Azure deployment outputs).
+- Trigger: `workflow_call` only.

--- a/generated/issue-packets/active/adr-0077-iac-bicep/07-actions-bicep-lint-pr-gate.md
+++ b/generated/issue-packets/active/adr-0077-iac-bicep/07-actions-bicep-lint-pr-gate.md
@@ -1,0 +1,177 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "infrastructure", "adr-0077", "wave-5"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0077", "ADR-0012"]
+wave: 5
+initiative: adr-0077-iac-bicep
+node: honeydrunk-actions
+---
+
+# Add bicep lint to pr-core.yml so PRs touching .bicep or .bicepparam files fail on linter / build-params violations
+
+## Summary
+Amend `.github/workflows/pr-core.yml` in `HoneyDrunk.Actions` with a Bicep validation job that runs `bicep lint` against every changed `.bicep` file and `bicep build-params` against every changed `.bicepparam` file in a PR per ADR-0077 D3. Fails the PR on any `error`-severity linter finding (per the `bicepconfig.json` shipped by packet 03) or any `build-params` validation error. Skips cleanly when the PR touches no Bicep files. Applies to PRs in `HoneyDrunk.Actions` (where the modules library lives) and is `workflow_call`-callable so per-Node `pr-core.yml` consumers inherit the gate when their Node has Bicep templates.
+
+> **`bicep lint` does NOT accept `.bicepparam` files.** The CLI's `lint` subcommand operates on `.bicep` template files only — passing a `.bicepparam` file fails the command. Parameter files are validated by `bicep build-params --file <file>.bicepparam`, which expands and type-checks the parameter file against its referenced template. This packet handles the two file kinds with two CLI invocations.
+
+## Context
+ADR-0077 D3 commits the enforcement gate:
+
+> **Enforcement:** Bicep linter rules in `bicepconfig.json` flag missing required tags and non-conformant names. CI (per ADR-0012) runs `bicep lint` and fails the PR if linter rules violate.
+
+The Grid's PR-time gate is `pr-core.yml` per ADR-0011 (the canonical Tier-1 gate workflow in `HoneyDrunk.Actions`). Adding a `bicep lint` step there gives per-Node PRs (which call `pr-core.yml` from their own `pr-core.yml`) the gate for free when they have Bicep files; PRs without Bicep files skip the step cleanly.
+
+**Where the rules live.** Packet 03 ships `bicep/bicepconfig.json` in `HoneyDrunk.Actions`. For the Actions repo's own PRs, the config is resolved by Bicep's standard file-system search (templates under `bicep/modules/` find the sibling `bicep/bicepconfig.json`). For per-Node PRs, the per-Node repo can either ship its own `bicepconfig.json` (recommended at first, copying the Actions one) or — if Bicep's config-file resolution allows it — fall back to defaults. Document the per-Node ownership of `bicepconfig.json` in the Bicep template scaffold pattern (packet 08).
+
+**Change detection.** The job runs `bicep lint` on `.bicep` files changed in the PR and `bicep build-params` on `.bicepparam` files changed in the PR. Determine the diff base via this resolution order:
+1. `inputs.base-ref` (when set by the calling workflow — required for `workflow_call` consumers whose own context does not naturally expose the PR base SHA).
+2. `${{ github.event.pull_request.base.sha }}` (when the workflow runs in a PR event context).
+3. `${{ github.event.merge_group.base_sha }}` (when the workflow runs in a merge-queue context).
+4. Hard fail with a clear message if none resolve.
+
+`${{ github.event.pull_request.base.sha }}` is the natural path when `pr-core.yml` is triggered on `pull_request` directly. When `job-bicep-lint.yml` is called via `workflow_call` from a consumer's `pr-core.yml`, propagation of `github.event.pull_request.base.sha` depends on the calling workflow's own trigger event — for cases where the consumer workflow is triggered by a non-PR event (manual dispatch, scheduled run, release tag) the base SHA is not present in `github.event`. The `inputs.base-ref` input is the fallback for those cases (consumer passes `base-ref: ${{ github.event.pull_request.base.sha }}` explicitly, or any other ref appropriate to the consumer's flow).
+
+If the diff is empty (no Bicep files touched), the job logs "no Bicep files changed" and exits 0. This keeps the gate fast and avoids re-validating unchanged modules.
+
+**Severity policy.** Fail the PR on any `error`-severity finding from `bicepconfig.json`. `warning`-severity findings are surfaced in the summary but do not fail the build (operator can tighten to error later, per Grid convention for warnings-vs-errors evolution).
+
+**Reusability shape.** Two surfaces:
+1. **Direct integration in the Actions repo's `pr-core.yml`** — the Actions repo's own PRs run the step against the modules library.
+2. **`workflow_call` shape** — extract the linter logic into a small reusable job (`job-bicep-lint.yml`) that the existing per-Node `pr-core.yml` consumers can opt into. **Recommended approach:** add the reusable `job-bicep-lint.yml` and have `pr-core.yml` consume it; per-Node repos that have Bicep templates add a single `bicep-lint` job to their own `pr-core.yml` consuming `job-bicep-lint.yml`. This keeps the gate composable.
+
+**Bicep CLI availability.** GitHub-hosted `ubuntu-latest` runners do not ship Bicep CLI by default, but `az bicep` is bundled with the `azure-cli` package which IS on `ubuntu-latest`. Use `az bicep install` (idempotent) at the top of the job to ensure the latest Bicep is present. No additional install action needed.
+
+`HoneyDrunk.Actions` is the CI/CD control plane per ADR-0012. This is a workflow/YAML packet — no .NET project, no NuGet.
+
+## Scope
+- `.github/workflows/job-bicep-lint.yml` (new) — reusable lint job, `workflow_call`-callable.
+- `.github/workflows/pr-core.yml` (amend) — call the new reusable job for the Actions repo's own PRs.
+- `docs/consumer-usage.md` (or equivalent) — document how per-Node `pr-core.yml` consumers opt into the gate.
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface.
+
+## Proposed Implementation
+1. **`job-bicep-lint.yml`** — new reusable workflow.
+   ```yaml
+   name: Bicep lint
+
+   on:
+     workflow_call:
+       inputs:
+         paths:
+           type: string
+           default: '**/*.bicep,**/*.bicepparam'
+           description: 'Comma-separated glob patterns to consider. Defaults to all Bicep files in the repo.'
+         fail-on-warnings:
+           type: boolean
+           default: false
+           description: 'Treat warning-severity findings as failures. Default false; tighten per-repo later.'
+         base-ref:
+           type: string
+           required: false
+           default: ''
+           description: 'Optional explicit diff base ref/SHA. When unset, falls back to github.event.pull_request.base.sha then github.event.merge_group.base_sha. Required when the calling workflow_call context does not expose a PR base (e.g. manual dispatch, non-PR triggers).'
+
+   permissions:
+     contents: read
+   ```
+   Single job: `lint`. Runs on `ubuntu-latest`. Steps:
+   1. `actions/checkout@v4` with `fetch-depth: 0` (needed for the base-vs-head diff).
+   2. **Resolve diff base.** Resolution order: `inputs.base-ref` → `github.event.pull_request.base.sha` → `github.event.merge_group.base_sha`. If none resolve, exit non-zero with a clear message naming `inputs.base-ref` as the required fallback.
+   3. **Resolve changed Bicep files.** Use `git diff --name-only $BASE_REF HEAD -- '*.bicep' '*.bicepparam'` (intersected with `inputs.paths` if non-default). Partition the result into two lists: `BICEP_FILES` (`.bicep`) and `BICEPPARAM_FILES` (`.bicepparam`). If both are empty, log "no Bicep files changed" and exit 0.
+   4. **Install Bicep.** `az bicep install`. Idempotent; ensures latest.
+   5. **Lint each changed `.bicep` file.** Loop over `BICEP_FILES`. For each, run `az bicep lint --file {path} --diagnostics-format sarif > lint-{i}.sarif`. Capture exit codes. **Do NOT pass `.bicepparam` files to `lint`** — the CLI rejects them.
+   6. **Build-params each changed `.bicepparam` file.** Loop over `BICEPPARAM_FILES`. For each, run `az bicep build-params --file {path} --stdout > /dev/null`. Capture exit codes. Non-zero exit means parameter-file shape or referenced-template type mismatch — surface to the summary table and fail.
+   7. **Aggregate findings.** Parse the SARIF outputs; count `error` and `warning` severities. Combine with the `build-params` exit codes. Write a summary table to `$GITHUB_STEP_SUMMARY` listing per-file findings (with a column distinguishing `lint` vs `build-params` source).
+   8. **Fail or pass.** If any `error`-severity lint finding or any `build-params` failure exists, exit non-zero. If `fail-on-warnings=true` and any `warning`-severity finding exists, exit non-zero. Otherwise exit 0.
+2. **Amend `pr-core.yml`.** Add a `bicep-lint` job that calls `job-bicep-lint.yml@main` (or the appropriate ref) with default inputs. The job is in parallel with the existing tier-1 build/test jobs — no sequencing.
+3. **Document the consumer pattern.** In `docs/consumer-usage.md`, add a section: "Adding `bicep lint` to your Node's `pr-core.yml`." Show the minimal block (just the `bicep-lint: uses: ...job-bicep-lint.yml@main`). Note that per-Node repos with no Bicep templates do not need to wire it; the gate is opt-in by inclusion.
+4. **Update the repo `CHANGELOG.md`** if it keeps one for the workflow surface.
+
+## Affected Files
+- `.github/workflows/job-bicep-lint.yml` (new)
+- `.github/workflows/pr-core.yml` (amend — new `bicep-lint` job)
+- `docs/consumer-usage.md` (consumer-pattern section)
+- The repo `CHANGELOG.md` if the repo keeps one for the workflow surface
+
+## NuGet Dependencies
+None. Workflow YAML — no .NET project.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo — ADR-0077 D3 names CI per ADR-0012; ADR-0012 places the gate in Actions.
+- [x] `pr-core.yml` is the canonical Tier-1 gate per ADR-0011 — the right place to add the linter step.
+- [x] No code change in any Node — workflow YAML only.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/job-bicep-lint.yml` exists, is `workflow_call`-callable, takes optional `paths`, `fail-on-warnings`, and `base-ref` inputs, and uses `permissions: { contents: read }`
+- [ ] The reusable workflow checks out with `fetch-depth: 0` and resolves changed `.bicep` / `.bicepparam` files via `git diff` against the resolved base ref (`inputs.base-ref` → `github.event.pull_request.base.sha` → `github.event.merge_group.base_sha`; hard fail with a clear message if none resolve)
+- [ ] If no Bicep files are changed, the workflow logs "no Bicep files changed" and exits 0 — fast skip on PRs that do not touch Bicep
+- [ ] `az bicep install` is invoked once (idempotent) to ensure latest Bicep on the runner
+- [ ] `az bicep lint --diagnostics-format sarif` runs against each changed `.bicep` file ONLY (the `lint` subcommand does not accept `.bicepparam`); SARIF outputs are aggregated
+- [ ] `az bicep build-params --file <path> --stdout > /dev/null` runs against each changed `.bicepparam` file; non-zero exit fails the workflow
+- [ ] A summary table is written to `$GITHUB_STEP_SUMMARY` listing per-file findings (severity + rule + message + tool source `lint` or `build-params`)
+- [ ] Any `error`-severity lint finding or any `build-params` failure fails the workflow
+- [ ] `warning`-severity findings fail the workflow only when `fail-on-warnings=true` (default `false`)
+- [ ] `.github/workflows/pr-core.yml` calls `job-bicep-lint.yml` as a parallel job — runs alongside the existing Tier-1 checks, not after
+- [ ] `docs/consumer-usage.md` documents the consumer opt-in pattern with a minimal example for per-Node `pr-core.yml`, including when to pass `base-ref` explicitly (non-PR-event triggers)
+- [ ] The repo `CHANGELOG.md` is updated if the repo keeps one for the workflow surface
+- [ ] An intentionally bad Bicep file in a test PR (e.g. a hardcoded `connectionString` literal, or a resource name not matching the prefix convention) causes the new job to fail; a clean PR passes
+- [ ] An intentionally bad `.bicepparam` file (e.g. parameter shape that does not match the referenced template's declared parameters) causes the new job to fail via `build-params`; a clean parameter file passes
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0077 D3 — Linter rules enforced by CI.** "CI (per ADR-0012) runs `bicep lint` and fails the PR if linter rules violate." This packet implements that gate. The rules themselves ship in packet 03's `bicepconfig.json`.
+
+**ADR-0011 — Code review pipeline (Tier-1 gate).** `pr-core.yml` is the canonical Tier-1 gate; new gates land there as parallel jobs.
+
+**ADR-0012 — Actions is the Grid CI/CD control plane.** Reusable workflows live in `.github/workflows/`.
+
+**Invariant 31 — Every PR traverses the Tier-1 gate before merge.** `bicep lint` becomes part of the gate when a PR touches Bicep files; the skip-on-no-Bicep behavior keeps it gracefully no-op otherwise.
+
+## Constraints
+- **Reusable shape.** Extract the lint logic into `job-bicep-lint.yml` so per-Node `pr-core.yml` consumers can opt in.
+- **Fast skip on no-Bicep.** A PR that touches no `.bicep` / `.bicepparam` files exits 0 in seconds. The gate adds zero cost to non-IaC PRs.
+- **Fail on errors; warn on warnings.** `error`-severity findings fail; `warning` does not unless `fail-on-warnings=true` is set per-consumer.
+- **No secret access.** The lint job runs `bicep lint` on source files only; it does not need Azure auth (`permissions: { contents: read }` only).
+- **Parallel, not sequential.** The new job runs in parallel with the existing Tier-1 jobs in `pr-core.yml` — no `needs:` chain.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `infrastructure`, `adr-0077`, `wave-5`
+
+## Agent Handoff
+
+**Objective:** Add the `bicep lint` PR gate as a new reusable workflow `job-bicep-lint.yml` and wire it into the Actions repo's own `pr-core.yml` (in parallel with existing Tier-1 jobs).
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Enforce ADR-0077 D3's linter gate at PR time across the Grid (Actions for its own modules; per-Node repos opt in via consumer pattern).
+- Feature: ADR-0077 IaC — Bicep rollout, Wave 5.
+- ADRs: ADR-0077 D3 (primary), ADR-0011 (Tier-1 gate), ADR-0012 (Actions as CI/CD control plane), invariant 31 (Tier-1 gate is mandatory).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — `bicep/bicepconfig.json` exists so the linter has rules to apply. The reusable workflow itself does not depend on the modules existing; it lint any Bicep file the PR touches.
+
+**Constraints:**
+- Reusable `job-bicep-lint.yml`, `workflow_call`-only.
+- Fast skip on no-Bicep PRs.
+- Fail on `error`; warn on `warning` (opt-in via `fail-on-warnings`).
+- `permissions: { contents: read }` only — no Azure auth.
+- Parallel in `pr-core.yml`, not sequential.
+
+**Key Files:**
+- `.github/workflows/job-bicep-lint.yml` (new)
+- `.github/workflows/pr-core.yml` (amend)
+- `docs/consumer-usage.md`
+
+**Contracts:**
+- Workflow inputs: `paths` (default `'**/*.bicep,**/*.bicepparam'`), `fail-on-warnings` (default `false`), `base-ref` (default `''`, optional fallback for the diff base when the workflow_call context does not expose `github.event.pull_request.base.sha`).
+- Trigger: `workflow_call` only.
+- Behavior: fail on `error`-severity `bicep lint` findings; fail on any `bicep build-params` non-zero exit; otherwise pass. `lint` runs on `.bicep`; `build-params` runs on `.bicepparam` (the CLI's `lint` subcommand does not accept `.bicepparam`).

--- a/generated/issue-packets/active/adr-0077-iac-bicep/08-architecture-per-node-bicep-template-scaffold-pattern.md
+++ b/generated/issue-packets/active/adr-0077-iac-bicep/08-architecture-per-node-bicep-template-scaffold-pattern.md
@@ -1,0 +1,234 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0077", "wave-6"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0077"]
+wave: 6
+initiative: adr-0077-iac-bicep
+node: honeydrunk-architecture
+---
+
+# Author the per-Node Bicep template scaffold pattern for new infrastructure work
+
+## Summary
+Author `infrastructure/patterns/per-node-bicep-template.md` — the canonical scaffold pattern that the `scope` agent (and human operators) consult when a Node needs to provision new Azure resources. The doc covers the per-Node `infra/` directory layout (`main.bicep` + `parameters.{env}.bicepparam` + per-Node `bicepconfig.json`), module registry-reference syntax, the `tags` parameter shape consumed by modules from packet 05, the `secretRef` shape for any secret-shaped input, the consumer-side `pr-core.yml` wiring for the `bicep lint` gate (packet 07), the consumer-side release-workflow wiring for `job-deploy-bicep.yml` (packet 06), and the per-environment approval-gate pattern per ADR-0033. The doc is the reference the `scope` agent uses to author packets for new per-Node infrastructure work going forward.
+
+## Context
+ADR-0077 D6 commits the discipline: "New infrastructure goes through Bicep from day one." Each Node standup (ADR-0059 Cache, ADR-0060 Identity, ADR-0061 Files) — and any future Node that provisions Azure resources — will need a per-Node `infra/main.bicep` and `parameters.{env}.bicepparam`. Without a canonical pattern, each Node's executor invents the layout, the module-reference style, the parameter-file shape, and the workflow wiring independently — guaranteed drift.
+
+This packet authors the pattern once, in the Architecture repo's `infrastructure/patterns/` directory (a new subdirectory; mirrors the existing `infrastructure/walkthroughs/` for repeatable portal procedures). The pattern doc is the canonical reference for:
+- The directory layout in a Node repo (`infra/main.bicep`, `infra/parameters.dev.bicepparam`, `infra/parameters.staging.bicepparam`, `infra/parameters.prod.bicepparam`, `infra/bicepconfig.json`).
+- The module reference syntax (`module identityVault 'br:acrhdbicep.azurecr.io/modules/secrets/keyVault:1.0.0' = { ... }`) and the immutable-version-pinning discipline.
+- The `tags` object the modules consume — composed once per Node, applied uniformly:
+  ```bicep
+  var tags = {
+    'hd:node': '{node}'
+    'hd:env': env
+    'hd:owner': 'honeydrunkstudios'
+    'hd:cost-center': '{cost-center}'
+    'hd:dr-tier': '{dr-tier}'
+    'hd:adr': '{provisioning-ADR}'
+  }
+  ```
+- The `secretRef` shape for module inputs that need a Vault-stored secret: `{ name: 'X', keyVaultUrl: kv.outputs.vaultUri, identity: containerApp.identity.principalId }` (never `{ password: '...' }`).
+- The consumer-side `pr-core.yml` block that wires the `job-bicep-lint.yml` gate (packet 07).
+- The consumer-side release-workflow block that wires `job-deploy-bicep.yml` (packet 06) with `environment:` approval gates per ADR-0033 for `staging` / `prod`.
+- The Vault-bootstrap pattern: the `keyVault` module outputs the vault URI; the Container App's environment variables wire `AZURE_KEYVAULT_URI` to that URI per invariant 18.
+- The DR tag (`hd:dr-tier`) selection per ADR-0036.
+
+The pattern doc explicitly **does not** author per-Node templates for any specific Node — that is per-Node work, scoped by that Node's standup ADR or by an opportunistic-import packet (per D6, see packet 09). The pattern is the scaffold; the per-Node templates are the implementations.
+
+The `scope` agent's instructions point to this pattern when authoring future infrastructure packets. The doc is also consumed by human operators authoring `infra/main.bicep` directly.
+
+This is a docs packet. No code, no .NET project.
+
+## Scope
+- `infrastructure/patterns/` (new directory — sibling to `infrastructure/walkthroughs/`)
+- `infrastructure/patterns/README.md` (new) — explains what the `patterns/` directory is (canonical scaffold patterns for repeatable per-Node infrastructure work; complements `walkthroughs/` which is for repeatable portal procedures).
+- `infrastructure/patterns/per-node-bicep-template.md` (new) — the canonical Bicep template scaffold pattern.
+
+## Proposed Implementation
+1. **Create `infrastructure/patterns/`** alongside `infrastructure/walkthroughs/`. Add a `README.md` explaining the directory's purpose.
+2. **`infrastructure/patterns/per-node-bicep-template.md`** — author the doc with these sections:
+   - **Purpose** — quote ADR-0077 D4/D6 verbatim.
+   - **When to use this pattern** — every time a Node needs to provision a new Azure resource (per ADR-0077 D6 "new infrastructure goes through Bicep from day one"); when importing an existing manually-provisioned resource per D6 (cross-reference packet 09's import playbook).
+   - **Per-Node `infra/` layout** — the directory shape:
+     ```
+     infra/
+       bicepconfig.json
+       main.bicep
+       parameters.dev.bicepparam
+       parameters.staging.bicepparam
+       parameters.prod.bicepparam
+     ```
+     Note: `bicepconfig.json` is a copy (or `# include`-style reference if Bicep supports it) of `HoneyDrunk.Actions/bicep/bicepconfig.json`; if the Bicep version supports config inheritance via a parent registry, prefer that. **Research the current best practice at execution time** and document the choice — Bicep is evolving.
+   - **`main.bicep` template skeleton** — show an annotated example consuming the modules from packet 05. Annotate every block:
+     ```bicep
+     // The composed Grid tag object applied uniformly to every resource.
+     // Required tags per ADR-0077 D3.
+     var tags = {
+       'hd:node': nodeId
+       'hd:env': env
+       'hd:owner': 'honeydrunkstudios'
+       'hd:cost-center': costCenter
+       'hd:dr-tier': drTier
+       'hd:adr': 'ADR-XXXX'  // the provisioning ADR for this Node's infra
+     }
+
+     module identityVault 'br:acrhdbicep.azurecr.io/modules/secrets/keyVault:1.0.0' = {
+       name: 'identityVault'
+       params: {
+         node: 'identity'
+         env: env
+         tags: tags
+         location: location
+         logAnalyticsWorkspaceId: logAnalyticsWorkspaceId  // for invariant-22 diagnostics
+       }
+     }
+
+     module identityApp 'br:acrhdbicep.azurecr.io/modules/compute/containerApp:1.0.0' = {
+       name: 'identityApp'
+       params: {
+         service: 'identity'
+         env: env
+         tags: tags
+         containerAppEnvironmentId: containerAppEnvironmentId
+         imageRef: imageRef
+         envVars: [
+           { name: 'AZURE_KEYVAULT_URI', value: identityVault.outputs.vaultUri }  // invariant 18
+         ]
+         secretRefs: []
+         ingress: { external: true, targetPort: 8080 }
+       }
+     }
+     ```
+     Highlight: (a) the `tags` variable is composed once and passed to every module; (b) all module references use the `br:acrhdbicep.azurecr.io/modules/{concern}/{name}:{semver}` form — no local-path references; (c) the `AZURE_KEYVAULT_URI` env var on the Container App wires invariant 18; (d) no secret value enters the template — secrets are seeded into the Vault out-of-band (portal walkthrough or a separate seed step) and referenced by URI.
+   - **`parameters.{env}.bicepparam` template skeleton** — show the shape:
+     ```bicep
+     using './main.bicep'
+
+     param env = 'dev'
+     param location = 'eastus'  // or whichever region this env pins to
+     param nodeId = 'honeydrunk-identity'
+     param costCenter = 'identity-core'
+     param drTier = 'T2'
+     param containerAppEnvironmentId = '/subscriptions/.../containerAppsEnvironments/cae-hd-dev'
+     param logAnalyticsWorkspaceId = '/subscriptions/.../workspaces/log-hd-shared-dev'
+     param imageRef = 'acrhdshareddev.azurecr.io/honeydrunk/identity:0.1.0'
+     ```
+     Note: per-environment parameter files differ only in their environment-specific values (env, location, the referenced shared resources by id, the image tag). No secret values; ARM resource ids are non-secret references.
+   - **Consumer-side `pr-core.yml` wiring** — show the minimal block to opt into the `bicep lint` gate (packet 07):
+     ```yaml
+     bicep-lint:
+       uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-bicep-lint.yml@main
+     ```
+   - **Consumer-side release-workflow wiring** — show the minimal block to deploy via `job-deploy-bicep.yml` (packet 06) per environment, with `environment:` gates per ADR-0033:
+     ```yaml
+     deploy-infra-dev:
+       if: github.ref_type == 'tag' && contains(github.ref, '-dev')
+       environment: dev
+       uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-deploy-bicep.yml@main
+       with:
+         env: dev
+         template-path: infra/main.bicep
+         parameters-path: infra/parameters.dev.bicepparam
+         deployment-scope: resourceGroup
+         resource-group: rg-hd-{node}-dev
+       secrets: inherit
+
+     deploy-infra-staging:
+       if: github.ref_type == 'tag' && contains(github.ref, '-staging')
+       environment: staging  # GitHub environment approval gate
+       uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-deploy-bicep.yml@main
+       with:
+         env: staging
+         # ... etc
+     ```
+     Highlight: the `environment:` requirement is what gates staging / prod per ADR-0033; the `job-deploy-bicep.yml` workflow itself is scope-pure.
+   - **Tag composition reference** — list each required tag from ADR-0077 D3 and where its value comes from (the node id, the env, the studio identifier, the cost center per the operator's lean tag scheme, the DR tier per ADR-0036, the provisioning ADR).
+   - **What this pattern does NOT cover** — multi-region deployment (per ADR-0077 D8 — DR cross-region is per-Node, not in the pattern); subscription-scoped resources beyond resource-group creation (the `subscription` deployment-scope is supported by packet 06 but its templates are not in this pattern's example); private-link networking (deferred).
+   - **Cross-references** — to packet 09's import playbook (for D6 opportunistic migration); to `infrastructure/walkthroughs/bicep-registry-acr-creation.md` (packet 02); to the per-concern module READMEs in `HoneyDrunk.Actions/bicep/modules/*/README.md`.
+3. **`infrastructure/patterns/README.md`** — short doc explaining what `patterns/` is and listing the patterns it contains (initially just `per-node-bicep-template.md`).
+
+## Affected Files
+- `infrastructure/patterns/` (new directory)
+- `infrastructure/patterns/README.md` (new)
+- `infrastructure/patterns/per-node-bicep-template.md` (new)
+
+## NuGet Dependencies
+None. Docs-only — no .NET project.
+
+## Boundary Check
+- [x] `HoneyDrunk.Architecture` is the correct home for patterns and walkthroughs — routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] The pattern doc does not author any per-Node template — it scaffolds the pattern; per-Node templates land in per-Node repos at infrastructure touchpoints.
+- [x] No code change in any other repo.
+
+## Acceptance Criteria
+- [ ] `infrastructure/patterns/` directory exists with a `README.md` explaining the directory's purpose
+- [ ] `infrastructure/patterns/per-node-bicep-template.md` exists and covers: (a) when to use the pattern (per ADR-0077 D6 — new infrastructure goes through Bicep from day one), (b) the per-Node `infra/` directory layout (`main.bicep`, per-environment `.bicepparam` files, per-Node `bicepconfig.json`), (c) an annotated `main.bicep` skeleton consuming modules from packet 05 with the `tags` variable and the registry-reference syntax, (d) a `parameters.{env}.bicepparam` skeleton with no secret values, (e) the consumer-side `pr-core.yml` wiring for the `bicep lint` gate, (f) the consumer-side release-workflow wiring for `job-deploy-bicep.yml` with `environment:`-gated staging / prod per ADR-0033, (g) the tag composition reference per ADR-0077 D3, (h) explicit out-of-scope items
+- [ ] Module references in the skeleton use the immutable registry-pinned form `br:acrhdbicep.azurecr.io/modules/{concern}/{name}:{semver}` — never local-path
+- [ ] No secret values, connection strings, instrumentation keys, or `AZURE_CREDENTIALS` JSON appear in any code block in the doc (invariant 8 / invariant 85)
+- [ ] The doc cross-references packet 02's ACR walkthrough, packet 09's import playbook, packets 06/07's workflows, and the per-concern module READMEs in `HoneyDrunk.Actions/bicep/modules/*/README.md`
+- [ ] The annotated skeleton's environment variable on the Container App wires `AZURE_KEYVAULT_URI` (invariant 18)
+- [ ] The doc explicitly notes what the pattern does NOT cover (multi-region DR, subscription-scoped beyond RG creation, private-link networking)
+- [ ] No per-Node template is authored — patterns scaffold the pattern; per-Node templates land in per-Node repos at infrastructure touchpoints
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0077 D4 — Per-environment deployment.** `main.bicep` entry-point + `parameters.{env}.bicepparam` per-environment. The pattern doc scaffolds this shape.
+
+**ADR-0077 D6 — Migration from existing manual provisioning.** "New infrastructure goes through Bicep from day one." The pattern is what executors follow for new infrastructure.
+
+**ADR-0077 D3 — Naming and tagging.** Required tags `hd:node`, `hd:env`, `hd:owner`, `hd:cost-center`, `hd:dr-tier`, `hd:adr`. The pattern's `tags` variable composes them once per Node.
+
+**ADR-0077 D7 — Secrets in Bicep.** Templates never contain secret values. The pattern's `secretRef` shape and `parameters.{env}.bicepparam` skeleton both demonstrate the discipline.
+
+**ADR-0033 — Environment-gated deploy triggers.** Per-environment release-workflow gating via GitHub `environment:` requirement. The pattern shows the consumer-side wiring.
+
+**ADR-0036 — DR tiers (T0/T1/T2).** The `hd:dr-tier` tag value comes from the Node's DR posture per ADR-0036.
+
+**Invariant 18 — Vault URIs and App Configuration endpoints reach Nodes via environment variables.** The pattern's Container App env-var section wires `AZURE_KEYVAULT_URI` from the `keyVault` module's output.
+
+**Invariant 19 — Service names in Azure resource naming must be ≤ 13 characters.** The pattern documents the constraint and the modules' `@maxLength(13)` enforcement.
+
+## Constraints
+- **Pattern, not template.** The doc is scaffold guidance; do not author any per-Node `main.bicep` here.
+- **No secret values in code blocks.** Every code block in the doc must be safe to copy-paste; no embedded credentials, even fake-looking ones (no "REPLACE_ME" connection strings).
+- **Registry references only.** Every module reference in the doc uses `br:acrhdbicep.azurecr.io/modules/...:{semver}` — never local-path. Reinforce that per-Node templates use registry references.
+- **Cross-reference dispatch.** The doc points to the import playbook (packet 09), the ACR walkthrough (packet 02), and the workflows (packets 06/07) so executors of future per-Node infrastructure packets have a single entry point.
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0077`, `wave-6`
+
+## Agent Handoff
+
+**Objective:** Author `infrastructure/patterns/per-node-bicep-template.md` (and the `infrastructure/patterns/` directory + README) as the canonical scaffold pattern for per-Node Bicep template work going forward.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Give the `scope` agent and human operators a single canonical reference for per-Node infrastructure work, so each new Node's `infra/main.bicep` is shaped consistently.
+- Feature: ADR-0077 IaC — Bicep rollout, Wave 6.
+- ADRs: ADR-0077 D3/D4/D6/D7 (primary), ADR-0033 (environment gating), ADR-0036 (DR tiers), invariants 18, 19.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0077 should be Accepted before its pattern doc lands.
+
+**Constraints:**
+- Pattern, not template — no per-Node `main.bicep` authored here.
+- No secret values in any code block (invariant 8 / 85).
+- Registry references only (`br:acrhdbicep.azurecr.io/...`).
+- Cross-reference packet 09 (import playbook), packet 02 (ACR walkthrough), packets 06/07 (workflows).
+
+**Key Files:**
+- `infrastructure/patterns/README.md` (new)
+- `infrastructure/patterns/per-node-bicep-template.md` (new)
+
+**Contracts:** None — docs only.

--- a/generated/issue-packets/active/adr-0077-iac-bicep/09-architecture-bicep-import-existing-resources-playbook.md
+++ b/generated/issue-packets/active/adr-0077-iac-bicep/09-architecture-bicep-import-existing-resources-playbook.md
@@ -1,0 +1,152 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0077", "wave-6"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0077"]
+wave: 6
+initiative: adr-0077-iac-bicep
+node: honeydrunk-architecture
+---
+
+# Author the bicep-import-existing-resources playbook for the D6 opportunistic-migration path
+
+## Summary
+Author `infrastructure/patterns/bicep-import-existing-resources.md` — the canonical playbook for the ADR-0077 D6 opportunistic-migration path: when a manually-provisioned Azure resource (an existing Vault namespace, Service Bus namespace, Container App, etc.) needs a configuration change, the operator imports it to Bicep before applying the change. The playbook documents the four-step path the ADR commits — export ARM → decompile to Bicep → reconcile drift → adopt — plus the per-Node responsibilities, the `grid-health.json` reconciliation pattern, the rollback path, and the failure modes specific to imported resources (deployment-mode safety, immutable property mismatches, missing tags).
+
+## Context
+ADR-0077 D6 commits the opportunistic-migration discipline:
+
+> **Existing resources are imported to Bicep opportunistically.** When an existing resource needs a configuration change, the operator authors a Bicep template for it as part of the change. The migration path: export the existing resource to ARM JSON (`az resource show --ids ... --query properties`), decompile it to Bicep (`az bicep decompile --file resource.json`), reconcile drift between the decompiled template and the desired state, and adopt the resource into the deploy pipeline thereafter.
+>
+> **A per-Node import-to-Bicep packet** is filed when the Node's next significant infrastructure work happens; not a campaign.
+
+The discipline matches the grandfather pattern from ADR-0058 D9, ADR-0074 D6, ADR-0075 D4 — no retroactive campaign, no flag-day migration, no parallel-track maintenance. Each Node converges on Bicep-managed-everything when its existing infrastructure naturally touches.
+
+The playbook is the canonical reference operators (or the `scope` agent) consult when they file a per-Node import packet. Without a documented playbook, each import is invented from scratch — including the parts where drift surfaces unexpected differences between the deployed resource and what the operator thought it was, where `az bicep decompile` produces ARM-ish Bicep that needs hand-cleanup to match the modules-library shape, and where immutable resource properties (Storage account kind, ACR SKU, etc.) make a naive deployment fail because Bicep wants to recreate-not-update.
+
+The playbook does **not** import any specific resource — that is per-Node work, filed as a per-Node packet when the Node's next infrastructure touch happens. The playbook is the procedure operators follow when they file that packet.
+
+Sibling to packet 08's per-Node template scaffold pattern. Together packets 08 + 09 cover the two D6 paths: (08) new infrastructure goes through Bicep from day one; (09) existing infrastructure is imported opportunistically. The `scope` agent uses them complementarily — packet 08 for greenfield infrastructure packets; packet 09 for import packets.
+
+This is a docs packet. No code, no .NET project.
+
+## Scope
+- `infrastructure/patterns/bicep-import-existing-resources.md` (new) — the import playbook.
+
+## Proposed Implementation
+1. **Author `infrastructure/patterns/bicep-import-existing-resources.md`** with these sections:
+
+   **Purpose.** Quote ADR-0077 D6 verbatim. Cross-reference packet 08 — the greenfield pattern — and explain when to use this playbook (import) vs that one (greenfield).
+
+   **When this playbook is the right choice.**
+   - An existing manually-provisioned Azure resource needs a configuration change. Importing first, then changing through Bicep, is the path.
+   - An existing resource is structurally in scope for the Bicep substrate (it would be re-provisioned via a module from packet 05 if it were new today) but is not yet under IaC.
+   - Not for: brand-new resources (packet 08 is the right pattern for those); not for resources the Grid is about to delete (just delete via portal — no import needed); not for cross-environment audit (running this on a clean dev resource that already matches a module's defaults is busywork).
+
+   **The four-step path.**
+   - **Step 1: Export.** Use `az resource show --ids {resource-id} --output json` to capture the full ARM representation. Save to `infra/imported-{resource}-snapshot.json` in the Node repo (gitignored if it contains anything sensitive, or scrubbed before commit). Document any non-default Azure resource configuration the operator did not remember setting.
+   - **Step 2: Decompile.** Run `az bicep decompile --file infra/imported-{resource}-snapshot.json`. This produces a `.bicep` file alongside the JSON. The output is ARM-shaped Bicep — verbose, full of explicit defaults, no use of the modules library. **It is a starting point, not the final template.**
+   - **Step 3: Reconcile drift.** Two reconciliations happen here:
+     1. **Library-shape reconciliation.** Hand-rewrite the decompiled `.bicep` to consume modules from `acrhdbicep` (packet 05) — replace the inline `Microsoft.KeyVault/vaults` resource with a `module identityVault 'br:acrhdbicep.azurecr.io/modules/secrets/keyVault:1.0.0' = { ... }` reference. Replace inline tags with the composed `tags` variable per packet 08's pattern. Replace inline secrets-as-properties with `secretRef`s per ADR-0077 D7.
+     2. **Drift reconciliation.** Compare the decompiled (now library-shaped) template against the desired state. If the deployed resource has properties that no longer match the Grid's desired configuration (e.g. soft-delete disabled where ADR-0005 wants it enabled, a wrong tag, a SKU below the module default), record the drift in the import packet's body. Decide for each drift: **(a)** the desired state takes precedence (the Bicep deploy will update the resource to match); **(b)** the deployed state takes precedence (the template carries the deployed value as a parameter / override). Document each decision in the per-Node import packet so the change is visible at PR review.
+
+   **Step 4: Adopt.** Apply the Bicep template via `job-deploy-bicep.yml` (packet 06). The first deploy executes the drift reconciliation. **Run `az deployment what-if` first** — what-if for an imported resource will list every property Azure considers different between the template and the live resource; review carefully before applying. Some property differences are immutable (resource kind, location, certain SKUs); a difference there means recreate-not-update, which is rarely what the import wants — fix the template to match the deployed property and try again.
+
+   **Per-Node responsibilities.**
+   - The per-Node import packet is filed by the `scope` agent when the operator declares the trigger (a configuration change needed on the existing resource).
+   - The packet's `target_repo` is the Node's repo (not Architecture); the templates land under the Node's `infra/`.
+   - The packet's body documents the drift decisions per resource.
+   - Acceptance includes a successful `what-if` + apply on at least the `dev` environment.
+
+   **`grid-health.json` reconciliation.** Add an `imported_via_bicep: true` (or similar) field on the per-resource entry, or move the entry from a "manually-provisioned" section to a "bicep-managed" section if the catalog uses that shape. Inspect `catalogs/grid-health.json` at packet execution time and follow its existing shape — do not invent a new structure.
+
+   **Common failure modes.**
+   - **Immutable property mismatch.** The deployed resource's `kind` or `location` differs from the decompiled template. Bicep wants to delete-and-recreate. Fix the template to match.
+   - **Missing tags.** Deployed resources may have no `hd:*` tags. The first Bicep apply adds them — this is a desirable drift, document the operator's awareness.
+   - **Secrets in the decompiled output.** `az bicep decompile` may surface secret-shaped properties (admin keys, connection strings) as inline parameters. Strip them; use `secretRef` shapes; re-route the consumer to the Vault.
+   - **Resource group mismatch.** The deployed resource may live in a non-conformant RG. The import packet either accepts the RG (and tolerates the naming mismatch) or moves the resource (which is a separate, more invasive operation — usually defer).
+   - **Existing role assignments.** RBAC assignments are separately-managed resources. The decompiled output may or may not include them. Add them to the template explicitly if they are part of the desired state.
+
+   **Rollback path.**
+   - **Before the first Bicep apply.** Revert the PR; no state changed; the existing resource stays as it was.
+   - **After the first Bicep apply.** The resource is now Bicep-managed and may have been updated to reconcile drift. Rollback requires either (a) re-applying the previous state via a captured ARM snapshot (which the import packet should commit alongside the new template — the snapshot from Step 1), or (b) accepting the Bicep-managed state and rolling forward with corrections.
+   - **Escape hatch.** A resource that fails import (immutable property mismatch the operator cannot resolve) can stay manually-provisioned — document in `grid-health.json` as `imported_via_bicep: false` and note the blocking property. The grandfather pattern is bidirectional under D6.
+
+   **Cross-references.** Packet 08 (greenfield pattern), packet 02 (ACR walkthrough), packets 06/07 (workflows), the existing `infrastructure/walkthroughs/` portal docs (for resources that have a sibling portal walkthrough — useful context on what the original provisioning shape was).
+
+2. **No `infrastructure/patterns/README.md` edit needed** — packet 08 creates that README; this packet adds a new file to the directory and packet 08's executor adds the cross-reference. If packets 08 and 09 land in different waves and packet 08 has not yet created the README, this packet's executor creates `infrastructure/patterns/README.md` instead, listing both patterns.
+
+## Affected Files
+- `infrastructure/patterns/bicep-import-existing-resources.md` (new)
+- `infrastructure/patterns/README.md` — extend the list of patterns to include this one (or create the README if packet 08 has not yet landed; coordinate by checking the file's existence at execution time)
+
+## NuGet Dependencies
+None. Docs-only — no .NET project.
+
+## Boundary Check
+- [x] `HoneyDrunk.Architecture` is the correct home for patterns — routing rule maps to it directly.
+- [x] The playbook does not import any specific resource — that is per-Node work.
+- [x] No code change in any other repo.
+
+## Acceptance Criteria
+- [ ] `infrastructure/patterns/bicep-import-existing-resources.md` exists and covers: (a) purpose with the verbatim ADR-0077 D6 quote, (b) when this playbook is the right choice (and when it is not), (c) the four-step path (export, decompile, reconcile drift in two reconciliations — library-shape and drift-decision, adopt via what-if + apply), (d) per-Node responsibilities (per-Node target repo, the `scope` agent files the per-Node packet, per-resource drift decisions documented in the packet body), (e) `grid-health.json` reconciliation, (f) common failure modes (immutable property mismatch, missing tags, secrets in decompiled output, RG mismatch, role assignments), (g) the rollback path including the snapshot-ARM-JSON safety
+- [ ] The playbook explicitly cross-references packet 08 (greenfield), packet 02 (ACR walkthrough), packets 06/07 (workflows)
+- [ ] The playbook covers the `what-if` review discipline: `az deployment what-if` runs first; immutable property mismatches are surfaced before any apply
+- [ ] The playbook documents the `secretRef`-shape replacement for any secret-shaped property that `az bicep decompile` surfaces in plain form (invariant 8 / invariant 85 / ADR-0077 D7)
+- [ ] The playbook documents the bidirectional grandfather posture: a resource that fails import can stay manually-provisioned with a note in `grid-health.json`
+- [ ] `infrastructure/patterns/README.md` lists this pattern (and `per-node-bicep-template.md` from packet 08); if packet 08 has not yet landed, create the README and list both
+- [ ] No specific resource is imported by this packet — the playbook is the procedure; per-Node imports are per-Node packets
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0077 D6 — Migration from existing manual provisioning.** "New infrastructure goes through Bicep from day one. Existing resources are imported to Bicep opportunistically. The migration path: export the existing resource to ARM JSON, decompile it to Bicep, reconcile drift between the decompiled template and the desired state, and adopt the resource into the deploy pipeline thereafter. A per-Node import-to-Bicep packet is filed when the Node's next significant infrastructure work happens; not a campaign."
+
+**ADR-0077 D7 — Secrets in Bicep.** The decompile step may surface secret-shaped properties in plain form; the playbook documents stripping them and replacing with `secretRef` shapes.
+
+**ADR-0077 D3 — Naming and tagging.** Imports may have missing tags; the first Bicep apply adds them. This is desirable drift; the playbook documents the operator's awareness.
+
+**Grandfather pattern precedents.** ADR-0058 D9 (caching), ADR-0074 D6 (testing library), ADR-0075 D4 (documentation tooling) all use the same opportunistic-migration shape.
+
+## Constraints
+- **Playbook, not import.** The doc is the procedure; do not import any specific resource here.
+- **The `what-if` discipline is mandatory.** Every import documents a `what-if` review before the first apply. Immutable property mismatches are caught before they become a recreate-not-update incident.
+- **No secret values in code blocks.** Every code block in the doc must be safe to copy-paste. Strip secrets that `az bicep decompile` surfaces — never paste an example with a real-shaped secret literal.
+- **Bidirectional grandfather.** A resource that fails import can stay manually-provisioned with documentation. The playbook documents this — D6's grandfather pattern is bidirectional.
+- **Coordinate with packet 08 on the README.** Whichever packet lands first creates `infrastructure/patterns/README.md`; the other extends it. Check at execution time.
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0077`, `wave-6`
+
+## Agent Handoff
+
+**Objective:** Author `infrastructure/patterns/bicep-import-existing-resources.md` — the canonical playbook for the ADR-0077 D6 opportunistic-migration path (export → decompile → reconcile drift → adopt).
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Document the import procedure so per-Node import packets — filed when an existing resource's next significant touch happens — have a single canonical reference.
+- Feature: ADR-0077 IaC — Bicep rollout, Wave 6.
+- ADRs: ADR-0077 D3/D6/D7 (primary).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0077 should be Accepted before its import playbook lands.
+
+**Constraints:**
+- Playbook, not import — do not import any specific resource.
+- `what-if` review is mandatory before every first apply.
+- No secret values in code blocks (invariant 8 / 85).
+- Bidirectional grandfather — resources can stay manually-provisioned if import fails; document in `grid-health.json`.
+- Coordinate with packet 08 on the `infrastructure/patterns/README.md` (whichever lands first creates it).
+
+**Key Files:**
+- `infrastructure/patterns/bicep-import-existing-resources.md` (new)
+- `infrastructure/patterns/README.md` (create or extend)
+
+**Contracts:** None — docs only.

--- a/generated/issue-packets/active/adr-0077-iac-bicep/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0077-iac-bicep/dispatch-plan.md
@@ -1,0 +1,155 @@
+# Dispatch Plan — ADR-0077: Infrastructure-as-Code — Bicep (Azure-native)
+
+**Initiative:** `adr-0077-iac-bicep`
+**ADR:** ADR-0077 (Proposed → Accepted via packet 00)
+**Sector:** Ops / cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0077 commits **Bicep** as the canonical IaC tool for every Azure resource the Grid provisions, with a per-concern modularization strategy, a shared `acrhdbicep` Bicep registry distinct from the per-environment container-image ACR (`acrhdshared{env}`), naming and tagging conventions enforced by linter rules, per-environment parameter files, and an explicit grandfather posture for already-manually-provisioned resources (D6). The ADR is Azure-deep by construction (D5); modularization is the hedge against future Terraform migration cost.
+
+This initiative delivers: ADR acceptance + the three new IaC invariants + catalog registration (Architecture); the Bicep registry ACR provisioning walkthrough and the live `acrhdbicep` resource (Architecture/Human); the `HoneyDrunk.Actions/bicep/modules/` library structure with `bicepconfig.json` linter rules, the first module set (Container App, Key Vault, App Configuration, Storage Account, Service Bus, Application Insights), the `bicep-publish.yml` reusable workflow that publishes modules on tagged releases, the `job-deploy-bicep.yml` reusable deploy workflow consumed by per-Node release workflows, the `bicep lint` PR gate added to `pr-core.yml`; and the per-Node template-scaffold pattern + the D6 import-existing-resources-to-Bicep playbook (Architecture).
+
+**10 packets across 6 waves**, targeting **2 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Actions`). 9 `Actor=Agent`, 1 `Actor=Human` (packet 02 — the ACR portal provisioning).
+
+## Trigger
+
+ADR-0077 is Proposed with no scope. The forcing functions (from the ADR's Context):
+
+- **ADR-0076** Redis provisioning needs per-environment Cache for Redis instances — without an IaC tool, that provisioning happens via Portal or ad-hoc CLI.
+- **ADR-0036** DR posture's "re-provision in recovery region" claim is a multi-day operator effort without declarative templates.
+- **ADR-0033** environment-gated deploy model requires per-environment parity (dev ≈ staging ≈ prod) — only declarative templates make that enforceable.
+- **ADR-0059 (Cache), ADR-0060 (Identity), ADR-0061 (Files)** are imminent Node standups; each provisions Container Apps, Vault namespaces, possibly Postgres/Storage/Redis. The compounding infrastructure surface is about to exceed what manual provisioning can sustain.
+
+The ADR needs decomposition before the next major infrastructure provisioning event lands.
+
+## Scope Detection
+
+**Multi-repo.** ADR-0077 touches `HoneyDrunk.Actions` (the canonical home of the Bicep modules library `bicep/modules/`, the `bicep-publish.yml` workflow, the `job-deploy-bicep.yml` reusable deploy workflow, and the `bicep lint` PR gate per ADR-0012 — Actions is the CI/CD control plane) and `HoneyDrunk.Architecture` (acceptance, invariants, catalog registration, the ACR provisioning walkthrough, the per-Node template-scaffold pattern, the D6 import playbook). Per-Node `infra/main.bicep` templates are deliberately deferred — D6 grandfathers existing infrastructure and per-Node templates land at the first significant infrastructure touchpoint per Node, not as a campaign.
+
+**No cascade into consuming Nodes during this initiative.** Per-Node `infra/main.bicep` adoption is the per-Node concern, executed when the Node provisions a new resource (e.g., ADR-0076 Redis provisioning for the Cache Node) or when an existing resource needs a configuration change (D6). This initiative ships the substrate; downstream Nodes consume it on demand.
+
+## Wave Diagram
+
+### Wave 1 (No Dependencies — governance + catalog)
+- [ ] **00** — Architecture: Accept ADR-0077, claim the size-3 invariant block in `invariant-reservations.md` (`{N1}–{N3}`, currently **90–92**), add the three IaC invariants, amend invariant 35 to carve out `acrhdbicep`, register the initiative. `Actor=Agent`.
+- [ ] **01** — Architecture: register the Bicep modules library, the `acrhdbicep` registry, and the `bicep-publish.yml` / `job-deploy-bicep.yml` workflows in the Grid catalogs. `Actor=Agent`. Blocked by: 00.
+
+> **Invariant numbering.** Packet 00 claims the next free block in `constitution/invariant-reservations.md` (size 3). At dispatch-plan authoring the block is **90–92**; if a racing ADR's packet 00 merges first, the block shifts upward and every `{N*}` placeholder in packet 00 / `invariants.md` is updated together. The companion text-only amendment to invariant 35 lands in the same PR and is not a renumber.
+
+### Wave 2 (Provision the Bicep registry — depends on Wave 1)
+- [ ] **02** — Architecture: author the `bicep-registry-acr-creation.md` walkthrough and provision `acrhdbicep` in the Azure subscription. `Actor=Human`. Blocked by: 00.
+
+### Wave 3 (Bicep substrate in Actions — depends on Wave 2)
+- [ ] **03** — Actions: scaffold `bicep/modules/` library layout + `bicepconfig.json` linter rules for naming and tagging conventions (D3). `Actor=Agent`. Blocked by: 00.
+- [ ] **04** — Actions: author the `bicep-publish.yml` reusable workflow that publishes modules to `acrhdbicep` on tagged releases (D2). `Actor=Agent`. Blocked by: 02, 03.
+
+### Wave 4 (First module set — depends on Wave 3)
+- [ ] **05** — Actions: author the first per-concern Bicep module set — `compute/containerApp`, `secrets/keyVault`, `secrets/appConfigurationStore`, `data/storageAccount`, `messaging/serviceBusNamespace`, `observability/applicationInsights` — and tag `modules/v1.0.0` to publish them. `Actor=Agent`. Blocked by: 03, 04.
+
+### Wave 5 (Deploy workflow + PR gate — depends on Wave 4)
+- [ ] **06** — Actions: author the `job-deploy-bicep.yml` reusable deploy workflow that applies a Node's `infra/main.bicep` with per-environment `.bicepparam` (D4). `Actor=Agent`. Blocked by: 05.
+- [ ] **07** — Actions: add the `bicep lint` step to `pr-core.yml` so PRs touching any `.bicep` or `.bicepparam` file fail on linter violations (D3 enforcement). `Actor=Agent`. Blocked by: 03.
+
+### Wave 6 (Per-Node adoption substrate — depends on Wave 1, can run in parallel with Wave 3+)
+- [ ] **08** — Architecture: author the per-Node Bicep template scaffold pattern in the repo context docs — `infra/main.bicep` + `parameters.{env}.bicepparam` shape, module registry references, the executor checklist for new infrastructure work. `Actor=Agent`. Blocked by: 00.
+- [ ] **09** — Architecture: author the `bicep-import-existing-resources.md` playbook for the D6 opportunistic-migration path (export to ARM, decompile to Bicep, reconcile drift, adopt). `Actor=Agent`. Blocked by: 00.
+
+Packets within a wave run in parallel except where noted. **Packets 03 and 07 share `HoneyDrunk.Actions`** but touch different files (`bicep/` vs `.github/workflows/pr-core.yml`); they can land in parallel. **Packets 04 and 05** both extend `bicep/modules/` and share the `bicep-publish.yml` execution path — land 04 first (the workflow), then 05 (which uses it to publish the first module set). **Packet 06** consumes the modules published by 05 in its workflow inputs but does not itself need them to exist at PR time; the workflow ships idle until a per-Node release workflow calls it. **Packets 08 and 09 are independent** of all Actions work and run as early as Wave 1.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0077](./00-architecture-adr-0077-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [Bicep modules + registry catalog registration](./01-architecture-bicep-catalog-registration.md) | Architecture | Agent | 1 | 00 |
+| 02 | [Bicep registry ACR walkthrough + provisioning](./02-architecture-bicep-registry-acr-walkthrough.md) | Architecture | Human | 2 | 00 |
+| 03 | [Bicep modules library scaffold + bicepconfig](./03-actions-bicep-modules-library-scaffold.md) | Actions | Agent | 3 | 00 |
+| 04 | [bicep-publish.yml reusable workflow](./04-actions-bicep-publish-workflow.md) | Actions | Agent | 3 | 02, 03 |
+| 05 | [First per-concern Bicep module set](./05-actions-bicep-first-module-set.md) | Actions | Agent | 4 | 03, 04 |
+| 06 | [job-deploy-bicep.yml reusable deploy workflow](./06-actions-job-deploy-bicep-workflow.md) | Actions | Agent | 5 | 05 |
+| 07 | [Add bicep lint gate to pr-core.yml](./07-actions-bicep-lint-pr-gate.md) | Actions | Agent | 5 | 03 |
+| 08 | [Per-Node Bicep template scaffold pattern](./08-architecture-per-node-bicep-template-scaffold-pattern.md) | Architecture | Agent | 6 | 00 |
+| 09 | [Import-existing-resources-to-Bicep playbook (D6)](./09-architecture-bicep-import-existing-resources-playbook.md) | Architecture | Agent | 6 | 00 |
+
+## Version Bumps
+
+- **`HoneyDrunk.Actions`** — not a versioned .NET solution; the repo ships GitHub Actions YAML + Bicep modules. The Bicep module library has its own SemVer namespace via the `modules/v{N}.{N}.{N}` git-tag pattern (D2); packet 05 ships `modules/v1.0.0`. The repo may keep a `CHANGELOG.md` for the workflow surface; if so, every Actions packet appends an entry per the repo convention.
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; governance/catalog/docs edits only.
+
+## Cross-Cutting Concerns
+
+### Coordination with ADR-0076 (Redis) — IMPORTANT
+
+ADR-0076 commits Azure Cache for Redis as the cache backing and names per-environment provisioning. ADR-0077 names ADR-0076 explicitly as the first forcing function. The two should be coordinated:
+
+- **ADR-0076's Redis provisioning is the first natural touchpoint for a per-Node Bicep template.** ADR-0076's provisioning work (when scoped) can land in two shapes: (a) a portal walkthrough (consistent with the operator's portal-over-CLI preference), or (b) a per-Node `infra/main.bicep` consuming the `data/redisCache` module — which the first module set (packet 05) does **not** include in v1.0.0 because the Cache Node standup (ADR-0059) is not yet scoped. **Recommendation:** packet 05 v1.0.0 ships the six concerns the ADR explicitly names; ADR-0076's Redis module lands as `modules/v1.1.0` once the Cache Node's provisioning work is scoped and the resource shape is concrete. Until then, ADR-0076's `dev` provisioning can take the portal route consistent with the D6 grandfather pattern (new resource, but documented as not-yet-Bicep-managed in `grid-health.json`). Do not bundle Redis into packet 05 prematurely.
+- **No hard dependency.** ADR-0077 acceptance does not block on ADR-0076's acceptance, and ADR-0076's provisioning does not block on this initiative completing — the first deferral path is "provision via portal now; import to Bicep when the Cache Node's Bicep template lands per D6."
+
+### Coordination with the Node standups (ADR-0059 Cache / ADR-0060 Identity / ADR-0061 Files)
+
+Each of these Node standups will provision Azure resources. Per D6 and the dispatch above:
+
+- **New infrastructure goes through Bicep from day one.** Per ADR-0077 D6: "New infrastructure goes through Bicep from day one." Each Node standup that comes after this initiative completes ships its `infra/main.bicep` + per-environment `.bicepparam` as part of the standup, consuming the modules published by packet 05.
+- **Per-Node Bicep templates are scoped by the standup ADR, not by this initiative.** This initiative does not pre-author per-Node templates; doing so would couple Node-shape decisions (Postgres? Storage? region?) to an initiative whose scope is the substrate, not the per-Node infrastructure. The per-Node template lands when the standup ADR is scoped.
+
+### Bicep registry vs container-image registry — separate ACRs
+
+ADR-0077 D2 is explicit: the Bicep modules registry (`acrhdbicep`) is a **dedicated** Azure Container Registry, distinct from the per-environment container-image ACR (`acrhdshared{env}` per ADR-0015 and invariant 35). Reason: Bicep modules are environment-agnostic templates; a single shared registry across environments is the right shape. Per-environment image ACRs are an environment isolation concern; per-environment module ACRs would force version-bump-and-republish per environment for no security gain.
+
+- **Packet 02** provisions `acrhdbicep` in a yet-to-be-decided resource group. Recommended: `rg-hd-platform-shared` (a new platform RG that holds non-environment-scoped resources — the Bicep registry, and any future shared substrate). The walkthrough records the RG decision.
+- **Naming.** `acrhdbicep` is alphanumeric, globally unique, 11 chars — comfortably inside the 5–50 char ACR name limit. No environment suffix per its environment-agnostic role.
+- **Invariant 35 amendment.** Invariant 35's existing text names `acrhdshared{env}` as "the" shared ACR — `acrhdbicep` is a literal second ACR and collides on a strict reading. Packet 00 amends invariant 35's text in the same PR that adds the new IaC invariants, explicitly carving out `acrhdbicep` as the environment-agnostic, modules-only Bicep registry. The amendment is text-only; invariant 35 keeps its number.
+
+### Naming and tagging linter rules — committed by D3
+
+ADR-0077 D3 commits naming and tagging conventions enforced by `bicepconfig.json` linter rules. Packet 03 ships the `bicepconfig.json` and the rule set; packet 07 wires `bicep lint` into `pr-core.yml` so the rules are enforced at PR time. The rule set must:
+
+- Flag missing required tags (`hd:node`, `hd:env`, `hd:owner`, `hd:cost-center`, `hd:dr-tier`, `hd:adr`).
+- Flag non-conformant resource names (per-resource-type prefix, `hd-` Grid identifier, `{service}` or `{node}` name within the ≤13-char service-name length rule from invariant 19, `{env}` suffix).
+- Reject hardcoded secret values in templates (D7 — codifies invariant 8 extended to IaC payloads).
+
+The rule set is a single committed `bicepconfig.json` shared across the modules library and per-Node templates; per-Node templates inherit the rule set via Bicep's config-file resolution (file-system search from the template's directory upward, picking up the first `bicepconfig.json`).
+
+### Secrets discipline — codified in invariant 85, enforced by linter
+
+ADR-0077 D7 commits "Bicep templates never contain secret values." Packet 00's invariant 85 codifies it; packet 03's `bicepconfig.json` flags hardcoded secret-shaped strings as a linter rule (best-effort — full secret detection is impractical, but the rule should catch the common cases: `accountKey`, `connectionString`, `password`, `apiKey` literals). The runtime enforcement is the deploy-identity scope (D7): the GitHub Actions OIDC-federated identity has rights to provision resources, not to read secret values — so even if a template accidentally referenced a secret value by name, the deploy would fail with an AAD permission error rather than leaking the secret. This is defense in depth.
+
+### Vendor-exit posture acknowledged in D5 — no rebalancing in this initiative
+
+ADR-0077 D5 names the Azure-deep posture explicitly. The vendor-exit playbook (named in `charter-aware draft cluster 2.1`) is **explicitly out of scope** for this initiative — it lands as a separate ADR when authored. This initiative pre-pays the part of the vendor-exit cost that modularization (D2) addresses; nothing more. Do not bundle vendor-exit work into this initiative.
+
+### Site sync
+
+No site-sync flag. ADR-0077 is internal Ops infrastructure substrate — no public-facing Studios website content changes.
+
+### Deferred follow-ups (explicitly out of scope)
+
+- **Per-Node `infra/main.bicep` adoption.** Per D6, opportunistic, at each Node's next significant infrastructure touchpoint. No campaign.
+- **Existing-resource imports.** Per D6, opportunistic. The playbook (packet 09) is the substrate; the actual imports are per-Node concerns.
+- **Vendor-exit playbook authoring.** Separate ADR (cluster 2.1).
+- **Azure Policy / Azure Blueprints adoption.** ADR-0077 D8 explicitly defers — governance via Policy is a future concern.
+- **Cost-allocation tagging beyond the D3 `hd:cost-center` baseline.** Future operational concern.
+- **Bicep-generated documentation** (`--summary` output). Nice-to-have; deferred.
+- **Subscription / resource-group topology decisions.** D8 defers — the current single-subscription, per-Node-RG convention stands.
+- **Cloudflare IaC.** ADR-0029 governs Cloudflare; Bicep is Azure-only by construction. Cloudflare IaC (if ever) is a separate ADR.
+- **DR-rehearsal exercise.** ADR-0036's DR-rehearsal is the validation event for the Bicep-driven re-provisioning path; rehearsal scheduling is its own work item, not in this initiative.
+
+## Rollback Plan
+
+- **Packets 00–01 (governance/catalog):** revert the PR. ADR returns to Proposed; the three invariants and the catalog entries are removed. No runtime impact.
+- **Packet 02 (ACR provisioning):** `acrhdbicep` can be deleted in the portal; the walkthrough doc reverted. Low cost (Basic SKU), easily reversed. No consumer depends on it until packets 04/05 publish modules.
+- **Packet 03 (modules library scaffold):** revert the PR; the `bicep/modules/` tree and `bicepconfig.json` leave the repo. No published module exists yet — clean revert.
+- **Packet 04 (publish workflow):** revert the PR; `bicep-publish.yml` leaves the repo. No module has been published unless packet 05 already ran — if so, the published `modules/v1.0.0` tag in `acrhdbicep` is left in place by convention; deleting it requires an explicit ACR-side action and is normally not warranted. **Tag-immutability on ACR Basic tier is honor-system, not enforced** — the Basic SKU does not support repository-level immutability policies (a Premium-tier feature); the workflow's SemVer-bump discipline is what prevents republish-overwrite, not the registry.
+- **Packet 05 (first module set):** revert the PR; the module files leave the repo. The published `modules/v1.0.0` in `acrhdbicep` stays in place by convention (tag-immutability is honor-system on Basic tier; SemVer-bump discipline is workflow-enforced — `bicep-publish.yml` refuses to overwrite an existing tag); a future republish bumps to v1.0.1 with the corrected templates rather than overwriting v1.0.0.
+- **Packet 06 (deploy workflow):** revert the PR; `job-deploy-bicep.yml` leaves the repo. No per-Node release workflow calls it yet — clean revert.
+- **Packet 07 (PR gate):** revert the PR; `bicep lint` is removed from `pr-core.yml`. Existing PRs that previously failed the gate now pass. No runtime impact.
+- **Packets 08–09 (docs):** revert the PR; the docs are removed. No runtime impact.
+- **Operational escape hatch:** if a Bicep deployment ever produces a worse-than-portal result for a specific resource, the operator can fall back to portal provisioning for that resource and document the deviation in `grid-health.json`. D6's grandfather pattern is bidirectional — manual provisioning was the prior state; Bicep is the forward state; falling back is supported until the issue is reconciled.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.


### PR DESCRIPTION
## Summary

- Eighth of the staged PRs from the 2026-05-23 ADR batch. Governance-only — no code lands in any Node.
- Three deployment-substrate ADRs: ADR-0065 (.NET Aspire AppHost for local-dev inner loop; Notify + Pulse first migrants), ADR-0068 (BackgroundService for in-Node + Azure Container Apps Jobs for cross-Node recurring work), ADR-0077 (Bicep as canonical IaC; bicep/modules library at acrhdbicep; first module set covers Container App, Key Vault, App Configuration, Storage, Service Bus, App Insights).
- These three are coupled: Bicep templates (0077) provision the Azure resources Aspire (0065) references locally; Container Apps Jobs (0068) deploy via the Bicep-authored job-deploy workflow.

## Validation

- Markdown + JSON only; no code changed.
- file-packets.yml will file 27 packet files on merge — verify in The Hive.
- Reservation registry rows for ADR-0065 (78-79), ADR-0068 (83-86), ADR-0077 (90-92) are inherited from #288. ADR-0077 also amends invariant 35 in the same packet 00 PR (carves out acrhdbicep alongside acrhdshared{env}).

## Authorship

Authorship: agent-claude-code

## Notes

- This PR is out-of-band per ADR-0011 D9 / invariant 32 — ships packet files but doesn't execute any single packet.
- ADR-0065 packet 02 introduces the AppHost template in HoneyDrunk.Standards; first migrants (Notify packet 04, Pulse packet 05) compose the existing Pulse.Collector via ProjectReference — no new runtime host gets created.
- ADR-0068 packets 03/04 depend on ADR-0042 (idempotency) and ADR-0045 (IErrorReporter) NuGet packages shipping first; both Human Prerequisites are explicit.
- ADR-0077 packet 05 module set ships App Insights as a Vault-reference shape (not raw connection string output) per refine feedback — secrets stay in Vault, modules emit listKeys expressions only.
- ADR-0077 packet 06's deploy-bicep workflow scrubs secureString/secureObject outputs before surfacing to the calling workflow's outputs context.
- ADR-0077 packet 07's bicep lint covers .bicep only; .bicepparam files validated via bicep build-params (the CLI doesn't lint .bicepparam directly).