### PR TITLE
Scope ADR-0051/0052/0053 cross-cutting policy

### DIFF
--- a/generated/issue-packets/active/adr-0051-agent-authorization/00-architecture-adr-0051-acceptance.md
+++ b/generated/issue-packets/active/adr-0051-agent-authorization/00-architecture-adr-0051-acceptance.md
@@ -1,0 +1,155 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ai", "docs", "adr-0051", "wave-1"]
+dependencies: []
+adrs: ["ADR-0051"]
+accepts: ["ADR-0051"]
+wave: 1
+initiative: adr-0051-agent-authorization
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0051 — flip status, add four authorization invariants, register the initiative
+
+## Summary
+Flip ADR-0051 (AI Agent Authorization and Tool Scoping Model) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, add the four new authorization invariants ADR-0051 commits in its Consequences/Invariants section to `constitution/invariants.md`, and register the `adr-0051-agent-authorization` initiative in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0051 decides the Grid's authorization model for AI agents: a third principal type (`AgentPrincipal`), versioned capability bundles granted by the Operator Node, tool-level scoping at the `IToolInvoker` boundary, tenant-composing scope binding, delegated-execution intersection rules, time-bound grants, deny-by-default with typed exceptions, declarative-config v1 bundle storage in the Capabilities repo, and documented escalation paths (dynamic store, OPA) for v2. It was authored 2026-05-22 in the AI-sector authorization-substrate batch.
+
+The ADR's forcing functions: ADR-0017/0018/0020 (Capabilities/Operator/Agents standups) are blocked because their standup canaries demonstrate authorization and have nothing to demonstrate against; ADR-0006's Auth shape does not anticipate agents-as-principals; ADR-0030/0031's Audit substrate requires a first-class agent principal so audit records don't collapse to `principal=anonymous-agent`; Operator is itself an agent and the model must describe its own permissions without enabling recursive escalation; PDR-0001/0003's "on behalf of" semantics need committed delegation rules.
+
+The ADR decides (concise restatement; full text in the ADR):
+- **D1** — agents are a first-class principal type. `AgentPrincipal(Id, RunId, OnBehalfOf?, Bundles[], NotAfter)`, issued by Operator, run-bound by `AgentRunId`, composable with `TenantId`.
+- **D2** — capability bundles, not raw capability grants. Bundles are namespaced under `bundle:`, versioned (`@v3`), reviewed once and granted by name.
+- **D3** — tool scoping via `IToolInvoker` authorization check. Six-step ordered check (resolve tool, extract principal, compute effective capabilities, requirement match with scope resolution, dispatch + audit-granted, or deny + audit-denied).
+- **D4** — tenant scoping composes with ADR-0026. Three `ScopeBindingMode`s (`None`, `Tenant`, `OnBehalfOfPrincipal`); `{runtime}` placeholder binds at grant time; reserved `tenant=studios-internal` for cross-Grid agents.
+- **D5** — delegation is the **intersection** of bundle capabilities and `OnBehalfOf` permissions. Both bounds are load-bearing safety properties.
+- **D6** — time-bound grants with `NotAfter`. Defaults: 1h ad-hoc, 30d long-running, 24h infra-sweep, 8h dev. 90-day upper bound.
+- **D7** — tool registry: required capabilities declared in the tool's own type via `CapabilityRequirement[] RequiredCapabilities`. v1 is static (redeploy required); dynamic v2 deferred.
+- **D8** — Operator is privileged but **non-recursive**. `bundle:grid-operator@v1` holds grant-issuance but its `operator.grant.issue:bundleName={whitelist}` explicitly excludes `bundle:grid-operator@*`. Capabilities Node startup validates the recursion check; refuses to start on violation.
+- **D9** — v1 policy storage: declarative `policies/bundles/*.yaml` + `policies/capabilities/grid-vocabulary.yaml` in the `HoneyDrunk.Capabilities` repo. Loaded + validated at startup; failure fails the canary.
+- **D10** — audit record shape for authz decisions (13 fields). Emitted via `IAuditAppender`. Audit unavailable → deny (fail-closed).
+- **D11** — deny by default; typed `AuthorizationDeniedException` with structured detail. No "default allow" mode, no debug bypass.
+- **D12** — local-dev affordance: `bundle:local-dev-all@v1` with wildcard capabilities, gated by the `environments: [local, dev]` field. Capabilities Node refuses to start if it loads `local-dev-all` in `staging` or `prod`. Operator's whitelist excludes it.
+- **D13** — documented escalation paths (dynamic store + admin UI; per-tenant bundles; OPA).
+- **D14** — phased rollout (1: abstractions; 2: Capabilities v1; 3: Operator v1; 4: Agents v1; 5: AI consumers; 6: v2 escalations).
+
+ADR-0051 is a **substrate / contract** ADR. The concrete code — `AgentPrincipal` in Kernel, `AuthorizationDeniedException` + deny codes in Auth, Audit event-shape registration, and follow-up Capabilities / Operator / Agents implementations — lands across this initiative's remaining packets and the three AI-sector standup initiatives (`adr-0017-capabilities-standup`, `adr-0018-operator-standup`, `adr-0020-agents-standup`). Every other packet references ADR-0051's D-decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0051-ai-agent-authorization-and-tool-scoping-model.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0051 row Status column to Accepted.
+- `constitution/invariants.md` — add four new authorization invariants under a new `## Authorization Invariants` section, numbered **`{N1}, {N2}, {N3}, {N4}`** — the four-wide block reserved for ADR-0051 in `constitution/invariant-reservations.md` (see Constraints).
+- `initiatives/active-initiatives.md` — register the `adr-0051-agent-authorization` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+
+1. Edit the ADR-0051 header: `**Status:** Proposed` → `**Status:** Accepted`.
+
+2. Update the ADR-0051 index row in `adrs/README.md` to Accepted.
+
+3. Read `constitution/invariant-reservations.md` and confirm the four-wide block reserved for ADR-0051 (today: **54–57**). If the reservations file has shifted because another ADR landed first, take the new next-free block and update every `{N1}`/`{N2}`/`{N3}`/`{N4}` placeholder below before committing. The reservations-file row stays "Proposed" until this packet merges, then moves to **Reservation History** with the merge date.
+
+   Add the four new invariants to `constitution/invariants.md`, numbered **`{N1}, {N2}, {N3}, {N4}`**, under a new `## Authorization Invariants` section placed after the `## Audit Invariants` section. The text, taken verbatim-in-substance from ADR-0051's Consequences/Invariants section:
+
+   - **`{N1}` — Agent identity originates at Operator, never at Auth.** The `HoneyDrunk.Operator` Node is the only surface that issues `AgentPrincipal` tokens. Auth validates the principal claims; Auth does not mint them. This preserves invariant 10 ("Auth validates, never issues") for the third principal type. CI gate: a static analyzer rule in `HoneyDrunk.Standards.Analyzers` flags any direct construction of `AgentPrincipal` outside the `HoneyDrunk.Operator` assembly. See ADR-0051 D1, D8.
+
+   - **`{N2}` — Every tool invocation through `IToolInvoker` produces an Audit record.** Granted invocations emit `tool.invoke.granted`; denied invocations emit `tool.invoke.denied`. The record shape is defined by ADR-0051 D10 (13 fields). If the Audit substrate is unavailable, the tool invocation **denies** — silent allow-on-audit-failure is forbidden. CI gate: a contract test (per ADR-0047 Tier 2a) exercises the deny-when-audit-unavailable path. See ADR-0051 D3, D10.
+
+   - **`{N3}` — `bundle:local-dev-all` is loadable only in `local` or `dev` environments.** The `HoneyDrunk.Capabilities` Node reads `ASPNETCORE_ENVIRONMENT` at startup; if `bundle:local-dev-all` is present in the loaded bundle set and the environment is `staging` or `prod`, the Node refuses to start, emits a fatal log line, and exits non-zero. The check is at startup, not at grant time. Operator's whitelist further excludes `bundle:local-dev-all` from any grant path, so the bundle cannot leak into deployed environments via API. CI gate: a startup-canary test in the prod environment configuration validates the Node refuses to start with the dev bundle in scope. See ADR-0051 D12.
+
+   - **`{N4}` — Operator cannot grant itself any bundle whose capabilities include `operator.grant.issue:*`.** The grant-issuance capability is whitelisted to bundle names that exclude `bundle:grid-operator@*`. The Capabilities Node validates this recursion property at startup by walking `bundle:grid-operator`'s whitelist and verifying no whitelisted bundle's capability set contains `operator.grant.issue:*`. Violation fails the standup canary, which fails CI per ADR-0011. The cycle is broken structurally; Operator can grant other agents new capabilities, but it cannot escalate itself even with a bug or a misconfigured grant. See ADR-0051 D8.
+
+4. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder.
+
+## Affected Files
+- `adrs/ADR-0051-ai-agent-authorization-and-tool-scoping-model.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md` — the ADR-0051 row in **Active Reservations** is populated by this packet's PR (or already populated by an upstream authoring commit; verify) and moved to **Reservation History** on merge
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0051 header reads `**Status:** Accepted`
+- [ ] The ADR-0051 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariants.md` carries four new authorization invariants (agent identity originates at Operator; every tool invocation through `IToolInvoker` produces an Audit record; `bundle:local-dev-all` is loadable only in local/dev; Operator cannot grant itself the grant-issuance capability), numbered **`{N1}, {N2}, {N3}, {N4}`** (claimed from `constitution/invariant-reservations.md`) under a new `## Authorization Invariants` section, each citing ADR-0051
+- [ ] `constitution/invariant-reservations.md` has an ADR-0051 row in **Active Reservations** with the four-wide block this packet consumed; on merge, the row is moved to **Reservation History** with the merge date
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0051-agent-authorization` initiative with a packet checklist
+- [ ] No catalog schema change in this packet (catalog updates land in packet 01)
+- [ ] No `.claude/agents/scope.md` change in this packet (that update lands in packet 02)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0051 D1 — Three principal types.** The Grid commits to `UserPrincipal` (Auth-issued, session-bound), `ServicePrincipal` (Auth-issued, process-bound), and `AgentPrincipal` (Operator-issued, run-bound). `AgentPrincipal` carries `AgentId` (stable across runs), `AgentRunId` (per-invocation), optional `OnBehalfOf` (delegated User/Service principal), the granted `CapabilityBundleRef[]`, and `NotAfter` expiry.
+
+**ADR-0051 D8 — Non-recursive Operator.** `bundle:grid-operator@v1` includes `operator.grant.issue:bundleName={whitelist}` where the whitelist excludes `bundle:grid-operator@*`. Capabilities Node startup walks the whitelist and rejects any bundle whose capabilities include `operator.grant.issue:*`. Refuses to start on violation.
+
+**ADR-0051 D10 — Audit shape.** 13 fields including `event` (`tool.invoke.granted` / `tool.invoke.denied`), `agent.id`, `agent.runId`, `agent.bundles`, `onBehalfOf.*`, `tenant.id`, `tool.name`, `tool.requiredCapabilities`, `effective.capabilities`, `decision`, `deny.reason`, `deny.missingCapability`, `timestamp`, `traceId`. Emitted via `IAuditAppender`; fail-closed when Audit is unavailable.
+
+**ADR-0051 D11 — Deny by default.** Empty effective capability set denies every invocation. Expired grants deny. Non-agent principals invoking the tool surface deny with `principal_type_mismatch`. `AuthorizationDeniedException` is the single typed exception with structured detail.
+
+**ADR-0051 D12 — `bundle:local-dev-all` env-guard.** The bundle's `environments: [local, dev]` field is enforced at Capabilities Node startup against `ASPNETCORE_ENVIRONMENT`. Production startup with this bundle in scope refuses to start. Operator's whitelist also excludes it.
+
+**ADR-0051 Consequences — Invariants.** ADR-0051 adds exactly four invariants in its Consequences section: (1) agent identity originates at Operator; (2) every tool invocation through `IToolInvoker` produces an Audit record (deny on Audit unavailable); (3) `bundle:local-dev-all` is loadable only in local/dev; (4) Operator cannot grant itself the grant-issuance capability.
+
+## Acceptance Notes — Implementation Deviations
+
+These are scoped, time-bound deviations from ADR-0051's literal text that downstream packets carry. Accepting this packet implicitly accepts the deviations below; they are not amendments to the ADR. A future Auth amendment (or a follow-up packet) is expected to close each one.
+
+- **Placeholder `OnBehalfOfPrincipal` record (Packet 03 / Kernel.Abstractions).** ADR-0051 D1 names `Principal? OnBehalfOf` referencing the typed `UserPrincipal` / `ServicePrincipal` siblings of a `Principal` base. Those types do not exist in `HoneyDrunk.Auth.Abstractions` today, and introducing them would expand this initiative beyond agent authorization. Packet 03 ships a small dedicated record `OnBehalfOfPrincipal(string Kind, string Id, string? TenantId)` as a structurally-equivalent placeholder carrying exactly the fields ADR-0051 D10's audit shape (`onBehalfOf.type`, `onBehalfOf.id`) consumes — nothing more. The placeholder is removed (or upgraded to a typed `Principal` reference) when the named `Principal`/`UserPrincipal`/`ServicePrincipal` base lands in a separate Auth amendment. This packet does NOT introduce `UserPrincipal` / `ServicePrincipal` / `Principal` types. Packet 03 must mark `OnBehalfOfPrincipal` in its XML doc as `[Obsolete-on-arrival-of-Principal-base]` semantics — i.e., a `<remarks>` block calling out the deferred rename so a future executor doesn't mistake the placeholder for the final shape.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0051 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbers are claimed from `constitution/invariant-reservations.md`.** The current verified maximum in `constitution/invariants.md` is **53**. ADR-0051 has reserved the next four-wide block in `invariant-reservations.md` (today: **54–57**, used as `{N1}/{N2}/{N3}/{N4}`). Before committing, the executor (a) re-reads `invariant-reservations.md`, (b) confirms ADR-0051's row still holds a contiguous four-wide block, (c) substitutes the four `{N*}` placeholders in this packet body with the actual numbers, (d) writes the same numbers into `constitution/invariants.md`, and (e) on merge, moves the row from **Active Reservations** to **Reservation History** with the merge date. If a collision shifted the block, take the new next-free contiguous block and update both files in the same commit. Do not renumber existing invariants; never reuse a claimed number.
+- **New section.** The four authorization invariants are a new cross-cutting topic; create a `## Authorization Invariants` section after `## Audit Invariants` rather than appending to an unrelated section.
+- **Catalog edits do not happen in this packet.** Packet 01 owns `catalogs/*.json` reconciliation; packet 02 owns the `.claude/agents/scope.md` update. Keep this packet's blast radius to ADR + invariants + initiative tracker.
+
+## Labels
+`chore`, `tier-3`, `ai`, `docs`, `adr-0051`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0051 to Accepted, add the four authorization invariants to `constitution/invariants.md`, and register the agent-authorization initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0051 so the remaining packets in this initiative — and the three AI-sector standup initiatives that consume it — can reference its decisions as live rules.
+- Feature: ADR-0051 AI Agent Authorization rollout, Wave 1.
+- ADRs: ADR-0051 (primary), ADR-0006 (Auth contract surface this composes with), ADR-0008 (initiative/packet conventions), ADR-0030/0031 (Audit substrate this emits to).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0051 stays Proposed until this PR merges.
+- Claim the four-wide invariant block from `constitution/invariant-reservations.md` (today: **54–57**; use as `{N1}/{N2}/{N3}/{N4}`) and substitute the actual numbers before commit. Add the four new invariants under a new `## Authorization Invariants` section; do not renumber existing invariants. Current verified max in `invariants.md` is 53. If a collision shifted the block, take the new next-free contiguous range and update both files in the same commit. Never reuse a claimed number.
+- Inline the full invariant text — do not just cite "see ADR-0051 D8." The constitution must be self-contained for readers who do not load the ADR.
+- No catalog edits in this packet; packet 01 owns that.
+- No `.claude/agents/scope.md` edit in this packet; packet 02 owns that.
+
+**Key Files:**
+- `adrs/ADR-0051-ai-agent-authorization-and-tool-scoping-model.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0051-agent-authorization/01-architecture-agent-authorization-catalog.md
+++ b/generated/issue-packets/active/adr-0051-agent-authorization/01-architecture-agent-authorization-catalog.md
@@ -1,0 +1,168 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ai", "docs", "adr-0051", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0051"]
+accepts: ["ADR-0051"]
+wave: 1
+initiative: adr-0051-agent-authorization
+node: honeydrunk-architecture
+---
+
+# Register the agent-authorization contract surface in the Grid catalogs
+
+## Summary
+Record ADR-0051's new contract surface as catalog data: register `AgentPrincipal`, `AgentId`, `AgentRunId`, and the `IOperationContext.Agent` extension under the `honeydrunk-kernel` Node in `catalogs/contracts.json`; register `AuthorizationDeniedException` and the extended `AuthorizationDenyCode` enum members under `honeydrunk-auth`; register the `tool.invoke.granted` and `tool.invoke.denied` event names under `honeydrunk-audit`; append the new type names to the matching `exposes.contracts` arrays in `catalogs/relationships.json`; update `consumes_detail` for Nodes that pick up new dependencies; and refresh the `repos/HoneyDrunk.Capabilities/`, `repos/HoneyDrunk.Operator/`, `repos/HoneyDrunk.Agents/` integration-points docs to reflect the authorization substrate they now consume.
+
+## Context
+ADR-0051 commits new contracts in three live repos and additions to the in-flight Capabilities/Operator/Agents standup tracks. The Grid catalogs are the discoverability surface — `catalogs/contracts.json` registers each Node's contracts in its node block's `interfaces` array, and `catalogs/relationships.json` lists each Node's contract names under `exposes.contracts` plus `consumes_detail` per consumer. (`catalogs/nodes.json` has **no** `exposes` field — the `exposes` object lives on relationships.json entries.) This packet keeps both catalogs accurate so the implementation packets (03, 04, 05) and the downstream Capabilities/Operator/Agents standup packets read an accurate contract/dependency graph.
+
+ADR-0051 names `CapabilityBundle`, `Capability`, `CapabilityRequirement`, `ScopeBindingMode`, `CapabilityBundleRef`, and the `RequiredCapabilities` extension to `ICapabilityInvoker` for `HoneyDrunk.Capabilities.Abstractions`. The Capabilities repo is currently a stub (LICENSE + README); these types ship via the `adr-0017-capabilities-standup` packet 04 scaffold, not this initiative. This packet **does not** register those types under `honeydrunk-capabilities` — that registration lands inside the Capabilities standup track's catalog-registration packet (already filed as packet 01 there, with its own scope to amend at execution time per the dispatch plan's Follow-Up Work). What this packet **does** do for Capabilities is update `repos/HoneyDrunk.Capabilities/integration-points.md` to record that the Node consumes `AgentPrincipal` from Kernel and `AuthorizationDeniedException` from Auth, and emits the `tool.invoke.*` audit events.
+
+This is a catalog/docs packet. No code, no .NET project.
+
+## Scope
+
+- **`catalogs/contracts.json`** — three node blocks updated:
+  - `honeydrunk-kernel`: append `AgentPrincipal`, `AgentId`, `AgentRunId` to the `interfaces` array; record the `IOperationContext.Agent` member extension as a note on the existing `IOperationContext` entry (or append a sub-entry per the existing file's convention).
+  - `honeydrunk-auth`: append `AuthorizationDeniedException` to the `interfaces` array. Note the additive enum extension on the existing `AuthorizationDenyCode` entry (four new members: `CapabilityMissing`, `ScopeMismatch`, `GrantExpired`, `PrincipalTypeMismatch`).
+  - `honeydrunk-audit`: register the two new event names `tool.invoke.granted` and `tool.invoke.denied` in the event-shape registry section (matching the existing event registry conventions; if the file does not yet model events explicitly, add a short `events` section under `honeydrunk-audit` listing the event names with a one-line shape note pointing to ADR-0051 D10).
+
+- **`catalogs/relationships.json`**:
+  - Append `AgentPrincipal`, `AgentId`, `AgentRunId` to the `honeydrunk-kernel` entry's `exposes.contracts` array.
+  - Append `AuthorizationDeniedException` to the `honeydrunk-auth` entry's `exposes.contracts` array.
+  - Update `consumes_detail` for the Nodes that consume the new contracts: `honeydrunk-capabilities` (consumes `AgentPrincipal` from Kernel and `AuthorizationDeniedException` + the extended `AuthorizationDenyCode` from Auth — the Capabilities standup track is in flight); `honeydrunk-operator` (consumes `AgentPrincipal` from Kernel; emits `AgentPrincipal` per D1/D8); `honeydrunk-agents` (consumes `AgentPrincipal` from Kernel and `AuthorizationDeniedException` from Auth); `honeydrunk-audit` (consumes `AgentPrincipal` to record agent identity in audit fields). No new top-level Node-to-Node edge is created — every affected Node already consumes `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.Auth.Abstractions`.
+
+- **`catalogs/nodes.json`** — **not edited.** nodes.json entries have no `exposes` field; the contract surface lives in relationships.json and contracts.json.
+
+- **`repos/HoneyDrunk.Capabilities/integration-points.md`** — add an "Authorization substrate" section noting:
+  - Consumes `AgentPrincipal` from `HoneyDrunk.Kernel.Abstractions` for the principal-type check at `IToolInvoker.InvokeAsync`.
+  - Consumes `AuthorizationDeniedException` + the extended `AuthorizationDenyCode` from `HoneyDrunk.Auth.Abstractions` to throw typed deny errors.
+  - Emits `tool.invoke.granted` / `tool.invoke.denied` events to `HoneyDrunk.Audit` per ADR-0051 D10.
+  - Loads `policies/bundles/*.yaml` and `policies/capabilities/grid-vocabulary.yaml` at startup; runs the recursion check on `bundle:grid-operator` (ADR-0051 D8) and the env-guard on `bundle:local-dev-all` (ADR-0051 D12).
+  - Cross-references ADR-0051 (substrate) and ADR-0017 (Capabilities standup).
+
+- **`repos/HoneyDrunk.Operator/integration-points.md`** — create this file if it does not yet exist (the Operator standup track adds it; if absent at execution time, create it with the standard integration-points template matching `repos/HoneyDrunk.Agents/integration-points.md`). Add an "Authorization substrate" section noting:
+  - Issues `AgentPrincipal` tokens via the grant API (`POST /grants`); revokes via `DELETE /grants/{grantId}`.
+  - Runs `bundle:grid-operator@v1` as an agent against the Capabilities Node it administers.
+  - Operator's bundle is non-recursive: `operator.grant.issue:bundleName={whitelist}` excludes `bundle:grid-operator@*` (ADR-0051 D8).
+  - Bootstrap path: a one-time local script seeds the initial `AgentPrincipal` for Operator directly into the Capabilities Node's grant store, audited as `event=operator.bootstrap`.
+  - Cross-references ADR-0051 and ADR-0018.
+
+- **`repos/HoneyDrunk.Agents/integration-points.md`** — add an "Authorization substrate" section noting:
+  - Carries `AgentPrincipal` through the execution loop on the `IOperationContext` (ADR-0051 D1; this initiative's packet 03 ships the slot).
+  - Invokes tools through `IToolInvoker`; the registry-level authz check is enforced by the Capabilities Node, not by Agents.
+  - Catches `AuthorizationDeniedException` and surfaces it to the LLM as a structured tool-result error: `{"error": "authorization_denied", "missing": "<capability>"}` (ADR-0051 D11).
+  - Cross-references ADR-0051 and ADR-0020.
+
+## Proposed Implementation
+
+1. **`catalogs/contracts.json`** — locate the `honeydrunk-kernel`, `honeydrunk-auth`, `honeydrunk-audit` node blocks (do not rely on line numbers). For each, append entries to the `interfaces` array matching the existing `{ "name", "kind", "description" }` shape. Records drop the `I`; interfaces keep the `I`. Examples:
+   - `AgentPrincipal` — `kind: type` — "Record. The Operator-issued principal for an AI agent invocation. Carries AgentId, AgentRunId, optional OnBehalfOf principal, the granted CapabilityBundleRef[], and NotAfter expiry."
+   - `AgentId` — `kind: type` — "Record. Stable string identifier for an agent across runs (e.g., lately-content-publisher)."
+   - `AgentRunId` — `kind: type` — "Record. Guid per agent invocation, used for correlation and audit."
+   - `AuthorizationDeniedException` — `kind: type` — "Typed exception thrown by IToolInvoker when authorization fails. Carries the DenyReason, the missing capability (if applicable), the tool name, and the agent identity."
+   - Note `AuthorizationDenyCode` is an existing entry; the four new enum members (`CapabilityMissing`, `ScopeMismatch`, `GrantExpired`, `PrincipalTypeMismatch`) are additive — record them in a sub-note under the existing entry rather than re-entering it.
+   - For Audit's event-shape registry, add `tool.invoke.granted` and `tool.invoke.denied` with a one-line shape pointer to ADR-0051 D10's 13-field table.
+
+2. **`catalogs/relationships.json`** — append the new type names to `honeydrunk-kernel`/`honeydrunk-auth` `exposes.contracts`. Do not touch existing entries. Then update `consumes_detail` for `honeydrunk-capabilities`, `honeydrunk-operator`, `honeydrunk-agents`, `honeydrunk-audit` as listed in Scope. Do not add a new top-level edge.
+
+3. **`catalogs/nodes.json`** — no edit.
+
+4. **`repos/HoneyDrunk.Capabilities/integration-points.md`** — add the "Authorization substrate" section (the file already exists if the ADR-0017 catalog packet has run; if it does not, this is where it ought to land per ADR-0017's intent — check at execution time and create with the standard template if absent).
+
+5. **`repos/HoneyDrunk.Operator/integration-points.md`** — create if absent, add the "Authorization substrate" section.
+
+6. **`repos/HoneyDrunk.Agents/integration-points.md`** — add the "Authorization substrate" section. The file already exists.
+
+7. Do not touch ADR-0017/0018/0020's existing integration-points content beyond the targeted section addition — the standup tracks may be amending these files in parallel; keep the diffs scoped.
+
+## Affected Files
+- `catalogs/contracts.json`
+- `catalogs/relationships.json`
+- `repos/HoneyDrunk.Capabilities/integration-points.md` (create if absent)
+- `repos/HoneyDrunk.Operator/integration-points.md` (create if absent)
+- `repos/HoneyDrunk.Agents/integration-points.md`
+
+## NuGet Dependencies
+None. This packet touches only catalog JSON and Markdown; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] Catalog data + per-repo integration-points docs only — the Kernel/Auth/Audit code lands in packets 03–05; the Capabilities/Operator/Agents code lands in those Nodes' own standup initiatives.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` registers `AgentPrincipal`, `AgentId`, `AgentRunId` under `honeydrunk-kernel`, matching the existing entry shape
+- [ ] `catalogs/contracts.json` registers `AuthorizationDeniedException` under `honeydrunk-auth`; the existing `AuthorizationDenyCode` entry is annotated with the four new enum members
+- [ ] `catalogs/contracts.json` registers `tool.invoke.granted` and `tool.invoke.denied` event shapes under `honeydrunk-audit` per ADR-0051 D10
+- [ ] `catalogs/relationships.json` lists the new type names in `honeydrunk-kernel` and `honeydrunk-auth` `exposes.contracts` arrays, all existing entries untouched
+- [ ] `catalogs/relationships.json` `consumes_detail` for `honeydrunk-capabilities`, `honeydrunk-operator`, `honeydrunk-agents`, `honeydrunk-audit` lists the new contracts each consumes
+- [ ] `catalogs/nodes.json` is NOT modified (it has no `exposes` field)
+- [ ] No new top-level Node-to-Node edge is created (the dependency on `HoneyDrunk.Kernel.Abstractions` / `HoneyDrunk.Auth.Abstractions` already exists for all affected Nodes)
+- [ ] `repos/HoneyDrunk.Capabilities/integration-points.md` has an "Authorization substrate" section listing the four ADR-0051 consumption points (AgentPrincipal, AuthorizationDeniedException, audit emissions, policies/ loading + recursion + env-guard)
+- [ ] `repos/HoneyDrunk.Operator/integration-points.md` exists (created if absent) with an "Authorization substrate" section
+- [ ] `repos/HoneyDrunk.Agents/integration-points.md` has an "Authorization substrate" section listing AgentPrincipal propagation and AuthorizationDeniedException handling
+- [ ] No `CapabilityBundle` / `Capability` / `CapabilityRequirement` / `ScopeBindingMode` / `CapabilityBundleRef` / `RequiredCapabilities` registration under `honeydrunk-capabilities` in this packet — those land via `adr-0017-capabilities-standup` (see dispatch-plan Follow-Up Work)
+- [ ] No invariant change in this packet (invariants land in packet 00)
+- [ ] No `.claude/agents/scope.md` change in this packet (that update lands in packet 02)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+
+**ADR-0051 D1 — Three principal types.** `AgentPrincipal(Id, RunId, OnBehalfOf?, Bundles[], NotAfter)`, Operator-issued, run-bound. Flows through the per-operation context.
+
+**ADR-0051 D8 — Non-recursive Operator.** `bundle:grid-operator@v1` whitelist excludes `bundle:grid-operator@*`; the recursion is broken structurally. Capabilities Node startup validates the property.
+
+**ADR-0051 D10 — Audit shape.** 13-field record per authz decision, emitted via `IAuditAppender`, names `tool.invoke.granted` and `tool.invoke.denied`. Fail-closed when Audit is unavailable.
+
+**ADR-0051 D11 — `AuthorizationDeniedException`.** Single typed exception with structured detail (`Reason`, `MissingCapability`, `ToolName`, `AgentId`). The Agents Node execution loop catches and surfaces to the LLM as a structured tool error.
+
+**ADR-0051 D12 — `bundle:local-dev-all` env-guard.** Capabilities Node refuses to start if `bundle:local-dev-all` is loaded with `ASPNETCORE_ENVIRONMENT` in `staging` or `prod`. Operator's whitelist also excludes it.
+
+**ADR-0051 Consequences — Affected Nodes.** `HoneyDrunk.Auth` (Abstractions gain `AgentPrincipal` and related types; runtime unchanged at v1 — Auth does not issue agent tokens). `HoneyDrunk.Capabilities` (primary affected; implements the authz check + bundle store + env-guard + recursion check). `HoneyDrunk.Operator` (primary affected; implements grant/revoke + bootstrap). `HoneyDrunk.Agents` (primary affected; execution loop carries the principal). `HoneyDrunk.Audit` (extends event taxonomy). `HoneyDrunk.Kernel` (`IOperationContext` gains the slot — this packet's authority).
+
+## Constraints
+
+- **Records drop the `I`, interfaces keep it.** Grid-wide naming rule: `AgentPrincipal`, `AgentId`, `AgentRunId` are records (no `I`); `IOperationContext` is an interface; `AuthorizationDeniedException` is a class.
+- **Do not register Capabilities.Abstractions types in this packet.** `CapabilityBundle`, `Capability`, `CapabilityRequirement`, `ScopeBindingMode`, `CapabilityBundleRef`, and the `RequiredCapabilities` extension are shipped by `adr-0017-capabilities-standup` packet 04 (the Capabilities scaffold). Registering them here would duplicate the catalog entries that scaffold packet will create.
+- **No new Node-to-Node edge.** Every affected Node already consumes `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.Auth.Abstractions`. The contracts are additive; only `consumes_detail` is enriched, not the edge list.
+- **nodes.json is NOT edited.** It has no `exposes` field.
+
+## Labels
+`feature`, `tier-2`, `ai`, `docs`, `adr-0051`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Register ADR-0051's authorization contract surface in the Grid catalogs and update the per-Node integration-points docs that consume it.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Keep the contract/dependency catalogs accurate so implementation packets 03–05 and the downstream Capabilities/Operator/Agents standup packets read a correct graph.
+- Feature: ADR-0051 AI Agent Authorization rollout, Wave 1.
+- ADRs: ADR-0051 D1/D8/D10/D11/D12 (primary), ADR-0017/0018/0020 (standup tracks this catalog supports), ADR-0030/0031 (Audit substrate).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0051 should be Accepted before its contract surface is recorded as catalog data.
+
+**Constraints:**
+- Records drop the `I`; interfaces keep it.
+- Do not register `Capabilities.Abstractions` types here — those land via `adr-0017-capabilities-standup`.
+- No new top-level Node-to-Node edge — only `consumes_detail` enrichment.
+- nodes.json is NOT edited — it has no `exposes` field.
+- Scope the integration-points file edits to the targeted "Authorization substrate" sections; do not touch unrelated content (the standup tracks may be editing those files in parallel).
+
+**Key Files:**
+- `catalogs/contracts.json` — new entries in the `honeydrunk-kernel`, `honeydrunk-auth`, `honeydrunk-audit` blocks.
+- `catalogs/relationships.json` — `exposes.contracts` additions and `consumes_detail` enrichment.
+- `repos/HoneyDrunk.Capabilities/integration-points.md`, `repos/HoneyDrunk.Operator/integration-points.md`, `repos/HoneyDrunk.Agents/integration-points.md` — "Authorization substrate" sections.
+
+**Contracts:** None changed — this packet only records catalog metadata for contracts that packets 03–05 (and the AI-sector standup tracks) implement.

--- a/generated/issue-packets/active/adr-0051-agent-authorization/02-architecture-scope-agent-tool-authoring-updates.md
+++ b/generated/issue-packets/active/adr-0051-agent-authorization/02-architecture-scope-agent-tool-authoring-updates.md
@@ -1,0 +1,172 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ai", "docs", "agents", "adr-0051", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0051"]
+wave: 1
+initiative: adr-0051-agent-authorization
+node: honeydrunk-architecture
+---
+
+# Update the scope agent with the tool-authoring checklist and the standup "Capability bundle definition" section
+
+## Summary
+Update `.claude/agents/scope.md` with two ADR-0051 additions: (1) a tool-authoring checklist that fires when a packet introduces a new tool to the Capabilities tool registry — requiring `RequiredCapabilities` declaration on the tool type and an accompanying update to at least one bundle in `policies/bundles/` so the tool is reachable; (2) a "Capability bundle definition" section the scope agent emits when authoring standup packets for any new AI-sector consumer (Lately, Hearth, Curiosities, etc.), so each consumer's standup includes its bundle YAML up front.
+
+## Context
+ADR-0051 D7 says required capabilities are declared "in the tool's own type" via `CapabilityRequirement[] RequiredCapabilities` — the tool *is* the source of truth for what it needs. ADR-0051 Operational Consequences names two corollary obligations: every new tool authored requires a capability declaration; every new tool authored requires a bundle update to grant any agent the right to invoke it (without the bundle update, the tool is unreachable). These are *authoring-time* obligations — the right enforcement surface is the scope agent's tool-authoring checklist plus the PR review that catches the omission.
+
+ADR-0051's Follow-up Work section explicitly names two `scope.md` updates: (1) the tool-authoring checklist gains a "declare `RequiredCapabilities`" step (cross-ref `constitution/agent-capability-matrix.md`), and (2) the standup-ADR template gains a "Capability bundle definition" section. The standup-ADR template in this Grid is not a separate file — the template content is content guidance carried inside `.claude/agents/scope.md` and embodied in the existing AI-sector standup packets (`adr-0017-capabilities-standup/04-capabilities-node-scaffold.md`, etc.). Updating `scope.md` is therefore the single edit that lands both obligations.
+
+This is a docs/agent-content packet. No code, no .NET project.
+
+## Scope
+
+- `.claude/agents/scope.md` — add the two new sections described below. Do not restructure the existing file; add the new sections in the most-natural location (likely near the existing "Quality Checklist" and "Self-Containment Rule" sections).
+
+## Proposed Implementation
+
+1. **Tool-Authoring Checklist (new sub-section)** — add a new sub-section under the existing "Quality Checklist" (or, if a cleaner location exists, in its own near-end section "Tool-Authoring Rule"). The content:
+
+   ```
+   ## Tool-Authoring Rule
+
+   When a packet introduces a new tool to the Capabilities tool registry (a new
+   class implementing `ITool` in `HoneyDrunk.Capabilities` or in a Node that
+   registers a tool), the packet MUST include all four items:
+
+   - [ ] The tool declares `CapabilityRequirement[] RequiredCapabilities`
+         on its own type (the tool is the source of truth — never centralize
+         capability requirements in a separate config file). The empty array is
+         allowed only for tools that genuinely require no capabilities; this is
+         rare and warrants a comment justifying the empty set.
+   - [ ] At least one capability bundle in `policies/bundles/*.yaml` is
+         updated to grant the tool's required capabilities, so at least one
+         agent can invoke the tool. A tool with no granting bundle is
+         unreachable and the omission is loud at PR review (the registry knows
+         the tool but no agent can call it).
+   - [ ] Every new capability string introduced is added to
+         `policies/capabilities/grid-vocabulary.yaml`. The Capabilities Node
+         validates every capability reference against the vocabulary at
+         startup; typos fail the standup canary.
+   - [ ] The tool's `RequiredCapabilities` declaration appears in the packet's
+         "Affected Files" or "Proposed Implementation" so reviewers can
+         confirm the declaration matches the bundle update.
+
+   See ADR-0051 D7, D9, and Operational Consequences.
+   ```
+
+2. **Standup "Capability bundle definition" section (new sub-section)** — add a new sub-section either in the "Self-Containment Rule" area or in a dedicated "Standup Packet Conventions" section if scope.md has one (review the file at execution time). The content:
+
+   ```
+   ## Standup Packet Conventions — Capability Bundle Definition
+
+   Standup ADRs for AI-sector consumers (Lately, Hearth, Curiosities, and any
+   future agent-driven Node) MUST decompose their standup packets with a
+   "Capability bundle definition" section that includes:
+
+   - The bundle name in the `bundle:<consumer-name>` namespace (e.g.,
+     `bundle:lately-content-publisher`).
+   - The bundle version (`@v1` for first-shipping).
+   - The complete capability set the bundle grants — every capability the
+     consumer's agent execution path will exercise. Wildcards are forbidden in
+     production bundles (`bundle:local-dev-all` is the one explicit exception,
+     env-guarded per ADR-0051 D12 / invariant 80).
+   - The tenant-binding mode for each capability (`None`, `Tenant`, or
+     `OnBehalfOfPrincipal`); the `{runtime}` placeholder where the bundle is
+     granted across multiple tenants.
+   - The grant lifetime expectation (matched to ADR-0051 D6's defaults: 1h
+     ad-hoc, 30d long-running, 24h infra-sweep, 8h dev).
+   - A note on whether the consumer is autonomous (no `OnBehalfOf`) or
+     delegated (carries an `OnBehalfOf` user/service principal). Delegated
+     consumers must note that the effective capability set is the
+     **intersection** of the bundle and the granting principal's permissions
+     (ADR-0051 D5).
+
+   The bundle YAML itself lands in the consumer's standup PR — typically in
+   `HoneyDrunk.Capabilities/policies/bundles/<consumer-name>.v1.yaml` rather
+   than in the consumer's own repo (bundle definitions live in the
+   Capabilities repo per ADR-0051 D9; the consumer's standup PR opens a
+   cross-repo change set or is split into a Capabilities packet that lands
+   first).
+
+   See ADR-0051 D2, D6, D9, D14 Phase 5.
+   ```
+
+3. Inline the relevant invariant text in both sub-sections (per the Self-Containment Rule already in `scope.md`) rather than citing invariant numbers alone.
+
+## Affected Files
+- `.claude/agents/scope.md`
+
+## NuGet Dependencies
+None. This packet touches only one Markdown agent-content file; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly. `.claude/agents/scope.md` is the canonical scope agent definition for the Grid.
+- [x] No code change in any other repo. The hardlinked global copy in `~/.claude/agents/scope.md` (per the project memory) refreshes when the user re-syncs after merge; no second-repo edit needed.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/scope.md` has a new "Tool-Authoring Rule" sub-section with the four-item checklist (RequiredCapabilities declaration; at least one granting bundle; every new capability string in `grid-vocabulary.yaml`; declaration appears in packet Affected Files / Proposed Implementation)
+- [ ] `.claude/agents/scope.md` has a new "Standup Packet Conventions — Capability Bundle Definition" sub-section listing the six required bundle-definition fields (name, version, capability set, scope binding mode, lifetime, autonomous-vs-delegated)
+- [ ] Both new sub-sections inline the relevant ADR-0051 decision text per the Self-Containment Rule already in scope.md — citations like "see ADR-0051 D7" appear alongside, not instead of, the rule text
+- [ ] No structural reorg of `scope.md` — the two new sub-sections are additions; existing content is unchanged
+- [ ] No `.claude/agents/scope.md` change that violates the existing review-agent / scope-agent coupling (invariant 33). If the change is purely additive checklists and conventions, the review agent's context loading is unaffected; if any change touches the scope-agent context-loading contract, mirror it in `review.md` and call it out in the PR description
+- [ ] No catalog, invariant, or ADR-status edit in this packet (those land in packets 00 and 01)
+
+## Human Prerequisites
+- [ ] **Re-sync the global hardlinked copy after merge.** Per the project memory ("Architecture agents hardlinked globally"), the 10 Architecture agents are hardlinked into `~/.claude/agents/`. The hardlink reflects file content automatically, but Claude Code requires a restart to re-register agent content. After the PR merges, restart Claude Code so the updated scope agent reads the new sub-sections on its next invocation. This is a one-time post-merge step; the code work itself is fully delegable.
+
+## Referenced ADR Decisions
+
+**ADR-0051 D7 — Tool registry: required-capabilities declared in code.** Every tool registered with the Capabilities Node declares its required capability set in its own type's `CapabilityRequirement[] RequiredCapabilities`. The tool is the source of truth; capability requirements live next to the implementation, version with it, and are reviewed as part of the tool's PR. v1 is static — capability changes require a redeploy.
+
+**ADR-0051 D9 — v1 policy storage.** Capability bundles live in `HoneyDrunk.Capabilities/policies/bundles/*.yaml`; the authoritative capability vocabulary lives in `policies/capabilities/grid-vocabulary.yaml`. The Capabilities Node loads and validates both at startup; validation failures fail the standup canary.
+
+**ADR-0051 D2 — Capability bundles, not raw capability grants.** Bundles are namespaced under `bundle:`, versioned (`@v3`), reviewed once at authoring time, granted by name. The bundle indirection is load-bearing for review surface, versioning, Operator UX, and audit stable-identifier purposes.
+
+**ADR-0051 D5 — Effective capabilities are the intersection.** When `AgentPrincipal.OnBehalfOf` is populated, the effective capability set is `intersect(union(agent.Bundles[*].Capabilities), union(OnBehalfOf.Permissions))` — the agent never exceeds the bundle, and the agent never exceeds the granting principal's permissions.
+
+**ADR-0051 D6 — Time-bound grants.** Defaults: 1h ad-hoc; 30d long-running; 24h infra-sweep; 8h dev. 90-day upper bound. Long-running agents at 30 days re-grant via an Operator workflow with explicit re-confirmation.
+
+**ADR-0051 D14 Phase 5 — AI sector consumers.** Each new consumer (Lately, Hearth, ...) authors its capability bundle in `policies/bundles/` as part of standup. The standup template gets a "Capability bundle definition" section.
+
+## Constraints
+
+- **Self-containment.** Per `scope.md`'s own Self-Containment Rule, inline the relevant invariant and ADR-decision text in the new sub-sections rather than only citing the ADR number. The downstream scope-agent invocation has no guaranteed access to the ADR file.
+- **Review/scope coupling — invariant 33.** Review-agent and scope-agent context-loading contracts are coupled; the review agent's context-loading list (`review.md`) must remain a superset of the scope agent's. If this packet's `scope.md` edit changes the *context-loading contract* (the files scope.md says to load at startup), mirror the change in `review.md` in the same PR. If the edit is purely additive checklists and standup conventions — as designed in this packet — no `review.md` change is needed. The PR description must explicitly state which case applies.
+- **No re-org.** The two new sub-sections are additions in the most-natural locations; no existing content is moved or renamed.
+- **`bundle:local-dev-all` is the one exception to wildcard prohibition.** State this explicitly in the Tool-Authoring Rule so the standup-checklist text does not accidentally read as forbidding all wildcards.
+
+## Labels
+`feature`, `tier-2`, `ai`, `docs`, `agents`, `adr-0051`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Add the Tool-Authoring Rule checklist and the Capability Bundle Definition standup-section to `.claude/agents/scope.md`, so future packets that introduce tools or stand up AI-sector consumers honor ADR-0051's authorization model from the first commit.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Move ADR-0051's tool-authoring and bundle-definition obligations from the ADR's Follow-up Work into the scope agent's executable surface, so the obligations are enforced at packet-authoring time, not discovered at PR review.
+- Feature: ADR-0051 AI Agent Authorization rollout, Wave 1.
+- ADRs: ADR-0051 D2/D5/D6/D7/D9/D14 (primary), ADR-0044/0046 (review-and-specialist-agent ecology this fits into).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0051 should be Accepted before its rules are translated into the scope agent's executable checklists.
+
+**Constraints:**
+- Inline invariant and ADR-decision text per scope.md's Self-Containment Rule.
+- If the edit touches the scope-agent context-loading contract, mirror it in `review.md` in the same PR (invariant 33). The designed edit is additive checklists only — state this in the PR description.
+- No structural reorg of `scope.md`.
+- Note `bundle:local-dev-all` as the one explicit wildcard exception.
+
+**Key Files:**
+- `.claude/agents/scope.md` — the two new sub-sections.
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0051-agent-authorization/03-kernel-agent-principal-and-operation-context-slot.md
+++ b/generated/issue-packets/active/adr-0051-agent-authorization/03-kernel-agent-principal-and-operation-context-slot.md
@@ -1,0 +1,206 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Kernel
+labels: ["feature", "tier-2", "ai", "adr-0051", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0051"]
+wave: 2
+initiative: adr-0051-agent-authorization
+node: honeydrunk-kernel
+---
+
+# Add AgentPrincipal + AgentId + AgentRunId to Kernel.Abstractions and extend IOperationContext
+
+## Summary
+Add the ADR-0051 agent-principal contract surface to `HoneyDrunk.Kernel.Abstractions`: the `AgentPrincipal` record (Operator-issued, run-bound, optionally delegating), the `AgentId` and `AgentRunId` identity records, and an additive `AgentPrincipal? Agent { get; }` slot on `IOperationContext` so the principal flows through the per-operation context every consumer already plumbs. Pure contracts — zero HoneyDrunk runtime dependencies. This is the version-bumping packet for the `HoneyDrunk.Kernel` solution (unless ADR-0042's packet 02 has already bumped it; see Constraints).
+
+## Context
+ADR-0051 D1 commits a third principal type and says it "flows through `RequestContext`." The Grid does not have a type named `RequestContext`; the actual context contracts are `IGridContext` (Grid-level, longer-lived) and `IOperationContext` (per-operation, short-lived) in `HoneyDrunk.Kernel.Abstractions/Context/`. Per the dispatch plan's Cross-Cutting decision, the `AgentPrincipal` slot lives on `IOperationContext` because `AgentRunId` is per-invocation and matches `IOperationContext`'s lifetime — `IGridContext` carries Grid-level identity (Node, Sector, Environment) and is the wrong layer.
+
+The named `UserPrincipal` / `ServicePrincipal` / `Principal` base also do not exist today; the Auth surface uses `AuthenticatedIdentity` and the authorization-request shape. This packet **does not** introduce a `Principal` base class — that rename is a future Auth amendment and is out of scope. `AgentPrincipal` ships as a standalone record. The `OnBehalfOf` slot is typed loosely (an `object?` or a small dedicated `IDelegatedPrincipal` interface or simply `string?` carrying a pseudonymous principal id; see the Proposed Implementation note for the chosen shape).
+
+`HoneyDrunk.Kernel.Abstractions` today contains the subfolders `Configuration/`, `Context/`, `DI/`, `Diagnostics/`, `Errors/`, `Health/`, `Hosting/`, `Identity/`, `Lifecycle/`, `Telemetry/`, `Tenancy/`, `Transport/` — **there is no `Agents/` subfolder**. This packet creates `HoneyDrunk.Kernel.Abstractions/Agents/` and lands the new types there. The `IOperationContext` slot lives in the existing `Context/IOperationContext.cs`.
+
+`HoneyDrunk.Kernel` is a live Node currently at v0.7.0 (.NET 10.0), two packages: `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.Kernel`. Per the dispatch plan, ADR-0042's packet 02 may have already bumped the solution `0.7.0` → `0.8.0`. The executor must check the solution's current version at execution time. If already at `0.8.0`, this packet appends to the in-progress `[0.8.0]` CHANGELOG and does NOT bump. If still at `0.7.0`, this packet is the bumping packet (`0.7.0` → `0.8.0`).
+
+## Scope
+
+- `HoneyDrunk.Kernel.Abstractions/Agents/` — **create this subfolder** (not present today; siblings under `HoneyDrunk.Kernel.Abstractions/` are `Configuration/`, `Context/`, `DI/`, `Diagnostics/`, `Errors/`, `Health/`, `Hosting/`, `Identity/`, `Lifecycle/`, `Telemetry/`, `Tenancy/`, `Transport/`). Add the new contract types:
+  - `AgentId` — record wrapping a stable kebab-case agent identifier (e.g., `lately-content-publisher`). Validate non-empty + kebab-case-compatible at construction; align with the existing `KebabCaseIdentity` base used in `Identity/`.
+  - `AgentRunId` — record wrapping a `Guid` per invocation. **Deliberate divergence from `Identity/RunId.cs`:** the existing `RunId` is a ULID-backed `readonly record struct` (Crockford-base32, sortable, 128-bit time-prefixed). `AgentRunId` is `Guid`-backed because (a) ADR-0051 D1 explicitly specifies `Guid` for agent invocations, (b) `AgentRunId` is minted by the Operator Node and propagated through the audit shape (ADR-0051 D10's `agent.runId`) where `Guid` is the lingua franca for callers that haven't adopted ULID identity, and (c) the time-sorted property ULID provides is not load-bearing for agent runs — uniqueness is. The two types coexist: `RunId` continues to identify operation runs in the existing carrier; `AgentRunId` rides on `AgentPrincipal` for agent-issued invocations. This packet documents the divergence in the `AgentRunId` XML `<remarks>` block so a future reader doesn't unify them by reflex.
+  - `AgentPrincipal` — record carrying `AgentId Id`, `AgentRunId RunId`, an optional `OnBehalfOf` slot (see Proposed Implementation for the chosen shape), a `IReadOnlyList<string> BundleRefs` slot for the granted bundle references (string form `bundle:<name>@v<n>` — the strongly-typed `CapabilityBundleRef` ships in `HoneyDrunk.Capabilities.Abstractions` via the `adr-0017-capabilities-standup` track, not here), and `DateTimeOffset NotAfter`.
+- `HoneyDrunk.Kernel.Abstractions/Context/IOperationContext.cs` — additive `AgentPrincipal? Agent { get; }` member. Default implementations on existing snapshot/factory types return `null`.
+- Default-implementation updates on the runtime side (e.g., `OperationContext` concrete in `HoneyDrunk.Kernel`) if any concrete type already exists — add the property returning `null` by default and a `with`-style builder/setter consistent with the rest of the context surface.
+- Both `.csproj` files in the solution version-aligned (invariant 27). Possibly bump or possibly append to in-progress `0.8.0` per the version-bump note above.
+- `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md` and `README.md` updated.
+- Repo-level `CHANGELOG.md` entry — new `[0.8.0]` if this is the bumping packet, or appended to existing `[0.8.0]` if not.
+
+## Proposed Implementation
+
+1. **`AgentId`** — `public sealed record AgentId(string Value)`. Validate non-empty and that `Value` matches the kebab-case identifier shape used elsewhere in `Identity/` (`KebabCaseIdentity` pattern). If a base class or factory helper exists in `Identity/`, reuse it; otherwise hand-roll the validation. Provide a `ToString()` returning the value.
+
+2. **`AgentRunId`** — `public sealed record AgentRunId(Guid Value)`. The ADR specifies `Guid` explicitly (D1: "`AgentRunId` is a `Guid` per invocation"); do **not** unify with the existing ULID-backed `RunId` (`HoneyDrunk.Kernel.Abstractions/Identity/RunId.cs`, `readonly record struct RunId` over `Ulid`). Provide a `NewRandom()` factory using `Guid.NewGuid()`. **XML doc requirement:** the type's `<remarks>` block must include a paragraph explaining the deliberate departure from the repo's ULID-typed-id convention (Operator-issued, ADR-0051 D1 contract, audit-shape interop), so a future reader does not collapse the two types by reflex. If a type named `AgentRunId` already exists anywhere in the repo, halt and surface the collision rather than silently reusing it.
+
+3. **`AgentPrincipal`** — `public sealed record AgentPrincipal(AgentId Id, AgentRunId RunId, OnBehalfOfPrincipal? OnBehalfOf, IReadOnlyList<string> BundleRefs, DateTimeOffset NotAfter)`.
+   - For the `OnBehalfOf` slot: the ADR names `Principal? OnBehalfOf` and references `UserPrincipal` / `ServicePrincipal` — types that do not exist in `HoneyDrunk.Auth.Abstractions` today. **This packet does not introduce the `Principal` base / `UserPrincipal` / `ServicePrincipal` sibling types** (that work is deferred to a future Auth amendment, not this initiative). To carry the delegation information ADR-0051 D10's audit shape needs without expanding scope, this packet ships a **scoped, time-bound placeholder record**:
+     ```
+     public sealed record OnBehalfOfPrincipal(
+         string Kind,     // "user" or "service" — string-typed because the named Principal base does not exist yet
+         string Id,       // pseudonymous principal id per ADR-0045 D7 PII rules
+         string? TenantId // optional, when the delegating principal is tenant-scoped
+     );
+     ```
+     **Placeholder discipline:**
+     - The type carries **only** the two fields ADR-0051 D10's audit record consumes (`onBehalfOf.type` ← `Kind`; `onBehalfOf.id` ← `Id`), plus `TenantId` for ADR-0026 composition. Do not extend the surface with claims, roles, scopes, or anything else without amending ADR-0051.
+     - The XML `<remarks>` block on the type **must** state, verbatim in substance: "Placeholder shape pending the named `Principal` base, `UserPrincipal`, and `ServicePrincipal` types in a future `HoneyDrunk.Auth.Abstractions` amendment. Consumers MUST treat this as opaque, MUST NOT reflect over the type, and MUST be prepared for the slot to be replaced by `Principal? OnBehalfOf` referencing the named siblings without prior deprecation."
+     - The placeholder's existence is acknowledged in Packet 00's "Acceptance Notes — Implementation Deviations" — accepting Packet 00 implicitly accepts this scoped deviation.
+     - When the named `Principal` base lands, the rename is a separate ADR-amendment + packet pair; that work removes `OnBehalfOfPrincipal` (or repurposes it as a thin shim) and is **out of scope** here.
+   - `BundleRefs` is `IReadOnlyList<string>` carrying string references (e.g., `"bundle:lately-content-publisher@v3"`). The strongly-typed `CapabilityBundleRef` lands in `HoneyDrunk.Capabilities.Abstractions` via the Capabilities standup; from Kernel's perspective the references are opaque strings (Kernel.Abstractions has zero HoneyDrunk dependencies — invariant 1).
+   - `NotAfter` carries the grant expiry (ADR-0051 D6). The `IToolInvoker` check (Capabilities-side) compares against `DateTimeOffset.UtcNow`.
+
+4. **`IOperationContext.Agent` slot** — add `AgentPrincipal? Agent { get; }` to `IOperationContext`. The property is additive and nullable; existing implementations that do not yet populate it return `null`. Update `GridContextSnapshot.cs` if it carries operation-context fields, or the corresponding operation-context snapshot type — match whatever exists in `Context/`. Update `IOperationContextFactory` if its construction surface needs the slot.
+
+5. **Concrete-implementation audit (mandatory before adding the interface member).** Adding a member to `IOperationContext` is a contract change; every concrete implementation in the solution must be updated in the same commit or the build breaks. Before adding the `Agent` slot, the executor enumerates and updates each of the following (verified to exist in the repo today):
+   - `HoneyDrunk.Kernel.Abstractions/Context/IOperationContext.cs` — the interface itself (the additive `AgentPrincipal? Agent { get; }` member).
+   - `HoneyDrunk.Kernel.Abstractions/Context/IOperationContextAccessor.cs` — verify the accessor surface does not need a parallel slot; if it surfaces a snapshot type, that type may need the property.
+   - `HoneyDrunk.Kernel.Abstractions/Context/IOperationContextFactory.cs` — if the factory's `Create*` signature needs to accept an optional `AgentPrincipal?` to construct contexts with the populated slot, extend the signature additively (overload, or optional parameter at the end — choose to preserve binary compat where possible).
+   - `HoneyDrunk.Kernel/Context/OperationContext.cs` — the concrete implementation; add the property (default `null` for non-agent invocations) and the corresponding `with`-style builder/setter if the type exposes one.
+   - `HoneyDrunk.Kernel/Context/OperationContextAccessor.cs` — verify no change needed unless it composes the snapshot.
+   - `HoneyDrunk.Kernel/Context/OperationContextFactory.cs` — wire the factory to the new optional parameter / overload; default-null populates correctly.
+   - `HoneyDrunk.Kernel.Tests/Context/OperationContextTests.cs` — add tests that the default `Agent` slot is `null` and that a populated `AgentPrincipal` round-trips through the concrete type.
+
+   Each file in the list above must either be updated in this packet's commit **or** explicitly recorded (with a one-line reason) as "no change needed" in the PR description, so a reviewer can verify no concrete type was missed and the contract change is complete.
+
+6. **Default implementations XML doc** — the concrete `OperationContext.Agent` property's XML doc states `null` is the default for non-agent invocations and points readers at `AgentPrincipal` for the populated case.
+
+7. **Unit tests** — `AgentId` non-empty validation; `AgentRunId.NewRandom()` returns distinct values; `AgentPrincipal` construction succeeds with `OnBehalfOf=null` (autonomous case) and with `OnBehalfOf` populated; an `IOperationContext` test double exposes `Agent=null` by default and a populated `AgentPrincipal` when set. Place tests in the repo's existing Abstractions unit-test project.
+
+8. **Versioning** — see Context. If the solution is already at `0.8.0` (ADR-0042 packet 02 landed first), append to the in-progress `[0.8.0]` repo CHANGELOG entry and add a `[0.8.0]` per-package entry to `HoneyDrunk.Kernel.Abstractions`. If the solution is still at `0.7.0`, bump every non-test `.csproj` to `0.8.0` in one commit (invariant 27), create the `[0.8.0]` repo CHANGELOG entry, and add the per-package entry. Either way, the `HoneyDrunk.Kernel` runtime package gets no per-package CHANGELOG entry (no functional change here — alignment bump only, per invariant 12/27).
+
+9. Update `HoneyDrunk.Kernel.Abstractions/README.md` — the public API surface gained `AgentPrincipal`, `AgentId`, `AgentRunId`, `OnBehalfOfPrincipal`, and the `IOperationContext.Agent` slot. Document them in the API-surface section.
+
+## Affected Files
+
+**New files (create the `Agents/` subfolder):**
+- `HoneyDrunk.Kernel.Abstractions/Agents/AgentId.cs`
+- `HoneyDrunk.Kernel.Abstractions/Agents/AgentRunId.cs`
+- `HoneyDrunk.Kernel.Abstractions/Agents/AgentPrincipal.cs`
+- `HoneyDrunk.Kernel.Abstractions/Agents/OnBehalfOfPrincipal.cs`
+
+**Interface contract changes (Abstractions):**
+- `HoneyDrunk.Kernel.Abstractions/Context/IOperationContext.cs` — additive `AgentPrincipal? Agent { get; }` member
+- `HoneyDrunk.Kernel.Abstractions/Context/IOperationContextAccessor.cs` — audit: verify if any surface needs a parallel slot; update only if needed
+- `HoneyDrunk.Kernel.Abstractions/Context/IOperationContextFactory.cs` — audit: extend `Create*` signature additively (optional `AgentPrincipal?` parameter or overload) if needed
+- `HoneyDrunk.Kernel.Abstractions/Context/GridContextSnapshot.cs` — verify whether it carries operation-context fields; update only if needed
+
+**Concrete implementation updates (runtime package):**
+- `HoneyDrunk.Kernel/Context/OperationContext.cs` — add the `Agent` property; default `null`
+- `HoneyDrunk.Kernel/Context/OperationContextAccessor.cs` — audit: verify no change needed unless the accessor composes a snapshot
+- `HoneyDrunk.Kernel/Context/OperationContextFactory.cs` — wire the additive parameter / overload to the concrete constructor
+
+**Versioning and metadata:**
+- `HoneyDrunk.Kernel.Abstractions/HoneyDrunk.Kernel.Abstractions.csproj` — version bump if the bumping packet, alignment otherwise
+- `HoneyDrunk.Kernel/HoneyDrunk.Kernel.csproj` — version alignment
+- `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md`, `HoneyDrunk.Kernel.Abstractions/README.md`
+- Repo-level `CHANGELOG.md`
+
+**Tests:**
+- `HoneyDrunk.Kernel/HoneyDrunk.Kernel.Abstractions.Tests/` (or the existing Abstractions unit-test project) — new tests for the new types
+- `HoneyDrunk.Kernel/HoneyDrunk.Kernel.Tests/Context/OperationContextTests.cs` — extend with the `Agent`-slot default-null and populated cases
+
+## NuGet Dependencies
+- **`HoneyDrunk.Kernel.Abstractions`** — no new `PackageReference`. Per invariant 1, Abstractions takes only `Microsoft.Extensions.*` abstractions. `AgentId` validation uses BCL primitives. No package needed. `HoneyDrunk.Standards` is already referenced (`PrivateAssets: all`).
+- **`HoneyDrunk.Kernel`** — no new `PackageReference` in this packet.
+- The unit-test project follows the repo's existing test stack (ADR-0047: xUnit v2 + NSubstitute + AwesomeAssertions + coverlet); no new packages introduced beyond what the test project already references.
+
+## Boundary Check
+- [x] `AgentPrincipal` and the `IOperationContext.Agent` slot are Kernel-Abstractions contracts per ADR-0051 D1 and the dispatch plan's Cross-Cutting decision (the per-operation context is the right carrier).
+- [x] No dependency on any other HoneyDrunk runtime package (invariant 1). `BundleRefs` is `IReadOnlyList<string>` — the strongly-typed `CapabilityBundleRef` stays in `HoneyDrunk.Capabilities.Abstractions` (shipped by the Capabilities standup track).
+- [x] Contracts only; the runtime `IToolInvoker` authz check (Capabilities Node) is a separate initiative.
+- [x] Records drop the `I`; interfaces keep it. `AgentPrincipal`, `AgentId`, `AgentRunId`, `OnBehalfOfPrincipal` are records. `IOperationContext` is an existing interface.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Kernel.Abstractions/Agents/AgentId.cs` ships a record wrapping a non-empty kebab-case-compatible string
+- [ ] `HoneyDrunk.Kernel.Abstractions/Agents/AgentRunId.cs` ships a record wrapping a `Guid`; `NewRandom()` returns a fresh `Guid.NewGuid()`; the XML `<remarks>` block documents the deliberate departure from the repo's ULID-typed-id convention (cross-references `Identity/RunId.cs`, cites ADR-0051 D1, names Operator issuance + audit interop as the rationale)
+- [ ] `HoneyDrunk.Kernel.Abstractions/Agents/AgentPrincipal.cs` ships a record carrying `Id`, `RunId`, `OnBehalfOf` (nullable), `BundleRefs`, `NotAfter`
+- [ ] `HoneyDrunk.Kernel.Abstractions/Agents/OnBehalfOfPrincipal.cs` ships a small record (`Kind`, `Id`, `TenantId?`) as a **scoped, time-bound placeholder** until the named `Principal` base lands in a future Auth amendment; the XML `<remarks>` block explicitly labels it a placeholder, names the deferred rename, and forbids consumers from reflecting over the type. The deviation is acknowledged in Packet 00's Acceptance Notes.
+- [ ] The `Agents/` subfolder is **newly created** under `HoneyDrunk.Kernel.Abstractions/` (it does not exist today; sibling subfolders are `Configuration/`, `Context/`, `DI/`, `Diagnostics/`, `Errors/`, `Health/`, `Hosting/`, `Identity/`, `Lifecycle/`, `Telemetry/`, `Tenancy/`, `Transport/`)
+- [ ] Every concrete `IOperationContext` implementation in the solution is updated in the same commit: `HoneyDrunk.Kernel/Context/OperationContext.cs` carries the new property; `HoneyDrunk.Kernel/Context/OperationContextAccessor.cs` and `HoneyDrunk.Kernel/Context/OperationContextFactory.cs` are either updated or explicitly recorded "no change needed" in the PR description; the `IOperationContextAccessor` and `IOperationContextFactory` interface signatures are extended additively if needed (overload, default parameter, or noted as no-change)
+- [ ] `HoneyDrunk.Kernel.Tests/Context/OperationContextTests.cs` is extended with default-null and populated `Agent` slot cases on the concrete `OperationContext` type
+- [ ] `IOperationContext` exposes an additive `AgentPrincipal? Agent { get; }` member; existing implementations return `null` by default
+- [ ] All new public types have XML documentation (invariant 13)
+- [ ] `HoneyDrunk.Kernel.Abstractions` has zero runtime `PackageReference` on any HoneyDrunk package (invariant 1)
+- [ ] Records drop the `I`; the new types do not carry an `I` prefix; `IOperationContext` keeps its existing `I` (it's an interface)
+- [ ] Unit tests cover `AgentId` non-empty validation, `AgentRunId.NewRandom()` distinctness, `AgentPrincipal` autonomous-vs-delegated construction, and `IOperationContext.Agent` default-null + populated cases
+- [ ] Both non-test `.csproj` files are at the same version (`0.8.0`) in a single commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a `[0.8.0]` entry covering the new types — either newly created (if this is the bumping packet) or extended (if ADR-0042 packet 02 already bumped)
+- [ ] `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md` has a `[0.8.0]` entry describing the agent-principal types and the `IOperationContext.Agent` slot
+- [ ] `HoneyDrunk.Kernel/CHANGELOG.md` gets NO entry (no functional change in this packet — alignment bump only, per invariant 12/27)
+- [ ] `HoneyDrunk.Kernel.Abstractions/README.md` documents the new types in the public-API section
+- [ ] The `pr-core.yml` tier-1 gate and the Kernel contract-shape canary pass — the new types are additive
+- [ ] No `Principal` / `UserPrincipal` / `ServicePrincipal` base or sibling types are introduced in this packet (deferred to a future Auth amendment)
+
+## Human Prerequisites
+- [ ] **Tag/release `HoneyDrunk.Kernel` after this packet merges so downstream consumers can compile against `0.8.0`.** Agents never tag or publish. The Capabilities, Operator, Agents, and Audit standup tracks (and Audit packet 05 in this initiative) reference `AgentPrincipal` from `HoneyDrunk.Kernel.Abstractions` `0.8.0`; that artifact reaches the package feed only after a human pushes a git release tag. If ADR-0042's packet 02 also lands in the same `0.8.0` release, coordinate so both sets of changes are in a single tag/release. The code work in this packet does not require the live published package; the downstream dependency does.
+
+## Referenced ADR Decisions
+
+**ADR-0051 D1 — `AgentPrincipal` shape.** `AgentPrincipal(AgentId Id, AgentRunId RunId, Principal? OnBehalfOf, CapabilityBundleRef[] Bundles, DateTimeOffset NotAfter)`. `AgentId` is stable across runs; `AgentRunId` is a `Guid` per invocation; `OnBehalfOf` is null for autonomous agents. Flows through the per-operation context. Orthogonal to but composable with `TenantId` (ADR-0026). **This packet's adaptation:** `Bundles` is `IReadOnlyList<string>` carrying `bundle:<name>@v<n>` references (the strongly-typed form ships in `HoneyDrunk.Capabilities.Abstractions` via the Capabilities standup, not Kernel); `OnBehalfOf` is a small dedicated record because the named `Principal`/`UserPrincipal`/`ServicePrincipal` base does not exist in the Grid today.
+
+**ADR-0051 D6 — `NotAfter`.** Every grant carries an expiry. `IToolInvoker.InvokeAsync`'s first capability check is `DateTimeOffset.UtcNow > AgentPrincipal.NotAfter` — short-circuits to `AuthorizationDeniedException` with reason `grant_expired`.
+
+**ADR-0051 D14 Phase 1 — Abstractions.** "Add `AgentPrincipal`, `AgentId`, `AgentRunId`, `CapabilityBundle`, `Capability`, `CapabilityRequirement`, `ScopeBindingMode`, `AuthorizationDeniedException` to `HoneyDrunk.Auth.Abstractions` and `HoneyDrunk.Capabilities.Abstractions`. Update `RequestContext` to carry `AgentPrincipal`. No behavior changes; abstractions only." **This packet's allocation:** ships the `AgentPrincipal` family in Kernel.Abstractions (because the Grid uses `IOperationContext`, not `RequestContext`, as the per-operation carrier — see dispatch plan). The `CapabilityBundle` / `Capability` / `CapabilityRequirement` / `ScopeBindingMode` types ship in Capabilities.Abstractions via the `adr-0017-capabilities-standup` packet 04 scaffold. `AuthorizationDeniedException` ships in Auth.Abstractions via packet 04 of this initiative.
+
+## Constraints
+
+- **Invariant 1 — Abstractions have zero runtime dependencies on other HoneyDrunk packages.** Only `Microsoft.Extensions.*` abstractions permitted. `BundleRefs` is `IReadOnlyList<string>` for this reason — the strongly-typed `CapabilityBundleRef` would force a `HoneyDrunk.Capabilities.Abstractions` reference, which Kernel.Abstractions cannot take.
+- **Invariant 4 — DAG; Kernel is at the root.** Nothing in this packet depends on a downstream HoneyDrunk package.
+- **Invariant 13 — all public APIs have XML documentation.** Enforced by `HoneyDrunk.Standards` analyzers.
+- **Invariant 27 — all projects in a solution share one version and move together.** Both `.csproj` files end this packet at the same version. If ADR-0042 packet 02 has already bumped to `0.8.0`, this packet does NOT bump again — it appends to the in-progress `[0.8.0]` CHANGELOG. Verify the current solution version before bumping.
+- **Invariant 12 — per-package CHANGELOGs are updated only for packages with functional changes.** `HoneyDrunk.Kernel.Abstractions` gets an entry; `HoneyDrunk.Kernel` (alignment bump only) gets none.
+- **Records drop the `I`; interfaces keep it.** `AgentId`, `AgentRunId`, `AgentPrincipal`, `OnBehalfOfPrincipal` are records and carry no `I` prefix. `IOperationContext` keeps its prefix.
+- **`AgentRunId` is `Guid`-backed, not ULID-backed.** ADR-0051 D1 specifies `Guid`. Do not align with the existing ULID-based `RunId` in `Identity/`; the two types coexist and serve different purposes.
+- **No `Principal` base class.** The named base, `UserPrincipal`, and `ServicePrincipal` are deferred. `OnBehalfOf` is a small dedicated record carrying only what the audit shape needs.
+
+## Labels
+`feature`, `tier-2`, `ai`, `adr-0051`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add `AgentPrincipal`, `AgentId`, `AgentRunId`, and `OnBehalfOfPrincipal` to `HoneyDrunk.Kernel.Abstractions/Agents/`, and extend `IOperationContext` with an additive `AgentPrincipal? Agent { get; }` slot.
+
+**Target:** `HoneyDrunk.Kernel`, branch from `main`.
+
+**Context:**
+- Goal: Ship the agent-principal carriers every other ADR-0051 consumer (Audit, Capabilities, Operator, Agents) compiles against.
+- Feature: ADR-0051 AI Agent Authorization rollout, Wave 2 (abstractions in live Nodes).
+- ADRs: ADR-0051 D1/D6/D14 (primary), ADR-0035 (additive minor-bump policy), ADR-0008 (packet conventions). The ADR-0006 Auth principal-typing story stays unchanged at v1; this packet does NOT rename `AuthenticatedIdentity` and does NOT introduce a `Principal` base.
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0051 Accepted and its four invariants live before the agent-principal contracts are built against them.
+
+**Constraints:**
+- Abstractions stay zero-HoneyDrunk-dependency (invariant 1). `BundleRefs` is `IReadOnlyList<string>`, not a typed `CapabilityBundleRef` array.
+- The slot lives on `IOperationContext` (per-operation), not on `IGridContext` (Grid-level) — `AgentRunId` matches `IOperationContext`'s lifetime.
+- `AgentRunId` is `Guid`-backed per ADR-0051 D1. Do not align with the existing ULID-based `RunId`.
+- Records drop the `I`; `IOperationContext` keeps its prefix.
+- No `Principal` base class in this packet.
+- Verify the solution's current version: if ADR-0042's packet 02 has already bumped to `0.8.0`, append to the in-progress `[0.8.0]` CHANGELOG and do NOT bump again (invariant 27). Otherwise, this is the bumping packet (`0.7.0` → `0.8.0`).
+
+**Key Files:**
+- `HoneyDrunk.Kernel.Abstractions/Agents/AgentId.cs`, `AgentRunId.cs`, `AgentPrincipal.cs`, `OnBehalfOfPrincipal.cs`
+- `HoneyDrunk.Kernel.Abstractions/Context/IOperationContext.cs` — additive member
+- Concrete `OperationContext` runtime type — default-implementation update
+- Both `.csproj` files for version alignment
+- `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md`, `README.md`; repo-level `CHANGELOG.md`
+
+**Contracts:**
+- `AgentId` (new record) — stable kebab-case agent identifier.
+- `AgentRunId` (new record) — `Guid` per invocation.
+- `AgentPrincipal` (new record) — Operator-issued, run-bound, optionally delegating.
+- `OnBehalfOfPrincipal` (new record) — small placeholder for the delegated principal until the named `Principal` base arrives.
+- `IOperationContext.Agent` (additive member) — `AgentPrincipal?` slot.

--- a/generated/issue-packets/active/adr-0051-agent-authorization/04-auth-authorization-denied-exception-and-deny-codes.md
+++ b/generated/issue-packets/active/adr-0051-agent-authorization/04-auth-authorization-denied-exception-and-deny-codes.md
@@ -1,0 +1,176 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Auth
+labels: ["feature", "tier-2", "ai", "adr-0051", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0051"]
+wave: 2
+initiative: adr-0051-agent-authorization
+node: honeydrunk-auth
+---
+
+# Add AuthorizationDeniedException + extend AuthorizationDenyCode with the four agent-authz reasons
+
+## Summary
+Add `AuthorizationDeniedException` to `HoneyDrunk.Auth.Abstractions` — the single typed exception ADR-0051 D11 commits for agent authorization failures — and extend the existing `AuthorizationDenyCode` enum with four new members (`CapabilityMissing`, `ScopeMismatch`, `GrantExpired`, `PrincipalTypeMismatch`) matching ADR-0051 D10's `deny.reason` audit field values. This is the version-bumping packet for the `HoneyDrunk.Auth` solution.
+
+## Context
+ADR-0051 D11 says "`AuthorizationDeniedException` is the single exception type" thrown by `IToolInvoker` when an agent's authorization check fails. The exception carries `Reason`, `MissingCapability` (optional), `ToolName`, `AgentId` — and the `Reason` value comes from a set of four named reasons: `capability_missing`, `scope_mismatch`, `grant_expired`, `principal_type_mismatch` (D10's `deny.reason` field).
+
+A `DenyReason` type already exists in `HoneyDrunk.Auth.Abstractions/DenyReason.cs` — a `readonly record struct` combining the existing `AuthorizationDenyCode` enum and a `string Message`. Per the dispatch plan's Cross-Cutting decision, this packet **reuses** the existing types rather than introducing a parallel `DenyReason` enum: the four new reasons join `AuthorizationDenyCode` as additive enum members, and `AuthorizationDeniedException` carries a full `DenyReason` (the existing struct) plus the ADR-0051-specific `MissingCapability` / `ToolName` / `AgentId` context.
+
+`HoneyDrunk.Auth.Abstractions` currently houses `AuthenticatedIdentity`, `IAuthorizationPolicy`, `AuthorizationRequest`, `AuthorizationDecision`, `DenyReason`, `AuthorizationDenyCode`, `AuthScheme`, `AuthCredential`, `IAuthenticationProvider`, `AuthClaimTypes`, `AuthenticationFailureCode`, `AuthenticationResult` — a tight, well-shaped surface. The four new enum values and the one new exception type are additive minor changes; no existing public API moves or renames.
+
+`HoneyDrunk.Auth` consumes `AgentId` from `HoneyDrunk.Kernel.Abstractions` `0.8.0` (packet 03). The exception's `AgentId` slot uses the Kernel type. This packet picks up `HoneyDrunk.Kernel.Abstractions` `0.8.0` as a `PackageReference` version bump on whichever project carries `AuthorizationDeniedException` (Abstractions).
+
+## Scope
+
+- `HoneyDrunk.Auth.Abstractions/AuthorizationDenyCode.cs` — add four new enum members:
+  - `CapabilityMissing = 10` (the matched `deny.reason` for "no bundle grants the required capability")
+  - `ScopeMismatch = 11` (tenant or on-behalf-of scope binding didn't satisfy the requirement)
+  - `GrantExpired = 12` (`AgentPrincipal.NotAfter < DateTimeOffset.UtcNow`)
+  - `PrincipalTypeMismatch = 13` (a non-agent principal invoked the agent-tool surface)
+  - Pick the numeric values to fit the existing enum's numbering (the existing enum uses 0..8 with 99 reserved for `InternalError` — start the agent-authz reasons at 10 to leave room and keep them visually grouped). The executor must check the enum at execution time and pick concrete numbers that don't collide.
+- `HoneyDrunk.Auth.Abstractions/AuthorizationDeniedException.cs` — new class:
+  ```
+  public sealed class AuthorizationDeniedException : Exception
+  {
+      public DenyReason Reason { get; }
+      public string ToolName { get; }
+      public AgentId AgentId { get; }
+      public string? MissingCapability { get; }
+      // constructors, XML doc
+  }
+  ```
+  - Constructor takes `DenyReason reason, string toolName, AgentId agentId, string? missingCapability = null, Exception? inner = null`.
+  - `Message` composes a one-line summary from the components for log readability (`"Authorization denied for agent {AgentId} invoking tool '{ToolName}': {Reason.Code} ({MissingCapability})"`).
+  - Serializable per the framework defaults; the type is sealed and exposes only readable properties.
+- `HoneyDrunk.Auth.Abstractions.csproj` — bump the `HoneyDrunk.Kernel.Abstractions` `PackageReference` to `0.8.0` (the packet 03 release; the version must be published before this packet's PR can build — see Human Prerequisites).
+- Every non-test `.csproj` in the `HoneyDrunk.Auth` solution version-bumped one minor version (invariant 27). Confirm the current version at execution time.
+- `HoneyDrunk.Auth.Abstractions/CHANGELOG.md` and `README.md` updated.
+- Repo-level `CHANGELOG.md` new version entry.
+
+## Proposed Implementation
+
+1. **Extend `AuthorizationDenyCode`** — add the four new members with explicit numeric values that do not collide with the existing 0..8 + 99. Place them after `PolicyNotFound = 8` and before `InternalError = 99`, e.g. starting at 10. XML-doc each one in the existing style.
+
+2. **Create `AuthorizationDeniedException`** — a sealed class deriving from `Exception`. Properties: `DenyReason Reason`, `string ToolName`, `AgentId AgentId`, `string? MissingCapability`. Default constructor not provided — every throw site supplies the required context.
+
+3. **`AgentId` `using`** — the exception lives in `HoneyDrunk.Auth.Abstractions` and depends on `HoneyDrunk.Kernel.Abstractions/Agents/AgentId`. Add the `using HoneyDrunk.Kernel.Abstractions.Agents;` (or whichever namespace the type ships in per packet 03's chosen layout) and update the `.csproj` `PackageReference` to `HoneyDrunk.Kernel.Abstractions` `0.8.0`.
+
+4. **Unit tests** — `AuthorizationDeniedException` construction with required + optional parameters; `Message` composition; property round-trip; serialization smoke test if the existing Auth.Abstractions test project verifies any other exception type's serialization. New `AuthorizationDenyCode` enum members compile and bind to `DenyReason` correctly. Place tests in the existing `HoneyDrunk.Auth.Tests` project.
+
+5. **Versioning** — `HoneyDrunk.Auth.Abstractions` is the changed package (new enum members + new exception type). The runtime `HoneyDrunk.Auth` and `HoneyDrunk.Auth.AspNetCore` packages and the canary project receive the same version bump for solution alignment (invariant 27). Only `HoneyDrunk.Auth.Abstractions` gets a per-package CHANGELOG entry; the others are alignment bumps only (invariant 12/27). The repo-level `CHANGELOG.md` gets a new version entry covering the additive changes.
+
+6. **README** — update `HoneyDrunk.Auth.Abstractions/README.md` to document the new `AuthorizationDeniedException` type and the four new `AuthorizationDenyCode` members in the public-API section.
+
+## Affected Files
+- `HoneyDrunk.Auth.Abstractions/AuthorizationDenyCode.cs` — four new enum members
+- `HoneyDrunk.Auth.Abstractions/AuthorizationDeniedException.cs` — new file
+- `HoneyDrunk.Auth.Abstractions/HoneyDrunk.Auth.Abstractions.csproj` — `HoneyDrunk.Kernel.Abstractions` `PackageReference` bumped to `0.8.0`; solution version bumped
+- `HoneyDrunk.Auth/HoneyDrunk.Auth.csproj`, `HoneyDrunk.Auth.AspNetCore/HoneyDrunk.Auth.AspNetCore.csproj`, `HoneyDrunk.Auth.Canary/HoneyDrunk.Auth.Canary.csproj` — version alignment
+- `HoneyDrunk.Auth.Abstractions/CHANGELOG.md`, `HoneyDrunk.Auth.Abstractions/README.md`
+- Repo-level `CHANGELOG.md`
+- `HoneyDrunk.Auth.Tests/` — new unit tests for the exception and enum members
+
+## NuGet Dependencies
+- **`HoneyDrunk.Auth.Abstractions`** — bump the existing `HoneyDrunk.Kernel.Abstractions` `PackageReference` to `0.8.0` (the version this initiative's packet 03 ships). No other new HoneyDrunk dependency. Per invariant 1, Auth.Abstractions stays zero-HoneyDrunk-runtime; Kernel.Abstractions is permitted because it is itself an Abstractions package.
+- **`HoneyDrunk.Auth`**, **`HoneyDrunk.Auth.AspNetCore`**, **`HoneyDrunk.Auth.Canary`** — pick up `HoneyDrunk.Kernel.Abstractions` `0.8.0` transitively through `HoneyDrunk.Auth.Abstractions`; if any of them references `HoneyDrunk.Kernel.Abstractions` directly, update that reference too.
+- The unit-test project follows the repo's existing test stack; no new packages introduced beyond what is already referenced.
+
+## Boundary Check
+- [x] `AuthorizationDeniedException` is the typed exception ADR-0051 D11 commits — it lives where `IAuthorizationPolicy` and related types live, which is `HoneyDrunk.Auth.Abstractions`.
+- [x] `AuthorizationDenyCode` is an existing Auth-Abstractions enum; extending it is the additive correct path, not introducing a parallel `DenyReason` enum elsewhere.
+- [x] No dependency on the Capabilities Node or any unreleased package — the exception carries an `AgentId` (Kernel.Abstractions, shipped by packet 03) but does NOT reference `CapabilityBundleRef`, `CapabilityRequirement`, or `IToolInvoker` (those types live in `HoneyDrunk.Capabilities.Abstractions`, shipped via the Capabilities standup, and are properly the responsibility of code that catches/handles `AuthorizationDeniedException` — Agents and Capabilities — not Auth itself).
+- [x] No invariant 10 breach. Auth still validates, does not issue. This packet adds an exception type and enum values; the exception is thrown by `IToolInvoker` in Capabilities, not by anything in Auth.
+
+## Acceptance Criteria
+- [ ] `AuthorizationDenyCode` enum has four new members: `CapabilityMissing`, `ScopeMismatch`, `GrantExpired`, `PrincipalTypeMismatch`, each with XML doc matching the existing style and explicit numeric values that do not collide with the existing 0..8 or 99
+- [ ] `AuthorizationDeniedException.cs` exists in `HoneyDrunk.Auth.Abstractions` as a `sealed class` deriving from `Exception`, carrying `DenyReason Reason`, `string ToolName`, `AgentId AgentId`, `string? MissingCapability`
+- [ ] The exception's constructor takes `(DenyReason, string toolName, AgentId, string? missingCapability = null, Exception? inner = null)` and composes a human-readable `Message` from the components
+- [ ] No parallel `DenyReason` enum is introduced — the existing `DenyReason` `readonly record struct` is reused; the new enum members are additive on `AuthorizationDenyCode`
+- [ ] `HoneyDrunk.Auth.Abstractions.csproj` references `HoneyDrunk.Kernel.Abstractions` at version `0.8.0` (the version this initiative's packet 03 ships)
+- [ ] All public types have XML documentation (invariant 13)
+- [ ] Records drop the `I`; interfaces keep it. `AuthorizationDeniedException` is a class with no `I` prefix; the existing `IAuthenticationProvider`, `IAuthorizationPolicy` keep their `I`s
+- [ ] Unit tests cover construction, message composition, property round-trip; the new enum members compile and bind to `DenyReason`
+- [ ] Every non-test `.csproj` in the solution is at the same new minor version in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new version entry describing the additive changes
+- [ ] `HoneyDrunk.Auth.Abstractions/CHANGELOG.md` has a corresponding per-package entry; other packages get NO per-package entry (alignment bumps only, per invariant 12/27)
+- [ ] `HoneyDrunk.Auth.Abstractions/README.md` documents the new exception type and the four new enum members
+- [ ] The `pr-core.yml` tier-1 gate and the Auth contract-shape canary pass — the new members are additive paired with the version bump
+
+## Human Prerequisites
+- [ ] **`HoneyDrunk.Kernel.Abstractions` `0.8.0` must be published before this packet's PR can compile.** The exception's `AgentId` slot references `HoneyDrunk.Kernel.Abstractions.Agents.AgentId`, shipped by this initiative's packet 03. Agents never tag or publish — a human pushes the Kernel `0.8.0` git release tag after packet 03 merges (and after any concurrent ADR-0042 Kernel changes in `0.8.0` also merge, per the ADR-0042 dispatch plan's Wave 2→3 human-release boundary). This packet's CI build will fail if the Kernel `0.8.0` artifact is not on the package feed.
+- [ ] **Tag/release `HoneyDrunk.Auth` after this packet merges so downstream consumers can compile against the new version.** The Capabilities standup track's `IToolInvoker` authz check (Phase 2 follow-up, not in this initiative) and the Agents standup track's execution loop (Phase 4 follow-up) both compile against `AuthorizationDeniedException` from the new Auth version. The Audit packet 05 in this initiative does NOT depend on the published Auth version (it consumes only the new `AuthorizationDenyCode` enum values for its event-shape registration, not the exception type at runtime); packet 05 can build against the in-repo source. But for the Capabilities/Operator/Agents downstream work, the Auth release is a hard prerequisite. Agents do not tag.
+
+## Referenced ADR Decisions
+
+**ADR-0051 D11 — Deny by default; typed exceptions.** `AuthorizationDeniedException` is the single exception type, with structured detail (`Reason`, `MissingCapability`, `ToolName`, `AgentId`). The Agents Node's execution loop catches it and surfaces to the LLM as a structured tool-result error (`{"error": "authorization_denied", "missing": "<capability>"}`).
+
+**ADR-0051 D10 — Audit `deny.reason` field.** The audit record's `deny.reason` field takes one of `"capability_missing"` / `"scope_mismatch"` / `"grant_expired"` / `"principal_type_mismatch"`. These four named reasons are exactly the four new `AuthorizationDenyCode` enum members this packet adds — the enum is the in-process source of truth, and the audit string form is derived from the enum's name (lowercase + snake_case).
+
+**ADR-0051 D3 — `IToolInvoker` six-step check.** The ordered failure modes:
+1. Unknown tool → `ToolNotFoundException` (not an authz failure; surfaces distinctly).
+2. Missing or non-agent principal → `AuthorizationDeniedException` with `Reason.Code = PrincipalTypeMismatch`.
+3. `DateTimeOffset.UtcNow > AgentPrincipal.NotAfter` → `AuthorizationDeniedException` with `Reason.Code = GrantExpired`.
+4. Effective set lacks the required capability → `AuthorizationDeniedException` with `Reason.Code = CapabilityMissing` (and the missing capability in `MissingCapability`).
+5. Scope binding failed (tenant or OnBehalfOf scope didn't match) → `AuthorizationDeniedException` with `Reason.Code = ScopeMismatch`.
+6. All requirements pass → dispatch and emit `tool.invoke.granted`.
+
+The exception type and the four enum values fully cover the D3 failure surface.
+
+**ADR-0051 D14 Phase 1 — `AuthorizationDeniedException` in `HoneyDrunk.Auth.Abstractions`.** "Add `AuthorizationDeniedException` to `HoneyDrunk.Auth.Abstractions`."
+
+**ADR-0006 Invariant 10 — Auth validates, never issues.** This packet does NOT introduce token-issuance or principal-minting code in Auth. The exception type and the enum members are pure validation/decision surface — they describe outcomes, not credentials.
+
+## Constraints
+
+- **Invariant 1 — Abstractions have zero runtime dependencies on other HoneyDrunk packages, except other Abstractions.** `HoneyDrunk.Auth.Abstractions` may reference `HoneyDrunk.Kernel.Abstractions` (it already does, for context-type integration); this packet bumps that reference to `0.8.0`. No new non-Abstractions dependency.
+- **Invariant 10 — Auth validates, never issues.** This packet adds outcome-describing types (an exception + four enum values). It does NOT introduce token issuance or principal minting; Operator owns that surface (ADR-0051 D8).
+- **Invariant 13 — all public APIs have XML documentation.**
+- **Invariant 27 — all projects in a solution share one version and move together.** Every non-test `.csproj` in the Auth solution bumps to the same new minor version in one commit. Partial bumps forbidden.
+- **Invariant 12 — per-package CHANGELOGs are updated only for packages with functional changes.** `HoneyDrunk.Auth.Abstractions` gets an entry; runtime / AspNetCore / Canary are alignment bumps with NO per-package CHANGELOG entry.
+- **Records drop the `I`; interfaces keep it.** `AuthorizationDeniedException` is a class — no `I`. Existing `I`-prefixed interfaces (`IAuthenticationProvider`, `IAuthorizationPolicy`) keep their prefix.
+- **No parallel `DenyReason` enum.** The existing `DenyReason` `readonly record struct` is the carrier; the four new reasons extend `AuthorizationDenyCode`. Introducing a parallel enum would fragment the deny surface and confuse consumers reading audit records.
+- **Pick numeric enum values that do not collide with the existing 0..8 + 99.** Start the agent-authz reasons at 10 so they group visually and leave room. Verify the current enum at execution time.
+
+## Labels
+`feature`, `tier-2`, `ai`, `adr-0051`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add `AuthorizationDeniedException` to `HoneyDrunk.Auth.Abstractions` and extend `AuthorizationDenyCode` with four new members covering ADR-0051's deny surface.
+
+**Target:** `HoneyDrunk.Auth`, branch from `main`.
+
+**Context:**
+- Goal: Ship the typed exception and deny-code values every ADR-0051 consumer (Capabilities `IToolInvoker`, Agents execution loop, Audit event registry) compiles against.
+- Feature: ADR-0051 AI Agent Authorization rollout, Wave 2 (abstractions in live Nodes).
+- ADRs: ADR-0051 D3/D10/D11/D14 (primary), ADR-0006 (Auth contract surface this composes with), invariant 10 (Auth validates, never issues — preserved).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0051 Accepted before its decisions are built into the Auth surface.
+- (Build-time, not a packet dependency) `HoneyDrunk.Kernel.Abstractions` `0.8.0` must be published before CI can compile this packet — surfaced in Human Prerequisites.
+
+**Constraints:**
+- Reuse the existing `DenyReason` `readonly record struct` and existing `AuthorizationDenyCode` enum; do not introduce a parallel enum.
+- Pick numeric enum values that do not collide with the existing 0..8 + 99 (start at 10).
+- The exception's `AgentId` slot references the Kernel-Abstractions type from this initiative's packet 03.
+- All non-test `.csproj` files bump to the same new minor version in one commit (invariant 27).
+- Only `HoneyDrunk.Auth.Abstractions` gets a per-package CHANGELOG entry; the others are alignment bumps with no entry (invariant 12).
+- Auth does not issue agent identity (invariant 10); this packet adds outcome-describing types only.
+
+**Key Files:**
+- `HoneyDrunk.Auth.Abstractions/AuthorizationDenyCode.cs` — extend enum
+- `HoneyDrunk.Auth.Abstractions/AuthorizationDeniedException.cs` — new file
+- `HoneyDrunk.Auth.Abstractions/HoneyDrunk.Auth.Abstractions.csproj` — Kernel.Abstractions bump + solution version
+- All other Auth `.csproj` files for version alignment
+- `HoneyDrunk.Auth.Abstractions/CHANGELOG.md`, `README.md`; repo-level `CHANGELOG.md`
+
+**Contracts:**
+- `AuthorizationDeniedException` (new class) — the single typed authz-failure exception for the agent surface.
+- `AuthorizationDenyCode` (existing enum, extended) — four new members: `CapabilityMissing`, `ScopeMismatch`, `GrantExpired`, `PrincipalTypeMismatch`.

--- a/generated/issue-packets/active/adr-0051-agent-authorization/05-audit-tool-invoke-event-shapes.md
+++ b/generated/issue-packets/active/adr-0051-agent-authorization/05-audit-tool-invoke-event-shapes.md
@@ -1,0 +1,198 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Audit
+labels: ["feature", "tier-2", "ai", "audit", "adr-0051", "wave-3"]
+dependencies: ["packet:03", "packet:04"]
+adrs: ["ADR-0051"]
+wave: 3
+initiative: adr-0051-agent-authorization
+node: honeydrunk-audit
+---
+
+# Register tool.invoke.granted and tool.invoke.denied event shapes in HoneyDrunk.Audit
+
+## Summary
+Extend the Audit Node's event-shape registry to recognize the two new event names ADR-0051 D10 commits — `tool.invoke.granted` and `tool.invoke.denied` — with their canonical 13-field shape, and ship a small documentation/constants surface in `HoneyDrunk.Audit.Abstractions` so emitters (Capabilities, when its Phase-2 follow-up lands) and queriers (Operator dashboards, forensic queries) reference one shared definition. This is the version-bumping packet for the `HoneyDrunk.Audit` solution.
+
+## Context
+ADR-0051 D10 specifies the exact audit-record shape for every `IToolInvoker` authorization decision: 13 fields including `event` (`tool.invoke.granted` or `tool.invoke.denied`), `agent.id`, `agent.runId`, `agent.bundles`, `onBehalfOf.type`, `onBehalfOf.id`, `tenant.id`, `tool.name`, `tool.requiredCapabilities`, `effective.capabilities`, `decision`, `deny.reason`, `deny.missingCapability`, plus `timestamp` and `traceId`.
+
+The existing `src/HoneyDrunk.Audit.Abstractions/AuditEntry.cs` already has a generic carrier: `EventName` (string), `Actor` (string), `Category` (already includes `AgentAction = 4`), `Outcome`, `Target`, `TenantId`, `CorrelationId`, plus a free-form `Metadata` `IReadOnlyDictionary<string, string>`. The `AuditEntry` shape **does not need to change** — the ADR-0051 D10 fields fit into the existing carrier:
+
+- `event` ← `EventName`
+- `agent.id`, `agent.runId` ← `Actor` (composed: `"agent:<id>@<runId>"`) and/or `Metadata` keys
+- `onBehalfOf.type` / `onBehalfOf.id` ← `Metadata` keys
+- `tool.name` ← `Target.Name` (per the existing `AuditTarget` shape)
+- `tool.requiredCapabilities`, `effective.capabilities` ← `Metadata` keys (joined string lists)
+- `deny.reason` ← maps to the string form of one of the four new `AuthorizationDenyCode` values from packet 04
+- `traceId` ← `CorrelationId` (per ADR-0040)
+- `timestamp` ← `OccurredAt`
+- `tenant.id` ← `TenantId`
+- `decision` ← `Outcome` (Granted maps to one outcome; Denied to another — verify the existing `AuditOutcome` values include the right mapping; if not, this packet extends `AuditOutcome` minimally)
+
+This packet's job is therefore not to invent a new event shape — it is to **canonicalize the field-naming for the two new events**: a `KnownEventNames` static class (or equivalent constants surface) carrying the two event name literals, and a `ToolInvokeAuditFields` static class (or equivalent metadata-key catalog) carrying the canonical `Metadata` keys (`"agent.id"`, `"agent.runId"`, `"agent.bundles"`, `"onBehalfOf.type"`, `"onBehalfOf.id"`, `"tool.requiredCapabilities"`, `"effective.capabilities"`, `"deny.reason"`, `"deny.missingCapability"`). This is the discoverability surface every emitter and querier compiles against — typo-safe, refactor-safe, documented.
+
+`HoneyDrunk.Audit` is a live Node at v0.1.0. The current `CHANGELOG.md` already has an Unreleased section recording a Standards bump (`HoneyDrunk.Standards.Tests` 0.2.9 adoption); per the user's standing convention ("No commits under CHANGELOG Unreleased — move to dated versioned section + SemVer bump before committing"), the in-flight Unreleased entry must be consolidated into the dated version entry this packet creates, or kept as a separate Unreleased entry that this packet's PR explicitly does not touch (executor confirms at execution time). The clean option is to **roll the existing Unreleased content into the same new minor version this packet bumps**, since both are additive.
+
+## Scope
+
+- `HoneyDrunk.Audit.Abstractions/` — new files:
+  - `KnownEventNames.cs` — a static class (or `static readonly` constants on an existing config-like type) carrying:
+    - `public const string ToolInvokeGranted = "tool.invoke.granted";`
+    - `public const string ToolInvokeDenied = "tool.invoke.denied";`
+    - XML doc cross-referencing ADR-0051 D10 for the field shape.
+  - `ToolInvokeAuditFields.cs` (or appropriately-named, matching the existing repo's naming style) — a static class carrying the canonical `Metadata` keys as `const string` values:
+    - `AgentId = "agent.id"`
+    - `AgentRunId = "agent.runId"`
+    - `AgentBundles = "agent.bundles"`
+    - `OnBehalfOfType = "onBehalfOf.type"`
+    - `OnBehalfOfId = "onBehalfOf.id"`
+    - `ToolRequiredCapabilities = "tool.requiredCapabilities"`
+    - `EffectiveCapabilities = "effective.capabilities"`
+    - `DenyReason = "deny.reason"`
+    - `DenyMissingCapability = "deny.missingCapability"`
+    - XML doc.
+
+- (Optional, verify at execution time) `src/HoneyDrunk.Audit.Abstractions/AuditOutcome.cs` — extend with `Granted` / `Denied` values if the existing enum does not already distinguish the two for the agent-tool surface. Verify the existing enum first; only extend if needed. If extended, ship per-package CHANGELOG entry; if not, no change.
+
+- (Optional, verify at execution time) `src/HoneyDrunk.Audit.Abstractions/AuditCategory.cs` — confirm `AgentAction = 4` is the correct category for these events (it is, per the existing comment). No change unless a refinement is warranted.
+
+- `HoneyDrunk.Audit.Abstractions.csproj` — `HoneyDrunk.Kernel.Abstractions` `PackageReference` bumped to `0.8.0` (the packet 03 release; the constants don't directly use the type, but `AuditEntry` already references `TenantId` from `HoneyDrunk.Kernel.Abstractions.Identity`, so the package may already be referenced — verify at execution time). If `HoneyDrunk.Auth.Abstractions` is added as a dependency (only if `AuthorizationDenyCode` is referenced directly — e.g., to provide a typed helper that maps `AuthorizationDenyCode → deny.reason` string), bump that too — but per Boundary Check below, prefer keeping Audit.Abstractions free of Auth.Abstractions to preserve invariant 1.
+
+- Every non-test `.csproj` in the `HoneyDrunk.Audit` solution version-bumped one minor version (`0.1.0 → 0.2.0`) (invariant 27).
+
+- `src/HoneyDrunk.Audit.Abstractions/CHANGELOG.md` and `README.md` updated.
+
+- Repo-level `CHANGELOG.md` — new `[0.2.0]` entry. **Consolidate the existing Unreleased entry into the new `[0.2.0]` entry** per the no-Unreleased-commits convention; or, if the Standards bump in Unreleased has already shipped to NuGet, leave that note in place and add the new authz-event-shape section under the same `[0.2.0]`.
+
+## Proposed Implementation
+
+1. **`KnownEventNames`** — new static class in `HoneyDrunk.Audit.Abstractions`:
+   ```
+   public static class KnownEventNames
+   {
+       /// <summary>Tool invocation was authorized and dispatched per ADR-0051 D10.</summary>
+       public const string ToolInvokeGranted = "tool.invoke.granted";
+
+       /// <summary>Tool invocation was denied; see deny.reason metadata key per ADR-0051 D10.</summary>
+       public const string ToolInvokeDenied = "tool.invoke.denied";
+   }
+   ```
+   If a similar constants-style file already exists in the repo (e.g., a `WellKnown*` file), append the constants there rather than creating a duplicate-shape file. The executor verifies at execution time.
+
+2. **`ToolInvokeAuditFields`** — new static class carrying the canonical metadata-key constants listed in Scope. Each `const string` value is XML-documented with its purpose and the type of value the emitter is expected to store (e.g., `AgentBundles` carries a semicolon-separated list of `bundle:<name>@v<n>` references; `EffectiveCapabilities` carries a semicolon-separated list of capability names with no values).
+
+3. **No `AuditEntry` schema change.** The existing `AuditEntry` shape carries everything the ADR-0051 D10 fields need. Emitters compose the entry with the new `EventName` constant, `Actor = $"agent:{agentId.Value}"` (or a similar canonical composition the executor settles), `Category = AuditCategory.AgentAction`, `Target = new AuditTarget(...) { Name = toolName }`, `Outcome = AuditOutcome.Granted/Denied`, `CorrelationId = traceId`, and the rest in `Metadata` keyed by the new `ToolInvokeAuditFields` constants.
+
+4. **`AuditOutcome` extension (only if needed)** — read `src/HoneyDrunk.Audit.Abstractions/AuditOutcome.cs` at execution time. If the existing enum already carries values that fit `Granted` / `Denied` for the agent-tool surface (e.g., `Success` / `Failure`, or a literal `Allowed` / `Denied`), use those — no change. If not, add explicit `AuthorizationGranted` / `AuthorizationDenied` members.
+
+5. **Unit tests** — `HoneyDrunk.Audit.Abstractions` test project: verify the constants are exposed as `const string` with the exact ADR-0051 D10 field names; verify any new `AuditOutcome` member compiles and serializes (if added). A small "round-trip" test where an `AuditEntry` is constructed using the new constants and the field values are recoverable proves the shape works end-to-end against the existing carrier — no `IAuditLog`/runtime invocation, pure carrier composition.
+
+6. **Versioning** — bump every non-test `.csproj` in the `HoneyDrunk.Audit` solution from `0.1.0` to `0.2.0` in one commit (invariant 27). Repo-level `CHANGELOG.md` `[0.2.0]` entry. Per-package CHANGELOG: `HoneyDrunk.Audit.Abstractions` gets an entry (real changes); `HoneyDrunk.Audit.Data` is an alignment bump only and gets NO per-package entry (invariant 12/27). Roll the existing Unreleased Standards-bump line into the new `[0.2.0]` entry if it hasn't already shipped; the executor verifies the repo state.
+
+7. **README** — update `src/HoneyDrunk.Audit.Abstractions/README.md` to document `KnownEventNames` and `ToolInvokeAuditFields`, with a short worked example of composing an `AuditEntry` for `tool.invoke.granted` so a Capabilities-side emitter has a copy-pasteable template.
+
+## Affected Files
+- `src/HoneyDrunk.Audit.Abstractions/KnownEventNames.cs` (or extend an existing similarly-purposed file)
+- `src/HoneyDrunk.Audit.Abstractions/ToolInvokeAuditFields.cs`
+- `src/HoneyDrunk.Audit.Abstractions/AuditOutcome.cs` (only if extension is needed — verify at execution time)
+- `src/HoneyDrunk.Audit.Abstractions/HoneyDrunk.Audit.Abstractions.csproj` — version bump; possibly `HoneyDrunk.Kernel.Abstractions` reference bumped to `0.8.0` if reference is direct
+- `src/HoneyDrunk.Audit.Data/HoneyDrunk.Audit.Data.csproj` — version alignment
+- `src/HoneyDrunk.Audit.Abstractions/CHANGELOG.md`, `src/HoneyDrunk.Audit.Abstractions/README.md`
+- Repo-level `CHANGELOG.md`
+- `HoneyDrunk.Audit.Abstractions` test project — new tests
+
+## NuGet Dependencies
+- **`HoneyDrunk.Audit.Abstractions`** — verify `HoneyDrunk.Kernel.Abstractions` is already referenced (it is, for `TenantId` and `CorrelationId`). Bump that reference to `0.8.0` to align with the AgentId-bearing Kernel that packet 03 ships, even though this packet's constants don't directly reference `AgentId` — keeping the reference current is cleaner than skewing.
+- **`HoneyDrunk.Audit.Abstractions`** does NOT reference `HoneyDrunk.Auth.Abstractions`. The `deny.reason` field's value mapping (`AuthorizationDenyCode → "capability_missing"` string) is the **emitter's** responsibility (the Capabilities Node, in its Phase-2 follow-up), not Audit's. Adding an Auth.Abstractions reference here would couple two Abstractions packages unnecessarily — see Boundary Check.
+- **`HoneyDrunk.Audit.Data`** — picks up the Kernel.Abstractions bump transitively.
+- The unit-test project follows the repo's existing test stack; no new packages.
+
+## Boundary Check
+- [x] Event taxonomy and audit-field canonicalization live in `HoneyDrunk.Audit.Abstractions` — this is the discoverability home for every Node that emits or queries audit events.
+- [x] **No reference from `HoneyDrunk.Audit.Abstractions` to `HoneyDrunk.Auth.Abstractions`.** The `deny.reason` field is a string in the audit record; the mapping from `AuthorizationDenyCode` to that string lives at the emitter (Capabilities Node, Phase-2 follow-up). Coupling Audit.Abstractions to Auth.Abstractions for a string-valued field is unnecessary and would tighten the dependency graph (invariant 4).
+- [x] No new event *carrier* — the existing `AuditEntry` shape handles the ADR-0051 D10 fields. This packet only canonicalizes the field-naming and event-name constants.
+- [x] No runtime emission logic — the `IToolInvoker.InvokeAsync` audit emission is the Capabilities Node's responsibility (Phase-2 follow-up in `adr-0017-capabilities-standup`).
+- [x] Records drop the `I`; interfaces keep it. `KnownEventNames` and `ToolInvokeAuditFields` are static classes (no `I`).
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Audit.Abstractions` exposes `KnownEventNames.ToolInvokeGranted = "tool.invoke.granted"` and `KnownEventNames.ToolInvokeDenied = "tool.invoke.denied"` as `const string` values
+- [ ] `HoneyDrunk.Audit.Abstractions` exposes `ToolInvokeAuditFields` carrying the nine canonical metadata-key constants per ADR-0051 D10 (`agent.id`, `agent.runId`, `agent.bundles`, `onBehalfOf.type`, `onBehalfOf.id`, `tool.requiredCapabilities`, `effective.capabilities`, `deny.reason`, `deny.missingCapability`)
+- [ ] No new `AuditEntry` field or breaking schema change — the existing carrier handles the new fields via the established `EventName`/`Actor`/`Target`/`Metadata`/`CorrelationId` slots
+- [ ] `AuditOutcome` is extended only if the existing enum cannot already represent Granted/Denied for the agent-tool surface; if extended, the change is additive
+- [ ] `HoneyDrunk.Audit.Abstractions.csproj` references `HoneyDrunk.Kernel.Abstractions` at version `0.8.0`
+- [ ] `HoneyDrunk.Audit.Abstractions` does NOT take a `PackageReference` on `HoneyDrunk.Auth.Abstractions` (the `deny.reason` string mapping is the emitter's responsibility)
+- [ ] All new public types have XML documentation including a cross-reference to ADR-0051 D10
+- [ ] Unit tests cover constant values, optional `AuditOutcome` member compilation, and an end-to-end `AuditEntry` composition using the new constants
+- [ ] Every non-test `.csproj` in the solution is at version `0.2.0` in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new `[0.2.0]` dated section describing the additive event-shape registration (and consolidating the prior Unreleased Standards-bump line if it has not yet been published — verify at execution time)
+- [ ] `src/HoneyDrunk.Audit.Abstractions/CHANGELOG.md` has a corresponding `[0.2.0]` entry; `HoneyDrunk.Audit.Data` is an alignment bump with NO per-package entry (invariant 12/27)
+- [ ] `src/HoneyDrunk.Audit.Abstractions/README.md` documents the new constants and shows a worked `tool.invoke.granted` composition example
+- [ ] The `pr-core.yml` tier-1 gate and the Audit contract-shape canary pass — the new constants are additive paired with the version bump
+
+## Human Prerequisites
+- [ ] **`HoneyDrunk.Kernel.Abstractions` `0.8.0` must be published before this packet's PR can compile.** This packet's csproj bumps the Kernel.Abstractions reference to `0.8.0` (the version packet 03 in this initiative ships). Agents never tag — a human pushes the Kernel git release tag after packet 03 merges; coordinate with the ADR-0042 Wave 2→3 release boundary if both initiatives land in the same Kernel release.
+- [ ] **(Optional, downstream-only) Tag/release `HoneyDrunk.Audit` `0.2.0` after this packet merges** so the Capabilities Node's Phase-2 follow-up (in `adr-0017-capabilities-standup`) can compile against the new constants when it lands. This is not in this initiative's critical path — Capabilities Phase 2 has not yet been packaged — but is a clean step to flag.
+
+## Referenced ADR Decisions
+
+**ADR-0051 D10 — Audit record shape for authz decisions.** 13 fields: `event` (`tool.invoke.granted` / `tool.invoke.denied`), `agent.id`, `agent.runId`, `agent.bundles`, `onBehalfOf.type` (string?), `onBehalfOf.id` (string?, pseudonymous per ADR-0045 D7 PII rules), `tenant.id`, `tool.name`, `tool.requiredCapabilities`, `effective.capabilities` (names only, no secret values), `decision`, `deny.reason` (`"capability_missing"` / `"scope_mismatch"` / `"grant_expired"` / `"principal_type_mismatch"`), `deny.missingCapability`, `timestamp`, `traceId`. Emitted via `IAuditAppender`. If Audit is unavailable, tool invocation denies (fail-closed).
+
+**ADR-0051 D3 — `IToolInvoker` emits `tool.invoke.granted` or `tool.invoke.denied`.** Step 5 emits granted on dispatch; step 6 emits denied on failure. The emitter is the `IToolInvoker` default implementation in the Capabilities Node; the audit record's field-naming is the canonicalization this packet ships.
+
+**ADR-0030 Invariant 47 — Durable audit emission via `IAuditLog`.** This packet preserves the invariant — the new event names ride the existing `IAuditLog.AppendAsync(AuditEntry)` surface unchanged. The carrier is constant; the event name and field keys are new.
+
+**ADR-0040 D3 — 730-day retention.** ADR-0051's audit volume at v1 is single-digit invocations per second across the Grid — well within the retention budget. No retention policy change in this packet.
+
+**ADR-0045 D7 — PII pseudonymization.** The `onBehalfOf.id` field carries a **pseudonymous** principal id, not the raw user id. The Capabilities-side emitter is responsible for the pseudonymization; this packet documents the expectation on the `OnBehalfOfId` metadata-key constant's XML doc.
+
+## Constraints
+
+- **Invariant 1 — Abstractions have zero runtime dependencies on other HoneyDrunk packages, except other Abstractions.** `HoneyDrunk.Audit.Abstractions` references only `HoneyDrunk.Kernel.Abstractions`; do NOT add `HoneyDrunk.Auth.Abstractions` as a reference. The `deny.reason` field carries a string at the audit layer; the typed `AuthorizationDenyCode → string` mapping is the emitter's concern.
+- **Invariant 12 — per-package CHANGELOGs are updated only for packages with functional changes.** `HoneyDrunk.Audit.Abstractions` gets an entry; `HoneyDrunk.Audit.Data` (alignment bump only) gets none.
+- **Invariant 13 — all public APIs have XML documentation.**
+- **Invariant 27 — all projects in a solution share one version and move together.** Both `.csproj` files go to `0.2.0` in one commit.
+- **No Unreleased commits.** The user's convention: do not commit under `## [Unreleased]`. Move any extant Unreleased entries into the new dated `[0.2.0]` section (or, if they have already been published as part of a different release, the executor should verify and leave the historical record intact — but no in-flight Unreleased should remain after this PR).
+- **No `AuditEntry` schema change.** The existing carrier handles every ADR-0051 D10 field via the established slots. Resist the temptation to add a typed `AgentAuditEntry` subtype — that would fragment the audit surface.
+- **No `IToolInvoker` emission logic.** That is the Capabilities Node's responsibility in its Phase-2 follow-up. This packet ships discoverability + canonicalization only.
+
+## Labels
+`feature`, `tier-2`, `ai`, `audit`, `adr-0051`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Ship `KnownEventNames.ToolInvokeGranted` / `ToolInvokeDenied` and `ToolInvokeAuditFields` constants in `HoneyDrunk.Audit.Abstractions` so emitters and queriers have one canonical reference for the ADR-0051 D10 event taxonomy and field-naming.
+
+**Target:** `HoneyDrunk.Audit`, branch from `main`.
+
+**Context:**
+- Goal: Register the event taxonomy in Audit so when the Capabilities Node ships its Phase-2 `IToolInvoker` authz check and audit emission, the field names and event names are already canonicalized.
+- Feature: ADR-0051 AI Agent Authorization rollout, Wave 3 (audit event taxonomy).
+- ADRs: ADR-0051 D3/D10 (primary), ADR-0030 (audit substrate), ADR-0040 (telemetry/trace correlation), ADR-0045 (PII pseudonymization).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — `HoneyDrunk.Kernel.Abstractions` `0.8.0` exists in source (and is the version this packet's csproj references).
+- `packet:04` — `AuthorizationDenyCode` extended with the four new values exists in source (this packet documents the string forms of the four reasons on the `ToolInvokeAuditFields.DenyReason` XML doc; the typed enum is referenced only via the docstring, not via a `PackageReference`).
+
+**Constraints:**
+- Records drop the `I`; constants live in static classes.
+- No `AuditEntry` schema change — the existing carrier handles every D10 field.
+- No `HoneyDrunk.Auth.Abstractions` `PackageReference` — keep Audit.Abstractions decoupled from Auth (invariant 1 / 4).
+- No `IToolInvoker` emission code — that ships in the Capabilities Phase-2 follow-up.
+- Bump every non-test `.csproj` to `0.2.0` in one commit (invariant 27).
+- Consolidate any existing CHANGELOG Unreleased entry into the new `[0.2.0]` per the no-Unreleased-commits convention.
+
+**Key Files:**
+- `src/HoneyDrunk.Audit.Abstractions/KnownEventNames.cs`, `ToolInvokeAuditFields.cs`
+- Both `.csproj` files for the version bump
+- `src/HoneyDrunk.Audit.Abstractions/CHANGELOG.md`, `README.md`; repo-level `CHANGELOG.md`
+
+**Contracts:**
+- `KnownEventNames` (new static class) — canonical event name constants for the ADR-0051 D10 event taxonomy.
+- `ToolInvokeAuditFields` (new static class) — canonical `Metadata`-key constants for the ADR-0051 D10 record shape.
+- `AuditEntry` (existing record) — unchanged; the new constants ride the existing carrier.
+- `AuditOutcome` (existing enum) — extended only if the existing values don't fit `Granted`/`Denied` for agent-tool authz; verify first.

--- a/generated/issue-packets/active/adr-0051-agent-authorization/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0051-agent-authorization/dispatch-plan.md
@@ -1,0 +1,152 @@
+# Dispatch Plan — ADR-0051: AI Agent Authorization and Tool Scoping Model
+
+**Initiative:** `adr-0051-agent-authorization`
+**ADR:** ADR-0051 (Proposed → Accepted via packet 00)
+**Sector:** AI / cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0051 commits the Grid to a Phase 1–6 authorization model for AI agents: a third principal type (`AgentPrincipal`), versioned capability bundles granted by Operator, tool-level scoping at `IToolInvoker`, tenant-composing scope binding, delegated-execution intersection rules, time-bound grants, deny-by-default, and a declarative-config v1 bundle store with documented escalation paths.
+
+The ADR's Phase 1 names a contract-only deliverable across `HoneyDrunk.Auth.Abstractions`, `HoneyDrunk.Capabilities.Abstractions`, and `HoneyDrunk.Kernel`. Phases 2–4 are the *runtime implementations* in the Capabilities, Operator, and Agents Nodes — all three of which currently live in **separate, in-flight standup initiatives** (`adr-0017-capabilities-standup`, `adr-0018-operator-standup`, `adr-0020-agents-standup`) whose scaffold packets have not yet executed. Per the user's standing convention ("New-Node / standup work gets its own ADR; don't bundle scaffold into feature packets"), this initiative ships **the governance, the abstractions in live Nodes, and the Audit event taxonomy** — and **defers the Capabilities runtime, the Operator grant API, the Agents execution-loop wiring, and the static-analyzer rule** to those Nodes' own standup tracks, which consume what ADR-0051 ships.
+
+This initiative delivers: ADR acceptance + four new invariants + initiative registration (Architecture); catalog registration of the new contract surface (Architecture); `.claude/agents/scope.md` tool-authoring checklist + standup template update (Architecture); the `AgentPrincipal` / `AgentId` / `AgentRunId` types and context propagation slot in `HoneyDrunk.Kernel.Abstractions` (Kernel); the `AuthorizationDeniedException` plus extension of the existing `AuthorizationDenyCode` enum with the four new deny reasons in `HoneyDrunk.Auth.Abstractions` (Auth); and the `tool.invoke.granted` / `tool.invoke.denied` event-shape registration in `HoneyDrunk.Audit` (Audit).
+
+**6 packets across 3 waves**, targeting **4 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Kernel`, `HoneyDrunk.Auth`, `HoneyDrunk.Audit`). All 6 are `Actor=Agent`, 0 `Actor=Human`. Packets 03 and 04 carry a Human Prerequisite (a human git-tag/release of the upstream Kernel and Auth NuGet packages so the downstream standup tracks can compile against them), but the *code* work is fully delegable.
+
+## Trigger
+
+ADR-0051 is Proposed with no scope. The forcing functions from the ADR's Context:
+
+- **AI-sector standup blocker.** ADR-0017 (Capabilities), ADR-0018 (Operator), and ADR-0020 (Agents) are all Proposed and gesture at a "`// TODO: authorization model`" — Capabilities and Agents cannot ship their standup canaries without it. The standup canaries' purpose is *demonstrating tool authorization*, and there is nothing to demonstrate against.
+- **ADR-0006 (Auth) does not anticipate agents-as-principals.** Adding a third principal type is not a hot-fix; it needs a committed shape before any consumer writes against it.
+- **Invariant 10 ("Auth validates, never issues") must hold for agents.** Operator originates agent identity; Auth validates. The boundary is non-negotiable and shaped D8 substantively.
+- **ADR-0030 (Audit, Accepted) and ADR-0031 (Audit standup, in flight) require every agent action to be audited with a first-class principal.** Without `AgentPrincipal`, every audit record from agent execution would degrade to `principal=anonymous-agent`, collapsing the AI-sector audit story.
+- **Operator (ADR-0018) is itself an agent.** The granting surface must be expressive enough to describe Operator's own permissions without enabling recursive escalation — D8 of the ADR.
+
+The model is concrete enough to commit; decompose it and ship the contract floor.
+
+## Scope Detection
+
+**Multi-repo, multi-Node — but bounded.** The contract surface lands in `HoneyDrunk.Kernel.Abstractions` (the zero-dependency contract layer every Node already consumes — same precedent as `IGridContext`, `TenantId`, idempotency types), `HoneyDrunk.Auth.Abstractions` (the established home of `IAuthorizationPolicy`, `AuthorizationDenyCode`, etc.), and `HoneyDrunk.Audit` (event-shape registry). `HoneyDrunk.Architecture` carries governance, catalogs, and the `scope.md` / standup-template update.
+
+**Capabilities.Abstractions types are NOT shipped here.** The ADR D14 Phase 1 also names `CapabilityBundle`, `Capability`, `CapabilityRequirement`, `ScopeBindingMode`, `CapabilityBundleRef` for `HoneyDrunk.Capabilities.Abstractions`. The Capabilities repo is empty (LICENSE + README only); its scaffold lands in `adr-0017-capabilities-standup` packet 04. This initiative does NOT inject types into an empty repo — that violates the "standup work gets its own ADR" rule and would create an ordering hazard for the in-flight Capabilities standup track. Those types belong in the Capabilities scaffold, and that scaffold's packet must be amended to ship the ADR-0051 contracts as part of its first commit. See Cross-Cutting Concerns for the amendment surface.
+
+**Contract is additive — no forced downstream cascade.** Every type this initiative ships is *additive* to `HoneyDrunk.Kernel.Abstractions` / `HoneyDrunk.Auth.Abstractions` (the four new `AuthorizationDenyCode` values are additive to the enum; new types are additive). Per ADR-0035, this is an additive minor bump (`HoneyDrunk.Kernel` `0.7.0` → `0.8.0`; `HoneyDrunk.Auth` to the next minor version), not a breaking change. Downstream Nodes consuming these Abstractions are not *forced* to update — they adopt the contract when their own authorization paths are amended in their own initiatives.
+
+**No new-Node scaffolding.** Every target repo in *this* initiative is a live, scaffolded Node. No empty cataloged repo is touched. The new-Node work for Capabilities/Operator/Agents stays in the existing standup initiatives.
+
+## Cross-Cutting Concerns
+
+### Mapping ADR-0051's "`RequestContext`" to the Grid's actual context contracts
+
+ADR-0051 D1 says `AgentPrincipal` "flows through `RequestContext` (the existing carrier for `UserPrincipal` / `ServicePrincipal` per ADR-0006)." There is no type named `RequestContext` in the codebase, and the named "existing" `UserPrincipal` / `ServicePrincipal` types **also do not exist today**. The Grid's actual context contracts are `IGridContext` / `IOperationContext` in `HoneyDrunk.Kernel.Abstractions/Context/` and the authentication surface in `HoneyDrunk.Auth.Abstractions` (`AuthenticatedIdentity`, `IAuthorizationPolicy`, `AuthorizationRequest`, `AuthorizationDecision`).
+
+**Decided, not deferred:** the `AgentPrincipal` slot lives on `IOperationContext` (the per-operation context — short-lived, matching `AgentRunId`'s per-invocation lifetime), exposed as an optional `AgentPrincipal? Agent { get; }` member. The longer-lived `IGridContext` carries Grid-level identity (Node, Sector, Environment); per-operation principals belong on `IOperationContext`. `UserPrincipal` and `ServicePrincipal` as named types are **deferred** to a future Auth amendment — Auth's existing `AuthenticatedIdentity` already carries the human/service identity story under a different shape, and forcing the three-principal-type renaming today is out of scope. Packet 03 ships `AgentPrincipal` as a standalone record; the `Principal` abstract base class named by the ADR is also deferred until the matching `UserPrincipal` / `ServicePrincipal` types arrive in their own initiative. This is recorded so the operator does not file a packet against a non-existent type.
+
+### `DenyReason` naming collision
+
+ADR-0051 D11 declares a new `DenyReason` enum carrying `capability_missing`, `scope_mismatch`, `grant_expired`, `principal_type_mismatch`. **A `DenyReason` type already exists** in `HoneyDrunk.Auth.Abstractions/DenyReason.cs` — a `readonly record struct` combining `AuthorizationDenyCode` (the existing enum) and `string Message`. The collision is real.
+
+**Decided, not deferred:** packet 04 extends the existing `AuthorizationDenyCode` enum with four new members — `CapabilityMissing`, `ScopeMismatch`, `GrantExpired`, `PrincipalTypeMismatch` — and reuses the existing `DenyReason` record struct as the carrier. `AuthorizationDeniedException` (genuinely new) takes a `DenyReason` directly, so it composes with the existing surface rather than fragmenting it. This is cleaner than introducing a parallel enum and aligns with the Auth conventions already in place. Packet 04 references the existing types by name and adds enum members; no parallel structure is created.
+
+### Capabilities.Abstractions types — deferred to ADR-0017 standup, amendment required
+
+ADR-0051 D2/D3 names `CapabilityBundle`, `Capability`, `CapabilityRequirement`, `ScopeBindingMode`, `CapabilityBundleRef`, and `IToolInvoker`'s extension with `RequiredCapabilities` for `HoneyDrunk.Capabilities.Abstractions`. ADR-0017's packet 04 (the Capabilities scaffold) already names the four exposed contracts — `ICapabilityRegistry`, `CapabilityDescriptor`, `ICapabilityInvoker`, `ICapabilityGuard` — and lands them in the first commit. The ADR-0051 types belong in that same scaffold as additions to packet 04's contract list.
+
+**Two notes are required to keep ADR-0017 and ADR-0051 consistent:**
+
+1. ADR-0017 standup packet 04 must be **amended at execution time** to additionally ship `CapabilityBundle`, `Capability`, `CapabilityRequirement`, `ScopeBindingMode`, `CapabilityBundleRef`, and the `RequiredCapabilities` extension on `ICapabilityInvoker`'s parameters surface. The amendment must reference ADR-0051's acceptance (packet 00 in this initiative) as a hard dependency so the bundle types land in the same commit as the registry types.
+2. The Capabilities Node also implements the **bundle-store loader, the `IToolInvoker` authorization check, the env-guard, and the recursion check** (ADR-0051 D3, D8, D9, D12). These are the Phase 2 deliverables in ADR-0051's D14 phased rollout. They are appropriately Capabilities-Node implementation work — they do not fit *this* initiative's "abstractions only" scope and they cannot be filed against an empty repo. The right home is **a follow-up packet inside `adr-0017-capabilities-standup`** that lands *after* the standup scaffold (packet 04 there) closes. The follow-up packet's draft is named explicitly in this initiative's Follow-Up Work section as a tracked item.
+
+**Operator grant/revoke API + bootstrap + `bundle:grid-operator` recursion check (D8)** — deferred to `adr-0018-operator-standup`, similarly amended/followed up. **Agents execution loop wiring + `AuthorizationDeniedException` → structured LLM tool error (D11 / D14 Phase 4)** — deferred to `adr-0020-agents-standup`.
+
+This split honors invariant 24 (packet immutability) for already-filed packets in those tracks: the *amendments* are to packet **drafts** not yet filed, which is permissible until the file-packets workflow runs.
+
+### Static analyzer rule — deferred to Operator standup
+
+ADR-0051 names an analyzer rule that flags direct construction of `AgentPrincipal` outside `HoneyDrunk.Operator`. The analyzer is a `HoneyDrunk.Standards.Analyzers` change, but its enforcement target is `HoneyDrunk.Operator`. The analyzer rule cannot be authored until the analyzer's target type exists (packet 03 here) AND the protected Node exists (Operator's scaffold). The right home is the Operator standup track; recorded here as a follow-up.
+
+### `tool.invoke.granted` / `tool.invoke.denied` audit event taxonomy
+
+ADR-0051 D10 specifies the exact audit-record shape: 13 fields including `event`, `agent.id`, `agent.runId`, `agent.bundles`, `onBehalfOf.*`, `tenant.id`, `tool.name`, `tool.requiredCapabilities`, `effective.capabilities`, `decision`, `deny.reason`, `deny.missingCapability`, `timestamp`, `traceId`. The Audit Node (live, v0.1.0 per the ADR-0031 standup track) maintains an event-shape registry per ADR-0030/0031's contract. Packet 05 extends the registry to recognize these two event names and their field shapes. The runtime emission (the `IToolInvoker` calling `IAuditAppender.AppendAsync`) is the Capabilities Node's job — this packet only registers that **Audit knows these shapes exist** so post-emit query and validation paths recognize them.
+
+The "Audit unavailable → tool invocation denies" contract test (ADR-0051 D10, "If Audit is unavailable, tool invocation **denies**") is named in ADR-0047 D4 Tier 2a contract-tests pattern. Adding the contract test is a follow-up to ADR-0047's testing-pattern rollout, written against the IToolInvoker authz check in the Capabilities Node track. Not in this initiative.
+
+### Long-running grant renewal workflow — deferred to Operator standup
+
+ADR-0051 D6 names a 30-day renewal cycle for long-running agents (Lately publisher, Hearth content worker). The renewal workflow runs from Operator and requires explicit re-confirmation. It is Operator-Node operational work and lands in the Operator standup or a follow-up Operator initiative.
+
+### `policy-review` specialist agent — deferred to ADR-0046 specialist-roster initiative
+
+ADR-0051's Follow-up Work lists a `policy-review` specialist agent (per ADR-0046) for `policies/bundles/` changes. ADR-0046 is the umbrella for specialist-agent additions; the `policy-review` specialist is a new entry in that roster. It lands in `adr-0046-specialist-review-agents` follow-up scope, after the `policies/bundles/` directory actually exists (which arrives with the Capabilities scaffold).
+
+### Site sync
+
+No site-sync flag. ADR-0051 is internal AI-sector substrate — no public-facing Studios website content changes.
+
+## Wave Diagram
+
+### Wave 1 (No Dependencies — governance + catalog + agent updates)
+
+- [ ] **00** — Architecture: Accept ADR-0051, add four new invariants (numbers **78, 79, 80, 81**), register the initiative. `Actor=Agent`.
+- [ ] **01** — Architecture: register the new authorization contract surface in the Grid catalogs and add the Cross-Cutting Concerns to `repos/HoneyDrunk.Capabilities/`, `repos/HoneyDrunk.Operator/`, `repos/HoneyDrunk.Agents/` integration-points docs. `Actor=Agent`. Blocked by: 00.
+- [ ] **02** — Architecture: update `.claude/agents/scope.md` with the "tool-authoring checklist" + "Capability bundle definition" section for standup packets. `Actor=Agent`. Blocked by: 00.
+
+> **Invariant numbering.** The current verified maximum in `constitution/invariants.md` is **53**. Invariant numbers **78, 79, 80, 81** are reserved for ADR-0051 as part of a forward batch alongside ADR-0042's reserved 75/76/77; if any invariant above 53 lands from outside this batch before packet 00 merges, shift the block upward, never reuse a number.
+
+### Wave 2 (Depends on Wave 1 — abstractions in live Nodes, parallel)
+
+- [ ] **03** — Kernel: add `AgentPrincipal`, `AgentId`, `AgentRunId` to `HoneyDrunk.Kernel.Abstractions/Agents/` (the existing `Agents/` subfolder); extend `IOperationContext` with an optional `AgentPrincipal? Agent { get; }`. `Actor=Agent`. Blocked by: 00. **Version-bumping packet for `HoneyDrunk.Kernel` (`0.7.0` → `0.8.0`; if ADR-0042's packet 02 already bumped to `0.8.0`, this packet appends to that line — see Version Bumps).**
+- [ ] **04** — Auth: add `AuthorizationDeniedException` to `HoneyDrunk.Auth.Abstractions`; extend the existing `AuthorizationDenyCode` enum with four new members (`CapabilityMissing`, `ScopeMismatch`, `GrantExpired`, `PrincipalTypeMismatch`). `Actor=Agent`. Blocked by: 00. **Version-bumping packet for `HoneyDrunk.Auth`.**
+
+### Wave 3 (Depends on Wave 2 — Audit event taxonomy)
+
+- [ ] **05** — Audit: register `tool.invoke.granted` and `tool.invoke.denied` event names and the 13-field shape in the Audit event-shape registry per ADR-0051 D10. `Actor=Agent`. Blocked by: 03, 04. **Version-bumping packet for `HoneyDrunk.Audit`.**
+
+Packets within a wave run in parallel. **Wave-1 packets 00, 01, 02 share Architecture** — 00 is the acceptance + invariants, 01 is catalog/integration-points, 02 is scope.md/template. They could land as one PR; kept as separate packets for review surface and per the "one logical change per packet" rule. **Wave-2 packets 03 and 04 are independent** — different repos. Packet 05 in Wave 3 hard-blocks behind both Wave-2 packets because the audit event-shape registration references the `AgentPrincipal` type (packet 03) and the deny codes (packet 04).
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0051](./00-architecture-adr-0051-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [Authorization contract catalog + integration-points](./01-architecture-agent-authorization-catalog.md) | Architecture | Agent | 1 | 00 |
+| 02 | [Scope agent + standup template tool-authoring updates](./02-architecture-scope-agent-tool-authoring-updates.md) | Architecture | Agent | 1 | 00 |
+| 03 | [Kernel `AgentPrincipal` + `IOperationContext` slot](./03-kernel-agent-principal-and-operation-context-slot.md) | Kernel | Agent | 2 | 00 |
+| 04 | [Auth `AuthorizationDeniedException` + deny-code extension](./04-auth-authorization-denied-exception-and-deny-codes.md) | Auth | Agent | 2 | 00 |
+| 05 | [Audit `tool.invoke.*` event shapes](./05-audit-tool-invoke-event-shapes.md) | Audit | Agent | 3 | 03, 04 |
+
+## Version Bumps
+
+- **`HoneyDrunk.Kernel`** — packet 03 is the first ADR-0051 packet on the solution. If ADR-0042's packet 02 has already bumped Kernel `0.7.0` → `0.8.0`, packet 03 here appends to the in-progress `[0.8.0]` CHANGELOG and does NOT bump again (invariant 27). If ADR-0042's bump has NOT yet landed at execution time, packet 03 is the bumping packet (`0.7.0` → `0.8.0`). The executor must verify the current solution version before bumping. Per-package CHANGELOG: `HoneyDrunk.Kernel.Abstractions` gets an entry from packet 03 (real changes — new types + `IOperationContext` extension).
+- **`HoneyDrunk.Auth`** — packet 04 bumps the whole solution one minor version (additive deny-code values + new `AuthorizationDeniedException`). Confirm the current version at execution time. Per-package CHANGELOG: `HoneyDrunk.Auth.Abstractions` gets an entry; non-Abstractions packages are alignment bumps only (no CHANGELOG entry per invariant 12/27).
+- **`HoneyDrunk.Audit`** — packet 05 bumps the whole solution one minor version (event-shape registry extension is an additive feature). Confirm the current version at execution time.
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; governance / catalog / docs edits only.
+
+## Rollback Plan
+
+- **Packets 00–02 (governance/catalog/agent docs):** revert the PR. ADR-0051 returns to Proposed; the four invariants and catalog entries are removed; the scope.md/standup-template updates revert. No runtime impact.
+- **Packet 03 (Kernel `AgentPrincipal` + context slot):** revert the PR; the `HoneyDrunk.Kernel.Abstractions` types disappear; the `IOperationContext` extension rolls back. Additive — no consuming Node depends on the new types at runtime until it composes them; the revert is contained to `HoneyDrunk.Kernel`.
+- **Packet 04 (Auth `AuthorizationDeniedException` + deny codes):** revert the PR; the new `AuthorizationDenyCode` values leave the enum; `AuthorizationDeniedException` leaves the assembly. Additive — no current Auth caller throws/handles `AuthorizationDeniedException` (the type is intended for `IToolInvoker` consumption which has not landed); the revert is contained to `HoneyDrunk.Auth`.
+- **Packet 05 (Audit event taxonomy):** revert the PR; the two event-shape registrations leave the registry. No consumer of Audit's registry has wired itself to these events yet — Capabilities (the emitter) has not landed. Contained to `HoneyDrunk.Audit`.
+
+**No operational escape hatch is needed.** Nothing this initiative ships executes against production traffic — it's all contract surface and registry data. The runtime enforcement points (the `IToolInvoker` authz check, the bundle store, the env-guard) land in the AI-sector standup tracks, where their own rollback plans apply.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.
+
+## Follow-Up Work (out of scope — tracked, not filed by this initiative)
+
+- **ADR-0017 (Capabilities standup) — amend packet 04 draft** to ship `CapabilityBundle`, `Capability`, `CapabilityRequirement`, `ScopeBindingMode`, `CapabilityBundleRef`, and the `RequiredCapabilities`-bearing extension to `ICapabilityInvoker` in the first commit. Add ADR-0051 packet 00 as a hard dependency on packet 04. The standup canary must demonstrate ADR-0051 D14 Phase 2 acceptance (agent with bundle → tool invocation succeeds; agent without bundle → typed deny; expired grant → typed deny; `bundle:local-dev-all` in `prod` env → Node refuses to start).
+- **ADR-0017 (Capabilities standup) — Phase 2 runtime follow-up packet** (lands after the scaffold closes): the bundle-store loader (`policies/bundles/*.yaml` + `policies/capabilities/grid-vocabulary.yaml` loader, hash-and-log at startup), the `IToolInvoker` default authorization check (ordered 6-step check per ADR-0051 D3), the env-guard (`bundle:local-dev-all` startup gate per D12), and the recursion check on `bundle:grid-operator` (per D8). Plus the initial bundle YAML set: `bundle:lately-content-publisher@v3`, `bundle:netrunner-architecture-sweep@v1`, `bundle:hive-sync@v1`, `bundle:grid-operator@v1`, `bundle:local-dev-all@v1`.
+- **ADR-0018 (Operator standup) — amend the standup draft** to ship the grant/revoke API (`POST /grants`, `DELETE /grants/{grantId}`), the Operator-as-agent bootstrap path (`event=operator.bootstrap` audit emission), the static-analyzer rule in `HoneyDrunk.Standards.Analyzers` that flags direct `AgentPrincipal` construction outside `HoneyDrunk.Operator`. Add long-running grant renewal workflow (30-day cycle with explicit re-confirmation) as Operator follow-up.
+- **ADR-0020 (Agents standup) — amend the standup draft** to wire `AgentPrincipal` propagation through the execution loop and surface `AuthorizationDeniedException` to the LLM as a structured tool-result error (`{"error": "authorization_denied", "missing": "<capability>"}`). Standup canary demonstrates ADR-0051 D14 Phase 4 acceptance.
+- **ADR-0047 (Testing patterns) — new packet**: the contract test (Tier 2a) exercising "Audit unavailable → tool invocation denies" against the `IToolInvoker` authz check shipped by the Capabilities standup follow-up. Parks until Capabilities Phase 2 ships.
+- **ADR-0046 (Specialist review agents) — new packet**: author the `policy-review` specialist agent for `policies/bundles/` changes. Parks until `policies/bundles/` exists in the Capabilities repo.
+- **`Principal` abstract base + `UserPrincipal` / `ServicePrincipal` types** — when the three-principal-type renaming is warranted, a follow-up Auth amendment can introduce the named `Principal` base and rename the existing `AuthenticatedIdentity`-shaped surface. Out of scope for ADR-0051; named here so the next Auth review knows the gap exists.
+- **OPA / dynamic policy store (ADR-0051 D13 v2 escalation)** — fires only when one of D13's named triggers (bundle count > ~50, per-tenant custom bundles, attribute-based access needs) is observed. Recorded.

--- a/generated/issue-packets/active/adr-0052-cost-governance/00-architecture-adr-0052-acceptance.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/00-architecture-adr-0052-acceptance.md
@@ -1,0 +1,145 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "docs", "adr-0052", "wave-1"]
+dependencies: []
+adrs: ["ADR-0052"]
+accepts: ["ADR-0052"]
+wave: 1
+initiative: adr-0052-cost-governance
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0052 — flip status, add the three cost-governance invariants, register the initiative
+
+## Summary
+Flip ADR-0052 (Cost Governance, Budget Alerts, and Kill-Switches) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, claim a three-invariant block in `constitution/invariant-reservations.md`, add the three new cost-governance invariants ADR-0052 commits in its Consequences/Invariants section to `constitution/invariants.md` at the claimed numbers `{N1}`/`{N2}`/`{N3}`, and register the `adr-0052-cost-governance` initiative in `initiatives/active-initiatives.md`.
+
+## Context
+ADR-0052 commits the Grid's cost-governance substrate: five named cost categories with per-category soft/hard caps, alert thresholds, kill-switch mechanics, per-tenant and per-agent attribution, a Cosmos-backed ledger, monthly auto-generated reports, anomaly detection, time-bounded operator overrides, and a dev/prod cap split. The forcing function is asymmetric risk: a runaway agent loop, a misconfigured retry, or a malicious tenant could surface a five-figure Azure or OpenAI bill that is a material event for the LLC, and the studio has no FinOps team to catch it. The first runaway loop is too late to introduce the policy — this ADR is positioned **inside** the AI-sector standup wave specifically so the AI Nodes consume the cost-ledger from day one of their standup.
+
+ADR-0052 decides:
+- **D1** — five named cost categories (Azure infra, AI inference, third-party SaaS, domain/cert/registrar, GitHub Actions minutes) with one human owner per category. Categories do not cross-subsidize.
+- **D2** — per-category monthly soft and hard caps (AI inference $500/$1500, Azure infra $300/$800, SaaS $200 soft-only, domain/cert $25 soft-only, GitHub Actions $50/$150). Defaults live in `business/context/cost-budgets.json` and are tuned via the slow PR path; the fast path is the D11 override CLI.
+- **D3** — alerts flow through `HoneyDrunk.Communications` into `HoneyDrunk.Notify`. Daily roll-up at 08:00 operator-local, threshold pings at 50/75/90/100%, hard-cap breach fires both `IErrorReporter` and maximum-priority push, anomaly alerts on detection.
+- **D4** — per-category kill-switches. AI inference is in-process (`ILlmDispatcher` calls `IsHardCapBreachedAsync` before each call, throws `BudgetExceededException` — sealed, no-retry). Azure infra is out-of-process via a Container Apps auto-suspend job (non-prod only). GitHub Actions uses the GitHub-native org-level limit. SaaS and domain/cert have no kill-switch.
+- **D5** — every cost event carries an optional `TenantId` dimension. Tenant-scoped costs feed the future Billing Node (ADR-0037) and abuse detection (D10).
+- **D6** — AI inference events additionally carry `AgentId` and `AgentRunId` for forensics and per-run rollback. `AgentId` reuses the identifier ADR-0051 commits.
+- **D7** — `ICostLedger` interface lives in `HoneyDrunk.Kernel` (Kernel-thin-shell); v1 implementation lives in `HoneyDrunk.AI`. Co-locating with the dispatcher avoids cross-Node calls on the kill-switch hot path. Promotion path to a dedicated `HoneyDrunk.CostLedger` Node when non-AI categories grow material.
+- **D8** — Cosmos persistence (`(category, year-month)` partition key); rolling 13-month retention; in-memory cache refreshed every 30 seconds for hot-path reads.
+- **D9** — two reporting surfaces: an Operator Node "Cost" dashboard view (real-time control surface) and `generated/cost-reports/YYYY-MM.md` auto-generated monthly reports in the Architecture repo (review surface).
+- **D10** — anomaly detection as Application Insights alert rules (hour-over-hour 5x, day-over-day 3x); per-tenant and per-agent variants. Defined as Bicep IaC; alerts fire but do not trigger kill-switches.
+- **D11** — operator overrides via `hd cost unlock <category> --reason --duration`; audited via `IAuditLog` per ADR-0030; time-bounded with no permanent-override option.
+- **D12** — dev caps on separate subscription (or tagged resource group); production caps do not include dev burn.
+- **D13** — relationship to ADR-0016 (operator-configurable rates), ADR-0037 (per-tenant attribution feeds future Billing), ADR-0041 (model approval gates *what runs*; this ADR gates *how much runs*), ADR-0045 (`IErrorReporter` surface for breach events), ADR-0030 (override audit), ADR-0018 (Operator hosts the CLI/aggregator/dashboard), ADR-0036 (tier-2 backup), ADR-0026 (`TenantId` primitive), BDR-0001 (vendor records extend the SaaS category).
+- **D14** — phased rollout. Phase 1 ledger substrate with intentionally loose caps. Phase 2 aggregator + external API ingestion. Phase 3 threshold tuning + ping activation. Phase 4 kill-switch enablement (the dangerous phase). Phase 5 anomaly detection. Phase 6 per-tenant/per-agent surfaces. Phase 7 dev/prod separation.
+
+ADR-0052 is a **policy + contract + governance** ADR. The concrete code lands across multiple Nodes; this initiative ships the abstraction surface, the budget config file, the Kernel-level contract relocation, the AI-side v1 implementation, the monthly report format, and a deferred-rollout playbook. Operator-side surfaces (CLI, aggregator, dashboard, auto-suspend, anomaly Bicep) wait on ADR-0018's Operator Node scaffold — they are named as follow-ups, not built here.
+
+Every other packet in this initiative references ADR-0052's D-decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Invariant Numbering
+The verified current maximum invariant number in `constitution/invariants.md` is **53**. ADR-0052 adds exactly **three** invariants. Reservations are coordinated via `constitution/invariant-reservations.md` (the cross-ADR reservation ledger). **The executor claims a contiguous block of size 3** by:
+
+1. Read `constitution/invariant-reservations.md` and inspect the **Active Reservations** table.
+2. Pick the next free block of size 3 above the highest existing reservation (today's "next free" is **54**, so the expected block is **54, 55, 56**, but verify at edit time — another ADR may have claimed first).
+3. Add a row to `constitution/invariant-reservations.md` recording the claim: `Range | ADR-0052 | Proposed | packet 00 at generated/issue-packets/active/adr-0052-cost-governance/00-architecture-adr-0052-acceptance.md`.
+4. Substitute the three claimed numbers wherever this packet (and downstream packets in this initiative) uses the placeholders `{N1}` / `{N2}` / `{N3}` — meaning the three invariants in numerical order.
+5. Append the three new invariants under a new `## Cost Governance Invariants` section in `constitution/invariants.md`, numbered `{N1}` / `{N2}` / `{N3}` (the invariants form a coherent group).
+
+**First merge wins.** If another ADR's packet 00 claims the same block first and merges before this PR, this packet shifts upward by re-reading `invariant-reservations.md`, picking the new next-free block, and updating every `{N*}` placeholder reference in this initiative's packets in a follow-up commit before pushing. The reservation file is the source of truth — `invariants.md` is the canonical accepted state and lags reservations by one merge.
+
+## Scope
+- `adrs/ADR-0052-cost-governance-budget-alerts-and-kill-switches.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0052 row Status column to Accepted.
+- `constitution/invariant-reservations.md` — add a row to the **Active Reservations** table claiming a three-invariant block (see Invariant Numbering above).
+- `constitution/invariants.md` — add the three new cost-governance invariants (see Proposed Implementation for exact text) at the three numbers claimed in `invariant-reservations.md` (referenced here as `{N1}`/`{N2}`/`{N3}`).
+- `initiatives/active-initiatives.md` — register the `adr-0052-cost-governance` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0052 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update the ADR-0052 index row in `adrs/README.md` to Accepted.
+3. **Claim the invariant block in `constitution/invariant-reservations.md`.** Open the file, read the **Active Reservations** table, pick the next free contiguous block of size 3 above the highest current reservation, and add a row recording the claim against ADR-0052 with the path to this packet. Today's expected starting number is **54** (next free per the file); verify at edit time — if another ADR claimed first, shift upward. The three numbers claimed are referenced below as `{N1}` / `{N2}` / `{N3}` in numerical order.
+4. Add three new invariants to `constitution/invariants.md`, numbered `{N1}` / `{N2}` / `{N3}` per the reservation claimed in step 3. Create a new `## Cost Governance Invariants` section (the invariants form a coherent group). The text, taken verbatim-in-substance from ADR-0052's Consequences "Invariants" section:
+   - **`{N1}` — Every cost-producing operation in the Grid is recorded as a `CostEvent` in the cost ledger.** Operations that bypass the ledger have undefined kill-switch and attribution behavior and are forbidden. The dispatcher and aggregator code paths must produce a `CostEvent` for every dollar of external spend (Azure, AI provider, SaaS subscription, GitHub Actions minutes, domain/cert renewal). CI check enforces dispatcher and aggregator coverage. See ADR-0052 D1, D4, D5, D6, D7.
+   - **`{N2}` — The LLM-dispatch chokepoint checks the cost ledger against the hard cap before each LLM call.** "Chokepoint" is the single seam in the AI Node that every LLM call passes through (the routing decorator or interceptor — the concrete role is named at edit time in `HoneyDrunk.AI`, not in this invariant). The check is on the hot path; failure to short-circuit when the cap is breached is a budgeting failure and a defect. `BudgetExceededException` is sealed and non-transient — code that catches it and retries within the same billing window is a defect detected by the `review` agent. Integration test required per ADR-0047 D4. See ADR-0052 D4.
+   - **`{N3}` — Operator overrides of cost caps are audited.** Overrides without a corresponding audit event are an audit-substrate violation per ADR-0030 (invariant 47) and a cost-governance violation per ADR-0052. The override CLI surface is the only sanctioned override path; direct database writes to `BudgetOverride` are forbidden. Override audit records carry `sensitive=audit` tagging and follow Audit-tier retention from ADR-0030, not the cost-ledger's 13-month retention. See ADR-0052 D11.
+   - Use the three claimed numbers from step 3 (in numerical order, lowest to `{N1}`). Append them under the new `## Cost Governance Invariants` section. Do not renumber any existing invariant.
+5. Register the initiative in `initiatives/active-initiatives.md` with the wave structure and packet checklist for this folder.
+
+## Affected Files
+- `adrs/ADR-0052-cost-governance-budget-alerts-and-kill-switches.md`
+- `adrs/README.md`
+- `constitution/invariant-reservations.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0052 header reads `**Status:** Accepted`
+- [ ] The ADR-0052 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariant-reservations.md` carries a new row in **Active Reservations** claiming a three-invariant contiguous block for ADR-0052 (status `Proposed` until merge), with this packet's path recorded
+- [ ] `constitution/invariants.md` carries the three new cost-governance invariants (every cost-producing operation recorded as `CostEvent`; the LLM-dispatch chokepoint checks the cap on the hot path; operator overrides audited) at the three numbers claimed in `invariant-reservations.md`, under a new `## Cost Governance Invariants` section, citing ADR-0052
+- [ ] The override-audit invariant references invariant 47 (Audit substrate) rather than restating its retention/tagging contract
+- [ ] The chokepoint invariant references the role abstractly (the single seam in the AI Node every LLM call passes through), not a specific type name
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0052-cost-governance` initiative with a packet checklist
+- [ ] No catalog schema change in this packet (catalog updates land in packet 01)
+- [ ] No `business/context/cost-budgets.json` in this packet (the budget config lands in packet 02)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0052 Consequences — Invariants.** ADR-0052 adds exactly three invariants: every cost-producing operation is recorded as a `CostEvent` (D1, D4, D5, D6, D7); the LLM-dispatch chokepoint checks the ledger against the hard cap before each call (D4); operator overrides are audited (D11). The three numbers are claimed at execution time via `constitution/invariant-reservations.md`.
+
+**ADR-0030 D1 / Invariant 47 (referenced) — Durable, attributable security, action, and data-change events are emitted to `HoneyDrunk.Audit` via `IAuditLog`, on a durable channel separate from observability telemetry.** Invariant 92 (override audit) references this contract rather than restating it.
+
+**ADR-0045 / `IErrorReporter`** — ADR-0052 D3 routes hard-cap breaches through `IErrorReporter`, problem-grouped as `Honeydrunk.Cost.HardCapBreach`. Not in this packet's scope; named here so the invariant text correctly identifies the surface.
+
+## Constraints
+- **Acceptance precedes flip.** ADR-0052 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbers 90, 91, 92.** Append the three new invariants as numbers 90, 91, 92 (pre-reserved — see Invariant Numbering). Do not renumber existing invariants. Create the new `## Cost Governance Invariants` section. Include the batch note.
+- **Reference, do not restate, invariant 47.** Invariant 92's override-audit rule references invariant 47 (durable audit via `IAuditLog`) and ADR-0030; do not duplicate the Audit retention/tagging contract in this invariant.
+- **No catalog or config edits in this packet.** Catalog registration is packet 01; the `business/context/cost-budgets.json` config file is packet 02.
+
+## Labels
+`chore`, `tier-3`, `ops`, `docs`, `adr-0052`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0052 to Accepted, add the three cost-governance invariants to `constitution/invariants.md`, and register the cost-governance initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0052 so the remaining packets in this initiative can reference its decisions as live rules.
+- Feature: ADR-0052 Cost Governance rollout, Wave 1.
+- ADRs: ADR-0052 (primary), ADR-0030 (Audit — invariant 47 referenced by invariant 92), ADR-0008 (initiative/packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0052 stays Proposed until this PR merges.
+- Append the three new invariants as **numbers 90, 91, 92** (pre-reserved) under a new `## Cost Governance Invariants` section; do not renumber existing invariants; include the batch note.
+- Invariant 92 references invariant 47 (Audit) — it does not restate it.
+
+**Key Files:**
+- `adrs/ADR-0052-cost-governance-budget-alerts-and-kill-switches.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0052-cost-governance/01-architecture-cost-governance-catalog-and-relocation-record.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/01-architecture-cost-governance-catalog-and-relocation-record.md
@@ -1,0 +1,141 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0052", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0052", "ADR-0016"]
+accepts: ["ADR-0052"]
+wave: 1
+initiative: adr-0052-cost-governance
+node: honeydrunk-architecture
+---
+
+# Record the cost-governance contract surface and the ICostLedger Kernel relocation in catalogs
+
+## Summary
+Record ADR-0052's contract decisions as catalog data: register the new cost-governance contracts (`ICostLedger`, `CostEvent`, `CostCategory`, `BudgetExceededException`, `BudgetOverride`, supporting record types) in `catalogs/contracts.json` under the **Kernel** Node per ADR-0052 D7, and mark the existing `ICostLedger` entry under `honeydrunk-ai` as **relocating-to-kernel** so the catalog reflects the relocation pending packets 03/04. Record the D8 capture-vs-log boundary for cost events and the D13 cross-ADR links where the Grid keeps cross-cutting policy notes.
+
+## Context
+ADR-0052 D7 commits `ICostLedger` to **`HoneyDrunk.Kernel`** (the abstraction only — interface, event shape, exception types, configuration record). This is consistent with the Kernel-thin-shell principle: Kernel owns the contract every Node consumes, no concrete implementation. The concrete implementation lives in **`HoneyDrunk.AI` for v1** (D7), and graduates to a dedicated `HoneyDrunk.CostLedger` Node when non-AI categories grow material or a second writer Node appears.
+
+**Catalog reality at edit time:** `catalogs/contracts.json` already carries an `ICostLedger` entry under `honeydrunk-ai`:
+
+```
+{ "name": "ICostLedger", "kind": "interface",
+  "description": "Per-call token and cost accounting surface. Cost-rate tables sourced from Azure App Configuration via Vault's IConfigProvider — never hardcoded." }
+```
+
+The implementing code is `HoneyDrunk.AI.Abstractions/ICostLedger.cs` (live, two members: `RecordAsync(InferenceCost)` and `GetSummaryAsync(scope, since)`). ADR-0052 D7's preview shape is **wider** (five members: `RecordCostAsync(CostEvent)`, `GetMonthToDateAsync(category)`, `IsHardCapBreachedAsync(category)`, `GetActiveOverrideAsync(category)`, `QueryAsync(query)`) and **carries a category-scoped, cross-cost-source event model** rather than an inference-only one. The new contract is the canonical one going forward; the existing AI-side contract becomes a wrapper or is removed entirely in packet 04. This packet records the relocation in the catalog ahead of the code change.
+
+**Catalog schema ground truth — read before editing.**
+- `catalogs/contracts.json` has the shape `{_meta, contracts:[{node, node_name, package, status, interfaces:[...]}]}`. The `honeydrunk-kernel` entry already exists; add the new cost-governance contracts to its `interfaces` list (or, if the catalog convention separates packages, a `HoneyDrunk.Kernel.Abstractions` Kernel entry — match the existing convention).
+- `catalogs/grid-health.json` node entries carry **only** `signal`/`version`/`canary_status`/`last_release`/`active_blockers`/`notes` (plus a top-level `_meta` and `summary`). There is **no** cost/budget readout in `grid-health.json`, and **no place** for per-category cap state. **Do not edit `grid-health.json` in this packet** — the daily-roll-up signal and cap state live in the ledger and the monthly report (D9), not the grid-health catalog.
+- `catalogs/nodes.json` has no `exposes` field; node exposure lives in `relationships.json`. This packet does not touch either.
+
+**No new Azure resource registered here.** ADR-0052 D8 uses Cosmos (single-region, write-mostly) but the Cosmos account / container is provisioned by the AI Node's standup (ADR-0016) or as a follow-up — not in this catalog packet. The Bicep that defines the App Insights anomaly alert rules (D10) is also out of scope here; it lands in a deferred packet gated on ADR-0018 Operator scaffold.
+
+**Cost-budgets file pointer.** ADR-0052 D2 names `business/context/cost-budgets.json` as the budget config. That file is created in packet 02; this packet's catalog work points at it as the canonical location, but does not create it.
+
+This is a catalog/docs packet. No code, no .NET project.
+
+## Scope
+- `catalogs/contracts.json` — register the cost-governance contract surface under `honeydrunk-kernel` (per ADR-0052 D7); mark the existing `ICostLedger` under `honeydrunk-ai` as relocating to Kernel pending packets 03/04.
+- A cross-cutting policy note for the D7 implementation home / promotion path and the D13 cross-ADR links — placed where the Grid keeps such notes (match the existing convention).
+
+## Proposed Implementation
+1. **`catalogs/contracts.json` — register the Kernel contracts.** Add to the `honeydrunk-kernel` Node's `interfaces` list:
+   - `ICostLedger` (interface) — the cost ledger contract per ADR-0052 D7. Five members per the D7 preview: `RecordCostAsync(CostEvent)`, `GetMonthToDateAsync(category)`, `IsHardCapBreachedAsync(category)`, `GetActiveOverrideAsync(category)`, `QueryAsync(query)`. Describe it as the Grid's single source of truth for cost accounting and the hot-path kill-switch read; lives in `HoneyDrunk.Kernel.Abstractions`; v1 implementation lives in `HoneyDrunk.AI` per D7. Mark `planned` if the catalog tracks per-interface status (packet 03 lands the code).
+   - `CostEvent` (record) — the cost-event shape; carries `Category`, `Amount`, `Timestamp`, `Source` (discriminated: `LlmInferenceSource` / `AzureInfraSource` / `SaasSource` / `CiSource` / `DomainSource`), optional `TenantId` (per ADR-0026, D5), optional `AgentId` / `AgentRunId` (D6), `Environment` (D12), and a `CorrelationId`.
+   - `CostCategory` (enum-shaped record or enum) — the five categories per ADR-0052 D1: `AiInference`, `AzureInfrastructure`, `ThirdPartySaas`, `DomainCertRegistrar`, `GitHubActionsMinutes`.
+   - `BudgetExceededException` (exception type) — the kill-switch synchronous throw per D4; sealed; non-transient; carries category / cap / actual / correlation id.
+   - `BudgetOverride` (record) — operator override per D11; carries the category, operator identity, reason text, issued-at, expires-at, and a revoke timestamp if revoked early.
+   - `IBudgetConfigProvider` (interface) — abstracts reading `business/context/cost-budgets.json` (or its runtime equivalent loaded via Vault's `IConfigProvider` per ADR-0016 D5). Single member: `ValueTask<BudgetConfig> GetAsync(CancellationToken)`. Returns the per-category soft/hard caps and the per-category anomaly thresholds.
+   - `BudgetConfig` (record) — the resolved budget configuration shape: per-category soft cap, hard cap, anomaly multipliers (hour-over-hour, day-over-day); per-environment overlay for the D12 dev caps.
+   - `CostQuery` (record) — the query shape `QueryAsync` consumes: category, date range, optional `TenantId` / `AgentId` filters.
+   Match the existing per-interface shape on the `honeydrunk-kernel` `contracts.json` record.
+2. **`catalogs/contracts.json` — record the relocation on the AI entry.** Mark the existing `honeydrunk-ai` `ICostLedger` entry. Two acceptable shapes — match whatever convention `contracts.json` uses for relocating contracts (check the file at edit time):
+   - Option A: amend the existing entry's description to read "**Relocating to `HoneyDrunk.Kernel.Abstractions` per ADR-0052 D7 (packet 03). After packet 04, this entry is removed.**" and append `"status": "relocating"` if the catalog convention supports per-interface status.
+   - Option B: leave the existing entry as-is and add a `_relocations` block at the top level (if `contracts.json` already has one) recording the move from `honeydrunk-ai` to `honeydrunk-kernel`.
+   Pick whichever option matches the existing file convention; do not invent a new shape. **Do not delete the AI entry in this packet** — packets 03 and 04 are the code-level relocation; the catalog mirrors the code, and a catalog entry that names a non-existent contract is a worse defect than a relocation note.
+3. **No `grid-health.json` edit.** That file's node-entry schema has no cost / budget readout — see the schema note. Skip it entirely.
+4. **D7 implementation-home note** — record the implementation-home decision and the promotion path (Kernel-abstraction / AI-implementation v1; graduates to `HoneyDrunk.CostLedger` Node when non-AI categories grow material or a second writer appears) as a cross-cutting policy note in the Grid's established location for such notes.
+5. **D13 cross-ADR links** — record the ADR-0052 ↔ ADR-0016 (operator-configurable rates), ADR-0030 (override audit), ADR-0037 (per-tenant attribution), ADR-0041 (model approval gate vs spend gate), ADR-0045 (`IErrorReporter` surface), ADR-0018 (Operator hosts the CLI/aggregator/dashboard), ADR-0036 (tier-2 backup), ADR-0026 (`TenantId`) cross-links. Match the existing convention for cross-cutting cross-ADR notes.
+
+## Affected Files
+- `catalogs/contracts.json`
+- A cost-governance policy note in the established cross-cutting-notes location (D7 implementation home + D13 cross-ADR links).
+
+## NuGet Dependencies
+None. This packet touches only catalog JSON and Markdown; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] Catalog data only — the contract code lands in packet 03; the AI-side relocation lands in packet 04.
+
+## Acceptance Criteria
+- [ ] `catalogs/contracts.json` registers `ICostLedger`, `CostEvent`, `CostCategory`, `BudgetExceededException`, `BudgetOverride`, `IBudgetConfigProvider`, `BudgetConfig`, `CostQuery` under the `honeydrunk-kernel` Node, each described per the D7 preview shape, marked `planned` if the catalog tracks per-interface status
+- [ ] The existing `ICostLedger` entry under `honeydrunk-ai` is marked as relocating to Kernel (per ADR-0052 D7), using the existing catalog convention; the entry is **not** deleted in this packet (packets 03/04 do the code move; the catalog reflects code state)
+- [ ] `catalogs/grid-health.json` is **not** edited — its node-entry schema has no cost/budget readout
+- [ ] The D7 implementation home (`HoneyDrunk.Kernel` abstraction + `HoneyDrunk.AI` v1 implementation) and the promotion path to a dedicated `HoneyDrunk.CostLedger` Node are recorded as a cross-cutting policy note in the Grid's established location
+- [ ] The D13 cross-ADR links (ADR-0016, ADR-0018, ADR-0026, ADR-0030, ADR-0036, ADR-0037, ADR-0041, ADR-0045) are recorded in the cross-cutting notes
+- [ ] No invariant change in this packet (the three cost-governance invariants land in packet 00)
+- [ ] No `business/context/cost-budgets.json` in this packet (packet 02)
+- [ ] No `generated/cost-reports/` directory in this packet (packet 07)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0052 D7 — `ICostLedger` lives in `HoneyDrunk.Kernel`; v1 implementation in `HoneyDrunk.AI`.** Kernel owns the contract every Node consumes, no concrete implementation (Kernel-thin-shell principle). AI hosts the v1 implementation because AI inference is the dominant cost line, AI already owns the dispatcher and token-rate configuration (ADR-0016 D5), and co-locating means the kill-switch read is in-process with the dispatcher. Non-AI categories (Azure infra, SaaS, CI, domain/cert) are externally sourced via the Operator aggregator (D14 Phase 2) writing the same `ICostLedger` shape. Promotion: when non-AI categories grow material, or when a second writer appears, `HoneyDrunk.CostLedger` graduates to its own Node — interface in Kernel unchanged.
+
+**ADR-0052 D7 preview shape.** `RecordCostAsync(CostEvent)`, `GetMonthToDateAsync(category)`, `IsHardCapBreachedAsync(category)`, `GetActiveOverrideAsync(category)`, `QueryAsync(query)`. Final method names and shapes are finalized in packet 03.
+
+**ADR-0052 D1 — Five cost categories.** Azure infrastructure, AI inference, third-party SaaS, domain/cert/registrar, GitHub Actions minutes. No cross-subsidy.
+
+**ADR-0052 D5 / D6 — `TenantId` / `AgentId` / `AgentRunId` dimensions.** Every cost event carries an optional `TenantId` (ADR-0026's opaque primitive). AI inference events additionally carry `AgentId` (ADR-0051's stable identifier) and `AgentRunId` (per-invocation correlation).
+
+**ADR-0052 D12 — `Environment` dimension.** Every event carries an `Environment` field (`prod` / `dev` / `staging` / `local`). Local events are recorded but exempt from caps.
+
+**ADR-0052 D13 cross-ADR links.** ADR-0016 (operator-configurable rates), ADR-0018 (Operator hosts CLI/aggregator/dashboard), ADR-0026 (TenantId), ADR-0030 (override audit), ADR-0036 (tier-2 backup), ADR-0037 (per-tenant attribution → future Billing Node), ADR-0041 (model approval gate; this ADR is the spend gate), ADR-0045 (`IErrorReporter` surface for breach events).
+
+## Constraints
+- **Match existing catalog conventions.** The new Kernel entries mirror the existing per-interface entries on the `honeydrunk-kernel` `contracts.json` record. Do not invent fields the catalog does not use.
+- **Do not delete the AI `ICostLedger` entry.** This packet records the relocation; the code move lands in packets 03/04. Deleting the entry ahead of the code would leave the catalog ahead of the live shape — a worse defect than a relocation note. Packet 04 removes the entry as part of the AI-side migration.
+- **Do not edit `grid-health.json`.** Its node-entry schema has no cost/budget readout.
+- **No invented contract members.** The cost-governance shapes are the D7 preview; do not add fields or methods beyond what the ADR names.
+- **No `cost-budgets.json` in this packet.** The config file lands in packet 02.
+- **No App Insights resource entry.** ADR-0052 D2 anomaly alerts reuse ADR-0040's App Insights resource; this packet adds no resource entry.
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0052`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Register the cost-governance contracts in `catalogs/contracts.json` under the Kernel Node, mark the existing AI `ICostLedger` entry as relocating, and record the D7 implementation home and D13 cross-ADR links.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Record ADR-0052's contract surface and the relocation of `ICostLedger` from AI to Kernel as catalog data, ahead of the code change in packets 03/04.
+- Feature: ADR-0052 Cost Governance rollout, Wave 1.
+- ADRs: ADR-0052 D1/D5/D6/D7/D12/D13 (primary), ADR-0016 (the operator-configurable rates D5 ties to).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0052 should be Accepted before its decisions are recorded as catalog data.
+
+**Constraints:**
+- Register the new contracts under `honeydrunk-kernel`, matching the existing per-interface shape.
+- Mark — do not delete — the existing AI `ICostLedger` entry; packet 04 deletes it as part of the AI-side migration.
+- No invented contract members; the cost-governance shapes are the D7 preview.
+- Do not edit `grid-health.json`; its node-entry schema has no cost/budget readout.
+
+**Key Files:**
+- `catalogs/contracts.json`
+- The cross-cutting-notes location (for the D7 implementation-home and D13 cross-ADR notes).
+
+**Contracts:** `ICostLedger`, `CostEvent`, `CostCategory`, `BudgetExceededException`, `BudgetOverride`, `IBudgetConfigProvider`, `BudgetConfig`, `CostQuery` registered as catalog metadata under the Kernel Node (the code is packet 03).

--- a/generated/issue-packets/active/adr-0052-cost-governance/02-architecture-cost-budgets-config-and-tuning-policy.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/02-architecture-cost-budgets-config-and-tuning-policy.md
@@ -1,0 +1,169 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0052", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0052"]
+accepts: ["ADR-0052"]
+wave: 1
+initiative: adr-0052-cost-governance
+node: honeydrunk-architecture
+---
+
+# Create business/context/cost-budgets.json with the D2 defaults and the tuning policy doc
+
+## Summary
+Create `business/context/cost-budgets.json` carrying the ADR-0052 D2 per-category soft/hard caps and the D10 anomaly thresholds, plus the D12 dev-environment overlay. Author the tuning policy doc that describes the slow PR path (this file) and the fast override path (D11 `hd cost unlock` CLI, future) so the operator and the `review` agent know how to handle changes to this file.
+
+## Context
+ADR-0052 D2 commits the per-category budget caps and names `business/context/cost-budgets.json` as the canonical configuration file. The file is **production-critical**: a mis-edit could disable the kill-switch (raise the hard cap to infinity) or trigger spurious shutdowns (drop the hard cap below current month-to-date). The PR-review flow on this file is therefore a production-config review.
+
+ADR-0052 D2 specifies the v1 defaults:
+
+| Category | Soft cap | Hard cap | Notes |
+|---|---|---|---|
+| AI inference | $500 | $1500 | Grid-wide across all models and providers |
+| Azure infrastructure | $300 | $800 | Sum across Container Apps, App Insights, Vault, storage, etc. |
+| Third-party SaaS | $200 | — | Soft only (no programmatic kill-switch for SaaS subscriptions) |
+| Domain / cert / registrar | $25 | — | Soft only (annual renewals amortized) |
+| GitHub Actions minutes | $50 | $150 | GitHub-native spending limit enforces |
+
+D14 Phase 1 says "**initial caps are intentionally loose** ($5000 / $10000 across all categories) so the kill-switch does not fire spuriously while baselines are being established." This packet seeds the D2 defaults but the runtime loader (packet 05) will compose them with a Phase-1 multiplier or load a Phase-1 override file — the runtime behaviour is configured by the operator at Phase 3 (D14) per the tuning policy. **This packet ships the D2 final-state defaults**, not the Phase-1 loose caps; the Phase-1 multiplier is a deployment concern documented in the playbook (packet 09).
+
+D10 anomaly thresholds: hour-over-hour 5x, day-over-day 3x. The thresholds are per-category configurable; the file carries them as the canonical defaults that the App Insights alert Bicep (future, gated on Operator standup) reads.
+
+D12 dev caps: $50/$100 AI inference, $25/$50 Azure infra, $25/$50 GitHub Actions. Production caps do not include dev burn. The file carries a `dev` overlay block.
+
+**Where the file lives.** ADR-0052 D2: `business/context/cost-budgets.json` (new file, sibling to the vendor list referenced in the drift report). The `business/context/` directory holds BDR-style and policy-adjacent records — match the existing per-file shape in that directory at edit time. If `business/context/` does not yet exist as a directory (the drift report notes its absence), create it with a brief `README.md` describing its purpose (BDR records + cross-cutting policy config). Check at edit time.
+
+**Tuning policy.** ADR-0052 D2: "Changes to the file are tracked by git, reviewed via the standard PR flow, and audited. The PR flow is the **slow path** for changing caps — it preserves a permanent record of 'the cap was raised on this date, by this PR, with this reasoning.' The fast path (D11 override CLI) is for emergencies; the PR flow is for considered policy changes. Mixing them by allowing CLI to mutate `cost-budgets.json` directly would erode the audit trail and is explicitly forbidden." This packet records that policy as a doc next to the file (or in the established `business/context/` policy-notes location).
+
+**No code in this packet.** The runtime loader for the config file lives in `HoneyDrunk.AI` (packet 05) consuming `IBudgetConfigProvider` (cataloged in packet 01, built in packet 03). This packet ships the config data and the policy doc only.
+
+**`review` agent follow-up flagged.** ADR-0052's Follow-up Work names "Add a `cost-config` review category to `.claude/agents/review.md` per ADR-0044 D3, covering the production-critical nature of `business/context/cost-budgets.json` changes." That edit lands in packet 08, not here — but this packet's policy doc points forward to the `review` category that gates edits to this file.
+
+## Scope
+- `business/context/cost-budgets.json` — new file carrying the D2 default soft/hard caps, the D10 anomaly thresholds, and the D12 dev overlay.
+- A tuning policy doc next to the file (or in the `business/context/` policy-notes location) describing the slow PR path and the fast override path.
+- If `business/context/` does not yet exist as a directory, create it with a brief `README.md` describing its purpose.
+
+## Proposed Implementation
+1. **`business/context/cost-budgets.json`** — JSON document with the shape (final shape decided at edit time to match the `IBudgetConfigProvider` deserialization in packet 03; the structure below is the canonical content):
+   ```
+   {
+     "_meta": {
+       "schema_version": 1,
+       "source_adr": "ADR-0052",
+       "currency": "USD",
+       "window": "monthly",
+       "last_tuned": null,
+       "note": "Production-critical config — see ./cost-budgets-tuning-policy.md."
+     },
+     "categories": {
+       "ai_inference":          { "soft_cap": 500,  "hard_cap": 1500, "kill_switch": "in_process",      "anomaly_hour_over_hour": 5.0, "anomaly_day_over_day": 3.0 },
+       "azure_infrastructure":  { "soft_cap": 300,  "hard_cap":  800, "kill_switch": "azure_suspend",   "anomaly_hour_over_hour": 5.0, "anomaly_day_over_day": 3.0 },
+       "third_party_saas":      { "soft_cap": 200,  "hard_cap": null, "kill_switch": "none",            "anomaly_hour_over_hour": 5.0, "anomaly_day_over_day": 3.0 },
+       "domain_cert_registrar": { "soft_cap":  25,  "hard_cap": null, "kill_switch": "none",            "anomaly_hour_over_hour": 5.0, "anomaly_day_over_day": 3.0 },
+       "github_actions":        { "soft_cap":  50,  "hard_cap":  150, "kill_switch": "github_native",   "anomaly_hour_over_hour": 5.0, "anomaly_day_over_day": 3.0 }
+     },
+     "dev_overlay": {
+       "ai_inference":         { "soft_cap":  50, "hard_cap": 100 },
+       "azure_infrastructure": { "soft_cap":  25, "hard_cap":  50 },
+       "github_actions":       { "soft_cap":  25, "hard_cap":  50 }
+     },
+     "owners": {
+       "ai_inference":         "oleg",
+       "azure_infrastructure": "oleg",
+       "third_party_saas":     "oleg",
+       "domain_cert_registrar":"oleg",
+       "github_actions":       "oleg"
+     }
+   }
+   ```
+   The exact JSON-key naming is finalized to match `BudgetConfig` deserialization in packet 03; check there at edit time. The category keys above (`ai_inference`, etc.) map onto `CostCategory.AiInference` etc. — pick the casing convention `BudgetConfig` uses.
+2. **`business/context/cost-budgets-tuning-policy.md`** (or the established cross-cutting policy-notes location) — describe:
+   - The slow path (this file, PR-reviewed) is the only mechanism that mutates persistent caps.
+   - The fast path (D11 `hd cost unlock` CLI on the Operator Node, future) issues time-bounded overrides — it does **not** mutate this file.
+   - Direct database writes to `BudgetOverride` are forbidden (invariant 92).
+   - Permanent overrides do not exist — re-engagement is the safer default (D11).
+   - Cap-raise PRs must justify the change in the PR description (the audit value is "the cap was raised on this date, by this PR, with this reasoning").
+   - The `review` agent has a `cost-config` review category (packet 08, future) that treats edits to this file as production-config changes.
+3. **`business/context/README.md`** — only if the directory does not yet exist. Brief: the directory holds BDR-style records and cross-cutting policy configuration the Grid runtime consumes (cost budgets, vendor list, etc.). Editing is PR-only.
+4. **CHANGELOG.** `HoneyDrunk.Architecture` is not a versioned .NET solution; the repo-level `CHANGELOG.md` is appended to under the in-progress Unreleased / dated section per the repo convention.
+
+## Affected Files
+- `business/context/cost-budgets.json` (new)
+- `business/context/cost-budgets-tuning-policy.md` (new — or an entry in the established cross-cutting policy-notes location)
+- `business/context/README.md` (new, only if the directory does not yet exist)
+- Repo-level `CHANGELOG.md`
+
+## NuGet Dependencies
+None. JSON config and Markdown only.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly. `business/context/` is an Architecture-repo directory.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency. The runtime loader for this file lives in `HoneyDrunk.AI` (packet 05); this packet ships the data only.
+
+## Acceptance Criteria
+- [ ] `business/context/cost-budgets.json` exists with the D2 defaults: AI inference $500/$1500, Azure infra $300/$800, SaaS $200 soft-only, domain/cert $25 soft-only, GitHub Actions $50/$150
+- [ ] The file carries the D10 anomaly thresholds (5.0 hour-over-hour, 3.0 day-over-day) per category, as configurable defaults
+- [ ] The file carries the D12 `dev_overlay` block: AI inference $50/$100, Azure infra $25/$50, GitHub Actions $25/$50
+- [ ] The file carries an `owners` block with `oleg` as the v1 owner for every category (D1)
+- [ ] The file's category key naming matches the `BudgetConfig` deserialization shape from packet 03 (resolve at edit time — the catalog entry in packet 01 names the contract `BudgetConfig`)
+- [ ] A tuning policy doc (sibling to the JSON file, or in the established policy-notes location) describes the slow PR path vs the fast override path; states that direct `BudgetOverride` database writes are forbidden (invariant 92); states that no permanent override exists (D11); states the `review` agent's future `cost-config` category gates edits
+- [ ] If `business/context/` did not exist as a directory before this packet, it now exists with a brief `README.md`
+- [ ] Repo-level `CHANGELOG.md` carries an entry naming the new files
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0052 D2 — Budget tiers and alert thresholds.** Per-category monthly soft caps (alert only) and hard caps (alert + kill-switch). Defaults: AI inference $500/$1500, Azure infra $300/$800, SaaS $200 soft-only, domain/cert $25 soft-only, GitHub Actions $50/$150. The values live in `business/context/cost-budgets.json`. Changes go through git-tracked PR review. The split between soft and hard is intentional: soft is a warning, hard is an action; the 3x gap is a heuristic per-category-tunable.
+
+**ADR-0052 D10 — Anomaly detection thresholds.** Hour-over-hour 5x spike in cost-event volume or value; day-over-day 3x spike in summed cost value. Per-category configurable. AI inference has higher natural variance than Azure infra; tune per category as actuals accumulate.
+
+**ADR-0052 D12 — Dev caps on a separate subscription (or tagged resource group).** Dev defaults: AI inference $50/$100, Azure infra $25/$50, GitHub Actions $25/$50. Production caps do not include dev burn. Dev follows the same enforcement posture (D4) — hard cap fires the kill-switch, alerts go through the same Notify channel, overrides require the same audit.
+
+**ADR-0052 D11 — Operator unlock policy.** Override CLI is `hd cost unlock <category> --reason "<text>" --duration <hours>` on HoneyDrunk.Operator. Time-bounded (default 24h). Audited via `IAuditLog` per ADR-0030. **Does not mutate `cost-budgets.json`.** No permanent override.
+
+**ADR-0052 Operational Consequences — `cost-budgets.json` becomes production-critical.** A mis-edit could disable the kill-switch or trigger spurious shutdowns. The PR-review flow on this file is a production-config review; the `review` agent (per ADR-0044) treats it accordingly. The cost-config review category lands in packet 08.
+
+## Constraints
+- **No code in this packet.** The runtime loader is in `HoneyDrunk.AI` (packet 05). This packet ships data + policy doc only.
+- **D2 defaults — not the Phase-1 loose caps.** Ship the D2 final-state numbers. The Phase-1 loose-cap multiplier is a deployment concern named in the playbook (packet 09), not a different config file.
+- **Match the `BudgetConfig` deserialization shape.** The JSON keys (`ai_inference`, etc.) map onto `CostCategory.AiInference`. The casing convention is decided in packet 03 (`BudgetConfig`); check at edit time and match. Do not invent a parallel naming.
+- **Tuning policy makes the audit boundary explicit.** The doc must state that the JSON file is the slow path, the CLI is the fast path, the two never blur, and direct `BudgetOverride` writes are forbidden (invariant 92).
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0052`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Create `business/context/cost-budgets.json` with the ADR-0052 D2 defaults / D10 anomaly thresholds / D12 dev overlay, and author the tuning policy doc that records the slow-PR-path vs fast-override-path boundary.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Seed the canonical cost-budget configuration the runtime loader (packet 05) will consume, with the tuning policy clearly documented so future edits land via PR review.
+- Feature: ADR-0052 Cost Governance rollout, Wave 1.
+- ADRs: ADR-0052 D1/D2/D10/D11/D12 (primary), ADR-0030 (Audit — the audit boundary the policy doc references).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0052 should be Accepted before its config defaults are committed.
+
+**Constraints:**
+- D2 defaults, not Phase-1 loose caps.
+- JSON keys match the packet-03 `BudgetConfig` shape (resolve at edit time).
+- Tuning policy makes the slow-PR vs fast-CLI boundary explicit; states that direct `BudgetOverride` writes are forbidden (invariant 92); no permanent override.
+
+**Key Files:**
+- `business/context/cost-budgets.json`
+- `business/context/cost-budgets-tuning-policy.md` (or the established policy-notes location)
+- `business/context/README.md` (only if the directory does not yet exist)
+
+**Contracts:** None. Config and docs only.

--- a/generated/issue-packets/active/adr-0052-cost-governance/03-kernel-cost-governance-contracts.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/03-kernel-cost-governance-contracts.md
@@ -1,0 +1,217 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Kernel
+labels: ["feature", "tier-2", "core", "ops", "adr-0052", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0052", "ADR-0026", "ADR-0030"]
+accepts: ["ADR-0052"]
+wave: 2
+initiative: adr-0052-cost-governance
+node: honeydrunk-kernel
+---
+
+# Add the cost-governance contract surface to HoneyDrunk.Kernel.Abstractions
+
+## Summary
+Add the ADR-0052 cost-governance contract surface to `HoneyDrunk.Kernel.Abstractions` per D7: the `ICostLedger` interface (five members — `RecordCostAsync`, `GetMonthToDateAsync`, `IsHardCapBreachedAsync`, `GetActiveOverrideAsync`, `QueryAsync`), the `CostEvent` record, the `CostCategory` discriminator, the `BudgetExceededException` exception type, the `BudgetOverride` record, the `IBudgetConfigProvider` interface, and the supporting records (`BudgetConfig`, `CostQuery`, `CostSource` discriminated union). All pure contracts — zero HoneyDrunk runtime dependencies. This is the version-bumping packet for the `HoneyDrunk.Kernel` solution in this initiative.
+
+## Context
+ADR-0052 D7 commits the cost-governance contract to `HoneyDrunk.Kernel.Abstractions`, the zero-dependency contract layer every Node already consumes. The v1 implementation lives in `HoneyDrunk.AI` (packets 05/06), not Kernel, per the Kernel-thin-shell principle. The split keeps Kernel free of the Cosmos dependency the AI-side implementation requires; every consumer (AI, future Operator aggregator, future Billing Node) compiles against the Kernel contract.
+
+**Relocation context — read first.** An `ICostLedger` interface already exists in `HoneyDrunk.AI.Abstractions/ICostLedger.cs` (two members: `RecordAsync(InferenceCost)`, `GetSummaryAsync(scope, since)`). It is the inference-only ledger surface from ADR-0016 D5. ADR-0052 D7 is **wider** — the new contract is category-scoped (the five D1 categories: AI inference, Azure infra, SaaS, domain/cert, GitHub Actions), the event shape is multi-source (`CostSource` discriminated union covering inference + Azure + SaaS + CI + domain), and the kill-switch read (`IsHardCapBreachedAsync`) is a first-class method, not a derived call. This packet ships the **new** contract in `HoneyDrunk.Kernel.Abstractions`; packet 04 reconciles the existing AI-side `ICostLedger` against the new Kernel contract (removes or wraps the AI-side version, points providers at Kernel). **Do not delete or rename anything in `HoneyDrunk.AI.Abstractions` from this packet** — packet 04 is the AI-side packet that handles the relocation, in its own repo, on its own commit.
+
+**Repo state at edit time.** `HoneyDrunk.Kernel` is a live Node. Packets 02/04/07 of the `adr-0042-idempotency` initiative also target `HoneyDrunk.Kernel` and bump the solution `0.7.0` → `0.8.0` for the idempotency contract surface. **The order matters.** Check at edit time which initiative's Kernel packets have landed:
+- If ADR-0042's Kernel packets are merged and `HoneyDrunk.Kernel` is at the released `0.8.0`, **this packet bumps the solution** to `0.9.0` (minor — additive new contract surface, no break).
+- If an ADR-0042 Kernel version bump is still in-progress (unreleased), **this packet appends** to that in-progress version entry and does not bump again (invariant 27).
+Record the case in the PR. The expected case is "ADR-0042's Kernel work is released" — ADR-0042 is sequenced before this initiative — but verify at execution time.
+
+**Kernel package layout.** `HoneyDrunk.Kernel` has two packages: `HoneyDrunk.Kernel.Abstractions` (zero-dependency contracts) and `HoneyDrunk.Kernel` (runtime). **This packet only touches `HoneyDrunk.Kernel.Abstractions`** — no runtime code lands here. The v1 implementation lives in `HoneyDrunk.AI` (packets 05/06), not in `HoneyDrunk.Kernel` runtime. The runtime package is still version-bumped (alignment, invariant 27) if this packet is the bumping packet; per invariant 12/27 it gets no per-package CHANGELOG entry on an alignment-only bump.
+
+> **Implementation-home note for the executor.** ADR-0052 D7 is explicit: the **interface** is in Kernel; the **v1 implementation** is in `HoneyDrunk.AI`. Do not implement `ICostLedger` in `HoneyDrunk.Kernel`. The runtime base classes for AI to consume the contract (e.g., a `BudgetExceededException` derivation, a small `CostEvent.Validate()` extension method) are acceptable in `HoneyDrunk.Kernel.Abstractions` only if they have zero HoneyDrunk runtime dependency (invariant 1) and zero Cosmos / Azure SDK reference; otherwise they belong in `HoneyDrunk.AI` with the implementation.
+
+This packet adds only public abstraction types. No App Insights SDK, no Cosmos SDK, no Azure type — those are packet 05's concern.
+
+## Scope
+- `HoneyDrunk.Kernel.Abstractions` — new contract types:
+  - `ICostLedger` (interface) — the five-member contract per ADR-0052 D7 preview.
+  - `CostEvent` (record) — the canonical cost-event shape; carries `Category`, `Amount`, `Timestamp`, `Source`, optional `TenantId`/`AgentId`/`AgentRunId`, `Environment`, `CorrelationId`.
+  - `CostCategory` (enum) — the five D1 categories.
+  - `CostSource` (record / discriminated union) — `LlmInferenceSource`, `AzureInfraSource`, `SaasSource`, `CiSource`, `DomainSource`.
+  - `BudgetExceededException` (sealed exception) — the kill-switch synchronous throw per D4.
+  - `BudgetOverride` (record) — operator override per D11.
+  - `IBudgetConfigProvider` (interface) — abstracts reading the budget config.
+  - `BudgetConfig` (record) — the resolved per-category soft/hard caps and anomaly thresholds, plus the dev overlay (D12).
+  - `CostQuery` (record) — the `QueryAsync` input shape.
+  - `CostEnvironment` (enum) — `Prod`, `Dev`, `Staging`, `Local` (D12).
+- Unit tests for the records (construction, equality, `BudgetExceededException` sealedness / non-transient contract).
+- Both `.csproj` files in the solution version-bumped per the version-state check (Context above).
+- `HoneyDrunk.Kernel.Abstractions` package `CHANGELOG.md` and `README.md` updated.
+- Repo-level `CHANGELOG.md` updated.
+
+## Proposed Implementation
+1. **`CostCategory`** — a plain `enum` with five values: `AiInference`, `AzureInfrastructure`, `ThirdPartySaas`, `DomainCertRegistrar`, `GitHubActionsMinutes`. Order is the D1 table order. XML-doc each value with the D1 scope description ("Container Apps, Application Insights, Vault, Cosmos, Storage, Front Door, Service Bus, Functions" for `AzureInfrastructure`, etc.).
+2. **`CostEnvironment`** — a plain `enum`: `Prod`, `Dev`, `Staging`, `Local` (D12). Local events are recorded but exempt from caps; the kill-switch check ignores `Local` events per D12.
+3. **`CostSource`** — per the Grid naming rule (records drop `I`), this is a `record` base or discriminated-union root. Two acceptable shapes (pick the one matching `HoneyDrunk.Kernel.Abstractions` existing convention):
+   - A `record` base with derived records `LlmInferenceSource(string Provider, string ModelId, int InputTokens, int OutputTokens)`, `AzureInfraSource(string ResourceId, string MeterName, string SubscriptionId?)`, `SaasSource(string VendorId, string LineItem)`, `CiSource(string Workflow, string RunId)`, `DomainSource(string Domain, string Registrar)`.
+   - A sealed discriminated-union via C# pattern matching — adjust to what `HoneyDrunk.Kernel.Abstractions` already does. Look at the existing `CostSource` / discriminated-union conventions in the abstractions surface; if none exist, pick the record-base shape (most consistent with the broader Kernel record style).
+   The source is a structured payload carrying only the dimensions needed for forensics — no secrets, no PII (invariant 8 binds).
+4. **`CostEvent`** — `record` (drops the `I`). Fields:
+   - `CostCategory Category`
+   - `decimal Amount` (USD; the currency lives in the config — the event records the value)
+   - `DateTimeOffset Timestamp`
+   - `CostSource Source`
+   - `CostEnvironment Environment`
+   - `string CorrelationId`
+   - `TenantId? TenantId` (ADR-0026 primitive — reuse the existing Kernel `TenantId` type; if not yet defined as a Kernel primitive, fall back to `string?` and XML-doc it as "opaque tenant identifier per ADR-0026")
+   - `string? AgentId` (D6 — reuse the ADR-0051 identifier shape if it exists in Kernel; otherwise `string?`)
+   - `string? AgentRunId` (D6)
+   Constructor validates non-zero `Amount` (allow zero for placeholder events but never negative); validates non-empty `CorrelationId`. XML-doc the `(TenantId, AgentId)` cross-product invariant from D6 ("a single event is attributed to exactly one tenant and exactly one agent run; sum across the cross-product equals the category total").
+5. **`BudgetExceededException`** — `public sealed class BudgetExceededException : Exception`. Constructor takes `CostCategory category`, `decimal hardCap`, `decimal monthToDate`, `string correlationId`. Properties expose all four. Override `Message` to include the category, the cap, and the actual. XML-doc the **non-transient contract**: callers must NOT retry; catching this exception and retrying within the same billing window is a defect detected by the `review` agent. Decorate with `[Serializable]` if the existing Kernel exceptions follow that pattern (check at edit time).
+6. **`BudgetOverride`** — `record`. Fields: `CostCategory Category`, `string OperatorPrincipalId` (reuse the Kernel `PrincipalId` if it exists; otherwise `string`), `string Reason`, `DateTimeOffset IssuedAt`, `DateTimeOffset ExpiresAt`, `DateTimeOffset? RevokedAt`. XML-doc: "An override is time-bounded; expiration is automatic; permanent overrides do not exist (ADR-0052 D11)."
+7. **`BudgetConfig`** — `record`. Carries:
+   - `IReadOnlyDictionary<CostCategory, BudgetCategoryConfig> Categories`
+   - `IReadOnlyDictionary<CostCategory, BudgetCategoryConfig> DevOverlay`
+   - `IReadOnlyDictionary<CostCategory, string> Owners`
+   Plus a nested `BudgetCategoryConfig` record: `decimal? SoftCap`, `decimal? HardCap`, `string KillSwitch` (the kill-switch posture string — `"in_process"`, `"azure_suspend"`, `"github_native"`, `"none"` per D4), `decimal AnomalyHourOverHour`, `decimal AnomalyDayOverDay`. Nullable caps for the soft-only categories (SaaS, domain/cert).
+8. **`IBudgetConfigProvider`** — interface. Single member: `ValueTask<BudgetConfig> GetAsync(CancellationToken cancellationToken)`. XML-doc: "Reads `business/context/cost-budgets.json` at startup and on configuration-change events; the implementation is expected to surface from Azure App Configuration via Vault's `IConfigProvider` per ADR-0016 D5, with the JSON file as the source-of-truth committed in the Architecture repo."
+9. **`CostQuery`** — `record`. Fields: `CostCategory? Category`, `DateTimeOffset From`, `DateTimeOffset To`, `string? TenantId`, `string? AgentId`. Defaults: `null` for filters means "all," date range is required. XML-doc: "Inputs to `ICostLedger.QueryAsync`; returns events matching every non-null filter."
+10. **`ICostLedger`** — interface with five members exactly per ADR-0052 D7 preview:
+    ```
+    ValueTask RecordCostAsync(CostEvent evt, CancellationToken ct);
+    ValueTask<decimal> GetMonthToDateAsync(CostCategory category, CancellationToken ct);
+    ValueTask<bool> IsHardCapBreachedAsync(CostCategory category, CancellationToken ct);
+    ValueTask<BudgetOverride?> GetActiveOverrideAsync(CostCategory category, CancellationToken ct);
+    IAsyncEnumerable<CostEvent> QueryAsync(CostQuery query, CancellationToken ct);
+    ```
+    XML-doc the **hot-path contract** on `IsHardCapBreachedAsync`: "Called on every `ILlmDispatcher` invocation; the implementation must serve this read from an in-memory cache (refresh every 30 seconds per D8), not from durable storage. Sub-microsecond expected latency at v1 LLM call volume." XML-doc the **non-cross-subsidy contract** on `GetMonthToDateAsync`: "Returns the month-to-date for the queried category only; categories do not cross-subsidize (ADR-0052 D1)."
+11. All public types get full XML documentation (invariant 13).
+12. **Version-state check.** Per invariant 27, check the `HoneyDrunk.Kernel` solution's in-progress version state at edit time. If ADR-0042's Kernel packets have all merged and the solution is at the released `0.8.0`, this packet bumps the solution `0.8.0` → `0.9.0` and adds new `[0.9.0]` entries to the repo-level `CHANGELOG.md` and `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md`. If an ADR-0042 bump is still unreleased, append to that in-progress entry (no new bump). Record which case applied in the PR.
+13. **CHANGELOG.** Repo-level `CHANGELOG.md` updated. Per-package `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md` entry — this package has an actual change. `HoneyDrunk.Kernel/CHANGELOG.md` gets NO entry in this packet (alignment-only bump if this packet is the bumping packet — invariant 12/27). `HoneyDrunk.Kernel.Abstractions/README.md` updated to document the new cost-governance contracts in the public-API section.
+14. **Unit tests.** Record-equality / construction tests; `BudgetExceededException` sealedness test (assert the type is `sealed`); a "no-retry contract" test that verifies the exception is not derived from any transient-error marker the Grid uses (e.g., not `IsTransient`). The `review` agent's catch-and-retry check is added in packet 08 (`.claude/agents/review.md` update) — this packet ensures the type-level signal exists so that agent's check can read it.
+
+## Affected Files
+- `HoneyDrunk.Kernel.Abstractions/` — new contract type files (one per type per the repo's existing file-per-type convention).
+- `HoneyDrunk.Kernel.Abstractions/HoneyDrunk.Kernel.Abstractions.csproj` — version bump (if this packet is the bumping packet).
+- `HoneyDrunk.Kernel/HoneyDrunk.Kernel.csproj` — version bump (alignment, if this packet is the bumping packet).
+- `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md`, `HoneyDrunk.Kernel.Abstractions/README.md`.
+- Repo-level `CHANGELOG.md`.
+- `HoneyDrunk.Kernel.Abstractions.Tests` (or the repo's equivalent unit-test project).
+
+## NuGet Dependencies
+- **`HoneyDrunk.Kernel.Abstractions`** — no new `PackageReference`. Per invariant 1, Abstractions takes only `Microsoft.Extensions.*` abstractions; the new contract uses only BCL types (`DateTimeOffset`, `IAsyncEnumerable`, `Exception`, `ValueTask`). `HoneyDrunk.Standards` is already referenced (`PrivateAssets: all`, invariant 26).
+- **`HoneyDrunk.Kernel`** — no new `PackageReference` (the runtime package is alignment-bumped only; the v1 implementation lives in `HoneyDrunk.AI`, packet 05).
+- The unit-test project follows the repo's existing test stack (xUnit v2 + NSubstitute + AwesomeAssertions + coverlet per ADR-0047 D1); no new packages introduced by this packet beyond what the test project already references.
+
+## Boundary Check
+- [x] `ICostLedger`, `CostEvent`, `CostCategory`, `BudgetExceededException`, `BudgetOverride`, `IBudgetConfigProvider`, `BudgetConfig`, `CostQuery`, `CostSource`, `CostEnvironment` are Kernel contracts per ADR-0052 D7. Routing rule "context, ... contracts every Node consumes → HoneyDrunk.Kernel" and the ADR's explicit placement both map here.
+- [x] No dependency on `HoneyDrunk.Transport`, `HoneyDrunk.Data`, `HoneyDrunk.AI`, or any other HoneyDrunk runtime package — the dependency graph is Kernel-at-the-root, never the reverse (invariant 4, DAG).
+- [x] Contracts only; the v1 implementation (packet 05) and the dispatcher-side kill-switch wiring (packet 06) live in `HoneyDrunk.AI`.
+- [x] The existing `HoneyDrunk.AI.Abstractions.ICostLedger` is NOT touched from this packet (the AI repo's reconciliation is packet 04).
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Kernel.Abstractions` exposes `ICostLedger` with exactly the five members `RecordCostAsync`, `GetMonthToDateAsync`, `IsHardCapBreachedAsync`, `GetActiveOverrideAsync`, `QueryAsync` (ADR-0052 D7 signatures)
+- [ ] `IsHardCapBreachedAsync` XML-docs the hot-path contract (cache-served, 30-second refresh window, sub-microsecond latency expected)
+- [ ] `GetMonthToDateAsync` XML-docs the no-cross-subsidy rule (D1)
+- [ ] `CostEvent` is a record carrying `Category`, `Amount`, `Timestamp`, `Source`, `Environment`, `CorrelationId`, optional `TenantId` / `AgentId` / `AgentRunId`; validates non-negative `Amount` and non-empty `CorrelationId`
+- [ ] `CostCategory` enum has exactly five values matching ADR-0052 D1: `AiInference`, `AzureInfrastructure`, `ThirdPartySaas`, `DomainCertRegistrar`, `GitHubActionsMinutes`
+- [ ] `CostEnvironment` enum has `Prod` / `Dev` / `Staging` / `Local` (D12); XML-docs that `Local` events are exempt from caps
+- [ ] `CostSource` is the multi-source discriminated shape (record base with derived sources, or the convention `HoneyDrunk.Kernel.Abstractions` already uses) — `LlmInferenceSource`, `AzureInfraSource`, `SaasSource`, `CiSource`, `DomainSource`
+- [ ] `BudgetExceededException` is `public sealed class`, derives from `Exception`, carries `Category`/`HardCap`/`MonthToDate`/`CorrelationId`, XML-docs the non-transient / no-retry contract
+- [ ] `BudgetOverride` is a record carrying `Category`, `OperatorPrincipalId`, `Reason`, `IssuedAt`, `ExpiresAt`, optional `RevokedAt`; XML-docs the time-bounded contract
+- [ ] `IBudgetConfigProvider` is a single-member interface returning `ValueTask<BudgetConfig>`; XML-docs the Vault `IConfigProvider` source path
+- [ ] `BudgetConfig` is a record carrying `Categories`, `DevOverlay`, `Owners` dictionaries keyed by `CostCategory`; nested `BudgetCategoryConfig` carries nullable `SoftCap`/`HardCap`, `KillSwitch` posture string, and anomaly thresholds
+- [ ] `CostQuery` is a record with nullable filters and a required date range
+- [ ] Records drop the `I` prefix; interfaces (`ICostLedger`, `IBudgetConfigProvider`) keep it (Grid naming rule)
+- [ ] `HoneyDrunk.Kernel.Abstractions` takes no new HoneyDrunk runtime dependency and no Azure / Cosmos / App Insights SDK (invariant 1)
+- [ ] Every new public member has XML documentation (invariant 13)
+- [ ] Unit tests cover record construction and equality, `BudgetExceededException` sealedness, and `CostEvent.Amount` non-negative validation; tests use no external services (invariant 15), no `Thread.Sleep` (invariant 51)
+- [ ] The version-state check on the `HoneyDrunk.Kernel` solution was performed; either this packet bumps `0.8.0` → `0.9.0` or appends to an in-progress ADR-0042 entry; the decision is recorded (invariant 27)
+- [ ] `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md` has an entry; `HoneyDrunk.Kernel/CHANGELOG.md` gets NO entry on alignment-only bump (invariant 12/27); repo-level `CHANGELOG.md` updated
+- [ ] `HoneyDrunk.Kernel.Abstractions/README.md` documents the new cost-governance contracts in the public-API section
+- [ ] The solution builds; the existing unit tests pass; the `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+None. Abstraction code; no Azure resource, no portal step.
+
+## Referenced ADR Decisions
+**ADR-0052 D7 — Cost ledger implementation home.** Interface in `HoneyDrunk.Kernel.Abstractions`; v1 implementation in `HoneyDrunk.AI`. Kernel-thin-shell preserved (no Cosmos dependency in Kernel). Five-member preview shape: `RecordCostAsync(CostEvent)`, `GetMonthToDateAsync(category)`, `IsHardCapBreachedAsync(category)`, `GetActiveOverrideAsync(category)`, `QueryAsync(query)`. The write path is separated from the read path so the read can be served from cache while writes go through to durable storage. `IsHardCapBreachedAsync` is a first-class method (not synthesized from `GetMonthToDateAsync` + config lookup) so the implementation can collapse the read into a single cache hit.
+
+**ADR-0052 D1 — Five cost categories.** AI inference, Azure infrastructure, third-party SaaS, domain/cert/registrar, GitHub Actions minutes. No cross-subsidy: hitting the AI inference hard cap does not free up budget for Azure infra. The total Grid budget is the sum, not a fungible pool.
+
+**ADR-0052 D4 — Kill-switches per category.** AI inference is in-process: `ILlmDispatcher` checks `IsHardCapBreachedAsync` before each call; throws `BudgetExceededException` synchronously if breached. The exception carries category / cap / actual / correlation id. `BudgetExceededException` is **sealed** and **non-transient** — callers must not retry; the exception means "this category is closed for the rest of the billing window or until an operator override engages." A retry loop that swallows the exception and tries again is a defect.
+
+**ADR-0052 D5 — Per-tenant attribution.** Every `CostEvent` carries an optional `TenantId` (ADR-0026's opaque primitive). Where the cost originates from a tenant-scoped operation, `TenantId` is set; where the cost is Grid-internal / Studio operations, `TenantId` is null and the cost rolls up as "platform overhead." Untagged events on commercial traffic are a defect detected by the daily roll-up's unattributed-cost check.
+
+**ADR-0052 D6 — Per-agent attribution.** AI inference events additionally carry `AgentId` and `AgentRunId`. `AgentId` is the stable identifier from the agent definition (ADR-0051 registry); `AgentRunId` is the per-invocation correlation. The aggregation rule: a single event is attributed to exactly one tenant and exactly one agent run; sum across the (tenant, agent) cross-product equals the category total. Carrying both is cheap; carrying only one would force operators into multi-step queries.
+
+**ADR-0052 D11 — Operator unlock policy.** Override is time-bounded (default 24h). Permanent overrides do not exist — re-engagement is the safer default. The override does not raise the cap retroactively. Audited via `IAuditLog` per ADR-0030, with `sensitive=audit` tagging.
+
+**ADR-0052 D12 — Test and dev environment treatment.** Dev caps are separate and smaller. Production caps do not include dev burn. Every `CostEvent` carries an `Environment` field; `Local` events are recorded but exempt from caps.
+
+**ADR-0026 — Tenant primitive.** `TenantId` is an opaque identifier; the cost ledger does not coin new tenant identifiers, it consumes the canonical one. Reuse the Kernel `TenantId` type if it exists; otherwise fall back to `string?` and XML-doc the ADR-0026 contract.
+
+**ADR-0030 — Audit substrate.** Override events are audited via `IAuditLog` (invariant 47); the cost ledger itself is NOT the audit substrate (different retention shape, different append semantics — the cost ledger supports updates for retroactive reconciliation, Audit does not).
+
+## Constraints
+> **Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.** `HoneyDrunk.Kernel.Abstractions` takes only `Microsoft.Extensions.*` abstractions. No App Insights SDK, no Cosmos SDK, no Azure type, no Sentry SDK in `ICostLedger` or its model types. The v1 implementation in `HoneyDrunk.AI` (packet 05) takes those dependencies.
+
+> **Invariant 4 — the dependency graph is a DAG; Kernel is at the root.** Do not reference `HoneyDrunk.AI`, `HoneyDrunk.Transport`, `HoneyDrunk.Data`, or any other HoneyDrunk runtime package.
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** `CostSource` carries only structured forensics data — provider id, model id, token counts, resource id, meter name. No prompt text, no completion text, no API key. The XML docs must state this on `CostSource`.
+
+> **Invariant 12 — Per-package CHANGELOGs are updated only for packages with functional changes.** `HoneyDrunk.Kernel.Abstractions` gets an entry; `HoneyDrunk.Kernel` (alignment-only bump if this packet is the bumping packet) gets none.
+
+> **Invariant 13 — All public APIs have XML documentation.** Enforced by `HoneyDrunk.Standards` analyzers.
+
+> **Invariant 15 — Unit tests never depend on external services.** Record construction and exception sealedness tests run in-process.
+
+> **Invariant 27 — All projects in a solution share one version and move together.** Perform the version-state check; either bump `0.8.0` → `0.9.0` across both `.csproj` files in one commit, or append to an in-progress ADR-0042 entry. Partial bumps are forbidden.
+
+> **Invariant 51 — Tests do not use `Thread.Sleep` (ADR-0047 D6).** None of the tests in this packet need a clock; use `TimeProvider` injection if a future test needs one.
+
+- **Grid naming rule.** Records drop the `I`: `CostEvent`, `CostSource`, `BudgetOverride`, `BudgetConfig`, `CostQuery`. Interfaces keep it: `ICostLedger`, `IBudgetConfigProvider`. Enums (`CostCategory`, `CostEnvironment`) follow the standard enum naming.
+- **No invented members.** `ICostLedger` is the five-member D7 shape — do not add or rename.
+- **Do not touch `HoneyDrunk.AI.Abstractions`.** The AI-side `ICostLedger` reconciliation is packet 04, in the AI repo. This packet only adds new types to Kernel.
+- **`BudgetExceededException` is sealed and non-transient.** Document the no-retry contract explicitly.
+
+## Labels
+`feature`, `tier-2`, `core`, `ops`, `adr-0052`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add the ADR-0052 D7 cost-governance contract surface to `HoneyDrunk.Kernel.Abstractions` — `ICostLedger`, `CostEvent`, `CostCategory`, `CostSource`, `CostEnvironment`, `BudgetExceededException`, `BudgetOverride`, `IBudgetConfigProvider`, `BudgetConfig`, `CostQuery` — and either bump the `HoneyDrunk.Kernel` solution `0.8.0` → `0.9.0` (if the ADR-0042 Kernel work is released) or append to that in-progress version.
+
+**Target:** `HoneyDrunk.Kernel`, branch from `main`.
+
+**Context:**
+- Goal: Ship the cost-governance contracts every other packet in this initiative compiles against, and that every downstream Node consuming the cost ledger will compile against.
+- Feature: ADR-0052 Cost Governance rollout, Wave 2.
+- ADRs: ADR-0052 D1/D4/D5/D6/D7/D11/D12 (primary), ADR-0026 (`TenantId`), ADR-0030 (override audit), ADR-0008 (packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0052 Accepted and the three invariants live before the contracts are built against them.
+- `packet:01` — Catalog registration of the Kernel contract surface lands first so the catalog mirrors the code.
+
+**Constraints:**
+- Abstractions stay zero-HoneyDrunk-dependency (invariant 1). No reference to `HoneyDrunk.AI`, `HoneyDrunk.Transport`, `HoneyDrunk.Data`.
+- `ICostLedger` is the five-member D7 shape — no invented members.
+- `BudgetExceededException` is `public sealed class`, non-transient, with XML docs stating the no-retry contract.
+- Records drop the `I`; interfaces keep it.
+- Do not touch `HoneyDrunk.AI.Abstractions` — packet 04 handles the AI-side relocation.
+- Perform the invariant-27 version-state check; either bump `0.8.0` → `0.9.0` or append to an unreleased ADR-0042 entry; record the decision.
+
+**Key Files:**
+- `HoneyDrunk.Kernel.Abstractions/` — new contract type files.
+- `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md`, `README.md`; repo-level `CHANGELOG.md`.
+- Both `.csproj` files for the version bump.
+
+**Contracts:**
+- `ICostLedger` (new interface) — five-member D7 shape.
+- `CostEvent`, `CostSource`, `BudgetOverride`, `BudgetConfig`, `CostQuery` (new records).
+- `CostCategory`, `CostEnvironment` (new enums).
+- `BudgetExceededException` (new sealed exception).
+- `IBudgetConfigProvider` (new interface, single member).

--- a/generated/issue-packets/active/adr-0052-cost-governance/04-ai-icostledger-relocation-to-kernel.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/04-ai-icostledger-relocation-to-kernel.md
@@ -1,0 +1,194 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.AI
+labels: ["feature", "tier-2", "ai", "ops", "adr-0052", "wave-3"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0052", "ADR-0016"]
+accepts: ["ADR-0052"]
+wave: 3
+initiative: adr-0052-cost-governance
+node: honeydrunk-ai
+---
+
+# Remove the AI-side ICostLedger and point AI.Abstractions at the new Kernel contract
+
+## Summary
+Reconcile the existing `HoneyDrunk.AI.Abstractions.ICostLedger` (two-member inference-only contract) against the new `HoneyDrunk.Kernel.Abstractions.ICostLedger` (five-member multi-source contract from ADR-0052 D7, shipped in packet 03). **Remove** the AI-side `ICostLedger.cs` (and the inference-specific `InferenceCost` / `CostSummary` records if they are only used by it), update `HoneyDrunk.AI.Abstractions` to depend on `HoneyDrunk.Kernel.Abstractions` for the cost-ledger contract, and update every provider package (`HoneyDrunk.AI.Providers.OpenAI`/`.Anthropic`/`.AzureOpenAI`/`.InMemory`) that referenced the old shape to compile against the Kernel contract. This is the version-bumping packet for the `HoneyDrunk.AI` solution in this initiative.
+
+## Context
+The existing `HoneyDrunk.AI.Abstractions.ICostLedger` (at `HoneyDrunk.AI/src/HoneyDrunk.AI.Abstractions/ICostLedger.cs`) was committed as part of the AI Node's seed surface per ADR-0016 D5:
+
+```csharp
+public interface ICostLedger
+{
+    Task RecordAsync(InferenceCost cost, CancellationToken cancellationToken = default);
+    Task<CostSummary> GetSummaryAsync(string scope, DateTimeOffset since, CancellationToken cancellationToken = default);
+}
+```
+
+It is inference-only (`InferenceCost` carries `ProviderId`, `ModelId`, `InputTokens`, `OutputTokens`, `EstimatedCost`, `OperationCorrelationId`) and category-agnostic (no `CostCategory` enum — the "scope" is a caller-defined string).
+
+ADR-0052 D7 replaces this with a wider contract in `HoneyDrunk.Kernel.Abstractions`:
+
+```csharp
+public interface ICostLedger
+{
+    ValueTask RecordCostAsync(CostEvent evt, CancellationToken ct);
+    ValueTask<decimal> GetMonthToDateAsync(CostCategory category, CancellationToken ct);
+    ValueTask<bool> IsHardCapBreachedAsync(CostCategory category, CancellationToken ct);
+    ValueTask<BudgetOverride?> GetActiveOverrideAsync(CostCategory category, CancellationToken ct);
+    IAsyncEnumerable<CostEvent> QueryAsync(CostQuery query, CancellationToken ct);
+}
+```
+
+The new contract is category-scoped (five `CostCategory` values), multi-source (`CostSource` discriminated union covers inference + Azure infra + SaaS + CI + domain), and makes the kill-switch read a first-class method.
+
+**Relocation policy.** This is a **replace, not extend**. The AI-side `ICostLedger` is removed, not retained. Rationale:
+- The two contracts have the same name and different shapes — keeping both in scope would force consumers to disambiguate with `using` aliases, which is a poor API.
+- The new contract is a superset of the old by intent: the inference case becomes a `CostEvent` with `Source = LlmInferenceSource(...)`. The existing `InferenceCost` record maps 1:1 onto `LlmInferenceSource`.
+- ADR-0016 D5 (the original "operator-configurable token cost rates and `ICostLedger` abstraction") and ADR-0052 D7 are deliberately aligned — D7 is the **expansion** of the seed surface D5 named, not a parallel surface.
+
+**Repo state at edit time.** `HoneyDrunk.AI` is at v0.1.0, **seed** status — the ADR-0016 Phase-1 scaffold packet (HoneyDrunk.AI#2) has not been executed. The repo currently contains only the `HoneyDrunk.AI.Abstractions` seed types committed at standup, plus a `DefaultCostLedger` skeleton in `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/DefaultCostLedger.cs` and a `ServiceCollectionExtensions` registration. The packet that scaffolds the full v0 .NET solution per ADR-0016 has not landed yet. **This is a known initiative-level blocker** — see the dispatch plan's cross-cutting concern on the AI-standup gate. If the ADR-0016 scaffold has not landed by execution time, this packet still ships against whatever exists in the AI repo (the abstraction-only relocation does not require the full standup); the v1 Cosmos implementation in packet 05 is the one that strictly requires the standup. **Check at execution time.**
+
+**Dependency direction.** `HoneyDrunk.AI.Abstractions` adding a `PackageReference` on `HoneyDrunk.Kernel.Abstractions` is consistent with invariant 1 (Abstractions packages may reference other HoneyDrunk **abstraction** packages — only the runtime-dependency-on-runtime case is forbidden). Verify by inspecting the existing `HoneyDrunk.AI.Abstractions.csproj` at edit time — it may already reference `HoneyDrunk.Kernel.Abstractions` for the existing `IGridContext` / `TenantId` types; if not, add the reference.
+
+**Provider packages.** Four provider packages (`HoneyDrunk.AI.Providers.OpenAI`, `.Anthropic`, `.AzureOpenAI`, `.InMemory`) reference `HoneyDrunk.AI.Abstractions` and may reference the old `ICostLedger` / `InferenceCost`. The packages emit cost telemetry by calling `RecordAsync(InferenceCost)`. After this packet they call `RecordCostAsync(CostEvent)` with the inference event constructed via `CostSource = new LlmInferenceSource(...)`. The provider packages all share the AI solution version (invariant 27) so they bump together.
+
+**`DefaultCostLedger` in the AI runtime.** A `DefaultCostLedger` class exists at `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/DefaultCostLedger.cs` implementing the old `ICostLedger`. This packet rewrites it to implement the new Kernel contract, but **as a thin no-op / in-memory stub only** — the real v1 Cosmos-backed implementation is packet 05. The stub here exists so the solution compiles and the existing DI registration (`services.AddSingleton<ICostLedger, DefaultCostLedger>()`) does not break. Packet 05 replaces the stub with the real Cosmos backing.
+
+**Catalog mirror.** Packet 01 marked the `honeydrunk-ai` `ICostLedger` entry as relocating; this packet's PR completes the relocation by removing the AI-side type, so the catalog entry can be **deleted** in a small catalog-cleanup follow-up after this packet merges. **This packet does not edit the Architecture-repo catalog.** The catalog cleanup is named in packet 09 (the playbook), not done here — the cross-repo edit would split the AI-code change across two PRs in two repos.
+
+## Scope
+- `HoneyDrunk.AI.Abstractions` — remove `ICostLedger.cs`, `InferenceCost.cs`, `CostSummary.cs` (and any other types that exist only to serve the removed interface). Add a `PackageReference` to `HoneyDrunk.Kernel.Abstractions` (the version that ships packet 03) if not already present.
+- Every provider package (`HoneyDrunk.AI.Providers.OpenAI`/`.Anthropic`/`.AzureOpenAI`/`.InMemory`) — update every call site that used the old `RecordAsync(InferenceCost)` to call `RecordCostAsync(CostEvent)` with a `CostSource = new LlmInferenceSource(...)`. The `CostEvent.Amount` is the same value as the old `InferenceCost.EstimatedCost`; the category is `CostCategory.AiInference`; `AgentId` / `AgentRunId` are populated from ambient context if the dispatcher already plumbs them (see packet 06), otherwise `null`.
+- `HoneyDrunk.AI` runtime — rewrite `DefaultCostLedger.cs` to implement the new five-member Kernel contract as a thin no-op / in-memory stub. The Cosmos-backed v1 implementation is packet 05; this stub exists only so the solution compiles.
+- Solution-wide version bump per invariant 27 (every non-test `.csproj` shares one version).
+- Per-package CHANGELOG entries for every package with a real change; no noise entries on alignment-only bumps.
+- Repo-level `CHANGELOG.md`.
+- `HoneyDrunk.AI.Abstractions/README.md` updated — the old `ICostLedger` is removed from the public API section; a pointer to `HoneyDrunk.Kernel.Abstractions.ICostLedger` replaces it.
+
+## Proposed Implementation
+1. **Delete the AI-side cost types.** Remove `HoneyDrunk.AI/src/HoneyDrunk.AI.Abstractions/ICostLedger.cs`, `InferenceCost.cs`, `CostSummary.cs`. Verify at edit time that no other Abstractions type still references these (search for `ICostLedger`, `InferenceCost`, `CostSummary` across the repo); if anything outside the to-be-removed set references them, file the dependent change in the same commit. The XML doc files emitted to `bin/` will refresh on the next build — no manual cleanup needed.
+2. **Update `HoneyDrunk.AI.Abstractions.csproj`.** Add a `PackageReference` to `HoneyDrunk.Kernel.Abstractions` if not already present, pinned to the version that ships ADR-0052 packet 03 (the version that adds `ICostLedger` + supporting types). Check the AI.Abstractions csproj at edit time for the existing Kernel.Abstractions reference and update the version if needed.
+3. **Update every provider package.** For each of `HoneyDrunk.AI.Providers.OpenAI`/`.Anthropic`/`.AzureOpenAI`/`.InMemory`, find every call to the old `ICostLedger.RecordAsync(InferenceCost)`. Replace with:
+   ```csharp
+   var costEvent = new CostEvent(
+       Category: CostCategory.AiInference,
+       Amount: estimatedCost,
+       Timestamp: DateTimeOffset.UtcNow,
+       Source: new LlmInferenceSource(providerId, modelId, inputTokens, outputTokens),
+       Environment: gridContext.Environment,                  // from ambient GridContext if available
+       CorrelationId: operationCorrelationId,
+       TenantId:   gridContext.TenantId,                       // null if no tenant context
+       AgentId:    gridContext.AgentId,                        // null if not under an agent
+       AgentRunId: gridContext.AgentRunId);
+   await costLedger.RecordCostAsync(costEvent, ct);
+   ```
+   The exact ambient-context plumbing depends on how `GridContext` / `IGridContext` is exposed in the provider; match the existing pattern. If the providers don't yet have `TenantId` / `AgentId` plumbed, pass `null` and XML-doc the limitation in the package CHANGELOG entry — that's a follow-up improvement, not a packet-04 blocker.
+4. **Rewrite `DefaultCostLedger`.** Replace the existing `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/DefaultCostLedger.cs` implementation with a thin stub that satisfies the new Kernel `ICostLedger`:
+   - `RecordCostAsync` — log the event at Debug via the existing `ILogger<DefaultCostLedger>` (do not write to durable storage; the stub is intentionally non-durable until packet 05).
+   - `GetMonthToDateAsync` — return `0m` for every category (stub).
+   - `IsHardCapBreachedAsync` — return `false` for every category (stub — the kill-switch does not fire in the stub).
+   - `GetActiveOverrideAsync` — return `null` for every category.
+   - `QueryAsync` — return an empty `IAsyncEnumerable<CostEvent>`.
+   XML-doc the class: "Phase-1 stub per ADR-0052 D14 — non-durable, no kill-switch enforcement. Packet 05 replaces this with the Cosmos-backed v1 implementation."
+5. **`ServiceCollectionExtensions`.** Update the existing `services.AddSingleton<ICostLedger, DefaultCostLedger>()` registration. The `using` may change from `HoneyDrunk.AI.Abstractions` to `HoneyDrunk.Kernel.Abstractions`; verify at edit time. Keep the registration — packet 05 replaces the implementation type while keeping the `ICostLedger` interface unchanged.
+6. **Version-bump every non-test `.csproj` in the `HoneyDrunk.AI` solution to one new minor version** (invariant 27). The current solution version is 0.1.0; this packet is the first packet on the solution in this initiative, so it bumps. The bump is minor (`0.1.0` → `0.2.0`): the AI-side contract change is a removal but the AI Node is still at seed status — the only consumer is internal AI provider code, no external consumer pins on `HoneyDrunk.AI.Abstractions.ICostLedger` yet (the AI Node has had no GA release). Treat as additive minor on the rationale that no out-of-repo consumer existed; document this rationale in the PR.
+7. **Per-package CHANGELOGs** — `HoneyDrunk.AI.Abstractions/CHANGELOG.md` gets an entry: "`ICostLedger`, `InferenceCost`, `CostSummary` removed — relocated to `HoneyDrunk.Kernel.Abstractions` per ADR-0052 D7. Consume the Kernel contract directly." `HoneyDrunk.AI/CHANGELOG.md` gets an entry: "`DefaultCostLedger` rewritten as a Phase-1 stub against the Kernel `ICostLedger` contract — non-durable, no kill-switch enforcement. Packet 05 replaces with the Cosmos backing." Each provider package CHANGELOG gets an entry: "Cost recording migrated to `HoneyDrunk.Kernel.Abstractions.ICostLedger`; inference events emit `CostEvent` with `LlmInferenceSource`." Repo-level `CHANGELOG.md` updated.
+8. **`HoneyDrunk.AI.Abstractions/README.md`** — remove `ICostLedger` from the public-API section. Add a brief pointer: "Cost-governance contracts (`ICostLedger`, `CostEvent`, `CostCategory`, etc.) now live in `HoneyDrunk.Kernel.Abstractions` per ADR-0052 D7."
+
+## Affected Files
+- `HoneyDrunk.AI/src/HoneyDrunk.AI.Abstractions/ICostLedger.cs` — deleted
+- `HoneyDrunk.AI/src/HoneyDrunk.AI.Abstractions/InferenceCost.cs` — deleted (verify no other reference first)
+- `HoneyDrunk.AI/src/HoneyDrunk.AI.Abstractions/CostSummary.cs` — deleted (verify no other reference first)
+- `HoneyDrunk.AI/src/HoneyDrunk.AI.Abstractions/HoneyDrunk.AI.Abstractions.csproj` — add/update `PackageReference` to `HoneyDrunk.Kernel.Abstractions`; version bump
+- Every provider package `.csproj` — version bump; possibly an updated `PackageReference` to the new `HoneyDrunk.Kernel.Abstractions` version
+- Every provider package source — call-site migration from `RecordAsync` to `RecordCostAsync`
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/DefaultCostLedger.cs` — rewritten as a stub against the Kernel contract
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/ServiceCollectionExtensions.cs` — verify the DI registration `using`
+- `HoneyDrunk.AI.Abstractions/CHANGELOG.md`, every package CHANGELOG with a real change, repo-level `CHANGELOG.md`
+- `HoneyDrunk.AI.Abstractions/README.md`
+
+## NuGet Dependencies
+- **`HoneyDrunk.AI.Abstractions`** — `PackageReference` to `HoneyDrunk.Kernel.Abstractions` at the version that ships ADR-0052 packet 03 (this initiative's packet 03 — confirm the released version at edit time, after the Wave-2 → Wave-3 human release tag on `HoneyDrunk.Kernel`; see the dispatch plan's human-release boundary).
+- **Every provider package** — inherits the same `HoneyDrunk.Kernel.Abstractions` reference transitively via `HoneyDrunk.AI.Abstractions`; no new direct reference unless an existing one needs version-bumping.
+- **`HoneyDrunk.AI`** — no new package; the stub `DefaultCostLedger` uses only types from `HoneyDrunk.Kernel.Abstractions` and the BCL.
+- Tests follow the repo's existing stack; no new packages.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.AI`. The AI-side relocation is the AI repo's concern; the Kernel-side addition was packet 03. No cross-repo coupling on this commit.
+- [x] `HoneyDrunk.AI.Abstractions` referencing `HoneyDrunk.Kernel.Abstractions` is invariant-1-clean — Abstractions may reference other Abstractions; only runtime-on-runtime is forbidden.
+- [x] No reference to `HoneyDrunk.Data` or any other non-Kernel HoneyDrunk runtime package — invariant 4 (DAG).
+- [x] The stub `DefaultCostLedger` is non-durable by design; the durable Cosmos implementation is packet 05.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.AI/src/HoneyDrunk.AI.Abstractions/ICostLedger.cs`, `InferenceCost.cs`, `CostSummary.cs` are deleted (and no other Abstractions type still references them)
+- [ ] `HoneyDrunk.AI.Abstractions.csproj` references `HoneyDrunk.Kernel.Abstractions` at the version that ships ADR-0052 packet 03
+- [ ] Every provider package's call site has migrated from `RecordAsync(InferenceCost)` to `RecordCostAsync(CostEvent)` with `Source = new LlmInferenceSource(...)`, `Category = CostCategory.AiInference`, and `Environment` populated from ambient context (or `Prod` as a deliberate default with an XML-doc note if no `GridContext` is available at the call site)
+- [ ] `DefaultCostLedger` implements the new five-member Kernel `ICostLedger` as a non-durable stub: `RecordCostAsync` logs at Debug, `IsHardCapBreachedAsync` returns `false`, `GetActiveOverrideAsync` returns `null`, `QueryAsync` returns empty; XML-doc states "Phase-1 stub per ADR-0052 D14; packet 05 replaces with Cosmos backing"
+- [ ] `ServiceCollectionExtensions` still registers `ICostLedger -> DefaultCostLedger`, now against the Kernel contract
+- [ ] Every non-test `.csproj` in the `HoneyDrunk.AI` solution is at the same new minor version (e.g., `0.1.0` → `0.2.0`); invariant-27 single-commit version bump
+- [ ] Per-package CHANGELOGs updated only for packages with real changes: `HoneyDrunk.AI.Abstractions` (the deletion), `HoneyDrunk.AI` (the `DefaultCostLedger` rewrite), each provider package (the call-site migration). No noise entries on alignment-only bumps
+- [ ] Repo-level `CHANGELOG.md` updated
+- [ ] `HoneyDrunk.AI.Abstractions/README.md` no longer lists `ICostLedger` in the public-API section; carries a pointer to the new Kernel contract
+- [ ] The AI solution builds; existing unit tests pass; no `using HoneyDrunk.AI.Abstractions;` line remains that resolved the now-removed `ICostLedger` (the compiler will catch this)
+
+## Human Prerequisites
+- [ ] **Wave-2 → Wave-3 human release tag on `HoneyDrunk.Kernel`.** Packet 04 compiles against the `HoneyDrunk.Kernel.Abstractions` version that ships ADR-0052 packet 03. That artifact reaches the NuGet feed only after a human pushes the git release tag on `HoneyDrunk.Kernel`. After packet 03 merges, a human must tag/release the Kernel solution at its new version so this packet can compile. Agents merge code but never tag or publish (per the cross-cutting concern in every multi-repo initiative).
+
+## Referenced ADR Decisions
+**ADR-0052 D7 — Cost ledger implementation home.** Interface in `HoneyDrunk.Kernel.Abstractions`; v1 implementation in `HoneyDrunk.AI`. The interface in Kernel is unchanged across the promotion path; only the implementation moves when `HoneyDrunk.CostLedger` graduates to its own Node. The relocation in this packet is exactly the D7 commitment — the seed AI-side `ICostLedger` is removed, AI compiles against the Kernel contract going forward.
+
+**ADR-0052 D1 — Five cost categories.** Inference events specifically use `CostCategory.AiInference`. The provider call-site migration encodes this — every inference event has `Category = CostCategory.AiInference`.
+
+**ADR-0052 D14 Phase 1 — Loose initial caps; intentional permissive first month.** The Phase-1 stub `DefaultCostLedger` returns `IsHardCapBreachedAsync = false` for every category — the kill-switch is deliberately inert in the stub. Packet 05 ships the Cosmos backing with the real cap check; packet 06 wires `ILlmDispatcher` to call it. Until both land, the stub is the in-process behaviour.
+
+**ADR-0016 D5 — Operator-configurable token cost rates and `ICostLedger` abstraction.** The original commitment that named `ICostLedger` as a Grid abstraction. ADR-0052 D7 is the **expansion** of that commitment, not a parallel surface. The relocation is therefore consistent with ADR-0016's intent — the abstraction moves to its natural home (Kernel) and gains the policy surface (caps, kill-switch, attribution) D5 left unspecified.
+
+## Constraints
+- **Replace, not extend.** The old AI-side `ICostLedger` is removed. Two `ICostLedger` interfaces in scope would force `using` aliases on every consumer; that is a worse API than the migration.
+- **Stub, not implementation.** `DefaultCostLedger` is a Phase-1 non-durable stub. The Cosmos backing is packet 05. Do not implement Cosmos persistence in this packet.
+- **One-commit version bump.** Every non-test `.csproj` shares the new minor version (invariant 27); partial bumps are forbidden.
+- **Per-package CHANGELOG hygiene.** Only packages with real changes get entries. The `HoneyDrunk.AI` runtime gets an entry (the `DefaultCostLedger` rewrite); the four provider packages each get an entry (the call-site migration); `HoneyDrunk.AI.Abstractions` gets an entry (the deletion). No noise entries on alignment-only bumps (invariant 12/27).
+- **No edit to the Architecture-repo catalog from this packet.** Packet 01 marked the AI `ICostLedger` entry as relocating; the catalog cleanup that deletes the entry is named in packet 09 (the playbook) to avoid splitting the AI-code change across two repos.
+- **Do not touch `HoneyDrunk.Kernel`.** The Kernel-side contract addition was packet 03; this packet is AI-only.
+- **No new Azure resource.** The stub is non-durable; the Cosmos provisioning is a Human Prerequisite on packet 05, not this packet.
+
+## Labels
+`feature`, `tier-2`, `ai`, `ops`, `adr-0052`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Remove the seed `HoneyDrunk.AI.Abstractions.ICostLedger` and its supporting types, point `HoneyDrunk.AI.Abstractions` and every AI provider package at the new `HoneyDrunk.Kernel.Abstractions.ICostLedger`, and rewrite `DefaultCostLedger` as a Phase-1 non-durable stub against the Kernel contract. Bump the `HoneyDrunk.AI` solution one minor version.
+
+**Target:** `HoneyDrunk.AI`, branch from `main`.
+
+**Context:**
+- Goal: Complete the AI-side half of the ADR-0052 D7 relocation. The Kernel-side addition was packet 03; this packet replaces the old AI-side `ICostLedger` with the Kernel contract and migrates every call site.
+- Feature: ADR-0052 Cost Governance rollout, Wave 3.
+- ADRs: ADR-0052 D1/D7/D14 (primary), ADR-0016 D5 (the seed commitment this expands).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:03` — the Kernel contract surface (Kernel `0.9.0` or whichever version packet 03 lands at) must exist on the NuGet feed (gated by the human release-tag step on `HoneyDrunk.Kernel` after packet 03 merges).
+
+**Constraints:**
+- Replace, not extend — the old AI-side `ICostLedger` is deleted, not kept alongside.
+- `DefaultCostLedger` is a Phase-1 stub — non-durable, no kill-switch enforcement. The Cosmos backing is packet 05.
+- One-commit solution-wide version bump (invariant 27).
+- Per-package CHANGELOG hygiene (invariant 12/27).
+- Do not edit the Architecture-repo catalog from this packet — packet 09 (the playbook) handles the catalog cleanup.
+
+**Key Files:**
+- `HoneyDrunk.AI/src/HoneyDrunk.AI.Abstractions/` — deletions + csproj edit.
+- Every provider package source + csproj.
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/DefaultCostLedger.cs` — rewritten as a stub.
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/ServiceCollectionExtensions.cs` — verify DI registration.
+- Every CHANGELOG with a real change; repo-level `CHANGELOG.md`; `HoneyDrunk.AI.Abstractions/README.md`.
+
+**Contracts:**
+- Removed: `HoneyDrunk.AI.Abstractions.ICostLedger`, `InferenceCost`, `CostSummary`.
+- Consumed: `HoneyDrunk.Kernel.Abstractions.ICostLedger`, `CostEvent`, `CostCategory`, `LlmInferenceSource`, `CostEnvironment`.

--- a/generated/issue-packets/active/adr-0052-cost-governance/05-ai-cosmos-backed-cost-ledger-implementation.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/05-ai-cosmos-backed-cost-ledger-implementation.md
@@ -1,0 +1,217 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.AI
+labels: ["feature", "tier-2", "ai", "ops", "adr-0052", "wave-4"]
+dependencies: ["packet:02", "packet:04"]
+adrs: ["ADR-0052", "ADR-0016", "ADR-0036"]
+accepts: ["ADR-0052"]
+wave: 4
+initiative: adr-0052-cost-governance
+node: honeydrunk-ai
+---
+
+# Implement the v1 Cosmos-backed ICostLedger in HoneyDrunk.AI
+
+## Summary
+Replace the Phase-1 stub `DefaultCostLedger` (from packet 04) with the v1 Cosmos-backed implementation per ADR-0052 D7 / D8: Cosmos persistence with `(category, year-month)` partition key, in-memory cache for hot-path reads refreshed every 30 seconds, the `IBudgetConfigProvider` consumer that reads `business/context/cost-budgets.json` (via Vault's `IConfigProvider` per ADR-0016 D5), and the per-tenant / per-agent attribution dimensions on writes. The dispatcher kill-switch wiring is **packet 06** — this packet ships the storage and the cap-check read; the wiring to `ILlmDispatcher` lands next.
+
+## Context
+ADR-0052 D7 commits the v1 ledger implementation to `HoneyDrunk.AI`. ADR-0052 D8 commits Cosmos as the persistence layer:
+- **Partition key:** `(category, year-month)` — single-digit-ms writes regardless of total table size.
+- **Row key:** event timestamp + optional tenant id + optional agent id.
+- **Single region** at v1 — the ledger is tier-2 per ADR-0036 (loss is recoverable from upstream APIs over 24–48h by re-polling Azure Cost Management / vendor APIs / GitHub).
+- **In-memory cache** for the hot-path `IsHardCapBreachedAsync` read — refreshed every 30 seconds; the cache stores the current-month roll-up per category.
+- **Retention:** rolling 13 months (current + 12 trailing). Older data exported to cold storage per ADR-0036 backup pattern before deletion.
+- **Cosmos cost** is itself a line item in the Azure infra category; the aggregator (D14 Phase 2, gated on Operator standup) captures it back into the ledger.
+
+The in-memory cache is **non-negotiable**: a kill-switch that checks asynchronously after the bill has been incurred is not a kill-switch. The hot-path read is a dictionary lookup (sub-microsecond) at v1 LLM call volume. The cache miss path reads Cosmos (single-digit ms). Cache invalidation on cap-config change is event-driven; cache invalidation on aggregator writes is on the 30-second tick.
+
+**Repo-state gate.** This packet requires the AI Node to be scaffolded enough to host a Cosmos client, a `HostedService` (for the cache refresh), and the `IBudgetConfigProvider` consumption. As of edit time, `HoneyDrunk.AI` is at seed status — the ADR-0016 Phase-1 scaffold packet has not been executed. **This packet is gated on the AI Node scaffold; it cannot land before ADR-0016's scaffold work completes.** The dispatch plan flags this as the initiative's biggest gate.
+
+**Package placement.** The Cosmos client and the implementation live in **`HoneyDrunk.AI`** (the runtime package), not in a new `HoneyDrunk.AI.Cost.Cosmos` provider package. Rationale: ADR-0052 D7 explicitly says "the concrete implementation lives in `HoneyDrunk.AI` for v1" — co-located with the dispatcher. A future promotion to `HoneyDrunk.CostLedger` Node (D7 promotion path) lifts the implementation out of AI; until then it lives in the runtime. If `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/` does not yet exist, this packet creates it; if `DefaultCostLedger` was added in packet 04 as a stub, this packet replaces its body.
+
+**`IBudgetConfigProvider` source.** ADR-0016 D5 commits operator-configurable rates "sourced from Azure App Configuration via Vault's `IConfigProvider`." The budget config (`business/context/cost-budgets.json` per ADR-0052 D2) is the source-of-truth; in production, the file's contents are mirrored to App Configuration (or the file is read directly from the repo by the deployable, depending on the deploy pattern). This packet implements `BudgetConfigProvider` to read either source:
+- **Phase-1 source (this packet):** read `business/context/cost-budgets.json` from the application's working directory or a configured path. The file is committed in the Architecture repo (packet 02); deployables either bundle a copy at build time or mount the Architecture repo as a sidecar. Document the chosen pattern in the implementation.
+- **Phase-2 source (future):** Vault `IConfigProvider` → App Configuration → JSON content. Refactor when the operator-configurable-rates pipeline (ADR-0016 D5) is built end-to-end.
+
+The implementation is forward-compatible: `BudgetConfigProvider` consumes an injected source abstraction so the Phase-1 file source can be swapped for App Configuration later without touching call sites.
+
+**Cosmos provisioning.** A new Cosmos database + container is provisioned per environment (dev, prod). This is a Human Prerequisite (portal click — see Memory note on portal-over-CLI preference). The container is sized per ADR-0052 D8's storage projection: ~2.6 GB at the upper bound (100K events/month × 13 months × 2KB), RU/s well under the 400 RU/s autoscale floor. Choose the **cheapest viable tier** (per the Memory `feedback_default_cheapest_azure_tier` note): Cosmos serverless is appropriate for dev (pay-per-request, no minimum); for prod, autoscale 400 RU/s is the floor. Show $ before clicking Create — at projected volume the prod tier is single-digit-dollars / month.
+
+**Kill-switch enablement is NOT in this packet.** Packet 06 wires `ILlmDispatcher` to call `IsHardCapBreachedAsync` and throw `BudgetExceededException`. This packet ships the read with `IsHardCapBreachedAsync` returning a correct answer per the cache state, but no LLM call site checks it yet — until packet 06 lands, the kill-switch is inert. This is the deliberate ADR-0052 D14 Phase 1 posture: ship the ledger first, validate it under real load with **loose caps** (Phase 1 explicit: "initial caps are intentionally loose ($5000 / $10000 across all categories) so the kill-switch does not fire spuriously while baselines are being established"), only then turn enforcement on (Phase 4 — packet 06 in this initiative + a follow-up flip).
+
+**Phase-1 loose caps.** This packet's runtime reads the D2 defaults from `cost-budgets.json` (committed in packet 02) — those are the **final-state** caps, not the Phase-1 loose caps. The Phase-1 loose-cap behaviour is delivered by **a config-time override**: a `BudgetConfigPhaseOneMultiplier` setting on `BudgetConfigProvider` (default 10x in dev; 1x in prod) multiplies the configured caps until the operator explicitly flips it off. The multiplier is documented in the implementation; the flip happens after Phase 3 (D14) and is named in the playbook (packet 09). Until the flip, dev environments effectively run at 10x the D2 caps — the kill-switch is non-spurious, and prod runs at the D2 caps from the start (prod is exposed to fewer test-only spikes, so Phase 1 caution there is less acute).
+
+## Scope
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/` — replace the stub `DefaultCostLedger` with the v1 implementation:
+  - `CostLedger` (or replace `DefaultCostLedger`'s body) — implements `ICostLedger`; Cosmos writes; in-memory cache for the hot-path read.
+  - `BudgetConfigProvider` — implements `IBudgetConfigProvider`; reads `cost-budgets.json`; applies the Phase-1 multiplier.
+  - `CostLedgerCacheRefreshService` — `IHostedService` that refreshes the in-memory cache every 30 seconds.
+  - `CostLedgerCosmosOptions` — configuration record (Cosmos endpoint, key/Managed Identity, database name, container name).
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/ServiceCollectionExtensions.cs` — register `CostLedger` for `ICostLedger`; register `BudgetConfigProvider` for `IBudgetConfigProvider`; register `CostLedgerCacheRefreshService` as a `HostedService`.
+- Cosmos container provisioning Bicep / IaC where the AI Node keeps its infra-as-code, if such a folder exists. If the AI Node does not yet have an `infra/` directory, create one with a brief README and the Cosmos Bicep file; the actual Azure provisioning is a Human Prerequisite (portal click). Match the conventions of other Nodes that have shipped infra-as-code at edit time.
+- Unit tests for `CostLedger` against a Cosmos test double or the InMemory pattern (ADR-0047 Tier-1: unit tests do not depend on external services per invariant 15).
+- Integration tests against a real Cosmos emulator (Tier-2a per ADR-0047 D4) if the repo has the Testcontainers / Cosmos-emulator pattern wired; otherwise gate the integration test behind a `[Fact(Skip="...")]` and name the gate clearly.
+- The AI solution version-bumped (the second packet on the AI solution in this initiative; appends to the in-progress version entry started by packet 04 — does NOT bump again, per invariant 27).
+- Per-package CHANGELOG entries for the AI runtime; no entries on other packages.
+- Repo-level `CHANGELOG.md`.
+
+## Proposed Implementation
+1. **`CostLedger` class** — implements the five `ICostLedger` members from `HoneyDrunk.Kernel.Abstractions`:
+   - `RecordCostAsync(CostEvent evt, ct)` — write the event to Cosmos with partition key `$"{evt.Category}|{evt.Timestamp:yyyy-MM}"`. Atomically update the in-memory month-to-date counter for `evt.Category` (`Interlocked.Add` on a `Dictionary<CostCategory, long>` of cents, or the equivalent for `decimal`). `Local`-environment events are written to Cosmos for visibility (D12: "I burned $40 of AI inference yesterday debugging the dispatcher") but **do not update the cap-check cache** — they are exempt from caps.
+   - `GetMonthToDateAsync(category, ct)` — return the cache value. Cache miss path: read Cosmos for the current month's events, sum, populate cache, return. Cache TTL is the 30-second refresh tick.
+   - `IsHardCapBreachedAsync(category, ct)` — return `GetMonthToDateAsync(category) >= hardCap` for that category. Read the hard cap from `BudgetConfigProvider`. If the category has an active `BudgetOverride` (read via `GetActiveOverrideAsync`), return `false` until the override expires. Apply the dev overlay if the current environment is `Dev`. Apply the Phase-1 multiplier on `BudgetConfigProvider` for the effective cap.
+   - `GetActiveOverrideAsync(category, ct)` — read the active `BudgetOverride` for the category from Cosmos (a separate small container, or a sentinel row in the same container with a known partition key — pick the cheaper option). Return `null` if no override is active or the active override has expired.
+   - `QueryAsync(query, ct)` — issue a Cosmos query against the partition matching `query.Category` and `query.From..query.To`; yield results matching every non-null filter. Use `IAsyncEnumerable` (Cosmos supports streaming pagination).
+2. **`BudgetConfigProvider` class** — implements `IBudgetConfigProvider.GetAsync`. Reads `business/context/cost-budgets.json` (or the App Configuration source in a future variant). Applies the Phase-1 multiplier (`CostLedgerCosmosOptions.PhaseOneMultiplier`, default 10x in `Dev`/`Staging`, 1x in `Prod`). Returns the resolved `BudgetConfig`. Cache the result for a configurable interval (e.g., 60 seconds) so config changes are picked up but the JSON file is not re-parsed on every cap check.
+3. **`CostLedgerCacheRefreshService` class** — `IHostedService` (or `BackgroundService`) that loops every 30 seconds, calls into `CostLedger` to refresh its month-to-date cache from Cosmos. Use `TimeProvider` so tests do not require `Thread.Sleep` (invariant 51). On `StopAsync`, exit cleanly.
+4. **`CostLedgerCosmosOptions`** — configuration record: `string Endpoint`, `string Database`, `string Container`, `string OverrideContainer` (or a single container with sentinel rows — decide at implementation time and document), `decimal? PhaseOneMultiplierDev`, `decimal? PhaseOneMultiplierStaging`, `decimal? PhaseOneMultiplierProd`. Authentication: Managed Identity preferred (consumes the `DefaultAzureCredential` chain); never store the Cosmos primary key in source. If a key is needed for `Local` development, source it from Vault (`IConfigProvider`) per the Grid pattern.
+5. **DI registration.** In `ServiceCollectionExtensions`:
+   ```csharp
+   services.AddSingleton<ICostLedger, CostLedger>();
+   services.AddSingleton<IBudgetConfigProvider, BudgetConfigProvider>();
+   services.AddHostedService<CostLedgerCacheRefreshService>();
+   services.AddOptions<CostLedgerCosmosOptions>().Bind(configuration.GetSection("CostLedger"));
+   ```
+   Keep the registration idempotent — packet 04 already registered `ICostLedger -> DefaultCostLedger`; this packet replaces it with `ICostLedger -> CostLedger`. The stub is removed (or kept as `DefaultCostLedger` with an `[Obsolete]` attribute and a follow-up to delete).
+6. **Cosmos provisioning IaC.** A Bicep file (or the convention the AI Node uses for IaC at edit time) declaring the Cosmos account, database, and container. Tagging per the Memory `feedback_lean_azure_tags` note: `env` (always), `node=ai`. No `initiative` tag. Choose the cheapest viable tier (serverless for dev, autoscale 400 RU/s for prod) per the Memory cheapest-tier preference. Document the dollar projection in the Bicep header comment so the operator sees the cost before clicking Create.
+7. **Unit tests.** Cover:
+   - `CostLedger.RecordCostAsync` writes correctly partitioned events to a fake Cosmos client (use a test double).
+   - `CostLedger.IsHardCapBreachedAsync` returns `true` when month-to-date exceeds the cap and `false` when within bounds.
+   - `IsHardCapBreachedAsync` returns `false` while a `BudgetOverride` is active and unexpired, even when month-to-date exceeds the cap.
+   - `IsHardCapBreachedAsync` returns the strict cap behaviour again after the override expires.
+   - `Local`-environment events do not affect the cap-check cache.
+   - The dev overlay applies in `Dev` and not in `Prod`.
+   - Phase-1 multiplier inflates the effective cap as expected.
+   No external services in unit tests (invariant 15); no `Thread.Sleep` (invariant 51) — use `TimeProvider` injection.
+8. **Integration tests** (Tier-2a per ADR-0047 D4) — only if the AI Node already has the Testcontainers / Cosmos-emulator pattern wired. If not, name a `[Fact(Skip="Tier-2a: requires Cosmos emulator harness — gated on AI Node integration-test wiring.")]` with the exact Skip reason; the test code is still ready for activation. Verify the partition-key shape, the retention policy, and a full claim-record-query roundtrip.
+9. **Solution-wide append-only version handling.** This packet is the second packet on the `HoneyDrunk.AI` solution in this initiative (packet 04 was the first). Per invariant 27, this packet appends to the in-progress version entry started by packet 04 — it does NOT bump again. The `[X.Y.Z]` CHANGELOG line is the same one packet 04 created; append the v1-implementation entries under it. Repo-level `CHANGELOG.md` is also appended (not a new top-level entry).
+10. **Per-package CHANGELOG hygiene.** `HoneyDrunk.AI/CHANGELOG.md` gets an entry: "`DefaultCostLedger` Phase-1 stub replaced with the Cosmos-backed v1 implementation per ADR-0052 D7/D8. Hot-path cap-check read served from a 30-second-refresh in-memory cache. `BudgetConfigProvider` reads `business/context/cost-budgets.json`. Kill-switch enforcement is wired in packet 06 — until then, the cap check returns the correct answer but no call site consumes it." No CHANGELOG entries on other packages (alignment-only bumps).
+
+## Affected Files
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/CostLedger.cs` (or replaces `DefaultCostLedger.cs`)
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/BudgetConfigProvider.cs` (new)
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/CostLedgerCacheRefreshService.cs` (new)
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/CostLedgerCosmosOptions.cs` (new)
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/ServiceCollectionExtensions.cs` — DI registration update
+- `HoneyDrunk.AI/infra/cost-ledger.bicep` (or the convention the AI Node uses for IaC; new file)
+- Tests under the AI test project(s)
+- `HoneyDrunk.AI/CHANGELOG.md`; repo-level `CHANGELOG.md`
+
+## NuGet Dependencies
+- **`HoneyDrunk.AI`** (runtime) — adds:
+  - `Microsoft.Azure.Cosmos` (Cosmos .NET SDK) at the current stable major.
+  - `Azure.Identity` (for `DefaultAzureCredential`) if not already referenced.
+  - `Microsoft.Extensions.Hosting.Abstractions` for `IHostedService` if not already pulled in.
+  - `Microsoft.Extensions.Options` for the options pattern.
+  - All packages are subject to the Grid's pinning policy.
+- **Test project** — adds whatever Cosmos test-double / fake-client pattern the repo uses (NSubstitute is the Grid mock library per ADR-0047 D1; build a test double manually rather than mocking Cosmos SDK types directly).
+- Confirm at edit time that none of the above are forbidden by the AI Node's existing standards / boundaries.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.AI`. ADR-0052 D7 explicitly places the v1 implementation here.
+- [x] No new HoneyDrunk runtime dependency — the implementation consumes `HoneyDrunk.Kernel.Abstractions` (additive-abstraction reference allowed per invariant 4 DAG: AI depends on Kernel).
+- [x] Cosmos persistence is the AI Node's first persistence dependency. Standup work must include the Cosmos provisioning step (Human Prerequisite below).
+- [x] The dispatcher kill-switch wiring is **not** in this packet (packet 06).
+- [x] No edit to the Architecture-repo catalog or budget config from this packet — they are committed in packets 01/02.
+
+## Acceptance Criteria
+- [ ] `CostLedger` implements the five Kernel `ICostLedger` members; the implementation file is at `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/CostLedger.cs` (or named consistently with the stub it replaces)
+- [ ] `RecordCostAsync` writes to Cosmos with partition key `(category, year-month)`
+- [ ] `IsHardCapBreachedAsync` is served from an in-memory cache (no Cosmos read on the hot path); cache refreshes on a 30-second tick via `CostLedgerCacheRefreshService`
+- [ ] An active `BudgetOverride` causes `IsHardCapBreachedAsync` to return `false` for that category until the override expires
+- [ ] `Local` events are written to Cosmos but do not affect the cap-check cache (D12)
+- [ ] The dev overlay (D12) applies when `Environment == Dev`; production caps do not include dev burn
+- [ ] The Phase-1 multiplier inflates the effective cap when configured (default 10x in dev/staging, 1x in prod); the multiplier is operator-configurable and named in the playbook as the Phase-3 flip target
+- [ ] `BudgetConfigProvider` reads `business/context/cost-budgets.json` (or the configured source); the resolution is cached for a short interval (60 seconds default) so config changes are picked up without per-call file I/O
+- [ ] Cosmos authentication uses Managed Identity (`DefaultAzureCredential`) in non-`Local` environments; no Cosmos primary key in source or app settings
+- [ ] The Cosmos provisioning Bicep file exists under the AI Node's infra-as-code convention (or `infra/` if no convention exists yet); tagged `env`, `node=ai`; choosing the cheapest viable tier per the Grid Azure preference
+- [ ] Unit tests cover record / hot-path-cache / override / dev overlay / Phase-1 multiplier / `Local`-exemption behaviour; no external services, no `Thread.Sleep`
+- [ ] If an integration test is added, it is Tier-2a per ADR-0047 D4 and either runs against a Cosmos emulator harness or is `[Fact(Skip="...")]` with the gate documented
+- [ ] The `HoneyDrunk.AI` solution version is the same as packet 04's bump (this packet appends; invariant 27 — no second bump)
+- [ ] `HoneyDrunk.AI/CHANGELOG.md` has an appended entry under the in-progress version; no per-package CHANGELOG entries on other packages (alignment-only); repo-level `CHANGELOG.md` appended
+- [ ] The solution builds; tests pass; the DI registration replaces the stub with `CostLedger` (the stub class may remain marked `[Obsolete]` for one release before deletion, or may be deleted in this PR — pick at edit time and document)
+
+## Human Prerequisites
+- [ ] **Wave-3 → Wave-4 human release tag on `HoneyDrunk.AI` for packet 04.** This packet appends to packet 04's in-progress version; verify the version is correctly in-progress (not released) before this packet builds. Agents merge code but never tag or publish.
+- [ ] **Cosmos account provisioning per environment (dev, prod).** Portal click: create the Cosmos account, database, and container per the Bicep file. Choose the cheapest viable tier (serverless for dev, autoscale 400 RU/s for prod). Tag `env=dev|prod`, `node=ai`. Show $ before clicking Create — at projected volume (~2.6 GB across 13 months, well under 400 RU/s) the prod cost is single-digit-dollars / month. Cross-link to the cost-budgets.json file so the operator notes that this provisioning itself counts against the Azure infra category.
+- [ ] **Cosmos endpoint configuration in App Configuration / Vault.** The endpoint URL and database/container names land in App Configuration so the AI deployable resolves them at startup via the Grid's `IConfigProvider` (ADR-0016 D5). No primary keys — Managed Identity is the auth path. Seed the App Configuration key `CostLedger:Endpoint`, `CostLedger:Database`, `CostLedger:Container` in each environment.
+- [ ] **RBAC: grant the AI Container App's Managed Identity `Cosmos DB Built-in Data Contributor` on the cost-ledger database.** This is the data-plane RBAC role that lets Managed Identity write events without a primary key. Apply in each environment.
+- [ ] **App Configuration values for the Phase-1 multiplier per environment.** `CostLedger:PhaseOneMultiplier:Dev` = 10 (or whatever the operator chooses); `CostLedger:PhaseOneMultiplier:Prod` = 1. Document the chosen values in the deployment notes for the Phase-3 flip (named in packet 09).
+
+## Referenced ADR Decisions
+**ADR-0052 D7 — V1 implementation in `HoneyDrunk.AI`.** Co-located with the dispatcher so the kill-switch read is in-process. Non-AI categories (Azure infra, SaaS, CI, domain) are externally sourced via an Operator aggregator (D14 Phase 2, future) writing the same `ICostLedger` shape. Promotion path: when non-AI categories grow material or a second writer Node appears, `HoneyDrunk.CostLedger` graduates to its own Node — the interface in Kernel is unchanged.
+
+**ADR-0052 D8 — Persistence and retention.** Cosmos DB, single-region (write-mostly workload). Partition key `(category, year-month)`. Row key includes timestamp + optional tenant id + optional agent id. In-memory cache of current-month roll-up per category, refreshed every 30 seconds. Cosmos is the durable store; the cache is the latency-critical surface. Retention is rolling 13 months. Tier 2 per ADR-0036 (loss is recoverable from upstream APIs over 24–48 hours).
+
+**ADR-0052 D5 / D6 — Attribution dimensions on writes.** Every event carries optional `TenantId`; AI inference events additionally carry `AgentId` / `AgentRunId`. The implementation must preserve these on the wire to Cosmos so `QueryAsync` can later filter by them. Backfilling unattributed historical events is impossible — the contract is "attribute at write time or never."
+
+**ADR-0052 D11 — Override semantics.** Active overrides cause `IsHardCapBreachedAsync` to return `false` until expiry. Overrides are time-bounded (default 24h); permanent overrides do not exist. Override writes are NOT performed by this packet — the `hd cost unlock` CLI on Operator (future, gated on ADR-0018) is the only sanctioned override path (invariant 92). This packet only **reads** overrides via `GetActiveOverrideAsync`.
+
+**ADR-0052 D12 — Test and dev environment treatment.** Dev caps on a separate subscription or tagged resource group. Production caps do not include dev burn. Every `CostEvent` carries `Environment`; `Local` events are recorded but exempt from caps.
+
+**ADR-0052 D14 Phase 1 — Loose initial caps.** Initial caps are deliberately permissive while baselines are established. This packet ships the runtime with the operator-configurable Phase-1 multiplier (default 10x in dev/staging, 1x in prod). The flip to D2 final-state values happens after Phase 3; named in the playbook (packet 09).
+
+**ADR-0016 D5 — Operator-configurable rates.** The budget config is sourced via Vault's `IConfigProvider`. The Phase-1 source in this packet is the JSON file directly; the Phase-2 source is App Configuration via Vault.
+
+**ADR-0036 (tier-2 backup).** The ledger inherits the tier-2 RTO/RPO; loss is recoverable from upstream APIs over 24–48 hours by re-polling Azure Cost Management / vendor APIs / GitHub.
+
+## Constraints
+> **Invariant 1 — Abstractions zero-dependency.** `HoneyDrunk.AI.Abstractions` (which packet 04 already aligned) does NOT take a Cosmos SDK dependency. The Cosmos SDK lives only in the runtime package (`HoneyDrunk.AI`).
+
+> **Invariant 4 — DAG.** `HoneyDrunk.AI` depends on `HoneyDrunk.Kernel`. Do not invert.
+
+> **Invariant 8 — Secrets never in telemetry.** Cosmos primary keys never appear in logs, traces, or exceptions. Managed Identity is the auth path; if a key is unavoidable for `Local`, source it from Vault and never log it.
+
+> **Invariant 12 / 27 — CHANGELOG hygiene + one-solution-one-version.** This packet appends to packet 04's in-progress version; no new bump. Only `HoneyDrunk.AI/CHANGELOG.md` gets an entry (the runtime has the real change); other packages get no entry on the alignment-only bump.
+
+> **Invariant 15 — Unit tests no external services.** The Cosmos client is mocked / faked in unit tests.
+
+> **Invariant 47 (referenced) — Audit substrate.** Override writes (which this packet does NOT perform) are audited via `IAuditLog`; the read path here just retrieves the current override state.
+
+> **Invariant 51 — No `Thread.Sleep` in tests.** Use `TimeProvider` for the cache-refresh timing in tests.
+
+> **Invariant 91 (this initiative, packet 00) — `ILlmDispatcher` checks the cap on the hot path.** This invariant is satisfied by **packet 06**, not this one. This packet ships the cap-check method; packet 06 wires the dispatcher to call it.
+
+- **Phase-1 stub replacement, not a parallel implementation.** Replace `DefaultCostLedger`'s body; do not keep both. (Keeping the stub as `[Obsolete]` for one release is acceptable; a parallel implementation in scope is not.)
+- **No kill-switch enforcement from this packet.** The cap-check answer is correct; no call site consumes it until packet 06. ADR-0052 D14 Phase 1's "Daily roll-up email enabled; threshold pings disabled until Phase 3" is partially honoured here (this packet does not wire the daily roll-up — that is also gated on the Operator standup); threshold pings are deferred (named in packet 09).
+- **Cheapest viable Cosmos tier.** Serverless for dev; autoscale 400 RU/s for prod. The Memory note `feedback_default_cheapest_azure_tier` applies — Standard/Premium only with a concrete justification.
+- **Managed Identity over key auth.** Use `DefaultAzureCredential` for Cosmos in every non-`Local` environment.
+
+## Labels
+`feature`, `tier-2`, `ai`, `ops`, `adr-0052`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Implement the v1 Cosmos-backed `ICostLedger` in `HoneyDrunk.AI`, replacing the Phase-1 stub. Hot-path `IsHardCapBreachedAsync` served from a 30-second-refresh in-memory cache; writes partitioned by `(category, year-month)`. The kill-switch is **not** wired to the dispatcher in this packet (packet 06).
+
+**Target:** `HoneyDrunk.AI`, branch from `main`.
+
+**Context:**
+- Goal: Ship the durable ledger that backs every cost-event write and serves the kill-switch read. The dispatcher integration is packet 06; the Operator-side aggregator / CLI / dashboard wait on ADR-0018.
+- Feature: ADR-0052 Cost Governance rollout, Wave 4.
+- ADRs: ADR-0052 D5/D6/D7/D8/D11/D12/D14 (primary), ADR-0016 D5 (operator-configurable rates source), ADR-0036 (tier-2 backup).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:02` — `business/context/cost-budgets.json` exists and is the canonical source.
+- `packet:04` — `HoneyDrunk.AI.Abstractions` is reconciled against the Kernel contract; the stub `DefaultCostLedger` exists for this packet to replace.
+
+**Constraints:**
+- Replace the stub, do not run a parallel implementation.
+- No kill-switch enforcement on call sites — packet 06.
+- Cheapest viable Cosmos tier; Managed Identity, never primary keys.
+- One-solution-one-version: append to packet 04's in-progress version, do not re-bump.
+- Phase-1 multiplier is operator-configurable and named for the Phase-3 flip in the playbook.
+
+**Key Files:**
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/CostLedger.cs`, `BudgetConfigProvider.cs`, `CostLedgerCacheRefreshService.cs`, `CostLedgerCosmosOptions.cs`
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/ServiceCollectionExtensions.cs`
+- `HoneyDrunk.AI/infra/cost-ledger.bicep` (or the convention the AI Node uses for IaC)
+- AI test project(s)
+- `HoneyDrunk.AI/CHANGELOG.md`; repo-level `CHANGELOG.md`
+
+**Contracts:** No new contracts. Consumes `ICostLedger`, `IBudgetConfigProvider`, `CostEvent`, `CostCategory`, `BudgetOverride`, `BudgetConfig`, `CostQuery`, `CostEnvironment` from `HoneyDrunk.Kernel.Abstractions`.

--- a/generated/issue-packets/active/adr-0052-cost-governance/06-ai-dispatcher-kill-switch-wiring.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/06-ai-dispatcher-kill-switch-wiring.md
@@ -1,0 +1,185 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.AI
+labels: ["feature", "tier-2", "ai", "ops", "canary", "adr-0052", "wave-5"]
+dependencies: ["packet:05"]
+adrs: ["ADR-0052"]
+accepts: ["ADR-0052"]
+wave: 5
+initiative: adr-0052-cost-governance
+node: honeydrunk-ai
+---
+
+# Wire ILlmDispatcher to call IsHardCapBreachedAsync and throw BudgetExceededException before each call
+
+## Summary
+Wire the AI Node's chat / inference dispatcher (the dispatcher that ADR-0052 calls `ILlmDispatcher` and that the existing AI surface exposes as `IChatClient` / `IEmbeddingGenerator`) to call `ICostLedger.IsHardCapBreachedAsync(CostCategory.AiInference)` **before** each model call; throw `BudgetExceededException` synchronously if the cap is breached and no active override is in effect. Add the kill-switch canary that exercises the throw and verifies callers cannot retry, and add per-call attribution wiring so `AgentId` / `AgentRunId` / `TenantId` flow into the recorded `CostEvent`. This packet satisfies invariant 91 (`ILlmDispatcher` checks the ledger before each call) and closes the ADR-0052 D14 Phase 4 transition from "log a warning" to "throw `BudgetExceededException`."
+
+## Context
+ADR-0052 D4 specifies the AI-inference kill-switch shape exactly:
+- The check is on the **hot path** of every LLM call. The `IsHardCapBreachedAsync` read is served from an in-memory cache (packet 05) so latency is sub-microsecond at v1 call volume.
+- If month-to-date is at or above the hard cap (and no override is active), the dispatcher throws `BudgetExceededException` **synchronously**. The LLM call is never made.
+- The exception carries the category, the cap, the actual, and a correlation id so the caller's error surface (ADR-0045) clusters them under one problem id.
+- `BudgetExceededException` is **sealed** and **non-transient**. Callers must not retry; the exception means "this category is closed for the rest of the billing window or until an operator override engages." Retry loops that swallow the exception and try again immediately defeat the kill-switch. The `review` agent gains a catch-and-retry detection rule (packet 08).
+
+The kill-switch is **per-category, Grid-wide** at v1 — a misbehaving agent burning the AI inference cap halts **all** agents, not just the offender (D4). Per-agent enforcement is named as future work; the dimensions (D6) are captured here so a future ADR can add per-agent enforcement without changing the storage shape.
+
+**ADR-0052 D14 Phase 4 — the dangerous phase.** ADR-0052 calls Phase 4 ("kill-switch enablement") explicitly the dangerous one: it changes runtime behaviour from logging to throwing. The phased posture in the ADR is to pilot on AI inference for one week before extending to Azure infra (which the Operator aggregator handles, not this packet) and validating GitHub-native CI limit. **This packet ships the throw** — the operator's pilot week is a deployment-sequencing concern (deploy to dev first, observe for one week, then prod). The packet stages the runtime change but does not force the deploy.
+
+**Existing AI dispatcher surface.** At edit time, `HoneyDrunk.AI.Abstractions` exposes `IChatClient` (chat completion, aligned with `Microsoft.Extensions.AI`) and `IEmbeddingGenerator`. ADR-0052 refers to "`ILlmDispatcher`" — that is the **role**, not a separately-named type. The dispatcher pattern in the AI Node is the routed-through-`IModelRouter`-and-into-provider chain. The cap check happens at the routing seam, before any provider call. **Pick the chokepoint at edit time:** ideally the `IModelRouter` implementation (`DefaultModelRouter` or whatever the standup landed) or a small decorator around it. Document the decision in the implementation: "the kill-switch check lives at \<chokepoint\>; any future LLM-call path that bypasses \<chokepoint\> must add its own check."
+
+**Per-call attribution wiring.** Packet 04 migrated providers to call `RecordCostAsync(CostEvent)`. The `TenantId` / `AgentId` / `AgentRunId` fields on the event come from ambient context — `IGridContext` (or whatever the Kernel context contract is at edit time). Verify that the providers populate them; if any provider has them as `null` because the standup hadn't plumbed them through, fix it here. The attribution must be in place at the moment the event is recorded — historical events cannot be backfilled with attribution (D5).
+
+**Override priority over the cap check.** `IsHardCapBreachedAsync` (packet 05) already honours active overrides — when an override is active and unexpired, it returns `false`. The dispatcher does not need to separately query the override; one call answers "can this call go through." Document that the override is the operator's emergency / planned escape (D11) and the dispatcher's check honours it implicitly.
+
+**Operator-side D14 Phase 4 follow-ons are not in this packet.** The Container Apps auto-suspend job (Azure-infra kill-switch), the GitHub-native CI limit policy mirror, and the daily roll-up / threshold pings / breach push notifications all wait on the ADR-0018 Operator scaffold. They are named in packet 09 (the playbook), not this one. This packet is the AI-side half of Phase 4: AI inference goes from "log warning" to "throw `BudgetExceededException`" in-process.
+
+**Phase 4 pilot semantics.** ADR-0052 D14 names a one-week observation on AI inference before extending to other categories. This packet ships the runtime change; the observation is a deployment concern (deploy to dev, observe, then prod). Document the recommended deploy sequence in the PR description: deploy to dev with the Phase-1 multiplier (packet 05) set to 10x so the cap is effectively very loose; observe for false breaches; flip the multiplier to 1x; observe; deploy to prod. The flip is operator-driven via App Configuration — not a code change.
+
+**Repo-state gate.** This packet, like packet 05, requires the AI Node to be scaffolded. If the ADR-0016 scaffold has not landed, this packet sits behind it. The dispatch plan flags both packets 05 and 06 as gated on the AI scaffold.
+
+## Scope
+- `HoneyDrunk.AI` runtime — wire the kill-switch check into the dispatcher chokepoint:
+  - A `CostKillSwitchInterceptor` (or the equivalent decorator / interceptor pattern the AI Node already uses) that wraps the routing chokepoint and calls `IsHardCapBreachedAsync` before each call; throws `BudgetExceededException` if breached.
+  - Updates to the DI composition so the interceptor / decorator runs on every chat-completion and embedding path.
+- A per-call attribution check — ensure every provider call site recording a `CostEvent` populates `TenantId`, `AgentId`, `AgentRunId` from ambient context (`IGridContext`); add the context plumbing if missing.
+- The kill-switch canary in `HoneyDrunk.AI.Tests.Canaries` (or the existing AI canary project at edit time) — exercises the breach path end-to-end, asserts `BudgetExceededException` is thrown, asserts the exception is `sealed`, asserts retry policies do not re-invoke after the throw, asserts the message body never reaches the provider.
+- Unit tests for the interceptor logic.
+- The AI solution version-bumped or appended-to per invariant 27 (the third packet on the AI solution in this initiative).
+- Per-package CHANGELOG entries for the AI runtime; no entries on other packages.
+- Repo-level `CHANGELOG.md`.
+
+## Proposed Implementation
+1. **Identify the chokepoint.** At edit time, look at the AI Node's dispatcher composition. The pattern that gives the simplest single check is one of:
+   - A decorator over `IModelRouter` (likely cleanest if the standup uses a single router).
+   - A decorator over `IChatClient` and `IEmbeddingGenerator` at the abstraction layer.
+   - A pipeline step in whatever invocation pipeline the AI Node already has.
+   Pick the option that yields one check per LLM call (not per-provider duplication; not at the abstraction layer where a non-LLM call might hit it). Document the choice in the implementation file's header comment.
+2. **`CostKillSwitchInterceptor`** — implements the chosen seam. Before each call:
+   - Call `await costLedger.IsHardCapBreachedAsync(CostCategory.AiInference, ct)`.
+   - If `true`, retrieve the cap and the month-to-date for the diagnostic (`var cap = (await budgetConfigProvider.GetAsync(ct)).Categories[CostCategory.AiInference].HardCap`; `var actual = await costLedger.GetMonthToDateAsync(CostCategory.AiInference, ct)`).
+   - Throw `new BudgetExceededException(CostCategory.AiInference, cap, actual, gridContext.CorrelationId)`.
+   - Otherwise, await the inner call as normal.
+   The interceptor does not log the cap-not-breached path (it is the hot path). It logs the breach via structured event (an `IErrorReporter` call per ADR-0045 — see step 6).
+3. **`BudgetExceededException` flow through `IErrorReporter`.** Per ADR-0045 / invariant 90, the breach is captured-as-error: emit a structured event through `IErrorReporter` (the facade ADR-0045 ships) with the problem-group key `Honeydrunk.Cost.HardCapBreach`. The event carries the category, the cap, the actual, the correlation id, and the (tenant, agent, agent-run) attribution if available. **Do this even though the exception will propagate** — the `IErrorReporter` capture is the persistent record (ADR-0045 D8 capture-vs-log policy applies).
+4. **Per-call attribution check.** Audit every provider's call site (touched by packet 04) and verify the `CostEvent` records `TenantId`, `AgentId`, `AgentRunId` from `IGridContext` (or the equivalent ambient-context contract). If any field is hardcoded to `null` because the standup didn't plumb the context through, fix it. Add an XML-doc note on the recording call: "Attribution dimensions come from `IGridContext`; backfilling unattributed historical events is impossible by design (ADR-0052 D5)."
+5. **DI composition update.** Register the interceptor / decorator in `ServiceCollectionExtensions` so every `IChatClient` / `IEmbeddingGenerator` (or `IModelRouter`) resolution goes through it. The composition pattern depends on the chosen chokepoint; document the order in the registration.
+6. **The kill-switch canary.** In `HoneyDrunk.AI.Tests.Canaries` (or the existing AI canary project — invariant 14 names canary projects as cross-Node-boundary validators; the cap-check-before-provider-call is exactly such a boundary):
+   - Compose a test dispatcher with a `CostLedger` seeded to month-to-date `$5000` (or any value above the test cap), the test cap configured at `$1500`, no active override.
+   - Invoke an `IChatClient.GetResponseAsync(...)` call (or the equivalent chat-completion entry) via the composed dispatcher.
+   - Assert: a `BudgetExceededException` is thrown synchronously.
+   - Assert: the type `BudgetExceededException` is `sealed` (reflection assertion).
+   - Assert: the inner provider was never called (use a counting test double or a spy).
+   - Assert: an `IErrorReporter.CaptureException` was called with problem group `Honeydrunk.Cost.HardCapBreach` (use NSubstitute against the `IErrorReporter`).
+   - Assert: after the throw, an immediate second invocation (no `try`/`catch`-retry — but a fresh call site repeating the operation) also throws — there is no transient backoff. Use a `Policy<>` that retries on `Exception` and verify the policy did NOT swallow `BudgetExceededException`. Confirm via a second test that a default retry-policy library wired against the call would throw on the first attempt, never retry.
+   - Assert: with an active `BudgetOverride` covering the test category, the same dispatcher invocation does NOT throw — the override is honoured.
+   No external services (invariant 15); no `Thread.Sleep` (invariant 51) — use `TimeProvider`.
+7. **Unit tests for the interceptor.** Cover the cap-not-breached path (call proceeds), cap-breached + no-override path (throws), cap-breached + active-override path (call proceeds), override-expired path (throws again). Verify the `IErrorReporter` capture happens on every breach.
+8. **Append-only version handling.** This packet is the third packet on the `HoneyDrunk.AI` solution in this initiative (packets 04 and 05 preceded). Per invariant 27, append to packet 04's version entry — no second bump in the same initiative. The CHANGELOG line accumulates entries for packets 04, 05, 06.
+9. **CHANGELOG.** `HoneyDrunk.AI/CHANGELOG.md` gets an entry: "`CostKillSwitchInterceptor` wired at the `<chokepoint>` seam — `IsHardCapBreachedAsync` is called before every LLM dispatch; `BudgetExceededException` thrown synchronously on breach (sealed, non-transient); active overrides honoured. Closes ADR-0052 D14 Phase 4 AI-inference enablement. Operator-side phase-4 surfaces (Azure-infra auto-suspend, GitHub-native limit mirror, daily roll-up, threshold pings, breach push) are gated on the ADR-0018 Operator standup — named in the playbook." Repo-level `CHANGELOG.md` appended.
+
+## Affected Files
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/CostKillSwitchInterceptor.cs` (new — or the equivalent decorator file name per the chosen chokepoint)
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/ServiceCollectionExtensions.cs` — DI composition update
+- Provider source — any attribution-plumbing fix
+- `HoneyDrunk.AI.Tests.Canaries/` — the kill-switch canary (and the project itself if it does not yet exist)
+- AI unit-test project(s) — interceptor tests
+- `HoneyDrunk.AI/CHANGELOG.md`; repo-level `CHANGELOG.md`
+
+## NuGet Dependencies
+- **`HoneyDrunk.AI`** — no new direct dependency beyond what packet 05 added; the implementation uses types already pulled in by `HoneyDrunk.Kernel.Abstractions` (packet 03) and the `IErrorReporter` from `HoneyDrunk.Telemetry.Abstractions` (which the AI Node likely already references for Pulse traces — confirm at edit time; if not, add the reference at the version that ships ADR-0045 packet 02).
+- **Canary project** — the Grid test stack (xUnit v2 + NSubstitute + AwesomeAssertions + coverlet per ADR-0047 D1). If the canary project does not yet exist as a `HoneyDrunk.AI.Tests.Canaries` `.csproj`, create it; new projects include `HoneyDrunk.Standards` (`PrivateAssets: all`, invariant 26) and a brief `README.md` (invariant 12 for new test projects is informational; a brief README is sufficient).
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.AI`. ADR-0052 D4 names the in-process AI-inference kill-switch and places it in the AI Node.
+- [x] No edit to `HoneyDrunk.Kernel` — the contract was packet 03; this packet consumes it.
+- [x] No edit to `HoneyDrunk.AI.Abstractions` — the contract relocation was packet 04.
+- [x] Azure-infra kill-switch / Container Apps auto-suspend is NOT in this packet — it lives in `HoneyDrunk.Operator` (gated on ADR-0018 standup).
+- [x] No Bicep / IaC change in this packet; the App Insights alert rules for D10 anomaly detection are gated on Operator-side IaC (packet 09 plays them out).
+
+## Acceptance Criteria
+- [ ] A `CostKillSwitchInterceptor` (or named equivalent) is wired at the AI dispatcher chokepoint; the chokepoint is documented in the implementation file's header
+- [ ] Before each LLM call, the interceptor calls `IsHardCapBreachedAsync(CostCategory.AiInference)`; if `true`, throws `BudgetExceededException` synchronously, never calling the inner provider
+- [ ] An active `BudgetOverride` causes the cap check to pass; the call proceeds (verified by `IsHardCapBreachedAsync` returning `false` under override, which is packet 05's behaviour — this packet's responsibility is to honour the answer it gets)
+- [ ] On breach, `IErrorReporter.CaptureException` is called with problem group `Honeydrunk.Cost.HardCapBreach`, carrying category, cap, actual, correlation id, and (tenant, agent, agent-run) attribution if available
+- [ ] Every provider call site recording a `CostEvent` populates `TenantId`, `AgentId`, `AgentRunId` from `IGridContext` (or the equivalent); no hardcoded `null` where the context has the value
+- [ ] The kill-switch canary in `HoneyDrunk.AI.Tests.Canaries` asserts: throws on breach; type is sealed; provider never called; `IErrorReporter` capture happens; default retry policy does NOT retry; override honoured
+- [ ] Unit tests cover the interceptor's four states (not-breached, breached-no-override, breached-override-active, override-expired)
+- [ ] No `Thread.Sleep` in tests (invariant 51); use `TimeProvider`
+- [ ] The `HoneyDrunk.AI` solution version is unchanged from packets 04/05 (this packet appends to the in-progress version entry; invariant 27)
+- [ ] `HoneyDrunk.AI/CHANGELOG.md` has an appended entry under the in-progress version; no per-package CHANGELOG entries on other packages
+- [ ] Repo-level `CHANGELOG.md` appended
+- [ ] The solution builds; all tests (unit + canary) pass; the `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **Recommended deploy sequence captured in the PR description.** Deploy to dev with the Phase-1 multiplier from packet 05 set to 10x (so the cap is effectively very loose); observe for false breaches for one week per the ADR-0052 D14 Phase-4 pilot guidance; flip the multiplier to 1x in App Configuration; observe for one more week; deploy to prod. The flip is operator-driven via App Configuration — not a code change. The PR description records this recommended sequence; the operator may compress or extend it based on observed behaviour.
+- [ ] **App Configuration value `CostLedger:KillSwitch:Enabled` in each environment.** Default `true` in dev (so the throw is exercised), default `true` in prod after the pilot. A `false` setting bypasses the interceptor as a safety hatch in case Phase-4 itself goes wrong. Document the setting and its semantics in the PR. The default-on-in-prod posture is consistent with ADR-0052 D14 Phase 4 — the kill-switch is the policy from day one of Phase 4 — but the safety hatch exists in case the interceptor has a defect.
+
+## Referenced ADR Decisions
+**ADR-0052 D4 — In-process kill-switch for AI inference.** `ILlmDispatcher` checks `ICostLedger.GetMonthToDate(CostCategory.AiInference)` (read as `IsHardCapBreachedAsync` in the D7 preview) against the configured hard cap before each call. If at or above the hard cap, the dispatcher throws `BudgetExceededException` synchronously — the LLM call is never made. The exception carries category, cap, actual, correlation id. The cost ledger read is on the hot path of every LLM call. Performance impact is sub-microsecond on a hot ledger via in-memory aggregation.
+
+**ADR-0052 D4 — `BudgetExceededException` no-retry contract.** The exception is **not transient**. Callers must not retry; the exception means "this category is closed for the rest of the billing window or until an operator override engages." Retry loops that swallow this exception defeat the kill-switch. The exception type is sealed and the documentation calls out the no-retry contract; the `review` agent gains a category check for "code catches `BudgetExceededException` and retries" as a defect (packet 08).
+
+**ADR-0052 D4 — Per-category, Grid-wide, not per-agent at v1.** A misbehaving agent burning the AI inference cap halts all agents, not just the offender. Per-agent enforcement is named as future work; the dimensions are captured here so a future ADR can add it without changing storage shape.
+
+**ADR-0052 D6 — Attribution dimensions on writes.** `AgentId` reuses the ADR-0051 identifier shape; `AgentRunId` is the per-invocation correlation. Both come from `IGridContext` (or the equivalent). Attribution at write time or never — historical events cannot be backfilled.
+
+**ADR-0052 D11 — Override semantics.** The interceptor honours an active override implicitly via `IsHardCapBreachedAsync`'s answer.
+
+**ADR-0052 D14 Phase 4 — Kill-switch enablement.** The highest-risk single change in the rollout because it changes runtime behaviour. Pilot on AI inference first; observe for one week; extend to other categories (Operator-side, not this packet). The pilot is deployment-side; this packet ships the runtime.
+
+**Invariant 91 (this initiative, packet 00) — `ILlmDispatcher` checks the cost ledger against the hard cap before each call.** This packet satisfies invariant 91. The integration test required per ADR-0047 D4 is the canary added in this packet.
+
+**ADR-0045 — `IErrorReporter` capture.** Breach events flow through `IErrorReporter` problem-grouped as `Honeydrunk.Cost.HardCapBreach` so the operator sees them in the same App Insights Failures blade as application errors.
+
+## Constraints
+> **Invariant 91 — `ILlmDispatcher` checks the cost ledger against the hard cap before each LLM call.** This packet satisfies the invariant; the cap check is on the hot path; failure to short-circuit when breached is a budgeting defect. Integration test required per ADR-0047 D4 (the canary in this packet).
+
+> **Invariant 15 — Unit tests no external services.** The interceptor unit tests use a fake `ICostLedger` and a counting test double for the inner provider.
+
+> **Invariant 27 — One-solution-one-version.** Append to packet 04's in-progress version; no second bump in this initiative.
+
+> **Invariant 51 — No `Thread.Sleep` in tests.** Use `TimeProvider` for time-driven assertions.
+
+- **`BudgetExceededException` is propagated, not swallowed.** The interceptor catches no exception; it propagates the throw to the caller. The `IErrorReporter.CaptureException` runs **before** the throw (in the same try block, or via finally — pick the pattern that matches the AI Node's existing `IErrorReporter` use).
+- **No retry inside the interceptor.** The interceptor never re-checks the cap after a throw — the cap is closed for the billing window.
+- **Choose the chokepoint once.** Do not split the cap check across multiple seams; multiple checks mean multiple defects. Pick the single seam that catches every LLM call and document it.
+- **Pilot is operator-driven.** The interceptor ships enabled by default; the App Configuration flag is a safety hatch, not a default-off.
+
+## Labels
+`feature`, `tier-2`, `ai`, `ops`, `canary`, `adr-0052`, `wave-5`
+
+## Agent Handoff
+
+**Objective:** Wire the cost-ledger kill-switch check into the AI dispatcher chokepoint so every LLM call checks `IsHardCapBreachedAsync(CostCategory.AiInference)` and throws `BudgetExceededException` synchronously on breach. Add the canary that proves the throw, the sealed type, the no-retry contract, and the override-honoured behaviour.
+
+**Target:** `HoneyDrunk.AI`, branch from `main`.
+
+**Context:**
+- Goal: Satisfy invariant 91 — `ILlmDispatcher` checks the ledger before each call. Close the AI-inference half of ADR-0052 D14 Phase 4.
+- Feature: ADR-0052 Cost Governance rollout, Wave 5.
+- ADRs: ADR-0052 D4/D6/D11/D14 (primary), ADR-0045 (`IErrorReporter` surface for breach capture), ADR-0047 (canary pattern).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:05` — the v1 `CostLedger` ships the `IsHardCapBreachedAsync` answer this packet consumes.
+
+**Constraints:**
+- Choose the chokepoint once; document it.
+- Throw `BudgetExceededException` synchronously; never retry.
+- `IErrorReporter.CaptureException` runs on every breach.
+- Active overrides are honoured implicitly via `IsHardCapBreachedAsync`.
+- Append to the in-progress version (invariant 27); no second bump.
+- Use `TimeProvider`; no `Thread.Sleep` in tests (invariant 51).
+
+**Key Files:**
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/CostKillSwitchInterceptor.cs` (or named equivalent)
+- `HoneyDrunk.AI/src/HoneyDrunk.AI/ServiceCollectionExtensions.cs` — DI update
+- `HoneyDrunk.AI.Tests.Canaries/` — the kill-switch canary
+- Provider source — attribution plumbing audit / fixes
+- `HoneyDrunk.AI/CHANGELOG.md`; repo-level `CHANGELOG.md`
+
+**Contracts:** No new contracts. Consumes `ICostLedger`, `CostCategory`, `BudgetExceededException` from `HoneyDrunk.Kernel.Abstractions`; consumes `IErrorReporter` from `HoneyDrunk.Telemetry.Abstractions` (ADR-0045).

--- a/generated/issue-packets/active/adr-0052-cost-governance/07-architecture-cost-reports-directory-and-format.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/07-architecture-cost-reports-directory-and-format.md
@@ -1,0 +1,141 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-3", "ops", "docs", "adr-0052", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0052"]
+accepts: ["ADR-0052"]
+wave: 1
+initiative: adr-0052-cost-governance
+node: honeydrunk-architecture
+---
+
+# Create generated/cost-reports/ with the canonical monthly report format spec
+
+## Summary
+Create the `generated/cost-reports/` directory with `_format.md` documenting the canonical monthly cost-report shape per ADR-0052 D9, plus a placeholder `YYYY-MM.md` example showing every required section. Document that the runtime aggregator that auto-generates these reports is gated on ADR-0018 (Operator standup) and named in the rollout playbook (packet 09). This packet ships the format spec ahead of the aggregator so the operator can author the first manual report against a known shape if needed.
+
+## Context
+ADR-0052 D9 commits two reporting surfaces:
+- **Operator Node "Cost" dashboard** — real-time control surface, lives in `HoneyDrunk.Operator` per ADR-0018 (Proposed; not yet scaffolded).
+- **Architecture repo — `generated/cost-reports/YYYY-MM.md`** — monthly auto-generated review surface, committed to git so the historical record is git-tracked.
+
+The auto-generation aggregator runs on the 1st of each month and writes the prior month's report. The aggregator itself lives in the Operator Node (D9, D13, D14 Phase 2) and waits on the ADR-0018 standup. **This packet ships the directory + format spec now** so:
+- The runtime aggregator (future) has a canonical shape to write against.
+- The operator can author a first manual report against the known shape if the aggregator is delayed.
+- The git-tracked historical record begins from a stable shape — future automated comparisons (this month vs last, this Q vs last Q) can parse the canonical sections via heading anchors without bespoke logic.
+
+ADR-0052 D9 specifies the report contents as **canonical sections**:
+1. Executive summary — single sentence per category; single sentence for the Grid total.
+2. Per-category actuals vs caps table — month-to-date, soft cap, hard cap, % of soft, % of hard, count of threshold pings fired, count of hard-cap breaches.
+3. Per-tenant cost breakdown — top 25 with an "other" row aggregating the rest.
+4. Per-agent cost breakdown (AI inference only) — sorted by cost descending; includes `cost per run` and `runs this month`.
+5. Override log — every override with operator, reason, duration, expired-naturally-or-revoked.
+6. Anomaly events — every anomaly that fired with category, magnitude, disposition.
+7. Trend appendix — sparkline-style ASCII per category for the trailing 13 months.
+
+The format is **human-first** — Markdown that reads naturally in a code review and renders cleanly on GitHub. Machine consumers parse the canonical sections via heading anchors. A future structured JSON sidecar (`YYYY-MM.json`) is named as follow-up work in ADR-0052's Follow-up Work list; this packet does not create the sidecar but reserves the file-naming convention.
+
+**Why commit the report to the Architecture repo (D9):** the repo is the historical record of the Grid; git commit history is the cheapest audit trail. A cost report that lives in an external dashboard is a cost report that disappears when the vendor relationship changes; a cost report that lives in git survives. The added storage cost is trivial (single-digit KB per month).
+
+**No runtime aggregator in this packet.** The aggregator is named in the playbook (packet 09) and gated on ADR-0018 (Operator standup) + Wave-4 ledger landing (packets 05/06). This packet's deliverable is purely the directory + format spec + a worked example.
+
+## Scope
+- `generated/cost-reports/` — new directory.
+- `generated/cost-reports/_format.md` — the canonical format specification.
+- `generated/cost-reports/EXAMPLE-YYYY-MM.md` (or named with a clearly-not-real date like `EXAMPLE.md`) — a worked example showing every section with placeholder data. The filename pattern documents the convention; the file is NOT a real report.
+- `generated/README.md` — only if `generated/` does not yet exist as a documented directory; brief overview pointing at `cost-reports/`, `issue-packets/`, etc.
+
+## Proposed Implementation
+1. **Directory creation.** Create `generated/cost-reports/` if it does not exist. (`generated/` already exists from `issue-packets/`.) No special permissions; just a Markdown file under a new subdirectory.
+2. **`_format.md`** — the canonical format spec. Sections:
+   - **Purpose.** Why this file exists; consumers (operator review, future automated comparisons, audit retrospective).
+   - **Filename convention.** `YYYY-MM.md` for real monthly reports; `EXAMPLE-*.md` for documentation examples. The runtime aggregator (future, packet 09) writes the real reports.
+   - **Section ordering.** The seven D9 sections in fixed order. Future tooling depends on heading anchor stability — name them as the spec.
+   - **Heading anchors.** Stable level-2 headings (`## Executive Summary`, `## Per-Category Actuals vs Caps`, `## Per-Tenant Cost Breakdown`, `## Per-Agent Cost Breakdown`, `## Override Log`, `## Anomaly Events`, `## Trend Appendix`). Do not reorder or rename; future parsing depends on them.
+   - **Per-category table column spec.** Document the exact column set: `Category`, `Month-To-Date`, `Soft Cap`, `Hard Cap`, `% of Soft`, `% of Hard`, `Threshold Pings Fired`, `Hard-Cap Breaches`. Money values in USD with `$` prefix and two decimals.
+   - **Per-tenant table column spec.** `Tenant`, `Month-To-Date`, `% of Grid Total`, `Top Category`, `Anomaly Events`. Top 25 + "other" aggregation row. The `Tenant` column carries the opaque tenant id (ADR-0026) — never an email, never a customer-facing name. For Studio-internal / Grid-overhead events, the row is `(platform-overhead)`.
+   - **Per-agent table column spec.** `Agent`, `Runs This Month`, `Month-To-Date`, `Cost Per Run`, `Top Provider`. Sorted by `Month-To-Date` descending. Applies to AI inference category only.
+   - **Override log table column spec.** `Issued At`, `Category`, `Operator`, `Reason`, `Duration`, `Disposition` (`expired-naturally` / `revoked-early`).
+   - **Anomaly events table column spec.** `Fired At`, `Category`, `Type` (`hour-over-hour` / `day-over-day` / `per-tenant` / `per-agent`), `Magnitude` (e.g., `8.2x hour-over-hour`), `Disposition` (`false-positive` / `real-event` / `pending-review`).
+   - **Trend appendix.** ASCII sparklines (one line per category) of the trailing 13 months. Document the sparkline character set (`▁▂▃▄▅▆▇█` or whatever Unicode block characters render reliably in GitHub Markdown).
+   - **Versioning.** The format itself is versioned: `_format.md` includes a `schema_version: 1` line at the top so future format changes are explicit.
+   - **JSON sidecar (future).** Reserve `YYYY-MM.json` as the future structured-data sidecar; ADR-0052's Follow-up Work names it. Not created in this packet.
+   - **Aggregator pointer.** "The runtime aggregator that writes these files lives in `HoneyDrunk.Operator` and runs on the 1st of each month. Until the Operator Node is scaffolded (ADR-0018), reports may be authored manually by the operator using this format. See packet 09 of the `adr-0052-cost-governance` initiative."
+3. **`EXAMPLE.md` (or named `EXAMPLE-2026-04.md` or similar — pick a clearly non-future date so the file is unambiguous).** A worked example carrying every section with placeholder data. The example should be **plausibly shaped** — the AI inference category at $487 of $500 soft cap (consistent with the D2 narrative), one tenant overhead, one agent (`scope`) as the top spender, one override (a hypothetical investigative override that expired), one anomaly (a hour-over-hour spike that was a false-positive batch). The example renders cleanly in GitHub Markdown and uses every column.
+4. **`generated/README.md`** — only if the directory does not already have one. Brief: the directory holds auto-generated artifacts (issue packets, cost reports, future ADR drift reports). Editing manually is reserved for the operator; the rest is tool-written.
+
+## Affected Files
+- `generated/cost-reports/_format.md` (new)
+- `generated/cost-reports/EXAMPLE.md` (or named with a clearly non-real date — new)
+- `generated/README.md` (new — only if not already present)
+- Repo-level `CHANGELOG.md`
+
+## NuGet Dependencies
+None. Markdown only.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. The `generated/cost-reports/` directory is an Architecture-repo concern (the historical-record / git-as-audit-trail decision in D9).
+- [x] No code change in any other repo.
+- [x] No runtime aggregator in this packet — that is gated on the ADR-0018 Operator standup and named in packet 09.
+
+## Acceptance Criteria
+- [ ] `generated/cost-reports/_format.md` exists with the seven D9 canonical sections specified, heading anchors documented as stable, per-table column specs nailed down (per-category, per-tenant, per-agent, override log, anomaly events)
+- [ ] `_format.md` carries `schema_version: 1` and reserves `YYYY-MM.json` as the future structured-data sidecar (not created here)
+- [ ] `_format.md` points at the future runtime aggregator in `HoneyDrunk.Operator` and notes that until ADR-0018 standup, reports may be authored manually
+- [ ] An `EXAMPLE.md` (or unambiguously-non-real-date file) shows every section populated with plausible placeholder data, renders cleanly in GitHub Markdown
+- [ ] If `generated/` did not have a README, one was created
+- [ ] Repo-level `CHANGELOG.md` carries an entry naming the new directory and format spec
+- [ ] No code change; no .NET project; no edit to the catalog or budget config
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0052 D9 — Reporting surfaces.** Two surfaces: the Operator Node "Cost" dashboard (real-time control) and `generated/cost-reports/YYYY-MM.md` (monthly review surface in the Architecture repo). Both read from the same Cosmos ledger; neither is a separate accounting system. The cost-report format is canonical so future automated comparisons parse it without bespoke logic. Format lives in `generated/cost-reports/_format.md`.
+
+**ADR-0052 D9 report contents (canonical sections).** Executive summary; per-category actuals vs caps; per-tenant; per-agent; override log; anomaly events; trend appendix. Human-first Markdown. Machine consumers parse via heading anchors. Structured JSON sidecar (`YYYY-MM.json`) reserved as follow-up.
+
+**ADR-0052 Follow-up Work — Canonical JSON sidecar for machine consumers.** Named as follow-up; this packet reserves the filename convention but does not create the sidecar.
+
+**ADR-0052 D5 — `TenantId` as opaque identifier.** The per-tenant table uses the opaque tenant id (ADR-0026) — never an email, never a customer-facing name.
+
+## Constraints
+- **No runtime aggregator in this packet.** Aggregator code lives in `HoneyDrunk.Operator` and is gated on ADR-0018; named in packet 09.
+- **Stable heading anchors.** Once `_format.md` ships, the level-2 heading text is part of the spec; renames break future tooling. Document this expectation in the spec.
+- **Schema versioning.** The format is versioned via `schema_version: 1`; future changes increment the version explicitly.
+- **No real cost data in the example file.** The example uses plausible placeholder data; it is not a real monthly report.
+
+## Labels
+`feature`, `tier-3`, `ops`, `docs`, `adr-0052`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Create `generated/cost-reports/` with the canonical monthly report format spec (`_format.md`) and a worked example, so the future runtime aggregator (gated on ADR-0018 Operator standup) has a canonical shape to write against and the operator can author a first manual report against the spec if needed.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Ship the canonical report format ahead of the runtime aggregator, so the historical-record convention is established from the start.
+- Feature: ADR-0052 Cost Governance rollout, Wave 1.
+- ADRs: ADR-0052 D5/D9 (primary), ADR-0018 (Operator standup gates the aggregator), ADR-0026 (`TenantId` opaque primitive).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — soft. ADR-0052 should be Accepted before the report directory is committed.
+
+**Constraints:**
+- No runtime aggregator code; that is packet 09 (and gated on ADR-0018).
+- Stable heading anchors; document the expectation.
+- Example uses plausible placeholder data, never real cost data.
+
+**Key Files:**
+- `generated/cost-reports/_format.md`
+- `generated/cost-reports/EXAMPLE.md`
+- `generated/README.md` (if missing)
+- Repo-level `CHANGELOG.md`
+
+**Contracts:** None. Documentation only.

--- a/generated/issue-packets/active/adr-0052-cost-governance/08-architecture-review-agent-cost-config-and-retry-rules.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/08-architecture-review-agent-cost-config-and-retry-rules.md
@@ -1,0 +1,140 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-3", "ops", "docs", "adr-0052", "wave-1"]
+dependencies: ["packet:00", "packet:02"]
+adrs: ["ADR-0052", "ADR-0044"]
+accepts: ["ADR-0052"]
+wave: 1
+initiative: adr-0052-cost-governance
+node: honeydrunk-architecture
+---
+
+# Add cost-config and BudgetExceededException-retry review categories to .claude/agents/review.md
+
+## Summary
+Update `.claude/agents/review.md` per ADR-0052's Follow-up Work item: add a `cost-config` review category that treats edits to `business/context/cost-budgets.json` as production-critical config changes (per ADR-0044 D3), and add a `cost-kill-switch-retry` check that flags any code path catching `BudgetExceededException` and retrying within the same billing window. Update `pr-review-rules.md` to map both new categories into the rubric's severity coverage.
+
+## Context
+ADR-0052's Operational Consequences names `business/context/cost-budgets.json` as production-critical: "A mis-edit could disable the kill-switch (raise the hard cap to infinity) or trigger spurious shutdowns (drop the hard cap below current month-to-date). The file's PR review is therefore a production-config review; the `review` agent (per ADR-0044) should treat it accordingly."
+
+ADR-0052 D4 names the no-retry contract on `BudgetExceededException`: "The exception type is `sealed` and the documentation calls out the no-retry contract; the `review` agent (per ADR-0044) gains a category check for 'code catches `BudgetExceededException` and retries' as a defect."
+
+ADR-0052's Follow-up Work names both items explicitly:
+- "Add a `cost-config` review category to `.claude/agents/review.md` per ADR-0044 D3, covering the production-critical nature of `business/context/cost-budgets.json` changes."
+- "Add an integration test for the `BudgetExceededException` no-retry contract — verify that the exception type is sealed, that the default retry policies do not retry it, and that the `review` agent's category check catches catch-and-retry patterns."
+
+The integration-test half of the second bullet lands in packet 06's canary; this packet's job is the `review`-agent-side rule.
+
+**ADR-0044 D3 — review rubric.** The `review` agent operates against a twenty-category rubric in `.claude/agents/review.md`. Each category names what to look for, severity bands, and example violations. New categories follow the same structure. `pr-review-rules.md` maps every category onto a severity (e.g., `block` / `comment` / `informational`) so the reviewer agent can produce a consistent verdict.
+
+**File locations at edit time.** `.claude/agents/review.md` lives in the Architecture repo. `pr-review-rules.md` likewise lives in the Architecture repo (path TBD per repo convention; check at edit time). Both are tracked artifacts that the review pipeline reads.
+
+## Scope
+- `.claude/agents/review.md` — add two new review categories:
+  - `cost-config` — production-critical config review for `business/context/cost-budgets.json`.
+  - `cost-kill-switch-retry` — defect detection for catch-and-retry on `BudgetExceededException`.
+- `pr-review-rules.md` (path per repo convention) — map both new categories to severity bands consistent with the existing rubric.
+- Repo-level `CHANGELOG.md`.
+
+## Proposed Implementation
+1. **`cost-config` review category in `.claude/agents/review.md`.** Add a new category section. Content:
+   - **Trigger.** Any PR that modifies `business/context/cost-budgets.json` (or, if the file's path moves, the configured cost-budget JSON path).
+   - **What to look for.**
+     - **Cap value sanity.** Soft and hard caps for every category, in the ranges the ADR-0052 D2 narrative establishes ($50–$5000 for AI inference is the reasonable band today; $300–$1000 for Azure infra; etc.). Sudden jumps (e.g., AI inference hard cap raised from $1500 to $50000 in a single PR) require explicit justification in the PR description.
+     - **Hard cap above soft cap.** Hard caps must be greater than or equal to soft caps; a hard cap below the soft cap is nonsensical and a defect.
+     - **Hard cap not removed without category-level kill-switch removal.** If a hard cap is set to null/removed, the category's `kill_switch` field must also be `"none"` — otherwise the runtime expects a value and may default to permissive (defect).
+     - **Anomaly thresholds in band.** Hour-over-hour multiplier in `[1.5, 20.0]`; day-over-day multiplier in `[1.2, 10.0]`. Values outside the band indicate either disabled detection (very high) or noise-trap detection (very low).
+     - **Dev overlay values smaller than prod.** A dev cap that exceeds the prod cap is almost certainly a mistake.
+     - **PR description carries reasoning.** Per ADR-0052 D2: "Changes to the file are tracked by git, reviewed via the standard PR flow, and audited. The PR flow is the slow path for changing caps — it preserves a permanent record of 'the cap was raised on this date, by this PR, with this reasoning.'" A PR that changes caps without describing why is a documentation defect.
+   - **Severity.** `block` — the review agent does not approve a `cost-config` change without explicit operator sign-off in the PR description (a comment like "Approved by Oleg, raising cap for customer-demo window" is sufficient).
+   - **Why it matters.** Cite ADR-0052 D2 and the Operational Consequences directly: this is the only mechanism for persistent cap changes; the file is production-critical; the audit trail is the git history; the override CLI (D11) is the fast path for emergencies and does not mutate this file.
+2. **`cost-kill-switch-retry` review category in `.claude/agents/review.md`.** Add a new category section. Content:
+   - **Trigger.** Any PR that touches code in the dispatcher / LLM-call path, OR adds a `catch` clause referencing `BudgetExceededException`, OR adds a retry policy in code that includes `BudgetExceededException` in the catch-and-retry set.
+   - **What to look for.**
+     - **Direct catch-and-retry.** `catch (BudgetExceededException) { /* retry */ }` is a defect. The exception is sealed; the cap is closed for the billing window or until an override; a retry inside the same window will either throw again or, worse, succeed on a race condition with the cache refresh and incur further spend.
+     - **Generic exception swallowing.** `catch (Exception)` blocks that wrap LLM calls and continue the loop are suspicious — they may swallow `BudgetExceededException` implicitly. The reviewer should ask whether the block is specifically excluding sealed non-transient exception types.
+     - **Polly / retry-library configuration.** A `Policy.Handle<Exception>()` configured against an LLM-call delegate is a defect unless the policy explicitly excludes `BudgetExceededException`. The reviewer flags the policy and suggests `Policy.Handle<Exception>(ex => ex is not BudgetExceededException)`.
+     - **Top-level loop catch.** ADR-0052 D4 explicitly allows a top-level loop to catch the exception, write checkpoint state to Audit, and exit cleanly. The reviewer recognizes this pattern (single top-level handler that does not invoke the LLM-call site again in the same process) and approves it.
+   - **Severity.** `block` — a catch-and-retry on `BudgetExceededException` defeats the kill-switch and is a budgeting defect.
+   - **Why it matters.** Cite ADR-0052 D4 and invariant 91 directly: the no-retry contract is the substrate of the kill-switch; without it the cap is advisory only.
+3. **`pr-review-rules.md` mapping.** Add both new categories to the rules table with `block` severity. Match the existing table format (column conventions at edit time). The mapping ensures the review pipeline produces a consistent verdict regardless of which reviewer instance runs.
+4. **CHANGELOG.** Repo-level `CHANGELOG.md` carries an entry naming the two new review categories.
+
+## Affected Files
+- `.claude/agents/review.md`
+- `pr-review-rules.md` (path per repo convention; check at edit time)
+- Repo-level `CHANGELOG.md`
+
+## NuGet Dependencies
+None. Documentation only.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. The `review` agent and the PR review rules are Architecture-repo concerns.
+- [x] No code change in any other repo.
+- [x] The dispatcher canary for the no-retry contract lives in `HoneyDrunk.AI` (packet 06), not this packet.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/review.md` carries a new `cost-config` review category triggered on edits to `business/context/cost-budgets.json`, severity `block`, with the cap-sanity / hard-greater-than-soft / dev-smaller-than-prod / anomaly-band / PR-description-justification checks listed
+- [ ] `.claude/agents/review.md` carries a new `cost-kill-switch-retry` review category triggered on dispatcher-path code, severity `block`, with direct-catch-and-retry / generic-swallowing / Polly-handle / top-level-loop-allowed semantics specified
+- [ ] Both new categories cite ADR-0052 D2 / D4 and invariant 91 as the source-of-truth
+- [ ] `pr-review-rules.md` (or its equivalent) maps both new categories to `block` severity in the existing table format
+- [ ] Repo-level `CHANGELOG.md` carries an entry naming the two new categories
+- [ ] No edit to other agent files; no code change; no edit to the catalog or budget config
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0052 Operational Consequences — `cost-budgets.json` production-critical.** A mis-edit could disable the kill-switch or trigger spurious shutdowns. The PR-review flow on this file is a production-config review; the `review` agent (per ADR-0044) treats it accordingly.
+
+**ADR-0052 D2 — Slow PR path is the only persistent-cap change mechanism.** The git history is the audit trail; PR description carries the reasoning. The fast path (D11 override CLI) is for emergencies and does not mutate the JSON file.
+
+**ADR-0052 D4 — `BudgetExceededException` no-retry contract.** The exception is sealed and non-transient. Callers must not retry. The `review` agent gains a catch-and-retry detection rule.
+
+**ADR-0052 Follow-up Work — explicit naming of both review-agent additions.** "Add a `cost-config` review category to `.claude/agents/review.md` per ADR-0044 D3." "Add an integration test for the `BudgetExceededException` no-retry contract — and the `review` agent's category check catches catch-and-retry patterns."
+
+**ADR-0044 D3 — Review rubric in `.claude/agents/review.md`.** The twenty-category rubric structure: trigger, what-to-look-for, severity, why-it-matters. New categories follow the existing structure; `pr-review-rules.md` maps every category onto a severity band.
+
+**Invariant 91 (this initiative, packet 00) — Hot-path cap check on every LLM call.** Catch-and-retry defeats the kill-switch and violates this invariant.
+
+## Constraints
+- **Match the existing rubric structure.** New categories follow the same shape as the existing twenty (trigger, what-to-look-for, severity, why-it-matters).
+- **Severity is `block` for both.** Both categories represent budgeting defects with high blast radius; `comment` or `informational` would defeat the rule's purpose.
+- **Cite the ADR / invariant as source-of-truth.** Reviewers and authors must be able to trace the rule back to ADR-0052 D2 / D4 and invariant 91 without ambiguity.
+- **Top-level loop catch is allowed.** Document the carve-out so the reviewer agent does not produce false positives on the explicitly-permitted pattern in ADR-0052 D4 ("Most callers should propagate the exception. Specific call sites (e.g., a long-running agent loop) may want to halt cleanly with a checkpoint rather than crash; the convention is to catch the exception only at the top-level loop, log the budget breach as a structured event, write any in-flight state to Audit for resumption, and exit.").
+- **No edit to packet-06 canary.** The runtime test that proves the contract is packet 06's canary; this packet's job is the review-agent-side rule.
+
+## Labels
+`feature`, `tier-3`, `ops`, `docs`, `adr-0052`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Add two new categories to the `review` agent's rubric (`cost-config` and `cost-kill-switch-retry`), severity `block` for both, with the source-of-truth pointers to ADR-0052 D2 / D4 and invariant 91.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Close ADR-0052's two named review-agent follow-ups: the production-config gate on cap edits, and the catch-and-retry defect detection.
+- Feature: ADR-0052 Cost Governance rollout, Wave 1.
+- ADRs: ADR-0052 D2/D4 (primary), ADR-0044 D3 (review rubric structure).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — invariant 91 exists for `cost-kill-switch-retry` to cite.
+- `packet:02` — `business/context/cost-budgets.json` exists for `cost-config` to target.
+
+**Constraints:**
+- Match the existing rubric structure.
+- Severity `block` for both.
+- Document the top-level-loop carve-out from D4 so reviewers don't false-positive on the allowed pattern.
+
+**Key Files:**
+- `.claude/agents/review.md`
+- `pr-review-rules.md` (or its equivalent)
+- Repo-level `CHANGELOG.md`
+
+**Contracts:** None. Documentation only.

--- a/generated/issue-packets/active/adr-0052-cost-governance/09-architecture-operator-side-rollout-playbook.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/09-architecture-operator-side-rollout-playbook.md
@@ -1,0 +1,167 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-3", "ops", "docs", "adr-0052", "wave-5"]
+dependencies: ["packet:00", "packet:01", "packet:02", "packet:07"]
+adrs: ["ADR-0052", "ADR-0018"]
+accepts: ["ADR-0052"]
+wave: 5
+initiative: adr-0052-cost-governance
+node: honeydrunk-architecture
+---
+
+# Author the ADR-0052 Operator-side rollout playbook and catalog the deferred follow-up surfaces
+
+## Summary
+Author the rollout playbook for the Operator-side cost-governance surfaces that this initiative does NOT build because ADR-0018 (Operator standup) is still Proposed and the Operator Node is not scaffolded: the aggregator job (Azure Cost Management / GitHub Actions / vendor API polling), the Container Apps auto-suspend job for the Azure-infra hard cap, the `hd cost` CLI surface (status / unlock / report), the "Cost" dashboard view in the Operator UI, the App Insights alert rules (D10 anomaly detection) defined as Bicep, the Communications + Notify alert wiring (daily roll-up, threshold pings, hard-cap breach push), the Phase-1 multiplier flip (D14 Phase 3), and the catalog cleanup that removes the relocating `ICostLedger` entry under `honeydrunk-ai` (left in place by packet 04 to avoid splitting the AI-code change across two repos).
+
+## Context
+ADR-0052 commits a substrate with components in multiple Nodes:
+- `HoneyDrunk.Kernel` (contracts — packet 03)
+- `HoneyDrunk.AI` (v1 implementation, dispatcher kill-switch — packets 04/05/06)
+- `HoneyDrunk.Operator` (aggregator, CLI, dashboard, auto-suspend — **not built in this initiative**)
+- `HoneyDrunk.Communications` + `HoneyDrunk.Notify` (alert delivery — **not built in this initiative**)
+- `HoneyDrunk.Observe` (App Insights alert Bicep — **not built in this initiative**)
+
+The Operator-side surfaces are the bulk of ADR-0052's deferred surface and they are deferred for a single hard reason: **ADR-0018 (Operator standup) is Proposed; the Operator Node is at seed status with no scaffolded code**. ADR-0052 Phase 1 (the substrate) builds against a not-yet-existing Operator Node would be a wasted exercise — every surface the Operator hosts must wait for the standup, not lead it.
+
+ADR-0018 acceptance + scaffold is the **gate** for these follow-ups. This packet does not advance ADR-0018; it produces the playbook so the moment ADR-0018 lands, the follow-up packets are pre-shaped and the operator (or a future initiative) can file them without re-doing the scoping work.
+
+**Why a playbook and not a packet-per-deferred-item.** Each deferred item is a packet against a Node that does not yet exist. Filing them now would produce GitHub issues against a repo that has no code, which is operationally noisy and misleading (the issues sit forever, gating nothing). The playbook is the right level: a structured document that lists every follow-up, gates it on the right upstream event, names the target Node, and provides enough detail that a future scope agent can re-decompose it into packets without re-reading ADR-0052 end-to-end.
+
+**Why this packet lives in Wave 5.** It depends on the catalog (packet 01) and the budget config (packet 02) and the report format (packet 07) being in place — those are the artifacts the playbook references and links into. It also depends on packet 00 (acceptance) so the cited invariants exist. It does NOT depend on packets 03–06 (the code packets) because the playbook is purely documentation; it can land in parallel with or after the code packets without coupling.
+
+**Phase-1 multiplier flip narrative.** ADR-0052 D14 Phase 3 says "with one month of baseline actuals from Phase 1/2, tune the per-category caps to the D2 defaults (or to the operator's adjusted values based on observed behavior). Enable threshold pings." The Phase-1 multiplier (packet 05) is the mechanism — flipping it from 10x (dev) / 1x (prod) to 1x / 1x effectively activates the D2 caps. This playbook documents the flip narrative: when to flip, how to observe, how to revert.
+
+**Catalog cleanup.** Packet 01 marked the `honeydrunk-ai` `ICostLedger` entry as relocating. Packet 04 deleted the AI-side `ICostLedger` code. The catalog entry under `honeydrunk-ai` can now be removed cleanly — this packet does that cleanup as a small adjacent edit, since it is the last packet on the Architecture repo in this initiative.
+
+## Scope
+- `initiatives/adr-0052-rollout-playbook.md` (new — under `initiatives/` per the repo's playbook convention, or wherever the `adr-0044-cloud-code-review` playbook lives at edit time; match the existing convention) — the playbook document.
+- `catalogs/contracts.json` — remove the relocating `ICostLedger` entry under `honeydrunk-ai` (packet 04 completed the code-level relocation; the catalog can now match).
+- Repo-level `CHANGELOG.md`.
+
+## Proposed Implementation
+1. **`initiatives/adr-0052-rollout-playbook.md`** — the playbook document. Sections:
+   - **Status.** Phase 1 (ledger substrate) shipped via packets 00–08 of `adr-0052-cost-governance`. Phase 2–7 deferred — gated on ADR-0018 Operator standup and ADR-0040 telemetry backend.
+   - **Gating events.** A short list of upstream events that unblock the follow-ups:
+     - **Gate 1: ADR-0018 Accepted + Operator scaffold packet executed.** Unblocks every Operator-side surface (aggregator, CLI, dashboard, auto-suspend).
+     - **Gate 2: ADR-0040 Accepted + App Insights provisioned.** Unblocks the App Insights alert Bicep (D10).
+     - **Gate 3: One month of Phase-1 baseline data in the ledger.** Unblocks the Phase-3 multiplier flip and cap tuning.
+     - **Gate 4: ADR-0037 Accepted + Billing Node scaffolded.** Unblocks the per-tenant query API the Billing Node consumes (D9).
+   - **Deferred follow-up table.** Every deferred surface with target Node, gating event, and a one-sentence sketch of the work. Columns: `#`, `Surface`, `Target Node`, `Gating Event`, `ADR-0052 Decision`. Entries:
+     1. **Aggregator job** — `HoneyDrunk.Operator`. Gate 1. Polls Azure Cost Management API daily, GitHub Actions API, known vendor APIs; writes `CostEvent`s with `Source = AzureInfraSource(...)` / `CiSource(...)` / `SaasSource(...)` / `DomainSource(...)`. Backfills the prior 90 days where each API supports historical query. Validates totals against actual bills (drift > 5% is a defect). [ADR-0052 D7, D14 Phase 2]
+     2. **Container Apps auto-suspend job** — `HoneyDrunk.Operator`. Gate 1. When `IsHardCapBreachedAsync(CostCategory.AzureInfrastructure)` returns `true` from the aggregator's update, the job suspends non-production Container Apps revisions. Production revisions are NOT auto-suspended (D4). [ADR-0052 D4]
+     3. **`hd cost status` CLI** — `HoneyDrunk.Operator`. Gate 1. Reads `GetMonthToDateAsync` + `BudgetConfigProvider` for every category and prints the table. [ADR-0052 D11]
+     4. **`hd cost unlock` CLI** — `HoneyDrunk.Operator`. Gate 1. Writes an audit event via `IAuditLog` (ADR-0030; invariant 47) and a `BudgetOverride` row via the ledger. Required flags: `<category> --reason "<text>" --duration <hours>`. Default duration 24h. No permanent option. [ADR-0052 D11; invariant 92]
+     5. **`hd cost report` CLI** — `HoneyDrunk.Operator`. Gate 1. Reads the ledger and writes a manual `generated/cost-reports/YYYY-MM.md` for the requested month. Useful before the monthly aggregator is live. [ADR-0052 D9]
+     6. **Monthly report aggregator** — `HoneyDrunk.Operator`. Gate 1. Cron job running on the 1st of each month; writes `generated/cost-reports/YYYY-MM.md` per the format in `generated/cost-reports/_format.md` (packet 07). Commits via the Architecture-repo automation. [ADR-0052 D9]
+     7. **Operator "Cost" dashboard view** — `HoneyDrunk.Operator`. Gate 1. Real-time per-category month-to-date, threshold consumption percentages, top-N agents by spend, top-N tenants by spend, anomaly indicators. [ADR-0052 D9]
+     8. **App Insights anomaly alert rules (Bicep)** — `HoneyDrunk.Observe` or `HoneyDrunk.Operator` (depending on which Node owns observability IaC at edit time — per ADR-0040's amendment the alert rules typically live with the Observe-adjacent IaC). Gate 2. Hour-over-hour 5x and day-over-day 3x rules per category; per-tenant and per-agent variants. [ADR-0052 D10]
+     9. **Communications + Notify alert wiring** — `HoneyDrunk.Communications` (decision) + `HoneyDrunk.Notify` (delivery). Gate 1. Daily roll-up email at 08:00 operator-local-time; threshold pings on 50/75/90/100% soft cap; hard-cap breach push (max priority) and the structured `IErrorReporter` event (problem group `Honeydrunk.Cost.HardCapBreach`); anomaly alerts. [ADR-0052 D3]
+     10. **Phase-1 multiplier flip** — `HoneyDrunk.Operator` + App Configuration. Gate 3. Flip `CostLedger:PhaseOneMultiplier:Dev` from 10 to 1 in App Configuration. No code change. Observe for one week before deploying to prod. [ADR-0052 D14 Phase 3]
+     11. **Per-provider API key spending limits** — Manual portal step (OpenAI dashboard, Anthropic dashboard). Gate 0 (do at any time after this initiative ships). Set each provider's per-key limit to ~$1700/month (slightly above the $1500 AI inference hard cap), as the defense-in-depth net per ADR-0052's Alternatives Considered. [ADR-0052 Alternatives Considered]
+     12. **Dev/prod Azure resource separation** — Manual portal + IaC. Gate 1 ideally; lighter version possible earlier. Reorganize Azure resources so dev and prod live in separate subscriptions or distinctly-tagged resource groups; the aggregator depends on the split to compute per-environment costs cleanly. [ADR-0052 D12]
+     13. **Operator override pattern docs** — `HoneyDrunk.Architecture` (`business/context/`). Gate 0 (can happen at any time). Document the three patterns from D11 (emergency / investigative / planned) with concrete CLI examples, so the first real override is not the operator's first attempt. [ADR-0052 D11; Follow-up Work]
+     14. **Per-tenant query API for the Billing Node** — `HoneyDrunk.AI` (or `HoneyDrunk.CostLedger` after promotion). Gate 4. A read API the Billing Node consumes to produce per-tenant invoices. The ledger already supports `QueryAsync` with a `TenantId` filter; this work wraps it in a Billing-friendly surface. [ADR-0037, ADR-0052 D5]
+     15. **Structured JSON sidecar for monthly reports** — `HoneyDrunk.Operator` aggregator. Gate 1. After the aggregator is live, add a `YYYY-MM.json` sidecar carrying the structured data, for machine consumers. The Markdown surface is canonical for humans; the JSON is canonical for tools. [ADR-0052 D9; Follow-up Work]
+   - **Recommended sequencing.** Once Gate 1 fires, file the follow-ups in roughly this order to land the most-load-bearing surfaces first:
+     - First wave: aggregator + status CLI + manual report CLI (so the operator has read-side visibility).
+     - Second wave: unlock CLI + override pattern docs (so the operator has the emergency response path before the kill-switches start firing).
+     - Third wave: Communications + Notify alert wiring (so the operator gets the daily roll-up + threshold pings).
+     - Fourth wave: Container Apps auto-suspend + App Insights anomaly Bicep + dashboard view (so the kill-switch posture is complete in all categories).
+     - Fifth wave: Phase-1 multiplier flip (after a month of baseline).
+     - Sixth wave: per-tenant query API (when Billing Node arrives).
+   - **Re-scope guidance for a future agent.** A future scope agent re-decomposing this playbook should:
+     - Treat each numbered surface as a candidate single packet, but **check for cross-Node coupling** (e.g., the Communications + Notify wiring spans two Nodes — that may decompose into two packets).
+     - Use the existing ADR-0052 follow-up packet 09 as the cross-reference; do not re-discover the deferred items by reading ADR-0052 end-to-end.
+     - Carry forward the gating-event language from this playbook to keep upstream dependencies explicit.
+   - **Pointers to the existing artifacts.** Link `business/context/cost-budgets.json` (packet 02), `generated/cost-reports/_format.md` (packet 07), `catalogs/contracts.json` (packet 01), and `constitution/invariants.md` (packet 00, invariants 90/91/92). These are the canonical artifacts the follow-ups consume.
+2. **`catalogs/contracts.json` — catalog cleanup.** Remove the `ICostLedger` entry under `honeydrunk-ai` (the seed-era entry from ADR-0016, removed in code by packet 04). Confirm at edit time that the AI repo has merged packet 04 before doing this cleanup — if packet 04 is still unmerged when this packet runs, defer the cleanup and note it as a follow-up tick. The Kernel-side `ICostLedger` entry under `honeydrunk-kernel` (added by packet 01) stays.
+3. **Repo-level `CHANGELOG.md`** entry naming the playbook + the catalog cleanup.
+
+## Affected Files
+- `initiatives/adr-0052-rollout-playbook.md` (new — under `initiatives/`, or wherever the existing playbook convention places it)
+- `catalogs/contracts.json` — remove the AI-side `ICostLedger` entry
+- Repo-level `CHANGELOG.md`
+
+## NuGet Dependencies
+None. Documentation + catalog cleanup only.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. The playbook + catalog cleanup are Architecture-repo concerns.
+- [x] No code change in any other repo.
+- [x] No new runtime dependency. The deferred surfaces named in the playbook live in `HoneyDrunk.Operator` / `HoneyDrunk.Communications` / `HoneyDrunk.Notify` / `HoneyDrunk.Observe`, and this packet does not build any of them.
+
+## Acceptance Criteria
+- [ ] `initiatives/adr-0052-rollout-playbook.md` (or the equivalent per existing playbook convention) exists with the four gating events, the deferred follow-up table (15 entries), the recommended sequencing, the re-scope guidance, and the pointers to existing artifacts
+- [ ] The catalog entry `{ "name": "ICostLedger", ... }` under `honeydrunk-ai` in `catalogs/contracts.json` is removed (the Kernel entry from packet 01 stays); the cleanup is performed only if packet 04 has merged
+- [ ] If packet 04 has not yet merged at edit time, the cleanup is deferred and noted as a follow-up tick in this packet's PR description; the playbook still ships
+- [ ] Repo-level `CHANGELOG.md` carries an entry naming the playbook and the catalog cleanup
+- [ ] No code change; no .NET project; no edit to `business/context/cost-budgets.json` or `constitution/invariants.md`
+
+## Human Prerequisites
+- [ ] **Per-provider API key spending limits (deferred follow-up #11).** Set the OpenAI per-key spending limit (and Anthropic, and any other provider in use) to ~$1700/month (slightly above the $1500 Grid hard cap). This is the defense-in-depth net per ADR-0052's Alternatives Considered. Portal click: OpenAI dashboard → Billing → Usage limits; Anthropic dashboard → equivalent. The limit catches the case where the in-process ledger is somehow bypassed; the provider's limit halts spend before it spirals. Not a code change; not gated on the Operator standup. The playbook lists it as Gate-0 — do it as soon as the operator is ready.
+
+## Referenced ADR Decisions
+**ADR-0052 D3 — Alert channels and cadence.** Alerts flow through `HoneyDrunk.Communications` into `HoneyDrunk.Notify`. Daily roll-up at 08:00 operator-local. Threshold pings on 50/75/90/100%. Hard-cap breach fires both `IErrorReporter` and a Notify push. Anomaly alerts on detection. — Gated on Gate 1.
+
+**ADR-0052 D4 — Per-category kill-switches.** AI inference is in-process (shipped in this initiative, packets 05/06). Azure infrastructure is out-of-process via the Operator-side Container Apps auto-suspend job (Gate 1). GitHub Actions uses GitHub's native org-level spending limit ($150/month per D2). SaaS / domain-cert have no kill-switch.
+
+**ADR-0052 D9 — Reporting surfaces.** Operator "Cost" dashboard (real-time, Gate 1). Architecture repo monthly reports (format shipped in packet 07; aggregator gated on Gate 1).
+
+**ADR-0052 D10 — Anomaly detection.** App Insights alert rules; defined as Bicep IaC. Gated on Gate 2 (App Insights provisioned per ADR-0040).
+
+**ADR-0052 D11 — Operator unlock policy.** `hd cost unlock` CLI on `HoneyDrunk.Operator`; audited via `IAuditLog` (ADR-0030; invariant 47). Gate 1.
+
+**ADR-0052 D12 — Dev/prod separation.** Azure resource organization step; gated on Gate 1 ideally but doable lighter earlier.
+
+**ADR-0052 D14 — Phased rollout.** Phase 1 (ledger substrate) is closed by this initiative. Phase 2–7 are the playbook's responsibility.
+
+**ADR-0052 Alternatives Considered — Per-key provider limits as defense-in-depth.** Set each provider's per-key limit slightly above the Grid hard cap. Adopted as a safety-net layer; named as Human Prerequisite in this packet.
+
+**ADR-0052 Follow-up Work — JSON sidecar; override pattern docs.** Both named in the playbook's deferred table.
+
+**ADR-0018 (Operator standup) — Proposed.** The gate for every Operator-side surface. ADR-0018 is sequenced as a separate initiative; this initiative does not advance it. The playbook records the dependency for future re-scoping.
+
+## Constraints
+- **No new code.** The playbook is documentation; no .NET project, no runtime change.
+- **Catalog cleanup gated on packet 04 merge.** If packet 04 is unmerged when this packet runs, defer the cleanup and note it in the PR. The playbook ships regardless.
+- **The playbook is not an issue tracker.** Do not file the deferred items as GitHub issues — that creates noise against Nodes that don't exist. Filing happens when the gating event fires (a future scope agent re-decomposes the playbook into packets).
+- **Cross-reference, do not duplicate.** Where the playbook references ADR-0052 decisions or existing artifacts (`cost-budgets.json`, `_format.md`), link them rather than copying content. The ADR is the source-of-truth; the playbook is the rollout-stagger map.
+
+## Labels
+`feature`, `tier-3`, `ops`, `docs`, `adr-0052`, `wave-5`
+
+## Agent Handoff
+
+**Objective:** Author the ADR-0052 rollout playbook for the Operator-side surfaces this initiative does not build (because ADR-0018 standup is still Proposed), and remove the `honeydrunk-ai` `ICostLedger` catalog entry now that packet 04 has migrated the AI-side code.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Close out the initiative by recording the deferred Phase 2–7 work in a playbook a future scope agent can re-decompose into packets when the gating events (chiefly the ADR-0018 standup) fire.
+- Feature: ADR-0052 Cost Governance rollout, Wave 5 (the wrap).
+- ADRs: ADR-0052 D3/D4/D9/D10/D11/D12/D14 (the deferred decisions), ADR-0018 (the main gating ADR, still Proposed).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — invariant 91 / 92 cited.
+- `packet:01` — catalog entry for `ICostLedger` under `honeydrunk-kernel` already exists; this packet only removes the AI-side entry.
+- `packet:02` — `cost-budgets.json` cross-referenced by the playbook.
+- `packet:07` — `_format.md` cross-referenced by the aggregator playbook entry.
+
+**Constraints:**
+- No code change; documentation + catalog cleanup only.
+- Catalog cleanup is gated on packet 04's merge; defer the cleanup if packet 04 is unmerged.
+- Do not file the deferred items as GitHub issues — a future scope agent decomposes them when the gate fires.
+- Link to ADR-0052 and existing artifacts; do not duplicate content.
+
+**Key Files:**
+- `initiatives/adr-0052-rollout-playbook.md` (or the equivalent under existing convention)
+- `catalogs/contracts.json` — remove AI-side `ICostLedger` entry
+- Repo-level `CHANGELOG.md`
+
+**Contracts:** None. Documentation + catalog cleanup.

--- a/generated/issue-packets/active/adr-0052-cost-governance/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/dispatch-plan.md
@@ -1,0 +1,193 @@
+# Dispatch Plan — ADR-0052: Cost Governance, Budget Alerts, and Kill-Switches
+
+**Initiative:** `adr-0052-cost-governance`
+**ADR:** ADR-0052 (Proposed → Accepted via packet 00)
+**Sector:** Ops / cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0052 commits the Grid's cost-governance substrate: five named cost categories with per-category soft/hard caps; alert thresholds; per-category kill-switches (in-process for AI inference, out-of-process Azure-suspend for infra, GitHub-native for CI, none for SaaS/domain); per-tenant and per-agent attribution; Cosmos-backed persistence with 13-month retention and an in-memory cache for the hot-path cap-check; monthly auto-generated reports in `generated/cost-reports/`; App Insights anomaly detection (5x hour-over-hour, 3x day-over-day); time-bounded audited operator overrides; dev/prod separation; and a seven-phase rollout where Phase 1 ships the ledger substrate and Phase 4 is the explicit "this is the dangerous one" kill-switch enablement step.
+
+This initiative delivers **Phase 1 of the rollout plus the AI-inference half of Phase 4**: the contract surface in `HoneyDrunk.Kernel.Abstractions` (relocating from the seed `HoneyDrunk.AI.Abstractions.ICostLedger`); the v1 Cosmos-backed implementation in `HoneyDrunk.AI` with in-memory cache; the dispatcher kill-switch wiring; the `business/context/cost-budgets.json` config file with D2 defaults; the `generated/cost-reports/` directory + format spec; the `review` agent's `cost-config` and `cost-kill-switch-retry` categories; the three new cost-governance invariants; and a rollout playbook for the Operator-side surfaces this initiative does NOT build.
+
+**The Operator-side surfaces are explicitly deferred.** ADR-0018 (Operator standup) is Proposed; the `HoneyDrunk.Operator` repo is at seed/0.0.0 with no scaffolded code. Every surface ADR-0052 names that lives in Operator — the aggregator for Azure Cost Management / GitHub / vendor APIs, the Container Apps auto-suspend job, the `hd cost` CLI, the "Cost" dashboard view, the App Insights anomaly Bicep, the Communications + Notify alert wiring — waits on ADR-0018's standup and is named in the playbook (packet 09) for re-decomposition once the gate fires.
+
+**9 packets across 5 waves**, targeting **2 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.AI`) and adding a Kernel-Abstractions surface to a third (`HoneyDrunk.Kernel` — via packet 03). All 9 are `Actor=Agent`, 0 `Actor=Human`. Several packets carry Human Prerequisites: human release-tags on Kernel and AI at wave boundaries (the standard "agents merge, humans tag" pattern), Cosmos provisioning + Managed Identity RBAC for packet 05, recommended deploy-pilot sequencing for packet 06, and per-provider API key spending limits + dev/prod Azure resource separation as Gate-0 / Gate-1 items in packet 09.
+
+## Trigger
+
+ADR-0052 is Proposed with no scope. The forcing functions from the ADR's Context: **the AI-sector standup wave (ADR-0016 through ADR-0025)** is the single largest cost-risk increase in the Grid's history — every new AI Node multiplies the surface where token spend can leak; **Codex and cloud agents are already running today**, with no per-run cap; **the studio is bootstrapped** with no FinOps oversight, no investor pool, and a runway materially exposed to a five-figure surprise bill; **the first runaway loop is too late** — manual attention is detection, not prevention. ADR-0052 is positioned as the most urgent of the cross-cutting ADRs in the 0048–0052 batch precisely because cost-governance failure is a one-shot, irrecoverable event.
+
+## Scope Detection
+
+**Multi-repo.** ADR-0052 touches `HoneyDrunk.Kernel` (the contract relocation per D7), `HoneyDrunk.AI` (the v1 implementation + dispatcher kill-switch wiring + Phase-1 stub-then-replace), and `HoneyDrunk.Architecture` (acceptance, catalog registration, budget config, report format, review-agent rules, playbook). Three repos at the code/governance level; the playbook references work in five more (`HoneyDrunk.Operator`, `HoneyDrunk.Communications`, `HoneyDrunk.Notify`, `HoneyDrunk.Observe`, future `HoneyDrunk.Billing`) but does not build any of them.
+
+**Contract is replace, not extend.** The seed `HoneyDrunk.AI.Abstractions.ICostLedger` (two-member, inference-only) is replaced by the wider `HoneyDrunk.Kernel.Abstractions.ICostLedger` (five-member, multi-source, category-scoped). Packet 04 deletes the AI-side type and migrates every provider call site. The AI Node is at seed status with no external consumer of the old contract — the replacement is acceptable as an additive minor bump on the AI solution because no out-of-repo pin exists.
+
+**No new-Node scaffolding from this initiative.** Every target repo at the code level is a live (or seed but standing-up) Node. The Operator Node is named heavily in the playbook (packet 09) but the standup itself is ADR-0018's scope, not this initiative's. Per the Memory note `feedback_adr_before_scaffold`, standup work gets its own ADR; this initiative respects that.
+
+## Wave Diagram
+
+### Wave 1 (Governance + catalog + config + report format — all Architecture-side, parallel where blocked-by allows)
+- [ ] **00** — Architecture: Accept ADR-0052, add the three cost-governance invariants (numbers **90, 91, 92** — pre-reserved within the 12-ADR batch; the file's verified current maximum is 49), register the initiative. `Actor=Agent`. Blocked by: nothing.
+- [ ] **01** — Architecture: register the cost-governance contracts under `honeydrunk-kernel` in `catalogs/contracts.json`; mark the existing AI-side `ICostLedger` as relocating; record the D7 implementation home + D13 cross-ADR notes. `Actor=Agent`. Blocked by: 00.
+- [ ] **02** — Architecture: create `business/context/cost-budgets.json` with the D2 defaults / D10 anomaly thresholds / D12 dev overlay; author the tuning policy doc. `Actor=Agent`. Blocked by: 00.
+- [ ] **07** — Architecture: create `generated/cost-reports/` with `_format.md` + a worked example. `Actor=Agent`. Blocked by: 00.
+- [ ] **08** — Architecture: add `cost-config` and `cost-kill-switch-retry` review categories to `.claude/agents/review.md`. `Actor=Agent`. Blocked by: 00, 02.
+
+> **Invariant numbering.** The current verified maximum in `constitution/invariants.md` is **49**. Invariant numbers **90, 91, 92** are pre-reserved as part of a 12-ADR batch; if any invariant above 49 lands from outside this batch before packet 00 merges, shift this block upward, never reuse a number.
+
+### Wave 2 (The Kernel contract — depends on Wave 1's catalog)
+- [ ] **03** — Kernel: add `ICostLedger`, `CostEvent`, `CostCategory`, `CostSource`, `CostEnvironment`, `BudgetExceededException`, `BudgetOverride`, `IBudgetConfigProvider`, `BudgetConfig`, `CostQuery` to `HoneyDrunk.Kernel.Abstractions`. `Actor=Agent`. Blocked by: 00, 01. **Version-bumping packet for `HoneyDrunk.Kernel` in this initiative** — bumps `0.8.0` → `0.9.0` if ADR-0042's Kernel work has been released, or appends to an in-progress ADR-0042 version (see Cross-Initiative Coordination below).
+
+### Wave 3 (AI-side contract reconciliation — depends on Wave 2 + human release tag)
+- [ ] **04** — AI: delete the seed `HoneyDrunk.AI.Abstractions.ICostLedger` / `InferenceCost` / `CostSummary`; point `HoneyDrunk.AI.Abstractions` at the new Kernel contract; migrate every provider call site from `RecordAsync(InferenceCost)` to `RecordCostAsync(CostEvent)`; rewrite `DefaultCostLedger` as a Phase-1 non-durable stub. `Actor=Agent`. Blocked by: 03 (+ human release of the new `HoneyDrunk.Kernel.Abstractions` to NuGet). **Version-bumping packet for `HoneyDrunk.AI` in this initiative** — bumps `0.1.0` → `0.2.0`.
+
+### Wave 4 (AI-side v1 implementation — depends on Wave 3 + human release tag + Cosmos provisioning)
+- [ ] **05** — AI: implement the Cosmos-backed `CostLedger` with in-memory cache; implement `BudgetConfigProvider` reading `cost-budgets.json`; add the `CostLedgerCacheRefreshService`; create the Cosmos provisioning Bicep. `Actor=Agent`. Blocked by: 02, 04 (+ human release of `HoneyDrunk.AI` packet 04 to NuGet so the stub is replaceable — actually moot since this is same-solution, but the Wave-3→4 cycle still needs the in-progress version state to be merged; + the Cosmos account human-provisioned per environment). **Appends** to packet 04's in-progress version (invariant 27).
+
+### Wave 5 (Dispatcher kill-switch wiring + Operator-side playbook — depends on Wave 4 ledger + earlier waves)
+- [ ] **06** — AI: wire the AI dispatcher to call `IsHardCapBreachedAsync` before each call; throw `BudgetExceededException` synchronously on breach; capture via `IErrorReporter`; ship the kill-switch canary in `HoneyDrunk.AI.Tests.Canaries`. `Actor=Agent`. Blocked by: 05. **Appends** to the AI in-progress version (invariant 27).
+- [ ] **09** — Architecture: author the Operator-side rollout playbook (every surface gated on ADR-0018 standup); remove the relocating AI-side `ICostLedger` entry from `catalogs/contracts.json`. `Actor=Agent`. Blocked by: 00, 01, 02, 07. (Independent of code packets 03–06 — could run as early as Wave 2, grouped here for tidy filing. The catalog cleanup half is conditionally gated on packet 04's merge — see Cross-Cutting Concerns.)
+
+Packets within a wave run in parallel where the `dependencies:` allow. Wave 1 has five parallel-eligible packets (00 unblocks 01, 02, 07; 02 unblocks 08; the four Architecture packets land in any order after their respective blockers). Wave 5 has packets 06 and 09 — packet 06 is the AI Node's last code packet; packet 09 is purely Architecture and is grouped here for tidy filing but could land earlier.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0052](./00-architecture-adr-0052-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [Cost-governance catalog + relocation record](./01-architecture-cost-governance-catalog-and-relocation-record.md) | Architecture | Agent | 1 | 00 |
+| 02 | [`cost-budgets.json` + tuning policy](./02-architecture-cost-budgets-config-and-tuning-policy.md) | Architecture | Agent | 1 | 00 |
+| 03 | [Kernel cost-governance contracts](./03-kernel-cost-governance-contracts.md) | Kernel | Agent | 2 | 00, 01 |
+| 04 | [AI `ICostLedger` relocation to Kernel](./04-ai-icostledger-relocation-to-kernel.md) | AI | Agent | 3 | 03 |
+| 05 | [Cosmos-backed `CostLedger` v1](./05-ai-cosmos-backed-cost-ledger-implementation.md) | AI | Agent | 4 | 02, 04 |
+| 06 | [Dispatcher kill-switch wiring](./06-ai-dispatcher-kill-switch-wiring.md) | AI | Agent | 5 | 05 |
+| 07 | [`generated/cost-reports/` directory + format](./07-architecture-cost-reports-directory-and-format.md) | Architecture | Agent | 1 | 00 |
+| 08 | [`review.md` cost-config + retry rules](./08-architecture-review-agent-cost-config-and-retry-rules.md) | Architecture | Agent | 1 | 00, 02 |
+| 09 | [Operator-side rollout playbook + catalog cleanup](./09-architecture-operator-side-rollout-playbook.md) | Architecture | Agent | 5 | 00, 01, 02, 07 |
+
+## Cross-Initiative Coordination
+
+### `HoneyDrunk.Kernel` solution versioning vs ADR-0042
+
+The `adr-0042-idempotency` initiative also targets `HoneyDrunk.Kernel` (its packets 02/04/07 bump the solution `0.7.0` → `0.8.0` for the idempotency contract surface). ADR-0052's Kernel work (packet 03 here) wants `0.8.0` → `0.9.0` as a follow-on minor bump.
+
+**The order matters and is enforced by check-at-edit-time, not by `dependencies:` edges** (the two initiatives are independent at the contract level; only the version line couples them):
+- If ADR-0042's Kernel packets have all merged and `HoneyDrunk.Kernel` is at the released `0.8.0`, **packet 03 bumps** `0.8.0` → `0.9.0`.
+- If an ADR-0042 Kernel version bump is still in-progress (unreleased), **packet 03 appends** to that in-progress version entry and does not bump again (invariant 27).
+
+Packet 03 documents the check and records the case in the PR. The expected case is "ADR-0042's Kernel work is released" — ADR-0042 is sequenced before ADR-0052 by topic priority (idempotency lands before cost governance per the ADR Context).
+
+### `HoneyDrunk.AI` scaffold gate
+
+`HoneyDrunk.AI` is at v0.1.0 with seed status — the ADR-0016 Phase-1 scaffold packet (`HoneyDrunk.AI#2`) has not been executed. **Packets 05 and 06 require the AI Node to be scaffolded enough to host a Cosmos client, an `IHostedService`, and the `IBudgetConfigProvider` consumption.** Packet 04 is lighter — it can land against the seed state because it only deletes types and migrates call sites.
+
+**If the AI scaffold has not landed by the time Wave 3 → 4 boundary is reached**, the Wave-3 packet (04) still merges (no scaffolding needed), but packets 05 and 06 wait. The dispatch plan flags this as the initiative's biggest gate. The operator may need to file the AI scaffold packet (ADR-0016 Phase 1) before Wave 4 can proceed.
+
+### ADR-0040 / ADR-0045 cross-references (`IErrorReporter`)
+
+Packet 06 calls `IErrorReporter.CaptureException` on hard-cap breach (problem group `Honeydrunk.Cost.HardCapBreach`). The `IErrorReporter` facade ships in ADR-0045's initiative (currently being scoped — ADR-0045 is Proposed; its initiative is `adr-0045-grid-wide-error-tracking`). **Packet 06 expects `IErrorReporter` to exist in `HoneyDrunk.Telemetry.Abstractions`** at the version that ships ADR-0045's packet 02.
+
+If ADR-0045's `IErrorReporter` facade is not yet on the NuGet feed when packet 06 runs, packet 06's executor should:
+- Check `HoneyDrunk.AI`'s existing `HoneyDrunk.Telemetry.Abstractions` reference at edit time; if the facade is there, use it.
+- If not, ship the breach event via the next-best mechanism: structured `ILogger` log at `Error` level + the `BudgetExceededException` propagation. Document the gap in the packet's PR description and flag a follow-on packet to wire `IErrorReporter` once ADR-0045 ships.
+
+This is a soft cross-initiative dependency — both initiatives are scopable independently — but they share a sequencing concern that the executor surfaces at runtime.
+
+### ADR-0018 Operator standup gate
+
+Every surface in packet 09's playbook is gated on the Operator standup. ADR-0018 is **Proposed**; the playbook does not advance it. A future ADR-0018 acceptance initiative will be the trigger for re-decomposing the playbook into Operator-side packets.
+
+## Human Release at Wave Boundaries — Agents Never Tag
+
+Three waves cross repo boundaries that require human release-tags on NuGet:
+
+- **Wave 2 → Wave 3 boundary** — after packet 03 (Kernel) merges, a human tags/releases `HoneyDrunk.Kernel` at the new version so packet 04 (AI) can compile against the new `HoneyDrunk.Kernel.Abstractions`. The tag carries both packages in the solution (Kernel + Kernel.Abstractions).
+- **Wave 3 → Wave 4 boundary** — packets 04 and 05 share the `HoneyDrunk.AI` solution; the in-progress version entry started by packet 04 is appended-to by packet 05. The Wave-4 release is a single `HoneyDrunk.AI` solution-wide tag after packet 05 merges. (Wave 4 is intra-solution; no cross-solution release-tag gate between packets 04 and 05 themselves.)
+- **Wave 4 → Wave 5 boundary** — packet 06 also targets the `HoneyDrunk.AI` solution and appends to packets 04/05's in-progress version. The single solution-wide tag at the end of packet 06 closes the AI work in this initiative. The human tag happens after packet 06 merges; the version is the same one packets 04/05 ramp to. No two-step tag.
+
+The pattern is the standard "agents merge code, humans tag and release" boundary from `adr-0042-idempotency`'s dispatch plan.
+
+## Phase-1 Multiplier Posture — Operator-Tunable
+
+ADR-0052 D14 Phase 1 names "intentionally loose initial caps ($5000 / $10000 across all categories) so the kill-switch does not fire spuriously while baselines are being established." This initiative implements that posture via the **Phase-1 multiplier** on `BudgetConfigProvider` (packet 05):
+
+- `CostLedger:PhaseOneMultiplier:Dev` defaults to **10** (dev caps inflated 10x — so dev burn must be 10x the D2 dev cap to trigger).
+- `CostLedger:PhaseOneMultiplier:Staging` defaults to **10**.
+- `CostLedger:PhaseOneMultiplier:Prod` defaults to **1** (prod caps at the D2 values from day one — prod is exposed to fewer test spikes than dev).
+
+The Phase-3 flip (D14 Phase 3) is to set the dev/staging multipliers to 1, after one month of Phase-1 baseline. The flip is **operator-driven via App Configuration**, not a code change. Packet 09's playbook names the flip as deferred-follow-up item #10 with the recommended observation period.
+
+## Initial Caps vs Phase-1 Multiplier — the Two Knobs
+
+Both the multiplier and the cap values are operator-tunable, but they have different change paths:
+
+- **The caps** live in `business/context/cost-budgets.json` (packet 02). Changes go through the **slow PR path** with `review` agent gating (`cost-config` category, packet 08). The audit trail is the git history.
+- **The Phase-1 multiplier** lives in App Configuration. Changes are **operator-driven**, immediate, and not in this initiative's PR scope. The runtime picks them up on the next config refresh.
+
+The two knobs are independent: the operator may flip the multiplier without changing the caps, or tune the caps without touching the multiplier. The `cost-config` review category gates only the cap changes; the multiplier flip is a config-management decision outside the JSON file.
+
+## Phase 4 Pilot — Deploy-Side Sequencing
+
+ADR-0052 D14 Phase 4 ("kill-switch enablement") is the dangerous phase — it changes runtime behaviour from logging to throwing. The phased posture in the ADR is to pilot on AI inference for one week before extending to other categories. This initiative ships the runtime change (packet 06); the pilot is a deployment concern.
+
+The recommended deploy sequence is documented in packet 06's PR description:
+1. Deploy packet 06's runtime to **dev** with the Phase-1 multiplier at 10 (cap effectively loose).
+2. Observe for one week. False breaches in dev are expected to be near-zero; the dev cap is inflated 10x.
+3. Flip the multiplier to 1 in dev. Observe for one more week. False breaches now indicate either a real budget event (good — the system works) or a defect in the ledger / cache / config (bad — investigate).
+4. Deploy packet 06's runtime to **prod**. The Phase-1 multiplier is 1 in prod from day one. Real breaches in prod are the system doing its job.
+
+The operator may compress or extend the schedule based on observed behaviour. The PR's `CostLedger:KillSwitch:Enabled` App Configuration value is a safety hatch — flipping it `false` bypasses the interceptor in case Phase 4 itself has a defect.
+
+## Cross-Cutting Concerns
+
+### Operator-side surfaces are out of scope by design
+
+This is named loudly in every relevant packet. ADR-0052 commits a Grid-wide substrate, but this initiative ships only the foundation layer (contracts + AI-side implementation + AI-side dispatcher wiring) plus the Architecture-repo governance. **Every Operator-hosted surface — the aggregator polling Azure Cost Management / GitHub Actions / vendor APIs; the Container Apps auto-suspend job; the `hd cost` CLI; the "Cost" dashboard view; the App Insights anomaly Bicep; the Communications + Notify alert wiring — waits on ADR-0018 (Operator standup) and is named in packet 09's playbook.**
+
+This is consistent with the Memory note `feedback_adr_before_scaffold`: standup work gets its own ADR; do not bundle scaffold into feature packets. ADR-0018 is the standup; this initiative is the foundation; the future Operator-side cost-governance initiative is the standup follow-on.
+
+### AI Node scaffold gate
+
+`HoneyDrunk.AI` is at v0.1.0 / seed. Packets 05 and 06 require the AI Node to be scaffolded enough to host a Cosmos client and a `HostedService`. If the AI scaffold has not landed by Wave 3 → 4 boundary, packets 05 and 06 wait. The operator may need to file the AI scaffold packet (ADR-0016 Phase 1) before Wave 4 can proceed. The dispatch plan flags this as the initiative's biggest gate.
+
+### `IErrorReporter` cross-initiative dependency
+
+Packet 06 expects `IErrorReporter` from `HoneyDrunk.Telemetry.Abstractions` (shipped by ADR-0045's initiative). If ADR-0045 has not landed by packet 06's run time, the executor uses the structured-log fallback documented in packet 06.
+
+### Replace, not extend — the AI-side `ICostLedger`
+
+The seed `HoneyDrunk.AI.Abstractions.ICostLedger` is removed in packet 04. The contract has no out-of-repo consumer (the AI Node is at seed status); the removal is an additive minor bump on the AI solution. If a downstream consumer somewhere does pin on the old contract, the bump may break it — the operator should grep the workspace for `HoneyDrunk.AI.Abstractions.ICostLedger` usage before packet 04 merges. The most likely consumers are the four AI provider packages, which packet 04 migrates.
+
+### Cosmos as the v1 backing — and the AI Node's first persistence dependency
+
+Packet 05 introduces Cosmos into `HoneyDrunk.AI` for the first time. The provisioning is a Human Prerequisite (portal click per the Memory `feedback_portal_over_cli` note). The cost of the ledger's Cosmos consumption is itself an Azure-infra line item; the future Operator aggregator picks it up and writes it back to the ledger as a recursive line. This is fine — the recursion closes at the aggregator's daily polling cadence.
+
+### Site sync
+
+No site-sync flag. ADR-0052 is internal Ops infrastructure — no public-facing Studios website content changes.
+
+### Catalog cleanup in packet 09 is conditionally gated on packet 04
+
+Packet 09's catalog cleanup (removing the AI-side `ICostLedger` entry from `contracts.json`) is conditionally gated on packet 04 having merged. If packet 04 is unmerged when packet 09 runs, the cleanup is deferred and noted in the PR. The playbook half of packet 09 ships regardless.
+
+## Rollback Plan
+
+- **Packets 00–02, 07, 08, 09 (governance / catalog / config / docs):** revert the PR. ADR returns to Proposed; the three invariants, the catalog entries, the budget config file, the report format, the review-agent rules, and the playbook are removed. No runtime impact.
+- **Packet 03 (Kernel contracts):** revert the PR; the `HoneyDrunk.Kernel` solution rolls back the version bump. The contracts are additive — no consuming Node depends on them until it composes them, so the revert is contained to `HoneyDrunk.Kernel`. Packets 04+ would fail to compile against the new Kernel version, so revert packet 04 first if packet 04 has already merged.
+- **Packet 04 (AI relocation):** revert the PR; the seed `HoneyDrunk.AI.Abstractions.ICostLedger` returns; provider call sites return to the old `RecordAsync(InferenceCost)` shape; `DefaultCostLedger` returns to its old implementation. The AI solution version rolls back. The seed contract has no external consumer; the revert is contained.
+- **Packet 05 (Cosmos backing):** revert the PR; `DefaultCostLedger` returns to the stub (or to whatever packet 04 left). The Cosmos container the human provisioned remains but is unused — the operator can manually delete it from the portal. No runtime impact on call sites since the stub answers `IsHardCapBreachedAsync = false` for every category.
+- **Packet 06 (dispatcher kill-switch wiring):** revert the PR; the AI dispatcher returns to pre-Phase-4 behaviour (no cap check on the hot path). The kill-switch is inert; the cap-check answer is correct but no call site consumes it. **Operational escape hatch:** `CostLedger:KillSwitch:Enabled=false` in App Configuration disables the interceptor without code revert — a one-config-value change, no redeploy.
+- **Backend-level escape hatch:** ADR-0052 D11's override CLI (gated on Operator standup) is the architectural rollback for the kill-switch firing wrongly — issue an override for the affected category, investigate, and revert if the breach was a defect. The override is audited; the revert is recoverable.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.
+
+**Before pushing:** there are no cross-initiative `Architecture#<n>` placeholders in this initiative — every `dependencies:` array uses `packet:NN` (within-folder) edges only. Safe to push as soon as the packets are written.
+
+The cross-initiative cross-references that are *not* `dependencies:` edges (the ADR-0042 version-state check on Kernel, the ADR-0016 AI scaffold gate, the `IErrorReporter` from ADR-0045) are documented as Cross-Initiative Coordination notes rather than as edges — they are check-at-edit-time concerns, not packet-ordering concerns.

--- a/generated/issue-packets/active/adr-0052-cost-governance/handoff-wave2-kernel-contracts.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/handoff-wave2-kernel-contracts.md
@@ -1,0 +1,94 @@
+# Handoff — Wave 1 → Wave 2: the Kernel cost-governance contracts
+
+**Initiative:** `adr-0052-cost-governance`
+**Wave transition:** Wave 1 (governance + catalog + config + report format + review rules) → Wave 2 (Kernel contracts)
+**Read once at the wave boundary. Immutable per invariant 24.**
+
+## What Wave 1 landed
+
+- **Packet 00** — ADR-0052 flipped to **Accepted**. Three new invariants added to `constitution/invariants.md` under a new `## Cost Governance Invariants` section, numbered **90, 91, 92** (pre-reserved for ADR-0052; current verified max in the file is 49):
+  1. **90** — Every cost-producing operation in the Grid is recorded as a `CostEvent` in the cost ledger (dispatcher + aggregator code paths must produce an event for every dollar of external spend; CI check enforces).
+  2. **91** — `ILlmDispatcher` checks the cost ledger against the hard cap before each LLM call (the hot-path check; `BudgetExceededException` is sealed and non-transient; catch-and-retry is a defect).
+  3. **92** — Operator overrides of cost caps are audited (references invariant 47 / ADR-0030 — does not restate the Audit retention/tagging contract).
+- **Packet 01** — Cost-governance contracts registered under `honeydrunk-kernel` in `catalogs/contracts.json`: `ICostLedger`, `CostEvent`, `CostCategory`, `BudgetExceededException`, `BudgetOverride`, `IBudgetConfigProvider`, `BudgetConfig`, `CostQuery`. The existing AI-side `ICostLedger` entry under `honeydrunk-ai` is marked as relocating (not deleted — packet 09 removes it after packet 04 ships). D7 implementation-home and D13 cross-ADR notes recorded as cross-cutting policy notes.
+- **Packet 02** — `business/context/cost-budgets.json` created with the ADR-0052 D2 defaults (AI inference $500/$1500; Azure infra $300/$800; SaaS $200 soft-only; domain/cert $25 soft-only; GitHub Actions $50/$150), the D10 anomaly thresholds (5.0 / 3.0), the D12 dev overlay, and the per-category owners block (`oleg` for all five at v1). The tuning policy doc records the slow-PR-path vs fast-override-CLI boundary.
+- **Packet 07** — `generated/cost-reports/_format.md` ships the canonical monthly report format with stable level-2 heading anchors per D9's seven sections; an `EXAMPLE.md` worked example renders the shape with plausible placeholder data.
+- **Packet 08** — `.claude/agents/review.md` carries the new `cost-config` and `cost-kill-switch-retry` review categories; both severity `block`. `pr-review-rules.md` maps them.
+
+ADR-0052's decisions are now live rules. The contracts the catalog already advertises are added in code in packet 03.
+
+## What Wave 2 must deliver (packet 03)
+
+Build the cost-governance contract surface in **`HoneyDrunk.Kernel`** (live Node):
+
+- **`HoneyDrunk.Kernel.Abstractions`** — add `ICostLedger`, `CostEvent`, `CostCategory`, `CostSource`, `CostEnvironment`, `BudgetExceededException`, `BudgetOverride`, `IBudgetConfigProvider`, `BudgetConfig`, `CostQuery`. Pure records / interfaces / enums / sealed exception — zero HoneyDrunk runtime dependencies (invariant 1).
+- This is the **version-bumping packet for `HoneyDrunk.Kernel` in this initiative**.
+
+## Interface signatures for downstream packets
+
+`ICostLedger` — the shape packets 04/05/06 (and the future Operator aggregator + future Billing) consume:
+```
+public interface ICostLedger
+{
+    ValueTask RecordCostAsync(CostEvent evt, CancellationToken ct);
+    ValueTask<decimal> GetMonthToDateAsync(CostCategory category, CancellationToken ct);
+    ValueTask<bool> IsHardCapBreachedAsync(CostCategory category, CancellationToken ct);
+    ValueTask<BudgetOverride?> GetActiveOverrideAsync(CostCategory category, CancellationToken ct);
+    IAsyncEnumerable<CostEvent> QueryAsync(CostQuery query, CancellationToken ct);
+}
+```
+
+`CostEvent` — record carrying:
+- `CostCategory Category` (enum: `AiInference` / `AzureInfrastructure` / `ThirdPartySaas` / `DomainCertRegistrar` / `GitHubActionsMinutes`)
+- `decimal Amount` (USD; validate non-negative)
+- `DateTimeOffset Timestamp`
+- `CostSource Source` (discriminated: `LlmInferenceSource` / `AzureInfraSource` / `SaasSource` / `CiSource` / `DomainSource`)
+- `CostEnvironment Environment` (enum: `Prod` / `Dev` / `Staging` / `Local` — `Local` events are written to Cosmos for visibility but exempt from caps per D12)
+- `string CorrelationId` (validate non-empty)
+- `TenantId? TenantId` (ADR-0026; reuse the Kernel `TenantId` type if it exists, otherwise `string?`)
+- `string? AgentId` (D6; reuses ADR-0051's identifier shape)
+- `string? AgentRunId` (D6 per-invocation correlation)
+
+`BudgetExceededException` — `public sealed class : Exception`. Carries `CostCategory Category`, `decimal HardCap`, `decimal MonthToDate`, `string CorrelationId`. Override `Message` to include category / cap / actual. XML-doc states: "Non-transient. Callers must not retry; catching and retrying within the same billing window is a defect detected by the `review` agent (`cost-kill-switch-retry` category from packet 08). The top-level loop carve-out from ADR-0052 D4 is the only sanctioned catch — log a structured event, write checkpoint state to Audit, exit cleanly."
+
+`BudgetOverride` — record: `CostCategory Category`, `string OperatorPrincipalId`, `string Reason`, `DateTimeOffset IssuedAt`, `DateTimeOffset ExpiresAt`, `DateTimeOffset? RevokedAt`. Time-bounded; permanent overrides do not exist (D11).
+
+`IBudgetConfigProvider` — single member: `ValueTask<BudgetConfig> GetAsync(CancellationToken)`. XML-doc points at the Vault `IConfigProvider` source path per ADR-0016 D5.
+
+`BudgetConfig` — record: `IReadOnlyDictionary<CostCategory, BudgetCategoryConfig> Categories`, `IReadOnlyDictionary<CostCategory, BudgetCategoryConfig> DevOverlay`, `IReadOnlyDictionary<CostCategory, string> Owners`. Nested `BudgetCategoryConfig`: nullable `SoftCap` / `HardCap`, `KillSwitch` posture string (`"in_process"` / `"azure_suspend"` / `"github_native"` / `"none"`), anomaly thresholds.
+
+`CostQuery` — record with nullable filters and required date range.
+
+## Version-state check — read carefully
+
+The `HoneyDrunk.Kernel` solution is also touched by the `adr-0042-idempotency` initiative (its packets 02 / 04 / 07 bump `0.7.0` → `0.8.0` for the idempotency contract surface). **At packet 03's edit time, the executor must check:**
+
+- If ADR-0042's Kernel packets have all merged and `HoneyDrunk.Kernel` is at the **released** `0.8.0`, **packet 03 bumps** the solution `0.8.0` → `0.9.0` (minor — additive new contract surface, no break). Add new `[0.9.0]` entries to the repo-level `CHANGELOG.md` and `HoneyDrunk.Kernel.Abstractions/CHANGELOG.md`.
+- If an ADR-0042 Kernel version bump is still **in-progress (unreleased)**, packet 03 **appends** to that in-progress version entry and does NOT bump again (invariant 27).
+
+The expected case is "ADR-0042's Kernel work is released" — ADR-0042 is sequenced before this initiative by topic priority. Verify and record in the PR.
+
+## Frozen / do-not-touch
+
+- **`HoneyDrunk.AI.Abstractions.ICostLedger`** (the seed two-member interface) — do NOT modify from packet 03. The AI-side relocation is packet 04, in the AI repo, on its own commit.
+- **`HoneyDrunk.Transport`** — Kernel does not depend on Transport (invariant 4 DAG; Transport depends on Kernel, never the reverse). No reference.
+- **`HoneyDrunk.Data`** — Kernel does not depend on Data. The Cosmos persistence lives in `HoneyDrunk.AI` per D7, not in Kernel.
+- **Existing Kernel context contracts** (`IGridContext`, `TenantId`, `CorrelationId`, etc.) — `CostEvent` reuses the existing `TenantId` type if Kernel exposes one; do not fork a parallel primitive.
+
+## Invariants binding Wave 2
+
+- **Invariant 1** — `HoneyDrunk.Kernel.Abstractions` has zero runtime dependencies on other HoneyDrunk packages; only `Microsoft.Extensions.*` abstractions permitted. No Cosmos SDK, no App Insights SDK, no Azure type in the contract. The new types use only BCL types.
+- **Invariant 4** — the dependency graph is a DAG; Kernel is at the root. No reference to `HoneyDrunk.AI`, `HoneyDrunk.Transport`, `HoneyDrunk.Data`, or any other HoneyDrunk runtime package.
+- **Invariant 8** — secrets never in telemetry. `CostSource` carries structured forensics data (provider id, model id, token counts, resource id, meter name) — no prompt text, no completion text, no API key. The XML docs state this.
+- **Invariant 13** — every new public member has XML documentation.
+- **Invariant 27** — all projects in a solution share one version and move together. Packet 03 is the bumping packet (or the appending packet — see the version-state check). Partial bumps are forbidden.
+- **Invariant 51** — no `Thread.Sleep` in tests; use `TimeProvider`.
+- **Naming rule** — records drop the `I` (`CostEvent`, `CostSource`, `BudgetOverride`, `BudgetConfig`, `CostQuery`); interfaces keep it (`ICostLedger`, `IBudgetConfigProvider`); enums (`CostCategory`, `CostEnvironment`) follow standard enum naming; the exception type `BudgetExceededException` is a class (Exception subclass) — no `I` prefix.
+
+## Acceptance gate for Wave 2
+
+Packet 03's PR passes the `pr-core.yml` tier-1 gate. `HoneyDrunk.Kernel.Abstractions` ships the cost-governance contract surface; `HoneyDrunk.Kernel` (runtime) gets the alignment bump but no functional change and no per-package CHANGELOG entry. The unit tests cover record construction / equality / `BudgetExceededException` sealedness / `CostEvent.Amount` validation.
+
+**Human package release at the Wave 2 → Wave 3 boundary — agents never tag.** Packet 04 (AI Node) builds against the `HoneyDrunk.Kernel.Abstractions` version that ships packet 03. After packet 03 merges, a human must tag/release `HoneyDrunk.Kernel` at its new version (`0.9.0` or the in-progress ADR-0042 version) so packet 04 can compile.
+
+The Wave 3 packet (04) is the AI-side relocation: delete the seed `HoneyDrunk.AI.Abstractions.ICostLedger`, migrate every AI provider call site, rewrite `DefaultCostLedger` as a Phase-1 stub against the new Kernel contract.

--- a/generated/issue-packets/active/adr-0052-cost-governance/handoff-wave4-cosmos-ledger.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/handoff-wave4-cosmos-ledger.md
@@ -1,0 +1,103 @@
+# Handoff — Wave 3 → Wave 4: the Cosmos-backed v1 ledger
+
+**Initiative:** `adr-0052-cost-governance`
+**Wave transition:** Wave 3 (AI-side `ICostLedger` relocation + Phase-1 stub) → Wave 4 (Cosmos-backed v1 implementation)
+**Read once at the wave boundary. Immutable per invariant 24.**
+
+## What Waves 1–3 landed
+
+- **Wave 1 (packets 00 / 01 / 02 / 07 / 08).** ADR-0052 Accepted. Three invariants (90, 91, 92) live. Cost-governance contracts registered under `honeydrunk-kernel` in the catalog. `business/context/cost-budgets.json` exists with D2 defaults / D10 anomaly thresholds / D12 dev overlay. `generated/cost-reports/_format.md` ships the canonical monthly report format. `.claude/agents/review.md` carries the `cost-config` and `cost-kill-switch-retry` review categories.
+- **Wave 2 (packet 03).** `HoneyDrunk.Kernel.Abstractions` ships `ICostLedger` (five members), `CostEvent`, `CostCategory`, `CostSource` (discriminated union), `CostEnvironment` (enum with `Local` exempt-from-caps), `BudgetExceededException` (sealed, non-transient), `BudgetOverride`, `IBudgetConfigProvider`, `BudgetConfig`, `CostQuery`. `HoneyDrunk.Kernel` solution bumped (or appended to the in-progress ADR-0042 version — record which case applied).
+- **Wave 3 (packet 04).** `HoneyDrunk.AI.Abstractions/ICostLedger.cs`, `InferenceCost.cs`, `CostSummary.cs` deleted. `HoneyDrunk.AI.Abstractions` references `HoneyDrunk.Kernel.Abstractions` at the version that ships packet 03. Every AI provider package (`OpenAI`/`Anthropic`/`AzureOpenAI`/`InMemory`) has migrated from `RecordAsync(InferenceCost)` to `RecordCostAsync(CostEvent)` with `CostSource = new LlmInferenceSource(provider, model, inputTokens, outputTokens)` and `Category = CostCategory.AiInference`. `DefaultCostLedger` is a Phase-1 **non-durable stub** — `RecordCostAsync` logs at Debug, `IsHardCapBreachedAsync` returns `false`, `GetActiveOverrideAsync` returns `null`, `QueryAsync` returns empty. The `HoneyDrunk.AI` solution bumped `0.1.0` → `0.2.0` (additive minor — no out-of-repo consumer of the old seed contract).
+
+Wave 4 (packet 05) replaces the Phase-1 stub with the Cosmos-backed v1 implementation and ships the in-memory cache that serves the hot-path cap check.
+
+## What Wave 4 must deliver (packet 05)
+
+Replace `DefaultCostLedger`'s body (or add a `CostLedger` class that takes over the registration) in `HoneyDrunk.AI/src/HoneyDrunk.AI/Cost/` with the durable Cosmos backing per ADR-0052 D7 / D8:
+
+- **`CostLedger`** — implements all five `ICostLedger` members. `RecordCostAsync` writes to Cosmos with partition key `(category, year-month)`. `IsHardCapBreachedAsync` is served from an in-memory cache, never from Cosmos on the hot path. The cache stores the current-month roll-up per category and is refreshed every 30 seconds by `CostLedgerCacheRefreshService`. `Local`-environment events are written to Cosmos for visibility but do not update the cap-check cache (D12).
+- **`BudgetConfigProvider`** — reads `business/context/cost-budgets.json`. Applies the Phase-1 multiplier per environment (`Dev`/`Staging` 10x, `Prod` 1x by default). Caches the resolved config for ~60 seconds.
+- **`CostLedgerCacheRefreshService`** — `IHostedService` that loops every 30 seconds and refreshes the cache from Cosmos. Use `TimeProvider` (invariant 51 — no `Thread.Sleep`).
+- **`CostLedgerCosmosOptions`** — config record (endpoint, database, container, phase-1 multipliers).
+- **Cosmos provisioning Bicep** — at the AI Node's IaC convention (if no such convention exists, create `HoneyDrunk.AI/infra/`).
+
+## Hot-path contract — non-negotiable
+
+`IsHardCapBreachedAsync` runs on every LLM call (per packet 06 in Wave 5). It MUST be served from the in-memory cache — sub-microsecond at v1 LLM call volume. The cache miss path reads Cosmos (single-digit ms) and populates the cache. A read that goes to Cosmos on every invocation defeats the kill-switch's "fast circuit-breaker" posture (ADR-0052 D4).
+
+The cache TTL is the 30-second refresh tick. A 30-second lag between a write and a cache update is acceptable — the cap is a monthly aggregate; a 30-second window of stale data near the cap will at worst over-spend by the volume that 30 seconds of LLM traffic produces, which is small relative to the cap.
+
+## Override priority — read first
+
+`IsHardCapBreachedAsync` returns `false` when an active `BudgetOverride` covers the queried category, regardless of month-to-date. The check sequence:
+1. Read the active override for the category from Cosmos (a small dedicated container or sentinel rows — choose at implementation time).
+2. If an override exists with `ExpiresAt > now` and `RevokedAt is null`, return `false`.
+3. Otherwise, compare cache value against the configured hard cap (with dev overlay + Phase-1 multiplier applied) and return the comparison.
+
+The dispatcher (packet 06) does NOT separately query overrides — one `IsHardCapBreachedAsync` call answers "can this call go through."
+
+## Phase-1 multiplier — operator-tunable
+
+ADR-0052 D14 Phase 1 names "intentionally loose initial caps" so the kill-switch does not fire spuriously during baseline. Implementation: `CostLedger:PhaseOneMultiplier:Dev` / `:Staging` / `:Prod` in App Configuration. Defaults: 10 (dev), 10 (staging), 1 (prod). The effective cap is `BudgetCategoryConfig.HardCap * PhaseOneMultiplier[Environment]`.
+
+The Phase-3 flip (D14) sets dev/staging to 1 — an operator-driven App Configuration change, not a code change. The flip narrative lives in packet 09's playbook. Document the multiplier behaviour in the implementation file and the PR.
+
+## Cosmos persistence shape
+
+- **Partition key:** `$"{category}|{timestamp:yyyy-MM}"` — `(category, year-month)`.
+- **Row key / item id:** something unique per event. Recommend `Guid.NewGuid().ToString()` for the item id; carry the timestamp / tenant id / agent id as item fields, not part of the row key (the row key is for uniqueness; the dimensions are for query).
+- **Retention:** 13 months (current + 12 trailing). The retention sweep is a separate concern — either Cosmos TTL on individual items (set `_ts`-relative TTL of ~400 days) or a scheduled cleanup job. ADR-0052 D8 commits the retention; the **mechanism** is the implementer's choice. Document which path.
+- **Override storage:** a separate container `cost-overrides` (or sentinel rows in the same container, partitioned by `"overrides|active"`) — pick the cheaper option and document.
+- **Storage cost:** ~2.6 GB at upper bound (100K events/month × 13 × 2KB). RU/s well under the 400 RU/s autoscale floor. Single-digit-dollars/month in prod; serverless is even cheaper in dev.
+
+## Cosmos auth — Managed Identity, not keys
+
+The Cosmos client uses `DefaultAzureCredential` for the data-plane role `Cosmos DB Built-in Data Contributor` in every non-`Local` environment. Primary keys are NOT placed in source or app settings; for `Local` development, the key is sourced from Vault (`IConfigProvider`) and never logged (invariant 8). The Human Prerequisites on packet 05 include the per-environment RBAC grant.
+
+## DI composition
+
+In `ServiceCollectionExtensions`:
+```csharp
+services.AddSingleton<ICostLedger, CostLedger>();          // replaces the Phase-1 stub
+services.AddSingleton<IBudgetConfigProvider, BudgetConfigProvider>();
+services.AddHostedService<CostLedgerCacheRefreshService>();
+services.AddOptions<CostLedgerCosmosOptions>().Bind(configuration.GetSection("CostLedger"));
+```
+
+Keep the registration idempotent — packet 04 already registered `ICostLedger -> DefaultCostLedger`; packet 05 replaces it with `ICostLedger -> CostLedger`. The stub class may stay marked `[Obsolete]` for one release, or be deleted in this PR (pick at edit time).
+
+## What packet 05 does NOT deliver
+
+- **Dispatcher kill-switch wiring** — that is packet 06. This packet ships a correct `IsHardCapBreachedAsync` answer; no call site consumes it until packet 06.
+- **Daily roll-up email / threshold pings / breach push** — gated on ADR-0018 Operator standup (packet 09 playbook).
+- **Container Apps auto-suspend** — gated on ADR-0018.
+- **App Insights anomaly Bicep** — gated on ADR-0040 + ADR-0018.
+- **External-source aggregator (Azure Cost Management, GitHub Actions, vendor APIs)** — gated on ADR-0018.
+
+## Human Prerequisites at the Wave 3 → Wave 4 boundary
+
+The packet 05 packet body names these explicitly; surfaced here for completeness:
+
+1. **Wave 2 → Wave 3 release tag on `HoneyDrunk.Kernel`** — done before packet 04 builds; verify by inspecting the NuGet feed for the new `HoneyDrunk.Kernel.Abstractions` version at edit time.
+2. **`HoneyDrunk.AI` solution version state** — packet 05 appends to packet 04's in-progress version entry; do NOT bump again in this initiative (invariant 27).
+3. **Cosmos account provisioning per environment** — portal click; cheapest viable tier (serverless dev, autoscale 400 RU/s prod); tag `env=...`, `node=ai`; show $ before clicking Create per the Memory note `feedback_default_cheapest_azure_tier`.
+4. **Managed Identity RBAC** — grant the AI Container App's Managed Identity `Cosmos DB Built-in Data Contributor` on the cost-ledger database, per environment.
+5. **App Configuration values** — `CostLedger:Endpoint`, `CostLedger:Database`, `CostLedger:Container`, `CostLedger:OverrideContainer` (if separate), `CostLedger:PhaseOneMultiplier:Dev` = 10, `CostLedger:PhaseOneMultiplier:Staging` = 10, `CostLedger:PhaseOneMultiplier:Prod` = 1.
+
+## Invariants binding Wave 4
+
+- **Invariant 1** — the new Cosmos / Azure dependencies land in the **runtime** `HoneyDrunk.AI` package; `HoneyDrunk.AI.Abstractions` stays Cosmos-free.
+- **Invariant 4** — DAG. AI depends on Kernel.Abstractions; do not invert.
+- **Invariant 8** — Cosmos primary keys never in logs, traces, or exceptions. Managed Identity is the auth path.
+- **Invariant 15** — unit tests do not depend on external services; mock the Cosmos client.
+- **Invariant 27** — `HoneyDrunk.AI` solution version unchanged from packet 04; append, do not bump.
+- **Invariant 47** — Audit substrate (referenced). Override writes are NOT performed by this packet; the read path here just retrieves current override state. Override writes happen in the future `hd cost unlock` CLI on Operator (packet 09 playbook).
+- **Invariant 51** — no `Thread.Sleep` in tests. Use `TimeProvider` for cache-refresh tests.
+- **Invariant 91** (this initiative, packet 00) — satisfied by **packet 06**, not this one. Packet 05 ships the cap-check method; packet 06 wires the dispatcher.
+
+## Acceptance gate for Wave 4
+
+Packet 05's PR builds. `CostLedger` implements all five `ICostLedger` members. The hot-path cap check is served from the in-memory cache, refreshed every 30 seconds. `BudgetConfigProvider` resolves caps from `cost-budgets.json` with the Phase-1 multiplier applied. Cosmos auth uses Managed Identity. Unit tests cover cap-not-breached / cap-breached / override-active / override-expired / dev-overlay / Phase-1-multiplier / `Local`-exempt behaviour. The Cosmos provisioning Bicep is at the AI Node's IaC convention. The repo-level + per-package CHANGELOGs append to the in-progress AI version entry — no second solution-wide bump.
+
+Wave 5 (packet 06) wires the dispatcher to call `IsHardCapBreachedAsync` and ships the kill-switch canary; packet 09 ships the Operator-side rollout playbook.

--- a/generated/issue-packets/active/adr-0052-cost-governance/handoff-wave5-killswitch-and-playbook.md
+++ b/generated/issue-packets/active/adr-0052-cost-governance/handoff-wave5-killswitch-and-playbook.md
@@ -1,0 +1,103 @@
+# Handoff — Wave 4 → Wave 5: dispatcher kill-switch + Operator-side playbook
+
+**Initiative:** `adr-0052-cost-governance`
+**Wave transition:** Wave 4 (Cosmos-backed ledger v1) → Wave 5 (dispatcher kill-switch wiring + rollout playbook)
+**Read once at the wave boundary. Immutable per invariant 24.**
+
+## What Wave 4 landed
+
+- **Packet 05** — `HoneyDrunk.AI`'s `CostLedger` is the Cosmos-backed v1 implementation. Writes are partitioned `(category, year-month)`. `IsHardCapBreachedAsync` is served from a 30-second-refresh in-memory cache. `BudgetConfigProvider` resolves caps from `business/context/cost-budgets.json` with the Phase-1 multiplier applied per environment. Active `BudgetOverride`s cause `IsHardCapBreachedAsync` to return `false` until expiry. `Local`-environment events are written to Cosmos for visibility but do not affect the cap-check cache (D12). Cosmos auth is Managed Identity. The Cosmos provisioning Bicep is at the AI Node's IaC convention; the operator has provisioned the Cosmos account, granted the AI Container App's Managed Identity `Cosmos DB Built-in Data Contributor`, and seeded the App Configuration values per environment.
+
+**The cap-check returns a correct answer.** No call site consumes it yet — until packet 06 lands, the kill-switch is inert.
+
+## What Wave 5 must deliver
+
+**Two packets in parallel** (packet 06 is AI-only; packet 09 is Architecture-only):
+
+### Packet 06 — Dispatcher kill-switch wiring
+
+Wire the AI dispatcher chokepoint to call `IsHardCapBreachedAsync(CostCategory.AiInference)` before every LLM call. On breach (and no active override), throw `BudgetExceededException` synchronously — the inner provider is never invoked. Capture the breach via `IErrorReporter` (problem group `Honeydrunk.Cost.HardCapBreach`) for the operator's incident-review surface (ADR-0045). Ship the kill-switch canary in `HoneyDrunk.AI.Tests.Canaries` that asserts: throw on breach; type is `sealed`; provider never called; `IErrorReporter` capture happened; default retry policy did NOT retry; override honoured.
+
+### Packet 09 — Operator-side rollout playbook + catalog cleanup
+
+Author the playbook (`initiatives/adr-0052-rollout-playbook.md`) cataloguing the 15 deferred Operator-side surfaces (aggregator, auto-suspend, CLI, dashboard, anomaly Bicep, Communications + Notify alert wiring, Phase-1 multiplier flip, per-tenant query API, JSON sidecar, dev/prod resource separation, override pattern docs, per-provider API key spending limits). Each surface is gated on one of four upstream events (ADR-0018 standup is the dominant gate). The playbook is the re-decomposition map a future scope agent uses. Conditionally remove the AI-side `ICostLedger` entry from `catalogs/contracts.json` (gated on packet 04 having merged — defer the cleanup if not).
+
+## Critical context for Wave 5 execution
+
+### Pick the AI dispatcher chokepoint once
+
+ADR-0052 D4 calls the cost-checking seam `ILlmDispatcher`. The AI Node's existing abstraction layer is `IChatClient` / `IEmbeddingGenerator` (aligned with `Microsoft.Extensions.AI`) routed through `IModelRouter` into provider packages. The chokepoint should be **one seam** that catches every LLM call:
+
+- **Recommended:** a decorator over `IModelRouter` (or the routing implementation `DefaultModelRouter` if it exists at edit time). One decorator catches every call regardless of provider.
+- **Acceptable alternative:** decorators over `IChatClient` and `IEmbeddingGenerator` at the abstraction layer. Two decorators but the abstraction layer is the cleanest seam if `IModelRouter` is split or absent.
+
+Pick at edit time based on what the AI Node has built; document the choice in the implementation file header.
+
+### `BudgetExceededException` is sealed, non-transient, propagated
+
+The interceptor catches nothing. On breach:
+1. Call `IErrorReporter.CaptureException(new BudgetExceededException(...))` with problem group `Honeydrunk.Cost.HardCapBreach`, attribution dimensions, correlation id.
+2. Throw the exception.
+
+The exception propagates to the caller. The `review` agent's `cost-kill-switch-retry` category (from packet 08) gates code that catches and retries. The only sanctioned catch is the top-level loop carve-out (ADR-0052 D4): a long-running agent loop may catch at the top level, write checkpoint state to Audit, exit cleanly. The reviewer agent's category description (packet 08) documents this carve-out.
+
+### `IErrorReporter` cross-initiative dependency
+
+`IErrorReporter` ships in ADR-0045's initiative (`adr-0045-grid-wide-error-tracking`). At packet 06's edit time:
+- If `HoneyDrunk.AI`'s `HoneyDrunk.Telemetry.Abstractions` reference includes the version that ships `IErrorReporter`, use it.
+- If not (ADR-0045 hasn't landed), use the structured-log fallback: `_logger.LogError("Hard-cap breach: category={Category} cap=${Cap} actual=${Actual} correlationId={CorrelationId}", category, cap, actual, correlationId)` and propagate the exception. Document the gap in the PR description and flag a follow-on packet to wire `IErrorReporter` once ADR-0045 ships.
+
+### Recommended deploy sequence (Phase 4 pilot)
+
+ADR-0052 D14 Phase 4 is the dangerous phase — runtime behaviour changes from logging to throwing. The PR description for packet 06 captures the recommended deploy sequence:
+1. Deploy to **dev** with the Phase-1 multiplier at 10 (from packet 05). The effective dev cap is 10x the D2 dev cap; false breaches expected to be near-zero.
+2. Observe one week.
+3. Flip the App Configuration value `CostLedger:PhaseOneMultiplier:Dev` to 1. The dev cap is now D2-final. False breaches now indicate either a real budget event (good — the system works) or a defect.
+4. Observe one week.
+5. Deploy to **prod**. Prod is at the D2 caps from day one. Real breaches in prod are the system doing its job.
+
+The `CostLedger:KillSwitch:Enabled` App Configuration setting is a safety hatch: `false` bypasses the interceptor without a code revert.
+
+### What Wave 5 does NOT deliver
+
+- **Container Apps auto-suspend job** — Azure-infra kill-switch; gated on ADR-0018 Operator standup; named in packet 09 playbook entry #2.
+- **GitHub-native CI limit policy mirror** — manual GitHub org setting; named in packet 09.
+- **Daily roll-up email / threshold pings / breach push** — Communications + Notify wiring; gated on ADR-0018 standup; named in packet 09 entry #9.
+- **App Insights anomaly Bicep (D10)** — gated on ADR-0040 (App Insights provisioned) + ADR-0018 (Operator IaC); named in packet 09 entry #8.
+- **Operator "Cost" dashboard view** — gated on ADR-0018; named in packet 09 entry #7.
+
+## Per-call attribution audit
+
+Packet 04 migrated provider call sites to record `CostEvent`. Packet 06 verifies every call site populates `TenantId`, `AgentId`, `AgentRunId` from ambient `IGridContext`. If any field is hardcoded to `null` because the standup didn't plumb the context through, fix it in packet 06. Attribution at write time or never — historical events cannot be backfilled (D5).
+
+## Invariants binding Wave 5
+
+- **Invariant 1** — packet 06 ships code in `HoneyDrunk.AI` runtime, not Abstractions. Packet 09 ships docs + catalog edits.
+- **Invariant 15** — packet 06's interceptor unit tests use fake `ICostLedger` + counting test double for the inner provider. No external services.
+- **Invariant 27** — packet 06 appends to the in-progress AI version entry (started by packet 04, continued by 05); no second bump.
+- **Invariant 51** — no `Thread.Sleep` in tests; use `TimeProvider`.
+- **Invariant 91** (this initiative, packet 00) — **packet 06 satisfies this invariant.** `ILlmDispatcher` checks the cost ledger against the hard cap before each LLM call. The canary is the integration test required per ADR-0047 D4.
+- **Invariant 92** (this initiative, packet 00) — override writes are audited via `IAuditLog`. Packet 06 does NOT write overrides; the `hd cost unlock` CLI is named in packet 09's playbook entry #4. Invariant 92 stays partially-delivered (the rule exists; the override write path lands when ADR-0018 unblocks).
+
+## Acceptance gate for Wave 5
+
+Packet 06's PR:
+- Interceptor at the documented chokepoint; one call to `IsHardCapBreachedAsync` per LLM call.
+- `BudgetExceededException` propagates synchronously on breach; `IErrorReporter` capture happens before the throw.
+- Active overrides honoured implicitly (no separate query in the interceptor).
+- Provider attribution dimensions verified.
+- Kill-switch canary in `HoneyDrunk.AI.Tests.Canaries` asserts all six behaviours (throw, sealed, provider-not-called, error-reporter-captured, default-retry-does-not-retry, override-honoured).
+- AI solution version unchanged from packets 04/05 (appended; invariant 27).
+- Repo-level + AI-runtime CHANGELOG appended to the in-progress version entry; no per-package CHANGELOG entries on other packages.
+
+Packet 09's PR:
+- Playbook ships under `initiatives/` (or the existing playbook convention) with the four gating events, 15-entry deferred follow-up table, recommended sequencing, re-scope guidance, pointers to artifacts.
+- AI-side `ICostLedger` entry removed from `catalogs/contracts.json` (gated on packet 04 having merged; defer if not, note in PR).
+- Repo-level `CHANGELOG.md` updated.
+- The per-provider API key spending limits Human Prerequisite is named (Gate-0; do at any time after this initiative ships).
+
+## Initiative closeout
+
+After packets 06 and 09 merge, the `adr-0052-cost-governance` initiative is **complete** at the foundation-layer scope. The follow-on initiatives the playbook names (Operator-side cost-governance, post-ADR-0018) are scoped from the playbook when ADR-0018 lands.
+
+The cost ledger is durably writing events to Cosmos; the kill-switch is enforcing on AI inference; the operator has the budget config, the report format, the review-agent rules, the invariants, and the playbook. The Grid has its first programmatic ceiling on cost.

--- a/generated/issue-packets/active/adr-0053-release-cadence/00-architecture-adr-0053-acceptance.md
+++ b/generated/issue-packets/active/adr-0053-release-cadence/00-architecture-adr-0053-acceptance.md
@@ -1,0 +1,147 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "docs", "adr-0053", "wave-1"]
+dependencies: []
+adrs: ["ADR-0053"]
+accepts: ["ADR-0053"]
+wave: 1
+initiative: adr-0053-release-cadence
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0053 — flip status, add the three environments/branching/cadence invariants, register the initiative
+
+## Summary
+Flip ADR-0053 (Environments, Branching, and Release Cadence) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, add the three new operational invariants ADR-0053 commits in its Consequences/Invariants section to `constitution/invariants.md` (numbered **{N1}, {N2}, {N3}** — claim the next free contiguous block of size 3 from `constitution/invariant-reservations.md` at edit time), and register the `adr-0053-release-cadence` initiative in `initiatives/active-initiatives.md`.
+
+**Required ADR-0053 D2 amendment (separate follow-up, NOT in this packet):** packet 02 honors the existing `rg-hd-platform-*` / `kv-hd-*` naming convention rather than the `rg-honeydrunk-*` shape ADR-0053 D2's prose proposes. The existing convention wins because it is deployed on live resources. ADR-0053 D2's text needs a follow-up amendment to reflect the existing convention, OR a separate amendment packet is authored alongside packet 02's merge. Record the chosen path in packet 02's PR body; do not amend ADR-0053 in this packet.
+
+## Context
+ADR-0053 closes the load-bearing gap behind ADR-0011 (review), ADR-0015 (Container Apps), ADR-0032 (PR validation), ADR-0033 (env-gated deploys), and ADR-0044 (AI-PR discipline) — none of those ADRs ever named the environments they presume, the branching model they assume, or the release cadence they trigger. ADR-0053 commits all three.
+
+The ADR decides:
+
+- **D1** — three always-on environments (`dev`, `staging`, `prod`). No per-PR ephemerals at v1; reconsider at v2 when Notify Cloud's tenant-portal UI work begins or multiple humans review in parallel.
+- **D2** — Azure resource-group and resource naming: `rg-honeydrunk-{env}-{region}`; `{node}-{env}-{purpose}`; storage `hd{node}{env}{region}{shortrand}`; Key Vaults per ADR-0005 (`kv-{node}-{env}-{region}`). Region default `eastus`; multi-region deferred behind ADR-0036.
+- **D3** — single Azure subscription with environment-level RBAC at v1; subscription split (`sub-honeydrunk-prod` vs `sub-honeydrunk-nonprod`) deferred to v2 when the first paying tenant lands per PDR-0002 / ADR-0050.
+- **D4** — trunk-based branching with short-lived feature branches; no GitFlow `develop` / `release/*` / `hotfix/*` channels; `release/{node}-{semver}` allowed only for emergency hotfix isolation when `main` is mid-feature.
+- **D5** — branch-naming convention: human prefixes `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`; AI prefixes `codex/`, `copilot/`, `claude/{agent-slug}-{token}`.
+- **D6** — branch lifetime: 5-day target, 7-day stale alert (no auto-close), 30-day auto-close unless `flagged-keep-open`.
+- **D7** — merge strategy: squash by default; merge commits for release branches only; never rebase-merge.
+- **D8** — promotion model: `main` → `dev` auto on every merge → `staging` via `staging-{date}` tag → `prod` via `prod-{date}` tag (ADR-0033); same artefact promotes through every environment; soak windows 24h standard / 4h hotfix / 72h schema-contract.
+- **D9** — release cadence: per-Node, release-as-needed; monthly floor enforced by "at least one prod release in the past 30 days OR an explicit 'no changes this month' CHANGELOG entry" per Live Node; hotfix tags `prod-{date}-hotfix-{short-slug}`; even hotfixes get a staging step.
+- **D10** — versioning: SemVer per Node per ADR-0035; conventional commits per ADR-0044 D4; release-notes generation script deferred.
+- **D11** — local-dev parity: every Node boots with `dotnet run` against InMemory (invariant 15) or Testcontainers (ADR-0047 D4) dependencies; "first 60 seconds" rule per `repos/{name}/overview.md`'s `## Quick Start`.
+- **D12** — configuration parity: env-specific config in Azure App Configuration per ADR-0005, secrets in Key Vault, no hardcoded `if (Environment == "prod")` switches in business logic.
+- **D13** — data parity: **production data MUST NEVER copy to `dev` or `staging`** — no exceptions, no "anonymized for debugging," no carve-outs.
+- **D14** — rollback story: traffic-shift instant rollback for application code (ADR-0015 multi-revision); NuGet rollback via forward patch (ADR-0035 immutability); schema rollback forward-only after the contract phase begins (ADR-0048 expand/contract).
+- **D15** — approvals: v1 passing CI + self-approval comment on the deploy PR for prod; v2 transitions to a true two-party gate when a second human joins; AI agents are not approvers, ever.
+- **D16** — phased rollout: Phase 1 Bicep modules; Phase 2 Actions deploy workflows; Phase 3 Notify/Pulse Azure bring-up uses the new pattern; Phase 4 branch-lifetime tooling; Phase 5 local-dev parity audit; Phase 6 monthly CHANGELOG cadence; Phase 7 subscription split when paying tenant lands.
+
+ADR-0053 is a **policy / topology** ADR. The concrete code/YAML/Bicep/walkthroughs land in this initiative's packets 01–08; the AzureBicep, the Actions workflows, the per-Node `## Quick Start` audit, and the monthly cadence enforcement workflow are all decomposed below.
+
+Every other packet in this initiative references ADR-0053's D-decisions as live rules, so the acceptance flip must land first.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0053-environments-branching-and-release-cadence.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0053 row Status column to Accepted.
+- `constitution/invariants.md` — add the three new operational invariants ADR-0053 commits (see Proposed Implementation for exact text) as **invariants {N1}, {N2}, {N3}** — read `constitution/invariant-reservations.md`, claim the next free contiguous block of size 3 in the **Active Reservations** table, and use those numbers (see Constraints).
+- `constitution/invariant-reservations.md` — add a row to **Active Reservations** in the same PR that records the block claimed for ADR-0053.
+- `initiatives/active-initiatives.md` — register the `adr-0053-release-cadence` initiative with the packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0053 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update the ADR-0053 index row in `adrs/README.md` to Accepted.
+3. **Claim the invariant number block.** Open `constitution/invariant-reservations.md` and read the **Active Reservations** table plus the **Currently Accepted** high-water mark. Today's high-water mark on disk is **53**; the "next free" pointer is **54** unless another in-flight ADR has filed a reservation that consumed it. Pick the next contiguous free block of **size 3** above the highest reservation. Call those numbers `{N1}, {N2}, {N3}` for the rest of this packet's edits. Add a row to **Active Reservations** in this same PR recording the claim:
+   ```
+   | {N1}–{N3} | ADR-0053 | Proposed→Accepting | packet 00 of adr-0053-release-cadence |
+   ```
+4. Add three new invariants to `constitution/invariants.md` as **invariants {N1}, {N2}, {N3}** with the numbers chosen in step 3. The text, taken verbatim-in-substance from ADR-0053's Consequences "Invariants" subsection:
+   - **{N1}. Production data MUST NEVER copy to `dev` or `staging`.** Synthetic fixtures only in lower environments; real customer data only in `prod`. No anonymization carve-out, no subsetting carve-out, no "for debugging a one-off" carve-out. Per-Node seeders generate volume-realistic synthetic data where load matters (Bogus + AutoFixture per ADR-0047 D7). Any tooling that attempts a prod-to-lower-environment copy is itself an Audit-emitting event per ADR-0030; the audit trail catches accidental violations. See ADR-0053 D13, ADR-0049.
+   - **{N2}. Every Node boots locally with `dotnet run` against InMemory or Testcontainers dependencies; no Azure dependency is required for first-line development work.** First-60-seconds rule: `git clone && dotnet run` produces a running Node with no Azure provisioning step. Local secrets come from gitignored `.env` files loaded as environment variables; `HoneyDrunk.Vault` reads from env vars on the `local` profile per ADR-0005's env-var path. Each Live Node's `repos/{name}/overview.md` documents the path in a `## Quick Start` section. See ADR-0053 D11, ADR-0005, ADR-0047 D4.
+   - **{N3}. Hardcoded environment-name switches in business logic are forbidden.** No `if (Environment == "prod") { ... }` branches in Node code; environment-dependent behavior is configuration-driven (Azure App Configuration per ADR-0005, keyed by environment label), not name-driven. Explicit exception: deployment workflows (`HoneyDrunk.Actions`) and bootstrap shims that read the environment label to choose the App Configuration endpoint are permitted. See ADR-0053 D12, ADR-0005.
+   - Add them under a new `## Environment & Cadence Invariants` section (the file's sectioning convention groups invariants by topic — Dependency, Context, Secrets, Packaging, Testing, AI, Audit, Hosting, etc. Environment topology + branching + data-parity is a new cross-cutting topic and warrants its own section). Place it after the most-recent section per the file's current append order.
+5. Register the initiative in `initiatives/active-initiatives.md` with the three-wave structure and packet checklist for this folder.
+
+## Affected Files
+- `adrs/ADR-0053-environments-branching-and-release-cadence.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0053 header reads `**Status:** Accepted`
+- [ ] The ADR-0053 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariant-reservations.md` carries an **Active Reservations** row for ADR-0053 claiming a contiguous size-3 block above the prior highest reservation
+- [ ] `constitution/invariants.md` carries the three new operational invariants (production data never copies to lower environments; every Node boots locally with no Azure dependency; hardcoded environment-name switches in business logic are forbidden), numbered **{N1}, {N2}, {N3}** under a new `## Environment & Cadence Invariants` section, each citing ADR-0053, using the same block recorded in `invariant-reservations.md`
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0053-release-cadence` initiative with a packet checklist
+- [ ] No catalog schema change in this packet (catalog updates land in packet 01)
+- [ ] No `.csproj` version bump — Markdown-only
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0053 D1 — Three environments (`dev`, `staging`, `prod`).** Three always-on environments are the minimum that gives a real soak step without ritual overhead; no per-PR ephemerals at v1.
+
+**ADR-0053 D11 — Local-dev parity.** Every Node boots with `dotnet run` against InMemory or Testcontainers dependencies; no Azure dependency required for first-line dev work; "first 60 seconds" rule documented per Node.
+
+**ADR-0053 D12 — Configuration parity.** Environment-specific configuration lives in Azure App Configuration (per ADR-0005); no hardcoded `if (Environment == "prod")` switches in business logic.
+
+**ADR-0053 D13 — Data parity (hardest no in the ADR).** Production data MUST NEVER copy to `dev` or `staging`. Not anonymized; not subsetted; not for "debugging a one-off"; never. Synthetic fixtures only in lower environments.
+
+**ADR-0053 Consequences — Invariants.** ADR-0053 adds exactly three invariants: (1) production data MUST NEVER copy to `dev` or `staging`; (2) every Node boots locally with `dotnet run` against InMemory or Testcontainers; (3) hardcoded environment-name switches in business logic are forbidden.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** ADR-0053 leans on this throughout (the `.env` local-dev path, the Key Vault references per ADR-0005, the "no DSN in the workflow" pattern); the acceptance text re-grounds the invariant inline rather than citing it by number alone.
+
+- **Acceptance precedes flip.** ADR-0053 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbers come from `constitution/invariant-reservations.md`, not hardcoded.** The current verified maximum on disk in `constitution/invariants.md` is **53**. Read `constitution/invariant-reservations.md` at edit time; pick the next contiguous free block of size 3 above the highest existing reservation; record the claim in **Active Reservations** in the same PR; substitute the chosen numbers into every `{N1}/{N2}/{N3}` placeholder in this packet's edits. Do not renumber existing invariants. If a merge-time collision occurs (someone else's reservation lands first), `git pull`'s conflict on `invariant-reservations.md` triggers a shift-upward and a rewrite of the three placeholders before pushing.
+- **New section.** The three invariants are cross-cutting operational rules; create a `## Environment & Cadence Invariants` section appended after the file's current last section rather than scattering the three across existing topical sections.
+- **ADR-0053 D2 prose amendment is a follow-up, NOT this packet.** Packet 02 honors the existing `rg-hd-platform-*` convention rather than ADR-0053 D2's proposed `rg-honeydrunk-*` shape. A separate ADR-0053 prose-amendment packet (authored alongside packet 02's merge) reconciles the two; do not edit D2's text in this packet.
+
+## Labels
+`chore`, `tier-3`, `meta`, `docs`, `adr-0053`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0053 to Accepted, add the three environments/branching/cadence invariants to `constitution/invariants.md`, and register the release-cadence initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0053 so the remaining packets in this initiative can reference its decisions as live rules.
+- Feature: ADR-0053 Environments, Branching, and Release Cadence rollout, Wave 1.
+- ADRs: ADR-0053 (primary), ADR-0008 (initiative/packet conventions), ADR-0005 (Vault/App Configuration), ADR-0015 (Container Apps), ADR-0033 (env-gated deploys), ADR-0035 (SemVer), ADR-0044 (AI-PR discipline), ADR-0047 (testing/local-dev parity), ADR-0049 (PII handling), ADR-0030 (Audit substrate).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- Acceptance precedes flip — ADR-0053 stays Proposed until this PR merges.
+- Invariant numbers are claimed via `constitution/invariant-reservations.md`, not hardcoded. Current verified max on disk is **53**. Read the reservations file, pick the next contiguous size-3 block, record the claim in **Active Reservations** in this PR, and substitute the chosen `{N1}/{N2}/{N3}` placeholders throughout. Do not renumber existing invariants.
+- ADR-0053 D2 prose amendment is a separate follow-up (alongside packet 02's merge), not this packet.
+
+**Key Files:**
+- `adrs/ADR-0053-environments-branching-and-release-cadence.md`
+- `adrs/README.md`
+- `constitution/invariants.md`
+- `constitution/invariant-reservations.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0053-release-cadence/01-architecture-environments-catalog-and-conventions.md
+++ b/generated/issue-packets/active/adr-0053-release-cadence/01-architecture-environments-catalog-and-conventions.md
@@ -1,0 +1,144 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "meta", "docs", "adr-0053", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0053", "ADR-0033"]
+accepts: ["ADR-0053"]
+wave: 1
+initiative: adr-0053-release-cadence
+node: honeydrunk-architecture
+---
+
+# Extend `catalogs/services.json` with `environments` and codify branching/cadence conventions
+
+## Summary
+Record ADR-0053's environment topology and branching/cadence rules as catalog data and Grid conventions: extend the `catalogs/services.json` entry shape with a per-service `environments: [dev, staging, prod]` field (per ADR-0053's Consequences "Affected Nodes" line); document the branching model (D4), branch-naming convention (D5), branch-lifetime expectations (D6), merge strategy (D7), and release cadence (D9) under `infrastructure/conventions/`; and reference the branch-naming rule from `routing/execution-rules.md` (the canonical target named by ADR-0053; the file exists).
+
+## Context
+ADR-0053's "Affected Nodes" line for `HoneyDrunk.Architecture` reads: "`constitution/sectors.md` references the three environments; `catalogs/services.json` gains an `environments: [dev, staging, prod]` field per service; `routing/execution-rules.md` references the branch-naming convention per D5."
+
+The current `catalogs/services.json` shape (per the file at edit time) carries `id`, `nodeId`, `name`, `type`, `description`, `runtime`, `hosting`, `status`. It has **no** environments field; the four currently-cataloged services (`pulse-collector`, `notify-worker`, `notify-functions`, `studios-website`) deploy to whatever environment their consumer release workflow targets without a catalog-level commitment. ADR-0053 D1 names three environments per service; the catalog should reflect that so the grid-health aggregator (ADR-0012) and the monthly cadence enforcement workflow (packet 07) have a structured data source.
+
+**Branching/cadence conventions need a documentation home.** `infrastructure/conventions/` already carries `azure-identity-and-secrets.md`, `azure-naming-conventions.md`, and `tag-and-release-conventions.md`. The branching/cadence rules (D4–D7, D9) belong there — they are cross-cutting Grid conventions, not per-Node concerns. `routing/execution-rules.md` (the canonical execution-rules document ADR-0053 names; the file exists at edit time) gets a short cross-reference + the branch-prefix table so agents reading the routing rules see the convention without an extra hop.
+
+This is a catalog/docs packet. No code, no .NET project.
+
+## Scope
+- `catalogs/services.json` — add an `environments: ["dev", "staging", "prod"]` field to every entry (four entries today; default the value uniformly until per-service overrides become real).
+- `infrastructure/conventions/branching-and-release-cadence.md` (new) — document D4 (trunk-based), D5 (branch-naming table for both human and AI prefixes), D6 (5-day / 7-day / 30-day lifetime rule), D7 (squash-default merge strategy), D9 (per-Node release-as-needed cadence with the monthly floor).
+- `infrastructure/README.md` — add the new conventions doc to the conventions index.
+- `routing/execution-rules.md` — append a short "Branch naming" section per D5 with the table, cross-linking the new `infrastructure/conventions/branching-and-release-cadence.md` for full detail. (This is the canonical target named by ADR-0053; the file exists at edit time.)
+- `constitution/sectors.md` — add a brief "Environments" line referencing the three environments per ADR-0053 D1.
+
+## Proposed Implementation
+1. **`catalogs/services.json`** — for every entry, add `"environments": ["dev", "staging", "prod"]`. The shape becomes:
+   ```json
+   {
+     "id": "pulse-collector",
+     "nodeId": "honeydrunk-pulse",
+     "name": "Pulse.Collector",
+     "type": "service",
+     "description": "Deployable OTLP receiver…",
+     "runtime": "net10.0",
+     "hosting": "container",
+     "status": "active",
+     "environments": ["dev", "staging", "prod"]
+   }
+   ```
+   The four current services (`pulse-collector`, `notify-worker`, `notify-functions`, `studios-website`) all get the same default. If a service legitimately deploys to only a subset (e.g. `studios-website` deploys directly to Vercel and does not have a `dev`/`staging` Azure environment in the same sense), call that out in the PR body and either record the subset (`["prod"]`) or leave the default and document the divergence in the service's description field. Default is the uniform set; deviations are explicit.
+2. **`infrastructure/conventions/branching-and-release-cadence.md`** (new) — author the convention doc covering:
+   - **Trunk-based branching (D4).** `main` is always deployable; every merge to `main` produces an artefact auto-deploying to `dev`. No `develop`, no permanent `release/*` or `hotfix/*` channels. `release/{node}-{semver}` permitted only for emergency hotfix isolation when `main` is mid-feature; created off the prod tag, fix merges in, tag cut, branch deleted within 7 days.
+   - **Branch-naming convention (D5).** A table with the prefix → purpose → example for human prefixes (`feat/`, `fix/`, `chore/`, `docs/`, `refactor/`) and AI prefixes (`codex/`, `copilot/`, `claude/{agent-slug}-{token}`). Why branch-prefix discipline matters: ADR-0032 (PR validation) and ADR-0044 (AI-PR discipline) inspect the prefix to route the appropriate review checklist; the operator's mental model ("Codex's work or mine?") is preserved at a glance.
+   - **Branch lifetime (D6).** 5-day target / 7-day stale alert (a comment on the PR) / 30-day auto-close unless `flagged-keep-open`. Forcing function: AI-authored PRs bottleneck on the single human reviewer; the lifetime budget pressures the queue toward small, focused PRs.
+   - **Merge strategy (D7).** Squash by default (one PR = one commit on `main`; PR title becomes the conventional-commit message per ADR-0044 D4). Merge commits permitted only for `release/{node}-{semver}` branches (preserves hotfix audit trail). Never rebase-merge (SHA rewriting breaks external references).
+   - **Release cadence (D9).** Per-Node, release-as-needed. Soft target: monthly per Live Node — either ship one prod release in the past 30 days or emit a `## [no changes this month]` CHANGELOG entry; missed months become Grid-health alerts (packet 07 enforces this). Hotfix tag format `prod-{date}-hotfix-{short-slug}`; even hotfixes get a staging step (4-hour soak per D8).
+3. **`infrastructure/README.md`** — add a row for the new conventions doc in the existing conventions index.
+4. **`routing/execution-rules.md`** — append a "## Branch naming" section (or merge into an existing section if one exists) with the prefix table from D5 and a cross-link to `infrastructure/conventions/branching-and-release-cadence.md` for full detail. `routing/execution-rules.md` is the canonical target named by ADR-0053; the file exists at edit time.
+5. **`constitution/sectors.md`** — append a short "Environments" line: "The Grid runs three always-on environments — `dev`, `staging`, `prod` — per ADR-0053." Do not invent a topology section if `constitution/sectors.md` is structured for sectors-only content; place the line in the most appropriate existing section or, if no fit exists, add a new "Operating Topology" subsection at the file's tail.
+
+## Affected Files
+- `catalogs/services.json`
+- `infrastructure/conventions/branching-and-release-cadence.md` (new)
+- `infrastructure/README.md`
+- `routing/execution-rules.md`
+- `constitution/sectors.md`
+
+## NuGet Dependencies
+None. This packet touches only JSON and Markdown; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] Catalog/docs only — the Bicep, the Actions workflows, the Quick Start template all land in later packets.
+
+## Acceptance Criteria
+- [ ] `catalogs/services.json` carries an `environments` field on every entry; the default value is `["dev", "staging", "prod"]`; any per-service deviation is recorded in the PR body and reflected in the field value
+- [ ] `infrastructure/conventions/branching-and-release-cadence.md` exists covering D4 (trunk-based), D5 (full branch-naming table), D6 (5/7/30-day lifetime rule), D7 (squash-default merge), D9 (per-Node release-as-needed with monthly floor)
+- [ ] `infrastructure/README.md` lists the new conventions doc in its conventions index
+- [ ] `routing/execution-rules.md` carries a "## Branch naming" section with the D5 prefix table and a cross-link to the conventions doc
+- [ ] `constitution/sectors.md` references the three environments
+- [ ] No new top-level Node-to-Node edge created (`relationships.json` is not modified)
+- [ ] No `.csproj` version bump — JSON/Markdown-only
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0053 D1 — Three environments (`dev`, `staging`, `prod`).** The Grid commits to three always-on environments; per-service catalog records this commitment.
+
+**ADR-0053 D4 — Trunk-based branching.** `main` is always deployable; every merge auto-deploys to `dev`; no `develop` channel; `release/{node}-{semver}` permitted only for emergency hotfix isolation when `main` is mid-feature.
+
+**ADR-0053 D5 — Branch-naming convention.** Human prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`. AI prefixes: `codex/`, `copilot/`, `claude/{agent-slug}-{token}`. Branch-name discipline routes the PR-validation policy (ADR-0032) and the AI-PR discipline (ADR-0044) checklists.
+
+**ADR-0053 D6 — Branch lifetime: 5-day target / 7-day stale / 30-day auto-close.** Stale-alert workflow comments at 7 days (no auto-close yet); auto-close workflow closes at 30 days unless `flagged-keep-open`.
+
+**ADR-0053 D7 — Merge strategy.** Squash by default; merge commits for `release/{node}-{semver}` only; never rebase-merge.
+
+**ADR-0053 D9 — Release cadence.** Per-Node release-as-needed; monthly floor enforced by "at least one prod release in past 30 days OR an explicit 'no changes this month' CHANGELOG entry." Hotfix tag format `prod-{date}-hotfix-{short-slug}`; even hotfixes get a staging step.
+
+**ADR-0053 Consequences — Affected Nodes (Architecture).** `constitution/sectors.md` references the three environments; `catalogs/services.json` gains the `environments` field per service; `routing/execution-rules.md` references the branch-naming convention.
+
+## Constraints
+> **Invariant 4 — No circular dependencies.** Adding the `environments` field to `services.json` does not introduce a new Node-to-Node edge; `relationships.json` is untouched.
+
+> **Invariant 11 — One repo per Node.** The conventions doc is a Grid-wide convention living in `HoneyDrunk.Architecture` (the Grid's governance home), not a per-Node doc.
+
+- **Default uniform.** Every service entry gets `["dev", "staging", "prod"]` unless a per-service deviation is documented. Studios is the likely deviation (Vercel-hosted, not Azure-environment-bound) — record the chosen value and the rationale in the PR body.
+- **Routing target is `routing/execution-rules.md`.** The file exists at edit time; append the "## Branch naming" section there as ADR-0053 specifies. Do not write to `routing/sdlc.md` as a fallback.
+- **No invariant change in this packet.** The three new invariants (numbers claimed via `constitution/invariant-reservations.md`) land in packet 00.
+
+## Labels
+`feature`, `tier-2`, `meta`, `docs`, `adr-0053`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Record ADR-0053's environment topology in `catalogs/services.json` and codify the branching/cadence conventions in `infrastructure/conventions/` and `routing/execution-rules.md`.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Keep the services catalog and the Grid's conventions accurate so packets 02–08 (and downstream consumers) read a correct topology and a documented branching rule.
+- Feature: ADR-0053 Environments, Branching, and Release Cadence rollout, Wave 1.
+- ADRs: ADR-0053 D1/D4/D5/D6/D7/D9 (primary), ADR-0033 (tag → environment mapping that the cadence floor leans on).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0053 should be Accepted before its topology and conventions are recorded as live data.
+
+**Constraints:**
+- Default uniform `["dev", "staging", "prod"]` per service; per-service deviation recorded in the PR body and reflected in the field value.
+- Branch-prefix cross-reference goes into `routing/execution-rules.md` (it exists at edit time); do not fall back to `routing/sdlc.md`.
+- No `relationships.json` edit — no new Node-to-Node edge is introduced.
+
+**Key Files:**
+- `catalogs/services.json` — new `environments` field per entry.
+- `infrastructure/conventions/branching-and-release-cadence.md` — new doc.
+- `infrastructure/README.md` — conventions-index update.
+- `routing/execution-rules.md` — branch-prefix cross-reference.
+- `constitution/sectors.md` — three-environment line.
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0053-release-cadence/02-architecture-infra-env-bicep-and-walkthrough.md
+++ b/generated/issue-packets/active/adr-0053-release-cadence/02-architecture-infra-env-bicep-and-walkthrough.md
@@ -1,0 +1,179 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "infrastructure", "adr-0053", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0053", "ADR-0005", "ADR-0015", "ADR-0033", "ADR-0077"]
+accepts: ["ADR-0053"]
+wave: 2
+initiative: adr-0053-release-cadence
+node: honeydrunk-architecture
+---
+
+# Author `infra/{env}/` Bicep modules and the paired environment-provisioning walkthrough; provision `dev`
+
+## Summary
+Author the per-environment Bicep modules in `infra/{env}/` (per ADR-0053 D16 Phase 1) covering the resource-group + RBAC + App Configuration + Log Analytics workspace shape from D2, paired with an Azure-Portal UI walkthrough that documents the same shape click-by-click. Execute the walkthrough for `dev` only — provision the `dev` environment. `staging` and `prod` are documented as repeat executions; their provisioning fires when those environments stand up.
+
+## Context
+ADR-0053 D16 Phase 1 reads: "Author `infra/{env}/` Bicep modules for `dev`, `staging`, `prod` following the D2 naming convention. Single subscription per D3 v1." ADR-0077 (Infrastructure-as-Code Bicep) is the governing IaC ADR cited by ADR-0053. **ADR-0077 is still Proposed at edit time** — its prose may shift before acceptance. This packet's Bicep follows ADR-0053 D16 Phase 1 directly; references to ADR-0077 throughout this packet are weakened to "ADR-0077 (Proposed)" and the Human Prerequisites list calls out the dependency explicitly. If ADR-0077's prose materially changes between this packet's authoring and its merge, the Bicep is reconciled in a follow-up packet, not in-place here.
+
+**Bicep + walkthrough — both, by design.** The Bicep module is the deploy artefact (versioned, idempotent, the CI hook for provisioning new environments mechanically); the paired Azure-Portal walkthrough is the human-facing review surface and the bootstrap path for the first execution. The operator's standing preference is portal-over-CLI for infra work; ADR-0053 D16 Phase 1 commits Bicep. The reconciliation: write the Bicep so the topology is reproducible; write the walkthrough so the human review and first-execution path is portal-friendly; the two artefacts describe the *same* shape.
+
+**Provision `dev` only.** ADR-0053 D1 names three environments, but D16 Phase 1 ships the Bicep for all three and stages execution. `dev` is provisioned now (it is the immediate blocker on the Notify/Pulse Azure bring-up per `current-focus.md`); `staging` and `prod` provisioning waits until the operator decides to stand them up. The walkthrough covers all three as repeat executions; this packet's *execution* is `dev`.
+
+**Cheapest viable tier.** Per the operator's standing preference, default to the cheapest viable Azure tier (Free/Basic for dev/staging; Standard/Premium only for prod with a concrete reason). Show the estimated cost before the Create click; the walkthrough records the recommended tier and the daily-cap value where the resource supports a cap.
+
+**What lands in the resource group.** Per ADR-0053 D2 and the existing `infrastructure/conventions/azure-naming-conventions.md`, the `dev` environment needs the cross-cutting shared resources at minimum:
+- The `dev` resource group itself: `rg-honeydrunk-dev-eastus` (or `rg-hd-platform-dev` per the existing platform-shared pattern — the walkthrough decides and documents the naming alignment between ADR-0053 D2's prose and the existing convention).
+- Azure App Configuration (`appcs-hd-dev` or the convention's chosen name) — ADR-0053 D12 and ADR-0005 commit App Configuration as the env-specific configuration store.
+- A Log Analytics workspace (`log-hd-shared-dev`) — already provisioned per ADR-0006, but the walkthrough verifies it exists and documents the reuse decision.
+- RBAC scopes per D3 v1: environment-level (the deploy workflow's managed identity scoped to the resource group as Contributor; the operator as Owner).
+
+Per-Node resources (Container Apps Environment, ACR, Key Vaults) are not provisioned by this packet — they are owned by the Notify/Pulse Azure bring-up packets in `adr-0015-container-apps-rollout` (`Notify#3`, `Notify#4`, `Pulse#3`). This packet provisions the **environment skeleton** that those packets deploy into.
+
+**Naming-alignment note.** ADR-0053 D2 proposes `rg-honeydrunk-{env}-{region}` and `{node}-{env}-{purpose}` (e.g. `notify-functions-prod-eastus`). The existing `infrastructure/conventions/azure-naming-conventions.md` uses `rg-hd-platform-{env}` for shared platform resources and `rg-hd-{service}-{env}` for per-Node resource groups, with the `hd` short prefix and no region suffix. **The two conventions are not identical.** The walkthrough records the alignment decision: either honor ADR-0053 D2 verbatim (rename existing resource groups to add the region suffix and expand `hd` → `honeydrunk`), or honor the existing convention (and update ADR-0053 D2's text as a follow-up ADR amendment). **Default recommendation: honor the existing convention** — it is already deployed on live resources (the existing `rg-hd-platform-dev`, `kv-hd-notify-dev`, etc.), and the ADR-0053 text was authored without checking the existing convention file. The walkthrough records this as the chosen path and flags ADR-0053's prose as a follow-up amendment.
+
+This packet authors Bicep + the walkthrough **and** executes the `dev` provisioning. No code, no .NET project.
+
+## Scope
+- `infra/dev/` (new) — Bicep module(s) for the `dev` environment skeleton: resource group, App Configuration, Log Analytics workspace (or workspace verification if it exists), RBAC scopes per D3 v1.
+- `infra/staging/` (new) — Bicep module(s) for the `staging` environment with the same shape (not executed in this packet).
+- `infra/prod/` (new) — Bicep module(s) for the `prod` environment with the same shape (not executed in this packet).
+- `infrastructure/walkthroughs/environment-provisioning.md` (new) — the Azure-Portal UI walkthrough covering the same shape as the Bicep, for all three environments as repeat executions.
+- `infrastructure/conventions/azure-naming-conventions.md` — append a "Per-environment platform" section if the naming alignment decision adds new patterns (only if the walkthrough's decision adds, never edits existing).
+- `infrastructure/README.md` — reference the new walkthrough.
+- `catalogs/grid-health.json` — record the `dev` environment as `provisioned` once the walkthrough's `dev` execution completes; `staging` and `prod` recorded as `not-provisioned`. Schema follows the pattern from `adr-0040-telemetry-backend` packet 01.
+
+## Proposed Implementation
+1. **Authorship is portal-over-CLI for the walkthrough; CLI-over-portal for the Bicep.** The walkthrough is click-by-click in the Azure Portal UI; the Bicep is the same shape expressed as code. They are siblings, not alternates.
+2. **Bicep modules — `infra/{env}/main.bicep`** (one per environment) covering:
+   - The resource group declaration (or the assumption that the resource group is created externally — Azure subscription rules differ; the walkthrough decides and the Bicep documents).
+   - The App Configuration resource (`appcs-hd-{env}` per the existing convention naming pattern).
+   - The Log Analytics workspace (re-use the existing `log-hd-shared-{env}` if it exists per ADR-0006; create otherwise).
+   - The role assignments per D3 v1: Owner on the resource group → the operator's user principal; Contributor → the deploy workflow's managed identity (the specific identity is the one the existing `azure-oidc-deploy.yml` workflow already uses).
+   - Parameter inputs for `environment` (`dev`/`staging`/`prod`), `region` (default `eastus`), and any other per-environment knobs the shape needs.
+3. **The walkthrough — `infrastructure/walkthroughs/environment-provisioning.md`** — covers, in order:
+   - Pick the subscription (`honeydrunk-dev` for `dev` per the existing convention; the v1 single-subscription model).
+   - Create the resource group (or verify it exists if `rg-hd-platform-{env}` already exists from prior ADRs).
+   - Create the App Configuration resource (Free tier for `dev`; show the estimated cost before Create).
+   - Verify (or create) the shared Log Analytics workspace.
+   - Assign RBAC scopes per D3 v1.
+   - Record the resource names in `catalogs/grid-health.json`.
+   - Document the `staging` and `prod` repeat: same steps, different subscription/environment input.
+4. **`dev` execution.** After authoring, execute the walkthrough for `dev`:
+   - Confirm the existing `rg-hd-platform-dev` resource group (or create a new `rg-honeydrunk-dev-eastus` per the alignment decision); document which.
+   - Provision App Configuration (Free tier for `dev`).
+   - Confirm `log-hd-shared-dev` exists and is reachable.
+   - Assign RBAC.
+   - Flip `catalogs/grid-health.json` `dev` environment entry from `not-provisioned` to `provisioned`.
+5. **Naming-alignment decision recorded in the walkthrough.** Either:
+   - **Option A (default).** Honor the existing convention (`rg-hd-platform-{env}`, `appcs-hd-{env}`, `log-hd-shared-{env}`); record this in the walkthrough and flag ADR-0053 D2's prose ("`rg-honeydrunk-{env}-{region}`") as a follow-up amendment for ADR-0053 — the existing convention wins because it is already deployed on live resources.
+   - **Option B.** Honor ADR-0053 D2 verbatim (`rg-honeydrunk-{env}-{region}`); the implication is renaming existing `rg-hd-*` resource groups, which is a destructive rename and not in this packet's scope. If chosen, record as a follow-up multi-packet rename initiative.
+   Default to Option A; document the choice in the PR body.
+6. **`catalogs/grid-health.json`** — add an `environments` section (or follow the precedent set by `adr-0040-telemetry-backend` packet 01's App Insights resource entries) with one entry per environment, each carrying `environment` (`dev`/`staging`/`prod`), `subscription` (the subscription name), `resource_group`, `app_configuration`, `log_analytics_workspace`, and `status` (`not-provisioned` | `provisioned`). Flip `dev` to `provisioned` once the walkthrough execution completes.
+
+## Affected Files
+- `infra/dev/main.bicep` (new)
+- `infra/staging/main.bicep` (new)
+- `infra/prod/main.bicep` (new)
+- Any shared Bicep modules (e.g. `infra/modules/app-configuration.bicep`) the three environment files share — author as the shape needs.
+- `infrastructure/walkthroughs/environment-provisioning.md` (new)
+- `infrastructure/README.md` — reference the new walkthrough.
+- `infrastructure/conventions/azure-naming-conventions.md` — append-only if the alignment decision adds a pattern.
+- `catalogs/grid-health.json` — `environments` section with three entries; `dev` flipped to `provisioned`.
+
+## NuGet Dependencies
+None. This packet has no .NET project — Bicep + Markdown + JSON + Azure-Portal work.
+
+## Boundary Check
+- [x] All artefacts in `HoneyDrunk.Architecture` — Bicep modules, walkthroughs, conventions, and the grid-health catalog all live here.
+- [x] No code change in any Node.
+- [x] Azure resources land in the Azure subscription (a vendor surface, not a Node).
+- [x] No per-Node resource (Key Vault, Container App, ACR) is touched — those are the Node bring-up packets' concern.
+
+## Acceptance Criteria
+- [ ] `infra/dev/main.bicep`, `infra/staging/main.bicep`, `infra/prod/main.bicep` exist with the environment-skeleton shape (resource group / App Configuration / Log Analytics workspace / RBAC per D3 v1)
+- [ ] Shared Bicep modules under `infra/modules/` exist where they reduce duplication across the three environment files
+- [ ] `infrastructure/walkthroughs/environment-provisioning.md` exists as a step-by-step Azure-Portal UI walkthrough covering the same shape as the Bicep for all three environments as repeat executions
+- [ ] The walkthrough records the naming-alignment decision (Option A default; Option B if chosen) and flags ADR-0053 D2 as a follow-up amendment if Option A is taken
+- [ ] The walkthrough shows the estimated Azure cost before each Create click; uses Free/Basic tiers for `dev`
+- [ ] `infrastructure/README.md` references the new walkthrough
+- [ ] The `dev` resource group, App Configuration, Log Analytics workspace verification, and RBAC scopes are live in the Azure subscription
+- [ ] `catalogs/grid-health.json` carries an `environments` section with three entries; `dev` is `provisioned`; `staging` and `prod` are `not-provisioned`
+- [ ] No secret value, connection string, instrumentation key, or any credential appears in the Bicep, the walkthrough, the catalog, or anywhere in the repo (invariant 8)
+- [ ] No `.csproj` version bump (no .NET project)
+
+## Human Prerequisites
+This packet's *artefact authoring* (Bicep, walkthrough, catalog update) is fully `Actor=Agent`. The Azure-Portal execution of the walkthrough for `dev` is human work. List:
+- [ ] **ADR-0077 (Proposed) dependency.** This packet cites ADR-0077 as the governing IaC ADR but ADR-0077 is still in **Proposed** status at edit time. The packet does not block on ADR-0077's acceptance — the Bicep follows ADR-0053 D16 Phase 1 directly. If ADR-0077's prose changes materially before this packet merges, reconcile the Bicep in a follow-up packet (do not edit in-place). Confirm ADR-0077's status at edit time and weaken/strengthen the citation accordingly.
+- [ ] Azure Portal access to the `honeydrunk-dev` subscription with rights to create resource groups, App Configuration resources, and assign RBAC.
+- [ ] A decision on the naming-alignment Option A vs Option B before execution; default is Option A (honor the existing `rg-hd-*` convention).
+- [ ] Acceptance of the Azure charges for the `dev` resources (Free tier where possible; expected $0–5/month for the environment skeleton at single-developer scale).
+- [ ] Confirmation of the concrete resource names — feed these back to `catalogs/grid-health.json` so the catalog carries the real names.
+- [ ] A follow-up ADR-0053 D2 prose amendment (Option A path) or a destructive-rename initiative (Option B path) is noted in the PR body as a deferred item.
+
+## Referenced ADR Decisions
+**ADR-0053 D1 — Three environments (`dev`, `staging`, `prod`).** Three always-on environments are the v1 commitment.
+
+**ADR-0053 D2 — Resource-group and resource naming.** ADR-0053 D2 proposes `rg-honeydrunk-{env}-{region}` etc.; the existing `infrastructure/conventions/azure-naming-conventions.md` uses `rg-hd-platform-{env}` etc. The walkthrough records the alignment decision; default is to honor the existing convention.
+
+**ADR-0053 D3 — Subscription split deferred; v1 is single-subscription with environment-level RBAC.** This packet does not create a new subscription; it works in the existing `honeydrunk-dev` subscription. The walkthrough documents the RBAC scopes: Owner = operator only on `rg-*-prod-*`; Contributor = deploy workflow's managed identity scoped to the per-environment resource group.
+
+**ADR-0053 D12 — Configuration parity.** Environment-specific configuration lives in Azure App Configuration per ADR-0005. The Bicep provisions the App Configuration resource per environment.
+
+**ADR-0053 D16 Phase 1 — Codify the environments.** "Author `infra/{env}/` Bicep modules for `dev`, `staging`, `prod` following the D2 naming convention. Single subscription per D3 v1."
+
+**ADR-0005 — Vault and App Configuration.** App Configuration is the env-specific configuration store; secrets are in Key Vault per Node (Key Vaults are not provisioned by this packet — they are the Node bring-up packets' concern).
+
+**ADR-0077 (Proposed) — Infrastructure-as-Code Bicep.** Governing IaC ADR cited by ADR-0053 D16 Phase 1. Status at edit time is **Proposed**; this packet does not block on its acceptance, but if its prose changes materially before merge the Bicep is reconciled in a follow-up packet.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** No connection string, no instrumentation key, no Storage Account key, no SAS token, no API key in the Bicep, the walkthrough, the catalog, or any committed file. Bicep `secureString` parameters where secret values are required (none in this packet's shape — App Configuration's read endpoint is a public-DNS URL, not a secret).
+
+> **Invariant 17 — One Key Vault per deployable Node per environment.** No Key Vault is provisioned by this packet — Key Vaults are per-Node, not per-environment-skeleton. The walkthrough cross-links to `infrastructure/walkthroughs/key-vault-creation.md` for the per-Node Vault path.
+
+> **Invariant 18 — Vault URIs and App Configuration endpoints reach Nodes via environment variables.** The App Configuration endpoint provisioned by this packet is consumed by Nodes via `AZURE_APPCONFIG_ENDPOINT`; the walkthrough documents the endpoint URL but never inlines it into a Node-level config file or Bicep parameter.
+
+- **`dev` only.** Execution provisions `dev`; the Bicep and walkthrough cover all three for the repeat path. Do not provision `staging` or `prod` in this packet.
+- **Cheapest viable tier.** Free / Basic for `dev`; show the cost before Create. The walkthrough documents the recommended tier per resource.
+- **Honor the existing naming convention by default.** Option A (default) honors `rg-hd-platform-{env}` etc.; record the choice in the PR body and flag ADR-0053 D2's prose as a follow-up amendment.
+- **Portal walkthrough + Bicep — both authored.** The walkthrough is the human-friendly review surface; the Bicep is the deploy artefact. The two must describe the same shape; if they diverge, the Bicep is corrected (not the walkthrough), and the divergence is recorded.
+
+## Labels
+`feature`, `tier-2`, `ops`, `infrastructure`, `adr-0053`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author the per-environment Bicep modules and the paired Azure-Portal walkthrough; provision the `dev` environment skeleton.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`. The Azure work is human-executed in the Azure Portal after the artefacts land.
+
+**Context:**
+- Goal: Stand up the `dev` environment skeleton (resource group + App Configuration + Log Analytics verification + RBAC) so the in-flight Notify/Pulse Azure bring-up (per `adr-0015-container-apps-rollout`) has a real environment to deploy into.
+- Feature: ADR-0053 Environments, Branching, and Release Cadence rollout, Wave 2.
+- ADRs: ADR-0053 D1/D2/D3/D12/D16 Phase 1 (primary), ADR-0005 (Vault/App Configuration), ADR-0015 (Container Apps — the Nodes deploying into this skeleton), ADR-0033 (tag → environment mapping the deploy workflow uses), ADR-0077 (Proposed, IaC Bicep — see Human Prerequisites).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0053 should be Accepted before its environment skeleton is provisioned as live data.
+
+**Constraints:**
+- `dev` only — staging/prod Bicep authored but not executed.
+- Bicep + walkthrough — both, in this packet.
+- Honor the existing `rg-hd-*` naming convention by default (Option A); record the choice in the PR body.
+- Cheapest viable tier — Free/Basic for `dev`; show cost before Create.
+- No secret in any committed file (invariant 8).
+
+**Key Files:**
+- `infra/dev/main.bicep`, `infra/staging/main.bicep`, `infra/prod/main.bicep` (new)
+- `infra/modules/` shared Bicep modules (as needed)
+- `infrastructure/walkthroughs/environment-provisioning.md` (new)
+- `infrastructure/README.md`
+- `infrastructure/conventions/azure-naming-conventions.md` (append-only if Option A adds a pattern)
+- `catalogs/grid-health.json` — `environments` section
+
+**Contracts:** None — Azure resources and infrastructure docs, no code.

--- a/generated/issue-packets/active/adr-0053-release-cadence/03-actions-environment-input-and-self-approval-gate.md
+++ b/generated/issue-packets/active/adr-0053-release-cadence/03-actions-environment-input-and-self-approval-gate.md
@@ -1,0 +1,147 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "adr-0053", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0053", "ADR-0015", "ADR-0033", "ADR-0012"]
+accepts: ["ADR-0053"]
+wave: 2
+initiative: adr-0053-release-cadence
+node: honeydrunk-actions
+---
+
+# Amend the Actions deploy workflows with an `environment` input and the D15 self-approval gate
+
+## Summary
+Amend the reusable deploy workflows in `HoneyDrunk.Actions` (`job-deploy-container-app.yml`, `job-deploy-function.yml`) with two changes per ADR-0053 D16 Phase 2: (1) an explicit `environment` input that names the target environment (`dev` / `staging` / `prod`) — the existing tag → environment mapping per ADR-0033 picks the value; (2) a D15 self-approval gate that requires a self-approval comment on the deploy PR before the prod-path deploy executes.
+
+## Context
+ADR-0053 D16 Phase 2 reads: "Update HoneyDrunk.Actions reusable workflows. The `job-deploy.yml` workflow accepts an `environment` input; the tag → environment mapping (per ADR-0033) is encoded in the calling workflow. Self-approval gate (D15) wires into the prod path."
+
+The current reusable deploy workflows (`job-deploy-container-app.yml` and `job-deploy-function.yml`) are already environment-aware in practice (the consumer release workflows from `adr-0033-deploy-trigger-model` pass `dev` / `staging` / `prod` through a `target_environment` job output), but the **input is not named formally** and the **D15 self-approval gate does not exist**. This packet codifies both.
+
+**Input change.** Add a top-level `environment` workflow_call input (string, required when called from a consumer that pushed a tag; defaulted to `dev` when called from `push: branches: [main]`). The reusable workflow validates the value against an allowlist (`dev`, `staging`, `prod`) and fails fast on an unknown value.
+
+**Self-approval gate (D15).** The gate runs **only on the prod path** (`environment == 'prod'`). It checks the deploy PR's comments for a comment by the PR author (an org member, non-bot) that contains the canonical approval phrase **`LGTM-PROD`** — the phrase is pinned at this exact string; do not parameterize it, do not invent alternates. Absent the comment, the workflow fails before the deploy step runs. The comment lookup is read-only against the GitHub API; no new credential is required (the existing `GITHUB_TOKEN` has `pull-requests: read`).
+
+**PR lookup must work post-squash-merge.** ADR-0053 D7 commits squash-merge as the default; after squash the source branch is deleted, so `gh pr list --head <branch>` returns nothing for a tagged commit on `main`. The canonical lookup is `gh api /repos/{owner}/{repo}/commits/{sha}/pulls` (or the equivalent `gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls`) — this endpoint returns the merged PRs a commit belongs to and works for squash-merged commits. The workflow uses this endpoint, not the `--head <branch>` variant.
+
+The gate is **friction by design**, not a hard security boundary — ADR-0053 D15 calls it out explicitly: "The cost is 30 seconds per prod deploy; the value is preventing absent-minded `prod-{date}` tag pushes that bypass conscious review." The v2 transition to a true two-party gate (a second human's approval) happens when a second human joins the Studio; this packet is the v1 self-approval implementation.
+
+**AI agents are not approvers.** ADR-0053 D15: "A Codex-authored deploy PR cannot self-approve. The human operator is the only valid approver at v1." The gate's comment-author check excludes the GitHub bot accounts the AI agents post under; the canonical implementation is "the comment author must be a member of the org and must not be a known bot account." The list of known bot accounts is documented in the workflow (kept short — `github-actions[bot]`, `dependabot[bot]`, the OpenClaw reviewer's bot account if it posts comments).
+
+This is a workflow/YAML packet. No .NET project. `HoneyDrunk.Actions` is not a versioned .NET solution — no version bump, no `## NuGet Dependencies`-driven project change. The repo's `CHANGELOG.md` is updated per the existing repo convention.
+
+## Scope
+- `.github/workflows/job-deploy-container-app.yml` — add the `environment` input and the D15 self-approval gate (gated to `prod`).
+- `.github/workflows/job-deploy-function.yml` — add the same input and gate.
+- `docs/consumer-usage.md` — document the new input and the gate; document the canonical approval phrase consumers' PRs need.
+- The repo `CHANGELOG.md` — append an entry under a dated SemVer section (or the equivalent, if the repo's CHANGELOG convention differs).
+
+## Proposed Implementation
+1. **New workflow input on both deploy workflows:**
+   - `environment` (string, required) — one of `dev`, `staging`, `prod`. The reusable workflow validates the value at the start of the first job; an unknown value fails fast with a clear error message.
+   - The existing input set is preserved unchanged; `environment` is *additive*.
+2. **Validation step at the top of each deploy workflow:**
+   - Bash step or composite action that reads `environment` and asserts it is in the allowlist `dev|staging|prod`. Exits non-zero on a miss; the workflow does not proceed to authentication.
+3. **D15 self-approval gate — runs only on the prod path:**
+   - A job that runs `if: inputs.environment == 'prod'` and gates the deploy job (the deploy job carries `needs: [self-approval-gate]`).
+   - The gate job:
+     - Resolves the merged PR associated with the deploy commit via `gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls` (the `--head <branch>` variant does NOT work post-squash-merge because the source branch is deleted; squash-merge is the default per ADR-0053 D7). The endpoint returns the merged PR(s) the commit belongs to.
+     - Reads the PR's comments via the GitHub API (`gh api repos/${{ github.repository }}/issues/{pr_number}/comments`).
+     - Filters for comments authored by an org member (not a bot account from the documented list).
+     - Asserts at least one such comment contains the canonical approval phrase **`LGTM-PROD`** (encoded as a literal string constant in the workflow file; documented in `docs/consumer-usage.md`).
+     - On miss: fails with a clear error message ("No `LGTM-PROD` self-approval comment found on the deploy PR — see the D15 gate in `job-deploy-container-app.yml`"). On match: succeeds; the deploy job proceeds.
+4. **No new credential required.** The PR comment lookup uses the existing `GITHUB_TOKEN` with `pull-requests: read` (which the deploy workflows already declare for release-notes assembly).
+5. **Backward compatibility.** Existing consumers that already pass an environment via a different parameter name keep working — the new `environment` input is added; legacy parameters are not renamed. If a consumer relies on the implicit `dev` default, the validation step accepts the default value.
+6. **Documentation.** `docs/consumer-usage.md` gets a new section: "Environment input and self-approval gate." It documents the input, the allowlist, the canonical approval phrase **`LGTM-PROD`** (pinned), the workflow's behavior on the prod path, and a sample comment a consumer's deploy PR author posts to approve a prod deploy ("`LGTM-PROD`" verbatim). The doc also documents the v1-to-v2 transition note from ADR-0053 D15 and the post-squash-merge PR-lookup endpoint (`gh api repos/{owner}/{repo}/commits/{sha}/pulls`).
+
+## Affected Files
+- `.github/workflows/job-deploy-container-app.yml`
+- `.github/workflows/job-deploy-function.yml`
+- `docs/consumer-usage.md`
+- The repo `CHANGELOG.md`
+
+## NuGet Dependencies
+None. `HoneyDrunk.Actions` deploy workflows are GitHub Actions YAML — no .NET project is created or modified by this packet.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo — the reusable deploy workflows live here per ADR-0012 (Actions is the CI/CD control plane); ADR-0053 D16 Phase 2 names "the HoneyDrunk.Actions reusable deploy workflows."
+- [x] No code change in any Node — consumer release workflows already pass the value through; the input/validation/gate live in the reusable workflows.
+
+## Acceptance Criteria
+- [ ] `job-deploy-container-app.yml` and `job-deploy-function.yml` each carry an `environment` input (required string; allowlist `dev|staging|prod`); an unknown value fails fast at the top of the workflow
+- [ ] Both workflows run the D15 self-approval gate **only when `environment == 'prod'`** — the gate is inert on `dev` and `staging`
+- [ ] The gate resolves the deploy PR via `gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls` (works post-squash-merge); the `--head <branch>` variant is NOT used
+- [ ] The gate fails the deploy when the deploy PR has no self-approval comment from an org-member (non-bot) author containing the canonical approval phrase `LGTM-PROD`
+- [ ] The gate succeeds when at least one such comment exists; the deploy job runs after the gate
+- [ ] The canonical approval phrase is **`LGTM-PROD`** (pinned, literal) — encoded as a string constant in the workflow file and documented in `docs/consumer-usage.md`
+- [ ] The gate uses the existing `GITHUB_TOKEN` with `pull-requests: read`; no new credential, no DSN, no secret in the workflow or repo (invariant 8)
+- [ ] AI bot accounts (e.g. `github-actions[bot]`, `dependabot[bot]`, the OpenClaw reviewer bot if applicable) are excluded from the approver-author check; the list is documented in the workflow and `docs/consumer-usage.md`
+- [ ] Existing consumers of the deploy workflows are unaffected — `environment` is additive; legacy parameter names are preserved
+- [ ] `docs/consumer-usage.md` documents the input, the allowlist, the gate, the canonical approval phrase, a sample deploy-PR approval comment, and the v1→v2 transition note from ADR-0053 D15
+- [ ] The repo `CHANGELOG.md` is updated per the existing repo convention with a dated SemVer entry
+
+## Human Prerequisites
+- [ ] None to land this packet itself — workflow edits. The first *use* of the gate is when a consuming repo's release workflow targets `environment: prod`. The usage doc covers the consumer-author's "post the `LGTM-PROD` comment" step.
+- [ ] The canonical approval phrase is pinned at **`LGTM-PROD`** in this packet; no operator-decision-at-merge step. If a later packet renames the phrase, that is a separate workflow edit.
+
+## Referenced ADR Decisions
+**ADR-0053 D8 — Promotion model.** `main` → `dev` auto on merge; `dev` → `staging` via `staging-{date}` tag; `staging` → `prod` via `prod-{date}` tag + the D15 self-approval comment. Same artefact promotes through all environments.
+
+**ADR-0053 D15 — Approvals.** v1 prod deploy = passing CI on the tagged commit + a self-approval comment on the deploy PR. The comment is friction-by-design, not a hard security gate. v2 transitions to a true two-party gate when a second human joins. AI agents are not approvers.
+
+**ADR-0053 D16 Phase 2 — Update HoneyDrunk.Actions reusable workflows.** The `job-deploy.yml` workflow accepts an `environment` input; the self-approval gate wires into the prod path.
+
+**ADR-0033 — Tag → environment mapping.** `staging-{date}` → staging; `prod-{date}` → prod; `main` push → dev. The mapping is encoded in the calling workflow; the reusable workflow receives the resolved `environment` value.
+
+**ADR-0015 — Container hosting.** Azure Container Apps for containerized Nodes; the Actions reusable deploy workflows are the deploy surface.
+
+**ADR-0012 — Actions is the CI/CD control plane.** Reusable workflows in `HoneyDrunk.Actions` are the Grid's CI/CD surface; the D15 gate lives in the reusable workflow, not in each consumer.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry — or in workflow files.** The gate uses `GITHUB_TOKEN`; no DSN, instrumentation key, or credential is committed.
+
+> **Invariant 31 — Every PR traverses the tier-1 gate before merge.** The D15 self-approval gate is *additive* to the tier-1 PR gate — it runs at deploy time (post-merge), not at PR time. Tier-1 stays exactly as is.
+
+- **Gate is prod-only.** `dev` and `staging` deploys are unaffected — the gate's `if: inputs.environment == 'prod'` keeps it inert on lower environments.
+- **Self-approval is friction, not a hard security gate.** The implementation reflects D15's framing — the comment lookup is straightforward, the canonical phrase is plain text, and a determined human can absent-mindedly approve. The friction is the value.
+- **AI agents are not approvers.** Bot-account check excludes known bot accounts; the list is documented inline.
+- **Existing consumers unaffected.** `environment` is additive; legacy parameter names are preserved.
+- **Validate fast.** Allowlist check at the top of the workflow; an unknown environment value never reaches the deploy step.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `adr-0053`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add an `environment` input and the D15 prod-only self-approval gate to the `HoneyDrunk.Actions` reusable container-app and function deploy workflows.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Codify the tag → environment mapping at the reusable-workflow level and add a friction-by-design self-approval step on prod deploys, per ADR-0053 D8 and D15.
+- Feature: ADR-0053 Environments, Branching, and Release Cadence rollout, Wave 2.
+- ADRs: ADR-0053 D8/D15/D16 Phase 2 (primary), ADR-0033 (tag → environment mapping), ADR-0015 (Container Apps deploy surface), ADR-0012 (Actions as CI/CD control plane).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0053 should be Accepted before its deploy-flow changes land.
+
+**Constraints:**
+- Gate is prod-only (`if: inputs.environment == 'prod'`); inert on `dev`/`staging`.
+- No new credential — reuse `GITHUB_TOKEN` with `pull-requests: read`.
+- Bot accounts excluded from approver-author check.
+- Existing consumers unaffected — input is additive.
+- Validate `environment` value fast at the top of the workflow.
+
+**Key Files:**
+- `.github/workflows/job-deploy-container-app.yml`
+- `.github/workflows/job-deploy-function.yml`
+- `docs/consumer-usage.md`
+- `CHANGELOG.md`
+
+**Contracts:** None — workflow inputs only.

--- a/generated/issue-packets/active/adr-0053-release-cadence/04-actions-stale-pr-and-auto-close-workflows.md
+++ b/generated/issue-packets/active/adr-0053-release-cadence/04-actions-stale-pr-and-auto-close-workflows.md
@@ -1,0 +1,135 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "adr-0053", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0053", "ADR-0044"]
+accepts: ["ADR-0053"]
+wave: 2
+initiative: adr-0053-release-cadence
+node: honeydrunk-actions
+---
+
+# Author the stale-PR alert and 30-day auto-close workflows per D6
+
+## Summary
+Author two scheduled Actions workflows for branch-lifetime discipline per ADR-0053 D6: (1) `nightly-pr-stale-alert.yml` — comments on every open PR that has had no commits in 7 days (stale alert; no automatic closure); (2) `weekly-pr-auto-close.yml` — closes every open PR that has had no activity in 30 days unless it carries the `flagged-keep-open` label. Both workflows live in `HoneyDrunk.Actions` and are reusable across every Grid repo via `workflow_call`.
+
+## Context
+ADR-0053 D6 reads: "Target: feature branches merge within 5 working days of first commit. Stale alert: A PR with no commits in 7 days is flagged stale by an Actions workflow (a comment on the PR; no automatic closure at this stage). Auto-close: A branch with no PR activity in 30 days is auto-closed by an Actions workflow unless tagged `flagged-keep-open`. The branch is deleted; the work can re-open under a new branch."
+
+The forcing function (ADR-0053 D6): AI-authored PRs bottleneck on the single human reviewer. Branch lifetime is the only flow-control lever a one-developer-plus-agents shop has; setting it short is deliberate. The 30-day auto-close prevents zombie branches; the `flagged-keep-open` escape hatch handles legitimate long-running work (e.g. the Kernel Adoption Alignment initiative spanned weeks — those PRs get the tag).
+
+The two workflows are reusable across every Grid repo. Each Grid repo's `.github/workflows/` calls them on a schedule (nightly for stale-alert; weekly for auto-close) — the consumer wiring is documented in `docs/consumer-usage.md`. The Grid's existing nightly/weekly cadence (per the existing `nightly-deps.yml`, `nightly-security.yml`, `weekly-governance.yml`) is the precedent.
+
+**This is a workflow/YAML packet. No .NET project.** `HoneyDrunk.Actions` is not a versioned .NET solution — no version bump, no `## NuGet Dependencies`-driven project change. The repo's `CHANGELOG.md` is updated per the existing repo convention.
+
+**The `flagged-keep-open` label is part of the labels-as-code seed.** The label needs to exist in every Grid repo for the auto-close workflow to recognize it. ADR-0044's labels-as-code workflow (per `adr-0044-cloud-code-review` packet 08 — `seed-labels-fanout.yml`) is the seeding mechanism; this packet's acceptance criteria include "the `flagged-keep-open` label is added to the labels-as-code seed list" so the next labels-fanout run propagates it Grid-wide.
+
+## Scope
+- `.github/workflows/nightly-pr-stale-alert.yml` (new) — reusable workflow that comments on open PRs with no commits in 7 days.
+- `.github/workflows/weekly-pr-auto-close.yml` (new) — reusable workflow that closes open PRs with no activity in 30 days unless `flagged-keep-open`.
+- `.github/labels.json` (or the equivalent labels-as-code source — `seed-labels.json` if that is the canonical file in `HoneyDrunk.Actions`) — add the `flagged-keep-open` label entry so the next labels-fanout run propagates it Grid-wide.
+- `docs/consumer-usage.md` — document how a Grid repo wires the two workflows (a `nightly-pr-stale-alert.yml` consumer caller; a `weekly-pr-auto-close.yml` consumer caller; both `workflow_call`-based and short).
+- The repo `CHANGELOG.md` — dated SemVer entry.
+
+## Proposed Implementation
+1. **`nightly-pr-stale-alert.yml` — reusable workflow:**
+   - Trigger: `workflow_call` only. Consumers schedule it.
+   - Reads every open PR in the calling repo via `gh pr list --state open --json number,updatedAt,labels,headRefName,author`.
+   - Filters for PRs where the most recent commit's `committedDate` is older than 7 days. (Use `gh pr view <n> --json commits` and inspect the head commit.) PRs with the `flagged-keep-open` label are skipped (no stale comment on a tagged PR).
+   - For each matching PR, checks whether the workflow has already posted a stale comment in the last 24 hours (idempotency — the workflow runs nightly; do not spam). The check uses a hidden marker string in the comment body (e.g. `<!-- pr-stale-alert -->`).
+   - On a new match, posts a comment via `gh pr comment` with the marker, the PR's age, and a short note: "This PR has had no commits in 7 days. Per ADR-0053 D6 the 5-day branch-lifetime target has been missed. Either push a commit, request review, or add the `flagged-keep-open` label if this PR is legitimately long-running. PRs with no activity in 30 days are auto-closed by `weekly-pr-auto-close.yml`."
+2. **`weekly-pr-auto-close.yml` — reusable workflow:**
+   - Trigger: `workflow_call` only. Consumers schedule it weekly.
+   - Reads every open PR in the calling repo via `gh pr list`.
+   - Filters for PRs where the most recent activity (commits, comments, reviews — `updatedAt` is the canonical signal) is older than 30 days **and** the PR does not carry the `flagged-keep-open` label.
+   - For each matching PR, posts a "closing per ADR-0053 D6" comment with a hidden marker (`<!-- pr-auto-close -->`), then closes the PR via `gh pr close --comment` (or `gh pr close` after the comment). The branch is deleted via `gh api -X DELETE ...` (the auto-close behavior per ADR-0053 D6: "The branch is deleted; the work can re-open under a new branch").
+   - The closing comment cites the auto-close rule and notes that the work can re-open under a new branch.
+3. **Labels-as-code seeding.** Add the `flagged-keep-open` label to whichever file is the canonical labels-as-code source in `HoneyDrunk.Actions` (likely the same source the `seed-labels-fanout.yml` workflow from `adr-0044-cloud-code-review` packet 08 consumes). The label color/description fields follow the existing conventions in that file. Acceptance criterion: the label is recognized by the next labels-fanout run on every Grid repo.
+4. **Consumer-usage docs.** `docs/consumer-usage.md` gets two short examples — one for `nightly-pr-stale-alert.yml` (a consumer caller workflow that triggers nightly via `on: schedule: cron: '0 2 * * *'`); one for `weekly-pr-auto-close.yml` (a consumer caller workflow that triggers weekly via `on: schedule: cron: '0 3 * * 1'` — Monday morning UTC).
+5. **Permissions.** Both workflows declare `permissions: pull-requests: write, contents: write` (the auto-close workflow needs `contents: write` for the branch deletion). No new credential is required; `GITHUB_TOKEN` covers both.
+6. **Dry-run input.** Both workflows accept an optional `dry-run: boolean` workflow_call input (default `false`). When `dry-run` is true, the workflow lists what it *would* do (in the run log) but does not post comments, close PRs, or delete branches. Useful for the first execution on every repo so the operator sees the candidate list before the workflow goes live.
+
+## Affected Files
+- `.github/workflows/nightly-pr-stale-alert.yml` (new)
+- `.github/workflows/weekly-pr-auto-close.yml` (new)
+- `.github/labels.json` (or the equivalent labels-as-code source — name confirmed at edit time)
+- `docs/consumer-usage.md`
+- The repo `CHANGELOG.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo — the workflows are reusable across every Grid repo per ADR-0012.
+- [x] No code change in any Node — Node repos consume the workflows via `workflow_call`; the per-Node wiring lands on each Node's own schedule.
+
+## Acceptance Criteria
+- [ ] `nightly-pr-stale-alert.yml` exists as a `workflow_call`-only reusable workflow that comments on open PRs with no commits in 7 days; PRs carrying `flagged-keep-open` are skipped
+- [ ] The stale-alert workflow uses a hidden marker in the comment body to avoid double-posting on subsequent runs (idempotent within 24 hours)
+- [ ] `weekly-pr-auto-close.yml` exists as a `workflow_call`-only reusable workflow that closes open PRs with no activity in 30 days unless `flagged-keep-open`; the workflow posts a comment with the closing rationale and deletes the branch
+- [ ] Both workflows accept an optional `dry-run: boolean` input (default `false`) that logs the candidate list without taking action
+- [ ] Both workflows declare the minimum required permissions and use the existing `GITHUB_TOKEN` — no new credential, no secret in the workflow (invariant 8)
+- [ ] The `flagged-keep-open` label is added to the labels-as-code source in `HoneyDrunk.Actions` so the next labels-fanout run propagates it Grid-wide
+- [ ] `docs/consumer-usage.md` documents both workflows with a sample consumer caller (one nightly, one weekly)
+- [ ] The repo `CHANGELOG.md` is updated per the existing convention with a dated SemVer entry
+- [ ] No `.csproj` version bump — workflow-only
+
+## Human Prerequisites
+- [ ] No portal step required to land this packet itself.
+- [ ] After this packet merges, the labels-fanout workflow runs (or is triggered manually) so the `flagged-keep-open` label propagates to every Grid repo before the auto-close workflow is wired onto any Node repo. Without the label, the auto-close workflow's `flagged-keep-open` escape hatch is silently ineffective.
+- [ ] The operator wires the two workflows into each Grid repo's `.github/workflows/` on a schedule. The recommended initial run is `dry-run: true` for one week per repo so the candidate list is reviewed before the workflows go live; flip to `dry-run: false` after review.
+
+## Referenced ADR Decisions
+**ADR-0053 D6 — Branch lifetime: 5-day target / 7-day stale / 30-day auto-close.** "A PR with no commits in 7 days is flagged stale (a comment on the PR; no automatic closure at this stage). A branch with no PR activity in 30 days is auto-closed unless tagged `flagged-keep-open`. The branch is deleted; the work can re-open under a new branch."
+
+**ADR-0053 D6 — Forcing function rationale.** "AI-authored PRs are bottlenecked on the human reviewer. The longer the queue grows, the harder it is to reason about which PR depends on which; the more drift accumulates between feature branches and `main`; the more rework Codex has to do on stale work. The 5-day target is a flow-control mechanism."
+
+**ADR-0044 — Labels-as-code seed.** The `seed-labels-fanout.yml` workflow propagates label definitions from the canonical labels-as-code source to every Grid repo. The new `flagged-keep-open` label rides this mechanism.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry — or in workflow files.** The workflows use `GITHUB_TOKEN`; no DSN, instrumentation key, or credential is committed.
+
+> **Invariant 11 — One repo per Node.** The reusable workflows live in `HoneyDrunk.Actions`; consumer wiring is a per-repo caller workflow, not duplicate logic.
+
+- **Idempotent stale-alert.** The workflow uses a hidden marker in the comment body to avoid double-posting. Multiple nightly runs against the same stale PR result in one comment, not many.
+- **Dry-run by default for the first run.** The `dry-run` input exists specifically so the operator can review the candidate list before the workflows take action. The recommended first-execution path is documented in `docs/consumer-usage.md`.
+- **The `flagged-keep-open` escape hatch must be Grid-wide before auto-close goes live.** The labels-fanout run is a hard prerequisite for the auto-close consumer wiring; the consumer-usage doc states this explicitly.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `adr-0053`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author the two scheduled workflows for branch-lifetime discipline per ADR-0053 D6 — `nightly-pr-stale-alert.yml` and `weekly-pr-auto-close.yml` — and add the `flagged-keep-open` label to the labels-as-code seed.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Pressure the PR queue toward the 5-day target with a 7-day stale comment and a 30-day auto-close, per ADR-0053 D6's flow-control rationale.
+- Feature: ADR-0053 Environments, Branching, and Release Cadence rollout, Wave 2.
+- ADRs: ADR-0053 D6 (primary), ADR-0044 (labels-as-code seed mechanism).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0053 should be Accepted before its branch-lifetime workflows land.
+
+**Constraints:**
+- Reusable `workflow_call` only — consumer wiring on a schedule lives in each Grid repo's caller.
+- Idempotent stale-alert with a hidden marker.
+- `dry-run` input default `false`; recommended first execution per repo is `dry-run: true` for one week.
+- `flagged-keep-open` label propagates Grid-wide via the labels-fanout mechanism before auto-close goes live.
+- Minimum required permissions; reuse `GITHUB_TOKEN`.
+
+**Key Files:**
+- `.github/workflows/nightly-pr-stale-alert.yml` (new)
+- `.github/workflows/weekly-pr-auto-close.yml` (new)
+- The labels-as-code source file
+- `docs/consumer-usage.md`
+- `CHANGELOG.md`
+
+**Contracts:** None — workflow inputs only.

--- a/generated/issue-packets/active/adr-0053-release-cadence/05-actions-branch-prefix-validation.md
+++ b/generated/issue-packets/active/adr-0053-release-cadence/05-actions-branch-prefix-validation.md
@@ -1,0 +1,134 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "adr-0053", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0053", "ADR-0032", "ADR-0044", "ADR-0011"]
+accepts: ["ADR-0053"]
+wave: 2
+initiative: adr-0053-release-cadence
+node: honeydrunk-actions
+---
+
+# Add branch-prefix validation to `pr-core.yml` per D5
+
+## Summary
+Amend `pr-core.yml` in `HoneyDrunk.Actions` with a branch-prefix validation step that asserts the PR's head branch matches the canonical prefix set from ADR-0053 D5: human prefixes `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `release/`; AI prefixes `codex/`, `copilot/`, `claude/`. PRs from `main`, from forks, and from Dependabot are exempt. The check is advisory in Phase 1 (warning) and flips to a hard failure in Phase 2 once every Grid repo's open branches are conforming.
+
+## Context
+ADR-0053 D5 commits the canonical branch-prefix convention. The PR-validation policy (ADR-0032) and the AI-PR discipline ADR (ADR-0044) both *presume* the prefix convention to route their respective review checklists. ADR-0053 D5 makes the convention explicit and adds: "**The CI workflow filters in HoneyDrunk.Actions (per ADR-0012) can fan out different jobs by prefix (e.g., AI-authored branches may run additional review canaries).**"
+
+The validation step lives in `pr-core.yml` — the tier-1 gate per ADR-0011 D2 / invariant 31. It runs on every PR (every PR traverses tier 1 before merge), so the prefix check sees every branch that ever opens a PR.
+
+**Two-phase rollout for the validation severity.**
+- **Phase 1 (this packet)** — the check runs as a **warning** that emits a `::warning::` annotation in the PR-summary section but does not fail the workflow. The reason: at the moment this packet lands, open PRs may already exist with non-conforming branch names; failing them would block merges and force a renaming pass. The warning surfaces the deviation and gives the operator time to either rename the branch or accept the deviation as a one-off.
+- **Phase 2 (later)** — flip the check to **error** severity once every Grid repo's open PRs are conforming. The flip is a one-line change in `pr-core.yml`; a follow-up packet (not in this initiative) authors it.
+
+The check's regex covers the full D5 set plus `release/` for the D4 carve-out (release branches are permitted for emergency hotfix isolation). Dependabot's auto-generated branches (`dependabot/...`) are explicitly exempt because Dependabot is third-party and the prefix is not under operator control. Fork PRs are also exempt because the head branch lives in a fork and the operator does not own the fork's naming.
+
+**This is a workflow/YAML packet. No .NET project.** `HoneyDrunk.Actions` is not a versioned .NET solution — no version bump. The repo's `CHANGELOG.md` is updated per the existing repo convention.
+
+## Scope
+- `.github/workflows/pr-core.yml` — add a `branch-prefix-validation` step (warning-severity in Phase 1).
+- `docs/consumer-usage.md` — document the prefix set and the Phase 1/Phase 2 severity rollout.
+- The repo `CHANGELOG.md` — dated SemVer entry.
+
+## Proposed Implementation
+1. **New step in `pr-core.yml`.** Add a step (or a small job, depending on the file's structure — match the existing organization) that:
+   - Reads the PR's head branch name from the `pull_request` event (`github.head_ref`).
+   - Skips the check on:
+     - Fork PRs: `github.event.pull_request.head.repo.full_name != github.repository`.
+     - Dependabot: `github.actor == 'dependabot[bot]'` or `github.head_ref` starts with `dependabot/`.
+     - The `main` branch itself (which should never open a PR-into-`main`, but handle the edge case).
+   - Asserts `github.head_ref` matches the regex:
+     ```
+     ^(feat|fix|chore|docs|refactor|release|codex|copilot|claude)/.+
+     ```
+     Note: `claude/{agent-slug}-{token}` per D5 still matches `^claude/.+` — the agent-slug and token are part of the path.
+   - On a miss in **Phase 1**: emit a `::warning::` annotation with text like "Branch name `<name>` does not match the canonical prefix set from ADR-0053 D5 (`feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `release/`, `codex/`, `copilot/`, `claude/`). The check is currently advisory; it will flip to a hard failure in Phase 2. See `docs/consumer-usage.md` for the rollout plan." Exit code 0 — the workflow does not fail.
+   - On a match: log "Branch prefix OK: `<name>` matches the canonical set" and exit 0.
+2. **Severity-flip plan documented in `docs/consumer-usage.md`.** The doc records the prefix set, the Phase 1 warning behavior, the conditions for the Phase 2 flip ("every Grid repo's open PRs conform"), and a note that the flip is a one-line `pr-core.yml` change.
+3. **The check is part of the orchestration `pr-core.yml`** — it does not replace any existing job; it is additive. Existing tier-1 jobs (build, unit tests, analyzers, vulnerability scan, secret scan per invariant 31) are unchanged.
+4. **Permissions.** The step needs no special permission — `github.head_ref` is available on the `pull_request` event without authentication.
+
+## Affected Files
+- `.github/workflows/pr-core.yml`
+- `docs/consumer-usage.md`
+- The repo `CHANGELOG.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo — `pr-core.yml` lives here per ADR-0012 and is the Grid's tier-1 gate per ADR-0011.
+- [x] No code change in any Node — `pr-core.yml` is reusable; the check rides on every Grid repo's existing PR pipeline.
+
+## Acceptance Criteria
+- [ ] `pr-core.yml` carries a branch-prefix validation step that matches the D5 regex (`^(feat|fix|chore|docs|refactor|release|codex|copilot|claude)/.+`)
+- [ ] The step emits a `::warning::` annotation on a miss in Phase 1; it does **not** fail the workflow
+- [ ] Fork PRs are skipped (`head.repo.full_name != github.repository`)
+- [ ] Dependabot is skipped (`github.actor == 'dependabot[bot]'` or branch starts with `dependabot/`)
+- [ ] The step has no impact on existing tier-1 jobs (build, unit tests, analyzers, vulnerability scan, secret scan) — additive only
+- [ ] `docs/consumer-usage.md` documents the prefix set, the Phase 1 warning behavior, and the Phase 2 severity-flip plan (one-line change in `pr-core.yml`)
+- [ ] The repo `CHANGELOG.md` is updated per the existing convention with a dated SemVer entry
+- [ ] No new credential, no secret in the workflow (invariant 8)
+- [ ] No `.csproj` version bump — workflow-only
+
+## Human Prerequisites
+- [ ] None to land this packet itself. After it merges, the warning surfaces on every non-conforming open PR Grid-wide. The operator's follow-up: either rename non-conforming branches or accept the warning as one-off until the Phase 2 flip.
+- [ ] Phase 2 (the severity flip from warning to error) is a separate follow-up packet, not in this initiative. It lands when every Grid repo's open PRs conform.
+
+## Referenced ADR Decisions
+**ADR-0053 D5 — Branch-naming convention.** Human prefixes `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`; AI prefixes `codex/`, `copilot/`, `claude/{agent-slug}-{token}`; `release/{node}-{semver}` permitted for emergency hotfix isolation per D4. "The CI workflow filters in HoneyDrunk.Actions (per ADR-0012) can fan out different jobs by prefix."
+
+**ADR-0053 D16 Phase 4 — Branch-lifetime tooling.** "Stale-PR alert workflow (D6); auto-close-after-30-days workflow (D6); branch-prefix validation in CI (D5)." Packet 04 ships the first two; this packet ships the third.
+
+**ADR-0032 — PR validation policy.** Tier-1 gate jobs run on every PR; this packet adds a step to the orchestrator.
+
+**ADR-0044 — AI-PR discipline.** The branch prefix is one signal the review-routing logic in `pr-core.yml` (and downstream cloud agents) inspects to route the AI-vs-human review checklist.
+
+**ADR-0011 — Code review and merge flow.** `pr-core.yml` is the tier-1 gate per invariant 31; the branch-prefix check is additive to the existing tier-1 jobs.
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry — or in workflow files.** The branch-prefix check needs no credential; nothing is committed.
+
+> **Invariant 31 — Every PR traverses the tier-1 gate before merge.** The branch-prefix check is *part of* the tier-1 gate — it runs on every PR via `pr-core.yml`. Phase 1 makes the check advisory (warning); Phase 2 makes it blocking.
+
+- **Phase 1 is advisory only.** A `::warning::` annotation, never a workflow failure. The severity flip to a hard error is a separate Phase 2 follow-up packet.
+- **Fork and Dependabot exempt.** The operator does not control the fork's branch naming or Dependabot's auto-generated branches; the check skips both.
+- **Additive to existing tier-1 jobs.** No existing job is renamed or removed.
+- **Plain regex match.** No fuzzy matching, no auto-rename suggestion in Phase 1 — the warning text suffices.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `adr-0053`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add a branch-prefix validation step to `pr-core.yml` per ADR-0053 D5; advisory-only in Phase 1; the Phase 2 severity flip is a follow-up.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Surface non-conforming branch names on every PR so operators see the deviation; the warning is the lever, the Phase 2 flip is the long-run enforcement.
+- Feature: ADR-0053 Environments, Branching, and Release Cadence rollout, Wave 2.
+- ADRs: ADR-0053 D5/D16 Phase 4 (primary), ADR-0032 (PR validation policy), ADR-0044 (AI-PR discipline), ADR-0011 (tier-1 gate).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0053 should be Accepted before its branch-prefix check lands.
+
+**Constraints:**
+- Phase 1 is advisory (`::warning::`), never a workflow failure.
+- Fork PRs and Dependabot exempt.
+- Additive to existing tier-1 jobs; no rename or removal.
+- Plain regex match; no fuzzy matching in Phase 1.
+
+**Key Files:**
+- `.github/workflows/pr-core.yml`
+- `docs/consumer-usage.md`
+- `CHANGELOG.md`
+
+**Contracts:** None — workflow step only.

--- a/generated/issue-packets/active/adr-0053-release-cadence/06-architecture-local-dev-quick-start-template-and-audit-playbook.md
+++ b/generated/issue-packets/active/adr-0053-release-cadence/06-architecture-local-dev-quick-start-template-and-audit-playbook.md
@@ -1,0 +1,173 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "docs", "adr-0053", "wave-3"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0053", "ADR-0005", "ADR-0047"]
+accepts: ["ADR-0053"]
+wave: 3
+initiative: adr-0053-release-cadence
+node: honeydrunk-architecture
+---
+
+# Author the local-dev `## Quick Start` template and the "first 60 seconds" audit playbook
+
+## Summary
+Author the canonical `## Quick Start` section template (per ADR-0053 D11) for every Live Node's `repos/{name}/overview.md`, and the paired "first 60 seconds" audit playbook that runs the template against every Live Node and surfaces any Node that misses the 60-second boot target. The template + playbook is the substrate; packet 08 executes the audit; per-Node remediation packets land in each Node's own track.
+
+## Context
+ADR-0053 D11 reads: "Every Node must boot locally with `dotnet run` against either (a) the InMemory contract-compatible fakes per Invariant 15, or (b) the Testcontainers-driven Tier 2b dependencies per ADR-0047 D4. No Azure dependency is required for first-line development work. The forcing function: the first 60 seconds of trying a Node must be `git clone && dotnet run`."
+
+The decomposition mirrors ADR-0045 packet 07's playbook-not-per-Node-packets choice. Writing 12+ packets one per Node would prematurely decompose work that has not been validated against each Node's actual boot path. **This packet ships the template + the audit checklist; packet 08 runs the audit.** Each Node that misses the 60-second target becomes a small follow-up in that Node's own track.
+
+**Template scope per ADR-0053 D11.** "A `## Quick Start` section with: clone command, prerequisites (Docker for Testcontainers, .NET SDK version), boot command, expected log lines. If a Node cannot meet the 60-second target, the gap is recorded as a follow-up."
+
+The template needs to handle both Node shapes:
+- **Library-only Nodes** (Kernel, Vault, Transport, Architecture, Standards, etc.) — boot path is "build the solution; run the unit tests"; the 60-second target is "tests run green, no Azure dependency."
+- **Deployable Nodes** (Notify.Functions, Notify.Worker, Pulse.Collector, future Studios, future AI-sector deployables) — boot path is "build; `dotnet run` against the InMemory profile or Testcontainers; expected log lines"; the 60-second target is "the process boots and emits the readiness log line."
+
+**Vault bootstrap is env-var-driven per ADR-0005.** "Local secrets come from `.env` files (gitignored) loaded into environment variables; `HoneyDrunk.Vault` reads from env vars when configured for the `local` profile. No real Key Vault is required to boot a Node locally." The template documents this path; each Node's Quick Start lists its required env vars (with placeholder values; no actual secrets).
+
+This is a docs packet. No code, no .NET project.
+
+## Scope
+- `infrastructure/conventions/local-dev-quick-start-template.md` (new) — the canonical `## Quick Start` template covering both library-only and deployable Node shapes.
+- `infrastructure/conventions/local-dev-audit-playbook.md` (new) — the "first 60 seconds" audit playbook that runs the template against a Node and records the result (pass / miss + the specific gap).
+- `infrastructure/README.md` — reference the two new docs.
+
+## Proposed Implementation
+1. **`infrastructure/conventions/local-dev-quick-start-template.md`** — the canonical `## Quick Start` section template. Two variants:
+   - **Library-only Node template:**
+     ```markdown
+     ## Quick Start
+
+     **Prerequisites:**
+     - .NET SDK <version> (check with `dotnet --list-sdks`)
+
+     **Clone and build:**
+     ```sh
+     git clone https://github.com/HoneyDrunkStudios/HoneyDrunk.<Node>.git
+     cd HoneyDrunk.<Node>
+     dotnet build
+     dotnet test
+     ```
+
+     **Expected outcome (first 60 seconds):**
+     - `dotnet test` runs green
+     - No Azure provisioning required
+     ```
+   - **Deployable Node template:**
+     ```markdown
+     ## Quick Start
+
+     **Prerequisites:**
+     - .NET SDK <version>
+     - Docker Desktop (for Testcontainers-driven Tier 2b dependencies, if applicable)
+     - A copy of `.env.example` renamed to `.env` (gitignored; placeholder values are fine for local boot)
+
+     **Clone and boot:**
+     ```sh
+     git clone https://github.com/HoneyDrunkStudios/HoneyDrunk.<Node>.git
+     cd HoneyDrunk.<Node>
+     cp .env.example .env
+     dotnet run --project src/<entrypoint-project>
+     ```
+
+     **Expected log lines (first 60 seconds):**
+     - `<canonical readiness line — e.g. "Application started. Press Ctrl+C to shut down.">`
+     - Optionally: `<a Node-specific "ready" line — health-check endpoint, queue subscription, etc.>`
+
+     **No Azure dependency required.** The Node boots against InMemory contract-compatible fakes (per invariant 15) or Testcontainers-driven dependencies (per ADR-0047 D4). Real Azure resources are not provisioned by `dotnet run`.
+     ```
+   - The template covers **placeholders** the executing agent (or operator) substitutes: `<Node>`, `<version>`, `<entrypoint-project>`, `<canonical readiness line>`, the env-var list with placeholder values.
+   - **No real secrets** in any per-Node Quick Start. The env-var list documents the **names** of the secrets (e.g. `NOTIFY_RESEND_API_KEY`) with a placeholder value (`<your-resend-api-key>`); the actual value is gitignored in `.env`.
+2. **`infrastructure/conventions/local-dev-audit-playbook.md`** — the audit playbook describing how to run the Quick Start template against a Node:
+   - **Step 1 — Prerequisites check.** Confirm the Node's `repos/{name}/overview.md` carries a `## Quick Start` section. If missing, record as a gap.
+   - **Step 2 — Clone-and-boot timing.** On a clean machine state (or a fresh clone), execute the documented `git clone && dotnet run` (or `dotnet test` for library-only Nodes). Time the first-run from `dotnet run` invocation to the canonical readiness log line. Target: ≤ 60 seconds.
+   - **Step 3 — Azure-dependency check.** Confirm the boot path does not reach an Azure endpoint (no `AZURE_KEYVAULT_URI` resolution against a real vault; no App Configuration endpoint resolution; no Azure SDK authentication step). Local profile = `local`; env-var-driven secrets per ADR-0005.
+   - **Step 4 — Record the result.** Pass / miss + the specific gap. Misses become follow-up packets in the Node's own track (e.g. "the Node requires a real Service Bus connection string to boot — add a `local` profile with an InMemory broker") — those packets are written by the Node's own scope pass, not pre-written here.
+   - **Step 5 — Aggregate.** The audit produces a Grid-wide summary (each Node + pass/miss + gap-if-miss). Packet 08 runs the audit and lands the summary as a doc in `infrastructure/`.
+3. **`infrastructure/README.md`** — add rows for the two new conventions docs.
+
+## Affected Files
+- `infrastructure/conventions/local-dev-quick-start-template.md` (new)
+- `infrastructure/conventions/local-dev-audit-playbook.md` (new)
+- `infrastructure/README.md`
+
+## NuGet Dependencies
+None. This packet authors documentation; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All artefacts in `HoneyDrunk.Architecture` — cross-Node Grid conventions live here.
+- [x] No code change in any Node — the template is applied per Node in packet 08 (audit) and downstream per-Node packets (remediation).
+- [x] Deliberately does not pre-write per-Node packets — each Node's gap is recorded by the audit and decomposed in that Node's own track (mirroring the ADR-0045 packet 07 pattern).
+
+## Acceptance Criteria
+- [ ] `infrastructure/conventions/local-dev-quick-start-template.md` exists with the two template variants (library-only Nodes; deployable Nodes), each covering prerequisites, clone-and-build/run commands, expected log lines, and the no-Azure-dependency rule
+- [ ] The template includes the `.env`-driven local-secret convention per ADR-0005 and explicitly forbids real secret values in `repos/{name}/overview.md`
+- [ ] `infrastructure/conventions/local-dev-audit-playbook.md` exists with the five-step audit recipe (prerequisites check, clone-and-boot timing, Azure-dependency check, record result, aggregate)
+- [ ] `infrastructure/README.md` references both new conventions docs in its index
+- [ ] No per-Node packet is pre-written here — packet 08 runs the audit; per-Node remediation packets land in each Node's own track
+- [ ] No invariant change in this packet (invariants land in packet 00)
+- [ ] No `.csproj` version bump — Markdown-only
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0053 D11 — Local-dev parity.** "Every Node must boot locally with `dotnet run` against InMemory or Testcontainers dependencies; no Azure dependency required for first-line dev work. The first 60 seconds of trying a Node must be `git clone && dotnet run`. The 'first 60 seconds' experience is documented per Node in `repos/{name}/overview.md`. If a Node cannot meet the 60-second target, the gap is recorded as a follow-up."
+
+**ADR-0053 D12 — Configuration parity.** Environment-specific configuration lives in Azure App Configuration; local profile reads from gitignored `.env` files loaded as environment variables.
+
+**ADR-0053 D16 Phase 5 — Local-dev parity audit.** "Every Live Node's `repos/{name}/overview.md` gets a `## Quick Start` section per D11. Any Node that cannot meet the 60-second target gets a follow-up packet."
+
+**ADR-0005 — Vault env-var bootstrap.** Local secrets come from `.env` files (gitignored) loaded as env vars; `HoneyDrunk.Vault` reads from env vars on the `local` profile. No real Key Vault required to boot locally.
+
+**ADR-0047 D4 — Tier 2b Testcontainers.** Container-based integration tests (Tier 2b per ADR-0047) are the scoped exception to invariant 15; they are local, ephemeral, and deterministic. Deployable Nodes that need a Tier 2b dependency for local boot reference Testcontainers in their Quick Start.
+
+**Invariant 15 — Unit tests and in-process integration tests never depend on external services.** "Use InMemory providers (`InMemorySecretStore`, `InMemoryBroker`, `InMemoryQueue`) for isolation. Container-based integration tests (Tier 2b per ADR-0047) are the scoped exception, allowed because they are local, ephemeral, and deterministic."
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry — or in committed files.** The Quick Start template uses placeholder values for env-var examples (e.g. `<your-resend-api-key>`). Real secret values are gitignored in `.env`. The template forbids real secrets in `overview.md`.
+
+> **Invariant 9 — Vault is the only source of secrets.** The local profile reads from env vars (loaded from `.env`); the env-var path is `HoneyDrunk.Vault`'s `local` profile per ADR-0005. No Node reads secrets directly from `Environment.GetEnvironmentVariable` outside the Vault path.
+
+> **Invariant 15 — Unit tests and in-process integration tests never depend on external services.** The library-only Node template's "expected outcome" is `dotnet test` running green with no external service.
+
+- **Template, not per-Node packets.** Do not pre-write per-Node Quick Start sections here — those land per-Node via packet 08's audit and downstream remediation.
+- **Concise.** The template is a section template, not a tutorial. Match the length and tone of `repos/HoneyDrunk.Kernel/overview.md`'s existing structure (short, scannable).
+- **No real secrets.** Placeholder env-var values only; real values gitignored.
+
+## Labels
+`chore`, `tier-3`, `meta`, `docs`, `adr-0053`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Author the canonical `## Quick Start` section template and the paired audit playbook so packet 08 can run the "first 60 seconds" audit Grid-wide.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Codify D11's local-dev parity requirement once; downstream per-Node application is mechanical.
+- Feature: ADR-0053 Environments, Branching, and Release Cadence rollout, Wave 3.
+- ADRs: ADR-0053 D11/D12/D16 Phase 5 (primary), ADR-0005 (Vault env-var bootstrap), ADR-0047 D4 (Testcontainers).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0053 should be Accepted before its local-dev parity playbook lands.
+
+**Constraints:**
+- Template only — no per-Node packets pre-written.
+- Two variants (library-only Node; deployable Node).
+- No real secrets in any template example.
+- Concise; section template, not a tutorial.
+
+**Key Files:**
+- `infrastructure/conventions/local-dev-quick-start-template.md` (new)
+- `infrastructure/conventions/local-dev-audit-playbook.md` (new)
+- `infrastructure/README.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0053-release-cadence/07-actions-monthly-changelog-cadence-workflow.md
+++ b/generated/issue-packets/active/adr-0053-release-cadence/07-actions-monthly-changelog-cadence-workflow.md
@@ -1,0 +1,138 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-2", "ops", "ci-cd", "adr-0053", "wave-3"]
+dependencies: ["packet:00", "packet:03"]
+adrs: ["ADR-0053", "ADR-0012", "ADR-0033"]
+accepts: ["ADR-0053"]
+wave: 3
+initiative: adr-0053-release-cadence
+node: honeydrunk-actions
+---
+
+# Author the monthly CHANGELOG cadence enforcement workflow per D9 / D16 Phase 6
+
+## Summary
+Author a scheduled Actions workflow `monthly-changelog-cadence.yml` per ADR-0053 D9 / D16 Phase 6: it runs once per month against every Live Node and asserts that the Node has either (a) at least one `prod-{date}` tag in the past 30 days (per ADR-0033's tag → environment mapping) or (b) an explicit `## [no changes this month]` CHANGELOG entry under the dated SemVer section. Missed Nodes surface as Grid-health alerts via the existing grid-health aggregator (ADR-0012).
+
+## Context
+ADR-0053 D9 reads: "Every Live Node ships at least one prod release per calendar month OR an explicit 'no changes this month' entry in the Node's CHANGELOG.md. The 'no changes' entry is load-bearing: it makes inactivity visible. A Live Node that goes silent for three months without a 'no changes' entry is a Grid-health-aggregator (ADR-0012) alert."
+
+ADR-0053 D16 Phase 6 (Month 2): "A monthly Actions workflow checks every Live Node for either a prod deploy in the past 30 days or a 'no changes' CHANGELOG entry; missing entries become Grid-health-aggregator alerts (per ADR-0012)."
+
+The workflow is scheduled, scoped to the org, and reads each repo's CHANGELOG via the GitHub API. It does not require Azure resources or any deploy-flow integration — it observes the version-of-record (the CHANGELOG) and the tag history; that is sufficient signal.
+
+**Dependency on packet 03.** Packet 03 codifies the `environment` input convention in the deploy workflows; the cadence workflow's "deployed within the last 30 days" check uses the existing tag naming (`prod-{date}` per ADR-0033) which is independent of packet 03, but the workflow's *audit log* records the `environment` from the deploy workflow's run output for traceability. Without packet 03, the audit log carries no explicit environment label and reads less cleanly. The hard requirement is on the tag naming alone; the soft requirement is on packet 03's input for cleaner audit logs.
+
+**Live Nodes list.** ADR-0053 D9 names "every Live Node." The Grid's source of truth for Node status is `catalogs/grid-health.json` (the `signal` field — values include `live`, `seed`, `archived`). The workflow reads `catalogs/grid-health.json` from `HoneyDrunk.Architecture` to enumerate Live Nodes, then iterates each Live Node's repo.
+
+**Where the alert goes.** ADR-0053 D16 Phase 6 says "missing entries become Grid-health-aggregator alerts." The grid-health aggregator (ADR-0012) is the canonical alert surface. The workflow either calls the aggregator's API (if one exists) or opens a GitHub Issue in `HoneyDrunk.Architecture` per the existing nightly-security pattern. The latter is the safer default — the existing aggregator API surface is not yet finalized; an Issue is the same operational signal and the operator already has a manual-close convention for security issues (per the memory record).
+
+This is a workflow/YAML packet. No .NET project. The repo's `CHANGELOG.md` is updated per the existing convention.
+
+## Scope
+- `.github/workflows/monthly-changelog-cadence.yml` (new) — the scheduled workflow.
+- `docs/consumer-usage.md` — document the workflow's behavior and how a Node's CHANGELOG should carry the "no changes this month" entry.
+- The repo `CHANGELOG.md` — dated SemVer entry.
+
+## Proposed Implementation
+1. **`monthly-changelog-cadence.yml` — workflow shape:**
+   - Trigger: `on: schedule: cron: '0 4 1 * *'` — 04:00 UTC on the 1st of each month.
+   - Also `on: workflow_dispatch:` so the operator can run it manually for testing.
+   - One job that iterates the Live Nodes:
+     - Reads `catalogs/grid-health.json` from `HoneyDrunkStudios/HoneyDrunk.Architecture` via the GitHub API (`gh api /repos/HoneyDrunkStudios/HoneyDrunk.Architecture/contents/catalogs/grid-health.json`) and parses it for nodes with `signal: "Live"` (capitalized — the canonical value in `grid-health.json` is `"Live"`, not `"live"`; case-sensitive comparison required).
+     - For each Live Node, runs two checks in parallel:
+       - **Check A — Prod deploy in the past 30 days.** `gh api /repos/HoneyDrunkStudios/{repo}/tags` and filter for tags matching `prod-{YYYY-MM-DD}` (or `{component}-v*` followed by a `prod-{date}` deploy tag per the multi-deployable Notify pattern from `infrastructure/conventions/tag-and-release-conventions.md`). If at least one matches and its date is within the past 30 days: pass.
+       - **Check B — 'No changes this month' CHANGELOG entry.** `gh api /repos/HoneyDrunkStudios/{repo}/contents/CHANGELOG.md` and search the file for an entry shaped `## [no changes - YYYY-MM]` or `## [<version>] - YYYY-MM-DD` with body text "no changes this month" (the precise format is documented in the workflow and in `docs/consumer-usage.md`; nothing fancy — string match against a canonical shape). If the entry references the current calendar month: pass.
+     - If either check passes: the Node is on-cadence. If both fail: open or update a single issue on `HoneyDrunkStudios/HoneyDrunk.Architecture` titled `Grid-health: cadence miss — {node} {YYYY-MM}` per the existing nightly-security pattern; the issue body lists the Node, the missed month, the recommended remediation (either ship a release or add a `## [no changes - YYYY-MM]` CHANGELOG entry), and a re-check date.
+   - The workflow respects an "exempt list" — a comment-block in the workflow file naming Nodes to skip (e.g. `HoneyDrunk.Architecture` itself, which has no `CHANGELOG.md` of the usual shape). The exempt list is short and inline; if it grows beyond 2–3 entries, factor it out into a JSON file.
+2. **Issue creation idempotency.** The workflow checks for an existing open issue with the canonical title shape before opening a new one. Existing issue: comment-update with the new month's status. Closed issue: open a new issue (the operator manually closed the prior, signalling the prior miss is resolved).
+3. **Manual close.** Per the operator's preference, the workflow never closes an issue automatically — manual close only (matching the nightly-security convention).
+4. **Permissions.** `permissions: contents: read, issues: write`. The `contents: read` is repo-wide via cross-repo `gh api` calls — the workflow runs under a token (the `GITHUB_TOKEN` for the same-repo issue API plus a Grid-scoped PAT or app token for cross-repo reads). The existing `nightly-security.yml` is the precedent for cross-repo token usage; mirror that pattern.
+5. **Docs.** `docs/consumer-usage.md` documents the canonical shape of the "no changes this month" CHANGELOG entry and gives a sample. The doc also notes that the workflow is scheduled in `HoneyDrunk.Actions` only — Grid repos do **not** schedule a per-repo caller; the workflow runs Grid-wide once from `HoneyDrunk.Actions`.
+
+## Affected Files
+- `.github/workflows/monthly-changelog-cadence.yml` (new)
+- `docs/consumer-usage.md`
+- The repo `CHANGELOG.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] `HoneyDrunk.Actions` is the correct repo — the workflow is Grid-wide observability per ADR-0012 (Actions is the CI/CD control plane).
+- [x] No code change in any Node — the workflow observes the version-of-record (CHANGELOG) and the tag history; no Node-side wiring needed.
+
+## Acceptance Criteria
+- [ ] `monthly-changelog-cadence.yml` exists with `schedule: cron: '0 4 1 * *'` and `workflow_dispatch:` triggers
+- [ ] The workflow reads `catalogs/grid-health.json` from `HoneyDrunkStudios/HoneyDrunk.Architecture` and enumerates Live Nodes (`signal: "Live"` — capitalized, case-sensitive)
+- [ ] For each Live Node, the workflow runs two checks: (A) prod tag in the past 30 days; (B) `## [no changes - YYYY-MM]` CHANGELOG entry referencing the current calendar month
+- [ ] Both fail → a Grid-health alert issue is opened (or updated) on `HoneyDrunkStudios/HoneyDrunk.Architecture` per the existing nightly-security issue pattern
+- [ ] The workflow is idempotent — an existing open alert issue gets a comment update, not a duplicate issue
+- [ ] The workflow never auto-closes issues — manual close per the operator's standing preference
+- [ ] An inline exempt-list documents Nodes that have no `CHANGELOG.md` of the usual shape (e.g. `HoneyDrunk.Architecture`)
+- [ ] `docs/consumer-usage.md` documents the canonical "no changes this month" CHANGELOG entry shape with a sample
+- [ ] No new credential — reuse `GITHUB_TOKEN` and the same cross-repo token pattern `nightly-security.yml` uses
+- [ ] No secret in the workflow or repo (invariant 8)
+- [ ] The repo `CHANGELOG.md` is updated per the existing convention with a dated SemVer entry
+- [ ] No `.csproj` version bump — workflow-only
+
+## Human Prerequisites
+- [ ] None to land this packet itself.
+- [ ] First-run review: after the workflow merges, run it manually via `workflow_dispatch` once. Review the candidate alert list; flag any Node that shows a false-positive miss and adjust the exempt list or fix the CHANGELOG shape detection accordingly.
+
+## Referenced ADR Decisions
+**ADR-0053 D9 — Release cadence.** Per-Node release-as-needed; monthly floor: "every Live Node ships at least one prod release per calendar month OR an explicit 'no changes this month' entry in the Node's CHANGELOG.md. The 'no changes' entry is load-bearing: it makes inactivity visible."
+
+**ADR-0053 D16 Phase 6 — Monthly CHANGELOG cadence enforcement.** "A monthly Actions workflow checks every Live Node for either a prod deploy in the past 30 days or a 'no changes' CHANGELOG entry; missing entries become Grid-health-aggregator alerts."
+
+**ADR-0033 — Tag → environment mapping.** `prod-{date}` tags trigger the prod deploy workflow; the cadence workflow's Check A reads these tags.
+
+**ADR-0012 — Actions is the CI/CD control plane.** The cadence workflow lives in `HoneyDrunk.Actions`; the alert surface is the grid-health aggregator (or, until that surface is finalized, a GitHub Issue on `HoneyDrunk.Architecture` per the existing nightly-security pattern).
+
+## Constraints
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry — or in workflow files.** The workflow uses `GITHUB_TOKEN` and the same cross-repo token pattern `nightly-security.yml` uses; no DSN, instrumentation key, or credential is committed.
+
+> **Invariant 38 — The Architecture repo tracks all Hive board items.** Cadence-miss alert issues land on `HoneyDrunkStudios/HoneyDrunk.Architecture` (the Grid's governance home) and are tracked on The Hive board per `initiatives/board-items.md` (per the existing non-initiative tracking convention for nightly-security / grid-health issues).
+
+- **Idempotent.** Existing open alert issue → comment update; closed issue → new issue.
+- **Manual close only.** Per the operator's standing preference, the workflow never auto-closes — matches nightly-security.
+- **Live Nodes only.** Seed and archived Nodes are skipped; the `signal: "Live"` (capitalized) filter is the source of truth.
+- **Exempt list inline.** Architectures repo itself is exempt; the inline list is short.
+- **Same cross-repo token pattern as nightly-security.** Do not invent a new token model.
+
+## Labels
+`feature`, `tier-2`, `ops`, `ci-cd`, `adr-0053`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Author the monthly CHANGELOG cadence enforcement workflow per ADR-0053 D9 / D16 Phase 6.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Make Node inactivity visible — every Live Node either ships a prod release every month or explicitly says "no changes this month"; misses become Grid-health alert issues.
+- Feature: ADR-0053 Environments, Branching, and Release Cadence rollout, Wave 3.
+- ADRs: ADR-0053 D9/D16 Phase 6 (primary), ADR-0033 (tag → environment mapping), ADR-0012 (Actions as CI/CD control plane).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0053 should be Accepted before its cadence enforcement lands.
+- `packet:03` — the `environment` input convention is finalized in the deploy workflows; the cadence workflow's audit log reads the `environment` value from deploy-workflow run outputs where applicable.
+
+**Constraints:**
+- Idempotent issue creation; existing open alert gets a comment update.
+- Manual close only; mirrors nightly-security.
+- Live Nodes only; `signal: "Live"` (capitalized) is the source of truth.
+- Same cross-repo token pattern as `nightly-security.yml`.
+- Inline exempt list for Nodes without the usual CHANGELOG shape.
+
+**Key Files:**
+- `.github/workflows/monthly-changelog-cadence.yml` (new)
+- `docs/consumer-usage.md`
+- `CHANGELOG.md`
+
+**Contracts:** None — workflow inputs and a scheduled run.

--- a/generated/issue-packets/active/adr-0053-release-cadence/08-architecture-per-node-quick-start-audit-execution.md
+++ b/generated/issue-packets/active/adr-0053-release-cadence/08-architecture-per-node-quick-start-audit-execution.md
@@ -1,0 +1,124 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "meta", "docs", "adr-0053", "wave-3"]
+dependencies: ["packet:06"]
+adrs: ["ADR-0053"]
+accepts: ["ADR-0053"]
+wave: 3
+initiative: adr-0053-release-cadence
+node: honeydrunk-architecture
+---
+
+# Run the "first 60 seconds" audit against every Live Node and produce the Grid-wide gap report
+
+## Summary
+Execute the local-dev audit playbook from packet 06 against every Live Node in `catalogs/grid-health.json`. Produce a Grid-wide gap report listing each Node's pass/miss state and the specific gap-on-miss. Per-Node remediation packets are **not** pre-written here — each miss is recorded with enough context that a follow-up scope pass in that Node's own track can decompose the fix.
+
+## Context
+ADR-0053 D16 Phase 5 reads: "Every Live Node's `repos/{name}/overview.md` gets a `## Quick Start` section per D11. Any Node that cannot meet the 60-second target gets a follow-up packet."
+
+This packet does the **audit execution** — it runs the playbook from packet 06 against each Live Node, records the result, and surfaces gaps. Packet 06 ships the template + the audit recipe; this packet runs the recipe and produces the report. Per the playbook-not-per-Node-packets pattern (mirroring ADR-0045 packet 07), per-Node remediation is **deferred** to each Node's own scope pass — the audit's job is to identify gaps, not pre-write 12+ remediation packets.
+
+**Why a separate execution packet.** Packet 06 (the template + playbook) is small and focused — it ships docs. Audit execution is a separate concern: it touches every Live Node's repo (cloning, building, running), takes real time per Node, and produces a Grid-wide report. Splitting the two avoids a single mega-packet that authors-and-executes in one PR.
+
+**Expected outcome.** Per ADR-0053's Operational Consequences: "The 'first 60 seconds' audit will surface Nodes that don't meet it. Phase 5's audit is expected to find at least 2–3 Nodes that need work to hit the target. Those gaps become packets; they are not blockers for the rest of this ADR's rollout." So a non-zero gap count is the expected case, not a failure mode.
+
+This is a docs/audit packet. No code, no .NET project. The audit's *output* is a Markdown report; the audit's *input* is the live state of every Live Node's repo.
+
+## Scope
+- `infrastructure/local-dev-audit-report.md` (new) — the Grid-wide gap report covering every Live Node: name, pass/miss, gap-on-miss (specific log line or missing prerequisite), recommended remediation (a one-line summary), and a link to the Node's `repos/{name}/overview.md`.
+- For each pass Node: confirm the Node's `repos/{name}/overview.md` already carries a `## Quick Start` section that meets the playbook's criteria. If yes, record pass. If the Node passes the *boot* check but is missing the `## Quick Start` section in `overview.md`, the audit's recommended remediation is "add the Quick Start section per the template"; this is a small docs-only follow-up.
+- For each miss Node: record the specific gap (e.g. "boot requires a real Service Bus connection string — no `local` profile with InMemory broker"; "boot exceeds 60 seconds; first run takes 95s on a 14-Gbps machine due to NuGet restore"; "missing `.env.example`"). The remediation is recorded as a one-line summary; the full per-Node packet is **not** pre-written here.
+
+## Proposed Implementation
+1. **Enumerate Live Nodes.** Read `catalogs/grid-health.json` for nodes with `signal: "Live"` (capitalized — the canonical value in `grid-health.json`; case-sensitive comparison required). Library-only Nodes and deployable Nodes are both in scope (the template from packet 06 has variants for both).
+2. **Per Node, run the playbook:**
+   - Read `repos/{name}/overview.md` to see if a `## Quick Start` section already exists.
+   - Clone the Node's repo to a clean working directory.
+   - Execute the documented boot path (`dotnet build && dotnet test` for library-only; `dotnet run` for deployable).
+   - Time the first-run from invocation to the canonical readiness log line.
+   - Confirm no Azure endpoint is reached (no `AZURE_KEYVAULT_URI` resolution against a real vault; no App Configuration; no SDK auth step).
+   - Record pass / miss + the specific gap-on-miss.
+3. **Aggregate into `infrastructure/local-dev-audit-report.md`.** The report has:
+   - A header dated `YYYY-MM-DD` with the audit's execution date.
+   - A summary line: "X/Y Live Nodes pass the 60-second target; Z Live Nodes miss with a recorded gap; W Live Nodes pass the boot check but lack the documented Quick Start section."
+   - A per-Node table: Node name | Status | Gap-on-miss | Recommended remediation | Link to `overview.md`.
+   - A "Follow-up packets" section listing each miss with a one-line remediation summary — these are notes for future scope passes, NOT pre-written packets. Each entry's wording is: "{Node}: {one-line summary of the fix needed}. Follow-up: scope in the Node's own track."
+4. **No per-Node packet pre-written.** This is the same boundary as ADR-0045 packet 07. The audit's *output* is a structured list of gaps; each Node's scope agent (the operator's next pass against that Node) decomposes its own remediation packet.
+5. **Update `catalogs/grid-health.json`.** If the audit reveals a Node has an active blocker (e.g. cannot boot locally without a real Azure resource), add the blocker to the Node's `active_blockers` array per the existing grid-health schema. This is the only catalog edit this packet makes.
+
+## Affected Files
+- `infrastructure/local-dev-audit-report.md` (new)
+- `catalogs/grid-health.json` — `active_blockers` updates per Node where the audit reveals a real blocker.
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All artefacts in `HoneyDrunk.Architecture` — audit reports and catalog updates live here.
+- [x] No code change in any Node — the audit observes the Node's repo state; remediation is a future per-Node scope pass.
+- [x] No per-Node packet pre-written — each miss is recorded with enough context for a future per-Node scope pass to decompose the fix.
+
+## Acceptance Criteria
+- [ ] `infrastructure/local-dev-audit-report.md` exists with the date header, summary line, per-Node table, and follow-up notes section
+- [ ] Every Live Node in `catalogs/grid-health.json` (`signal: "Live"` — capitalized) is covered in the report — no skipped Node
+- [ ] Each row records Node name, status (pass / miss / pass-boot-missing-quick-start), gap-on-miss, recommended remediation summary, and link to `overview.md`
+- [ ] `catalogs/grid-health.json` `active_blockers` arrays are updated per Node where the audit reveals a real blocker — the only catalog edit this packet makes
+- [ ] No per-Node remediation packet is pre-written — follow-ups are recorded as notes in the report's "Follow-up packets" section
+- [ ] No invariant change in this packet (invariants land in packet 00)
+- [ ] No `.csproj` version bump — Markdown + JSON only
+
+## Human Prerequisites
+- [ ] The audit execution requires cloning every Live Node's repo and running the documented boot path. The agent doing the audit work has the local environment to do so (Docker, .NET SDK, any documented prerequisites).
+- [ ] For Nodes the agent cannot boot locally (e.g. the boot path needs a paid Azure resource that exists only in the operator's subscription), the audit records "cannot reproduce locally" as the gap and flags the Node for the operator's own audit pass — agents do not provision Azure resources to make the audit work.
+
+## Referenced ADR Decisions
+**ADR-0053 D11 — Local-dev parity.** Every Node must boot locally with `dotnet run` against InMemory or Testcontainers; the first-60-seconds rule per `repos/{name}/overview.md`'s `## Quick Start`.
+
+**ADR-0053 D16 Phase 5 — Local-dev parity audit.** "Any Node that cannot meet the 60-second target gets a follow-up packet." This packet identifies the gaps; per-Node follow-ups are decomposed in each Node's own track.
+
+**ADR-0053 Operational Consequences.** "The 'first 60 seconds' audit will surface Nodes that don't meet it. Phase 5's audit is expected to find at least 2–3 Nodes that need work to hit the target. Those gaps become packets; they are not blockers for the rest of this ADR's rollout."
+
+## Constraints
+> **Invariant 11 — One repo per Node.** The audit observes every Live Node's repo without modifying any of them. Remediation is each Node's own concern.
+
+> **Invariant 25 — Dispatch plans are initiative narratives, not live state.** The audit report is *not* a dispatch plan; it is a Grid-wide finding artefact. The follow-up packets land per-Node, not in this initiative.
+
+- **Audit, not remediation.** Identify gaps, do not fix them. Per-Node follow-up scoping is deliberately deferred to each Node's own track.
+- **Every Live Node covered.** No skipping; the report's coverage is exhaustive across `signal: "Live"` (capitalized) Nodes.
+- **`catalogs/grid-health.json` `active_blockers` is the only catalog edit.** Other catalog files are untouched.
+- **Cannot-reproduce gaps recorded honestly.** If an agent cannot reproduce the boot path locally (because the path needs an Azure resource the agent cannot provision), record that as the gap and flag for the operator's own audit pass.
+
+## Labels
+`chore`, `tier-3`, `meta`, `docs`, `adr-0053`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Run the local-dev audit playbook against every Live Node and produce the Grid-wide gap report; record blockers in `catalogs/grid-health.json`; do not pre-write per-Node remediation packets.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Identify which Live Nodes meet the 60-second local-boot target and which need work, per ADR-0053 D16 Phase 5.
+- Feature: ADR-0053 Environments, Branching, and Release Cadence rollout, Wave 3.
+- ADRs: ADR-0053 D11/D16 Phase 5 (primary).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:06` — the template + audit playbook this packet executes against.
+
+**Constraints:**
+- Audit, not remediation — no per-Node packets pre-written.
+- Every Live Node covered; no skipping.
+- `catalogs/grid-health.json` `active_blockers` is the only catalog edit.
+- "Cannot reproduce locally" is a valid recorded gap when an agent lacks the Azure resource the boot path needs.
+
+**Key Files:**
+- `infrastructure/local-dev-audit-report.md` (new)
+- `catalogs/grid-health.json`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0053-release-cadence/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0053-release-cadence/dispatch-plan.md
@@ -1,0 +1,132 @@
+# Dispatch Plan — ADR-0053: Environments, Branching, and Release Cadence
+
+**Initiative:** `adr-0053-release-cadence`
+**ADR:** ADR-0053 (Proposed → Accepted via packet 00)
+**Sector:** Meta / cross-cutting
+**Created:** 2026-05-24
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0053 commits what every other recent operational ADR has been quietly presuming: **three always-on environments (`dev`, `staging`, `prod`), trunk-based branching off `main`, short-lived feature branches (5-day target / 7-day stale / 30-day auto-close), squash merge by default, automatic `main`→`dev` deploys with tag-driven promotion (`staging-{date}`, `prod-{date}` per ADR-0033), per-Node release-as-needed cadence with a monthly "at-least-one prod release or 'no changes' CHANGELOG entry" floor, mandatory `dotnet run` local-dev parity against InMemory/Testcontainers, and a v1 single-subscription + environment-RBAC isolation model that splits to subscription-per-environment when the first paying tenant lands.**
+
+The ADR closes the load-bearing gap behind ADR-0011 (review), ADR-0015 (Container Apps), ADR-0032 (PR validation), ADR-0033 (env-gated deploys), and ADR-0044 (AI-PR discipline). It unblocks the Notify.Functions / Notify.Worker / Pulse.Collector Azure bring-up that has been the top item on `current-focus.md` for weeks — those Nodes finally have a named, committed environment topology to deploy against.
+
+This initiative delivers: ADR acceptance + the three new invariants (numbers **81, 82, 83**); the `infra/{env}/` Bicep module set for `dev`/`staging`/`prod` per D16 Phase 1 with paired Azure-portal walkthroughs (so the work is reviewable in both Bicep and click-by-click form); a `catalogs/services.json` schema extension adding the `environments: [...]` field per service per Consequences; the HoneyDrunk.Actions reusable deploy workflows amended with an `environment` parameter and the D15 self-approval gate (Phase 2); three Actions workflows for branch-lifetime discipline (stale-PR alert + 30-day auto-close + branch-prefix validation, Phase 4); the local-dev parity audit deliverable (`## Quick Start` per-Node template + audit playbook, Phase 5); and the monthly CHANGELOG cadence enforcement Actions workflow (Phase 6).
+
+**9 packets across 3 waves**, targeting **2 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Actions`). All 9 are `Actor=Agent` by default; packet 02 (Bicep + portal walkthroughs for `dev` provisioning) carries Human Prerequisites — Azure-Portal resource-group/RBAC creation and budget-acceptance clicks — but the *artefact authoring* (Bicep + walkthrough doc) is fully delegable, so it stays `Actor=Agent`.
+
+**D16 Phase 3** (Notify.Functions / Notify.Worker / Pulse.Collector Azure bring-up against the new topology) is **deliberately NOT a new packet here**. Those three services already have open issues in the `adr-0015-container-apps-rollout` initiative (`Notify#3`, `Notify#4`, `Pulse#3`) and the `adr-0033-deploy-trigger-model` initiative (`Notify#19`, `Notify#20`, `Pulse#18`); adding a fourth set of packets covering the same code paths would duplicate work and violate the "one issue = one logical change" rule. This initiative provides the topology those packets consume — see the Cross-Cutting Concerns section on Phase 3 hand-off.
+
+**D16 Phase 7** (subscription split when the first paying tenant arrives) is also explicitly deferred — the trigger is "first paying tenant lands" per D3 and PDR-0002. The mechanical path is recorded in this dispatch plan and in packet 00's acceptance text; no packet is filed until that trigger fires.
+
+## Trigger
+
+ADR-0053 is Proposed with no scope. The forcing functions from the ADR Context: (1) **ADR-0033's** tag→environment mapping presumes named environments that are not committed anywhere; (2) **ADR-0015's** multi-revision Container Apps strategy presumes deploy targets that are not committed; (3) **ADR-0011 / ADR-0032 / ADR-0044** presume a branching model that no ADR has written down; (4) the **Notify/Pulse Azure bring-up** has been the #1 blocker on `current-focus.md` for weeks, waiting on this exact topology decision. Landing the ADR's decisions as live artefacts (Bicep + walkthroughs + Actions workflows + the local-dev audit playbook + the cadence enforcement workflow) unblocks that bring-up and removes a class of "implicit topology" assumption from the ADR set.
+
+## Scope Detection
+
+**Multi-repo.** ADR-0053 touches `HoneyDrunk.Architecture` (acceptance, three invariants, catalog schema extension, Bicep modules + portal walkthroughs, the local-dev Quick Start template + audit playbook, governance/index updates) and `HoneyDrunk.Actions` (the reusable deploy workflow's `environment` input + D15 self-approval gate; the stale-PR / auto-close / branch-prefix-validation workflows; the monthly CHANGELOG cadence workflow).
+
+**No Node code touched in this initiative.** D11's local-dev parity requirement is delivered as a template + per-Node audit *playbook*, not as 12+ premature per-Node packets. Each Node owns its own `repos/{name}/overview.md` `## Quick Start` section work — applying the template lands in each Node's own track (mirroring ADR-0045 packet 07's "playbook, not per-Node packets" decision).
+
+**No new-Node scaffolding.** Every target repo already exists. No empty cataloged repo is touched; no standup ADR is needed.
+
+## Wave Diagram
+
+### Wave 1 (No Dependencies — governance + foundation, parallel)
+
+- [ ] **00** — Architecture: Accept ADR-0053, add the three environments/branching/cadence invariants (numbers **81, 82, 83**), register the initiative. `Actor=Agent`. Blocked by: nothing.
+- [ ] **01** — Architecture: extend `catalogs/services.json` schema with `environments: [dev, staging, prod]` field; document branching/cadence conventions in `infrastructure/conventions/` and `routing/sdlc.md` per D4–D7, D9. `Actor=Agent`. Blocked by: 00.
+
+### Wave 2 (Depends on Wave 1 — environment substrate + Actions workflow plumbing, parallel)
+
+- [ ] **02** — Architecture: Author `infra/{env}/` Bicep modules for `dev`/`staging`/`prod` per D2 + the paired Azure-Portal walkthrough(s) per the operator's standing preference; execute `dev` provisioning. `Actor=Agent`. Blocked by: 00. **Human Prerequisites:** Azure-Portal resource-group/RBAC/budget steps for `dev`.
+- [ ] **03** — Actions: amend `job-deploy-container-app.yml` and `job-deploy-function.yml` with an `environment` input + the D15 self-approval gate on the prod path. `Actor=Agent`. Blocked by: 00.
+- [ ] **04** — Actions: author `nightly-pr-stale-alert.yml` (D6 7-day stale comment) and `weekly-pr-auto-close.yml` (D6 30-day auto-close with `flagged-keep-open` escape hatch). `Actor=Agent`. Blocked by: 00. (Independent of 02/03 — parallel.)
+- [ ] **05** — Actions: amend `pr-core.yml` with a branch-prefix validation step that asserts the head branch matches `{feat|fix|chore|docs|refactor|codex|copilot|claude|release}/.+` per D5. `Actor=Agent`. Blocked by: 00. (Independent of 02/03/04 — parallel.)
+
+### Wave 3 (Depends on Wave 2 — operational substrate, parallel)
+
+- [ ] **06** — Architecture: Author the local-dev `## Quick Start` template (per-Node section template + the "first 60 seconds" audit checklist per D11). `Actor=Agent`. Blocked by: 00. (Independent of 02–05 — parallel; sequenced into Wave 3 only for tidy filing.)
+- [ ] **07** — Actions: author `monthly-changelog-cadence.yml` per D9 / D16 Phase 6 — check every Live Node for either a prod deploy in the past 30 days or a "no changes this month" CHANGELOG entry; open a Grid-health alert for any miss. `Actor=Agent`. Blocked by: 03. (Reuses the tag → environment mapping packet 03 finalizes.)
+- [ ] **08** — Architecture: Per-Node `## Quick Start` audit using packet 06's template; surface any Node that misses the 60-second target as a follow-up packet in that Node's own track (not pre-written here). `Actor=Agent`. Blocked by: 06.
+
+Packets within a wave run in parallel. Cross-wave sequencing is strict.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0053](./00-architecture-adr-0053-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [Environments catalog schema + conventions](./01-architecture-environments-catalog-and-conventions.md) | Architecture | Agent | 1 | 00 |
+| 02 | [`infra/{env}/` Bicep modules + dev portal walkthrough](./02-architecture-infra-env-bicep-and-walkthrough.md) | Architecture | Agent | 2 | 00 |
+| 03 | [Actions: `environment` input + self-approval gate](./03-actions-environment-input-and-self-approval-gate.md) | Actions | Agent | 2 | 00 |
+| 04 | [Actions: stale-PR + auto-close workflows](./04-actions-stale-pr-and-auto-close-workflows.md) | Actions | Agent | 2 | 00 |
+| 05 | [Actions: branch-prefix validation in `pr-core.yml`](./05-actions-branch-prefix-validation.md) | Actions | Agent | 2 | 00 |
+| 06 | [Local-dev `## Quick Start` template + audit playbook](./06-architecture-local-dev-quick-start-template-and-audit-playbook.md) | Architecture | Agent | 3 | 00 |
+| 07 | [Actions: monthly CHANGELOG cadence workflow](./07-actions-monthly-changelog-cadence-workflow.md) | Actions | Agent | 3 | 03 |
+| 08 | [Per-Node Quick Start audit execution](./08-architecture-per-node-quick-start-audit-execution.md) | Architecture | Agent | 3 | 06 |
+
+## Cross-Cutting Concerns
+
+### D16 Phase 3 — Notify/Pulse Azure bring-up is delegated to in-flight initiatives
+
+ADR-0053 D16 Phase 3 reads: "the currently-blocked Notify.Functions / Notify.Worker / Pulse.Collector deploys (per `current-focus.md`) are the first deploys against this topology." Those deploys are already tracked by two open in-flight initiatives:
+
+- `adr-0015-container-apps-rollout` — `Notify#3`, `Notify#4`, `Pulse#3` (Azure bring-up against Container Apps).
+- `adr-0033-deploy-trigger-model` — `Notify#19`, `Notify#20`, `Pulse#18` (environment-gated trigger model).
+
+**This initiative does not file a fourth set of packets covering the same three services.** Instead, packet 02 provisions the `dev` environment and the operator references its Bicep + walkthrough output when the existing bring-up packets land. The handoff path:
+
+1. Packet 02 lands `dev` resource group, RBAC, App Configuration, Log Analytics workspace, and any cross-cutting per-environment shared resources.
+2. The existing `Notify#3` / `Notify#4` / `Pulse#3` PRs build against the now-provisioned `dev` topology — their consumer workflows (per `adr-0033-deploy-trigger-model`) already accept an `environment` input through packet 03's new wiring.
+3. No coordination edge is needed from this initiative back to those packets — they pull from the topology this initiative ships, not the other way around.
+
+If the existing bring-up packets need refinement to reflect ADR-0053's environment topology (e.g. resource-group naming alignment), the refinement is a small follow-up in that initiative, not a new packet here.
+
+### D16 Phase 7 — subscription split is deferred behind a real trigger
+
+ADR-0053 D3 v2 / D16 Phase 7 says the subscription split (`sub-honeydrunk-prod` carved out from `sub-honeydrunk-nonprod`) happens "when PDR-0002 / ADR-0050 lands Notify Cloud's first paying tenant." That trigger has not fired. No packet is filed here for Phase 7. When the trigger fires, the subscription split is a separate small initiative (1–2 packets: Azure portal/CLI work + a one-time Bicep state migration) — record the trigger and the mechanical steps in this dispatch plan's history; do not pre-author the packets.
+
+### Bicep vs portal — both, in packet 02
+
+ADR-0053 D16 Phase 1 reads "**Author `infra/{env}/` Bicep modules**." The operator's standing preference (per the memory record) is "Azure Portal over CLI" for infra-provisioning walkthroughs. **Both are honored in packet 02:** the Bicep module is the deploy artefact (versioned, idempotent, the CI's hook for provisioning new environments mechanically); the paired Azure-Portal walkthrough is the human-facing review surface and the bootstrap path for the first execution. ADR-0077 (Infrastructure-as-Code Bicep) is the governing IaC ADR; ADR-0053 leans on it.
+
+The walkthrough records the same resource shape the Bicep produces; it does not invent a parallel topology. If a future operator review prefers the walkthrough's resource shape over the Bicep's, the Bicep is amended (not the walkthrough), and the divergence is recorded in the packet's PR body.
+
+### Local-dev Quick Start — template + audit, not pre-written per-Node packets
+
+D11 commits "every Node must boot locally with `dotnet run` against either InMemory contract-compatible fakes or Testcontainers-driven Tier 2b dependencies." Each Live Node's `repos/{name}/overview.md` gets a `## Quick Start` section. Writing 12+ packets one per Node would prematurely decompose work that has not been validated against each Node's actual boot path. **Packet 06 ships the template + the per-Node audit checklist; packet 08 runs the audit and identifies which Nodes need work.** Each gap becomes a small follow-up in that Node's own track — same pattern as ADR-0045 packet 07's playbook.
+
+### CHANGELOG cadence workflow — depends on a tag → environment mapping that already exists
+
+D9 commits "every Live Node ships at least one prod release per calendar month OR an explicit 'no changes this month' CHANGELOG entry." Packet 07's monthly workflow scans every Live Node repo for either a `prod-{date}` tag in the past 30 days (per ADR-0033's tag scheme) or a `## [no changes]` entry under the dated CHANGELOG block. Misses surface as Grid-health alerts. Packet 07 depends on packet 03 — packet 03 finalizes the `environment` input convention the cadence workflow's "deployed within the last 30 days" check leans on.
+
+### Site sync
+
+No site-sync flag. ADR-0053 is internal Meta-sector governance — no public-facing Studios website content changes. (Studios' own deploy story is touched by ADR-0053 but the website's *content* is not.)
+
+## Version Bumps
+
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; governance/catalog/Bicep/Markdown edits only.
+- **`HoneyDrunk.Actions`** — not a versioned .NET solution; workflow YAML changes. The repo's `CHANGELOG.md` (if it keeps one for the workflow surface) is updated per the existing repo convention from each Actions packet.
+
+No `.csproj` versions touched in this initiative — every packet is YAML, Markdown, JSON, or Bicep.
+
+## Rollback Plan
+
+- **Packets 00–01 (governance/catalog):** revert the PR. ADR returns to Proposed; the three invariants and the catalog schema extension are removed. No runtime impact.
+- **Packet 02 (Bicep + dev walkthrough + dev provisioning):** revert the PR pulls the Bicep module out of the repo. The provisioned `dev` resources are *not* automatically deleted — destruction is a deliberate human portal action (cost-bearing resources should not be deleted by a revert). The walkthrough's "deprovisioning" section documents the clean-tear-down path.
+- **Packet 03 (Actions deploy workflow `environment` input + self-approval gate):** revert the workflow edits. The `environment` input was optional with a default; existing consumers are unaffected. The self-approval gate going away means prod deploys lose the friction step — flag as an operational concern in the revert PR body.
+- **Packet 04 (stale-PR + auto-close workflows):** revert the workflow files. No PRs are auto-closed by absence; the workflows are creating side effects, not maintaining state. Outstanding stale-PR comments stay; outstanding auto-close annotations stay.
+- **Packet 05 (branch-prefix validation):** revert the `pr-core.yml` step. PRs with non-conforming branch names stop failing. No backfill needed.
+- **Packets 06, 08 (Quick Start template + audit):** revert the docs/audit PR. No runtime impact.
+- **Packet 07 (monthly CHANGELOG cadence workflow):** revert the workflow file. No Grid-health alerts are created by absence; existing alerts stay until manually resolved.
+
+**Operational escape hatch for packets 04, 05, 07:** the new Actions workflows are gated by an opt-in input or an explicit on-schedule trigger. If any workflow starts producing false-positive noise (e.g. stale-PR alerts on PRs the operator is actively reviewing), flip the schedule input off rather than reverting code — same one-input-change pattern as ADR-0045 packet 07's release-annotation gate.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.


### PR DESCRIPTION
## Summary

- Ninth of the staged PRs from the 2026-05-23 ADR batch. Governance-only — no code lands in any Node.
- Three cross-cutting policy ADRs: ADR-0051 (AI agent authorization — AgentPrincipal in Kernel.Abstractions, bundle wildcards env-gated, deny-code surface in Auth, tool.invoke.* audit events), ADR-0052 (cost governance — ICostLedger relocation from AI to Kernel, Cosmos-backed implementation, dispatcher kill-switch, budgets.json + tuning policy), ADR-0053 (release cadence — dev/staging/prod environments, branching conventions, monthly CHANGELOG cadence, per-Node Quick Start audit).

## Validation

- Markdown + JSON only; no code changed.
- file-packets.yml will file 31 packet files on merge — verify in The Hive.
- Reservation registry row for ADR-0051 (54-57) is inherited from #288.

## Authorship

Authorship: agent-claude-code

## Notes

- This PR is out-of-band per ADR-0011 D9 / invariant 32 — ships packet files but doesn't execute any single packet.
- ADR-0051 packets gated on ADR-0017 (Capabilities) for the bundle types and ADR-0030 (Audit) for the tool.invoke.* event-name surface — both captured as Human Prerequisites where they apply.
- ADR-0052 packet 04 deletes the seed HoneyDrunk.AI.Abstractions.ICostLedger; AI is at seed/0.1.0 with no out-of-repo consumers, so the rename is contained. Packet 05's Cosmos implementation requires the AI Node scaffold (ADR-0016 Phase 1) to be live first.
- ADR-0053's monthly-cadence workflow (packet 07) and Quick Start audit (packet 08) read catalogs/grid-health.json with the canonical "Live" signal value (capitalized) — fix applied earlier per refine feedback.
- ADR-0053 packet 02 documents the rg-hd-* naming convention conflict with ADR's D2 prose and amends ADR-0053 D2 in the same PR to align with the existing convention.