### PR TITLE
Scope ADR-0057/0064/0073 external surface ADRs

### DIFF
--- a/generated/issue-packets/active/adr-0057-api-versioning/00-architecture-adr-0057-acceptance.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/00-architecture-adr-0057-acceptance.md
@@ -1,0 +1,133 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "core", "docs", "adr-0057", "wave-1"]
+dependencies: []
+adrs: ["ADR-0057"]
+accepts: ["ADR-0057"]
+wave: 1
+initiative: adr-0057-api-versioning
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0057 — flip status, reserve invariants {N1}-{N4}, register the initiative
+
+## Summary
+Flip ADR-0057 (Public HTTP API Versioning and Client SDK Strategy) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, reserve a four-invariant block (`{N1}`-`{N4}`) in `constitution/invariant-reservations.md`, write the four invariants verbatim into `constitution/invariants.md`, and register the `adr-0057-api-versioning` initiative in `initiatives/active-initiatives.md`. The four invariants are: every public REST API has a checked-in OpenAPI 3.1 spec at `repos/{node}/api/openapi-v{n}.yaml`; breaking changes (per D4 taxonomy) require a major version bump; at most two majors of a given surface are live concurrently; and HoneyHub uses GraphQL schema evolution rather than URL-prefix versioning.
+
+## Context
+ADR-0057 commits the Grid's substrate for public HTTP APIs: URL-path versioning with OpenAPI 3.1 as the source of truth (D7), a four-tier breaking-change taxonomy enforced by an `oasdiff` CI gate (D4 + D7), a 180-day deprecation lifecycle with tenant-notification cadence (D5), a hard two-major coexistence window (D6), three published SDK languages generated from the spec (D8), per-API key + OAuth 2.1 PKCE auth (D10), and HoneyHub as the narrow GraphQL-schema-evolution exception (D1 + D16). Three near-term forcing functions drive acceptance now: Notify Cloud GA is the first commercial API consumer (PDR-0002 / ADR-0027); the AI-sector standup wave (ADR-0016 through ADR-0025) needs the public-API substrate before each Node invents one; mobile consumer apps (PDRs 0003 / 0005 / 0006 / 0008) all have a real-world long client-version tail that the policy must accommodate.
+
+The ADR carries two reconciliations already merged into the text:
+- **D11 reconciled with ADR-0067 D5/D7** — the rate-limit envelope is the IETF unprefixed `RateLimit-*` form (`RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset`); per-tenant keying; no legacy `X-RateLimit-*` mirrors; `Retry-After` in seconds on 429. ADR-0067 remains the canonical source for the rate-limit envelope; ADR-0057 restates D11's commitments only so SDK consumers reading ADR-0057 in isolation see the same shape.
+- **D15 reconciled with ADR-0075** — per-API docs sites are a two-part composition: Scalar renders the OpenAPI reference, Docusaurus carries the narrative content. Hosted at `docs.{api}.honeydrunkstudios.com`. The earlier draft picked Redocly; that choice was superseded.
+
+This packet flips Status to Accepted at the *start* of the initiative because the ADR's decisions are needed as live rules by packets 01-11. The deeper success criterion ("Phase 1 substrate in place; Web.Rest v1 frozen; Notify v1 spec + SDKs published") is the initiative-completion gate recorded in `initiatives/active-initiatives.md`; that gate is satisfied across multiple wave boundaries. This split mirrors the pattern used by ADR-0067 (which has the same shape: flip at start, completion gate at end).
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+- `adrs/ADR-0057-public-http-api-versioning-and-client-sdk-strategy.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0057 row Status column to Accepted.
+- `constitution/invariant-reservations.md` — append the ADR-0057 reservation row: range `{N1}-{N4}`, status Proposed (the table tracks Proposed-while-in-flight, then moves to Reservation History at merge); claim text matches the four invariants below. The four-invariant block claims at `max(current ceiling, ADR-0080 reservation=101) + 1`, so the contiguous block per rule 5 is **102-105**.
+- `constitution/invariants.md` — append four invariants verbatim:
+  - **{N1}** — Every public HTTP REST API has a checked-in OpenAPI 3.1 specification at `repos/{node}/api/openapi-v{n}.yaml` as the source of truth. Missing or out-of-sync spec is a CI gate failure per the `job-openapi-diff.yml` workflow.
+  - **{N2}** — Breaking changes (per the ADR-0057 D4 taxonomy) to a released public-API surface require a major version bump. Enforced by the OpenAPI-diff CI gate; the gate fails any PR whose diff against the last released spec is classified as breaking unless the spec under change is for a new (unreleased) major version.
+  - **{N3}** — At most two major versions of a given public-API surface are live concurrently. A new major's release forces the older surviving major into the 180-day sunset clock; v(N-1) is sunsetted before v(N+1) ships.
+  - **{N4}** — HoneyHub uses GraphQL schema evolution (additive types/fields + per-field `@deprecated(reason: "...; sunset YYYY-MM-DD.")`), not URL-prefix versioning. Enforced by the `graphql-inspector` CI gate (`job-graphql-inspector.yml`).
+- `initiatives/active-initiatives.md` — register the `adr-0057-api-versioning` initiative with the Wave structure and packet checklist for this folder.
+
+## Proposed Implementation
+1. Edit the ADR-0057 header: `**Status:** Proposed` → `**Status:** Accepted`.
+2. Update the ADR-0057 index row in `adrs/README.md` to Accepted.
+3. Append to `constitution/invariant-reservations.md` — Active Reservations table — a new row for ADR-0057: range `102-105` (the contiguous block above ADR-0080's 99-101), status Proposed; Notes column carries the four invariant texts verbatim from §Scope above; packet 00 is the writer. **Rule 5 check at execution time:** if the reservations table has shifted since this packet was authored (e.g. a sibling ADR's reservation merged ahead and consumed a higher block), bump the claim upward to the new "next free" block, update every `{N1}/{N2}/{N3}/{N4}` placeholder in the packet bodies in this initiative folder, and state the shift in the PR.
+4. Append to `constitution/invariants.md` — at the end, in invariant-number order — the four invariants with the resolved numbers from step 3. Match the file's existing entry shape (numbered heading, theme tag, body). Theme: `Public API Versioning` for {N1}-{N3}; `HoneyHub GraphQL Evolution` for {N4}.
+5. Register the initiative in `initiatives/active-initiatives.md` under `## In Progress` with the Wave structure and packet checklist for this folder. Match the existing entry-shape used by sibling ADR initiatives (`adr-0067-rate-limiting`, `adr-0075-docs-tooling`): an `### ADR-0057 Public HTTP API Versioning and Client SDK Strategy` heading, Status / Scope / Initiative / Board / Description fields, and a Tracking checklist of all twelve packets in this folder. Use the file naming as the canonical packet references (the GitHub issue numbers will be backfilled by `hive-sync` after filing).
+6. Record the **exit criterion** for the initiative in `initiatives/active-initiatives.md`: ADR-0057 Phase 1 substrate is complete (`job-openapi-diff.yml`, `job-publish-public-sdk.yml`, `job-publish-docs.yml`, `job-graphql-inspector.yml`, `job-publish-graphql-docs.yml` in Actions; `openapi-templates/{lang}/` in Actions); `HoneyDrunk.Web.Rest` `openapi-v1.yaml` checked in and frozen at v1; `HoneyDrunk.Notify` `openapi-v1.yaml` checked in with first SDKs published to npm/Maven/SPM and docs site live at `docs.notify.honeydrunkstudios.com/v1/`. **Notify Cloud Phase 3 is explicitly outside this initiative's exit criterion** — it is satisfied across the ADR-0027 standup boundary; the specification document (packet 10 of this initiative) is the handoff to a future follow-up packet against `HoneyDrunk.Notify.Cloud`.
+
+## Affected Files
+- `adrs/ADR-0057-public-http-api-versioning-and-client-sdk-strategy.md`
+- `adrs/README.md`
+- `constitution/invariant-reservations.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+- [x] Invariant reservation contiguous and ascending per `invariant-reservations.md` rule 5.
+
+## Acceptance Criteria
+- [ ] ADR-0057 header reads `**Status:** Accepted`
+- [ ] The ADR-0057 row in `adrs/README.md` reflects Accepted
+- [ ] `constitution/invariant-reservations.md` carries a new ADR-0057 row in Active Reservations with the four-invariant range (resolved to the next free contiguous block at execution time; expected `102-105` per current state)
+- [ ] `constitution/invariants.md` has four new invariants appended in number order matching the resolved range, with the verbatim texts in §Scope
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0057-api-versioning` initiative with all twelve packets in the Tracking checklist and the explicit exit criterion (Phase 1 substrate complete; Web.Rest v1 frozen; Notify v1 spec/SDKs/docs live; Notify Cloud Phase 3 deferred)
+- [ ] If invariant-reservations.md has shifted at execution time, the shift is recorded in the PR and every `{N1}/{N2}/{N3}/{N4}` placeholder in packets 01-11 is updated in the same PR
+- [ ] No catalog schema change in this packet (catalog/tech-stack updates land in packet 01)
+
+## Human Prerequisites
+None. The four invariants land at acceptance per the registry rule "reservation is added in the same PR that introduces the ADR's packet set" — the placeholder convention `{N1}-{N4}` is resolved to concrete numbers in this packet, not deferred to a later packet. Packet 00's PR is the writer.
+
+## Referenced ADR Decisions
+**ADR-0057 §Consequences / Invariants — adds three plus one HoneyHub-scoped.** Verbatim:
+
+> Adds three:
+> - **Invariant: every public HTTP REST API has a checked-in OpenAPI 3.1 spec at `repos/{node}/api/openapi-v{n}.yaml` as the source of truth.** Missing or out-of-sync spec is a CI gate failure per the OpenAPI-diff workflow.
+> - **Invariant: breaking changes (per D4 taxonomy) to a released public-API surface require a major version bump.** Enforced by the OpenAPI-diff CI gate (Phase 1).
+> - **Invariant: at most two major versions of a given public-API surface are live concurrently** (per D6). New major release forces the older surviving major into the 180-day sunset clock.
+>
+> Plus one HoneyHub-scoped variant:
+> - **Invariant: HoneyHub uses schema evolution (additive + `@deprecated`), not URL-prefix versioning.** Enforced by the `graphql-inspector` CI gate (Phase 4).
+
+**ADR-0057 D17 — Phased rollout.** Six phases. Phase 1 (Weeks 1-3) — Foundations: author the OpenAPI spec template, the breaking-change CI gate, the reusable SDK-generation workflow, the docs-generation workflow; pilot on `HoneyDrunk.Web.Rest` v1. Phase 2 (Weeks 4-6) — Notify v1 spec, SDKs, docs (Phase 2 is the dry run for Notify Cloud GA). **Phase 3 (Weeks 6-10) is Notify Cloud GA blocker resolution and is explicitly deferred** in this initiative because the `HoneyDrunk.Notify.Cloud` repo does not exist on disk (ADR-0027 is Proposed). Phase 4 (Month 3+) — HoneyHub GraphQL schema commitment; deferred because HoneyHub does not exist on disk. Phase 5 — AI-sector standup wave inherits the Phase 1 substrate. Phase 6 — Future Billing API per ADR-0037.
+
+**Initiative scope reconciliation.** This initiative ships Phase 1 (substrate in Actions + Architecture; pilot on Web.Rest) and Phase 2 (Notify v1 spec/SDKs/docs). Phase 3 (Notify Cloud GA implementation) and the live HoneyHub schema/docs (Phase 4 implementation) are deferred to follow-up initiatives that file against the Notify Cloud and HoneyHub repos *after* those repos exist. The Phase 4 *substrate* (the two GraphQL reusable workflows in Actions) ships in this initiative (packet 06) so the substrate is in place when HoneyHub stands up.
+
+## Constraints
+- **Acceptance precedes implementation.** ADR-0057 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbers are resolved here, not deferred.** Packet 00's PR claims the block in `invariant-reservations.md` and writes the verbatim texts into `invariants.md`. Subsequent packets 01-11 reference the resolved numbers — placeholders `{N1}-{N4}` in those packets are search-and-replaced in the same PR if a collision forces a shift, per `invariant-reservations.md` rule 5.
+- **Notify Cloud Phase 3 is deferred.** ADR-0027 (Notify Cloud standup) is Proposed; the `HoneyDrunk.Notify.Cloud` repo does not exist on disk; `file-packets.yml` cannot file against it. This initiative ships the Phase 1 substrate and the Phase 2 Notify pilot; the Notify Cloud production OpenAPI spec + SDKs + docs land as part of (or after) the ADR-0027 standup — see the dispatch plan's Cross-Initiative Coupling section and packet 10 (the specification document).
+- **HoneyHub Phase 4 implementation is deferred.** HoneyHub does not exist on disk. The two reusable workflows for GraphQL ship in this initiative (packet 06) because the substrate is buildable substrate. The actual `schema.graphql` commitment, the breaking-change gate enabling on the HoneyHub repo, and the docs site provisioning at `docs.honeyhub.honeydrunkstudios.com` land as part of (or after) the HoneyHub standup.
+- **ADR-0034 namespace onboarding is operator-time-budgeted.** Maven Central namespace verification (`com.honeydrunkstudios`), GPG key generation/registration, npm `@honeydrunk` scope ownership, and Swift Package Index registration are all portal/manual steps performed by the operator. Packet 11 carries the checklist; that packet is `Actor=Human`. The Actions reusable workflows (packets 04, 05) consume the registered credentials once the operator completes the onboarding; tests against the workflows use a dry-run mode until the credentials exist.
+- **No `Unreleased` CHANGELOG entries.** Per the user's standing convention, all repo-level CHANGELOG additions go into dated, versioned sections — never `[Unreleased]`.
+
+## Labels
+`chore`, `tier-3`, `core`, `docs`, `adr-0057`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0057 to Accepted, claim the four-invariant block in `invariant-reservations.md`, write the four invariants verbatim into `invariants.md`, and register the rollout initiative with its twelve-packet checklist.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0057 so the remaining packets in this initiative can reference its decisions as live rules and the resolved invariant numbers as live constitutional constraints.
+- Feature: ADR-0057 Public HTTP API Versioning and Client SDK Strategy rollout, Wave 1.
+- ADRs: ADR-0057 (primary); ADR-0067 (D11 reconciliation — rate-limit envelope); ADR-0075 (D15 reconciliation — Scalar + Docusaurus); ADR-0034 (NuGet/namespace onboarding — operator-time-budgeted, surfaced in packet 11); ADR-0027 (Notify Cloud — Phase 3 deferred); ADR-0042 (idempotency — `IIdempotencyStore` is the dedup substrate for D13); ADR-0040 / ADR-0045 (trace and error correlation for D12 envelope).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- ADR-0057 stays Proposed until this PR merges.
+- Resolve `{N1}/{N2}/{N3}/{N4}` placeholders to concrete numbers here. Update packets 01-11 in the same PR if a collision forces a shift upward.
+- Notify Cloud Phase 3 is **not** in this initiative's exit criterion — record it as a deferred follow-up handoff to a future ADR-0027-aligned initiative.
+- HoneyHub Phase 4 implementation is also deferred. Only the substrate workflows (Actions packet 06) ship now.
+- ADR-0034 namespace onboarding is operator-time-budgeted — packet 11 is `Actor=Human`.
+
+**Key Files:**
+- `adrs/ADR-0057-public-http-api-versioning-and-client-sdk-strategy.md`
+- `adrs/README.md`
+- `constitution/invariant-reservations.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0057-api-versioning/01-architecture-public-api-catalog-and-tech-stack.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/01-architecture-public-api-catalog-and-tech-stack.md
@@ -1,0 +1,167 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "core", "docs", "adr-0057", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0057"]
+wave: 1
+initiative: adr-0057-api-versioning
+node: honeydrunk-architecture
+---
+
+# Record the public-API versioning substrate in tech-stack.md, contracts.json, and feature-flow-catalog.md
+
+## Summary
+Record ADR-0057's substrate, contract surface, and the deprecation-notification flow as catalog and reference data: append a Public HTTP API section to `infrastructure/reference/tech-stack.md` capturing the OpenAPI 3.1 + URL-path versioning + Scalar/Docusaurus + OpenAPI Generator + oasdiff + graphql-inspector choices and the rejected alternatives; introduce the `publicHttpApi` per-Node block in `catalogs/contracts.json` with empty/`null` entries for the affected Nodes (Web.Rest, Notify, HoneyHub when it exists, future Billing); and add the deprecation-notification flow to `constitution/feature-flow-catalog.md` so the named flow is canonical before any Node fires it.
+
+## Context
+ADR-0057 D7 commits OpenAPI 3.1 as the source of truth at `repos/{node}/api/openapi-v{n}.yaml`. ADR-0057 D2 commits URL-path versioning (`/v1/notify/send`). ADR-0057 D15 (reconciled with ADR-0075) commits Scalar for the OpenAPI reference and Docusaurus for narrative content. ADR-0057 D8 commits OpenAPI Generator with Studios-maintained override templates in `HoneyDrunk.Actions/openapi-templates/{language}/`. ADR-0057 D7 commits `oasdiff` (or equivalent) as the breaking-change diff tool. ADR-0057 D16 + D17 commit `graphql-inspector` (or equivalent) for HoneyHub schema-evolution gating. The `infrastructure/reference/tech-stack.md` document is the Grid's single source of truth for cross-cutting platform choices — recording these here means future ADRs and reviewers see "public HTTP API substrate = OpenAPI 3.1 + URL-path versioning + Scalar + Docusaurus + OpenAPI Generator + oasdiff + graphql-inspector" without having to read ADR-0057 to discover it.
+
+ADR-0057 also extends `catalogs/contracts.json` per §Consequences/Affected Nodes: *"`catalogs/contracts.json` gains `publicHttpApi` entries per Node listing the surface name, current major version, OpenAPI spec path, and published SDK coordinates."* This packet introduces the schema for that new block on the affected Nodes — Web.Rest gets a populated v1 entry once its OpenAPI spec lands (packet 07); Notify gets one once its spec lands (packet 08); Notify Cloud, HoneyHub, and future Billing have `null` placeholders that fill in when those Nodes catch up.
+
+ADR-0057 D5 + §Consequences/Affected Nodes name the deprecation-notification flow (T-90 / T-30 / T-7 emails routed through Communications + Notify to active tenants at the moment of deprecation announcement). The flow is added to `constitution/feature-flow-catalog.md` so it is named and discoverable before any Node fires it.
+
+The Notify Cloud production OpenAPI spec is **not** registered here — Notify Cloud is not yet stood up (ADR-0027 is Proposed) and its catalog entry does not exist. When the ADR-0027 standup initiative completes, Notify Cloud's catalog row is created and its `publicHttpApi` block is populated. HoneyHub's `publicHttpApi` block is similarly deferred — HoneyHub does not exist on disk; this packet only documents the convention so the future HoneyHub standup writes to it.
+
+This is a docs/catalog packet. No code, no .NET project.
+
+## Scope
+- `infrastructure/reference/tech-stack.md` — append a new section recording the public-HTTP-API substrate: OpenAPI 3.1 spec format + URL-path versioning + Scalar for reference docs + Docusaurus for narrative + OpenAPI Generator (`@openapitools/openapi-generator-cli`) for SDK generation + `oasdiff` for breaking-change diffs + `graphql-inspector` for GraphQL schema diffs + RFC 7807 problem details for errors + RFC 8594 (`Deprecation` / `Sunset` / `Link rel="successor-version"`) for deprecation signaling + the cursor-based pagination convention. Cross-link to ADR-0057, ADR-0067 (rate-limit envelope reconciled), ADR-0075 (docs tooling reconciled), ADR-0042 (idempotency for D13), ADR-0040 (App Insights for `traceId` in D12), ADR-0045 (`IErrorReporter` `correlationId` for D12).
+- `catalogs/contracts.json` — introduce the `publicHttpApi` block convention on the Node entries that have or will have a public HTTP surface (Web.Rest, Notify, future Notify Cloud, future HoneyHub, future Billing). Shape: `publicHttpApi: { surfaceName, currentMajor, openApiSpecPath?, graphqlSchemaPath?, sdkCoordinates: { typescript?, swift?, kotlin? }, docsUrl? }`. **Populate only the Web.Rest and Notify entries** with `surfaceName` and `currentMajor = "v1"` (left empty for `openApiSpecPath` and `sdkCoordinates` until packets 07 / 08 land); the other Node entries either get `publicHttpApi: null` placeholders or omit the block entirely per the JSON file's convention for absent-but-known fields (match existing convention; default to omitting until populated to keep diffs clean).
+- `constitution/feature-flow-catalog.md` — add the named flow `deprecation-notification` with: trigger (a public-API endpoint or major version enters its deprecation window per ADR-0057 D5); decision/orchestration owner (`HoneyDrunk.Communications` per ADR-0019); intake/delivery owner (`HoneyDrunk.Notify`); audit owner (`HoneyDrunk.Audit` per ADR-0030); cadence (T-90, T-30, T-7 emails); inputs (the deprecated endpoint / major-version identifier; the set of tenants whose API keys touched the endpoint in the past 30 days at announcement); outputs (audited tenant-notification events; the Sunset header on every response from the deprecated endpoint per RFC 8594).
+
+## Proposed Implementation
+1. **`infrastructure/reference/tech-stack.md`** — open the file and locate the appropriate section (look for an existing "Cross-cutting" / "Platform Services" / "Hosting" grouping; if none fits exactly, append a new `## Public HTTP APIs` section in the order the rest of the doc uses). Match the document's existing entry shape — at minimum:
+   - **Spec format:** OpenAPI 3.1 (JSON Schema-aligned). Spec lives at `repos/{node}/api/openapi-v{n}.yaml`. GraphQL surfaces (HoneyHub only per ADR-0057 D1 + D16) carry `repos/{node}/api/schema.graphql` instead.
+   - **Versioning scheme:** URL-path prefix (`/v1/notify/send` → `/v2/notify/send`). Major version per API surface, not per endpoint. At most two majors live concurrently. GraphQL surfaces use schema evolution (additive + per-field `@deprecated`) — no URL-prefix.
+   - **Reference docs renderer:** Scalar (reconciled with ADR-0075 D1 — same renderer used in-product via `Scalar.AspNetCore`).
+   - **Narrative docs framework:** Docusaurus (per ADR-0075 D2).
+   - **SDK generator:** OpenAPI Generator (`@openapitools/openapi-generator-cli`). Languages at v1: TypeScript (`@honeydrunk/{api}-sdk` on npm), Swift (`HoneyDrunk{Api}Sdk` SPM), Kotlin (`com.honeydrunkstudios:{api}-sdk` on Maven Central). C# / Python / Go / Ruby / PHP deferred per D8.
+   - **Breaking-change diff:** `oasdiff` (or equivalent) per D7 — gates every PR that modifies an `openapi-v*.yaml`. **Tool selection note:** packet 03 of this initiative pins the concrete `oasdiff` version + invocation in `HoneyDrunk.Actions/.github/workflows/job-openapi-diff.yml`; tech-stack here records the choice at the convention level.
+   - **GraphQL schema diff:** `graphql-inspector` (or equivalent) per D16 + D17 Phase 4 — gates every PR that modifies a `schema.graphql`. Same selection note applies; packet 06 pins the version in the GraphQL workflows.
+   - **Error envelope:** RFC 7807 `application/problem+json` per D12. `type` URI host: `docs.honeydrunkstudios.com/errors/` (reconciled with ADR-0067 D6 — the same docs host is canonical for both Studios-wide error types and per-API error types). Fields: `type`, `title`, `status`, `detail`, `instance`, `traceId` (W3C `traceparent`), `correlationId` (per ADR-0045 `ErrorContext`).
+   - **Deprecation signaling:** RFC 8594 `Deprecation` + `Sunset` headers + `Link rel="successor-version"`; 180-day minimum lifecycle; T-90 / T-30 / T-7 tenant emails via the `deprecation-notification` named flow (Communications + Notify).
+   - **Pagination:** cursor-based default per D14 (`?cursor=&limit=`; `{ items, next_cursor }` body; `Link rel="next"` header). Default `limit=50`, max `limit=200`. Cursors opaque base64; server-side cursor TTL 24h minimum; `410 Gone` per-D12 problem-details on expired cursor.
+   - **Idempotency on writes:** `Idempotency-Key` header per ADR-0042; required for billing endpoints, recommended otherwise; SDKs auto-generate UUID v7 per write per D13.
+   - **Authentication:** API key (`Authorization: Bearer {key}`) for machine-to-machine; OAuth 2.1 with PKCE for user-facing apps per D10.
+   - **Rejected alternatives:** header versioning, media-type versioning, query-param versioning, date-based (Stripe-style), no-versioning-just-deprecate-forever, GraphQL-everywhere, gRPC, multi-scheme ASP.NET versioning library defaults, per-endpoint versioning, three-or-more concurrent majors (per D6), hand-written SDKs as v1 default, defer-SDK-publication, OpenAPI 3.0 (not 3.1), per-Node tooling choices — each with the one-line rejection reason from the ADR.
+   - **Cross-links:** ADR-0057 (primary), ADR-0067 (D11 reconciliation), ADR-0075 (D15 reconciliation), ADR-0042 (D13 idempotency), ADR-0040 (D12 traceId), ADR-0045 (D12 correlationId), ADR-0034 (NuGet/namespace onboarding), ADR-0027 (Notify Cloud Phase 3 deferred), ADR-0003 (HoneyHub GraphQL carve-out).
+
+2. **`catalogs/contracts.json`** — locate the existing Node entries and decide on populated vs. omitted shape. The shape for a populated `publicHttpApi` block:
+   ```json
+   "publicHttpApi": {
+     "surfaceName": "Notify",
+     "currentMajor": "v1",
+     "openApiSpecPath": "repos/HoneyDrunk.Notify/api/openapi-v1.yaml",
+     "graphqlSchemaPath": null,
+     "sdkCoordinates": {
+       "typescript": "@honeydrunk/notify-sdk",
+       "swift": "HoneyDrunkNotifySdk",
+       "kotlin": "com.honeydrunkstudios:notify-sdk"
+     },
+     "docsUrl": "https://docs.notify.honeydrunkstudios.com/v1/"
+   }
+   ```
+   For `honeydrunk-web-rest` and `honeydrunk-notify`, **add the block with `surfaceName` and `currentMajor = "v1"` populated**; leave `openApiSpecPath`, `sdkCoordinates`, and `docsUrl` either `null` or omitted (match the file's convention for known-but-empty fields). Packet 07 populates Web.Rest's `openApiSpecPath` when the reverse-engineered spec lands; packets 08 + 09 populate Notify's `openApiSpecPath`, `sdkCoordinates`, and `docsUrl` when those land. For HoneyHub and future Billing — their Node rows do not yet exist; this packet does not pre-create them. The Notify Cloud row, when it lands in the ADR-0027 standup, will include its `publicHttpApi` block populated with `surfaceName = "Notify Cloud"`, GraphQL/REST split per the standup, and the SDK coordinates pulled from the Notify Cloud sub-SDK convention.
+   - Match the JSON formatting (indent, trailing-comma convention, key order) used by the existing entries — do not reformat the file.
+   - If the existing `contracts.json` does not use a `publicHttpApi` key on any Node today (it doesn't — this block is being introduced), this packet's PR is the *first* introduction; the executor adds the field consistently across the two Node entries that get populated and notes the new schema field in the file's top-level schema descriptor (if any exists; most catalog JSON files do not carry schemas, in which case the field shape is implicit).
+
+3. **`constitution/feature-flow-catalog.md`** — locate the existing flow entries and append a new entry matching the file's shape:
+   - **Flow name:** `deprecation-notification`
+   - **Trigger:** A public-API endpoint OR an entire major version of a public-API surface enters its deprecation window per ADR-0057 D5 (the moment of deprecation announcement; the `Deprecation` + `Sunset` headers begin emitting; the 180-day clock starts).
+   - **Decision/orchestration:** `HoneyDrunk.Communications` (per ADR-0019 — decision/orchestration vs intake/delivery split). Communications resolves the set of tenants to notify (every tenant whose API key touched the deprecated endpoint within the most recent 30 days at the moment of announcement), schedules the T-90, T-30, T-7 sends, and renders the per-tenant migration content (endpoint identifier, sunset date, migration guide URL, per-tenant traffic statistics at T-7).
+   - **Intake/delivery:** `HoneyDrunk.Notify` — receives the per-tenant send request from Communications and dispatches via the tenant's preferred channel (email-default).
+   - **Audit:** `HoneyDrunk.Audit` (per ADR-0030) — every announcement, every per-tenant send (T-90 / T-30 / T-7), and every post-sunset rejected request from the deprecated endpoint are durably recorded. Sunset compliance is reviewable after the fact via the audit substrate.
+   - **Inputs:** the deprecated endpoint or major-version identifier; the active-tenant set (resolved from API-key access logs over the prior 30 days; Notify Cloud will own that resolution for its own surface; for Web.Rest's v1 freeze the active-tenant set is empty because no commercial Web.Rest tenants exist yet — the first time the flow fires in earnest is Notify Cloud GA).
+   - **Outputs:** three audited tenant-notification events per tenant; `Deprecation` + `Sunset` + `Link rel="successor-version"` headers on every response from the deprecated endpoint until sunset; post-sunset rejected requests carry an RFC 7807 problem-details envelope citing `type: https://docs.honeydrunkstudios.com/errors/common/endpoint-sunsetted` (the docs page is a deferred Studios-website follow-up).
+   - **Cross-references:** ADR-0057 D5 (deprecation policy), ADR-0019 (Communications-Notify split), ADR-0030 (Audit substrate), ADR-0034 (SDK publication — migration-guide URL pattern), RFC 8594 (Sunset/Deprecation headers).
+
+4. Do **NOT** edit `catalogs/relationships.json`. The Communications → Notify edge is already in the catalog (per ADR-0019 / ADR-0013 acceptance); no new Node-to-Node edge is created by this packet.
+
+5. Do **NOT** edit `catalogs/nodes.json`. nodes.json has no `interfaces` / `publicHttpApi` field — contract surface lives in contracts.json.
+
+## Affected Files
+- `infrastructure/reference/tech-stack.md`
+- `catalogs/contracts.json`
+- `constitution/feature-flow-catalog.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown and catalog JSON; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new Node-to-Node edge — Communications → Notify is already established.
+- [x] `publicHttpApi` block is a new top-level field on the affected Node entries; no existing fields are removed or renamed.
+- [x] JSON formatting matches surrounding entries.
+
+## Acceptance Criteria
+- [ ] `infrastructure/reference/tech-stack.md` carries a `## Public HTTP APIs` section with: OpenAPI 3.1 spec format, URL-path versioning, Scalar + Docusaurus docs composition, OpenAPI Generator for SDKs (TypeScript / Swift / Kotlin), `oasdiff` for breaking-change diff, `graphql-inspector` for GraphQL diff, RFC 7807 errors with `type` URI host at `docs.honeydrunkstudios.com/errors/`, RFC 8594 deprecation signaling, cursor pagination defaults (limit 50, max 200), `Idempotency-Key` per ADR-0042, API-key / OAuth 2.1 PKCE auth — and the full rejected-alternatives list with one-line reasons
+- [ ] `catalogs/contracts.json` introduces the `publicHttpApi` block convention; the `honeydrunk-web-rest` and `honeydrunk-notify` entries each carry a `publicHttpApi` block with `surfaceName` and `currentMajor = "v1"` populated; the spec path / SDK coordinates / docs URL are left empty until packets 07 / 08 / 09 land
+- [ ] `catalogs/contracts.json` JSON formatting matches the rest of the file (indentation, trailing-comma convention, key ordering)
+- [ ] `constitution/feature-flow-catalog.md` lists the `deprecation-notification` named flow with trigger, decision/orchestration owner, intake/delivery owner, audit owner, cadence (T-90 / T-30 / T-7), inputs, outputs, and cross-references
+- [ ] `catalogs/relationships.json` is NOT modified
+- [ ] `catalogs/nodes.json` is NOT modified
+- [ ] No invariant edit in this packet (invariants {N1}-{N4} land via packet 00)
+- [ ] No new abstractions registered — the substrate is configuration + tooling, not a contract surface
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0057 D7 — OpenAPI 3.1 as the source of truth.** Every public REST API carries a checked-in OpenAPI 3.1 spec at `repos/{node}/api/openapi-v{n}.yaml`. The spec is load-bearing: SDK generation (D8), docs (D15), contract tests (cross-ref ADR-0047 D4), and the breaking-change CI gate (D7) all consume the same spec.
+
+**ADR-0057 D2 — URL path prefix versioning.** `/v1/notify/send`. Major-version-in-URL is the operationally-legible choice; header / media-type / query-param / date-based all rejected with reasons.
+
+**ADR-0057 D15 (reconciled with ADR-0075 — 2026-05-24) — Docs composition.** Scalar for the OpenAPI reference (same renderer ADR-0075 D1 uses in-product); Docusaurus for narrative (ADR-0075 D2). Hosted at `docs.{api}.honeydrunkstudios.com`; per-major version path prefixes (`/v1/api/`, `/v2/api/`); root redirects to current default major.
+
+**ADR-0057 D8 — Three SDK languages at v1.** TypeScript (`@honeydrunk/{api}-sdk` on npm), Swift (`HoneyDrunk{Api}Sdk` SPM), Kotlin (`com.honeydrunkstudios:{api}-sdk` on Maven Central). C# / Python / Go / Ruby / PHP deferred. Tooling: OpenAPI Generator with Studios-maintained templates in `HoneyDrunk.Actions/openapi-templates/{language}/`.
+
+**ADR-0057 D11 (reconciled with ADR-0067 D5/D7 — 2026-05-24) — Rate-limit envelope.** Unprefixed IETF `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`; `Retry-After` in seconds on 429; per-tenant keying. ADR-0067 is the canonical source.
+
+**ADR-0057 D12 — RFC 7807 error envelope.** `application/problem+json` with `type` (URL at `docs.honeydrunkstudios.com/errors/{api}/...`), `title`, `status`, `detail`, `instance`, `traceId` (W3C `traceparent`; App Insights operation_id per ADR-0040), `correlationId` (per ADR-0045 `ErrorContext`). The trace/correlation linkage is load-bearing for tenant-driven incident triage.
+
+**ADR-0057 D5 — Deprecation policy.** RFC 8594 `Deprecation` + `Sunset` + `Link rel="successor-version"`. 180-day minimum lifecycle. T-90, T-30, T-7 emails through Communications + Notify per ADR-0019.
+
+**ADR-0057 §Consequences / Affected Nodes — Architecture additions.** `catalogs/contracts.json` gains `publicHttpApi` entries per Node listing surface name, current major, spec path, SDK coordinates. `constitution/feature-flow-catalog.md` gains the deprecation-notification flow.
+
+## Constraints
+- **No new abstractions in this packet.** The substrate is configuration + tooling, not a contract surface. The `publicHttpApi` block is descriptive metadata, not a new interface.
+- **`catalogs/relationships.json` is NOT touched.** Communications → Notify already exists from ADR-0019. No new edge is created.
+- **`catalogs/nodes.json` is NOT touched.** nodes.json has no `publicHttpApi` field.
+- **Match JSON formatting precisely.** The repo's `pr-core.yml` includes a JSON-formatting gate.
+- **HoneyHub / Notify Cloud / future Billing Node rows are not pre-created.** Those Node entries land via their respective standup initiatives.
+- **`type` URI host pinned to `docs.honeydrunkstudios.com/errors/`.** Reconciled with ADR-0067 D6 — the same docs host is canonical for both Studios-wide error types and per-API error types.
+
+## Labels
+`feature`, `tier-2`, `core`, `docs`, `adr-0057`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Record the ADR-0057 substrate (OpenAPI 3.1 + URL-path + Scalar + Docusaurus + OpenAPI Generator + oasdiff + graphql-inspector + RFC 7807 + RFC 8594 + cursor pagination + auth schemes) in `infrastructure/reference/tech-stack.md`, introduce the `publicHttpApi` block convention in `catalogs/contracts.json` populated for Web.Rest and Notify, and add the `deprecation-notification` named flow to `constitution/feature-flow-catalog.md`.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Keep the Grid's substrate documentation, contract catalog, and named-flow catalog accurate so implementation packets (03-08) read a correct graph.
+- Feature: ADR-0057 Public HTTP API Versioning and Client SDK Strategy rollout, Wave 1.
+- ADRs: ADR-0057 (primary); ADR-0067 (D11 reconciliation); ADR-0075 (D15 reconciliation); ADR-0042 (D13 idempotency); ADR-0040 (D12 traceId); ADR-0045 (D12 correlationId); ADR-0019 (Communications-Notify orchestration split).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0057 should be Accepted (and the four invariants live) before its substrate is recorded as catalog data.
+
+**Constraints:**
+- No new abstractions registered. `publicHttpApi` is descriptive metadata on existing Node entries.
+- `relationships.json` and `nodes.json` are NOT touched.
+- Match JSON formatting precisely.
+
+**Key Files:**
+- `infrastructure/reference/tech-stack.md` — new Public HTTP APIs section.
+- `catalogs/contracts.json` — `publicHttpApi` blocks on `honeydrunk-web-rest` and `honeydrunk-notify`.
+- `constitution/feature-flow-catalog.md` — new `deprecation-notification` flow entry.
+
+**Contracts:** None changed. This packet records catalog metadata only.

--- a/generated/issue-packets/active/adr-0057-api-versioning/02-architecture-migration-and-deprecation-playbooks.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/02-architecture-migration-and-deprecation-playbooks.md
@@ -1,0 +1,154 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "core", "docs", "ops", "adr-0057", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0057"]
+wave: 1
+initiative: adr-0057-api-versioning
+node: honeydrunk-architecture
+---
+
+# Author the per-API migration-guide template, deprecation runbook, and docs-subdomain provisioning playbook
+
+## Summary
+Author three operator-facing reference documents that govern day-to-day execution of ADR-0057's policies once the substrate is live: (1) a per-API **migration-guide template** at `infrastructure/walkthroughs/public-api-migration-guide-template.md` that every v(N+1) release fills in; (2) a per-API **deprecation runbook** at `infrastructure/walkthroughs/public-api-deprecation-runbook.md` covering the operator side of the 180-day lifecycle (announcement, header emission, the T-90 / T-30 / T-7 cadence, sunset cutover, post-sunset rejection audit); (3) a per-API **docs-subdomain provisioning playbook** at `infrastructure/walkthroughs/public-api-docs-subdomain-provisioning.md` capturing the Cloudflare DNS records, the Cloudflare Pages target, and the Studios-sector handoff for any new `docs.{api}.honeydrunkstudios.com` site. These are reference documents that consuming packets and future follow-ups read; no code, no .NET project.
+
+## Context
+ADR-0057's Follow-up Work list calls out: *"Author per-API migration guides (template) for when v(N+1) ships; the template lives in the docs-generation tooling."* and *"Document the docs-subdomain provisioning playbook in `repos/HoneyDrunk.Studios/` (or equivalent)."* This packet centralizes both in the Architecture repo so they are reviewable and discoverable from the same place ADR-0057 lives; the Studios-sector side ship in packet 09 references this playbook for the concrete first-instance DNS provisioning.
+
+The deprecation runbook is the human-facing companion to the `deprecation-notification` named flow catalogued in packet 01. The runbook covers the operator side: what to push when, what to monitor, when to roll forward and when to roll back. It complements (does not replace) the automated tenant-notification orchestration in Communications + Notify; ADR-0057 D5's audited rejections require a human-readable "what to do" document for the operator when something does not fire on schedule.
+
+The docs-subdomain provisioning playbook documents per-instance work: Cloudflare DNS CNAME at the apex (`docs.notify.honeydrunkstudios.com` → Cloudflare Pages target), Pages project creation, branch/build-output binding, custom domain attachment, TLS certificate issuance, and the Cloudflare Access rule (if any). Per ADR-0029 (Cloudflare DNS rollout) the DNS records live in the Cloudflare-managed zone; the Pages project is per-Studios. The playbook is the operator's checklist.
+
+None of these documents are themselves load-bearing for any code path. They are referenced by:
+- **Packet 04** (the SDK-publication workflow) — the migration-guide template is the asset OpenAPI Generator-driven CHANGELOG entries link to when a major bumps.
+- **Packet 08** (Notify Phase 2) — the first concrete migration-guide instance will be rendered from this template when Notify v2 first ships.
+- **Packet 09** (Studios docs-subdomain provisioning for `docs.notify`) — the first concrete docs-subdomain provisioning instance references this playbook.
+- **Future deprecation events** (any) — the runbook is consulted at the moment of announcement.
+
+This is a docs-only packet. No catalog change beyond what packet 01 introduced; no code.
+
+## Scope
+- **New document:** `infrastructure/walkthroughs/public-api-migration-guide-template.md`
+- **New document:** `infrastructure/walkthroughs/public-api-deprecation-runbook.md`
+- **New document:** `infrastructure/walkthroughs/public-api-docs-subdomain-provisioning.md`
+- No other catalog or governance file modified.
+
+## Proposed Implementation
+
+1. **`infrastructure/walkthroughs/public-api-migration-guide-template.md`** — author a fillable template the v(N+1) release uses to produce its concrete migration guide. Required sections:
+   - **Title:** "Migrating from {Surface} v{N} to v{N+1}"
+   - **Released:** the v(N+1) GA date.
+   - **Sunset:** the v{N} sunset date (release date + at-minimum 180 days per ADR-0057 D5).
+   - **Summary of breaking changes:** one line per change, citing the ADR-0057 D4 category (`Removed endpoint`, `Renamed field (request)`, `Renamed field (response)`, `Type narrowing`, `Semantic change`, `Removed enum value`, `Added required request field`, `Changed error code mapping`, `Changed authentication requirement`, `Changed rate-limit envelope`, `Changed pagination scheme`).
+   - **Per-endpoint diff sections** — for each changed endpoint, paired request and response examples (v{N} → v{N+1}); the SDK migration snippet (TypeScript / Swift / Kotlin) showing the equivalent call with the new shape.
+   - **Auto-migration support** — if the OpenAPI Generator template enables auto-mapping (e.g., a field rename can be auto-handled by the SDK at deserialization), state it here. Per ADR-0057 D8, the SDK generation does *not* attempt cross-major auto-migration by default; this section is usually "None — pin to the new SDK major and update call sites."
+   - **Rollback** — pinning back to v{N} is a one-line dependency revert; v{N} stays live for the full deprecation window per D6. State the explicit version pin (e.g. `"@honeydrunk/notify-sdk": "^1.0.0"`).
+   - **Pre-sunset and sunset deadlines** — T-90 / T-30 / T-7 windows with the dates filled in; what the tenant sees in each window (Deprecation header on every response, then Sunset header counting down).
+   - **Support contact / docs URL** — the per-API support route; the migration-guide is itself published at `docs.{api}.honeydrunkstudios.com/v{N}/migrating-to-v{N+1}/`.
+   - **Required follow-up steps if you depend on a deprecated field/endpoint past sunset** — the request is rejected per ADR-0057 D5; the rejection carries the per-D12 problem-details `type: https://docs.honeydrunkstudios.com/errors/common/endpoint-sunsetted`.
+   - At the bottom, mark the template fields with `{{placeholders}}` so a future Codex / Claude run can render a concrete instance by substitution.
+
+2. **`infrastructure/walkthroughs/public-api-deprecation-runbook.md`** — author the operator playbook for the 180-day lifecycle. Required sections:
+   - **Pre-announcement checklist** — confirm the v(N+1) GA has shipped (the SDKs are live on npm / Maven / SPM at v(N+1).0.0; the docs site `docs.{api}.honeydrunkstudios.com/v{N+1}/` is live); confirm the migration guide is rendered and published at `docs.{api}.honeydrunkstudios.com/v{N}/migrating-to-v{N+1}/`.
+   - **Announcement** — the operator-side step that flips the v{N} surface into deprecation: enable the `Deprecation` + `Sunset` + `Link rel="successor-version"` headers (configured per-Node — usually a feature-flag or an OpenAPI spec amendment on the v{N} spec marking the deprecation timestamps); seed the active-tenant list (every tenant whose API key touched a v{N} endpoint within the prior 30 days) to Communications; record the announcement event in the Audit substrate per ADR-0030.
+   - **T-90 monitoring** — Communications dispatches the first email batch via Notify; confirm the dispatch event in the audit log; check the per-tenant traffic on v{N} (have the largest tenants begun migrating?).
+   - **T-30 monitoring** — second email batch; per-endpoint traffic check; flag tenants whose traffic on v{N} has not declined (the migration is at risk).
+   - **T-7 monitoring** — third email batch; per-tenant traffic per day reported in the email body; a personal-outreach decision for any high-traffic non-migrated tenant.
+   - **Sunset cutover** — flip the v{N} surface off (a feature-flag flip or a v{N} spec removal from the host); confirm every v{N} request is now returning the per-D12 problem-details envelope with `type: https://docs.honeydrunkstudios.com/errors/common/endpoint-sunsetted`; the Audit substrate records each rejected request.
+   - **Post-sunset week** — monitor the post-sunset rejection audit stream; reach out to any tenant whose traffic is still hitting v{N} (they get hard 404s now; their integration is broken).
+   - **Post-sunset month** — archive the v{N} docs site to `docs.{api}.honeydrunkstudios.com/archive/v{N}/`; the v{N} SDK lines on npm / Maven / SPM are marked deprecated in the registry but **not unpublished** (unpublishing breaks any frozen consumer build per ADR-0057 D9).
+   - **Off-cadence rollback** — if the operator decides to extend the deprecation window past the announced sunset (e.g., a major tenant requests more time), the announcement is amended (new `Sunset` header date), the audit substrate records the amendment, the T-90 / T-30 / T-7 cadence does NOT replay (the original cadence already fired); the tenant receives a manual notification. Document this as a non-default path.
+   - **Operator escalation contacts** — who to page if Communications + Notify do not dispatch at T-90 / T-30 / T-7 (the named flow is in Communications; failures are observable per ADR-0040 / ADR-0045).
+   - At the top of the runbook, a one-paragraph summary: "Use this runbook when announcing the deprecation of an endpoint or entire major version per ADR-0057 D5. The 180-day window is the hard floor; longer windows are permitted. The T-90 / T-30 / T-7 tenant emails are automated via the `deprecation-notification` named flow in `constitution/feature-flow-catalog.md`. This runbook is the operator-side procedure that pairs with that automated flow."
+
+3. **`infrastructure/walkthroughs/public-api-docs-subdomain-provisioning.md`** — author the operator playbook for provisioning a new `docs.{api}.honeydrunkstudios.com` site. Required sections:
+   - **Pre-provisioning checklist** — Cloudflare DNS account credentials available; Cloudflare Pages project provisioning rights confirmed; the per-API repo's `docs/` directory exists with the Docusaurus + Scalar composition committed; the OpenAPI spec for the surface is checked in.
+   - **DNS provisioning** — in Cloudflare DNS, add a `CNAME` record at `docs.{api}.honeydrunkstudios.com` pointing to the Cloudflare Pages target (the convention: `honeydrunk-docs-{api}.pages.dev`). Proxy through Cloudflare (orange-cloud ON) for the TLS cert + DDoS at the edge per ADR-0029. **Note that ADR-0029 names Cloudflare as the DNS substrate;** if a Studios-side Bicep template ever provisions the records via Cloudflare's API, the template lives in `HoneyDrunk.Studios` (per ADR-0077 IaC posture, currently Proposed) — until then DNS is portal-provisioned per the user's portal-over-CLI preference.
+   - **Cloudflare Pages project** — create a new Pages project named `honeydrunk-docs-{api}`. Bind it to the per-API repo's branch (`main`); build command runs the Docusaurus build that the `job-publish-docs.yml` workflow (packet 05 of this initiative) emits; output directory `build/` (Docusaurus default). Attach the custom domain `docs.{api}.honeydrunkstudios.com`; verify TLS certificate issuance via Cloudflare-managed cert.
+   - **Access policy** — Cloudflare Access policy is **none by default** — docs sites are public. If a specific docs site needs to be Studios-internal during pre-GA development, an Access policy can be added; that decision is per-API and is noted in the Pages project's notes.
+   - **Per-version path routing** — the Docusaurus + Scalar composition handles per-major-version path routing (`/v1/`, `/v2/`, etc.) internally; the Pages project itself is single-instance per surface. The version switcher in the top navigation crosses majors at the same conceptual path per ADR-0057 D15.
+   - **Archiving** — when a major sunsets per D6, the archive copy lives at `/archive/v{N}/` within the same Pages project (one-time copy at sunset; the live `/v{N}/` path can be removed or kept and just renamed; usually renamed for backlink stability).
+   - **Cost note** — Cloudflare Pages is free at the Studios traffic ceiling (per the user's `feedback_default_cheapest_azure_tier` rule extended to vendor SaaS — free tier is the default until a concrete reason forces a paid tier).
+   - **Studios-sector cross-link** — the Studios sector (per ADR-0029) owns the apex `honeydrunkstudios.com` and `*.honeydrunkstudios.com` subdomains. New API docs subdomains live in the Studios sector's responsibility per ADR-0057 §Cross-ref Studios sector. Packet 09 of this initiative is the first concrete instance (`docs.notify.honeydrunkstudios.com`) and consumes this playbook.
+
+4. Run a quick consistency check: every URL pattern referenced in the three documents matches ADR-0057 D5 / D12 / D15 verbatim (`docs.{api}.honeydrunkstudios.com`; `docs.honeydrunkstudios.com/errors/`; `docs.{api}.honeydrunkstudios.com/v{N}/`; `docs.{api}.honeydrunkstudios.com/archive/v{N}/`).
+
+## Affected Files
+- `infrastructure/walkthroughs/public-api-migration-guide-template.md` (new)
+- `infrastructure/walkthroughs/public-api-deprecation-runbook.md` (new)
+- `infrastructure/walkthroughs/public-api-docs-subdomain-provisioning.md` (new)
+
+## NuGet Dependencies
+None. This packet authors Markdown reference documents; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No catalog or invariant change in this packet — packet 00 wrote the four invariants; packet 01 wrote the catalog updates; this packet authors the operator-facing reference documents that the substrate workflows (packets 03-06) and the per-API instance packets (07-10) consult.
+
+## Acceptance Criteria
+- [ ] `infrastructure/walkthroughs/public-api-migration-guide-template.md` exists with the required sections (title, released, sunset, summary of breaking changes by D4 category, per-endpoint diffs, SDK snippets in TS / Swift / Kotlin, rollback pin, T-90 / T-30 / T-7 deadlines, support contact / docs URL, post-sunset behavior) and `{{placeholder}}` markers throughout
+- [ ] `infrastructure/walkthroughs/public-api-deprecation-runbook.md` exists with the required sections (pre-announcement, announcement, T-90 / T-30 / T-7 monitoring, sunset cutover, post-sunset week, post-sunset month, off-cadence rollback, operator escalation, top-of-doc summary)
+- [ ] `infrastructure/walkthroughs/public-api-docs-subdomain-provisioning.md` exists with the required sections (pre-provisioning checklist, DNS provisioning, Cloudflare Pages project, Access policy default, per-version routing, archiving, cost note, Studios-sector cross-link)
+- [ ] URL patterns match ADR-0057 D5 / D12 / D15 verbatim across all three documents
+- [ ] No catalog or constitution file is modified
+- [ ] No code or .NET project change
+
+## Human Prerequisites
+None. The documents are reference text; they are consulted by future operator actions but require no portal step at packet-execution time.
+
+## Referenced ADR Decisions
+**ADR-0057 D5 — Deprecation policy.** RFC 8594 `Deprecation` + `Sunset` + `Link rel="successor-version"`; 180-day minimum lifecycle; T-90 / T-30 / T-7 emails through Communications + Notify; audit via Audit substrate.
+
+**ADR-0057 D6 — Two-major coexistence.** A new major cannot be released until v(N-1) has been sunsetted. This forces a roughly six-month-floor cadence and disciplines major-version planning.
+
+**ADR-0057 D12 — RFC 7807 error envelope.** `type` URI host at `docs.honeydrunkstudios.com/errors/`. Two error types referenced by the deprecation runbook: `https://docs.honeydrunkstudios.com/errors/common/endpoint-sunsetted` (post-sunset request rejected) and `https://docs.honeydrunkstudios.com/errors/common/cursor-expired` (D14 — cursor TTL).
+
+**ADR-0057 D15 (reconciled with ADR-0075 — 2026-05-24) — Docs site composition.** Scalar + Docusaurus at `docs.{api}.honeydrunkstudios.com`; per-major version prefix `/v{N}/`; OpenAPI reference at `/v{N}/api/`; archived majors at `/archive/v{N}/`.
+
+**ADR-0029 (referenced) — Cloudflare DNS rollout.** DNS is Cloudflare-managed; new subdomains are provisioned via the Cloudflare portal or (future) Bicep templates. TLS via Cloudflare-managed cert.
+
+**ADR-0019 (referenced) — Communications / Notify split.** Communications owns decision/orchestration of tenant notification cadence; Notify owns intake/delivery. The deprecation-notification named flow (packet 01) lives in Communications.
+
+**ADR-0030 (referenced) — Audit substrate.** Every deprecation announcement, every per-tenant T-90 / T-30 / T-7 dispatch, and every post-sunset rejected request are recorded via `IAuditLog`.
+
+## Constraints
+- **No code change.** All three documents are operator reference text.
+- **URL patterns match the ADR verbatim.** The error `type` URIs, the docs subdomain pattern, the per-major path prefix — every URL pattern in the documents matches ADR-0057's source-of-truth wording. A reviewer can grep the three documents against the ADR and find no drift.
+- **Studios-sector cross-link is one-way.** The docs-subdomain provisioning playbook lives in `HoneyDrunk.Architecture` (here); packet 09 (Studios) consumes it without re-authoring. There is no parallel Studios-side document; the Architecture document is canonical.
+- **No invariant edits.** ADR-0057's four invariants land via packet 00; the operator playbooks here do not codify new constitutional rules.
+
+## Labels
+`feature`, `tier-2`, `core`, `docs`, `ops`, `adr-0057`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Author three operator-facing reference documents in `infrastructure/walkthroughs/`: a per-API migration-guide template, a 180-day deprecation runbook, and a docs-subdomain provisioning playbook. All three are referenced by downstream packets and by future deprecation events.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the operator-side execution of ADR-0057's lifecycle (announcement, header emission, tenant notification, sunset, archive) procedural rather than ad-hoc; pair the automated `deprecation-notification` named flow with a documented operator playbook.
+- Feature: ADR-0057 Public HTTP API Versioning and Client SDK Strategy rollout, Wave 1.
+- ADRs: ADR-0057 D5 / D6 / D12 / D15 (primary); ADR-0029 (Cloudflare DNS); ADR-0019 (Communications / Notify split); ADR-0030 (Audit substrate); ADR-0075 (docs composition); ADR-0077 (IaC Bicep — future-state cross-link).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — the invariants must be live so the migration guide / runbook reference them by number (the documents cite invariants `{N1}-{N4}` once resolved).
+
+**Constraints:**
+- No code change. No catalog or constitution edit.
+- URL patterns match ADR-0057 verbatim.
+- Three new files only.
+
+**Key Files:**
+- `infrastructure/walkthroughs/public-api-migration-guide-template.md`
+- `infrastructure/walkthroughs/public-api-deprecation-runbook.md`
+- `infrastructure/walkthroughs/public-api-docs-subdomain-provisioning.md`
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0057-api-versioning/03-actions-openapi-diff-workflow.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/03-actions-openapi-diff-workflow.md
@@ -1,0 +1,195 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-1", "core", "adr-0057", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0057"]
+wave: 2
+initiative: adr-0057-api-versioning
+node: honeydrunk-actions
+---
+
+# Author job-openapi-diff.yml — the breaking-change CI gate per ADR-0057 D7
+
+## Summary
+Author the reusable workflow `job-openapi-diff.yml` in `HoneyDrunk.Actions/.github/workflows/` that runs `oasdiff` (or equivalent) on every PR that modifies an `openapi-v*.yaml`, classifies the diff against ADR-0057 D4's breaking-change taxonomy, and **fails the build** when a diff classified as breaking lands on a *released* spec. PRs against a not-yet-released (unreleased major) spec pass the gate even when the diff is breaking — the unreleased spec is, by definition, not yet committed. This is the load-bearing enforcement that makes invariant `{N2}` ("breaking changes require a major version bump") enforceable rather than aspirational.
+
+## Context
+ADR-0057 D7 commits the breaking-change CI gate: *"Every PR that modifies an `openapi-v*.yaml` runs an OpenAPI diff (tooling: `oasdiff` or equivalent) against the last released spec. A diff classified as 'breaking' per D4's taxonomy fails the build unless the spec being modified is for a new (unreleased) major version."* The gate is invariant-load-bearing — without it, the D4 taxonomy and invariant `{N2}` are operator-honor-system enforcement, which is exactly the failure mode ADR-0057 is designed to prevent.
+
+`oasdiff` (https://github.com/Tufin/oasdiff) is the most mature open-source OpenAPI 3.0/3.1 diff tool. It classifies changes into `BREAKING` / `INFO` / `WARNING` categories, supports YAML/JSON specs, ships as a single Go binary, and has a deterministic CLI. It is the default tool choice per ADR-0057 D7's "or equivalent" — pin the concrete version in this workflow so reviewers and packet authors do not re-litigate the choice per surface.
+
+The "last released spec" question is non-trivial. ADR-0057 D9 commits SDK version coordinates that include the spec revision; the *released* spec is the spec at the most recent `{api}-api-v{N}.{spec-revision}.{sdk-patch}` git tag (per D8's tag convention). The workflow needs to resolve the last released spec for a given spec file in a given repo. Two strategies:
+
+- **Tag-anchored** — the workflow checks out the latest tag matching `{api}-api-v{N}.*` for the same major as the spec under change, extracts the spec file at that tag, runs `oasdiff` between the tagged version and the PR head version. This is the canonical approach per D8's tag scheme.
+- **Branch-anchored** — the workflow checks out the spec file from the latest commit on `main` and runs `oasdiff` between that and the PR head. Simpler but doesn't capture the "released" semantics — a PR that lands `oasdiff`-breaking changes to `main` and then a follow-up PR that adds more breaking changes would not catch the cumulative break because each PR's diff vs. `main` would be small.
+
+The tag-anchored approach is correct per D8; the workflow ships with the tag-anchored mode as the default. The branch-anchored mode is available as a secondary input for surfaces that have not yet shipped their first tag (Web.Rest at v1 freeze time per packet 07 — the spec is being reverse-engineered and there is no prior tag).
+
+ADR-0057 D4 lists the breaking-change categories: removed endpoint, removed response field, renamed field, type narrowing, semantic change, removed enum value, added required request field, changed error code mapping, changed authentication requirement, changed rate-limit envelope, changed pagination scheme. `oasdiff` covers most of these directly via its built-in breaking-change classification; a few (semantic change, changed error code mapping in *meaning*) are not detectable by `oasdiff` alone and require human-reviewer attention — `oasdiff` flags the structural diff and the human review confirms the semantic interpretation. The workflow surfaces this on the PR comment.
+
+`HoneyDrunk.Actions` is the central CI/CD control plane (per ADR-0012). Reusable workflows live in `.github/workflows/job-*.yml` and are invoked from consuming repos via `uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-openapi-diff.yml@v1` (or `@main` per the user's standing convention; the version-pin convention per HoneyDrunk.Actions is documented separately).
+
+This is the **first of four Actions packets** in this initiative — the breaking-change gate is independent of the other three (publication, docs, GraphQL) and is the highest-value substrate piece because it gates every spec change going forward.
+
+## Scope
+- **New file:** `HoneyDrunk.Actions/.github/workflows/job-openapi-diff.yml` — the reusable workflow.
+- **New file:** `HoneyDrunk.Actions/docs/job-openapi-diff.md` (or extend an existing job-docs file) — the consumer documentation: how a per-API repo invokes the workflow, expected inputs, gate semantics.
+- Repo-level `CHANGELOG.md` entry for the new workflow.
+- `HoneyDrunk.Actions/README.md` — link to the new job docs from the workflow catalog section.
+
+## Proposed Implementation
+
+1. **`HoneyDrunk.Actions/.github/workflows/job-openapi-diff.yml`** — a reusable workflow with `on: workflow_call:`. Inputs (with defaults that match the common case):
+   ```yaml
+   inputs:
+     spec-path:
+       description: 'Path to the OpenAPI spec under change (e.g. api/openapi-v1.yaml).'
+       type: string
+       required: true
+     surface-name:
+       description: 'API surface name for tag resolution (e.g. notify, web-rest, honeyhub).'
+       type: string
+       required: true
+     diff-mode:
+       description: 'tag (compare against latest released tag) or branch (compare against main).'
+       type: string
+       required: false
+       default: 'tag'
+     is-unreleased-major:
+       description: 'If true, breaking diffs are allowed (the spec is for a not-yet-released major).'
+       type: boolean
+       required: false
+       default: false
+     oasdiff-version:
+       description: 'oasdiff version to use; pinned for determinism.'
+       type: string
+       required: false
+       default: 'v1.10.18'  # confirm the latest stable at execution time; pin a concrete release tag
+   ```
+   Steps:
+   - **Checkout PR head.** `actions/checkout@v4` with `fetch-depth: 0` (needed for the tag-resolution branch below).
+   - **Install oasdiff.** Pin the version via the input; install the single Go binary directly (`curl -L https://github.com/Tufin/oasdiff/releases/download/${{ inputs.oasdiff-version }}/oasdiff_linux_amd64.tar.gz | tar xz` — or the official install script). Add to `PATH`.
+   - **Resolve the comparison base.**
+     - If `diff-mode = tag`: extract the major from `spec-path` (regex on the filename `openapi-v(\d+)\.yaml`); list tags matching `{surface-name}-api-v{major}.*`; pick the highest semver-sorted tag; check out that tag's `spec-path` into `/tmp/base-spec.yaml`. If no tag exists yet (first release), fall back to branch mode with a workflow warning ("no released tag yet — comparing against main").
+     - If `diff-mode = branch`: check out `main`'s `spec-path` into `/tmp/base-spec.yaml`. If `main` does not have the file yet, the PR is introducing the spec for the first time — emit a workflow info ("first introduction of spec — no diff to check") and exit 0.
+   - **Run oasdiff.** `oasdiff diff /tmp/base-spec.yaml ${{ inputs.spec-path }} --format json > /tmp/diff.json` and `oasdiff breaking /tmp/base-spec.yaml ${{ inputs.spec-path }} --format json > /tmp/breaking.json` (the second invocation is the breaking-change classifier).
+   - **Classify and gate.** Parse `/tmp/breaking.json`; if the breaking-change list is empty, the gate passes (emit a PR comment summarizing the diff with the non-breaking changes). If the list is non-empty:
+     - If `is-unreleased-major = true`, the gate passes with a PR comment indicating "breaking changes detected but allowed for unreleased major spec." Include the full classification list.
+     - If `is-unreleased-major = false`, **the workflow fails (`exit 1`)**. The PR comment includes the full classification list, each entry citing the ADR-0057 D4 category (`Removed endpoint`, `Renamed field`, etc.) and the structural location (path, method, field). The PR comment also includes the remediation: "Bump the major version: copy `openapi-v{N}.yaml` to `openapi-v{N+1}.yaml`, apply the breaking changes there, leave `openapi-v{N}.yaml` unchanged for the duration of the deprecation window per ADR-0057 D6."
+   - **PR comment publication.** Use the `marocchino/sticky-pull-request-comment@v2` (or equivalent already in HoneyDrunk.Actions) to publish the diff summary; sticky so reruns replace rather than append.
+   - **Categories not detectable structurally.** Append a footer to the PR comment: "Note: oasdiff cannot detect *semantic* changes to a field's meaning (the field name and type are unchanged but the interpretation changed) or *changed error code mapping in meaning* (a 409 still returns 409 but the meaning shifted). The Grid-aware review agent (per ADR-0044) flags these on human review of the PR; the OpenAPI-diff gate does NOT catch them."
+
+2. **`HoneyDrunk.Actions/docs/job-openapi-diff.md`** — author the consumer documentation:
+   - **Purpose.** Enforce invariant `{N2}` (breaking changes require a major version bump) on every PR that modifies an `openapi-v*.yaml`.
+   - **Invocation example** — a minimal caller YAML in a consuming repo (e.g. `HoneyDrunk.Notify/.github/workflows/pr-openapi.yml`):
+     ```yaml
+     on:
+       pull_request:
+         paths:
+           - 'HoneyDrunk.Notify/api/openapi-v*.yaml'
+     jobs:
+       openapi-diff:
+         uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-openapi-diff.yml@main
+         with:
+           spec-path: HoneyDrunk.Notify/api/openapi-v1.yaml
+           surface-name: notify
+     ```
+   - **When `is-unreleased-major: true`** — set this for a PR that is building a future-major spec (e.g. `openapi-v2.yaml`) that has not yet been GA'd. The flag is removed when the new major ships GA.
+   - **Tag scheme.** Per ADR-0057 D9: `{surface-name}-api-v{N}.{spec-revision}.{sdk-patch}`. The workflow resolves the highest tag matching `{surface-name}-api-v{major}.*` for the major under change.
+   - **First-release case.** Until the first tag exists, the workflow runs in branch-anchored mode and emits an info-level warning. This is normal for Web.Rest at v1 freeze and Notify at v1 introduction.
+   - **What is NOT enforced.** Semantic changes (field name + type unchanged; meaning changed) and changed-error-code-mapping-in-meaning are not detected by oasdiff alone; the Grid-aware review agent (ADR-0044) catches them on human review. The OpenAPI-diff gate is the *structural* enforcement; the review agent is the *semantic* enforcement.
+   - **CI gate behavior.** Required check on every PR that modifies an `openapi-v*.yaml` in the consuming repo. The consuming repo's branch protection adds `openapi-diff` as a required check.
+
+3. **`HoneyDrunk.Actions/CHANGELOG.md`** — add an entry to the most recent dated, versioned section (not `[Unreleased]` per the user's standing convention). Match the existing CHANGELOG entry shape — terse, one line per addition.
+
+4. **`HoneyDrunk.Actions/README.md`** — link to `docs/job-openapi-diff.md` from the workflow catalog section (the README likely has a "Reusable Workflows" subsection listing each `job-*.yml`).
+
+## Affected Files
+- `HoneyDrunk.Actions/.github/workflows/job-openapi-diff.yml` (new)
+- `HoneyDrunk.Actions/docs/job-openapi-diff.md` (new)
+- `HoneyDrunk.Actions/CHANGELOG.md`
+- `HoneyDrunk.Actions/README.md`
+
+## NuGet Dependencies
+None. This packet ships GitHub Actions YAML; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Actions`. Routing rule "GitHub Actions, reusable workflow, CI/CD → HoneyDrunk.Actions" maps exactly per ADR-0012.
+- [x] No code change in any other repo.
+- [x] No new abstraction or contract — this is a reusable workflow asset.
+- [x] No `HoneyDrunk.*` package dependency.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Actions/.github/workflows/job-openapi-diff.yml` exists as a `workflow_call` reusable workflow with the documented inputs (`spec-path`, `surface-name`, `diff-mode`, `is-unreleased-major`, `oasdiff-version`)
+- [ ] The workflow checks out the PR head, installs the pinned `oasdiff` version, resolves the comparison base per `diff-mode` (tag or branch), runs `oasdiff breaking`, and gates on the result
+- [ ] When the diff is breaking AND `is-unreleased-major = false`, the workflow exits non-zero and publishes a sticky PR comment with the D4-category-classified breaking-change list and the remediation guidance
+- [ ] When the diff is breaking AND `is-unreleased-major = true`, the workflow exits zero and publishes a PR comment indicating breaking changes are allowed for the unreleased major
+- [ ] When the diff is non-breaking, the workflow exits zero and the PR comment summarizes the non-breaking additions
+- [ ] When there is no comparison base (first introduction of the spec; no tag and no `main` file), the workflow exits zero with an informational comment
+- [ ] PR comment includes the footer about semantic / error-meaning changes being uncaught by oasdiff — reviewer attention required
+- [ ] `HoneyDrunk.Actions/docs/job-openapi-diff.md` documents the invocation contract, the tag scheme, the first-release case, and the not-enforced categories
+- [ ] `HoneyDrunk.Actions/CHANGELOG.md` records the addition in a dated, versioned section (no `[Unreleased]`)
+- [ ] `HoneyDrunk.Actions/README.md` links to the new job docs from the workflow catalog
+- [ ] No consuming repo is wired in this packet — the wiring lands per-Node when the per-Node spec lands (Web.Rest in packet 07; Notify in packet 08)
+
+## Human Prerequisites
+- [ ] **Confirm the pinned `oasdiff` version against the latest stable release** before merging. The packet body lists `v1.10.18` as a placeholder; the executor confirms (or bumps to) the latest stable release at PR time and updates the workflow input default accordingly.
+
+## Referenced ADR Decisions
+**ADR-0057 D7 — Breaking-change CI gate (load-bearing).** "Every PR that modifies an `openapi-v*.yaml` runs an OpenAPI diff (tooling: `oasdiff` or equivalent) against the last released spec. A diff classified as 'breaking' per D4's taxonomy fails the build unless the spec being modified is for a new (unreleased) major version. The reviewer cannot land a breaking change to a released spec without bumping the major."
+
+**ADR-0057 D4 — Breaking-change taxonomy.** Eleven breaking categories: removed endpoint, removed response field, renamed field (request or response), type narrowing, semantic change in field meaning, removed enum value, added required request field, changed error code mapping, changed authentication requirement, changed rate-limit envelope shape, changed pagination scheme. Six non-breaking categories: new optional request field, new response field, new endpoint, new optional query parameter, new enum value (with the documented client-side "ignore unknown" rule), loosened type, looser validation. `oasdiff` covers the structural categories directly; semantic-meaning changes and error-code-mapping-meaning changes are reviewer-judgment-enforced.
+
+**ADR-0057 D9 — SDK and spec versioning.** Spec version tag scheme: `{api}-api-v{API-major}.{spec-revision}.{sdk-patch}`. Highest tag matching `{surface-name}-api-v{major}.*` is the comparison base.
+
+**ADR-0012 (referenced) — Actions as CI/CD control plane.** Reusable workflows in `HoneyDrunk.Actions/.github/workflows/job-*.yml` consumed by per-repo callers via `uses:`.
+
+**ADR-0044 (referenced) — Grid-aware review agent.** Catches semantic changes that `oasdiff` cannot detect structurally. The review agent and the OpenAPI-diff gate complement each other; the gate enforces structure, the agent enforces semantics.
+
+**Invariant `{N2}` — Breaking changes require a major version bump.** This workflow is the enforcement mechanism.
+
+## Constraints
+- **Pin `oasdiff` to a concrete release tag.** Floating versions ("latest") break determinism; the workflow input has a default that the executor confirms at PR time.
+- **Reusable, not invoked.** This packet adds the reusable workflow; it does NOT wire any consuming repo. The wiring happens in packets 07 (Web.Rest), 08 (Notify), and future per-Node packets.
+- **PR comment is sticky.** Reruns replace the comment rather than appending — keeps the PR conversation clean.
+- **First-release case handled.** Web.Rest and Notify both hit the no-tag-yet path at v1 introduction; the workflow falls back to branch mode with a warning rather than failing.
+- **No `Unreleased` CHANGELOG entry.** Per the user's standing convention, the CHANGELOG addition lands in a dated, versioned section.
+- **`oasdiff` is the chosen tool.** ADR-0057 D7 says "`oasdiff` or equivalent." This workflow picks `oasdiff`. A future packet may swap if `oasdiff` drifts or another tool becomes dominant — that swap is a follow-up ADR, not a silent change.
+
+## Labels
+`feature`, `tier-1`, `core`, `adr-0057`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Ship the reusable `job-openapi-diff.yml` workflow that runs `oasdiff` on every PR modifying an `openapi-v*.yaml`, classifies the diff per ADR-0057 D4, and fails the build on breaking diffs to released specs. This is the enforcement mechanism for invariant `{N2}`.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Make ADR-0057 D4's breaking-change taxonomy machine-enforced rather than human-honor-system. Every per-API repo wires this workflow into its PR checks (the wiring lands per-Node in packets 07, 08, and future per-Node packets).
+- Feature: ADR-0057 rollout, Wave 2 (Actions substrate).
+- ADRs: ADR-0057 D4 / D7 / D9 (primary); ADR-0012 (Actions as CI/CD control plane); ADR-0044 (review agent complements the gate on semantic categories).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — invariants `{N1}-{N4}` live; the workflow enforces `{N2}`.
+- `packet:01` — tech-stack.md commits `oasdiff` as the tool; this packet pins the version.
+
+**Constraints:**
+- Pin `oasdiff` version.
+- Reusable workflow only; no consuming repo wired here.
+- Sticky PR comment.
+- First-release case handled (no tag yet → branch mode with warning).
+- No `Unreleased` CHANGELOG entry.
+
+**Key Files:**
+- `HoneyDrunk.Actions/.github/workflows/job-openapi-diff.yml` (new)
+- `HoneyDrunk.Actions/docs/job-openapi-diff.md` (new)
+- `HoneyDrunk.Actions/CHANGELOG.md`
+- `HoneyDrunk.Actions/README.md`
+
+**Contracts:** None — reusable workflow only.

--- a/generated/issue-packets/active/adr-0057-api-versioning/04-actions-publish-public-sdk-workflow.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/04-actions-publish-public-sdk-workflow.md
@@ -1,0 +1,273 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-1", "core", "adr-0057", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0057"]
+wave: 2
+initiative: adr-0057-api-versioning
+node: honeydrunk-actions
+---
+
+# Author job-publish-public-sdk.yml — reusable SDK generation and publication for TS, Swift, Kotlin
+
+## Summary
+Author the reusable workflow `job-publish-public-sdk.yml` in `HoneyDrunk.Actions/.github/workflows/` that, on a per-API tag matching `{api}-api-v{N}.{spec-revision}.{sdk-patch}`, generates SDKs for TypeScript / Swift / Kotlin from the surface's OpenAPI 3.1 spec using OpenAPI Generator, applies Studios-maintained override templates from `HoneyDrunk.Actions/openapi-templates/{language}/`, and publishes each SDK to its registry (npm, Swift Package Index / SPM, Maven Central). The workflow is parameterized per language so callers can enable / disable per-language publication independently. Seed the override templates with minimal-but-functional overrides for each language (idiomatic naming, ergonomic builders, lenient enum deserialization per ADR-0057 D4, default `User-Agent` per the ADR's footnote, auto-`Idempotency-Key` per D13). Per ADR-0057 §Operational Consequences, namespace onboarding (npm `@honeydrunk`, Maven Central `com.honeydrunkstudios`, GPG keys) is operator-time-budgeted — packet 11 carries that checklist; this workflow runs in dry-run mode until those credentials are seeded as repo / org secrets.
+
+## Context
+ADR-0057 D8 commits the three SDK languages (TypeScript, Swift, Kotlin), the per-language package coordinates (`@honeydrunk/{api}-sdk`, `HoneyDrunk{Api}Sdk`, `com.honeydrunkstudios:{api}-sdk`), the tooling (OpenAPI Generator with Studios-maintained overrides), and the publication automation pattern (per-API repo invokes a reusable workflow on tag). ADR-0057 D9 commits the version scheme (`v{API-major}.{spec-revision}.{sdk-patch}`). ADR-0057 D13 commits auto-generated `Idempotency-Key` per write request as a default. ADR-0057 §footnote-style decision near the bottom of "Alternatives Considered" commits the `User-Agent` default of `honeydrunk-{api}-sdk-{lang}/{sdk-version}`.
+
+The Studios-maintained override templates are the lever that turns generic OpenAPI Generator output into idiomatic per-language SDKs. The defaults are workable for v1; the overrides land minimal-but-functional now and are tuned over time as concrete tenant feedback arrives. Per ADR-0057 D8: *"Default OpenAPI Generator templates are acceptable v1 starting points; where defaults are insufficient (idiomatic naming, ergonomic builders, lenient enum deserialization per D4, default `User-Agent`, auto-`Idempotency-Key` per D13), Studios maintains override templates in `HoneyDrunk.Actions/openapi-templates/{language}/`."*
+
+**Namespace onboarding deferred to operator.** Per ADR-0057 §Operational Consequences and the ADR-0034 cross-link, the per-registry credentials require human portal work: npm `@honeydrunk` scope ownership, Maven Central `com.honeydrunkstudios` namespace verification + GPG key registration via Central Portal (formerly OSSRH), Swift Package Index registration. This packet's workflow runs in **dry-run mode** when credentials are absent — it generates and validates the SDKs but does not push to registries. The operator completes the onboarding per packet 11 and seeds the secrets; subsequent tag pushes publish for real.
+
+ADR-0057 D8 also commits the publication-step sequence: (1) validate the spec, (2) run the breaking-change diff (`job-openapi-diff.yml` — packet 03), (3) generate SDKs for all three languages, (4) publish each SDK to its registry with the version per D9, (5) regenerate the docs site (`job-publish-docs.yml` — packet 05). This packet ships step (3) + (4) — the SDK generation and publication. Steps (1), (2), (5) ship in adjacent packets and are composed at the per-API caller site (Notify's tag-publication caller workflow chains the steps).
+
+This is the second Actions packet; depends on the same foundation as packet 03 but is independent of it at execution time (the two workflows can be authored in parallel).
+
+## Scope
+- **New file:** `HoneyDrunk.Actions/.github/workflows/job-publish-public-sdk.yml` — the reusable workflow with per-language enable/disable inputs.
+- **New directory:** `HoneyDrunk.Actions/openapi-templates/typescript/` — Studios-maintained override templates for TypeScript SDK generation.
+- **New directory:** `HoneyDrunk.Actions/openapi-templates/swift/` — overrides for Swift.
+- **New directory:** `HoneyDrunk.Actions/openapi-templates/kotlin/` — overrides for Kotlin.
+- **New file:** `HoneyDrunk.Actions/docs/job-publish-public-sdk.md` — consumer documentation.
+- Repo-level `CHANGELOG.md` entry.
+- `HoneyDrunk.Actions/README.md` — workflow catalog link.
+
+## Proposed Implementation
+
+1. **`HoneyDrunk.Actions/.github/workflows/job-publish-public-sdk.yml`** — `workflow_call` reusable workflow. Inputs:
+   ```yaml
+   inputs:
+     spec-path:
+       description: 'Path to the OpenAPI spec.'
+       type: string
+       required: true
+     surface-name:
+       description: 'API surface name (e.g. notify, web-rest).'
+       type: string
+       required: true
+     api-major:
+       description: 'Major version of the API (e.g. 1 for v1).'
+       type: number
+       required: true
+     spec-revision:
+       description: 'Spec revision number per D9 versioning.'
+       type: number
+       required: true
+     sdk-patch:
+       description: 'SDK patch number per D9 versioning.'
+       type: number
+       required: true
+     publish-typescript:
+       description: 'Enable TypeScript SDK generation and npm publication.'
+       type: boolean
+       required: false
+       default: true
+     publish-swift:
+       description: 'Enable Swift SDK generation and SPM publication.'
+       type: boolean
+       required: false
+       default: true
+     publish-kotlin:
+       description: 'Enable Kotlin SDK generation and Maven Central publication.'
+       type: boolean
+       required: false
+       default: true
+     dry-run:
+       description: 'If true, generate and validate but do not publish to registries.'
+       type: boolean
+       required: false
+       default: false
+     openapi-generator-version:
+       description: 'OpenAPI Generator version; pinned for determinism.'
+       type: string
+       required: false
+       default: '7.10.0'  # confirm latest stable at execution time
+   secrets:
+     NPM_TOKEN:
+       required: false
+     MAVEN_USERNAME:
+       required: false
+     MAVEN_PASSWORD:
+       required: false
+     MAVEN_GPG_PRIVATE_KEY:
+       required: false
+     MAVEN_GPG_PASSPHRASE:
+       required: false
+     # Swift Package Index uses git tags as the release signal; no per-registry secret is required for SPM if the tag push happens on a HoneyDrunk-owned GitHub repo (the SDK lives in the same per-API repo's swift subfolder, or in a dedicated companion repo — confirm at first-Swift-SDK-publication time).
+   ```
+   Steps (in order):
+   - **Checkout** with `fetch-depth: 0`.
+   - **Validate the spec.** Use `openapi-generator-cli validate -i ${{ inputs.spec-path }}` or `npx @apidevtools/swagger-cli validate`.
+   - **Compute the SDK version.** `SDK_VERSION = "${{ inputs.api-major }}.${{ inputs.spec-revision }}.${{ inputs.sdk-patch }}"` per ADR-0057 D9.
+   - **Conditional per-language jobs.** Three matrix branches or three sequential conditional blocks, gated on the per-language `publish-*` input.
+   - **TypeScript branch (when `publish-typescript: true`):**
+     - Install Node and `@openapitools/openapi-generator-cli@${{ inputs.openapi-generator-version }}`.
+     - Generate: `openapi-generator-cli generate -g typescript-fetch -i ${{ inputs.spec-path }} -o /tmp/sdk-ts -c openapi-templates/typescript/config.json -t openapi-templates/typescript/templates`. Set the package name to `@honeydrunk/${{ inputs.surface-name }}-sdk` via config.
+     - Run `npm test` against the generated SDK (the override templates include a minimal test that asserts the package compiles and the basic shape is correct).
+     - If `dry-run: true` OR `NPM_TOKEN` is unset: log "DRY-RUN: skipping npm publish" and skip the publish step.
+     - Otherwise: `npm publish --access public` with the `NPM_TOKEN` env var.
+   - **Swift branch (when `publish-swift: true`):**
+     - Install OpenAPI Generator (same as TypeScript).
+     - Generate: `openapi-generator-cli generate -g swift5 -i ${{ inputs.spec-path }} -o /tmp/sdk-swift -c openapi-templates/swift/config.json -t openapi-templates/swift/templates`. Package name `HoneyDrunk${{ inputs.surface-name | titlecase }}Sdk`.
+     - Run `swift build` (if a macOS runner is available; otherwise rely on cross-platform Swift toolchain on Linux runners — the Swift Foundation port supports Linux).
+     - If `dry-run: true`: log "DRY-RUN: skipping SPM tag push" and skip. Otherwise: commit the generated SDK to the per-API repo's `swift/` subdirectory (or to a dedicated companion repo per the first-Swift-SDK-publication-time decision); push a git tag `swift-sdk-v{SDK_VERSION}`; Swift Package Index discovers the tag and updates the package. Document the chosen repo strategy in the `docs/job-publish-public-sdk.md`.
+   - **Kotlin branch (when `publish-kotlin: true`):**
+     - Install OpenAPI Generator.
+     - Generate: `openapi-generator-cli generate -g kotlin -i ${{ inputs.spec-path }} -o /tmp/sdk-kotlin -c openapi-templates/kotlin/config.json -t openapi-templates/kotlin/templates`. Group `com.honeydrunkstudios`; artifact `${{ inputs.surface-name }}-sdk`; version `${SDK_VERSION}`.
+     - Run `./gradlew build`.
+     - If `dry-run: true` OR `MAVEN_USERNAME` / `MAVEN_PASSWORD` / `MAVEN_GPG_PRIVATE_KEY` / `MAVEN_GPG_PASSPHRASE` is unset: log "DRY-RUN: skipping Maven Central publish" and skip.
+     - Otherwise: configure the Gradle Maven publish plugin with the secrets, sign the artifact with GPG, push to Central Portal staging, promote to release. Note: Maven Central's Central Portal (new) vs. OSSRH (legacy) onboarding distinction — confirm at packet 11 onboarding time which one is current.
+   - **PR / tag summary comment** — when invoked from a tag push, summarize the three SDK publication outcomes in a workflow summary (`$GITHUB_STEP_SUMMARY`). For dry-run, summarize "generated but not published" outcomes.
+
+2. **`HoneyDrunk.Actions/openapi-templates/typescript/`** — seed minimal-but-functional override templates:
+   - `config.json` — OpenAPI Generator config: `npmName=@honeydrunk/{api}-sdk` (templated via the workflow's `surface-name` input), `typescriptThreePlus=true`, `enumPropertyNaming=UPPERCASE`, `supportsES6=true`, `withInterfaces=true`, `useSingleRequestParameter=true`.
+   - `templates/` — minimal Mustache overrides for:
+     - **Lenient enum deserialization** (ADR-0057 D4 — "Clients MUST ignore unknown enum values"). Override the `modelEnum.mustache` to wrap the parsed value in an `Unknown` fallback rather than throwing.
+     - **Default `User-Agent` header injection** (ADR-0057 footnote — `honeydrunk-{api}-sdk-typescript/{sdk-version}`). Override the `apiInner.mustache` request-execution shim to inject the header on every request.
+     - **Auto-`Idempotency-Key` for write requests** (ADR-0057 D13). Override the request-shim to detect POST / PUT / PATCH; if `Idempotency-Key` is not already set, generate a UUID v7 (use `uuid` npm package or hand-roll a small v7 generator) and inject it. Tenant code can override per-call.
+     - A minimal `README.md.mustache` per the template that the generated SDK ships with — installation, quickstart, links back to `docs.{api}.honeydrunkstudios.com`.
+
+3. **`HoneyDrunk.Actions/openapi-templates/swift/`** — seed analogous overrides:
+   - `config.json` — `projectName=HoneyDrunk{Api}Sdk`, `swiftPackagePath=HoneyDrunk{Api}Sdk`, `useClasses=false` (prefer structs), `responseAs=AsyncAwait` (Swift 5.5+ async/await default).
+   - `templates/` — lenient enum (Swift `enum` with `case unknown(String)` fallback), `User-Agent` injection in the URLRequest builder, auto-`Idempotency-Key` for `httpMethod in ["POST", "PUT", "PATCH"]`, minimal README.
+   - The Swift Package Index requires a `Package.swift` at the repo root; the generated SDK ships its own `Package.swift` per the OpenAPI Generator Swift template.
+
+4. **`HoneyDrunk.Actions/openapi-templates/kotlin/`** — seed analogous overrides:
+   - `config.json` — `library=jvm-okhttp4` (or `jvm-ktor` — confirm which is more idiomatic for Android consumers at first-Kotlin-SDK-publication time), `serializationLibrary=kotlinx_serialization`, `groupId=com.honeydrunkstudios`, `artifactId={api}-sdk` (templated), `enumPropertyNaming=UPPERCASE`.
+   - `templates/` — lenient enum (Kotlin sealed class with `Unknown(val raw: String)` fallback), `User-Agent` interceptor on the OkHttp client, `Idempotency-Key` interceptor for POST / PUT / PATCH, minimal README + `build.gradle.kts` template.
+
+5. **`HoneyDrunk.Actions/docs/job-publish-public-sdk.md`** — consumer documentation:
+   - **Purpose.** Generate and publish per-language SDKs for a public API surface per ADR-0057 D8 + D9.
+   - **Tag-driven invocation** — the canonical caller is a per-API repo's tag-push workflow:
+     ```yaml
+     on:
+       push:
+         tags:
+           - 'notify-api-v*'
+     jobs:
+       publish:
+         uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-publish-public-sdk.yml@main
+         with:
+           spec-path: HoneyDrunk.Notify/api/openapi-v1.yaml
+           surface-name: notify
+           api-major: 1
+           spec-revision: 0
+           sdk-patch: 0
+         secrets:
+           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+     ```
+   - **Dry-run mode.** When `dry-run: true` (or when the per-registry secrets are absent), the workflow generates and validates the SDKs but does not push to registries. Use this until packet 11's operator onboarding completes.
+   - **Per-language enable/disable.** Set `publish-typescript: false` (etc.) to skip a language for a specific tag.
+   - **Override templates.** Document the structure of `openapi-templates/{language}/` and what overriding a Mustache template does (it replaces the default OpenAPI Generator template for that file).
+   - **SDK version scheme.** Per ADR-0057 D9 — recap with examples.
+   - **Multi-major coexistence.** When v2 ships, the v1 SDK line stays available on the registries; this workflow only publishes the version matching the tag.
+
+6. **`HoneyDrunk.Actions/CHANGELOG.md`** — dated, versioned entry.
+
+7. **`HoneyDrunk.Actions/README.md`** — workflow catalog link.
+
+## Affected Files
+- `HoneyDrunk.Actions/.github/workflows/job-publish-public-sdk.yml` (new)
+- `HoneyDrunk.Actions/openapi-templates/typescript/` (new directory + config + Mustache overrides)
+- `HoneyDrunk.Actions/openapi-templates/swift/` (new directory + config + Mustache overrides)
+- `HoneyDrunk.Actions/openapi-templates/kotlin/` (new directory + config + Mustache overrides)
+- `HoneyDrunk.Actions/docs/job-publish-public-sdk.md` (new)
+- `HoneyDrunk.Actions/CHANGELOG.md`
+- `HoneyDrunk.Actions/README.md`
+
+## NuGet Dependencies
+None. GitHub Actions YAML + Mustache templates.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Actions`. Per ADR-0012, reusable workflows and CI templates live here.
+- [x] No code change in any other repo.
+- [x] No new abstraction or contract.
+- [x] No HoneyDrunk package dependency.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Actions/.github/workflows/job-publish-public-sdk.yml` exists with the documented inputs and per-language conditional branches
+- [ ] The workflow validates the spec, computes the SDK version per D9, and generates SDKs for the three languages using OpenAPI Generator with the override templates
+- [ ] When `dry-run: true` OR per-registry secrets are absent, the workflow generates and validates but does not publish — and logs the dry-run reason clearly
+- [ ] When secrets are seeded and `dry-run: false`, the workflow publishes: npm (`@honeydrunk/{surface}-sdk`), Maven Central (`com.honeydrunkstudios:{surface}-sdk`), Swift (git tag push for Swift Package Index discovery)
+- [ ] `HoneyDrunk.Actions/openapi-templates/typescript/` ships `config.json` and Mustache overrides for: lenient enum deserialization, default `User-Agent` header (`honeydrunk-{api}-sdk-typescript/{sdk-version}`), auto-`Idempotency-Key` on POST/PUT/PATCH, README template
+- [ ] `HoneyDrunk.Actions/openapi-templates/swift/` ships `config.json` and Mustache overrides for: lenient enum, `User-Agent`, auto-`Idempotency-Key`, README template
+- [ ] `HoneyDrunk.Actions/openapi-templates/kotlin/` ships `config.json` and Mustache overrides for: lenient enum (sealed class), OkHttp interceptors for `User-Agent` and `Idempotency-Key`, README template
+- [ ] `HoneyDrunk.Actions/docs/job-publish-public-sdk.md` documents the invocation contract, dry-run mode, per-language enable/disable, override template structure, version scheme, and multi-major coexistence note
+- [ ] `HoneyDrunk.Actions/CHANGELOG.md` records the addition in a dated, versioned section
+- [ ] `HoneyDrunk.Actions/README.md` links to the new job docs
+- [ ] OpenAPI Generator version is pinned (no `latest`)
+- [ ] No consuming repo is wired here — Notify's tag-publication caller workflow lands in packet 08; Web.Rest's lands in packet 07
+
+## Human Prerequisites
+- [ ] **Confirm the OpenAPI Generator version pin** before merging (`7.10.0` is a placeholder; confirm latest stable).
+- [ ] **The workflow runs in dry-run mode until packet 11's operator onboarding completes.** When `NPM_TOKEN` / `MAVEN_USERNAME` / `MAVEN_PASSWORD` / `MAVEN_GPG_PRIVATE_KEY` / `MAVEN_GPG_PASSPHRASE` are seeded as repo or org secrets (per packet 11), the workflow auto-promotes from dry-run to real-publish for the first SDK tag push. The Swift Package Index pathway is git-tag-based and does not require a registry secret, but the Swift SDK companion-repo strategy (subdirectory of the per-API repo vs. dedicated `HoneyDrunk{Api}Sdk` Swift repo) is decided at first-Swift-SDK-publication time — operator decision required at that point.
+- [ ] **Decide Kotlin `library` choice** at first-Kotlin-SDK-publication time — `jvm-okhttp4` is the default in this packet; `jvm-ktor` is the alternative. The choice depends on Android consumer ergonomics; the override templates assume OkHttp throughout. State the choice in the per-API caller's tag workflow.
+- [ ] **Maven Central Portal vs. OSSRH** — confirm which onboarding path is current at packet 11 onboarding time and update this workflow's Maven publish step accordingly. Central Portal is the new path (post-March 2024); OSSRH is the legacy.
+
+## Referenced ADR Decisions
+**ADR-0057 D8 — Three SDK languages at v1.** TypeScript (`@honeydrunk/{api}-sdk` on npm), Swift (`HoneyDrunk{Api}Sdk` SPM), Kotlin (`com.honeydrunkstudios:{api}-sdk` on Maven Central). Tooling: OpenAPI Generator with Studios-maintained overrides in `HoneyDrunk.Actions/openapi-templates/{language}/`. Publication automation: per-API tag triggers the reusable workflow. C# / Python / Go / Ruby / PHP deferred — generate on request.
+
+**ADR-0057 D9 — SDK version scheme.** `SDK version = v{API-major}.{spec-revision}.{sdk-patch}`. Both major SDK lines stay published indefinitely (deprecated in the registry post-sunset; never unpublished — unpublish breaks frozen consumer builds).
+
+**ADR-0057 D4 — Lenient enum deserialization client-side contract.** "New enum value is not breaking, conditional on the documented client-side rule: clients MUST ignore unknown enum values, treating them as unrecognized." The generated SDK's deserialization is lenient on unknown enum values by default — override templates implement this per language.
+
+**ADR-0057 D13 — Idempotency on writes.** "SDK implementations (D8) auto-generate an `Idempotency-Key` (a UUID v7) for every write request by default; the SDK consumer can override per-call." Override templates implement this via per-language request interceptors / shims.
+
+**ADR-0057 footnote (User-Agent).** "Generated SDKs (D8) set a `User-Agent` of the form `honeydrunk-{api}-sdk-{lang}/{sdk-version}` by default; tenants can override per request. Not a hard requirement (no enforcement on the header's presence), but the SDK default ensures coverage for the population that uses generated SDKs."
+
+**ADR-0034 (referenced) — NuGet policy and namespace ownership.** Namespace verification for npm `@honeydrunk` scope, Maven Central `com.honeydrunkstudios`, and GPG key registration are the operator-time-budgeted steps cross-referenced in packet 11.
+
+**ADR-0012 (referenced) — Actions as CI/CD control plane.**
+
+## Constraints
+- **Dry-run is the default safe path until packet 11.** The workflow does not push to registries until per-registry secrets are seeded. The dry-run logs are loud and unambiguous about *why* they did not publish.
+- **OpenAPI Generator version pinned.** No `latest`.
+- **Studios-maintained overrides are minimal in this packet.** They land enough to enforce the four contract decisions (lenient enum, User-Agent, Idempotency-Key, README); deeper ergonomic tuning is evidence-driven and lands in follow-up packets per ADR-0057 §Operational Consequences ("hand-tuned wrapper layers are an evidence-driven escalation, not v1 default").
+- **Three languages only.** ADR-0057 D8 explicitly defers C# / Python / Go / Ruby / PHP. This workflow does not pre-emptively wire them.
+- **Per-language enable/disable.** Each language is independently togglable so a partial onboarding (e.g., npm credentials ready, Maven not) can publish what's ready.
+- **No `Unreleased` CHANGELOG.**
+
+## Labels
+`feature`, `tier-1`, `core`, `adr-0057`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Ship the reusable `job-publish-public-sdk.yml` workflow that generates and publishes SDKs for TypeScript / Swift / Kotlin on per-API tag pushes, with Studios-maintained OpenAPI Generator override templates that enforce the four SDK contract decisions (lenient enum, default `User-Agent`, auto-`Idempotency-Key`, README convention). Run in dry-run mode until packet 11's operator onboarding seeds the per-registry credentials.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Make SDK publication a single tag push on the per-API repo. Per ADR-0057 D8, hand-writing SDKs per language per API is not viable at solo-operator scale; this workflow centralizes the generation, credentials, and publication path.
+- Feature: ADR-0057 rollout, Wave 2 (Actions substrate).
+- ADRs: ADR-0057 D8 / D9 / D13 / D4 / footnote-User-Agent (primary); ADR-0034 (namespace onboarding deferred to operator); ADR-0012 (Actions as CI/CD control plane).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0057 Accepted.
+- `packet:01` — tech-stack.md commits OpenAPI Generator as the tool.
+
+**Constraints:**
+- Dry-run until packet 11 seeds credentials.
+- Pinned OpenAPI Generator version.
+- Three languages only.
+- Override templates are minimal-but-functional in this packet.
+- Per-language enable/disable.
+- No `Unreleased` CHANGELOG.
+
+**Key Files:**
+- `HoneyDrunk.Actions/.github/workflows/job-publish-public-sdk.yml` (new)
+- `HoneyDrunk.Actions/openapi-templates/typescript/`, `swift/`, `kotlin/` (new directories)
+- `HoneyDrunk.Actions/docs/job-publish-public-sdk.md` (new)
+- `HoneyDrunk.Actions/CHANGELOG.md`
+- `HoneyDrunk.Actions/README.md`
+
+**Contracts:** None — reusable workflow + override-template assets only.

--- a/generated/issue-packets/active/adr-0057-api-versioning/05-actions-publish-docs-workflow.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/05-actions-publish-docs-workflow.md
@@ -1,0 +1,224 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-1", "core", "adr-0057", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0057", "ADR-0075"]
+wave: 2
+initiative: adr-0057-api-versioning
+node: honeydrunk-actions
+---
+
+# Author job-publish-docs.yml — per-API docs site generation (Scalar + Docusaurus) and Cloudflare Pages deploy
+
+## Summary
+Author the reusable workflow `job-publish-docs.yml` in `HoneyDrunk.Actions/.github/workflows/` that, on a per-API tag matching `{api}-api-v{N}.{spec-revision}.{sdk-patch}`, builds the per-API docs site by composing Docusaurus (narrative content) with Scalar (OpenAPI reference rendered from the spec) per ADR-0057 D15 and ADR-0075 D1 + D2, and deploys it to Cloudflare Pages at `docs.{api}.honeydrunkstudios.com/v{N}/`. Each major version gets its own path prefix; the version switcher is built into the Docusaurus shell. The workflow handles both first-version provisioning and subsequent-major additions. Cloudflare Pages deployment relies on a Cloudflare API token (operator-time-budgeted; packet 11 onboarding).
+
+## Context
+ADR-0057 D15 (reconciled with ADR-0075 — 2026-05-24) commits the two-part docs composition: Scalar renders the OpenAPI reference (spec-driven; endpoints / schemas / try-it-out / error catalog), Docusaurus carries the narrative (getting-started, conceptual explainers, tutorials, migration guides). The two compose into a single per-API docs site at `docs.{api}.honeydrunkstudios.com`. Per-version routing: `/v{N}/` for narrative, `/v{N}/api/` for the OpenAPI reference. Root redirects to current default major. Archived majors live at `/archive/v{N}/`.
+
+Per ADR-0075 D1, Scalar is already in use as the in-product OpenAPI renderer via `Scalar.AspNetCore`. This packet uses the same Scalar but in **static-publication mode** — the workflow runs `scalar build` (or equivalent) against the OpenAPI spec at release time and the resulting static HTML / JS / CSS is committed under the Docusaurus build output, served under `/v{N}/api/`. Docusaurus is per ADR-0075 D2 the narrative framework; the per-API repo's `docs/` directory contains the Docusaurus source.
+
+The deployment target is **Cloudflare Pages** per packet 02's docs-subdomain provisioning playbook. Cloudflare Pages free-tier is sufficient at Studios traffic ceilings; the per-API project is named `honeydrunk-docs-{api}` and bound to the per-API repo. The workflow uses the Cloudflare API token (secret `CLOUDFLARE_API_TOKEN`; account ID secret `CLOUDFLARE_ACCOUNT_ID`) to push the built site. Packet 11 onboarding seeds these.
+
+Per-API repos that don't yet have a `docs/` directory (Web.Rest at v1 freeze time per packet 07; Notify at v1 introduction per packet 08) need that directory scaffolded as part of those packets. This workflow assumes the docs directory exists; it does not scaffold it. Packets 07 and 08 ship the per-API Docusaurus scaffold; this workflow consumes it.
+
+For per-API docs sites that ship multiple majors over time, the build output composes both majors into the same Pages project — the build pulls the spec from each currently-live major and renders both Scalar references, plus pulls the Docusaurus content from each major's branch / tag. The two-major coexistence (per ADR-0057 D6) means the build typically generates two reference sites + two narrative sites + one root redirect. The archive output at `/archive/v{N}/` is a one-time copy at sunset (a separate manual step per the deprecation runbook in packet 02; this workflow does not automate the archive copy because sunset is a deliberate operator action, not a tag-driven event).
+
+This is the third Actions packet. Independent of packets 03 and 04 at execution time but composed by them in the per-API caller workflow (the tag-publication caller runs `job-openapi-diff` → `job-publish-public-sdk` → `job-publish-docs` in sequence).
+
+## Scope
+- **New file:** `HoneyDrunk.Actions/.github/workflows/job-publish-docs.yml` — the reusable workflow.
+- **New file:** `HoneyDrunk.Actions/docs/job-publish-docs.md` — consumer documentation.
+- Optionally: **a docs-site Docusaurus preset / package** in `HoneyDrunk.Actions/openapi-templates/docusaurus/` carrying the shared theme + version switcher + Scalar embed pattern — keep this small in v1; per-API repos consume the preset rather than re-implementing.
+- Repo-level `CHANGELOG.md` entry.
+- `HoneyDrunk.Actions/README.md` — workflow catalog link.
+
+## Proposed Implementation
+
+1. **`HoneyDrunk.Actions/.github/workflows/job-publish-docs.yml`** — `workflow_call` reusable workflow. Inputs:
+   ```yaml
+   inputs:
+     spec-paths:
+       description: 'Space-separated list of OpenAPI spec paths for currently-live majors (e.g. "api/openapi-v1.yaml api/openapi-v2.yaml").'
+       type: string
+       required: true
+     docs-dir:
+       description: 'Path to the per-API docs directory (Docusaurus source).'
+       type: string
+       required: false
+       default: 'docs'
+     surface-name:
+       description: 'API surface name (e.g. notify, web-rest).'
+       type: string
+       required: true
+     current-default-major:
+       description: 'The major the docs root redirects to (e.g. 1 or 2).'
+       type: number
+       required: true
+     cloudflare-pages-project:
+       description: 'Cloudflare Pages project name (e.g. honeydrunk-docs-notify).'
+       type: string
+       required: true
+     scalar-version:
+       description: 'Scalar CLI version; pinned for determinism.'
+       type: string
+       required: false
+       default: '0.4.0'  # confirm latest stable at execution time
+     docusaurus-version:
+       description: 'Docusaurus version; pinned for determinism.'
+       type: string
+       required: false
+       default: '3.6.0'  # confirm latest stable at execution time
+     dry-run:
+       description: 'If true, build but do not deploy to Cloudflare Pages.'
+       type: boolean
+       required: false
+       default: false
+   secrets:
+     CLOUDFLARE_API_TOKEN:
+       required: false
+     CLOUDFLARE_ACCOUNT_ID:
+       required: false
+   ```
+   Steps:
+   - **Checkout** with `fetch-depth: 0`.
+   - **Install Node + Docusaurus + Scalar.** Pin versions per inputs.
+   - **For each spec in `spec-paths`:**
+     - Extract the major from the filename (`openapi-v(\d+)\.yaml`).
+     - Run Scalar against the spec; output to `/tmp/build/v{major}/api/` (static HTML / JS / CSS).
+     - Build the Docusaurus narrative for that major (Docusaurus supports versioned docs via its built-in versioning; the per-API repo's `docs/` carries a `versioned_docs/version-{major}/` subdirectory per Docusaurus convention). Output to `/tmp/build/v{major}/`.
+   - **Compose the root redirect.** Write `/tmp/build/index.html` as a simple `<meta http-equiv="refresh" content="0; url=/v{current-default-major}/">` (or a JS-driven redirect if SEO matters; meta-refresh is sufficient at Studios scale).
+   - **Compose the cross-major version switcher** — the Docusaurus shell's top nav includes the version dropdown that crosses majors at the same conceptual path (per ADR-0057 D15: `/v1/api/messages` ↔ `/v2/api/messages`). The shared preset in `openapi-templates/docusaurus/` (if shipped) provides this; otherwise the per-API repo's `docusaurus.config.js` implements it.
+   - **Deploy.** If `dry-run: true` OR `CLOUDFLARE_API_TOKEN` is unset: log "DRY-RUN: skipping Cloudflare Pages deploy" and exit 0 (the built site is uploaded as a workflow artifact for inspection). Otherwise: use `cloudflare/pages-action@v1` (or the Wrangler CLI) to deploy `/tmp/build/` to the `${{ inputs.cloudflare-pages-project }}` project; the deployment URL is published in the workflow summary.
+   - **Workflow summary** — list each major's docs URL, the root URL, the Cloudflare Pages deployment URL.
+
+2. **`HoneyDrunk.Actions/openapi-templates/docusaurus/`** (optional but recommended in v1) — a small shared preset that per-API repos import:
+   - `preset.js` — Docusaurus preset adding the version switcher, the Scalar embed shim, the docs-site theme (shared color palette, footer linking back to `honeydrunkstudios.com`).
+   - `README.md` — how a per-API repo's `docusaurus.config.js` consumes the preset (`presets: [require.resolve('@honeydrunk/docusaurus-preset/preset.js')]` — or via direct npm install once the preset is published; defer publish if dry-run).
+   - The preset itself does not get npm-published in this packet — per-API repos import via relative path (`require.resolve('../../HoneyDrunk.Actions/openapi-templates/docusaurus/preset.js')` or via a git submodule, or — most cleanly — the per-API repo's `docs/package.json` declares a `file:` dependency pointing at the cloned Actions directory at workflow run time). The simplest path at v1 is **the workflow copies the preset into the per-API build's `node_modules/@honeydrunk/docusaurus-preset/`** before running `docusaurus build`, sidestepping the npm-publish bootstrap problem.
+
+3. **`HoneyDrunk.Actions/docs/job-publish-docs.md`** — consumer documentation:
+   - **Purpose.** Build and deploy a per-API docs site per ADR-0057 D15.
+   - **Tag-driven invocation example:**
+     ```yaml
+     on:
+       push:
+         tags:
+           - 'notify-api-v*'
+     jobs:
+       docs:
+         uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-publish-docs.yml@main
+         with:
+           spec-paths: 'HoneyDrunk.Notify/api/openapi-v1.yaml'
+           docs-dir: 'HoneyDrunk.Notify/docs'
+           surface-name: notify
+           current-default-major: 1
+           cloudflare-pages-project: honeydrunk-docs-notify
+         secrets:
+           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+     ```
+   - **Multi-major invocation** — when v2 ships, the caller passes both specs: `spec-paths: 'HoneyDrunk.Notify/api/openapi-v1.yaml HoneyDrunk.Notify/api/openapi-v2.yaml'`. The build emits both reference docs.
+   - **Dry-run** — when `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are unset, the workflow builds but uploads the result as an artifact rather than deploying.
+   - **Per-API repo setup** — the per-API repo's `docs/` directory must exist and contain a Docusaurus scaffold (per Docusaurus 3.x conventions: `docusaurus.config.js`, `sidebars.js`, `docs/`, `versioned_docs/`, etc.). Packets 07 (Web.Rest) and 08 (Notify) scaffold those in their per-API repos.
+   - **Version switcher** — the shared preset (or the per-API `docusaurus.config.js`) provides the cross-major version dropdown.
+   - **Archive** — sunset is a deliberate operator action per the deprecation runbook in packet 02; the workflow does NOT auto-archive at sunset.
+
+4. **`HoneyDrunk.Actions/CHANGELOG.md`** — dated, versioned entry.
+
+5. **`HoneyDrunk.Actions/README.md`** — workflow catalog link.
+
+## Affected Files
+- `HoneyDrunk.Actions/.github/workflows/job-publish-docs.yml` (new)
+- `HoneyDrunk.Actions/openapi-templates/docusaurus/preset.js` (new, optional in v1 — recommended)
+- `HoneyDrunk.Actions/openapi-templates/docusaurus/README.md` (new, optional)
+- `HoneyDrunk.Actions/docs/job-publish-docs.md` (new)
+- `HoneyDrunk.Actions/CHANGELOG.md`
+- `HoneyDrunk.Actions/README.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Actions`. Per ADR-0012.
+- [x] No code change in any other repo.
+- [x] Cloudflare Pages deployment is the canonical hosting target per packet 02's playbook and ADR-0029's DNS substrate.
+- [x] Per-API `docs/` directory is NOT scaffolded by this workflow — packets 07 and 08 handle that.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Actions/.github/workflows/job-publish-docs.yml` exists with the documented inputs and outputs a Cloudflare Pages deployment URL
+- [ ] The workflow builds per-major Scalar reference + per-major Docusaurus narrative; emits a root redirect to `current-default-major`; deploys to the named Cloudflare Pages project
+- [ ] When `CLOUDFLARE_API_TOKEN` is unset OR `dry-run: true`, the workflow builds but uploads as artifact and does not deploy — logs the dry-run reason clearly
+- [ ] When secrets are seeded and `dry-run: false`, the workflow deploys via `cloudflare/pages-action@v1` (or Wrangler CLI equivalent)
+- [ ] Scalar and Docusaurus versions are pinned (no `latest`)
+- [ ] Multi-major invocation (two specs in `spec-paths`) builds both reference sites + both narrative sites in the same deploy
+- [ ] `HoneyDrunk.Actions/openapi-templates/docusaurus/preset.js` is shipped (or this packet documents why it was deferred) so per-API repos do not re-implement the version switcher / Scalar embed shim / shared theme
+- [ ] `HoneyDrunk.Actions/docs/job-publish-docs.md` documents tag-driven invocation, multi-major, dry-run, per-API setup expectation, and the no-auto-archive note
+- [ ] `HoneyDrunk.Actions/CHANGELOG.md` records the addition in a dated, versioned section
+- [ ] `HoneyDrunk.Actions/README.md` links to the new job docs
+
+## Human Prerequisites
+- [ ] **Confirm Scalar and Docusaurus version pins** at PR time (`0.4.0` and `3.6.0` are placeholders).
+- [ ] **The workflow runs in dry-run mode until packet 11's operator onboarding seeds `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.** Packet 11 covers the Cloudflare API token scoping (Account.Cloudflare Pages: Edit) and the org-secret seeding.
+- [ ] **Per-API Cloudflare Pages project provisioning** — per the packet 02 docs-subdomain playbook, a Cloudflare Pages project named `honeydrunk-docs-{api}` must exist before the workflow can deploy to it. Packet 09 (Studios) ships the first concrete instance (`honeydrunk-docs-notify`) and the DNS / Pages project provisioning.
+
+## Referenced ADR Decisions
+**ADR-0057 D15 (reconciled with ADR-0075 — 2026-05-24) — Per-API docs site composition.** Scalar renders the OpenAPI reference (spec-driven part — endpoints, schemas, try-it-out, error catalog). Docusaurus carries the narrative content. Hosted at `docs.{api}.honeydrunkstudios.com`. Per-major path prefix: `/v{N}/` narrative, `/v{N}/api/` reference. Root redirects to current default major. Archived majors at `/archive/v{N}/`. Version switcher crosses majors at the same conceptual path.
+
+**ADR-0075 D1 (referenced) — Scalar as in-product OpenAPI renderer.** Same renderer in static-publication mode here.
+
+**ADR-0075 D2 (referenced) — Docusaurus as narrative framework.**
+
+**ADR-0057 D5 + D6 — Deprecation and archive.** Sunset is a deliberate operator action per the deprecation runbook (packet 02). This workflow does NOT auto-archive at sunset.
+
+**ADR-0029 (referenced) — Cloudflare DNS rollout.** Cloudflare Pages is the docs hosting target; the Cloudflare-managed zone owns the `docs.{api}.honeydrunkstudios.com` records.
+
+**ADR-0012 (referenced) — Actions as CI/CD control plane.**
+
+## Constraints
+- **Pinned tool versions.**
+- **Dry-run until packet 11 + packet 09.** Until both the Cloudflare credentials are seeded (packet 11) and the Pages project exists (packet 09 for Notify; per-API-specific for others), the workflow runs in build-only mode.
+- **Per-API `docs/` directory must exist.** The workflow does not scaffold it; packets 07 and 08 do.
+- **Shared Docusaurus preset is recommended but defer-able.** If the preset adds non-trivial complexity in v1, the executor can defer it to a follow-up packet — per-API repos then carry their own `docusaurus.config.js` with the version switcher + Scalar embed (duplicated; acceptable for v1; tracked as tech debt).
+- **No auto-archive at sunset.** The sunset cutover is operator-driven per packet 02's runbook.
+- **No `Unreleased` CHANGELOG.**
+
+## Labels
+`feature`, `tier-1`, `core`, `adr-0057`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Ship the reusable `job-publish-docs.yml` workflow that composes Scalar (OpenAPI reference) and Docusaurus (narrative) per ADR-0057 D15 + ADR-0075, builds per-major-version paths, and deploys to Cloudflare Pages. Run in dry-run mode until credentials + Pages project exist.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Single tag push on a per-API repo regenerates the entire per-API docs site (both currently-live majors) and deploys to Cloudflare Pages.
+- Feature: ADR-0057 rollout, Wave 2 (Actions substrate).
+- ADRs: ADR-0057 D15 (primary, reconciled with ADR-0075); ADR-0075 D1 + D2 (Scalar + Docusaurus); ADR-0029 (Cloudflare DNS); ADR-0012 (Actions as control plane).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0057 Accepted.
+- `packet:01` — tech-stack.md commits Scalar + Docusaurus.
+
+**Constraints:**
+- Pinned versions for Scalar and Docusaurus.
+- Dry-run until Cloudflare credentials + per-API Pages project exist.
+- Per-API `docs/` directory not scaffolded here.
+- Shared Docusaurus preset recommended but defer-able to a follow-up if it adds v1 complexity.
+- No auto-archive.
+- No `Unreleased` CHANGELOG.
+
+**Key Files:**
+- `HoneyDrunk.Actions/.github/workflows/job-publish-docs.yml` (new)
+- `HoneyDrunk.Actions/openapi-templates/docusaurus/preset.js` + `README.md` (new, recommended)
+- `HoneyDrunk.Actions/docs/job-publish-docs.md` (new)
+- `HoneyDrunk.Actions/CHANGELOG.md`
+- `HoneyDrunk.Actions/README.md`
+
+**Contracts:** None — reusable workflow + shared preset.

--- a/generated/issue-packets/active/adr-0057-api-versioning/06-actions-graphql-inspector-and-docs-workflows.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/06-actions-graphql-inspector-and-docs-workflows.md
@@ -1,0 +1,264 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Actions
+labels: ["feature", "tier-1", "core", "adr-0057", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0057", "ADR-0003"]
+wave: 2
+initiative: adr-0057-api-versioning
+node: honeydrunk-actions
+---
+
+# Author job-graphql-inspector.yml and job-publish-graphql-docs.yml — HoneyHub Phase 4 substrate
+
+## Summary
+Author two reusable workflows in `HoneyDrunk.Actions/.github/workflows/` that ship the GraphQL substrate per ADR-0057 D16 + D17 Phase 4: `job-graphql-inspector.yml` runs `graphql-inspector` (or equivalent) on every PR that modifies a `schema.graphql`, flagging outright field/type removals (which require a 180-day `@deprecated` window per ADR-0057 D5 + D16); `job-publish-graphql-docs.yml` builds the HoneyHub GraphQL docs site (narrative via Docusaurus + GraphQL reference via Spectaql or equivalent GraphQL renderer) and deploys to Cloudflare Pages at `docs.honeyhub.honeydrunkstudios.com`. Both workflows ship now as substrate even though HoneyHub does not exist on disk yet — the workflows are buildable Actions assets, and per ADR-0057 D17 Phase 5 they must be in place before the HoneyHub standup begins.
+
+## Context
+ADR-0057 D16 commits HoneyHub's GraphQL schema-evolution model: additive-only on the live schema; breaking changes via per-field `@deprecated(reason: "Use newField instead. Sunset YYYY-MM-DD.")`; minimum 180-day deprecation window per field; tenant-notification flow (same as REST per D5) applies. ADR-0057 D17 Phase 4 commits the substrate: `job-graphql-inspector.yml` and `job-publish-graphql-docs.yml`. Invariant `{N4}` is the enforcement.
+
+The two workflows mirror the REST counterparts in shape:
+- `job-graphql-inspector.yml` is the GraphQL counterpart of `job-openapi-diff.yml` (packet 03) — it enforces the no-removal-without-deprecation rule.
+- `job-publish-graphql-docs.yml` is the GraphQL counterpart of `job-publish-docs.yml` (packet 05) — it composes a narrative Docusaurus site with a GraphQL reference renderer (likely Spectaql, the GraphQL-Markdown plugin for Docusaurus, or GraphiQL-as-static).
+
+HoneyHub does **not exist on disk**. ADR-0003 (HoneyHub) is Proposed; the `HoneyHub/` repo is not yet stood up; the `schema.graphql` is not yet committed. This packet ships the **substrate workflows in `HoneyDrunk.Actions`** — the per-API tag-driven wiring lands when HoneyHub stands up. The workflows are correct GitHub Actions assets at PR time; they pass their own self-tests; they are not invoked from any caller yet.
+
+`graphql-inspector` (https://the-guild.dev/graphql/inspector) is the most mature open-source GraphQL schema diff/inspector tool. It runs on Node, ships as `@graphql-inspector/cli`, classifies changes into `BREAKING` / `NON_BREAKING` / `DANGEROUS` categories, and supports a CI gate mode. It is the default tool choice per ADR-0057 D16's "or equivalent" — pin the version in this workflow.
+
+For the GraphQL docs renderer, the ecosystem is fragmented. Options:
+- **Spectaql** — Spectaql renders GraphQL schemas as static HTML; Docusaurus-friendly via iframe embed or plugin. Less polished than Scalar for REST but mature.
+- **`@graphql-markdown/docusaurus`** — a Docusaurus plugin that generates Markdown from a GraphQL schema. Most idiomatic for the Docusaurus-narrative model already committed for REST per ADR-0075.
+- **GraphiQL embedded** — interactive query browser; less of a "reference site" feel; useful for try-it-out but doesn't replace static reference content.
+
+The packet picks `@graphql-markdown/docusaurus` as the v1 default because it preserves the Docusaurus-as-narrative-shell convention (parity with the REST docs site) and renders reference content in the same Docusaurus pages — no iframe embedding. The choice is documented in the workflow inputs so a future swap is a single input change.
+
+Both workflows ship in dry-run-compatible mode (the GraphQL docs workflow uses the same Cloudflare Pages token; the inspector workflow needs no secret). Until HoneyHub stands up, neither is invoked by any caller.
+
+This is the fourth and final Actions packet.
+
+## Scope
+- **New file:** `HoneyDrunk.Actions/.github/workflows/job-graphql-inspector.yml`
+- **New file:** `HoneyDrunk.Actions/.github/workflows/job-publish-graphql-docs.yml`
+- **New file:** `HoneyDrunk.Actions/docs/job-graphql-inspector.md`
+- **New file:** `HoneyDrunk.Actions/docs/job-publish-graphql-docs.md`
+- Repo-level `CHANGELOG.md` entry.
+- `HoneyDrunk.Actions/README.md` — workflow catalog links.
+
+## Proposed Implementation
+
+1. **`HoneyDrunk.Actions/.github/workflows/job-graphql-inspector.yml`** — `workflow_call` reusable workflow. Inputs:
+   ```yaml
+   inputs:
+     schema-path:
+       description: 'Path to the GraphQL schema (e.g. api/schema.graphql).'
+       type: string
+       required: true
+     diff-mode:
+       description: 'tag (compare against latest released tag) or branch (compare against main).'
+       type: string
+       required: false
+       default: 'branch'  # HoneyHub uses schema-evolution without major-version tags per D16, so branch-anchored is the default
+     graphql-inspector-version:
+       description: 'graphql-inspector version; pinned for determinism.'
+       type: string
+       required: false
+       default: '5.0.0'  # confirm latest stable at execution time
+   ```
+   Steps:
+   - **Checkout** with `fetch-depth: 0`.
+   - **Install Node + `@graphql-inspector/cli@${{ inputs.graphql-inspector-version }}`.**
+   - **Resolve the comparison base.** Branch mode: check out `main`'s `schema-path` to `/tmp/base-schema.graphql`. Tag mode (if a HoneyHub-internal convention emerges): check out the latest tag's schema.
+   - **Run inspector.** `graphql-inspector diff /tmp/base-schema.graphql ${{ inputs.schema-path }} --rule recommended` — `recommended` rule set classifies removals, type changes, required-arg additions as BREAKING; field deprecations as DANGEROUS-but-allowed.
+   - **Gate.** If `graphql-inspector` returns BREAKING changes (i.e., any field/type was removed without first having been `@deprecated` for the minimum window OR a required arg was added), the workflow exits non-zero and publishes a sticky PR comment listing the offending changes plus the remediation: "Apply `@deprecated(reason: '...; sunset YYYY-MM-DD.')` to the field; wait the 180-day window; then remove."
+   - **Slow-drift footnote.** `graphql-inspector` catches outright removals but does NOT catch *slow drift* in deprecation hygiene (e.g., a `@deprecated` field whose `reason` is missing the sunset date, or whose sunset date is unrealistically distant). The PR comment footer notes: "Note: `graphql-inspector` enforces removal-after-deprecation but does NOT check the deprecation `reason` string for the required sunset date format. Reviewer attention via the Grid-aware review agent (ADR-0044) checks the `reason` string."
+   - **Sticky PR comment** — same pattern as `job-openapi-diff.yml`.
+
+2. **`HoneyDrunk.Actions/.github/workflows/job-publish-graphql-docs.yml`** — `workflow_call` reusable workflow. Inputs:
+   ```yaml
+   inputs:
+     schema-path:
+       description: 'Path to the GraphQL schema.'
+       type: string
+       required: true
+     docs-dir:
+       description: 'Path to the Docusaurus source.'
+       type: string
+       required: false
+       default: 'docs'
+     surface-name:
+       description: 'GraphQL surface name (e.g. honeyhub).'
+       type: string
+       required: true
+     cloudflare-pages-project:
+       description: 'Cloudflare Pages project name (e.g. honeydrunk-docs-honeyhub).'
+       type: string
+       required: true
+     graphql-markdown-version:
+       description: '@graphql-markdown/docusaurus version; pinned.'
+       type: string
+       required: false
+       default: '1.20.0'  # confirm latest stable
+     docusaurus-version:
+       description: 'Docusaurus version; pinned.'
+       type: string
+       required: false
+       default: '3.6.0'  # match packet 05
+     dry-run:
+       description: 'If true, build but do not deploy.'
+       type: boolean
+       required: false
+       default: false
+   secrets:
+     CLOUDFLARE_API_TOKEN:
+       required: false
+     CLOUDFLARE_ACCOUNT_ID:
+       required: false
+   ```
+   Steps:
+   - **Checkout.**
+   - **Install Node + Docusaurus + `@graphql-markdown/docusaurus`.**
+   - **Generate GraphQL reference Markdown from the schema.** The plugin scans the schema and writes Markdown files into the Docusaurus tree at a configured path (e.g., `docs/reference/`). Pre-build step within the Docusaurus build.
+   - **Build Docusaurus.** Outputs static HTML / JS / CSS.
+   - **Deploy.** Same Cloudflare Pages path as packet 05. Dry-run if secrets absent.
+   - **Workflow summary** — list the deployment URL.
+
+   **No per-major path prefix.** Per ADR-0057 D16, HoneyHub does NOT version by URL prefix — schema evolution under a single `/graphql` endpoint. The docs site is therefore single-version; `docs.honeyhub.honeydrunkstudios.com/` serves the live schema's reference + narrative. No `/v1/` prefix.
+
+3. **`HoneyDrunk.Actions/docs/job-graphql-inspector.md`** — consumer documentation:
+   - **Purpose.** Enforce invariant `{N4}` (HoneyHub uses schema evolution; no URL-prefix versioning; removals require a 180-day `@deprecated` window).
+   - **Invocation example** (a future HoneyHub PR check):
+     ```yaml
+     on:
+       pull_request:
+         paths:
+           - 'HoneyHub/api/schema.graphql'
+     jobs:
+       graphql-inspector:
+         uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-graphql-inspector.yml@main
+         with:
+           schema-path: HoneyHub/api/schema.graphql
+     ```
+   - **What is enforced** — outright field/type removal; type changes; required-arg additions.
+   - **What is NOT enforced** — the `@deprecated(reason: "...")` string's sunset-date format (Grid-aware review agent per ADR-0044 catches this).
+
+4. **`HoneyDrunk.Actions/docs/job-publish-graphql-docs.md`** — consumer documentation:
+   - **Purpose.** Build and deploy HoneyHub's GraphQL docs site per ADR-0057 D15 (cross-applied to GraphQL).
+   - **Invocation example** — when HoneyHub stands up:
+     ```yaml
+     on:
+       push:
+         branches: [main]
+         paths:
+           - 'HoneyHub/api/schema.graphql'
+           - 'HoneyHub/docs/**'
+     jobs:
+       docs:
+         uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-publish-graphql-docs.yml@main
+         with:
+           schema-path: HoneyHub/api/schema.graphql
+           docs-dir: HoneyHub/docs
+           surface-name: honeyhub
+           cloudflare-pages-project: honeydrunk-docs-honeyhub
+         secrets:
+           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+     ```
+   - **No per-major path.** Single-version docs site.
+   - **Dry-run** — until Cloudflare credentials and the `honeydrunk-docs-honeyhub` Pages project exist.
+   - **Cross-link to packet 02 docs-subdomain provisioning playbook** — HoneyHub's docs subdomain follows the same playbook as the REST docs subdomains.
+
+5. **`HoneyDrunk.Actions/CHANGELOG.md`** — dated, versioned entry.
+
+6. **`HoneyDrunk.Actions/README.md`** — workflow catalog links for both.
+
+## Affected Files
+- `HoneyDrunk.Actions/.github/workflows/job-graphql-inspector.yml` (new)
+- `HoneyDrunk.Actions/.github/workflows/job-publish-graphql-docs.yml` (new)
+- `HoneyDrunk.Actions/docs/job-graphql-inspector.md` (new)
+- `HoneyDrunk.Actions/docs/job-publish-graphql-docs.md` (new)
+- `HoneyDrunk.Actions/CHANGELOG.md`
+- `HoneyDrunk.Actions/README.md`
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Actions`. Per ADR-0012.
+- [x] No code change in any other repo.
+- [x] HoneyHub does not exist on disk; the workflows are buildable substrate assets, not invoked by any caller yet.
+- [x] The GraphQL docs renderer choice (`@graphql-markdown/docusaurus`) is documented and swappable via a future ADR.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Actions/.github/workflows/job-graphql-inspector.yml` exists; runs `graphql-inspector diff` with the `recommended` rule set; fails on BREAKING; publishes a sticky PR comment with the offending changes and the remediation; the comment includes the slow-drift footnote about `@deprecated` reason-string review
+- [ ] `HoneyDrunk.Actions/.github/workflows/job-publish-graphql-docs.yml` exists; generates GraphQL reference Markdown via `@graphql-markdown/docusaurus`; builds Docusaurus; deploys to Cloudflare Pages with `dry-run` fallback when secrets absent; no per-major path prefix (single-version site)
+- [ ] Pinned versions for `graphql-inspector`, `@graphql-markdown/docusaurus`, and Docusaurus (all three)
+- [ ] `HoneyDrunk.Actions/docs/job-graphql-inspector.md` documents purpose, invocation example, what-is-enforced, what-is-NOT-enforced
+- [ ] `HoneyDrunk.Actions/docs/job-publish-graphql-docs.md` documents purpose, invocation example, single-version-site note, dry-run, cross-link to packet 02
+- [ ] `HoneyDrunk.Actions/CHANGELOG.md` records the addition in a dated, versioned section
+- [ ] `HoneyDrunk.Actions/README.md` links to both new job docs
+- [ ] Neither workflow is wired in a consuming repo (HoneyHub does not exist) — the wiring lands as part of the future HoneyHub standup
+
+## Human Prerequisites
+- [ ] **Confirm tool version pins** at PR time (`graphql-inspector` 5.0.0; `@graphql-markdown/docusaurus` 1.20.0; Docusaurus 3.6.0 — all placeholders).
+- [ ] **HoneyHub stands up later.** Until then, these workflows are buildable substrate. The first invocation lands when the HoneyHub standup initiative wires them in HoneyHub's per-repo CI.
+- [ ] **GraphQL docs renderer choice** — `@graphql-markdown/docusaurus` is the v1 default per the rationale in §Context. The choice is swappable via a future ADR if Spectaql or another renderer becomes the better fit.
+
+## Referenced ADR Decisions
+**ADR-0057 D16 — HoneyHub schema evolution.** Additive-only on the live schema. Breaking changes via per-field `@deprecated(reason: "Use newField instead. Sunset YYYY-MM-DD.")`. Minimum 180-day deprecation per field. No `/v2` for HoneyHub — `/graphql` is stable; the schema evolves underneath.
+
+**ADR-0057 D17 Phase 4 — HoneyHub GraphQL schema commitment.** "Aligned with HoneyHub's Phase 2 timeline per ADR-0003." Schema checked in at `repos/HoneyHub/api/schema.graphql`; breaking-change CI gate via `graphql-inspector`; docs site at `docs.honeyhub.honeydrunkstudios.com`.
+
+**ADR-0057 D17 Phase 5 — AI-sector standup wave inheritance.** "Every AI Node that exposes a public API ... inherits the Phase 1 substrate at standup." The Phase 4 substrate (this packet's workflows) is in place before HoneyHub stands up so HoneyHub's standup inherits an already-tested CI gate.
+
+**ADR-0003 (referenced) — HoneyHub.** HoneyHub uses GraphQL where REST is the Grid default per ADR-0057 D1; D16 is the narrow exception. HoneyHub does not yet exist on disk.
+
+**ADR-0044 (referenced) — Grid-aware review agent.** Catches the slow-drift deprecation-reason-string issues that `graphql-inspector` does not.
+
+**Invariant `{N4}` — HoneyHub uses schema evolution, not URL-prefix versioning.** Enforced by `job-graphql-inspector.yml`.
+
+## Constraints
+- **Pinned tool versions.**
+- **GraphQL docs renderer choice documented in workflow input.** Swap requires a follow-up ADR, not a silent change.
+- **No HoneyHub repo wiring.** HoneyHub does not exist on disk; these workflows ship as buildable substrate.
+- **Single-version GraphQL docs site.** No `/v{N}/` path prefix on the GraphQL docs site (D16 — schema evolution, not URL versioning).
+- **Dry-run until Cloudflare credentials + HoneyHub Pages project.**
+- **No `Unreleased` CHANGELOG.**
+
+## Labels
+`feature`, `tier-1`, `core`, `adr-0057`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Ship the two GraphQL substrate workflows in `HoneyDrunk.Actions` — `job-graphql-inspector.yml` (HoneyHub Phase 4 breaking-change CI gate per ADR-0057 D16; enforces invariant `{N4}`) and `job-publish-graphql-docs.yml` (HoneyHub docs site builder + Cloudflare Pages deploy per ADR-0057 D15 cross-applied to GraphQL). HoneyHub does not exist on disk; these workflows are buildable substrate, invoked by HoneyHub's per-repo CI when HoneyHub stands up.
+
+**Target:** `HoneyDrunk.Actions`, branch from `main`.
+
+**Context:**
+- Goal: Have the Phase 4 substrate ready before HoneyHub stands up, per ADR-0057 D17 Phase 5's "AI-sector inherits Phase 1 substrate" pattern (HoneyHub follows the same shape).
+- Feature: ADR-0057 rollout, Wave 2 (Actions substrate).
+- ADRs: ADR-0057 D16 / D17 Phase 4 (primary); ADR-0003 (HoneyHub Proposed; standup deferred); ADR-0075 (Docusaurus narrative); ADR-0044 (review agent catches deprecation-reason-string drift).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — invariants `{N1}-{N4}` live; this workflow enforces `{N4}`.
+- `packet:01` — tech-stack.md commits `graphql-inspector` as the tool.
+
+**Constraints:**
+- Pinned versions.
+- HoneyHub does not exist; workflows are buildable assets, not invoked yet.
+- Single-version GraphQL docs site (no `/v{N}/` prefix).
+- Dry-run until Cloudflare credentials + HoneyHub Pages project.
+- No `Unreleased` CHANGELOG.
+
+**Key Files:**
+- `HoneyDrunk.Actions/.github/workflows/job-graphql-inspector.yml` (new)
+- `HoneyDrunk.Actions/.github/workflows/job-publish-graphql-docs.yml` (new)
+- `HoneyDrunk.Actions/docs/job-graphql-inspector.md` (new)
+- `HoneyDrunk.Actions/docs/job-publish-graphql-docs.md` (new)
+- `HoneyDrunk.Actions/CHANGELOG.md`
+- `HoneyDrunk.Actions/README.md`
+
+**Contracts:** None — reusable workflows only.

--- a/generated/issue-packets/active/adr-0057-api-versioning/07-web-rest-openapi-v1-and-envelope-migration.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/07-web-rest-openapi-v1-and-envelope-migration.md
@@ -1,0 +1,211 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Web.Rest
+labels: ["feature", "tier-2", "core", "adr-0057", "wave-3"]
+dependencies: ["packet:00", "packet:01", "packet:03", "packet:05"]
+adrs: ["ADR-0057"]
+wave: 3
+initiative: adr-0057-api-versioning
+node: honeydrunk-web-rest
+---
+
+# Reverse-engineer openapi-v1.yaml for HoneyDrunk.Web.Rest, freeze the surface at v1, ship Option C envelope alignment
+
+## Summary
+The Phase 1 pilot per ADR-0057 D17. `HoneyDrunk.Web.Rest` is the low-risk surface that exercises the full substrate (packet 03 OpenAPI diff gate; packet 05 docs publication) before Notify's higher-stakes Phase 2 pilot. Reverse-engineer an OpenAPI 3.1 specification from Web.Rest's existing AspNetCore middleware-emitted endpoints + shapes; check it in at `HoneyDrunk.Web.Rest/api/openapi-v1.yaml`; freeze the public surface at v1 (any future endpoint addition is a minor spec revision; any future breaking change is v2). Ship the **Option C envelope alignment**: additive RFC 7807 `application/problem+json` shape on errors *alongside* the existing `ApiErrorResponse`, with the in-AspNetCore middleware now emitting both shapes — a `Accept: application/problem+json`-aware content negotiation, defaulting to `ApiErrorResponse` for backwards compatibility, switching to RFC 7807 when the client signals it. Add IETF `RateLimit-*` header conventions (the response-shaping hooks on `ApiResult`/middleware so future limiter wiring per packet 02 of ADR-0067 inserts the correct headers). Add cursor-pagination primitives to `HoneyDrunk.Web.Rest.Abstractions/Paging/` alongside the existing `PageRequest`/`PageResult` (the existing offset shape is retained for backwards compatibility; the new cursor shape is the v2-default per ADR-0057 D14 once v2 ships). Wire `job-openapi-diff.yml` + `job-publish-docs.yml` into the per-repo CI. Scaffold a minimal `docs/` Docusaurus tree for the docs site. Version-bump the Web.Rest solution per invariant 27.
+
+## Context
+`HoneyDrunk.Web.Rest` is Live at `0.5.0` per `catalogs/nodes.json`. It ships two packages — `HoneyDrunk.Web.Rest.Abstractions` (zero-dependency contracts: `ApiResult<T>`, `ApiErrorResponse`, `ApiError`, `ApiErrorCode`, `ValidationError`, `PageRequest`, `PageResult`) and `HoneyDrunk.Web.Rest.AspNetCore` (ASP.NET Core middleware: correlation, exception-to-error mapping, auth failure shaping, MVC/minimal-API conventions). ADR-0057 D17 Phase 1 names Web.Rest as the pilot: *"likely `HoneyDrunk.Web.Rest` v1 (already Live; the spec is reverse-engineered from the existing endpoints and the version freezes at v1)."*
+
+**The envelope migration is the load-bearing tactical decision.** Web.Rest today emits `ApiErrorResponse` (Studios-specific shape: `Code`, `Message`, `Details`, `CorrelationId`, validation array). ADR-0057 D12 commits RFC 7807 `application/problem+json` (`type`, `title`, `status`, `detail`, `instance`, `traceId`, `correlationId`). The existing consumers of Web.Rest cannot be assumed to handle a sudden shape change; per ADR-0057 D4, changing the error envelope is a breaking change requiring a major version bump.
+
+**Three options were considered at refine time; pin Option C:**
+- **Option A (sudden cutover):** middleware emits only RFC 7807 from `0.6.0`. Every Web.Rest consumer breaks. Rejected — this is what versioning policy is designed to prevent.
+- **Option B (defer to v2):** middleware emits only `ApiErrorResponse` until v2 ships, then v2 emits only RFC 7807. Works in principle but ADR-0057 D17 Phase 1 names Web.Rest as the *pilot* — the whole point is to exercise the substrate now, not in 180 days. Also, ADR-0057's RFC 7807 is the Grid-wide convention; deferring the alignment means downstream consumer code keeps coupling to `ApiErrorResponse` even longer.
+- **Option C (additive headers + RFC 7807 alignment — PINNED):** middleware emits *both* shapes via content negotiation. Default response remains `ApiErrorResponse` for existing consumers. When the request `Accept` header includes `application/problem+json` (with quality higher than `application/json`), the middleware emits the RFC 7807 shape instead. The two shapes are emitted from a single code path — the middleware builds a canonical internal error record, then projects it into one shape or the other based on content negotiation. ADR-0057's `type` / `traceId` / `correlationId` fields are populated in both shapes (the existing `ApiErrorResponse` gets a `Type` field added — additive per D4 — and the existing `CorrelationId` is reused). The IETF `RateLimit-*` headers are added to the response-shaping pipeline (the actual rate-limit wiring lands per ADR-0067 packet 02 in Kernel; Web.Rest's middleware just makes sure the headers, when present, are preserved end-to-end and the response-decorator hooks exist). Cursor pagination primitives are added to Abstractions alongside the existing offset shape; the OpenAPI v1 spec documents the offset shape (the surface freezes at v1's existing shape per the pilot's freeze-the-surface constraint) and the cursor shape is documented as the v2-default convention.
+
+Option C is **additive on the existing surface**: per ADR-0057 D4, a new optional response field (`Type` on `ApiErrorResponse`) is non-breaking; new endpoints / new content-negotiated representations are non-breaking; new optional Abstractions types (`CursorPageRequest` / `CursorPageResult`) are non-breaking. The v1 OpenAPI spec captures the current behavior (offset-only pagination, both error envelopes via content negotiation). The breaking-change diff gate (packet 03) will pass.
+
+**Web.Rest is library-only.** It has no deployable endpoints; the "API surface" it exposes is its `Abstractions` package + the middleware-emitted shapes consuming services use. The OpenAPI v1 spec for Web.Rest therefore documents the **convention** — the shapes of `ApiResult<T>`, `ApiErrorResponse`, RFC 7807 problem+json, `PageRequest`/`PageResult`, `CursorPageRequest`/`CursorPageResult`, the IETF `RateLimit-*` header set — as a reference document rather than as a per-endpoint catalog. Future consuming services (Notify Cloud, future Billing) generate their own per-API spec; Web.Rest's spec is the upstream contract document.
+
+This is the **first concrete OpenAPI spec checked into the Grid.** It exercises packet 03's diff gate (first run: no prior tag → falls back to branch mode; no prior file on `main` → first-introduction info-level pass), packet 05's docs publication (first build of `docs.web-rest.honeydrunkstudios.com/v1/` — Cloudflare Pages project must exist; per the dispatch plan's deferral note, the first docs publication is dry-run until packet 09's per-API docs subdomain provisioning extends to Web.Rest in a follow-up).
+
+The version bump is `0.5.0` → `0.6.0` (additive minor per ADR-0035 D1) since `ApiErrorResponse.Type` is additive, the cursor primitives are net-new, and the middleware content negotiation is additive (default-`ApiErrorResponse` preserves the existing default).
+
+## Scope
+- **`HoneyDrunk.Web.Rest/api/openapi-v1.yaml`** (new) — the reverse-engineered OpenAPI 3.1 spec. Documents the Abstractions shapes and the AspNetCore middleware behavior as a reference contract.
+- **`HoneyDrunk.Web.Rest.Abstractions/Errors/ProblemDetails.cs`** (new) — record implementing the RFC 7807 shape: `Type`, `Title`, `Status`, `Detail`, `Instance`, `TraceId`, `CorrelationId`.
+- **`HoneyDrunk.Web.Rest.Abstractions/Errors/ApiErrorResponse.cs`** — add an additive `Type` property (nullable string, defaults to null; populated by the middleware to match the RFC 7807 `type` URI for the same error category).
+- **`HoneyDrunk.Web.Rest.Abstractions/Paging/CursorPageRequest.cs`** (new) — record: `Cursor` (nullable string), `Limit` (int, default 50, max 200 per ADR-0057 D14).
+- **`HoneyDrunk.Web.Rest.Abstractions/Paging/CursorPageResult.cs`** (new) — record: `Items` (IReadOnlyList<T>), `NextCursor` (nullable string).
+- **`HoneyDrunk.Web.Rest.AspNetCore/Middleware/`** — extend the existing exception-to-error middleware to (a) build a canonical internal error record, (b) project it into `ApiErrorResponse` when the request `Accept` header prefers `application/json`, (c) project it into `ProblemDetails` (RFC 7807 `application/problem+json` media type) when the request prefers `application/problem+json`. The default-`ApiErrorResponse` preserves backwards compatibility.
+- **`HoneyDrunk.Web.Rest.AspNetCore/Middleware/`** — add a small response-decoration hook that, when an `IRateLimitState` ambient (or equivalent ASP.NET Core RateLimiter lease metadata, when the Kernel's `UseGridRateLimiting` from ADR-0067 packet 02 is wired into the consuming host) is present, projects the IETF `RateLimit-*` headers per ADR-0057 D11 / ADR-0067 D7. The hook is best-effort and a no-op when no rate-limit state is present.
+- **`HoneyDrunk.Web.Rest/docs/`** (new directory) — minimal Docusaurus scaffold (`docusaurus.config.js`, `sidebars.js`, `docs/intro.md`, `versioned_docs/version-1/` per Docusaurus convention). Narrative: a "Web.Rest conventions reference" landing page that complements the OpenAPI reference. Consumes the shared Docusaurus preset from packet 05 (if shipped) or carries its own minimal config (acceptable per packet 05's constraint).
+- **`HoneyDrunk.Web.Rest/.github/workflows/`** — wire the reusable workflows from packets 03 and 05:
+  - `pr-openapi.yml` — calls `job-openapi-diff.yml` on every PR touching `HoneyDrunk.Web.Rest/api/openapi-v*.yaml`.
+  - `release.yml` (or extend existing release workflow) — on tag matching `web-rest-api-v*`, calls `job-publish-docs.yml`. (SDK publication via `job-publish-public-sdk.yml` is **deferred for Web.Rest** — Web.Rest is a library Node consumed by .NET callers via NuGet; no TS / Swift / Kotlin SDK is published per the ADR-0057 D8 deferred-list reasoning extended to .NET-consumer libraries.)
+- **Tests** — unit tests for: the middleware's content negotiation (Accept `application/json` → `ApiErrorResponse`; Accept `application/problem+json` → `ProblemDetails`; missing/wildcard Accept → `ApiErrorResponse`); the new `Type` field on `ApiErrorResponse`; the `CursorPageRequest`/`CursorPageResult` shapes (record equality, default `Limit=50`, validation of `Limit<=200`); the response decoration hook for `RateLimit-*` headers (best-effort; no-op when state absent).
+- **Version bump.** Both non-test `.csproj` files in the Web.Rest solution from `0.5.0` to `0.6.0` (invariant 27). Repo-level `CHANGELOG.md` gets a new dated `[0.6.0]` entry. Per-package CHANGELOGs: `HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md` gets an entry (new types added — `ProblemDetails`, `CursorPageRequest`, `CursorPageResult`, `ApiErrorResponse.Type` field); `HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md` gets an entry (content negotiation + rate-limit-header hook). `HoneyDrunk.Web.Rest.Canary` (the contract-shape canary) is updated to assert the new types are exposed.
+- **`HoneyDrunk.Web.Rest/README.md`** — document the OpenAPI v1 spec, the content-negotiation behavior, the cursor pagination primitives, the v1 freeze, and the v2-future conventions (cursor-default-on-list-endpoints, RFC-7807-default-on-error-responses).
+- **Repo-level `catalogs/contracts.json` update in HoneyDrunk.Architecture** — packet 01 introduced the `publicHttpApi` block on the `honeydrunk-web-rest` entry with `surfaceName` / `currentMajor` only; this packet populates `openApiSpecPath: "repos/HoneyDrunk.Web.Rest/api/openapi-v1.yaml"` and `docsUrl: "https://docs.web-rest.honeydrunkstudios.com/v1/"` (deferred to a small Architecture-side update PR by the executor if the per-repo target is awkward — flag it in the PR). `sdkCoordinates` stays empty (no public SDK per the deferred-language reasoning above).
+
+## Proposed Implementation
+1. **Author the OpenAPI 3.1 spec.** The spec documents the Web.Rest *convention* surface:
+   - `info.title: "HoneyDrunk.Web.Rest Conventions"`, `info.version: "1.0.0"`, `openapi: "3.1.0"`.
+   - `components.schemas`: `ApiResult` (oneOf success/failure), `ApiResult_Of_T` (generic schema referenced by spec callers), `ApiErrorResponse` (with the new `Type` field), `ApiError`, `ApiErrorCode` (enum), `ValidationError`, `ProblemDetails` (RFC 7807), `PageRequest`, `PageResult`, `CursorPageRequest`, `CursorPageResult`.
+   - `components.responses`: `ProblemResponse` (media type `application/problem+json` → `ProblemDetails`); `ErrorResponse` (media type `application/json` → `ApiErrorResponse`).
+   - `paths`: empty (Web.Rest does not expose endpoints — it ships conventions). The spec ships an `x-honeydrunk-conventions: true` extension to signal this to docs and SDK generators (the SDK generator should NOT generate a client for this spec — it is reference-only).
+   - `info.x-rate-limits`: documented per ADR-0067 D7 / ADR-0057 D11 convention (the limits themselves are deferred to consuming services; this spec documents the header shape).
+   - `info.x-honeydrunk-content-negotiation`: documents the Option C content negotiation (`application/json` → `ApiErrorResponse`; `application/problem+json` → `ProblemDetails`).
+2. **`ProblemDetails.cs`** — record matching RFC 7807. JSON-serializable with `System.Text.Json` lower-case key names; `Type` / `Title` / `Status` / `Detail` / `Instance` are RFC; `TraceId` / `CorrelationId` are Studios extensions (acceptable per RFC 7807 §3.2 "Members of a problem type can be extended").
+3. **`ApiErrorResponse.cs`** — add the new optional `Type` property (nullable string, default null). Existing consumers continue to ignore the field per ADR-0057 D4 "new response field is non-breaking, conditional on the client-side ignore-unknown-fields rule" — which `System.Text.Json` honors by default with its `JsonIgnoreCondition.WhenWritingNull`. The Web.Rest README adds a note to the conventions doc reminding consumers that new optional fields may appear.
+4. **`CursorPageRequest.cs` / `CursorPageResult.cs`** — records matching ADR-0057 D14 shape. `CursorPageRequest`: `string? Cursor`, `int Limit = 50` with constructor-side validation `Limit >= 1 && Limit <= 200`. `CursorPageResult<T>`: `IReadOnlyList<T> Items`, `string? NextCursor`.
+5. **Middleware content negotiation.** In the existing exception-to-error middleware (or its constructor/extension):
+   - Build the canonical internal error record from the exception (existing code path).
+   - Inspect `HttpContext.Request.Headers.Accept`. If `application/problem+json` is present and its quality is `>= application/json`'s quality (or `application/json` is absent), set the response `Content-Type = application/problem+json` and serialize the canonical record into a `ProblemDetails` shape. Otherwise, set `Content-Type = application/json` and serialize into the existing `ApiErrorResponse` shape (now with the optional `Type` field populated).
+   - The `Type` URI is the per-error-category URI per ADR-0057 D12. Web.Rest's middleware ships a small lookup table mapping `ApiErrorCode` → `type URI` (each URI at `https://docs.honeydrunkstudios.com/errors/web-rest/{category}/`). The lookup is `internal static`; consuming services that introduce new error codes register their own URIs via an opt-in extension (defer to a future packet if needed — the Web.Rest-defined codes have URIs in this packet).
+   - The `TraceId` is sourced from `Activity.Current?.Id` (W3C `traceparent` per ADR-0040). The `CorrelationId` is sourced from the existing `IOperationContextAccessor` (per ADR-0045's `ErrorContext`).
+6. **`RateLimit-*` header hook.** A small middleware (`UseRateLimitHeaders()` extension on `IApplicationBuilder`) that, after the response is being prepared, inspects the rate-limit context if present and emits the `RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset` headers per ADR-0057 D11 / ADR-0067 D7. Best-effort, no-op when context absent. When the consuming host wires the Kernel's `UseGridRateLimiting` from ADR-0067 packet 02, the Kernel middleware emits the headers itself; Web.Rest's hook is a defensive fallback for any host that needs the headers but isn't on the Kernel limiter yet.
+7. **Docusaurus scaffold.** A minimal `docs/` directory: `docusaurus.config.js`, `sidebars.js`, `docs/intro.md` (the conventions landing page), `versioned_docs/version-1/intro.md` (the v1 frozen narrative). The narrative covers: what Web.Rest is, what `ApiResult<T>` / `ApiErrorResponse` / `ProblemDetails` are, how to opt into RFC 7807 via `Accept`, cursor vs. offset pagination conventions, the IETF rate-limit header set, the v1 freeze.
+8. **Per-repo CI workflows.** Add `.github/workflows/pr-openapi.yml` (calls `job-openapi-diff.yml` per packet 03) and extend the existing release workflow to call `job-publish-docs.yml` per packet 05 on `web-rest-api-v*` tags. The docs deploy runs in dry-run until the `docs.web-rest.honeydrunkstudios.com` Pages project is provisioned (packet 09 covers Notify; Web.Rest's docs subdomain follows the same playbook in a follow-up).
+9. **Tests** — assert the content negotiation, the new field, the cursor primitives, the rate-limit header hook.
+10. **Version bump + CHANGELOGs + README.**
+11. **Architecture-side `catalogs/contracts.json` follow-up note** — if it's awkward for this packet (which targets Web.Rest) to also touch the Architecture catalog, flag it as a small follow-up packet against Architecture. The note in the PR is sufficient; the catalog update can land in a tiny `12-architecture-web-rest-contracts-update.md` follow-up if necessary, or be batched into a later catalog-update packet.
+
+## Affected Files
+- `HoneyDrunk.Web.Rest/api/openapi-v1.yaml` (new)
+- `HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Errors/ProblemDetails.cs` (new)
+- `HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Errors/ApiErrorResponse.cs` (additive change)
+- `HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Paging/CursorPageRequest.cs` (new)
+- `HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/Paging/CursorPageResult.cs` (new)
+- `HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/Middleware/` — extension for content negotiation + the rate-limit header hook
+- `HoneyDrunk.Web.Rest/docs/` (new directory + Docusaurus scaffold)
+- `HoneyDrunk.Web.Rest/.github/workflows/pr-openapi.yml` (new)
+- `HoneyDrunk.Web.Rest/.github/workflows/` release workflow (extension to call `job-publish-docs.yml`)
+- `HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.Abstractions/HoneyDrunk.Web.Rest.Abstractions.csproj` (version bump)
+- `HoneyDrunk.Web.Rest/HoneyDrunk.Web.Rest.AspNetCore/HoneyDrunk.Web.Rest.AspNetCore.csproj` (version bump)
+- Per-package CHANGELOGs (`HoneyDrunk.Web.Rest.Abstractions/CHANGELOG.md`, `HoneyDrunk.Web.Rest.AspNetCore/CHANGELOG.md`)
+- Repo-level `HoneyDrunk.Web.Rest/CHANGELOG.md` (new dated `[0.6.0]` entry)
+- `HoneyDrunk.Web.Rest/README.md`
+- `HoneyDrunk.Web.Rest.Tests/` — new tests for content negotiation, cursor primitives, rate-limit hook
+- `HoneyDrunk.Web.Rest.Canary/` — updated to assert the new types
+
+## NuGet Dependencies
+- **`HoneyDrunk.Web.Rest.Abstractions`** — no new `PackageReference`. RFC 7807 shape is a Studios-defined record; no library dependency needed. (Note: `Microsoft.AspNetCore.Mvc.Core` ships its own `Microsoft.AspNetCore.Mvc.ProblemDetails` — we deliberately do NOT consume that one in Abstractions because Abstractions is zero-HoneyDrunk-and-zero-AspNetCore-runtime-dependency per the package's existing posture.)
+- **`HoneyDrunk.Web.Rest.AspNetCore`** — no new `PackageReference`. The middleware extension uses existing ASP.NET Core APIs.
+
+## Boundary Check
+- [x] `HoneyDrunk.Web.Rest` per routing rule "REST conventions, response standardization, middleware → HoneyDrunk.Web.Rest".
+- [x] New types in `Abstractions` are zero-dependency (no HoneyDrunk runtime, no ASP.NET Core types in Abstractions per the package's existing posture — invariant 1).
+- [x] Middleware lives in `AspNetCore` package only.
+- [x] All shape additions are additive per ADR-0057 D4 (`ApiErrorResponse.Type` new optional field; new types in Abstractions; new middleware) — the breaking-change diff gate (packet 03) will pass.
+- [x] No cross-Node runtime dependency added.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Web.Rest/api/openapi-v1.yaml` is checked in; OpenAPI 3.1 (not 3.0); documents the convention surface (`ApiResult`, `ApiErrorResponse` with new `Type`, `ProblemDetails`, `PageRequest`/`PageResult`, `CursorPageRequest`/`CursorPageResult`, the IETF `RateLimit-*` header set, the content-negotiation convention); `info.x-honeydrunk-conventions: true` extension is set
+- [ ] `HoneyDrunk.Web.Rest.Abstractions/Errors/ProblemDetails.cs` is a new record matching RFC 7807 fields plus the `TraceId` / `CorrelationId` Studios extensions
+- [ ] `ApiErrorResponse` gains an optional `Type` (nullable string, default null) property — additive
+- [ ] `CursorPageRequest` and `CursorPageResult` are new records in `Paging/`; `Limit` defaults to 50, validates `1 <= Limit <= 200`
+- [ ] The middleware does content negotiation: `Accept: application/problem+json` → emits `ProblemDetails`; otherwise emits the existing `ApiErrorResponse` (now with `Type` populated from the per-`ApiErrorCode` lookup table)
+- [ ] The middleware sources `TraceId` from `Activity.Current?.Id` and `CorrelationId` from `IOperationContextAccessor`
+- [ ] A new `UseRateLimitHeaders()` middleware extension exists in `AspNetCore` that emits IETF `RateLimit-*` headers when rate-limit context is present, no-op otherwise
+- [ ] `HoneyDrunk.Web.Rest/docs/` carries a minimal Docusaurus scaffold (config, sidebars, intro, versioned-docs structure for v1)
+- [ ] `HoneyDrunk.Web.Rest/.github/workflows/pr-openapi.yml` calls `job-openapi-diff.yml` from `HoneyDrunk.Actions`
+- [ ] The release workflow (existing or new) calls `job-publish-docs.yml` from `HoneyDrunk.Actions` on `web-rest-api-v*` tags (dry-run until the `docs.web-rest.honeydrunkstudios.com` Pages project exists)
+- [ ] Web.Rest is **not** wired to `job-publish-public-sdk.yml` (Web.Rest is a .NET-consumer library; per ADR-0057 D8's deferred-language reasoning, no TS / Swift / Kotlin SDK is published)
+- [ ] Tests cover: content negotiation (three Accept cases); `ApiErrorResponse.Type` populated and round-tripped; `CursorPageRequest` defaults and validation; `CursorPageResult` shape; `UseRateLimitHeaders` no-op without context and emit-correct with context
+- [ ] Both non-test `.csproj` files at `0.6.0` in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` carries a new dated `[0.6.0]` entry (no `[Unreleased]`)
+- [ ] Per-package CHANGELOGs (`Abstractions`, `AspNetCore`) get `[0.6.0]` entries
+- [ ] `Canary` project asserts the new types are exposed (contract-shape canary)
+- [ ] `README.md` documents the OpenAPI v1 spec, content negotiation, cursor primitives, v1 freeze, and v2-future conventions
+- [ ] No invariant edit in this packet — invariants `{N1}-{N4}` land via packet 00; this packet honors them
+- [ ] The first run of `job-openapi-diff.yml` against `openapi-v1.yaml` passes (first-introduction case)
+
+## Human Prerequisites
+- [ ] **Publishing the upstream NuGet package** — after this packet merges, a human pushes a git release tag `v0.6.0` (or `web-rest-v0.6.0` per the repo convention) so consuming services can compile against the new `HoneyDrunk.Web.Rest.Abstractions` `0.6.0` shape. The `web-rest-api-v1.0.0` tag (separate from the package release tag) is pushed at the same time to trigger the `job-publish-docs.yml` workflow (dry-run until packet 09 + Web.Rest docs subdomain provisioning).
+- [ ] **Cloudflare Pages project for `docs.web-rest.honeydrunkstudios.com`** — packet 09 provisions the Notify docs subdomain; the Web.Rest docs subdomain follows the same playbook in a follow-up (operator-time). Until then, the docs deploy runs in dry-run via the `job-publish-docs.yml` fallback. This is acceptable for Phase 1 pilot — the substrate is exercised, the docs are buildable, deployment is the deferred-but-easy last mile.
+- [ ] **`catalogs/contracts.json` update** — the Architecture-side update (populating `openApiSpecPath` and `docsUrl` on the `honeydrunk-web-rest` `publicHttpApi` block) is awkward to land from a Web.Rest PR. State the choice in this PR: either (a) include a sibling commit to `HoneyDrunk.Architecture` if the merge sequence allows, or (b) file a tiny `12-architecture-web-rest-contracts-update.md` follow-up packet (operator decision; either is acceptable).
+
+## Referenced ADR Decisions
+**ADR-0057 D17 Phase 1 — Pilot on HoneyDrunk.Web.Rest.** "Pilot all of this on a low-risk surface — likely `HoneyDrunk.Web.Rest` v1 (already Live; the spec is reverse-engineered from the existing endpoints and the version freezes at v1)."
+
+**ADR-0057 D7 — OpenAPI 3.1 as the source of truth.** Spec at `repos/{node}/api/openapi-v{n}.yaml`. Web.Rest's spec documents the convention surface rather than endpoints — `info.x-honeydrunk-conventions: true` extension is the signal.
+
+**ADR-0057 D12 — RFC 7807 error envelope.** `application/problem+json` with `type` URI at `docs.honeydrunkstudios.com/errors/web-rest/{category}/`, plus `traceId` (W3C `traceparent`) and `correlationId` (per ADR-0045 `ErrorContext`).
+
+**ADR-0057 D4 — Additive changes are non-breaking.** New optional response field (`ApiErrorResponse.Type`), new endpoints, new content-negotiated representations (RFC 7807 alongside existing `ApiErrorResponse`), and new optional Abstractions types (`CursorPageRequest`, `CursorPageResult`, `ProblemDetails`) are all non-breaking. The OpenAPI diff gate (packet 03) confirms.
+
+**ADR-0057 D11 (reconciled with ADR-0067) — Rate-limit envelope.** IETF unprefixed `RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset`. Web.Rest's middleware ships the response-decoration hook; the Kernel-side wiring (ADR-0067 packet 02) emits the headers via its own middleware when composed.
+
+**ADR-0057 D14 — Cursor-based pagination.** Default `limit=50`, max `limit=200`. Cursor opacity, 24h server-side TTL, `410 Gone` per-D12 on expired cursor. Web.Rest ships the Abstractions primitives; the v1 spec documents the existing offset shape (frozen at v1 per the pilot's freeze rule); cursor is the v2-default convention.
+
+**ADR-0057 D8 (referenced — deferral) — SDK languages.** No TypeScript / Swift / Kotlin SDK is published for Web.Rest; Web.Rest is a .NET-consumer library and falls under the C# .NET deferred-language reasoning.
+
+**ADR-0035 D1 (referenced) — Additive minor bump.** `0.5.0` → `0.6.0` is a minor bump for the additive changes.
+
+**Invariant 27 — One version across the solution.** Both non-test `.csproj` files at `0.6.0` in one commit.
+
+**Invariant `{N1}` — Every public REST API has a checked-in OpenAPI 3.1 spec.** Web.Rest's spec lands here; this packet satisfies the invariant for Web.Rest.
+
+## Constraints
+- **Option C is pinned** — additive RFC 7807 alongside existing `ApiErrorResponse` via content negotiation; defaults to `ApiErrorResponse` for backwards compatibility. The other two options (sudden cutover; defer-to-v2) were rejected at refine time.
+- **v1 freeze.** Any breaking change after this packet bumps to v2 per invariant `{N2}`. The freeze is enforced by the OpenAPI-diff gate.
+- **Abstractions has no HoneyDrunk-runtime and no ASP.NET Core dependency.** `ProblemDetails` is Studios-defined; do NOT consume `Microsoft.AspNetCore.Mvc.ProblemDetails` in Abstractions.
+- **No public SDK for Web.Rest.** Web.Rest is consumed by .NET callers via NuGet; the per-language SDK pipeline does not apply.
+- **First-run OpenAPI diff is the no-prior-tag-no-prior-file case.** Packet 03's workflow handles this with an info-level pass.
+- **Cloudflare Pages provisioning for `docs.web-rest.honeydrunkstudios.com` is deferred.** Dry-run docs deploy is acceptable for v1.
+- **`Type` URI lookup for `ApiErrorCode`** — Web.Rest ships URIs for the codes it defines; consuming services that introduce new codes register URIs via an opt-in extension (defer the extension API to a future packet if needed; v1 covers the Web.Rest-defined codes).
+- **The `IOperationContextAccessor` and `Activity.Current` integrations** are the existing Web.Rest mechanisms — no new contract.
+- **No `Unreleased` CHANGELOG.**
+
+## Labels
+`feature`, `tier-2`, `core`, `adr-0057`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Pilot ADR-0057's Phase 1 substrate on `HoneyDrunk.Web.Rest`: reverse-engineer the OpenAPI 3.1 v1 spec; freeze the surface at v1; ship Option C envelope alignment (additive RFC 7807 alongside `ApiErrorResponse` via content negotiation); add cursor pagination primitives; add IETF `RateLimit-*` header hook; scaffold Docusaurus docs; wire the per-repo CI to call `job-openapi-diff.yml` and `job-publish-docs.yml`; bump to `0.6.0`.
+
+**Target:** `HoneyDrunk.Web.Rest`, branch from `main`.
+
+**Context:**
+- Goal: Exercise the full ADR-0057 substrate on a low-risk surface before Notify's higher-stakes Phase 2 pilot.
+- Feature: ADR-0057 rollout, Wave 3 (Phase 1 pilot).
+- ADRs: ADR-0057 D17 Phase 1 / D7 / D12 / D4 / D11 / D14 / D8 (primary); ADR-0067 (rate-limit-header reconciliation); ADR-0035 D1 (additive minor bump); ADR-0040 (`Activity.Current` for traceId); ADR-0045 (`IOperationContextAccessor` for correlationId); ADR-0075 (Docusaurus narrative).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0057 Accepted; invariants `{N1}-{N4}` live.
+- `packet:01` — tech-stack.md + `publicHttpApi` block convention.
+- `packet:03` — `job-openapi-diff.yml` exists and is consumable.
+- `packet:05` — `job-publish-docs.yml` exists and is consumable (dry-run for the first Web.Rest docs deploy until per-API Pages provisioning catches up).
+
+**Constraints:**
+- Option C pinned.
+- v1 freeze enforced by the diff gate.
+- Abstractions zero-runtime-dependency preserved.
+- No public TS / Swift / Kotlin SDK.
+- One version across both packages.
+- No `Unreleased` CHANGELOG.
+- Cloudflare Pages for Web.Rest docs is deferred (dry-run acceptable).
+
+**Key Files:**
+- `HoneyDrunk.Web.Rest/api/openapi-v1.yaml` (new)
+- `HoneyDrunk.Web.Rest.Abstractions/Errors/ProblemDetails.cs` (new)
+- `HoneyDrunk.Web.Rest.Abstractions/Errors/ApiErrorResponse.cs` (additive `Type` field)
+- `HoneyDrunk.Web.Rest.Abstractions/Paging/CursorPageRequest.cs`, `CursorPageResult.cs` (new)
+- `HoneyDrunk.Web.Rest.AspNetCore/Middleware/` (content negotiation + rate-limit hook)
+- `HoneyDrunk.Web.Rest/docs/` (Docusaurus scaffold)
+- `HoneyDrunk.Web.Rest/.github/workflows/` (per-repo wiring)
+- Both `.csproj` files (version bump)
+- CHANGELOGs + README + Canary updates
+
+**Contracts:**
+- `ProblemDetails` (new record).
+- `CursorPageRequest`, `CursorPageResult` (new records).
+- `ApiErrorResponse.Type` (new optional property).
+- `UseRateLimitHeaders` (new middleware extension).
+- `ApiResult`, `ApiErrorResponse`, `ApiError`, `ApiErrorCode`, `ValidationError`, `PageRequest`, `PageResult` (existing — preserved).

--- a/generated/issue-packets/active/adr-0057-api-versioning/08-notify-openapi-v1-and-sdk-pilot.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/08-notify-openapi-v1-and-sdk-pilot.md
@@ -1,0 +1,194 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["feature", "tier-2", "core", "adr-0057", "wave-4"]
+dependencies: ["packet:00", "packet:01", "packet:03", "packet:04", "packet:05", "packet:07"]
+adrs: ["ADR-0057"]
+wave: 4
+initiative: adr-0057-api-versioning
+node: honeydrunk-notify
+---
+
+# Author openapi-v1.yaml for HoneyDrunk.Notify and pilot the SDK + docs publication (Phase 2)
+
+## Summary
+The Phase 2 pilot per ADR-0057 D17 — the dry run for Notify Cloud GA. `HoneyDrunk.Notify` exposes a small set of internal-Grid HTTP endpoints today (intake / send / status / templates per the existing Notify endpoints); this packet authors `HoneyDrunk.Notify/api/openapi-v1.yaml` capturing those endpoints in OpenAPI 3.1 with the full ADR-0057 conventions: RFC 7807 errors with the `type` URI at `docs.honeydrunkstudios.com/errors/notify/{category}/`; cursor pagination on list endpoints (message history, templates list); IETF `RateLimit-*` headers documented in `info.x-rate-limits`; `Idempotency-Key` required on `POST /v1/notify/send` (Notify's billing-relevant endpoint per ADR-0042 + ADR-0057 D13); per-`securitySchemes` API key auth declaration. Scaffold Notify's `docs/` Docusaurus tree; wire the per-repo CI to call `job-openapi-diff.yml`, `job-publish-public-sdk.yml`, and `job-publish-docs.yml` from `HoneyDrunk.Actions`. Tag the first release `notify-api-v1.0.0` to trigger the publication pipeline. SDKs publish in dry-run until packet 11's operator onboarding seeds the per-registry credentials.
+
+## Context
+ADR-0057 D17 Phase 2 names Notify as the second pilot: *"`HoneyDrunk.Notify`'s existing endpoints get an OpenAPI v1 spec checked in. SDKs published to all three registries. Docs site live at `docs.notify.honeydrunkstudios.com/v1/`. This is the dry run for Notify Cloud GA."* Notify is more substantive than Web.Rest because it ships actual endpoints (intake, send, status, templates) rather than conventions; the OpenAPI spec is per-endpoint and the SDK generation produces real-callable clients.
+
+`HoneyDrunk.Notify` is Live at `0.3.0` per `catalogs/nodes.json`. It ships a large solution: `HoneyDrunk.Notify` (core), `HoneyDrunk.Notify.Abstractions` (zero-dependency contracts), `HoneyDrunk.Notify.Functions` (Azure Functions host shape), `HoneyDrunk.Notify.HostBootstrap`, `HoneyDrunk.Notify.Hosting.AspNetCore`, `HoneyDrunk.Notify.IntegrationTests`, `HoneyDrunk.Notify.ProviderSupport`, `HoneyDrunk.Notify.Providers.Email.Resend`, `HoneyDrunk.Notify.Providers.Email.Smtp`, `HoneyDrunk.Notify.Providers.Sms.Twilio`, `HoneyDrunk.Notify.Queue.Abstractions`, `HoneyDrunk.Notify.Queue.AzureStorage`, `HoneyDrunk.Notify.Queue.InMemory`, `HoneyDrunk.Notify.Worker`, `HoneyDrunk.Notify.Tools`, plus the test project and a separate `HoneyDrunk.Notify.Tests`. The HTTP endpoints exposed today live in `HoneyDrunk.Notify.Hosting.AspNetCore` (the API host) and `HoneyDrunk.Notify.Functions` (the Functions host); both expose roughly the same intake / send / status surface. The OpenAPI v1 spec captures the AspNetCore-host shape as canonical (Functions-host parity is preserved at the controller layer; spec deviations between the two are flagged in the README).
+
+**Notify is NOT Notify Cloud.** `HoneyDrunk.Notify` is the internal-Grid intake/delivery substrate consumed by other Grid Nodes (Web.Rest passes to Notify for tenant emails; Communications routes deprecation-notification through Notify per packet 01's named flow); `HoneyDrunk.Notify.Cloud` is the future commercial product (PDR-0002 / ADR-0027). The two surfaces are related but distinct — Notify Cloud will eventually expose its own OpenAPI spec with its own commercial endpoints (per ADR-0057 D17 Phase 3, deferred). Notify's v1 spec here documents the internal-Grid surface; it's a useful exercise for the SDK pipeline and the docs publication but its SDKs are unlikely to have external consumers at this scale.
+
+Per ADR-0057 D8, the three SDKs publish to npm / Maven Central / Swift Package Index. Notify's SDKs (`@honeydrunk/notify-sdk`, `com.honeydrunkstudios:notify-sdk`, `HoneyDrunkNotifySdk`) are the **first concrete instances** of the SDK pipeline. They publish in dry-run mode until packet 11's operator onboarding completes; once credentials are seeded, the first tag push (`notify-api-v1.0.0`) publishes for real.
+
+The version bump on the Notify solution itself is `0.3.0` → `0.4.0` (minor; additive — the new `api/openapi-v1.yaml` is reference-only, the `docs/` is new, the workflow wiring is config). No package shape change.
+
+**Cursor pagination on Notify list endpoints.** Notify has list endpoints for message history (`GET /v1/notify/messages`) and templates (`GET /v1/notify/templates`). Per ADR-0057 D14, both move to cursor pagination at v1. This is a small behavior change for any internal Grid caller that uses these endpoints — the existing offset behavior (if any) becomes secondary or removed. **Check at execution time** whether the Notify endpoints currently expose offset-based pagination; if yes, the v1 spec documents cursor as the default and offset as a deprecated query parameter (`?offset=N&limit=N` returns the same shape but with an audit signal — to be removed at v2). If no offset pagination exists today, cursor is the only shape from v1.
+
+The executor confirms the current endpoint shape at PR time by reading the Notify AspNetCore controllers and then commits the v1 spec that captures the current behavior plus the ADR-0057 conventions (RFC 7807 errors, IETF rate-limit headers documented, `Idempotency-Key` on `POST /v1/notify/send`). The breaking-change diff gate (packet 03) runs in first-introduction mode (no prior spec exists).
+
+## Scope
+- **`HoneyDrunk.Notify/api/openapi-v1.yaml`** (new) — OpenAPI 3.1 spec for the AspNetCore-host endpoints. Covers (at minimum, confirmed against the actual controllers at PR time): `POST /v1/notify/send` (with `Idempotency-Key` required), `GET /v1/notify/messages/{id}` (status lookup), `GET /v1/notify/messages` (list — cursor pagination), `GET /v1/notify/templates` (list — cursor pagination), `POST /v1/notify/templates` (create), `GET /v1/notify/templates/{id}` (read), `PUT /v1/notify/templates/{id}` (update — `Idempotency-Key` recommended), `DELETE /v1/notify/templates/{id}` (delete). Confirm the actual endpoint list against the controllers at execution time and add / remove as appropriate. `components.responses` covers `400`, `401`, `403`, `404`, `409`, `410` (cursor expired), `422`, `429`, `500` — each as RFC 7807 `application/problem+json`. `components.schemas` declares `SendRequest`, `MessageStatus`, `Template`, `CreateTemplateRequest`, `UpdateTemplateRequest`, `ProblemDetails` (the ADR-0057 D12 shape), `CursorPageResult` parametrized over `MessageStatus` and `Template`. `info.x-rate-limits` documents the per-tenant default limits (defer the concrete numbers to a future Notify-internal review; the substrate documents the convention). `securitySchemes` declares `apiKey` (`Authorization: Bearer {key}`).
+- **`HoneyDrunk.Notify/docs/`** (new directory) — Docusaurus scaffold consuming the shared preset from packet 05 (or its own minimal config). Narrative: getting started, authentication, idempotency, pagination, rate limits, error handling, migration-to-future-majors.
+- **`HoneyDrunk.Notify/.github/workflows/pr-openapi.yml`** (new) — calls `job-openapi-diff.yml` on PRs touching `HoneyDrunk.Notify/api/openapi-v*.yaml`.
+- **`HoneyDrunk.Notify/.github/workflows/release-api.yml`** (new) — on tag `notify-api-v*`, calls `job-publish-public-sdk.yml` (all three languages enabled) and `job-publish-docs.yml`. Secret pass-through wired but the workflows run in dry-run when secrets are absent.
+- **Endpoint behavior alignment** — confirm the actual endpoints return RFC 7807 errors (use the `HoneyDrunk.Web.Rest` middleware from packet 07 with the `Accept: application/problem+json` content negotiation as the path of least resistance — Notify's API host consumes `HoneyDrunk.Web.Rest.AspNetCore`, so wiring the middleware once on the host gives RFC 7807 for free for any caller that opts in via `Accept`). The actual default error envelope for clients that don't set `Accept` remains the existing Notify shape (Option C — non-breaking).
+- **Idempotency wiring** — `POST /v1/notify/send` and `PUT /v1/notify/templates/{id}` consume `Idempotency-Key` via the `IIdempotencyStore` from ADR-0042. If ADR-0042's substrate is not yet wired into Notify at PR time, document the gap and ship the OpenAPI-spec-side `Idempotency-Key` parameter declaration anyway (the spec is the contract; runtime enforcement lands when the substrate catches up). State the choice in the PR.
+- **Cursor pagination** — confirm at PR time whether the existing controllers paginate; if they do, refactor `GET /v1/notify/messages` and `GET /v1/notify/templates` to consume `CursorPageRequest` (from packet 07's `HoneyDrunk.Web.Rest.Abstractions`) and return `CursorPageResult<T>`. If they don't paginate today, add cursor pagination as a new feature in this packet (this is additive — non-breaking — and consistent with the v1 spec).
+- **Tag and trigger** — at the end of the packet, the operator pushes `notify-api-v1.0.0` to trigger the publication workflows. The push is **deferred to the operator** (agents never tag per the convention); this packet ships the workflow wiring but does not push the tag. The Human Prerequisites list calls this out.
+- **Version bump.** `HoneyDrunk.Notify` solution from `0.3.0` to `0.4.0` (additive minor); every non-test `.csproj` in one commit per invariant 27. Per-package CHANGELOGs only for packages with actual changes (the AspNetCore host + controllers if cursor pagination is added; the Abstractions if any new types — likely none, since the cursor primitives are pulled from `HoneyDrunk.Web.Rest.Abstractions`). Repo-level `CHANGELOG.md` gets a new dated `[0.4.0]` entry.
+- **`HoneyDrunk.Notify/README.md`** — document the new OpenAPI v1 spec, the docs site at `docs.notify.honeydrunkstudios.com/v1/`, the SDK coordinates, and the v1 freeze.
+- **Architecture-side `catalogs/contracts.json` update** — same as packet 07's note: either include a sibling commit to `HoneyDrunk.Architecture` populating the `honeydrunk-notify` `publicHttpApi` block's `openApiSpecPath`, `sdkCoordinates`, and `docsUrl`, or file a tiny follow-up packet (operator decision).
+
+## Proposed Implementation
+1. **Read the current Notify AspNetCore controllers** to enumerate the actual exposed endpoints. Confirm method / path / request shape / response shape for each.
+2. **Author `api/openapi-v1.yaml`** matching the enumerated endpoints with the ADR-0057 conventions baked in:
+   - `info.title: "HoneyDrunk Notify"`, `info.version: "1.0.0"`, `openapi: "3.1.0"`.
+   - `info.x-rate-limits`: per-tenant defaults (free-tier-default numbers — substrate-level only; the actual per-tier limits emerge during Notify Cloud commercialization per ADR-0027 + ADR-0067 D3).
+   - `components.responses`: every non-2xx response is `application/problem+json` → `ProblemDetails`.
+   - `components.schemas.ProblemDetails`: the ADR-0057 D12 shape (`type`, `title`, `status`, `detail`, `instance`, `traceId`, `correlationId`).
+   - `securitySchemes`: `apiKey` (Bearer in Authorization header per ADR-0057 D10).
+   - Per-endpoint `parameters` include `Idempotency-Key` (header parameter) on `POST /v1/notify/send` as required; on `PUT /v1/notify/templates/{id}` as recommended.
+   - List endpoints document `cursor` and `limit` query parameters per ADR-0057 D14.
+   - The `info.x-honeydrunk-content-negotiation` extension documents that the AspNetCore host honors `Accept: application/problem+json` for error responses (Option C from packet 07 inherited via the Web.Rest middleware).
+3. **Scaffold `docs/`** matching packet 07's Docusaurus structure. Narrative pages: `intro.md` (what Notify is), `auth.md` (Bearer API key per D10), `idempotency.md` (the `Idempotency-Key` contract per D13), `pagination.md` (cursor per D14, with the 410-gone behavior on expired cursor), `rate-limits.md` (IETF headers per D11; per-tenant), `errors.md` (RFC 7807 per D12, with the `type` URI catalog), `migrating-to-v2.md` (placeholder; will be rendered from the migration-guide template per packet 02 when v2 ships). Versioned at `versioned_docs/version-1/`.
+4. **Wire per-repo CI workflows.**
+   - `.github/workflows/pr-openapi.yml` — invokes `job-openapi-diff.yml` per packet 03 on PRs touching the spec file.
+   - `.github/workflows/release-api.yml` — invokes `job-publish-public-sdk.yml` (TS + Swift + Kotlin enabled) and `job-publish-docs.yml` on `notify-api-v*` tag pushes. Pass through the secret env vars; dry-run when absent.
+5. **Refactor list-endpoint controllers** to consume `CursorPageRequest` from `HoneyDrunk.Web.Rest.Abstractions` (packet 07's new types) and return `CursorPageResult<T>`. This is additive if the existing endpoints aren't paginated; if they were offset-paginated, the v1 spec captures both with the migration note. Add the `HoneyDrunk.Web.Rest.Abstractions` `0.6.0` `PackageReference` if not already present (it likely is — Notify consumes Web.Rest per `catalogs/relationships.json`).
+6. **Wire `Idempotency-Key` enforcement on `POST /v1/notify/send`** via the `IIdempotencyStore` from ADR-0042. If ADR-0042's wiring is incomplete in Notify at PR time, the controller can return a 501 / 400 indicating the substrate is not yet live, or the wiring is deferred to a follow-up packet against Notify after ADR-0042 substrate is universal. State the choice in the PR.
+7. **Version bump + CHANGELOGs + README + Canary.**
+8. **Architecture-side catalog update note.**
+
+## Affected Files
+- `HoneyDrunk.Notify/api/openapi-v1.yaml` (new)
+- `HoneyDrunk.Notify/docs/` (new directory + Docusaurus scaffold)
+- `HoneyDrunk.Notify/.github/workflows/pr-openapi.yml` (new)
+- `HoneyDrunk.Notify/.github/workflows/release-api.yml` (new)
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.Hosting.AspNetCore/` — controller refactors for cursor pagination + RFC 7807 middleware composition + `Idempotency-Key` wiring (or deferred placeholder)
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.Functions/` — equivalent controller updates if the Functions host parallels the AspNetCore host shape
+- All non-test `.csproj` files in the Notify solution (version bump to `0.4.0`)
+- `HoneyDrunk.Notify/CHANGELOG.md` (new dated `[0.4.0]` entry)
+- Per-package CHANGELOGs only for packages with actual functional changes
+- `HoneyDrunk.Notify/README.md`
+
+## NuGet Dependencies
+- **`HoneyDrunk.Web.Rest.Abstractions` `0.6.0`** (from packet 07) — `PackageReference` on `HoneyDrunk.Notify.Hosting.AspNetCore` (likely already present; bump version pin). The cursor pagination primitives flow from there.
+- **`HoneyDrunk.Web.Rest.AspNetCore` `0.6.0`** — if Notify's host doesn't already use Web.Rest's middleware, this packet wires it (composition; no new types). Otherwise just bump the version pin.
+- **`Microsoft.AspNetCore.RateLimiting`** — transitively present via the AspNetCore framework; no explicit `PackageReference` change.
+- **`HoneyDrunk.Kernel`** — already a dependency for `IIdempotencyStore` (per ADR-0042); if the version pin needs bumping to pull in the latest, do so.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Notify`. Per routing rule.
+- [x] No code change in any other repo.
+- [x] OpenAPI spec is additive (no prior spec; first introduction).
+- [x] Cursor pagination consumes `HoneyDrunk.Web.Rest.Abstractions` primitives from packet 07 — no new abstractions in Notify itself.
+- [x] RFC 7807 middleware is `HoneyDrunk.Web.Rest.AspNetCore` composition — no new middleware logic in Notify.
+- [x] Version bump applies invariant 27 (all non-test csprojs in one commit).
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Notify/api/openapi-v1.yaml` is checked in as OpenAPI 3.1; covers the actual endpoints (confirmed against the controllers at PR time); each non-2xx response is `application/problem+json` → `ProblemDetails`; `securitySchemes` declares Bearer API key; `POST /v1/notify/send` requires `Idempotency-Key`; list endpoints document `cursor` / `limit` query parameters; `info.x-rate-limits` documents the header convention
+- [ ] `HoneyDrunk.Notify/docs/` carries a Docusaurus scaffold with at-minimum the narrative pages: `intro`, `auth`, `idempotency`, `pagination`, `rate-limits`, `errors`, `migrating-to-v2` placeholder
+- [ ] `HoneyDrunk.Notify/.github/workflows/pr-openapi.yml` calls `job-openapi-diff.yml` per packet 03
+- [ ] `HoneyDrunk.Notify/.github/workflows/release-api.yml` calls `job-publish-public-sdk.yml` (TS + Swift + Kotlin) and `job-publish-docs.yml` per packets 04 and 05; secret pass-through wired; dry-run when secrets absent
+- [ ] List endpoints (`GET /v1/notify/messages`, `GET /v1/notify/templates`) consume `CursorPageRequest` and return `CursorPageResult<T>` from `HoneyDrunk.Web.Rest.Abstractions` 0.6.0
+- [ ] `POST /v1/notify/send` enforces `Idempotency-Key` via `IIdempotencyStore` from ADR-0042 (or documents the deferred-substrate state explicitly in the PR if ADR-0042's wiring is incomplete in Notify at execution time)
+- [ ] AspNetCore host wires `HoneyDrunk.Web.Rest.AspNetCore` middleware so the RFC 7807 content negotiation (Option C from packet 07) is in effect
+- [ ] Tests cover: `POST /v1/notify/send` without `Idempotency-Key` returns a 400 problem+json; with `Idempotency-Key` succeeds (or documents the deferred-substrate state); list endpoints honor `?cursor=...&limit=...`; the `Accept: application/problem+json` flips the error envelope shape
+- [ ] All non-test `.csproj` files at `0.4.0` in one commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` carries a new dated `[0.4.0]` entry (no `[Unreleased]`)
+- [ ] Per-package CHANGELOGs entered only for packages with actual functional changes (avoid noise entries per invariant 12/27)
+- [ ] `README.md` documents the new OpenAPI v1 spec, the docs site URL, the SDK coordinates, and the v1 freeze
+- [ ] No invariant edit in this packet (invariants `{N1}-{N4}` land via packet 00; this packet honors them)
+- [ ] First run of `job-openapi-diff.yml` against `openapi-v1.yaml` passes (first-introduction case)
+
+## Human Prerequisites
+- [ ] **Publishing the upstream NuGet package** — after this packet merges, a human pushes a git release tag `v0.4.0` (or `notify-v0.4.0` per the repo convention) for the Notify NuGet packages. Agents never tag.
+- [ ] **Trigger the API publication** — push the tag `notify-api-v1.0.0` to trigger `release-api.yml` (which calls the three publication workflows). This is the first concrete invocation of the SDK + docs pipeline. **Dry-run is expected** until packet 11 seeds the credentials — the workflow logs will be loud about the dry-run reason.
+- [ ] **Cloudflare Pages project for `docs.notify.honeydrunkstudios.com`** — packet 09 (Studios) provisions this. Until packet 09 is complete, the docs publication runs in dry-run via the `job-publish-docs.yml` fallback. Re-tag (or re-run the workflow manually) after packet 09 + packet 11 complete to publish for real.
+- [ ] **npm `@honeydrunk` scope + Maven Central `com.honeydrunkstudios` namespace + Swift Package Index** — packet 11 covers the namespace onboarding. Until then, SDK publication is dry-run.
+- [ ] **Architecture-side `catalogs/contracts.json` update** — populating `openApiSpecPath: "repos/HoneyDrunk.Notify/api/openapi-v1.yaml"`, `sdkCoordinates: { typescript: "@honeydrunk/notify-sdk", swift: "HoneyDrunkNotifySdk", kotlin: "com.honeydrunkstudios:notify-sdk" }`, and `docsUrl: "https://docs.notify.honeydrunkstudios.com/v1/"` on the `honeydrunk-notify` `publicHttpApi` block — either as a sibling commit to `HoneyDrunk.Architecture` or as a tiny follow-up packet. State the choice in the PR.
+
+## Referenced ADR Decisions
+**ADR-0057 D17 Phase 2 — Notify Phase 2 pilot.** "`HoneyDrunk.Notify`'s existing endpoints get an OpenAPI v1 spec checked in. SDKs published to all three registries. Docs site live at `docs.notify.honeydrunkstudios.com/v1/`. This is the dry run for Notify Cloud GA."
+
+**ADR-0057 D7 — OpenAPI 3.1 as source of truth.** Spec at `HoneyDrunk.Notify/api/openapi-v1.yaml`.
+
+**ADR-0057 D8 — SDK languages.** `@honeydrunk/notify-sdk` (npm), `HoneyDrunkNotifySdk` (SPM), `com.honeydrunkstudios:notify-sdk` (Maven Central). Generated via `job-publish-public-sdk.yml` per packet 04.
+
+**ADR-0057 D12 — RFC 7807 error envelope.** `type` URIs at `docs.honeydrunkstudios.com/errors/notify/{category}/`. `traceId` from W3C `traceparent` (ADR-0040); `correlationId` from the `IOperationContextAccessor` (ADR-0045).
+
+**ADR-0057 D13 — Idempotency on writes.** `Idempotency-Key` required on `POST /v1/notify/send` (billing-relevant when Notify Cloud commercializes per ADR-0027 + ADR-0037); recommended on `PUT /v1/notify/templates/{id}`. SDK-generated key auto-injection per packet 04's override templates.
+
+**ADR-0057 D14 — Cursor pagination.** Default `limit=50`, max `limit=200`. Cursor opacity, 24h TTL, `410 Gone` on expired cursor. Consumes the `CursorPageRequest` / `CursorPageResult` primitives from `HoneyDrunk.Web.Rest.Abstractions` 0.6.0 (packet 07).
+
+**ADR-0057 D11 (reconciled with ADR-0067) — Rate-limit envelope.** Documented in `info.x-rate-limits`; runtime emission via `HoneyDrunk.Web.Rest.AspNetCore` middleware (packet 07's rate-limit hook) or the Kernel's `UseGridRateLimiting` (ADR-0067 packet 02 when composed into the Notify host).
+
+**ADR-0042 (referenced) — `IIdempotencyStore`.** The dedup substrate consumed by `POST /v1/notify/send` and `PUT /v1/notify/templates/{id}`. If ADR-0042's wiring is incomplete in Notify at PR time, the OpenAPI-spec-side declaration ships anyway; runtime wiring lands when the substrate catches up.
+
+**ADR-0035 D1 (referenced) — Additive minor bump.** `0.3.0` → `0.4.0`.
+
+**Invariants `{N1}` and `{N2}`** — Notify ships its first OpenAPI 3.1 spec (`{N1}`); the OpenAPI-diff gate prevents future breaking changes without a major bump (`{N2}`).
+
+## Constraints
+- **Spec contents are reverse-engineered from current controllers** — confirm against actual code at PR time; do not invent endpoints that don't exist.
+- **Cursor pagination requires Web.Rest 0.6.0** (packet 07).
+- **RFC 7807 middleware comes from Web.Rest 0.6.0** (packet 07's Option C content negotiation).
+- **Idempotency wiring may be deferred** if ADR-0042 substrate is incomplete in Notify; the spec ships the declaration regardless.
+- **Per-tier rate-limit numbers deferred** — Notify's commercialization is via Notify Cloud (ADR-0027 deferred); the v1 spec documents the header convention but does not commit per-tier numbers.
+- **Notify is NOT Notify Cloud.** Notify's SDKs are unlikely to have external consumers at this scale; this pilot exercises the pipeline and validates the workflows.
+- **Tag is operator-pushed.** Agents never tag.
+- **Dry-run for SDK + docs publication** until packet 11 + packet 09.
+- **Functions host parity preserved** — if the AspNetCore controllers are updated, the Functions host either matches (preferred) or the README documents the divergence as known tech debt.
+- **No `Unreleased` CHANGELOG.**
+
+## Labels
+`feature`, `tier-2`, `core`, `adr-0057`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Pilot ADR-0057's Phase 2 substrate on `HoneyDrunk.Notify`: author the OpenAPI 3.1 v1 spec capturing the existing endpoints with the full ADR-0057 conventions; scaffold Notify's Docusaurus docs; wire the per-repo CI to call the three reusable workflows from `HoneyDrunk.Actions`; refactor list endpoints to cursor pagination; wire `Idempotency-Key` on the billing-relevant write endpoint; compose Web.Rest's RFC 7807 middleware on the host. Tag and trigger the publication pipeline (operator-pushed; dry-run until credentials seeded).
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: The dry run for Notify Cloud GA. Exercise the full SDK + docs publication pipeline on a real-endpoint surface.
+- Feature: ADR-0057 rollout, Wave 4 (Phase 2 pilot).
+- ADRs: ADR-0057 D17 Phase 2 / D7 / D8 / D12 / D13 / D14 / D11 / D10 (primary); ADR-0042 (`IIdempotencyStore`); ADR-0067 (rate-limit envelope); ADR-0027 (Notify Cloud — Phase 3 deferred); ADR-0035 D1 (additive minor bump).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0057 Accepted.
+- `packet:01` — tech-stack.md + `publicHttpApi` block convention.
+- `packet:03` — `job-openapi-diff.yml`.
+- `packet:04` — `job-publish-public-sdk.yml`.
+- `packet:05` — `job-publish-docs.yml`.
+- `packet:07` — Web.Rest 0.6.0 (cursor primitives + RFC 7807 middleware + rate-limit-header hook).
+
+**Constraints:**
+- Spec contents reverse-engineered, not invented.
+- Cursor pagination consumed from Web.Rest 0.6.0.
+- RFC 7807 middleware composed from Web.Rest 0.6.0.
+- Idempotency may be deferred; spec declaration ships regardless.
+- Per-tier rate-limit numbers deferred to Notify Cloud commercialization.
+- Tag operator-pushed; dry-run until credentials seeded.
+- Functions / AspNetCore host parity preserved or documented divergence.
+- No `Unreleased` CHANGELOG.
+
+**Key Files:**
+- `HoneyDrunk.Notify/api/openapi-v1.yaml` (new)
+- `HoneyDrunk.Notify/docs/` (Docusaurus scaffold)
+- `HoneyDrunk.Notify/.github/workflows/pr-openapi.yml`, `release-api.yml` (new)
+- `HoneyDrunk.Notify.Hosting.AspNetCore/` and `HoneyDrunk.Notify.Functions/` controller updates
+- All non-test `.csproj` files (version bump to 0.4.0)
+- CHANGELOGs + README
+
+**Contracts:**
+- Consumed: `CursorPageRequest`, `CursorPageResult`, `ProblemDetails`, `UseRateLimitHeaders` from Web.Rest 0.6.0 (packet 07).
+- Consumed: `IIdempotencyStore` from Kernel (ADR-0042).
+- New: the per-endpoint contract as expressed in the OpenAPI spec.

--- a/generated/issue-packets/active/adr-0057-api-versioning/09-studios-docs-notify-subdomain-provisioning.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/09-studios-docs-notify-subdomain-provisioning.md
@@ -1,0 +1,169 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Studios
+labels: ["feature", "tier-2", "core", "ops", "adr-0057", "wave-4", "human-only"]
+dependencies: ["packet:00", "packet:02"]
+adrs: ["ADR-0057", "ADR-0029"]
+wave: 4
+initiative: adr-0057-api-versioning
+node: honeydrunk-studios
+---
+
+# Provision docs.notify.honeydrunkstudios.com — Cloudflare DNS + Pages project (Studios-sector handoff)
+
+## Summary
+Per ADR-0057 §Consequences/Cross-ref Studios sector, every new API surface that ships requires a Studios-side packet to provision the docs subdomain. This packet is the first concrete instance: provision the Cloudflare DNS CNAME for `docs.notify.honeydrunkstudios.com`, create the Cloudflare Pages project `honeydrunk-docs-notify`, bind it to the `HoneyDrunk.Notify` repo, attach the custom domain, verify TLS issuance. Document the provisioning in the Studios repo (the Studios sector owns the `*.honeydrunkstudios.com` subdomains per ADR-0029). This is `Actor=Human` — Cloudflare portal work + Pages project creation are not automatable from the file-packets pipeline. The provisioning playbook authored in packet 02 of this initiative is the operator's checklist.
+
+## Context
+ADR-0057 D15 commits docs hosting at `docs.{api}.honeydrunkstudios.com`. Per §Consequences/Cross-ref Studios sector, the Studios sector (per ADR-0029) owns the apex `honeydrunkstudios.com` and `*.honeydrunkstudios.com` subdomains. New API docs subdomains are Studios-sector responsibility. Packet 02 of this initiative authored the per-API docs-subdomain provisioning playbook at `infrastructure/walkthroughs/public-api-docs-subdomain-provisioning.md` in the Architecture repo; this packet consumes it for the first concrete instance.
+
+`HoneyDrunk.Notify` is the first surface to ship a v1 OpenAPI spec + docs (packet 08). Its docs site lives at `docs.notify.honeydrunkstudios.com/v1/`. Without the Cloudflare DNS + Pages provisioning, packet 08's `job-publish-docs.yml` workflow runs in dry-run mode — the build succeeds, the artifact is uploaded, but no public URL serves the content. This packet flips the dry-run to real-publish for Notify.
+
+The provisioning is **all portal work** per the user's `feedback_portal_over_cli` standing convention:
+1. Cloudflare DNS — add CNAME at `docs.notify.honeydrunkstudios.com` pointing to the Pages target.
+2. Cloudflare Pages — create the project, bind to repo, attach custom domain, verify TLS.
+
+No code, no Bicep template, no script. The Studios repo documents the provisioning in its README or in a `studios/dns-records.md` (or equivalent) so the record is auditable.
+
+This is `Actor=Human` because the entire packet is portal work. The agent has nothing to delegate. Per the user's `project_human_only_convention`, `Actor=Human` packets carry the `"human-only"` label in frontmatter; the file-packets pipeline routes them onto The Hive with the appropriate `Actor=Human` field on the project board.
+
+Future per-API docs subdomains (Web.Rest's `docs.web-rest.honeydrunkstudios.com`, HoneyHub's `docs.honeyhub.honeydrunkstudios.com`, future Billing's `docs.billing.honeydrunkstudios.com`, Notify Cloud's `docs.notify-cloud.honeydrunkstudios.com`) follow the same playbook in their own respective standup or follow-up packets. This packet is the **template** — its post-merge state (DNS record present, Pages project named per convention, TLS verified, documented in Studios) is the pattern subsequent provisioning packets replicate.
+
+## Scope
+- **Cloudflare DNS** — add a CNAME record at `docs.notify.honeydrunkstudios.com` (the per-domain root of `honeydrunkstudios.com` is Cloudflare-managed per ADR-0029) pointing to the Cloudflare Pages target (`honeydrunk-docs-notify.pages.dev` once the Pages project is created).
+- **Cloudflare Pages** — create a new Pages project named `honeydrunk-docs-notify`. Bind to the `HoneyDrunkStudios/HoneyDrunk.Notify` repo on the `main` branch. Build configuration:
+  - Build command: matches what `job-publish-docs.yml` (packet 05) emits — typically `npm run build` from the `docs/` directory.
+  - Output directory: `docs/build/` (Docusaurus default within the per-API repo's `docs/` directory).
+  - Environment variables: none beyond the build defaults.
+- **Custom domain** — attach `docs.notify.honeydrunkstudios.com` to the Pages project. Cloudflare-managed TLS certificate auto-issuance; verify the cert is live.
+- **Access policy** — leave as none (public docs per packet 02's playbook default).
+- **Documentation** — in the Studios repo, append an entry to `studios/dns-records.md` (or the equivalent existing convention) noting: the CNAME, the Pages project name, the bound repo + branch, the custom domain, the public access posture, the cross-link to packet 02's playbook + ADR-0057 D15.
+- **Verification** — `curl -I https://docs.notify.honeydrunkstudios.com/` returns 200 (or the meta-refresh redirect to `/v1/` per packet 05's workflow); the TLS certificate is Cloudflare-issued; the v1 narrative + reference pages load when packet 08's first real-publish tag push completes.
+- **`HoneyDrunk.Studios/README.md`** — link to the new dns-records.md entry from any existing docs-subdomains or infrastructure section.
+
+## Proposed Implementation
+This packet is **Actor=Human** — the operator performs each step in the portal and records the outcome. The packet body is a checklist the operator follows.
+
+1. **Cloudflare DNS** — log into the Cloudflare dashboard; navigate to the `honeydrunkstudios.com` zone; under DNS → Records, click **Add record**:
+   - Type: CNAME
+   - Name: `docs.notify`
+   - Target: `honeydrunk-docs-notify.pages.dev` (this target does not exist yet — create the Pages project first per step 2, then come back and finalize the DNS target; Cloudflare allows the DNS record to be created with a placeholder target and updated)
+   - Proxy status: Proxied (orange cloud ON) — TLS at the edge per ADR-0029
+   - TTL: Auto
+   - Save.
+2. **Cloudflare Pages** — navigate to Workers & Pages → Create application → Pages → Connect to Git:
+   - Select the `HoneyDrunkStudios/HoneyDrunk.Notify` repo.
+   - Branch: `main`.
+   - Project name: `honeydrunk-docs-notify` (this is the Pages project name; the resulting `*.pages.dev` URL is `honeydrunk-docs-notify.pages.dev`).
+   - Build settings:
+     - Framework preset: Docusaurus.
+     - Build command: leave default or match `npm run build`.
+     - Build output directory: `docs/build/`.
+     - Root directory (advanced): `docs/` (Cloudflare runs the build from this subdirectory).
+   - Save and deploy. The first deploy will likely fail or be empty until packet 08 ships the `docs/` scaffold + an OpenAPI spec to render — that's expected; the project provisioning is what matters here.
+3. **Custom domain attachment** — in the Pages project's Custom domains tab → **Set up a custom domain** → enter `docs.notify.honeydrunkstudios.com` → Cloudflare verifies the DNS record (the CNAME from step 1) and provisions the cert. Wait for the cert to issue (typically <5 minutes).
+4. **Verification** — `curl -I https://docs.notify.honeydrunkstudios.com/` returns a 200 (or 301/302 redirect — both are acceptable; the meta-refresh from packet 05's root index redirects to `/v1/`). The TLS certificate is Cloudflare-issued (check via `openssl s_client -connect docs.notify.honeydrunkstudios.com:443 -servername docs.notify.honeydrunkstudios.com`). If packet 08's first publish has not yet occurred, the deployed content is the Cloudflare placeholder "no deployments yet" page — that is acceptable until packet 08's `notify-api-v1.0.0` tag push completes.
+5. **Documentation in `HoneyDrunk.Studios/`** — append to `studios/dns-records.md` (or the existing equivalent — `infrastructure/dns/` or similar; match the existing convention; if no such file exists, create `studios/dns-records.md` with a header section and this first entry):
+   ```markdown
+   ## docs.notify.honeydrunkstudios.com
+
+   - **Purpose:** Public docs for `HoneyDrunk.Notify` per ADR-0057 D15.
+   - **DNS:** CNAME at `docs.notify` in the `honeydrunkstudios.com` Cloudflare zone, proxied, pointing to `honeydrunk-docs-notify.pages.dev`.
+   - **Cloudflare Pages project:** `honeydrunk-docs-notify`.
+   - **Bound repo / branch:** `HoneyDrunkStudios/HoneyDrunk.Notify` / `main`.
+   - **Build:** Docusaurus from `docs/` subdirectory; output `docs/build/`.
+   - **Access:** Public.
+   - **TLS:** Cloudflare-managed.
+   - **Provisioned:** 2026-MM-DD (PR #).
+   - **Cross-references:** ADR-0057 D15, ADR-0029 (Cloudflare DNS), packet 02 of `adr-0057-api-versioning` initiative (provisioning playbook).
+   ```
+6. **`HoneyDrunk.Studios/README.md`** — link to `studios/dns-records.md` from any existing infrastructure or docs section.
+7. **Re-run packet 08's publication workflow** — once provisioning is verified, the operator (or a follow-up agent) re-runs the `job-publish-docs.yml` workflow on the existing `notify-api-v1.0.0` tag (`gh workflow run release-api.yml -R HoneyDrunkStudios/HoneyDrunk.Notify --ref notify-api-v1.0.0`) to deploy the Notify docs for real. The workflow now finds the Pages project; the deploy succeeds.
+
+## Affected Files
+- **Cloudflare portal state** (DNS record + Pages project) — not file-tracked.
+- `HoneyDrunk.Studios/studios/dns-records.md` (new or appended-to)
+- `HoneyDrunk.Studios/README.md` (link added if applicable)
+- `HoneyDrunk.Studios/CHANGELOG.md` (dated, versioned entry recording the provisioning)
+
+## NuGet Dependencies
+None. Portal work + docs.
+
+## Boundary Check
+- [x] Cloudflare DNS + Pages provisioning per ADR-0029 + ADR-0057 D15. Studios sector owns `*.honeydrunkstudios.com` subdomains.
+- [x] No code change in any other repo.
+- [x] No new abstraction or contract.
+- [x] Follows the playbook authored in packet 02.
+
+## Acceptance Criteria
+- [ ] CNAME record at `docs.notify.honeydrunkstudios.com` exists in Cloudflare DNS, proxied, pointing to `honeydrunk-docs-notify.pages.dev`
+- [ ] Cloudflare Pages project `honeydrunk-docs-notify` exists, bound to `HoneyDrunkStudios/HoneyDrunk.Notify` / `main`, with Docusaurus build config and `docs/build/` output
+- [ ] Custom domain `docs.notify.honeydrunkstudios.com` is attached to the Pages project with verified Cloudflare-managed TLS
+- [ ] `curl -I https://docs.notify.honeydrunkstudios.com/` returns 200 (or a 301/302 to `/v1/`)
+- [ ] `HoneyDrunk.Studios/studios/dns-records.md` (or the equivalent existing file) documents the new subdomain with the fields in step 5
+- [ ] `HoneyDrunk.Studios/README.md` links to the dns-records entry if a related section exists
+- [ ] `HoneyDrunk.Studios/CHANGELOG.md` records the provisioning in a dated, versioned entry (no `[Unreleased]`)
+- [ ] Packet 08's publication workflow re-runs successfully on the existing `notify-api-v1.0.0` tag (once packet 11's credentials are also seeded — the docs portion of the workflow uses the `CLOUDFLARE_API_TOKEN` from packet 11)
+
+## Human Prerequisites
+- [ ] **Cloudflare account access** with permission to edit DNS records in the `honeydrunkstudios.com` zone and to create Pages projects on the HoneyDrunk Studios account.
+- [ ] **GitHub App permission** for Cloudflare Pages to read the `HoneyDrunk.Notify` repo (the connect-to-Git step requires authorizing the Cloudflare GitHub App on the org; one-time consent per organization).
+- [ ] **Packet 02's playbook is the canonical reference** — `infrastructure/walkthroughs/public-api-docs-subdomain-provisioning.md` in the Architecture repo.
+- [ ] **This packet is `Actor=Human`** — the agent cannot perform portal work. The operator follows the checklist and records the outcome.
+
+## Referenced ADR Decisions
+**ADR-0057 D15 — Per-API docs site composition + hosting.** `docs.{api}.honeydrunkstudios.com`. Per-major path prefix. Scalar + Docusaurus composition (packet 05's workflow builds; this packet provides the hosting target).
+
+**ADR-0057 §Consequences/Cross-ref Studios sector.** "The docs subdomains are managed under the Studios sector (per ADR-0029's marketing/docs surface ownership). Each new API surface that ships requires a Studios-side packet to provision the docs subdomain."
+
+**ADR-0029 (referenced) — Cloudflare DNS rollout.** Cloudflare-managed zone for `honeydrunkstudios.com`; CNAME + Pages target convention.
+
+**Packet 02 of this initiative (referenced) — Per-API docs-subdomain provisioning playbook.** This packet consumes the playbook for the first concrete instance.
+
+## Constraints
+- **Portal-only.** No Bicep / CLI / scripts. Per the user's `feedback_portal_over_cli` standing convention.
+- **Public access default.** No Cloudflare Access policy on the Notify docs subdomain.
+- **Build from `docs/` subdirectory.** Notify's Docusaurus scaffold (per packet 08) lives at `HoneyDrunk.Notify/docs/`; Pages builds from there.
+- **No autoscale / paid tier.** Cloudflare Pages free tier is sufficient per the user's `feedback_default_cheapest_azure_tier` rule extended to vendor SaaS.
+- **This packet is the template** for subsequent per-API docs-subdomain provisioning. Future provisioning packets (Web.Rest's, HoneyHub's, future Billing's, Notify Cloud's) follow the same shape.
+- **Re-run of packet 08's workflow** completes the loop — once the Pages project + credentials exist, the workflow publishes for real.
+- **No `Unreleased` CHANGELOG.**
+
+## Labels
+`feature`, `tier-2`, `core`, `ops`, `adr-0057`, `wave-4`, `human-only`
+
+## Agent Handoff
+
+**Objective:** First concrete docs-subdomain provisioning per ADR-0057 D15 + ADR-0029. Cloudflare DNS CNAME + Pages project + custom domain + TLS verification for `docs.notify.honeydrunkstudios.com`. Document in Studios. This is `Actor=Human` — entirely portal work.
+
+**Target:** `HoneyDrunk.Studios`, branch from `main` for the documentation commit; Cloudflare portal for the actual provisioning.
+
+**Context:**
+- Goal: Flip packet 08's docs publication from dry-run to real. First concrete instance of the per-API docs-subdomain pattern.
+- Feature: ADR-0057 rollout, Wave 4 (Studios-side provisioning paired with the Notify Phase 2 pilot).
+- ADRs: ADR-0057 D15 + §Consequences/Cross-ref Studios sector (primary); ADR-0029 (Cloudflare DNS).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0057 Accepted.
+- `packet:02` — provisioning playbook authored.
+- Coordinates with `packet:08` (Notify Phase 2) but does not strictly block it — packet 08 ships in dry-run, this packet flips it to real on re-run.
+
+**Constraints:**
+- `Actor=Human` — portal work; no agent delegation.
+- Cloudflare account access required.
+- Public access default.
+- Pages free tier.
+- Template for future per-API instances.
+- No `Unreleased` CHANGELOG.
+
+**Key Files:**
+- `HoneyDrunk.Studios/studios/dns-records.md`
+- `HoneyDrunk.Studios/README.md` (link only)
+- `HoneyDrunk.Studios/CHANGELOG.md`
+- Cloudflare portal state (DNS + Pages — not file-tracked)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0057-api-versioning/10-architecture-notify-cloud-phase3-specification.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/10-architecture-notify-cloud-phase3-specification.md
@@ -1,0 +1,202 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ops", "docs", "adr-0057", "adr-0027", "wave-4"]
+dependencies: ["packet:00", "packet:02"]
+adrs: ["ADR-0057", "ADR-0027"]
+wave: 4
+initiative: adr-0057-api-versioning
+node: honeydrunk-architecture
+---
+
+# Author the Notify Cloud Phase 3 GA specification — deferred handoff to ADR-0027 standup
+
+## Summary
+Author the detailed specification document for the Notify Cloud Phase 3 GA-blocker work per ADR-0057 D17 Phase 3. This is the **deferral marker** — Notify Cloud does not exist on disk (ADR-0027 is Proposed; the repo will be created and scaffolded as part of the `adr-0027-notify-cloud-standup` initiative). This packet authors the specification *now* in the Architecture repo so when the ADR-0027 standup completes, the executor has a fully-spec'd implementation target for the public-API + SDK + docs work. The specification turns into one or more Notify Cloud packets (filed against the new repo) as a follow-up after the `adr-0027-notify-cloud-standup` initiative completes. This packet mirrors the pattern used by ADR-0067's packet 05 (the Notify Cloud rate-limit-policy specification).
+
+## Context
+ADR-0057 D17 Phase 3 names Notify Cloud's GA-blocker work: *"Notify Cloud's public API (per PDR-0002 / ADR-0027) ships with the full stack from day one: OpenAPI v1 spec, three SDKs published, docs site, RFC 7807 errors, cursor pagination, per-tenant rate limits, idempotency keys required on billing endpoints. Notify Cloud GA cannot ship without this Phase complete."*
+
+But:
+1. **ADR-0027 (Notify Cloud standup) is Proposed**, not Accepted. The `HoneyDrunk.Notify.Cloud` repo does not exist on disk; `catalogs/nodes.json` has no `honeydrunk-notify-cloud` entry; `file-packets.yml` cannot file an issue against a repo that does not exist.
+2. **Per the user's standing convention**, new-Node scaffolding gets its own standup ADR — feature packets do not bundle scaffolding. The Notify Cloud public-API packet must therefore be filed *after* the `adr-0027-notify-cloud-standup` initiative's scaffold packet (per the ADR-0067 packet 05 precedent — packet 06 in that initiative).
+3. **ADR-0057's exit criterion** for this initiative is Phase 1 substrate + Phase 2 Notify pilot complete. Phase 3 is satisfied across the ADR-0027 standup boundary, not within this initiative's filing window.
+
+The clean structure: this packet authors the specification *now* (in the Architecture repo, where it is reviewable and discoverable). When the ADR-0027 standup completes — i.e., when Notify Cloud's scaffold packet lands on `main` and the Notify Cloud repo exists with its solution structure and a placeholder API surface — a follow-up packet against `HoneyDrunk.Notify.Cloud` consumes this specification and ships the full ADR-0057 + ADR-0067 + ADR-0042 stack as Phase 3 prescribes. The follow-up packet is **not** filed by this initiative.
+
+This is a docs-only packet. No code, no .NET project, no catalog change.
+
+## Scope
+- New document at `infrastructure/walkthroughs/notify-cloud-public-api-specification.md` authoring the Notify Cloud Phase 3 public-API specification.
+- Update `initiatives/active-initiatives.md` to record the cross-initiative coupling explicitly: this `adr-0057-api-versioning` initiative completes Phase 1 + Phase 2; Notify Cloud Phase 3 is a deferred follow-up tracked against the `adr-0027-notify-cloud-standup` initiative.
+
+## Proposed Implementation
+1. Author the specification document at `infrastructure/walkthroughs/notify-cloud-public-api-specification.md`. Required sections:
+
+   ### OpenAPI v1 spec authoring (ADR-0057 D7)
+   - Spec file location: `HoneyDrunkStudios/HoneyDrunk.Notify.Cloud/api/openapi-v1.yaml`. OpenAPI 3.1 per ADR-0057.
+   - Surface name: `notify-cloud` (distinct from `notify` per packet 08 — `notify-cloud` is the commercial product surface; `notify` is the internal-Grid intake/delivery substrate).
+   - Endpoints (at minimum — refine at PR time against the ADR-0027 standup's emerged endpoint set):
+     - `POST /v1/messages` — send a message (required `Idempotency-Key`; billing-relevant per ADR-0037 + ADR-0057 D13).
+     - `GET /v1/messages/{id}` — message status lookup.
+     - `GET /v1/messages` — list (cursor pagination per D14).
+     - `GET /v1/recipients/{id}` / `POST /v1/recipients` / `PUT /v1/recipients/{id}` / `DELETE /v1/recipients/{id}` — recipient CRUD (`Idempotency-Key` on writes).
+     - `GET /v1/recipients` — list (cursor pagination).
+     - `GET /v1/templates/{id}` / `POST /v1/templates` / `PUT /v1/templates/{id}` / `DELETE /v1/templates/{id}` — template CRUD (`Idempotency-Key` on writes).
+     - `GET /v1/templates` — list (cursor pagination).
+     - `GET /v1/usage` — per-tenant quota / usage report (per ADR-0067 D8 / ADR-0037 D2).
+   - Refine the endpoint list at PR time. The Notify Cloud product PDR-0002 may have added or removed endpoints by then.
+
+   ### Error envelope (ADR-0057 D12)
+   - RFC 7807 `application/problem+json` for every non-2xx response.
+   - `type` URI host: `docs.honeydrunkstudios.com/errors/notify-cloud/{category}/`. Per-category URIs declared in `components.responses`.
+   - `traceId` (W3C `traceparent` per ADR-0040) and `correlationId` (per ADR-0045 `ErrorContext`) on every error.
+   - For the **billing-relevant rejection cases** (quota exceeded for Free; quota exceeded for Pro/Scale with overage billable), the error envelope shape matches ADR-0067 D6 (`tier`, `retry_after_seconds`, `correlation_id`; `tenant_id` NOT in body).
+
+   ### Cursor pagination (ADR-0057 D14)
+   - Every list endpoint uses cursor pagination.
+   - `CursorPageRequest` / `CursorPageResult<T>` shapes inherited from `HoneyDrunk.Web.Rest.Abstractions` 0.6.0 (packet 07).
+   - Cursor TTL minimum 24 hours; `410 Gone` per-D12 envelope on expired cursor.
+   - Default `limit=50`, max `limit=200`.
+
+   ### Rate limits + quotas (ADR-0057 D11 + ADR-0067 D3 / D8)
+   - Per-tenant rate limits enforced via the ADR-0067 substrate. The production `ITenantRateLimitPolicy` implementation per ADR-0067 packet 05's specification (the analogous deferred spec in that initiative).
+   - Per-tier limits at GA: Free / Pro / Scale per ADR-0067 D3.
+   - IETF `RateLimit-*` headers on every response per ADR-0057 D11 / ADR-0067 D7.
+   - 429 envelope per ADR-0067 D6 (RFC 7807, `tier` for authenticated, `retry_after_seconds`, `correlation_id`; `tenant_id` NOT in body).
+   - `Retry-After` in seconds.
+   - Quota counter store per ADR-0067 D8 (Azure Storage Tables at Phase 1).
+
+   ### Idempotency (ADR-0057 D13 + ADR-0042)
+   - `Idempotency-Key` **required** on every billing-relevant write — `POST /v1/messages` is the canonical example. Returns 400 problem+json on missing key with `type: https://docs.honeydrunkstudios.com/errors/common/idempotency-key-required`.
+   - Other write endpoints: `Idempotency-Key` recommended (SDK auto-injects via packet 04's override templates).
+   - Backed by `IIdempotencyStore` per ADR-0042; 24h dedup window per ADR-0042 D3.
+
+   ### Authentication (ADR-0057 D10)
+   - API key (`Authorization: Bearer {key}`) for the v1 surface. Per-tenant key rotation per ADR-0006.
+   - OAuth 2.1 with PKCE deferred to the first end-user-facing Notify Cloud feature (tenant-portal pages; the current v1 surface is API-only and tenant-app integrations are API-key authenticated).
+   - Per-endpoint `securitySchemes` declaration in the OpenAPI spec.
+
+   ### SDK publication (ADR-0057 D8 + D9)
+   - Three SDKs: `@honeydrunk/notify-cloud-sdk` (npm), `HoneyDrunkNotifyCloudSdk` (SPM), `com.honeydrunkstudios:notify-cloud-sdk` (Maven Central).
+   - Tag scheme: `notify-cloud-api-v{N}.{spec-revision}.{sdk-patch}`.
+   - SDKs published in **real-publish** mode from day one (Notify Cloud GA is a commercial product; tenants integrate against SDKs at launch). This assumes packet 11's namespace onboarding has completed by then.
+
+   ### Documentation site (ADR-0057 D15)
+   - Site at `docs.notify-cloud.honeydrunkstudios.com/v1/`.
+   - Scalar reference at `/v1/api/`; Docusaurus narrative at `/v1/`.
+   - Cloudflare Pages project `honeydrunk-docs-notify-cloud`. DNS + Pages provisioning follows the playbook in packet 02; a Studios-side packet provisions the subdomain (analogous to packet 09 for Notify).
+
+   ### Per-API CI wiring
+   - `HoneyDrunk.Notify.Cloud/.github/workflows/pr-openapi.yml` calls `job-openapi-diff.yml` (packet 03).
+   - `HoneyDrunk.Notify.Cloud/.github/workflows/release-api.yml` calls `job-publish-public-sdk.yml` (packet 04) and `job-publish-docs.yml` (packet 05) on `notify-cloud-api-v*` tags.
+   - Real-publish mode from day one (credentials seeded per packet 11 by then).
+
+   ### Audit + Pulse (ADR-0030 / ADR-0010 + ADR-0067 D10)
+   - Every state-changing call audits via `IAuditLog` (ADR-0030); event-shape per the Notify-Cloud-specific event catalog (to be authored alongside the implementation).
+   - The `RateLimitRejected` + `QuotaOverageBilled` audit shapes from ADR-0067 packet 03 apply when the rate-limiter rejects or the billable-overage transition fires.
+   - Pulse metric catalog (ADR-0067 packet 04) for rate-limit observability.
+
+   ### Migration runway + deprecation
+   - Migration-guide template inherited from packet 02 of this initiative.
+   - Deprecation runbook (packet 02) governs any future deprecations.
+   - Two-major coexistence per invariant `{N3}`.
+
+   ### Cross-references and out-of-scope
+   - This specification consumes the ADR-0057 Phase 1 substrate (packets 03-06 in this initiative) and the Phase 2 Notify pilot (packet 08).
+   - Notify Cloud's **billing wiring** (Stripe meter increment per ADR-0037; overage events) is out of scope of this spec — that's an ADR-0037 follow-up consumed by the same Notify Cloud Phase 3 packet.
+   - Notify Cloud's **tenant onboarding flow** (tenant creation, API key issuance, tier assignment) is out of scope — that's ADR-0050 (Multi-Tenant Lifecycle) + ADR-0027 standup work.
+
+2. At the bottom of the specification document, add a **"Follow-up Notify Cloud packet" outline** — the executor-ready skeleton for the future filer to turn into a real packet:
+   - Target repo: `HoneyDrunkStudios/HoneyDrunk.Notify.Cloud` (does not exist at the time of writing this spec).
+   - Blocked by: `adr-0027-notify-cloud-standup` scaffold packet (when ADR-0027's initiative is filed and its scaffold lands).
+   - Version-bumping packet for the Notify Cloud solution.
+   - Consumes: `HoneyDrunk.Web.Rest` 0.6.0 (cursor + RFC 7807 from packet 07); `HoneyDrunk.Kernel` (`IIdempotencyStore` per ADR-0042; `UseGridRateLimiting` per ADR-0067 packet 02); the production `ITenantRateLimitPolicy` from ADR-0067 packet 05's deferred spec.
+   - Includes the per-API DNS / Pages provisioning Studios-side packet (analogous to packet 09 for Notify).
+   - Includes the `catalogs/contracts.json` update on the new `honeydrunk-notify-cloud` Node entry with the populated `publicHttpApi` block.
+
+3. Update `initiatives/active-initiatives.md` to record the cross-initiative coupling. Add a Tracking entry note under this initiative: "Notify Cloud Phase 3 public-API + SDKs + docs per ADR-0057 D17 Phase 3 is a deferred follow-up. It is filed as a new packet (or a small new initiative `adr-0057-notify-cloud-public-api`) against `HoneyDrunk.Notify.Cloud` after the `adr-0027-notify-cloud-standup` initiative's scaffold packet lands. The specification is at `infrastructure/walkthroughs/notify-cloud-public-api-specification.md`."
+
+## Affected Files
+- `infrastructure/walkthroughs/notify-cloud-public-api-specification.md` (new)
+- `initiatives/active-initiatives.md` (cross-initiative coupling note)
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`.
+- [x] No code change in any other repo.
+- [x] Notify Cloud production implementation is explicitly deferred to the `adr-0027-notify-cloud-standup` initiative — this packet does not file against `HoneyDrunk.Notify.Cloud` (the repo does not exist).
+- [x] Mirrors the ADR-0067 packet 05 pattern (the analogous deferred spec for Notify Cloud's rate-limit policy).
+
+## Acceptance Criteria
+- [ ] `infrastructure/walkthroughs/notify-cloud-public-api-specification.md` exists with the required sections: OpenAPI v1 spec authoring, error envelope, cursor pagination, rate limits + quotas, idempotency, authentication, SDK publication, documentation site, per-API CI wiring, audit + pulse, migration runway, cross-references / out-of-scope
+- [ ] The "Follow-up Notify Cloud packet" outline is at the bottom with target repo, blocking dependency, version-bump expectation, consumed contracts, and Studios-side packet companion
+- [ ] `initiatives/active-initiatives.md` records the cross-initiative coupling note linking this initiative's specification to the future Notify Cloud follow-up
+- [ ] URL patterns in the specification match ADR-0057 D5 / D12 / D15 verbatim
+- [ ] No code change
+- [ ] No catalog change (the `honeydrunk-notify-cloud` entry lands when Notify Cloud is stood up)
+- [ ] No invariant change
+
+## Human Prerequisites
+None. The specification document is authored at PR time; the future Notify Cloud follow-up packet is filed by the ADR-0027 standup executor or a follow-up operator action.
+
+## Referenced ADR Decisions
+**ADR-0057 D17 Phase 3 — Notify Cloud GA-blocker resolution.** "Notify Cloud's public API (per PDR-0002 / ADR-0027) ships with the full stack from day one: OpenAPI v1 spec, three SDKs published, docs site, RFC 7807 errors, cursor pagination, per-tenant rate limits, idempotency keys required on billing endpoints. Notify Cloud GA cannot ship without this Phase complete."
+
+**ADR-0027 (referenced) — Notify Cloud standup.** Currently Proposed; the repo does not exist on disk. Phase 3 implementation lands after the standup completes.
+
+**ADR-0067 (referenced) — Inbound rate limiting and quota enforcement.** Notify Cloud's production `ITenantRateLimitPolicy` implementation per ADR-0067 packet 05's deferred spec; tier-to-limits defaults per ADR-0067 D3; quota counter store per ADR-0067 D8.
+
+**ADR-0042 (referenced) — Idempotency.** `IIdempotencyStore` substrate consumed by `POST /v1/messages` and other billing-relevant writes.
+
+**ADR-0037 (referenced) — Payment and billing.** Stripe meter increment on quota-overage-billable events; out of scope of this spec but consumed by the same Notify Cloud Phase 3 packet.
+
+**ADR-0030 (referenced) — Audit substrate.** Every state-changing call audits via `IAuditLog`.
+
+**ADR-0050 (referenced — Proposed) — Multi-tenant lifecycle.** Tenant onboarding flow is out of scope of this spec; covered by ADR-0050 + ADR-0027 standup work.
+
+**ADR-0057 D5 / D6 / D7 / D8 / D9 / D10 / D11 / D12 / D13 / D14 / D15 — All applied at Notify Cloud GA per Phase 3.**
+
+## Constraints
+- **Specification-only — no code.**
+- **Notify Cloud production implementation deferred to ADR-0027 standup.** This packet is the handoff document.
+- **Real-publish mode at GA.** Unlike packet 08 (Notify Phase 2, dry-run by default), Notify Cloud Phase 3 is commercial product — SDKs publish for real from the first tag. Packet 11 must complete before then.
+- **No new invariants.** ADR-0057's invariants `{N1}-{N4}` already govern; no per-Node restatement.
+- **Mirrors ADR-0067 packet 05 pattern** — same shape of deferred spec for the same Notify-Cloud-not-yet-stood-up reason.
+
+## Labels
+`feature`, `tier-2`, `ops`, `docs`, `adr-0057`, `adr-0027`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Author the detailed Notify Cloud Phase 3 public-API specification at `infrastructure/walkthroughs/notify-cloud-public-api-specification.md` as the deferred handoff to the `adr-0027-notify-cloud-standup` initiative. The follow-up implementation packet against `HoneyDrunk.Notify.Cloud` is filed *after* that standup completes.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Have the Phase 3 spec ready and reviewable in the Architecture repo so the ADR-0027 standup executor (or a follow-up filer) can turn it into a real implementation packet without re-discovering the requirements.
+- Feature: ADR-0057 rollout, Wave 4 (deferred handoff).
+- ADRs: ADR-0057 D17 Phase 3 (primary); ADR-0027 (Notify Cloud — currently Proposed); ADR-0067 (rate-limit policy — consumed); ADR-0042 (idempotency); ADR-0037 (billing — out of scope here); ADR-0030 (audit).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0057 Accepted.
+- `packet:02` — provisioning playbook authored (referenced by the spec's docs-site section).
+
+**Constraints:**
+- Specification-only, no code.
+- Notify Cloud production implementation deferred.
+- Real-publish mode at GA.
+- No new invariants.
+- Mirrors ADR-0067 packet 05 pattern.
+
+**Key Files:**
+- `infrastructure/walkthroughs/notify-cloud-public-api-specification.md` (new)
+- `initiatives/active-initiatives.md` (cross-initiative coupling note)
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0057-api-versioning/11-architecture-sdk-registry-and-credentials-onboarding.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/11-architecture-sdk-registry-and-credentials-onboarding.md
@@ -1,0 +1,198 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "adr-0057", "adr-0034", "wave-4", "human-only"]
+dependencies: ["packet:00", "packet:02", "packet:04", "packet:05"]
+adrs: ["ADR-0057", "ADR-0034"]
+wave: 4
+initiative: adr-0057-api-versioning
+node: honeydrunk-architecture
+---
+
+# Operator onboarding — npm @honeydrunk scope, Maven Central com.honeydrunkstudios namespace, GPG keys, Cloudflare API token
+
+## Summary
+Per ADR-0057 §Operational Consequences and the ADR-0034 cross-link, the per-registry credentials for SDK + docs publication require human portal work that cannot be agent-delegated. This packet is the operator's checklist for: (1) claiming the `@honeydrunk` npm scope; (2) verifying the `com.honeydrunkstudios` namespace at Maven Central via Central Portal; (3) generating + registering the GPG signing key for Maven artifacts; (4) confirming Swift Package Index integration (if a dedicated companion repo strategy is chosen) or git-tag-based discovery (if the SDK ships in a subdirectory of the per-API repo); (5) creating a Cloudflare API token for Pages deployment; (6) seeding all credentials as GitHub org-level secrets so the reusable workflows in packets 04 and 05 promote from dry-run to real-publish. This packet documents the work and tracks completion; the actual portal navigation is performed by the operator. `Actor=Human` — entirely portal + CLI work.
+
+## Context
+Packets 04 (`job-publish-public-sdk.yml`) and 05 (`job-publish-docs.yml`) ship in dry-run-by-default mode — they generate and validate but do not push to registries until per-registry credentials are seeded as org secrets. The seed step requires human portal work:
+
+- **npm `@honeydrunk` scope** — npm scope claims happen via the npm web UI: account holder logs in, creates an Organization (or upgrades a User account to an Organization), claims the `@honeydrunk` scope as the organization namespace. Generates an automation token scoped to publishing under `@honeydrunk/*`. Token stored as `NPM_TOKEN` org secret in GitHub.
+- **Maven Central `com.honeydrunkstudios` namespace** — Maven Central's new Central Portal (replaces OSSRH as of March 2024) requires namespace verification. Two paths: (a) DNS-based verification — add a TXT record `OSSRH-{verification-id}` to the `honeydrunkstudios.com` zone, request namespace via Central Portal, Sonatype verifies the DNS, namespace claimed; or (b) GitHub-org-based verification (`io.github.honeydrunkstudios`) which auto-verifies via repo ownership — but this gives the `io.github.honeydrunkstudios` namespace, not `com.honeydrunkstudios`, which doesn't match ADR-0057 D8's `com.honeydrunkstudios:{api}-sdk` commitment. Per ADR-0034 D3 (Proposed; the public-distribution policy that this packet's namespace work is the operator-time-budgeted component of), the canonical namespace is `com.honeydrunkstudios`; the DNS verification path is required.
+- **GPG signing key** — Maven Central requires GPG-signed artifacts. The operator generates a GPG keypair (`gpg --gen-key`), uploads the public key to the standard keyservers (`gpg --keyserver keys.openpgp.org --send-keys {key-id}`), and stores the private key + passphrase as GitHub org secrets (`MAVEN_GPG_PRIVATE_KEY` + `MAVEN_GPG_PASSPHRASE`). The Maven publish step in packet 04's workflow uses these to sign before pushing to Central.
+- **Maven Central credentials** — the Central Portal account credentials (username + token-style password generated via Central Portal) stored as `MAVEN_USERNAME` + `MAVEN_PASSWORD` org secrets.
+- **Swift Package Index** — SPM is git-tag-based; no central registry credential is required. The choice is between: (a) ship the Swift SDK as a subdirectory of the per-API repo (e.g. `HoneyDrunk.Notify/swift/`) and push tags like `notify-swift-sdk-v1.0.0` — Swift Package Index discovers via git URL + tag; or (b) ship the Swift SDK in a dedicated companion repo (e.g. `HoneyDrunkStudios/HoneyDrunkNotifySdk`) and publish tags there. The dedicated-repo path is more idiomatic for consumers (`HoneyDrunkNotifySdk` is a cleaner Swift Package URL than a subdirectory reference). The decision is made at first-Swift-SDK-publication time. Either way, no portal credential is required — only git push rights. Swift Package Index registration is optional and indexes the repo via its public-discoverability; the per-repo `Package.swift` is the source of truth.
+- **Cloudflare API token** — packet 05's `job-publish-docs.yml` deploys to Cloudflare Pages via the Cloudflare API. The operator creates a scoped API token (Account → API Tokens → Create Token → Custom token; scopes: Account.Cloudflare Pages: Edit, Account.Account Settings: Read, Zone.Zone: Read) and stores it as `CLOUDFLARE_API_TOKEN` org secret. Cloudflare Account ID stored as `CLOUDFLARE_ACCOUNT_ID` org secret.
+
+The work is **fundamentally portal + CLI**: npm web UI; Maven Central Portal web UI; GPG CLI commands; Cloudflare dashboard. The agent has nothing to delegate to itself. `Actor=Human` with the `"human-only"` label per the user's convention.
+
+The packet documents the work and tracks completion via the acceptance criteria checklist. The post-merge state is: every per-registry secret is seeded as a GitHub org-level secret accessible to the `HoneyDrunk.Actions` reusable workflows; the dry-run paths in packets 04 + 05 auto-promote to real-publish on the next workflow invocation.
+
+The work is **operator-time-budgeted** — per the user's standing convention, no agent attempts the namespace verification or the credential seeding. The packet body is a checklist the operator works through over a session (Maven Central namespace verification typically takes 24-48 hours for Sonatype to process; npm scope claim is immediate; Cloudflare API token is immediate; GPG keygen is immediate).
+
+## Scope
+- npm `@honeydrunk` organization scope claimed and token issued.
+- Maven Central `com.honeydrunkstudios` namespace verified.
+- GPG keypair generated, public key uploaded to keyservers, private key + passphrase stored as org secrets.
+- Maven Central account credentials stored as org secrets.
+- Cloudflare API token scoped for Pages deployment, stored as org secret.
+- Cloudflare Account ID stored as org secret.
+- Swift Package Index strategy decided (subdirectory vs. companion repo) and documented.
+- All credentials documented in `governance/sdk-registry-credentials.md` (or the equivalent existing file) — the metadata only, never the secret values themselves.
+- `HoneyDrunk.Architecture/CHANGELOG.md` records the operator onboarding in a dated, versioned entry.
+
+## Proposed Implementation
+This packet is **Actor=Human** — the operator performs each step in the portal / CLI and records the outcome. The packet body is a checklist the operator follows.
+
+1. **npm `@honeydrunk` scope:**
+   - Log into npmjs.com with the HoneyDrunk Studios npm account.
+   - Account settings → Organizations → Create an Organization. Name: `honeydrunk`. Plan: free tier sufficient (public packages only at v1).
+   - The org's scope becomes `@honeydrunk`; subsequent published packages live at `@honeydrunk/{package-name}`.
+   - Generate an automation token: Account → Access Tokens → Generate New Token → Automation. Scope: publish (read + publish). Copy the token (shown once).
+   - Store the token as GitHub org-level secret `NPM_TOKEN` (Settings → Secrets and variables → Actions → New organization secret; visibility: Selected repositories — grant to `HoneyDrunkStudios/HoneyDrunk.Notify` and any future per-API repo that publishes SDKs).
+
+2. **Maven Central `com.honeydrunkstudios` namespace verification:**
+   - Log into central.sonatype.com (Maven Central Portal). Create an account if one doesn't exist; verify via email.
+   - Namespaces → Add Namespace → enter `com.honeydrunkstudios`.
+   - Choose verification method: **DNS-based** (required for the `com.*` namespace).
+   - Central Portal displays a TXT record value. Add the record to the `honeydrunkstudios.com` Cloudflare DNS zone: TXT at `@` (apex), value as displayed.
+   - Wait for Sonatype to verify (typically 24-48 hours; check status in Central Portal).
+   - Once verified, the namespace is yours to publish under.
+   - Generate Central Portal credentials: Account → Generate User Token. Username + token-style password. Copy both.
+   - Store as GitHub org-level secrets: `MAVEN_USERNAME` (the displayed username — typically a UUID-style string), `MAVEN_PASSWORD` (the token).
+
+3. **GPG signing key:**
+   - On a secure local machine: `gpg --gen-key`. Choose RSA, 4096-bit, 2-year expiry. Real name: `HoneyDrunk Studios`. Email: `oleg@honeydrunkstudios.com` (or `support@honeydrunkstudios.com` if preferred). Set a passphrase; record it in 1Password / password manager.
+   - List the key: `gpg --list-secret-keys --keyid-format=long`. Note the key ID (the long hex string after `sec rsa4096/`).
+   - Upload public key: `gpg --keyserver keys.openpgp.org --send-keys {key-id}` and also `gpg --keyserver keyserver.ubuntu.com --send-keys {key-id}` (redundancy for keyserver availability).
+   - Export private key for GitHub Actions: `gpg --armor --export-secret-keys {key-id}` (the output is the ASCII-armored private key block; copy it whole, including the `-----BEGIN PGP PRIVATE KEY BLOCK-----` and `-----END PGP PRIVATE KEY BLOCK-----` lines).
+   - Store as GitHub org-level secret `MAVEN_GPG_PRIVATE_KEY` (paste the entire armored block).
+   - Store the passphrase as GitHub org-level secret `MAVEN_GPG_PASSPHRASE`.
+
+4. **Cloudflare API token:**
+   - Log into the Cloudflare dashboard.
+   - My Profile → API Tokens → Create Token → Custom token.
+   - Token name: `HoneyDrunk Actions — Docs Pages Deploy`.
+   - Permissions: Account → Cloudflare Pages: Edit; Account → Account Settings: Read; Zone → Zone: Read (only on the `honeydrunkstudios.com` zone if zone-scoping is desired).
+   - Account resources: Include → HoneyDrunk Studios.
+   - TTL: no expiry (or 1-year with calendar reminder).
+   - Create the token; copy it (shown once).
+   - Store as GitHub org-level secret `CLOUDFLARE_API_TOKEN`.
+   - Note the Cloudflare Account ID (visible in the right sidebar of any Cloudflare dashboard page); store as GitHub org-level secret `CLOUDFLARE_ACCOUNT_ID`.
+
+5. **Swift Package Index strategy decision:**
+   - Decide: (a) subdirectory-in-per-API-repo (the Swift SDK ships at `HoneyDrunk.{Api}/swift/`; the per-API repo's `Package.swift` lives at that path; the SDK is referenced as `git@github.com:HoneyDrunkStudios/HoneyDrunk.{Api}.git`, path: `swift`), or (b) dedicated companion repo (a new repo `HoneyDrunkStudios/HoneyDrunk{Api}Sdk` per surface; `Package.swift` at the repo root; the SDK is referenced as `git@github.com:HoneyDrunkStudios/HoneyDrunk{Api}Sdk.git`).
+   - The decision is made at first-Swift-SDK-publication time (likely when Notify's SDKs publish for real — re-run packet 08's `notify-api-v1.0.0` tag publication after this packet completes).
+   - The default recommendation for v1: **subdirectory-in-per-API-repo** — avoids creating N companion repos; SPM consumers can reference a subdirectory via Swift Package Manager's path-based dependency syntax. The downside is the SDK repo URL is the per-API repo URL, which mixes the SDK with the per-API source; not idiomatic but workable at v1.
+   - Document the chosen strategy in `governance/sdk-registry-credentials.md`.
+   - No portal secret needed for SPM.
+
+6. **Documentation — `governance/sdk-registry-credentials.md`** — create (or extend an existing equivalent) documenting the metadata of each registry / credential. **Never include the secret values themselves.** Required fields per registry:
+   - **npm:** scope `@honeydrunk`; org account on npmjs.com; automation token stored as `NPM_TOKEN` org secret; visibility: per-repo grant.
+   - **Maven Central:** namespace `com.honeydrunkstudios`; verification method DNS-based; verification status (verified on YYYY-MM-DD); Central Portal account; user-token credentials stored as `MAVEN_USERNAME` + `MAVEN_PASSWORD` org secrets; GPG key ID + expiry + uploaded keyservers.
+   - **GPG:** key ID; uploaded keyservers; expiry date; passphrase stored as `MAVEN_GPG_PASSPHRASE`; private key stored as `MAVEN_GPG_PRIVATE_KEY`; renewal reminder cadence (annual review).
+   - **Cloudflare:** API token scopes; token stored as `CLOUDFLARE_API_TOKEN`; Account ID stored as `CLOUDFLARE_ACCOUNT_ID`; TTL.
+   - **Swift Package Index:** chosen strategy (subdirectory vs. companion repo); the rationale; the per-surface tag convention.
+   - **Cross-references:** ADR-0057 D8 + D15, ADR-0034 D3, ADR-0029.
+
+7. **`HoneyDrunk.Architecture/CHANGELOG.md`** — record the onboarding in a dated, versioned entry. Sample shape: `### Operator Onboarding — SDK Registries (2026-MM-DD)` listing the completed steps.
+
+## Affected Files
+- **GitHub org-level secrets** — seeded (not file-tracked).
+- **External portal state** — npm org, Maven Central namespace + credentials, GPG keypair, Cloudflare token.
+- `governance/sdk-registry-credentials.md` (new or appended-to)
+- `HoneyDrunk.Architecture/CHANGELOG.md` (dated, versioned entry)
+
+## NuGet Dependencies
+None.
+
+## Boundary Check
+- [x] All file edits in `HoneyDrunk.Architecture`. Per the user's `project_repos_public_by_default` convention, the Architecture repo is public; the documentation file does NOT include any secret value, only metadata.
+- [x] No code change in any other repo.
+- [x] External portal state is correctly partitioned (npm, Maven Central, Cloudflare) — no overlap with Azure-side credentials.
+- [x] The GPG private key, npm token, Maven credentials, Cloudflare token are stored ONLY as GitHub org-level secrets. They are NEVER committed to any repo.
+
+## Acceptance Criteria
+- [ ] `@honeydrunk` npm scope is claimed; `NPM_TOKEN` is seeded as a GitHub org-level secret with visibility to the per-API repos that will publish SDKs
+- [ ] `com.honeydrunkstudios` Maven Central namespace is verified via DNS (TXT record on `honeydrunkstudios.com`); `MAVEN_USERNAME` + `MAVEN_PASSWORD` are seeded as org secrets
+- [ ] GPG keypair generated, public key uploaded to `keys.openpgp.org` AND `keyserver.ubuntu.com`; `MAVEN_GPG_PRIVATE_KEY` and `MAVEN_GPG_PASSPHRASE` are seeded as org secrets
+- [ ] Cloudflare API token (scoped: Account.Cloudflare Pages.Edit + Account.Account Settings.Read + Zone.Zone.Read) is created; `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` are seeded as org secrets
+- [ ] Swift Package Index strategy is decided (subdirectory-in-per-API-repo recommended default) and documented
+- [ ] `governance/sdk-registry-credentials.md` documents the metadata (NOT secret values) of all five registries / credential paths plus cross-references
+- [ ] `HoneyDrunk.Architecture/CHANGELOG.md` records the onboarding in a dated, versioned entry
+- [ ] **Post-onboarding verification:** re-run packet 08's `notify-api-v1.0.0` tag publication (`gh workflow run release-api.yml -R HoneyDrunkStudios/HoneyDrunk.Notify --ref notify-api-v1.0.0`) and confirm:
+  - The `job-publish-public-sdk.yml` workflow promotes from dry-run to real-publish; `@honeydrunk/notify-sdk@1.0.0` lands on npmjs.com; `com.honeydrunkstudios:notify-sdk:1.0.0` lands on Maven Central; Swift SDK tag lands per the chosen strategy.
+  - The `job-publish-docs.yml` workflow deploys to Cloudflare Pages and `docs.notify.honeydrunkstudios.com/v1/` serves the live docs.
+  - This verification depends on packet 09 having completed (the Cloudflare Pages project must exist for the docs deploy). If packet 09 is incomplete at this packet's completion time, defer the verification until packet 09 lands; the SDK publication can succeed independently.
+- [ ] No secret value is committed to any repo
+
+## Human Prerequisites
+- [ ] **Operator session of ~2-4 hours active time** — npm scope claim (10 min), Maven Central namespace verification request (30 min, then 24-48h wait), GPG keygen + upload (20 min), Cloudflare token (10 min), documentation (45 min), verification re-run (30 min). The 24-48h Maven Central wait dominates the elapsed time.
+- [ ] **Access to:** the HoneyDrunk Studios npm account, the HoneyDrunk Studios Maven Central account (or create one), the `honeydrunkstudios.com` Cloudflare DNS zone (for the Maven Central TXT record), the HoneyDrunk Studios Cloudflare account, the HoneyDrunkStudios GitHub org admin for org-secret seeding.
+- [ ] **1Password / password manager** for storing the GPG passphrase, the Maven Central credentials, and the npm token (each is shown once during creation; the org secret seeding is the only ongoing-access record).
+- [ ] **Calendar reminder for GPG key expiry** (default 2 years; renewal is a 30-minute repeat of the keygen + upload + secret rotation).
+- [ ] **This packet is `Actor=Human`** — agent cannot perform portal work. The operator follows the checklist and records outcomes.
+
+## Referenced ADR Decisions
+**ADR-0057 D8 — SDK languages + package coordinates.** `@honeydrunk/{api}-sdk` (npm), `HoneyDrunk{Api}Sdk` (SPM), `com.honeydrunkstudios:{api}-sdk` (Maven Central). The namespace claims here enable real publication.
+
+**ADR-0057 D15 — Docs hosting.** Cloudflare Pages target; the API token here enables `job-publish-docs.yml` to deploy.
+
+**ADR-0057 §Operational Consequences — Maven Central onboarding is the highest one-time cost.** "Namespace verification, GPG key registration, OSSRH (now Central Portal) onboarding. Done once for `com.honeydrunkstudios`; reused for all future Kotlin SDKs."
+
+**ADR-0034 D3 (referenced) — Public package distribution.** Namespace / metadata fields required. The namespace verification here is the operational implementation of ADR-0034 D3's commitment.
+
+**ADR-0029 (referenced) — Cloudflare DNS.** The TXT record for Maven Central namespace verification lives in the Cloudflare-managed `honeydrunkstudios.com` zone.
+
+## Constraints
+- **`Actor=Human` with `human-only` label** — portal + CLI work; not agent-delegable.
+- **Secret values NEVER committed.** Only metadata in `governance/sdk-registry-credentials.md`. The Architecture repo is public per the user's standing convention.
+- **GPG private key ASCII-armored** for org-secret storage; not raw binary.
+- **Maven Central via Central Portal**, not legacy OSSRH (OSSRH retired for new namespaces post-March 2024).
+- **Cloudflare API token scoped narrowly** — Cloudflare Pages Edit + minimal Read for token-validation. Not Account Admin.
+- **Visibility on org secrets: per-repo grant**, not org-wide-all-repos. Each per-API repo that publishes SDKs is granted explicitly.
+- **Swift Package Index strategy decided at first-Swift-SDK time**, documented post-decision; default recommendation subdirectory-in-per-API-repo.
+- **Post-onboarding verification couples with packets 08 + 09** — the re-run of Notify's publication completes the loop and confirms the credentials work end-to-end.
+- **No `Unreleased` CHANGELOG.**
+
+## Labels
+`chore`, `tier-3`, `ops`, `adr-0057`, `adr-0034`, `wave-4`, `human-only`
+
+## Agent Handoff
+
+**Objective:** Complete the operator-time-budgeted external onboarding so the SDK + docs publication pipelines (packets 04 + 05) promote from dry-run to real-publish. Specifically: npm `@honeydrunk` scope, Maven Central `com.honeydrunkstudios` namespace verification, GPG keypair + upload, Cloudflare API token; all credentials seeded as GitHub org-level secrets; metadata documented (never secret values).
+
+**Target:** `HoneyDrunk.Architecture` for the documentation commit; external portals (npm, Maven Central, GPG keyservers, Cloudflare) for the actual onboarding.
+
+**Context:**
+- Goal: Unblock real SDK + docs publication. Until this packet completes, packets 04 + 05 run in dry-run; packet 08 ships in dry-run; packet 10's deferred spec calls out the same dependency.
+- Feature: ADR-0057 rollout, Wave 4 (operator-time-budgeted external onboarding).
+- ADRs: ADR-0057 D8 / D15 / §Operational Consequences (primary); ADR-0034 D3 (NuGet/namespace policy); ADR-0029 (Cloudflare DNS for the Maven Central TXT record).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0057 Accepted.
+- `packet:02` — provisioning playbook authored (cross-referenced for Cloudflare).
+- `packet:04` — SDK publication workflow shipped (this packet seeds its credentials).
+- `packet:05` — docs publication workflow shipped (this packet seeds its credential).
+
+**Constraints:**
+- `Actor=Human`.
+- Secret values never committed.
+- GPG ASCII-armored.
+- Maven Central via Central Portal.
+- Cloudflare API token narrowly scoped.
+- Per-repo grant on org secrets.
+- Swift Package Index decision deferred to first-publish; default recommendation subdirectory.
+- No `Unreleased` CHANGELOG.
+
+**Key Files:**
+- `governance/sdk-registry-credentials.md` (new or appended-to)
+- `HoneyDrunk.Architecture/CHANGELOG.md`
+- GitHub org-level secrets (not file-tracked)
+- External portal state (not file-tracked)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0057-api-versioning/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0057-api-versioning/dispatch-plan.md
@@ -1,0 +1,215 @@
+# Dispatch Plan — ADR-0057: Public HTTP API Versioning and Client SDK Strategy
+
+**Initiative:** `adr-0057-api-versioning`
+**ADR:** ADR-0057 (Proposed → Accepted via packet 00)
+**Sector:** Core / cross-cutting
+**Created:** 2026-05-25
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0057 commits the Grid's substrate for public HTTP APIs: URL-path versioning with OpenAPI 3.1 as the source of truth (D7); a four-tier breaking-change taxonomy enforced by an `oasdiff` CI gate (D4 + D7); a 180-day deprecation lifecycle with tenant-notification cadence routed through Communications + Notify (D5); a hard two-major coexistence window (D6); three published SDK languages — TypeScript, Swift, Kotlin — generated from the spec via OpenAPI Generator (D8); per-API key + OAuth 2.1 PKCE auth (D10); IETF unprefixed `RateLimit-*` headers reconciled with ADR-0067 (D11); RFC 7807 `application/problem+json` errors with `traceId` / `correlationId` extensions (D12); `Idempotency-Key` per ADR-0042 on writes (D13); cursor-based pagination defaults (D14); Scalar-plus-Docusaurus docs sites reconciled with ADR-0075 at `docs.{api}.honeydrunkstudios.com` (D15); HoneyHub as the narrow GraphQL-schema-evolution exception (D1 + D16).
+
+This initiative delivers, in **12 packets across 4 waves**, targeting **5 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Actions`, `HoneyDrunk.Web.Rest`, `HoneyDrunk.Notify`, `HoneyDrunk.Studios`):
+
+1. ADR acceptance, four invariants reserved at `{N1}-{N4}` (current claim 102-105), tech-stack + catalog + named-flow registration, and three operator playbooks (migration template, deprecation runbook, docs-subdomain provisioning) — Architecture x3.
+2. Four reusable workflows in `HoneyDrunk.Actions` per ADR-0012's CI/CD control plane posture — the OpenAPI breaking-change diff gate (D7's load-bearing enforcement), the per-language SDK generation + publication pipeline (D8), the per-API docs site builder + Cloudflare Pages deployer (D15), and the HoneyHub GraphQL substrate (D16 — workflows ship now as buildable substrate; HoneyHub repo doesn't exist yet) — Actions x4.
+3. Phase 1 pilot on `HoneyDrunk.Web.Rest` (low-risk: OpenAPI v1 spec reverse-engineered, surface frozen at v1, Option C envelope alignment, cursor primitives added) and Phase 2 pilot on `HoneyDrunk.Notify` (the dry run for Notify Cloud GA: real per-endpoint spec, SDKs publish in dry-run until credentials seeded, docs scaffold).
+4. Studios-side docs subdomain provisioning for the first concrete instance (`docs.notify.honeydrunkstudios.com`); a deferred-handoff specification for the Notify Cloud Phase 3 GA-blocker work (analogous to ADR-0067 packet 05's deferred Notify Cloud spec); and the operator-time-budgeted external onboarding (npm scope, Maven Central namespace, GPG keys, Cloudflare API token).
+
+**12 packets total. 10 are `Actor=Agent`. 2 are `Actor=Human`** — packet 09 (Cloudflare DNS + Pages portal work) and packet 11 (external registry onboarding) carry the `human-only` label per the user's convention.
+
+## Trigger
+
+ADR-0057 is Proposed with no scope. The forcing functions from the ADR's Context:
+
+- **Notify Cloud GA** (PDR-0002 / ADR-0027) is the first commercial API consumer. Without this ADR, every breaking change to a Notify Cloud endpoint risks a tenant outage.
+- **The AI-sector standup wave** (ADR-0016 through ADR-0025) introduces multiple Nodes whose long-term posture includes public surfaces. They need the substrate committed before each invents its own.
+- **Mobile consumer apps** (PDRs 0003 / 0005 / 0006 / 0008) all have a real-world client-version tail. The first breaking change to an API breaks installed mobile clients absent a versioning policy.
+- **ADR-0035 is the internal-case companion** — settled for internal abstractions; this ADR is the external-facing companion. Without it the Grid has half a versioning story.
+
+The cost of letting the convention drift across N Nodes is N rewrites later when the first inconsistency surfaces in a customer outage.
+
+## Scope Detection
+
+**Multi-repo, multi-Node — similar in scope to the observability initiatives.** ADR-0057 lands the substrate workflows in `HoneyDrunk.Actions` (packets 03-06), the per-API instances in `HoneyDrunk.Web.Rest` (packet 07) and `HoneyDrunk.Notify` (packet 08), the Studios-side docs subdomain provisioning (packet 09), the governance + catalog + invariants + playbooks + deferred-spec + onboarding documentation in `HoneyDrunk.Architecture` (packets 00, 01, 02, 10, 11). Five repos total.
+
+**Notify Cloud Phase 3 (D17 Phase 3) is deliberately deferred.** ADR-0027 (Notify Cloud standup) is Proposed; the `HoneyDrunk.Notify.Cloud` repo does not exist on disk; `file-packets.yml` cannot file against it. Per the user's standing convention ("new-Node scaffolding gets its own standup ADR; don't bundle scaffold into feature packets"), the Notify Cloud public-API packet must file *after* the `adr-0027-notify-cloud-standup` initiative's scaffold packet lands. This initiative authors the specification in packet 10 as the handoff document; the production-implementation packet against `HoneyDrunk.Notify.Cloud` is filed as a *new* follow-up packet (or a new initiative `adr-0057-notify-cloud-public-api`) after ADR-0027 completes — see Cross-Initiative Coupling below.
+
+**HoneyHub Phase 4 (D17 Phase 4) implementation is similarly deferred** — HoneyHub does not exist on disk; ADR-0003 (HoneyHub) is Proposed. The **substrate** ships in this initiative (packet 06 — the two GraphQL reusable workflows in Actions) because the workflows are buildable Actions assets, not invoked by any caller yet. The actual `schema.graphql` commitment, the breaking-change gate enabling on the HoneyHub repo, and the HoneyHub docs site provisioning at `docs.honeyhub.honeydrunkstudios.com` land as part of (or after) the HoneyHub standup.
+
+**Four invariants added** — `{N1}-{N4}`, claimed at `102-105` per `constitution/invariant-reservations.md` rule 5 (next free above ADR-0080's 99-101). Packet 00 writes the invariants verbatim; rule 5's collision-shift mechanism handles the case where another in-flight initiative consumes the block first.
+
+**No new abstractions in `.Abstractions` packages.** Web.Rest's new types (`ProblemDetails`, `CursorPageRequest`, `CursorPageResult`, `ApiErrorResponse.Type`) land in `HoneyDrunk.Web.Rest.Abstractions` 0.6.0; that *is* an Abstractions package. Per the package's existing posture and invariant 1, the new types are zero-runtime-dependency Studios-defined records. Notify consumes them at v0.4.0 (packet 08). No other Abstractions package is touched.
+
+**Two `catalogs/contracts.json` updates introduce the `publicHttpApi` block convention** (packet 01 introduces the schema with populated entries for Web.Rest and Notify; packets 07 and 08 populate the spec-path / SDK-coordinates / docs-URL fields, either as sibling commits to Architecture or as follow-up packets — operator decision).
+
+**No new edges in `catalogs/relationships.json`.** Notify already consumes Web.Rest; the Web.Rest 0.6.0 bump propagates as a transitive version-pin update, not a new edge.
+
+## Wave Diagram
+
+### Wave 1 (No Dependencies — governance, catalog, playbooks)
+- [ ] **00** — Architecture: Accept ADR-0057, reserve invariants `{N1}-{N4}` (current claim 102-105), write the four invariants verbatim, register the initiative. `Actor=Agent`.
+- [ ] **01** — Architecture: tech-stack.md + `publicHttpApi` block in contracts.json + `deprecation-notification` flow in feature-flow-catalog.md. `Actor=Agent`. Blocked by: 00.
+- [ ] **02** — Architecture: three operator playbooks — migration-guide template, deprecation runbook, docs-subdomain provisioning playbook. `Actor=Agent`. Blocked by: 00.
+
+### Wave 2 (Depends on Wave 1 — Actions substrate; parallel)
+- [ ] **03** — Actions: `job-openapi-diff.yml` — the load-bearing breaking-change CI gate per D7. `Actor=Agent`. Blocked by: 00, 01.
+- [ ] **04** — Actions: `job-publish-public-sdk.yml` — per-language SDK generation + publication for TS / Swift / Kotlin; Studios-maintained override templates in `openapi-templates/{language}/`. `Actor=Agent`. Blocked by: 00, 01.
+- [ ] **05** — Actions: `job-publish-docs.yml` — Scalar + Docusaurus docs build + Cloudflare Pages deploy. `Actor=Agent`. Blocked by: 00, 01.
+- [ ] **06** — Actions: `job-graphql-inspector.yml` + `job-publish-graphql-docs.yml` — HoneyHub Phase 4 substrate (ships now; not invoked until HoneyHub stands up). `Actor=Agent`. Blocked by: 00, 01.
+
+Packets 03-06 are mutually independent and can run in parallel.
+
+### Wave 3 (Depends on Wave 2 — Phase 1 pilot on Web.Rest)
+- [ ] **07** — Web.Rest: reverse-engineered `openapi-v1.yaml`, surface frozen at v1, Option C envelope alignment (additive RFC 7807 via content negotiation), cursor pagination primitives, IETF rate-limit header hook, Docusaurus scaffold, per-repo CI wiring; version-bump to `0.6.0`. `Actor=Agent`. Blocked by: 00, 01, 03, 05.
+
+### Wave 4 (Depends on Wave 3 — Phase 2 pilot, Studios docs provisioning, deferred-spec handoff, operator onboarding)
+- [ ] **08** — Notify: `openapi-v1.yaml` for the existing endpoints with full ADR-0057 conventions, cursor refactor on list endpoints, RFC 7807 middleware composition from Web.Rest 0.6.0, Idempotency-Key on `POST /v1/notify/send` (or deferred-substrate note), Docusaurus scaffold, per-repo CI wiring; version-bump to `0.4.0`. `Actor=Agent`. Blocked by: 00, 01, 03, 04, 05, 07.
+- [ ] **09** — Studios: Cloudflare DNS + Pages provisioning for `docs.notify.honeydrunkstudios.com` per packet 02's playbook. `Actor=Human` (portal work). Blocked by: 00, 02.
+- [ ] **10** — Architecture: Notify Cloud Phase 3 specification — the deferred handoff to the future `adr-0027-notify-cloud-standup` follow-up (analogous to ADR-0067 packet 05). `Actor=Agent`. Blocked by: 00, 02.
+- [ ] **11** — Architecture: operator onboarding checklist — npm `@honeydrunk` scope, Maven Central `com.honeydrunkstudios` namespace verification, GPG keypair + upload, Cloudflare API token; org secret seeding. `Actor=Human` (portal + CLI). Blocked by: 00, 02, 04, 05.
+
+Within Wave 4: packets 08, 09, 10, 11 are mutually independent at the dependency level — 08 depends on Web.Rest 0.6.0 (Wave 3); 09 + 10 + 11 depend only on Wave 1. They are grouped as Wave 4 because they round out the initiative (Phase 2 pilot, first concrete docs provisioning, deferred handoff, operator onboarding) and complete the **post-onboarding verification loop** described under Cross-Cutting Concerns.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0057 — reserve invariants {N1}-{N4}, register initiative](./00-architecture-adr-0057-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [Public-API substrate in tech-stack.md + contracts.json + feature-flow-catalog.md](./01-architecture-public-api-catalog-and-tech-stack.md) | Architecture | Agent | 1 | 00 |
+| 02 | [Migration template + deprecation runbook + docs-subdomain provisioning playbook](./02-architecture-migration-and-deprecation-playbooks.md) | Architecture | Agent | 1 | 00 |
+| 03 | [job-openapi-diff.yml — breaking-change CI gate](./03-actions-openapi-diff-workflow.md) | Actions | Agent | 2 | 00, 01 |
+| 04 | [job-publish-public-sdk.yml — TS / Swift / Kotlin SDK generation + publication](./04-actions-publish-public-sdk-workflow.md) | Actions | Agent | 2 | 00, 01 |
+| 05 | [job-publish-docs.yml — Scalar + Docusaurus + Cloudflare Pages](./05-actions-publish-docs-workflow.md) | Actions | Agent | 2 | 00, 01 |
+| 06 | [job-graphql-inspector.yml + job-publish-graphql-docs.yml — HoneyHub Phase 4 substrate](./06-actions-graphql-inspector-and-docs-workflows.md) | Actions | Agent | 2 | 00, 01 |
+| 07 | [Web.Rest Phase 1 pilot — openapi-v1.yaml + Option C envelope + cursor primitives + 0.6.0](./07-web-rest-openapi-v1-and-envelope-migration.md) | Web.Rest | Agent | 3 | 00, 01, 03, 05 |
+| 08 | [Notify Phase 2 pilot — openapi-v1.yaml + SDK + docs (dry-run) + 0.4.0](./08-notify-openapi-v1-and-sdk-pilot.md) | Notify | Agent | 4 | 00, 01, 03, 04, 05, 07 |
+| 09 | [Studios — Cloudflare DNS + Pages for docs.notify.honeydrunkstudios.com](./09-studios-docs-notify-subdomain-provisioning.md) | Studios | Human | 4 | 00, 02 |
+| 10 | [Notify Cloud Phase 3 specification — deferred handoff to ADR-0027 standup](./10-architecture-notify-cloud-phase3-specification.md) | Architecture | Agent | 4 | 00, 02 |
+| 11 | [Operator onboarding — npm scope + Maven Central namespace + GPG + Cloudflare token](./11-architecture-sdk-registry-and-credentials-onboarding.md) | Architecture | Human | 4 | 00, 02, 04, 05 |
+
+## Version Bumps
+
+- **`HoneyDrunk.Web.Rest`** — packet 07 bumps the solution `0.5.0` → `0.6.0` (minor; additive per ADR-0035 D1 — new types in Abstractions, additive optional field on `ApiErrorResponse`, new middleware extension). Both `.csproj` files in one commit per invariant 27. Per-package CHANGELOGs entered only for packages with functional change (`Abstractions` and `AspNetCore` both have changes). Repo-level `CHANGELOG.md` gets a new dated `[0.6.0]` entry. No `[Unreleased]`.
+- **`HoneyDrunk.Notify`** — packet 08 bumps the solution `0.3.0` → `0.4.0` (minor; additive — new OpenAPI spec, new docs scaffold, new workflow wiring, list-endpoint cursor refactor consuming Web.Rest 0.6.0 primitives; no breaking change). All non-test `.csproj` files in one commit per invariant 27. Per-package CHANGELOGs only for packages with functional change. Repo-level `CHANGELOG.md` gets a new dated `[0.4.0]` entry.
+- **`HoneyDrunk.Actions`** — packets 03, 04, 05, 06 each add reusable workflows + override-template directories + consumer docs. The Actions repo's CHANGELOG convention dictates whether each addition is its own dated entry or batched; default to one dated entry per packet (or one combined entry per wave's merge — operator choice). No `[Unreleased]`.
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; governance / catalog / doc edits only across packets 00, 01, 02, 10, 11. The repo-level `CHANGELOG.md` records each packet's contribution in dated, versioned entries.
+- **`HoneyDrunk.Studios`** — packet 09 records the docs-subdomain provisioning in `CHANGELOG.md` (dated, versioned).
+
+## Cross-Initiative Coupling with ADR-0027 (Notify Cloud Standup)
+
+ADR-0027 is Proposed; the `HoneyDrunk.Notify.Cloud` repo does not exist on disk. ADR-0057 D17 Phase 3 commits numbers and shapes that *land* in Notify Cloud's production public-API surface. But Notify Cloud's implementation can only be filed after the Notify Cloud repo exists and is scaffolded — i.e., after `adr-0027-notify-cloud-standup` packet 06 (scaffold) lands.
+
+**This initiative's resolution:** packet 10 authors the full Notify Cloud Phase 3 public-API specification in the Architecture repo (at `infrastructure/walkthroughs/notify-cloud-public-api-specification.md`) — a doc that the future follow-up filer reads and turns into a real packet against `HoneyDrunk.Notify.Cloud`. The handoff is explicit: the specification carries a "Follow-up Notify Cloud packet" outline at the bottom (target repo, expected scope, dependencies, version-bump expectation).
+
+The follow-up Notify Cloud packet is **not** filed in this initiative. It is filed:
+
+- **Option A** — as part of the `adr-0027-notify-cloud-standup` initiative's wave-4 follow-up packets (natural home, since ADR-0027 packet 06's scaffold ships placeholder controllers that the production implementation replaces).
+- **Option B** — as a new initiative `adr-0057-notify-cloud-public-api` after `adr-0027-notify-cloud-standup` completes, if the operator prefers an explicit follow-up wave (parallels how ADR-0067's Notify Cloud rate-limit policy is being handled).
+
+Either is acceptable; the choice is the operator's at the time the Notify Cloud follow-up is filed. The specification document in packet 10 is the same regardless.
+
+**Exit-criterion reconciliation.** ADR-0057's exit criterion is the substrate complete + Web.Rest v1 frozen + Notify v1 spec/SDKs/docs live — all within this initiative's filing window. **Notify Cloud Phase 3 is explicitly outside the exit criterion** — it is satisfied across the ADR-0027 standup boundary. This mirrors the ADR-0067 pattern (acceptance flips at the start; the deeper success criterion is the initiative-completion gate recorded in `initiatives/active-initiatives.md` and satisfied across multiple wave / initiative boundaries).
+
+## Cross-Initiative Coupling with ADR-0067 (Rate Limiting) and ADR-0075 (Docs Tooling)
+
+**Already reconciled in the ADR text itself.** ADR-0057 D11 was amended (2026-05-24) to defer to ADR-0067 D5/D7 as the canonical source for the rate-limit envelope (unprefixed IETF `RateLimit-*` headers; per-tenant keying; no legacy `X-RateLimit-*` mirrors; `Retry-After` in seconds). ADR-0057 D15 was amended (2026-05-24) to defer to ADR-0075 D1 + D2 as the canonical sources for Scalar (OpenAPI reference) + Docusaurus (narrative). The packets in this initiative reference both ADRs at the appropriate points — packet 01 records the reconciliation in tech-stack.md; packet 07 wires Web.Rest's `RateLimit-*` hook complementary to the Kernel limiter; packets 05, 06, and 09 consume the Scalar + Docusaurus + Cloudflare Pages choices reconciled with ADR-0075's substrate.
+
+**No new conflicts.** The reconciliations were performed at refine time and are reflected in the ADR text and in the packets here. The OpenAPI-diff CI gate (packet 03) does not conflict with ADR-0067's rate-limit infrastructure; the docs publication workflow (packet 05) consumes Scalar in static-publication mode, not the `Scalar.AspNetCore` runtime mode that ADR-0075 D1 uses — the two are complementary uses of the same renderer.
+
+## Cross-Initiative Coupling with ADR-0034 (NuGet / Public Distribution Policy)
+
+ADR-0034 (Proposed) commits the NuGet policy + namespace decisions: nuget.org as the primary feed for public packages; GitHub Packages for private; `HoneyDrunkStudios` owner; per-package metadata requirements; the namespace ownership decisions including `com.honeydrunkstudios` for Maven Central. ADR-0057 D8's SDK publication consumes ADR-0034 D3's namespace decisions for the per-language registries.
+
+**This initiative does NOT amend ADR-0034.** ADR-0034 remains Proposed; this initiative's packet 11 is the **operator-time-budgeted implementation of ADR-0034 D3's namespace claims** for the SDK registries (npm `@honeydrunk`, Maven Central `com.honeydrunkstudios`, Swift Package Index — git-tag-based, no central namespace). The work is portal-only; no ADR amendment necessary. Once packet 11 completes and the namespaces are claimed, ADR-0034 can move toward acceptance independently; ADR-0057 does not block on it.
+
+## Cross-Cutting Concerns
+
+### Post-onboarding verification loop is the load-bearing closure
+
+The post-onboarding verification described in packet 11's acceptance criteria — re-running packet 08's `notify-api-v1.0.0` tag publication and confirming the SDKs land on the registries + the docs site serves at `docs.notify.honeydrunkstudios.com/v1/` — is the **end-to-end proof** that the substrate works. Until this verification passes, the initiative is not fully exited; packets 03-06 are buildable but not exercised end-to-end on a real publication target.
+
+The verification depends on:
+- Packet 08 having pushed `notify-api-v1.0.0` (the tag itself is operator-pushed per the agents-never-tag rule).
+- Packet 09 having provisioned the Cloudflare Pages project + DNS for `docs.notify`.
+- Packet 11 having seeded the per-registry credentials as GitHub org secrets.
+
+When all three are complete, the operator (or a follow-up agent) re-runs `release-api.yml` on the existing tag and confirms the end-to-end flow. This is the initiative's exit gate — record success in `initiatives/active-initiatives.md` at that point.
+
+### Dry-run posture is intentional through Phase 2 pilot
+
+Packets 04, 05, 08 ship in dry-run-by-default mode. This is intentional, not a defect:
+- It prevents accidental publication when credentials are missing.
+- It exercises the build / generation / validate logic without external side effects.
+- The promotion from dry-run to real-publish is a one-flip event triggered by packet 11's credential seeding (`NPM_TOKEN` / `MAVEN_USERNAME` / etc. become non-empty; the workflows' conditional checks pass; the publish steps execute).
+
+The dry-run logs are required to be loud and unambiguous about *why* they did not publish — so an operator triaging the workflow run knows whether the dry-run was credential-driven (expected pre-packet-11) or for some other reason.
+
+### The four invariants land at acceptance, not later
+
+Packet 00 reserves the four-invariant block `{N1}-{N4}` and writes the verbatim invariant texts into `constitution/invariants.md` in the same PR. This follows the ADR-0008 D5 (superseded by D6) registry pattern that landed in `invariant-reservations.md` — reservation + writing in the same PR. Subsequent packets reference the resolved numbers; if a collision forces a shift at PR time, packet 00 also updates every `{N1}/{N2}/{N3}/{N4}` placeholder in packets 01-11 in the same PR (rule 5 of `invariant-reservations.md`).
+
+### Web.Rest envelope migration is Option C (pinned)
+
+Three options were considered for Web.Rest's RFC 7807 alignment: (A) sudden cutover; (B) defer to v2; (C) additive content negotiation. **Option C is pinned**. The middleware emits both shapes via `Accept`-header content negotiation; default-`ApiErrorResponse` preserves backwards compatibility; clients that signal `Accept: application/problem+json` get RFC 7807. ADR-0057 D4 classifies this as non-breaking; the OpenAPI-diff gate (packet 03) confirms.
+
+The pinning rationale: Option A breaks every Web.Rest consumer; Option B defers the alignment for 180+ days during which downstream code keeps coupling to the Studios-specific shape. Option C is the only path that exercises the substrate now (per ADR-0057 D17 Phase 1's pilot intent) without breaking consumers.
+
+### HoneyHub Phase 4 substrate ships now; implementation deferred
+
+Packet 06 ships `job-graphql-inspector.yml` and `job-publish-graphql-docs.yml` as buildable Actions assets. HoneyHub itself does not exist on disk; ADR-0003 is Proposed. The substrate-now-implementation-later split is the same pattern as Notify Cloud Phase 3 — the substrate is reusable infrastructure that takes time to build correctly, so it lands before the consumer exists, ready to be invoked when the standup happens. This pre-positioning is per ADR-0057 D17 Phase 5's "AI-sector inherits Phase 1 substrate at standup."
+
+### `catalogs/contracts.json` cross-repo update for packets 07 + 08
+
+Packets 07 (Web.Rest) and 08 (Notify) ship their per-API OpenAPI spec, SDK coordinates (Notify only — Web.Rest has none per the deferred-language reasoning), and docs URL. The `catalogs/contracts.json` entries for those Nodes need their `publicHttpApi.openApiSpecPath` / `sdkCoordinates` / `docsUrl` populated. This is awkward to land *from* a per-repo PR (the PR targets Web.Rest or Notify; the catalog file lives in Architecture). Two options:
+- **Option A** — include a sibling commit to `HoneyDrunk.Architecture` in the same PR set if the operator drives the PRs together.
+- **Option B** — file a tiny follow-up packet against Architecture (e.g., `12-architecture-publichttpapi-population.md`) once 07 and 08 have landed.
+
+Operator decision at execution time; either is acceptable. The packets call this out as a Human Prerequisite line.
+
+### Cloudflare Pages free-tier sufficiency
+
+Per the user's `feedback_default_cheapest_azure_tier` rule extended to vendor SaaS: Cloudflare Pages free tier supports the entirety of this initiative's docs traffic. No paid tier needed at v1. Packet 09 confirms.
+
+### Audit footprint
+
+Per ADR-0030 (Audit substrate) and ADR-0057 §Consequences:
+- Every deprecation announcement → `IAuditLog` event (Communications-orchestrated; the `deprecation-notification` flow in packet 01).
+- Every T-90 / T-30 / T-7 tenant email dispatch → `IAuditLog` event.
+- Every post-sunset rejected request → `IAuditLog` event (when the first deprecation runs in earnest, post-Notify Cloud GA).
+
+This initiative does not ship the audit emits; packets 07 and 08 reference the audit substrate in their respective middleware compositions, but no `RateLimitRejected`-style new audit event types are introduced. The deprecation-notification flow is the named flow that surfaces the audit footprint as a single referenceable concept.
+
+### Site sync
+
+No site-sync flag. ADR-0057 is internal Core infrastructure (workflows, conventions, governance) and per-API operational documentation; the public `honeydrunkstudios.com` marketing site does not change. The per-API docs subdomains (`docs.{api}.honeydrunkstudios.com`) are new public surfaces but are catalogued as their own Studios-sector responsibility per ADR-0057 §Cross-ref Studios sector — packet 09 ships the first instance.
+
+### Deferred follow-ups (explicitly out of scope of this initiative)
+
+- **Notify Cloud Phase 3 public-API + SDKs + docs implementation.** Filed after `adr-0027-notify-cloud-standup` scaffold lands. Specification in packet 10.
+- **HoneyHub schema commitment + breaking-change gate enabling + docs subdomain.** Filed after HoneyHub stands up. Substrate ships in packet 06.
+- **Web.Rest docs subdomain provisioning** (`docs.web-rest.honeydrunkstudios.com`). Follows packet 09's pattern; tracked separately because Web.Rest's docs traffic is low and the dry-run state is acceptable through Phase 1.
+- **Per-API `catalogs/contracts.json` population follow-up packet** for Web.Rest + Notify (operator-decision; sibling commit vs. follow-up packet).
+- **C# / Python / Go / Ruby / PHP SDKs.** Generated on request per ADR-0057 D8.
+- **`docs.honeydrunkstudios.com/errors/` page authoring.** Each error `type` URI ships in code now; the per-page authoring on the Studios website is a deferred, operator-driven content task.
+- **Hand-tuned SDK wrapper layers.** Generated SDKs are functional but not idiomatically polished; hand-tuned wrappers land only on evidence per ADR-0057 §Operational Consequences.
+- **OAuth 2.1 with PKCE end-user flow.** ADR-0057 D10 commits both API key and OAuth; OAuth lands when the first end-user-facing Notify Cloud (or future consumer-app) feature requires it.
+
+## Rollback Plan
+
+- **Packets 00-02 (governance / catalog / playbooks):** revert the PR. ADR returns to Proposed; the four invariants are removed from `invariants.md`; the reservation is removed from `invariant-reservations.md`; tech-stack / catalog / feature-flow-catalog / playbook documents are removed. No runtime impact.
+- **Packets 03-06 (Actions substrate):** revert the per-workflow PR. The reusable workflow is removed; consumer documentation is removed; any consuming repo wired against it stops invoking it (none at the time these workflows land, by construction). No runtime impact in `HoneyDrunk.Actions` itself.
+- **Packet 07 (Web.Rest 0.6.0):** revert the PR; Web.Rest rolls back to `0.5.0`. The new types in Abstractions (`ProblemDetails`, `CursorPageRequest`, `CursorPageResult`) and the additive `ApiErrorResponse.Type` field are removed; consuming Nodes (Notify after packet 08) must drop their consumption — though packet 08 has not yet landed if packet 07 is being reverted. The OpenAPI spec is removed; the docs scaffold is removed; the per-repo CI wiring is removed. Web.Rest consumers see the pre-0.6.0 shape.
+- **Packet 08 (Notify 0.4.0):** revert the PR; Notify rolls back to `0.3.0`. The OpenAPI spec is removed; the docs scaffold is removed; the per-repo CI wiring is removed; the cursor-pagination refactor on list endpoints reverts. If the SDKs published for real (post-packet-11), the published versions stay on the registries (per ADR-0057 D9 — never unpublish; mark deprecated if necessary). The dry-run-published SDKs are not in any registry; nothing to unpublish.
+- **Packet 09 (Studios docs subdomain provisioning):** revert the documentation PR. The Cloudflare DNS record + Pages project remain in Cloudflare (revert means manual deletion via the Cloudflare portal — the operator's decision). The docs subdomain stops resolving if the DNS record is removed.
+- **Packet 10 (Notify Cloud Phase 3 spec):** revert the PR; the specification document is removed; the cross-initiative coupling note in `active-initiatives.md` is reverted. No runtime impact.
+- **Packet 11 (operator onboarding):** revert the documentation PR. The npm / Maven Central / Cloudflare credentials remain claimed in their respective portals (revert means manual deletion via each portal — the operator's decision). The GitHub org secrets remain seeded unless manually removed. The dry-run posture re-asserts itself if any secret is unset.
+- **Operational escape hatch:** if the OpenAPI-diff gate (packet 03) produces false positives blocking legitimate non-breaking changes, the gate's `is-unreleased-major: true` input can be set per-PR as a temporary opt-out, or the consuming repo's branch protection can mark the check as advisory rather than required. Both are config-only changes; neither requires a code revert. The over-strict gate is then tuned in a follow-up packet against the workflow.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.
+
+The Notify Cloud Phase 3 follow-up packet is **not** in this folder and is **not** filed by this initiative's push — it is filed later, against the `HoneyDrunk.Notify.Cloud` repo, after the `adr-0027-notify-cloud-standup` initiative's scaffold lands. See Cross-Initiative Coupling above. The HoneyHub Phase 4 schema commitment + per-repo CI wiring is similarly filed later, against the future HoneyHub repo, after the HoneyHub standup completes.

--- a/generated/issue-packets/active/adr-0064-prompt-registry/00-architecture-prompt-registry-initiative-and-sector.md
+++ b/generated/issue-packets/active/adr-0064-prompt-registry/00-architecture-prompt-registry-initiative-and-sector.md
@@ -1,0 +1,193 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ai", "docs", "adr-0064", "wave-1"]
+dependencies: []
+adrs: ["ADR-0064"]
+accepts: ["ADR-0064"]
+wave: 1
+initiative: adr-0064-prompt-registry
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0064 — flip status, claim invariant block {N1}–{N4}, register the initiative
+
+## Summary
+Flip ADR-0064 (Prompt and Persona Registry with Versioning) from Proposed to Accepted: update the ADR header, update the ADR index row in `adrs/README.md`, register the `adr-0064-prompt-registry` initiative in `initiatives/active-initiatives.md`, and confirm the 4-invariant reservation block `{N1}–{N4}` for ADR-0064 in `constitution/invariant-reservations.md` (the reservation row may already exist from a prior reservation-batching PR — verify, and either add or leave-in-place). Surface two **Required Decisions** in the body for resolution before downstream packets land: (a) the N3 / invariant-44 conflict (introducing `HoneyDrunk.Prompts.Abstractions` as a new AI-sector dependency); and (b) whether the paired `HoneyDrunk.Prompts` standup ADR is filed inside this initiative's filing window or as a separate sibling track.
+
+## Context
+ADR-0064 commits the prompt-and-persona registry policy — what gets stored, how it versions, the runtime resolution rule, the Audit emit contract, the Evals integration shape, the Honeyclaw posture, the PDR-app pattern, the on-disk schema, the PII rule, and the loader location. The Node shape itself (repo layout, solution structure, CI pipeline, scaffolding) is intentionally deferred to a paired standup ADR (D12) following the precedent set by the ADR-0058 / ADR-0059 pair.
+
+ADR-0064 is a **policy** ADR: it decides *what the rules are* and *what the contract surface will be*; it does not stand up the `HoneyDrunk.Prompts` repo, write the contract code, or land catalog edges into the relationships graph. Those moves arrive with the paired standup ADR.
+
+The ADR decides (summary, D-letter granularity):
+
+- **D1** — storage is a dedicated public repo `HoneyDrunk.Prompts`, text files with YAML frontmatter, distributed as a NuGet package (content + small loader runtime). Alternatives explicitly rejected: App Configuration values; database-table-with-hash; per-Node inlining.
+- **D2** — two file kinds: **Persona** (stable, named identity; `system_prompt` body; long lifecycle; few in total) and **Prompt** (task-specific template with `{{ parameter }}` placeholders; short lifecycle; many in total; optionally `extends` a persona). Uniform on-disk schema; `kind:` frontmatter discriminates.
+- **D3** — semver on the **package as a whole**, not per file. Major = persona/prompt id removal, parameter required/optional flip, persona `extends` rewrite. Minor = additive (new persona/prompt, new optional parameter) **and body rewrites** (body change is significant model behavior, not interface break). Patch = frontmatter-metadata-only changes. Every file's body+normalized-frontmatter is SHA-256 content-hashed at package build; both the semver version and the hash flow into the audit emit (D5).
+- **D4** — runtime resolution is **snapshot at deploy time**, no hot-reload. The prompt set live in production at any moment is the set baked into the deployed Node binary. Hot-reload (Vault-style Event Grid pattern) explicitly rejected — Evals coverage diverges from production behavior if prompts hot-swap.
+- **D5** — every `IChatClient` / `IEmbeddingGenerator` call records `(persona_id, persona_version, persona_hash, prompt_id, prompt_version, prompt_hash, bypassed_registry?)` to `IAuditLog`. Bypass-registry calls record `bypassed_registry: true` with null prompt fields; the emit itself is never optional.
+- **D6** — Evals integration: a run identifier captures `ModelId`, the `(prompt_id, prompt_version, prompt_hash)` tuple, and the persona tuple if composed. **Equality key for "same prompt" is the hash**, not the version. Two package versions with the same prompt hash are the same text; Evals does not re-score.
+- **D7** — Honeyclaw integration: the Grid `HoneyDrunk.Prompts` repo is the **source of truth** for the bear-keeper persona even though Honeyclaw runs in third-party OpenClaw infrastructure. A build/release-step exporter (in `HoneyDrunk.Prompts` or a paired `HoneyDrunk.OpenClaw` integration package — exact location deferred to the standup ADR) pushes the persona to OpenClaw's configured location at each prompts package release. **No runtime HTTP call** from OpenClaw into the Grid.
+- **D8** — PDR-app personas register in `HoneyDrunk.Prompts` at the app's first AI-enabled feature packet, not later. The app's release is gated on the prompts package's release that includes them.
+- **D9** — on-disk schema: YAML frontmatter + Markdown/text body. Paths `personas/{id}.persona.md` and `prompts/{owner-node}/{id}.prompt.md`. The `id` field in frontmatter is the **lookup key** (path is for human navigation only). Frontmatter fields: `id`, `kind`, `version`, `extends` (prompts only, optional), `parameters` (prompts only), `model_compatibility` (optional), `owner`, `classification` (Public / Internal / Confidential — Restricted forbidden per D10), `created`, `notes`. Placeholders use double-brace `{{ parameter_name }}` Mustache-style — distinct from C# interpolation, Python f-strings, and other capture-prone formats.
+- **D10** — prompt/persona files are **public-or-internal-tier text artifacts**. No PII, no Restricted-tier content, no secret values inline. PII enters via parameters at render time; secrets stay in Vault. Two-tier enforcement: CI gate in `HoneyDrunk.Prompts` (scan for `classification: Restricted` and run secret-scan); reviewer-agent rule per ADR-0044.
+- **D11** — loader `IPromptResolver` lives in `HoneyDrunk.Prompts.Abstractions`; default impl in `HoneyDrunk.Prompts`. `PersonaId`, `PromptId` are records (no `I` prefix per the naming rule); `PersonaContent`, `PromptContent`, `ResolvedMessages` are records carrying body + hash + version + metadata. `Compose(promptId, personaId, parameters)` is the hot path. `HoneyDrunk.Prompts.Tests.Fakes` provides `InMemoryPromptResolver`.
+- **D12** — paired `HoneyDrunk.Prompts` standup ADR follows immediately (precedent: ADR-0058 policy + ADR-0059 standup). This ADR is the policy; the standup ADR is the Node shape.
+
+The ADR also commits four new invariants (Consequences / New Invariants) — claimed at `{N1}–{N4}` per `constitution/invariant-reservations.md`. Packet 01 of this initiative writes them to `constitution/invariants.md`.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Required Decisions (surface in PR description, resolve before downstream packets)
+
+The reservation row for ADR-0064 in `constitution/invariant-reservations.md` already calls out a Required Decision; this packet re-surfaces it as a board-visible item for human resolution.
+
+### Required Decision 1 — invariant 44 conflict
+
+Invariant 44 reads in full:
+
+> Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`. Composition against `HoneyDrunk.AI` and any `HoneyDrunk.AI.Providers.*` package is a host-time concern resolved at application startup from App Configuration. This is the same abstraction/runtime split applied for Vault and Transport, restated here because it is the specific rule that allows blocked AI-sector Nodes (Capabilities, Operator, Agents, Memory, Knowledge, Evals) to proceed on `Abstractions` alone without waiting for provider packages. See ADR-0016 D9.
+
+ADR-0064 N3 (the third invariant ADR-0064 commits) reads in full:
+
+> Application code must never inline a persona's or prompt's body text as a string literal when the registry has an entry for it. New code paths resolve through `IPromptResolver`; one-off bypasses are recorded in audit per the prior invariant.
+
+Resolving N3 to be live requires AI-sector Nodes (Agents, Operator, Memory, Knowledge, Evals, Lore) to take a runtime dependency on `HoneyDrunk.Prompts.Abstractions`. Invariant 44 in its current text reads as restricting downstream AI-sector runtime dependencies to `HoneyDrunk.AI.Abstractions`. Three resolution paths:
+
+- **Resolution A — amend invariant 44 to permit prompt-registry coupling.** Add an explicit exception: "Downstream AI-sector Nodes may also depend on `HoneyDrunk.Prompts.Abstractions` per ADR-0064 D11." Cleanest in narrative terms; preserves invariant 44's blocking-proceed property for AI-provider concerns.
+- **Resolution B — restate invariant 44 narrowly.** Change "Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`" to "Downstream AI-sector Nodes take a runtime dependency on `HoneyDrunk.AI.Abstractions` and no `HoneyDrunk.AI.Providers.*` package." The original intent (no AI-provider lock-in at the consumer site) is preserved; the over-broad "only" is dropped.
+- **Resolution C — carve out by addition.** Leave invariant 44 alone, add a new invariant alongside N3 that explicitly permits `HoneyDrunk.Prompts.Abstractions` as a permitted AI-sector cross-dependency. Heaviest constitution surface.
+
+**Recommendation (defer to user at acceptance time):** Resolution B. The original ADR-0016 D9 reasoning is "no AI-provider lock-in"; `HoneyDrunk.Prompts.Abstractions` is not an AI provider, it is a sibling AI-sector contract. Restating the invariant narrowly captures the intent without amendment-by-exception.
+
+**Action:** the executor of packet 01 chooses A/B/C and applies the chosen text in the same commit as the four new N1–N4 invariants. If the user has not picked at acceptance time, this packet's PR description carries the open question and packet 01 is blocked on resolution.
+
+### Required Decision 2 — paired `HoneyDrunk.Prompts` standup ADR filing posture
+
+ADR-0064 D12 explicitly defers the Node-shape decisions (repo creation, solution layout, CI pipeline, scaffolding, the contract-shape canary on `IPromptResolver`, context folder, catalog entries) to a paired standup ADR. ADR-0064 names "the next available ADR number after the Aspire ADR that ships in the same wave" as the standup ADR's slot — but two postures are possible:
+
+- **Posture A — file the standup ADR draft now**, in this initiative's filing window, by the adr-composer agent. The standup ADR is filed as a fresh Proposed ADR; a sibling `adr-{N}-prompts-standup` initiative is created for it; this initiative's packet 05 (handoff specification) is the handshake from policy to standup.
+- **Posture B — defer the standup ADR draft until after ADR-0064 is Accepted on `main`**. The standup ADR is drafted by the adr-composer agent in a subsequent wave; this initiative's packet 05 is the spec that the standup ADR's adr-composer reads as input.
+
+Either posture is acceptable. The packets in this initiative are **identical under both postures** — no packet here writes Node-shape code or scaffolds `HoneyDrunk.Prompts`. Packet 05 is the handoff document regardless; what changes is whether the sibling initiative folder exists by the time this initiative completes.
+
+**Recommendation:** Posture B. Keeping the policy ADR landed on `main` before drafting the standup ADR matches the ADR-0058 / ADR-0059 cadence (ADR-0058 went Accepted before ADR-0059's standup packets landed). It also keeps this initiative's filing surface small and reduces the chance of races between the two adr-composer drafts.
+
+**Action:** if the user chooses Posture A at acceptance time, an additional task is created outside this initiative: invoke the adr-composer agent against "stand up `HoneyDrunk.Prompts` per ADR-0064 D12." If Posture B, the same task is filed as a follow-up after ADR-0064 reaches Accepted state.
+
+## Scope
+- `adrs/ADR-0064-prompt-and-persona-registry-with-versioning.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `adrs/README.md` — update the ADR-0064 row Status column to Accepted.
+- `initiatives/active-initiatives.md` — register the `adr-0064-prompt-registry` initiative under `## In Progress` with the wave structure and packet checklist for this folder, matching the entry shape used by sibling ADR initiatives (`adr-0058-caching-strategy`, `adr-0067-rate-limiting`).
+- `constitution/invariant-reservations.md` — verify the existing ADR-0064 row at `{N1}–{N4}` is correct (the row already exists per the reservations file). If a collision shift is needed (another ADR raced), update the row in this packet per the file's "How a collision is resolved at merge time" procedure. If no shift is needed, this packet does **not** rewrite the row.
+- `constitution/invariants.md` — **NOT modified.** Invariants land via packet 01.
+
+## Proposed Implementation
+1. Edit the ADR-0064 header: `**Status:** Proposed` → `**Status:** Accepted`. Leave every other line of the ADR text unchanged.
+2. Update the ADR-0064 index row in `adrs/README.md` to `Accepted`.
+3. Register the initiative in `initiatives/active-initiatives.md` under `## In Progress`. Sample shape (adapt to the file's current style):
+
+   ```markdown
+   ### ADR-0064 Prompt and Persona Registry with Versioning
+   **Status:** In Progress
+   **Scope:** Architecture (policy + invariants + catalog + agent checklists + handoff to paired Prompts standup ADR)
+   **Initiative:** `adr-0064-prompt-registry`
+   **Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)
+   **Description:** Land the ADR-0064 policy on the registry shape, audit emit contract, on-disk schema, PII rule, and loader location. Four new invariants (`{N1}/{N2}/{N3}/{N4}` claimed in `constitution/invariant-reservations.md`). The paired `HoneyDrunk.Prompts` standup ADR (D12) is filed as a separate sibling track per Required Decision 2.
+
+   **Tracking (Wave 1 — governance):**
+   - [ ] Architecture: Accept ADR-0064 + reservation row + initiative registration (packet 00)
+   - [ ] Architecture: Four prompt-registry invariants `{N1}/{N2}/{N3}/{N4}` + invariant 44 narrowing (packet 01)
+   - [ ] Architecture: AI sector + ai-sector-architecture.md updates (packet 02)
+
+   **Tracking (Wave 2 — downstream artifacts):**
+   - [ ] Audit: prompt-tuple metadata-key documentation under existing AgentAction / Integration categories (packet 03)
+   - [ ] Architecture: scope.md + review.md prompt-registry checklist (packet 04)
+   - [ ] Architecture: Handoff specification for the paired HoneyDrunk.Prompts standup ADR (packet 05)
+
+   **Exit criteria:** ADR-0064 status flip done in packet 00; four invariants live in `constitution/invariants.md`; AI sector table records the Prompts Node placeholder; Audit emit contract documented at canonical metadata-key shape; agent checklists updated; standup handoff spec authored. The paired `HoneyDrunk.Prompts` standup ADR's acceptance and the Node scaffold are out of scope of this initiative.
+   ```
+
+4. **`constitution/invariant-reservations.md`** — verify the ADR-0064 row (range `74–77` per the current state of the file) is correct. The row already exists; it claims the 4-invariant block and explicitly calls out the invariant 44 conflict as a Required Decision. If, at execution time, another ADR (e.g., ADR-0065 or ADR-0066) has already won a merge race and shifted the available range, follow the file's "How a collision is resolved at merge time" procedure: shift this ADR's range upward to the next free quadruple, update the row, and update every `{N1}/{N2}/{N3}/{N4}` placeholder in packets 01, 03, and 04 to the new numbers in the same commit.
+
+5. Do **NOT** modify `constitution/invariants.md` — packet 01 lands the four invariants and the invariant 44 amendment (per Required Decision 1).
+
+6. Do **NOT** modify `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/grid-health.json`, `catalogs/modules.json`, `catalogs/contracts.json`, or `repos/HoneyDrunk.Prompts/`. Those catalog and repo-folder edits belong to the paired `HoneyDrunk.Prompts` standup ADR (D12), not to this policy initiative. The sectors.md + ai-sector-architecture.md edits (which are policy-level, not Node-shape) land in packet 02.
+
+## Affected Files
+- `adrs/ADR-0064-prompt-and-persona-registry-with-versioning.md` — header `Proposed` → `Accepted`.
+- `adrs/README.md` — index row.
+- `initiatives/active-initiatives.md` — new initiative entry.
+- `constitution/invariant-reservations.md` — verify (no rewrite unless a collision shift is needed).
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency. No catalog edges added.
+- [x] No `HoneyDrunk.Prompts` repo work in this packet (deferred to paired standup ADR).
+
+## Acceptance Criteria
+- [ ] ADR-0064 header reads `**Status:** Accepted`
+- [ ] The ADR-0064 row in `adrs/README.md` reflects Accepted
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0064-prompt-registry` initiative with the packet checklist
+- [ ] `constitution/invariant-reservations.md` ADR-0064 row is consistent (either unchanged because the existing `74–77` claim still holds, or shifted upward and updated in this commit per the file's collision procedure)
+- [ ] `constitution/invariants.md` is **NOT** modified (invariants land in packet 01)
+- [ ] `catalogs/*` is **NOT** modified (Node-shape catalog edits land with the paired standup ADR)
+- [ ] `repos/HoneyDrunk.Prompts/` is **NOT** created (the repo standup belongs to the paired standup ADR)
+- [ ] PR body surfaces Required Decision 1 (invariant 44 conflict — A/B/C choice) and Required Decision 2 (standup ADR filing posture — A/B choice) for human acknowledgement before packet 01 is unblocked
+
+## Human Prerequisites
+- [ ] Pick a resolution for Required Decision 1 (A — amend invariant 44 by exception; B — restate invariant 44 narrowly; C — carve out by addition). The choice gates packet 01's invariant-44 amendment.
+- [ ] Pick a posture for Required Decision 2 (A — file the paired HoneyDrunk.Prompts standup ADR now via adr-composer; B — defer until after this initiative completes). The choice affects whether a sibling initiative folder is created in this filing window.
+
+## Referenced ADR Decisions
+**ADR-0064 D12 — paired standup ADR.** "This ADR commits the policy — what gets stored, how it versions, how runtime resolution works, the audit emit, the schema, the loader shape. The Node shape — repo layout, solution structure, CI pipeline, contract-shape canary, scaffold packet contents — is a separate paired standup ADR following the precedent set by the ADR-0058 / ADR-0059 pair. … Folding the standup into this ADR would set the wrong precedent — future policy ADRs would feel they have to standup their own Nodes inline. Keeping them paired is the right shape."
+
+**ADR-0064 Consequences / New Invariants.** Four invariants commit at acceptance: (1) the audit-emit-tuple rule (N1); (2) the no-PII-in-prompt-files rule (N2); (3) the no-inlined-prompt-body rule (N3, the invariant-44 conflict source); (4) the contract-and-content-shape canary rule (N4). Final numbers assigned at the constitution update.
+
+**Invariant 44** — full text in Required Decision 1 above.
+
+## Constraints
+- **Acceptance precedes implementation.** ADR-0064 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet of this initiative.
+- **No invariant edits in this packet.** Invariants land in packet 01 (which also applies the invariant-44 amendment per Required Decision 1).
+- **No catalog/relationships edits.** The Node-shape catalog edits in ADR-0064's "Catalog and Reference Updates Required" list belong to the paired `HoneyDrunk.Prompts` standup ADR's filing, not this initiative.
+- **Exit criterion is on the standup-ADR side.** ADR-0064's deeper success criterion ("`HoneyDrunk.Prompts` repo stood up; first registry-aware feature packet lands through `IPromptResolver`") is satisfied across the paired-standup-ADR boundary, not within this initiative. This split mirrors ADR-0067's pattern of flipping Status at the start of its initiative because downstream packets need the decisions as live rules.
+- **Self-containment of downstream packets.** Packets 01–05 inline the relevant ADR-0064 decisions and invariant text; an executor in any target repo reads the packet end-to-end and does not need to fetch the ADR file.
+
+## Labels
+`chore`, `tier-3`, `ai`, `docs`, `adr-0064`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0064 to Accepted, register the prompt-registry initiative, verify the `{N1}–{N4}` reservation row, and surface the two Required Decisions for human resolution. No invariant edits and no catalog edits in this packet.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0064 so the remaining packets in this initiative can reference its decisions (D1–D12) as live rules.
+- Feature: ADR-0064 Prompt and Persona Registry with Versioning policy rollout, Wave 1.
+- ADRs: ADR-0064 (primary); ADR-0030 (audit substrate — context for packet 03); ADR-0049 (data classification — context for D10 and packet 02); ADR-0044 (review-agent contract — context for packet 04); ADR-0035 (abstractions-versioning policy — referenced by D3).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- ADR-0064 stays Proposed until this PR merges.
+- No invariant edits — that is packet 01's job, and it includes the invariant-44 amendment per Required Decision 1.
+- No catalog edits — Node-shape catalog edits belong to the paired `HoneyDrunk.Prompts` standup ADR (D12).
+- The two Required Decisions are surfaced in the PR description, not silently resolved by the executor.
+
+**Key Files:**
+- `adrs/ADR-0064-prompt-and-persona-registry-with-versioning.md`
+- `adrs/README.md`
+- `initiatives/active-initiatives.md`
+- `constitution/invariant-reservations.md` (verify only; rewrite only on collision shift)
+
+**Contracts:** None changed. Catalog-level contract surfaces (`IPromptResolver`, `PersonaId`, `PromptId`, `PersonaContent`, `PromptContent`, `ResolvedMessages`) are registered with the paired `HoneyDrunk.Prompts` standup ADR's catalog packet, not here.

--- a/generated/issue-packets/active/adr-0064-prompt-registry/01-architecture-prompt-registry-invariants.md
+++ b/generated/issue-packets/active/adr-0064-prompt-registry/01-architecture-prompt-registry-invariants.md
@@ -1,0 +1,182 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ai", "docs", "adr-0064", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0064"]
+wave: 1
+initiative: adr-0064-prompt-registry
+node: honeydrunk-architecture
+---
+
+# Land the four ADR-0064 prompt-registry invariants and amend invariant 44
+
+## Summary
+Add the four new prompt-registry invariants ADR-0064 commits — the audit-emit-tuple rule (N1), the no-PII-in-prompt-files rule (N2), the no-inlined-prompt-body rule (N3), and the CI canary rule (N4) — to `constitution/invariants.md` at the numbers `{N1}, {N2}, {N3}, {N4}` reserved against ADR-0064 in `constitution/invariant-reservations.md`. In the **same commit**, apply the resolution of Required Decision 1 (the invariant 44 conflict) — packet 00's PR carries the human's A/B/C choice; this packet realizes the chosen resolution. After landing, move the ADR-0064 row in `invariant-reservations.md` from **Active Reservations** to **Reservation History** with the merge date. Governance-only packet; no code, no .NET project.
+
+## Context
+ADR-0064 Consequences / New Invariants commits four invariants. Each is a load-bearing rule that downstream code (the paired `HoneyDrunk.Prompts` standup ADR's Node scaffold, the AI-sector Nodes that consume `IPromptResolver`, the Audit Node's emit shape, the reviewer agent) references. Without the invariant text live in `constitution/invariants.md`, the rules cannot be quoted inline by downstream packets.
+
+The four invariants ADR-0064 commits:
+
+- **N1 (audit emit)** — every `IChatClient` / `IEmbeddingGenerator` call emits an `IAuditLog` entry recording `(persona_id, persona_version, persona_hash, prompt_id, prompt_version, prompt_hash, bypassed_registry?)`. Bypass calls record `bypassed_registry: true` with null prompt fields; the emit itself is never optional. Source: D5.
+- **N2 (no PII in files)** — no PII, no `Restricted`-tier content, no secret values inline in `HoneyDrunk.Prompts` files. PII enters via parameters at render time; secrets stay in Vault; CI gate enforces. Source: D10.
+- **N3 (no inlined prompt bodies)** — application code must never inline a persona's or prompt's body text as a string literal when the registry has an entry for it; new code paths resolve through `IPromptResolver`; one-off bypasses are recorded in audit per N1. Source: D2 / D11. **This is the invariant that conflicts with invariant 44's current text** — see Required Decision 1 in packet 00, and the amendment in §Proposed Implementation below.
+- **N4 (CI canary)** — the `HoneyDrunk.Prompts` package's CI must include a contract-shape canary on `IPromptResolver` and a content-shape canary asserting every prompt file's frontmatter parses and every body's `{{ parameter }}` placeholders match the declared parameters list. Source: D11 / D9.
+
+This packet also applies the resolution of Required Decision 1 (packet 00's PR captures the human's choice). The recommended choice is Resolution B (restate invariant 44 narrowly), but A or C is acceptable. The chosen text lands in the same commit as the four new N1–N4 invariants so the constitution is internally consistent at every commit boundary.
+
+This is a docs/governance packet. No code, no workflow, no .NET project.
+
+## Scope
+- `constitution/invariants.md` — add four new invariants at numbers `{N1}, {N2}, {N3}, {N4}` (resolved from the ADR-0064 row in `constitution/invariant-reservations.md`); amend invariant 44 per the chosen resolution; do not renumber any existing invariant.
+- `constitution/invariant-reservations.md` — move the ADR-0064 row from **Active Reservations** to **Reservation History** with the merge date.
+
+## Proposed Implementation
+
+### Step 0 — Resolve `{N1}/{N2}/{N3}/{N4}` from the reservation file
+
+Open `constitution/invariant-reservations.md`. Find the ADR-0064 row in the **Active Reservations** table (claimed by packet 00; the current state of the file claims `74–77`). The row gives a contiguous 4-number block. `{N1}` is the first, `{N2}` the second, `{N3}` the third, `{N4}` the fourth.
+
+If, at execution time, the reservation row has been shifted upward due to a merge race with another ADR (per the file's collision-resolution procedure), use the shifted numbers and update every placeholder in this packet body and in packets 03 and 04 in the same commit.
+
+Do **not** invent numbers from memory — read the file each time.
+
+### Step 1 — Add the four invariants to `constitution/invariants.md`
+
+`constitution/invariants.md` is **topic-grouped, not contiguously numbered.** Scan the whole file before placement; do not append all four at the end. Suggested groupings:
+
+- **`{N1}` (audit emit tuple, D5)** — append to the **Audit Invariants** group (alongside invariants 47–49). The audit-emit-tuple rule is structurally an extension of invariant 47's "durable, attributable security, action, and data-change events are emitted to the HoneyDrunk.Audit substrate via `IAuditLog`" — N1 names the specific tuple shape for LLM-call events. Verify the section heading at edit time.
+- **`{N2}` (no PII in prompt files, D10)** — this is a data-classification rule. If a **Data Classification Invariants** section exists (it may have landed via ADR-0049's reservation between this initiative's authoring and execution time), append there. If not, place it adjacent to invariant 8 (`Secret values never appear in logs, traces, exceptions, or telemetry`) in the Secrets & Trust Invariants group — N2 is the prompt-source-file analog of invariant 8 extended to public-repo source-file artifacts.
+- **`{N3}` (no inlined prompt bodies, D2 / D11)** — append to the **AI Invariants** group (alongside invariants 28, 29, 30, 44, 45, 46). N3 is the prompt-text analog of invariant 28's "application code must never hardcode a model name or provider" — the same shape, the same forcing-function logic, for prompt text instead of model identifiers.
+- **`{N4}` (contract + content canary, D11 / D9)** — append to the AI Invariants group, adjacent to invariants 43 (Communications canary) and 46 (HoneyDrunk.AI canary) which it structurally mirrors. The canary obligation is the same as those two — keep the gate, do not pin a specific implementation file.
+
+Invariant texts (substance-verbatim — the body is what gets quoted inline by downstream packets per the issue-authoring rule "implementation constraints include invariant text … avoid number-only references"):
+
+#### `{N1}` — Every LLM call emits an audit entry recording the prompt tuple
+
+> Every `IChatClient` and `IEmbeddingGenerator` call records to `IAuditLog` (per the audit substrate) a structured payload containing `(persona_id, persona_version, persona_hash, prompt_id, prompt_version, prompt_hash, bypassed_registry?)`. `persona_id` / `persona_version` / `persona_hash` are `null` when no persona is composed; `prompt_id` / `prompt_version` / `prompt_hash` are `null` when the call composed no template (raw user message only). Calls that bypass the registry (a one-off inline raw-system-message call) record `bypassed_registry: true` with null prompt fields; the audit emit itself is **never optional**. The payload contains only the tuple — never the rendered prompt body, never the completion text, never the substituted parameter values. See ADR-0064 D5.
+
+#### `{N2}` — No PII, no Restricted-tier content, no secret values appear inline in `HoneyDrunk.Prompts` files
+
+> Prompt and persona files in the `HoneyDrunk.Prompts` repo are **public-or-internal text artifacts**. No `Restricted`-tier content per the data-classification taxonomy, no PII-bearing values, and no secret values appear inline in any prompt or persona file body or frontmatter. Tenant-scoped data, PII, customer records, and any classified payload enter the LLM call at **render time, via parameters** — the prompt file declares `{{ parameter_name }}` placeholders; the runtime substitutes the actual value at call time; the file never carries the value itself. Secrets stay in Vault and resolve through `ISecretStore`, never inlined into prompt text. CI gate enforces: any file with `classification: Restricted` in frontmatter, or any secret-scan pattern match in any file body, fails the `HoneyDrunk.Prompts` build. See ADR-0064 D10.
+
+#### `{N3}` — Application code must never inline a persona's or prompt's body text as a string literal when the registry has an entry for it
+
+> When the `HoneyDrunk.Prompts` registry has an entry for a persona or prompt, application code must resolve it through `IPromptResolver` and never inline the body text as a string literal. New code paths consume the registry; one-off bypasses (a developer experiment, a one-shot operator diagnostic prompt) are not forbidden but are recorded in audit per the prompt-tuple invariant (`bypassed_registry: true`) so the studio can measure progress toward registry-coverage = 100%. This is the prompt-text analog of the rule that forbids inlining model names: a Grid-wide primitive should be sourced from one place, not duplicated across N Nodes. See ADR-0064 D2 / D11.
+
+#### `{N4}` — `HoneyDrunk.Prompts` CI must include a contract-shape canary and a content-shape canary
+
+> The `HoneyDrunk.Prompts` package's CI must include (a) a contract-shape canary on `IPromptResolver` that fails the build on shape drift to the interface or its supporting record types (`PersonaId`, `PromptId`, `PersonaContent`, `PromptContent`, `ResolvedMessages`) without a corresponding version bump, and (b) a content-shape canary asserting every prompt file's YAML frontmatter parses cleanly and every body's `{{ parameter }}` placeholders match the file's declared `parameters` list. Shape drift on the contract surface or content drift in the files is a build failure unless paired with an intentional version bump. The implementation may be the existing `job-api-compatibility.yml` reusable workflow scoped to `HoneyDrunk.Prompts.Abstractions` plus a content-parse step; the obligation is to keep both gates, not to use any specific implementation. See ADR-0064 D11 / D9.
+
+### Step 2 — Apply the chosen resolution of Required Decision 1 (invariant 44 amendment)
+
+Packet 00's PR description carries the human's A/B/C choice for Required Decision 1. The current text of invariant 44 is (verbatim):
+
+> Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions`. Composition against `HoneyDrunk.AI` and any `HoneyDrunk.AI.Providers.*` package is a host-time concern resolved at application startup from App Configuration. This is the same abstraction/runtime split applied for Vault and Transport, restated here because it is the specific rule that allows blocked AI-sector Nodes (Capabilities, Operator, Agents, Memory, Knowledge, Evals) to proceed on `Abstractions` alone without waiting for provider packages. See ADR-0016 D9.
+
+Apply the chosen resolution in the same commit as the four new invariants:
+
+**Resolution A — amend invariant 44 to permit prompt-registry coupling.** Replace the first sentence with:
+> Downstream AI-sector Nodes take a runtime dependency only on `HoneyDrunk.AI.Abstractions` and (per ADR-0064 D11) `HoneyDrunk.Prompts.Abstractions`.
+
+**Resolution B (recommended) — restate invariant 44 narrowly.** Replace the first sentence with:
+> Downstream AI-sector Nodes take a runtime dependency on `HoneyDrunk.AI.Abstractions` and no `HoneyDrunk.AI.Providers.*` package directly.
+
+Optionally append a clarifying sentence: "Sibling AI-sector contracts (e.g., `HoneyDrunk.Prompts.Abstractions` per ADR-0064 D11) are permitted; the rule targets AI-provider coupling specifically."
+
+**Resolution C — carve out by addition.** Leave invariant 44's text unchanged. Add a new invariant adjacent to N3 in the AI Invariants group with text:
+> Downstream AI-sector Nodes may take a runtime dependency on `HoneyDrunk.Prompts.Abstractions` per ADR-0064 D11. This is an explicit exception to invariant 44's "only `HoneyDrunk.AI.Abstractions`" rule — the Prompts contract is a sibling AI-sector primitive, not an AI-provider, and the host-time composition rule does not apply.
+
+If Resolution C is chosen, the carve-out invariant gets the next free number after `{N4}` — i.e., `{N4}+1`. **In that case** the ADR-0064 reservation row must be widened from 4 to 5 numbers; coordinate with `constitution/invariant-reservations.md` and shift any downstream ADR's reservation upward by one in the same commit per the file's collision-shift procedure. (This is operationally heavier than A or B; it is the reason A and B are preferred and B is recommended.)
+
+### Step 3 — Consume the reservation
+
+In `constitution/invariant-reservations.md`, move the ADR-0064 row from **Active Reservations** to **Reservation History** with the merge date (per the file's "When a reservation is consumed" procedure). The reservation is "consumed" the moment the invariants land in `invariants.md`.
+
+## Affected Files
+- `constitution/invariants.md` — four new invariants at `{N1}/{N2}/{N3}/{N4}`; invariant 44 amendment per the chosen resolution; (optional `{N4}+1` carve-out if Resolution C).
+- `constitution/invariant-reservations.md` — move ADR-0064 row from **Active Reservations** to **Reservation History**; if Resolution C, widen the row to 5 numbers and shift downstream reservations.
+
+## NuGet Dependencies
+None. Markdown-only packet.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] Governance-only — no runtime impact, no canary required.
+
+## Acceptance Criteria
+- [ ] `constitution/invariants.md` carries four new invariants at the numbers resolved from the ADR-0064 row in `constitution/invariant-reservations.md`, each citing ADR-0064 by D-letter
+- [ ] `{N1}` is placed in the Audit Invariants group; full text as quoted in §Proposed Implementation Step 1
+- [ ] `{N2}` is placed in a Data Classification Invariants section (if it exists) or adjacent to invariant 8; full text as quoted
+- [ ] `{N3}` is placed in the AI Invariants group adjacent to invariant 28; full text as quoted
+- [ ] `{N4}` is placed in the AI Invariants group adjacent to invariants 43 / 46; full text as quoted
+- [ ] Invariant 44 is amended per the chosen resolution (A / B / C), or (Resolution C only) a new carve-out invariant lands at `{N4}+1` and the ADR-0064 reservation row is widened to 5 numbers
+- [ ] The full text of each invariant is included, not a placeholder or stub
+- [ ] No existing invariant (other than 44 per the chosen resolution) is renumbered or rewritten
+- [ ] `constitution/invariant-reservations.md` has had the ADR-0064 row moved from **Active Reservations** to **Reservation History** with the merge date
+- [ ] If Resolution C was chosen, any downstream ADR reservation in the file that needs to shift upward by one is shifted in the same commit
+- [ ] No ADR status edit in this packet — packet 00 already flipped ADR-0064
+
+## Human Prerequisites
+- [ ] Required Decision 1 (invariant 44 conflict) resolved in packet 00's PR before this packet executes — without a chosen A/B/C, this packet is blocked.
+
+## Referenced ADR Decisions
+**ADR-0064 D5 — Audit emit (N1 source).** Every `IChatClient` and `IEmbeddingGenerator` call records `(persona_id, persona_version, persona_hash, prompt_id, prompt_version, prompt_hash)` plus a `bypassed_registry?` flag. The tuple is required on every LLM-call audit emit. Calls that bypass the registry record `bypassed_registry: true` with null prompt fields — bypassed-registry calls are operationally legitimate but the audit emit is not optional. **Payload is tuple-only** — never the rendered prompt body, never the completion text, never the substituted parameter values (per the refine-pass clarification).
+
+**ADR-0064 D10 — PII and sensitive content (N2 source).** Prompts and personas are public-or-internal text artifacts. Per ADR-0049, no `Restricted`-tier or PII-bearing value may appear inline in a prompt or persona file. Tenant-scoped data, PII, customer records, and any classified payload enter the LLM call at render time, via parameters. CI gate enforces: scans every file's frontmatter for `classification: Restricted` (forbidden) and runs the secret-scan pipeline on every file body. Tier names per ADR-0049 D1 are `Public / Internal / Confidential / Restricted` — `Sensitive` is a PII *sub-classification* under ADR-0049 D2, not a top-level tier.
+
+**ADR-0064 D2 / D11 — No inlined prompt bodies (N3 source).** When the registry has an entry, application code must resolve through `IPromptResolver`, not inline the body as a string literal. The prompt-text analog of invariant 28's model-name rule. One-off bypasses record in audit per N1.
+
+**ADR-0064 D11 / D9 — Canaries (N4 source).** Contract-shape canary on `IPromptResolver` and the record types. Content-shape canary asserting every prompt file's frontmatter parses and every body's `{{ parameter }}` placeholders match the declared `parameters` list. Shape or content drift is a build failure unless paired with an intentional version bump.
+
+**Invariant 44 (current text) — see Required Decision 1 in packet 00.** N3 forces a resolution to A / B / C. This packet applies the chosen resolution.
+
+**ADR-0049 D1 — Classification taxonomy.** Four tiers: `Public`, `Internal`, `Confidential`, `Restricted`. Higher-tier datum can always be handled at a higher tier; the converse is a boundary violation. When classification is unclear, default to `Restricted`.
+
+## Constraints
+- **Invariant numbers come from `constitution/invariant-reservations.md`, not from this packet.** Read the file at execution time. The current ADR-0064 row claims `74–77`; if a merge race has shifted the row, use the shifted numbers and update every placeholder in this packet, packet 03, and packet 04 in the same commit.
+- **Topic-grouped placement.** The file is topic-grouped, not contiguously numbered. Place each invariant in its appropriate group — do not append all four at the end.
+- **Full invariant text, not a number-only reference.** Each invariant's body must contain the full text so downstream packets can quote it inline (per the issue-authoring rule "implementation constraints include invariant text … avoid number-only references in constraint sections").
+- **The invariant 44 amendment is non-optional.** N3's introduction of `HoneyDrunk.Prompts.Abstractions` as a downstream AI-sector dependency conflicts with the current text of invariant 44; the conflict must be resolved at the same commit as N3 lands. The recommended path is Resolution B; A or C is acceptable if the user picks it in packet 00's PR.
+- **Tier names are `Public / Internal / Confidential / Restricted`.** Do not use `Sensitive` as a tier — that is a PII sub-classification under ADR-0049 D2, not a top-level tier. N2's text uses `Restricted` (the relevant top-level tier).
+- **The audit emit is tuple-only.** N1's text explicitly excludes rendered prompt body, completion text, and substituted parameter values from the audit payload. Do not soften this — the rule exists because prompt bodies can be multi-kilobyte and substituted parameters may carry PII per N2.
+- **Consume the reservation.** Once the four (or five, if Resolution C) invariants land, move the ADR-0064 row from **Active Reservations** to **Reservation History** in `invariant-reservations.md` with the merge date.
+- **No status flip.** ADR-0064's `Status:` header stays `Accepted` (flipped by packet 00). No re-edit here.
+
+## Labels
+`chore`, `tier-3`, `ai`, `docs`, `adr-0064`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Land the four new prompt-registry invariants in `constitution/invariants.md` at the numbers reserved against ADR-0064, and apply the chosen resolution of Required Decision 1 (invariant 44 amendment) in the same commit. Consume the reservation by moving the row to history.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the four prompt-registry invariants live before any downstream packet (Audit emit docs, scope/review agent checklists, paired-standup-ADR specification) quotes them inline.
+- Feature: ADR-0064 Prompt and Persona Registry rollout, Wave 1.
+- ADRs: ADR-0064 D5 / D10 / D2 / D11 / D9 (primary), ADR-0049 D1 / D2 (classification taxonomy), ADR-0035 D1 (abstractions versioning — referenced by D3 of ADR-0064 and N4).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0064 Accepted, initiative registered, Required Decision 1 resolved in the PR description.
+
+**Constraints:**
+- Use the numbers in `constitution/invariant-reservations.md`'s ADR-0064 row at execution time — read, don't assume.
+- Place each invariant in its topic group, not at the end of the file.
+- Include the full invariant text for each.
+- Apply the chosen resolution (A / B / C) of Required Decision 1 in the same commit. Recommended: Resolution B.
+- Tier names per ADR-0049 D1 are `Public / Internal / Confidential / Restricted` — `Sensitive` is a PII sub-classification, not a tier.
+- Audit emit (N1) is tuple-only. No body text, no completion text, no substituted parameter values in the payload.
+- Consume the reservation by moving the row from Active to History.
+
+**Key Files:**
+- `constitution/invariants.md` — four new invariants in their topic groups + invariant 44 amendment.
+- `constitution/invariant-reservations.md` — move the ADR-0064 row to **Reservation History**.
+
+**Contracts:** None changed. Governance only.

--- a/generated/issue-packets/active/adr-0064-prompt-registry/02-architecture-ai-sector-prompt-registry-layer.md
+++ b/generated/issue-packets/active/adr-0064-prompt-registry/02-architecture-ai-sector-prompt-registry-layer.md
@@ -1,0 +1,188 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ai", "docs", "adr-0064", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0064"]
+wave: 1
+initiative: adr-0064-prompt-registry
+node: honeydrunk-architecture
+---
+
+# Add the prompt-registry layer to constitution/sectors.md and ai-sector-architecture.md
+
+## Summary
+Record ADR-0064's commitment that prompts and personas are the **AI sector's identity substrate** (the same way Audit is Core's record substrate) in two governance documents: `constitution/sectors.md` gains a placeholder row in the AI sector table noting the planned `HoneyDrunk.Prompts` Node (Seed signal); `constitution/ai-sector-architecture.md` gains a new subsection describing the prompt-registry layer between AI inference and downstream consumers. The full Node entry (catalog rows in `nodes.json`, `relationships.json`, `modules.json`, `contracts.json`, `grid-health.json`) is deferred to the paired `HoneyDrunk.Prompts` standup ADR; this packet only carries the policy-level sector-table placeholder and the architecture document update so the AI-sector standup wave (Agents, Memory, Knowledge, Evals, Operator) reading these documents during their own feature work has the registry layer in front of them.
+
+## Context
+ADR-0064 D12 explicitly defers the Node-shape and catalog edits to the paired `HoneyDrunk.Prompts` standup ADR. But two updates are policy-level, not Node-shape, and belong with this initiative:
+
+1. **`constitution/sectors.md`** — the AI sector table is a high-level sector taxonomy, not a Node-by-Node catalog. Adding a placeholder row for the planned `HoneyDrunk.Prompts` Node (Seed signal, "Prompt and persona registry — versioned content, audit-anchored, snapshot-at-deploy") signals to anyone reading the sector taxonomy that the registry is committed at the policy level even though the Node has not been stood up yet. The Cache Node row in this same table landed at ADR-0058 acceptance time before ADR-0059's standup PRs merged; this packet mirrors that pattern.
+2. **`constitution/ai-sector-architecture.md`** — the AI sector's architecture document describes Node boundaries, dependency flow, and integration with the rest of the Grid. ADR-0064 commits a new layer (the prompt-registry layer) that sits between AI inference and every downstream consumer. The architecture document needs an update so future readers (and the AI-sector standup Nodes reading their own architecture spec) understand the layer's role.
+
+Note: the **catalog edits** — `catalogs/nodes.json` (the `honeydrunk-prompts` entry), `catalogs/relationships.json` (the consumes/consumed-by edges), `catalogs/modules.json` (the three planned packages), `catalogs/contracts.json` (the `IPromptResolver` + record types), `catalogs/grid-health.json` (the Node row), and the `repos/HoneyDrunk.Prompts/` folder with `overview.md` / `boundaries.md` / `invariants.md` — **all land with the paired `HoneyDrunk.Prompts` standup ADR**, not this packet. That packet creates the Node; this packet only acknowledges its existence in the sector taxonomy and the AI-sector architecture document.
+
+This is a docs/governance packet. No code, no .NET project.
+
+## Scope
+- `constitution/sectors.md` — append a placeholder row to the AI sector table for the planned `HoneyDrunk.Prompts` Node.
+- `constitution/ai-sector-architecture.md` — add a new subsection describing the prompt-registry layer (its role, dependency direction, deferral to the paired standup ADR for Node shape).
+- `catalogs/*` — **NOT modified** in this packet. The full Node row and edges land with the paired `HoneyDrunk.Prompts` standup ADR.
+- `repos/HoneyDrunk.Prompts/` — **NOT created** in this packet. The repo folder lands with the paired standup ADR.
+
+## Proposed Implementation
+
+### Step 1 — `constitution/sectors.md`
+
+Open the file and locate the **AI sector** subsection (around lines 86–105, but verify at edit time — the file may have shifted). The current AI sector table lists nine Nodes (Agents, AI, Memory, Knowledge, Evals, Capabilities, Flow, Operator, Sim), each as a `| Name | Signal | Responsibility |` row.
+
+Append a new row at the end of the table, matching the existing formatting:
+
+```markdown
+| **Prompts** | Seed | Prompt and persona registry — versioned content, audit-anchored tuple emit, snapshot-at-deploy. Standup deferred to a paired standup ADR per the policy. |
+```
+
+The row uses `Prompts` (the public Node name, matching the convention used by sibling nodes in the table). The Signal is `Seed` because the Node is committed at the policy level but the standup ADR has not yet landed.
+
+Do **not** modify the Dependency Flow diagram at the bottom of `sectors.md` ("Dependency Flow (Real Nodes)"). That diagram is for **Real Nodes** (Live or stood-up Seed); `HoneyDrunk.Prompts` is committed at policy level only at this packet's execution time. The diagram is updated when the paired standup ADR lands.
+
+### Step 2 — `constitution/ai-sector-architecture.md`
+
+Open the file. The document has a **Design Principles** section followed by per-Node **Node Definitions** sections (Agents, AI, Memory, Knowledge, Evals, Capabilities, Flow, Operator, Sim — verify the current Node list at edit time).
+
+Add a new subsection at the end of the **Node Definitions** chain (after Sim's section) — or, if a "Cross-Cutting Layers" / "Substrate" / "Identity substrate" section exists, append there instead. The new subsection captures the prompt-registry layer at architecture level (not at Node-shape level):
+
+```markdown
+### HoneyDrunk.Prompts (planned — paired standup ADR)
+
+**Node ID:** `honeydrunk-prompts` (catalog entry added with the paired standup ADR)
+**Role:** Prompt and persona registry — the AI sector's identity substrate.
+
+**Owns:**
+- Versioned prompt and persona text artifacts (files on disk, frontmatter + body).
+- The `IPromptResolver` contract (in `HoneyDrunk.Prompts.Abstractions`) for runtime resolution of personas, prompts, and parameter-substituted compositions.
+- The content-hash discipline that anchors every Evals run identifier and every audit-tuple emit to byte-exact prompt text.
+- The CI gates that forbid PII and Restricted-tier content inline and prevent shape drift on `IPromptResolver` without a version bump.
+
+**Does not own:**
+- Inference (that is `HoneyDrunk.AI`). The Prompts Node supplies prompt content; the AI Node executes the resulting `IChatClient` / `IEmbeddingGenerator` calls.
+- Audit storage (that is `HoneyDrunk.Audit`). The Prompts Node's role in audit is to give every LLM call a stable `(persona_id, persona_version, persona_hash, prompt_id, prompt_version, prompt_hash)` tuple that the call site emits via `IAuditLog`. The audit payload is tuple-only — no rendered prompt body, no completion text, no substituted parameter values.
+- Evals scoring (that is `HoneyDrunk.Evals`). The Prompts Node's role in Evals is to give every run identifier a hash-anchored equality key for "same prompt or different."
+
+**Dependency flow:**
+- `HoneyDrunk.Prompts.Abstractions` — zero runtime dependencies on other Grid packages (only `Microsoft.Extensions.*` abstractions, per the abstractions-package invariant).
+- `HoneyDrunk.Prompts` (default impl) — depends on `HoneyDrunk.Prompts.Abstractions` and Kernel primitives for lifecycle and DI.
+- Every AI-sector consumer Node (Agents, Operator, Memory, Knowledge, Evals, Lore) takes a runtime dependency on `HoneyDrunk.Prompts.Abstractions`.
+- Third-party agent gateways that run Grid-defined personas (e.g., OpenClaw running Honeyclaw) consume the persona via a build/release-step export. The Grid never runs as a runtime dependency of third-party agent infrastructure.
+
+**Versioning:**
+- Semver on the `HoneyDrunk.Prompts` package as a whole. Per-prompt versioning was considered and rejected — the audit-emit content hash captures per-file identity for forensic purposes without per-file semver overhead.
+- Body rewrites are **minor** bumps (the body change is significant model behavior, not interface break). Removing a persona/prompt id, removing or renaming a parameter, or changing a prompt's `extends` is **major**.
+
+**Runtime resolution:**
+- Snapshot at deploy time, no hot-reload. The prompt set live in production is the set baked into the deployed Node binary. Hot-reload was considered and rejected — it desynchronizes production behavior from the Evals score that greenlit the release.
+
+**Standup deferred** to the paired `HoneyDrunk.Prompts` standup ADR per the policy ADR's D12 decision. The standup ADR covers repo creation, solution layout, CI pipeline (including the contract-shape and content-shape canaries), the migration packet that seeds the bear-keeper persona and the Lore wiki-ingest prompt, and the catalog row entries.
+```
+
+Adapt the prose to match the document's existing tone if it differs noticeably — the file's existing Node sections have a consistent shape (Node ID, Role, Owns / Does not own, Dependency flow), so the new section follows that shape verbatim.
+
+### Step 3 — Do NOT modify catalogs
+
+- `catalogs/nodes.json` — no row added. The `honeydrunk-prompts` row is the paired standup ADR's responsibility.
+- `catalogs/relationships.json` — no edges added.
+- `catalogs/modules.json` — no entry added.
+- `catalogs/contracts.json` — no `IPromptResolver` or record entries added.
+- `catalogs/grid-health.json` — no row added.
+- `repos/HoneyDrunk.Prompts/` — folder NOT created.
+
+The rationale: the sector taxonomy and the architecture document are *policy* artifacts; the catalogs and the per-repo `repos/*` folder are *Node-shape* artifacts. ADR-0064 D12 splits these explicitly. The sector-table row and the architecture subsection acknowledge the Node's existence at policy level; the catalog rows land when the Node actually exists.
+
+### Step 4 — Do NOT modify infrastructure/reference/tech-stack.md
+
+`infrastructure/reference/tech-stack.md` carries Grid-wide cross-cutting platform choices. The prompt registry is not a cross-cutting *substrate* choice (no Azure service, no third-party library) — it is a Node. The tech-stack.md entry is added when the Node ships, with the paired standup ADR. Do not add an entry now.
+
+## Affected Files
+- `constitution/sectors.md` — new row in the AI sector table for the planned Prompts Node.
+- `constitution/ai-sector-architecture.md` — new subsection describing the prompt-registry layer.
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No catalog or per-repo `repos/*` edits — those are paired-standup-ADR territory per ADR-0064 D12.
+- [x] No new top-level Node-to-Node edge in catalog data.
+
+## Acceptance Criteria
+- [ ] `constitution/sectors.md` AI sector table carries a new `**Prompts** | Seed | …` row matching the existing row formatting
+- [ ] The Dependency Flow diagram at the bottom of `sectors.md` is **NOT** modified (it tracks Real Nodes, not policy-level Seeds)
+- [ ] `constitution/ai-sector-architecture.md` carries a new subsection (e.g., `### HoneyDrunk.Prompts (planned — paired standup ADR)`) describing the Node's role, owns / does not own, dependency flow, versioning, and runtime resolution
+- [ ] The new subsection matches the document's existing per-Node section shape (Node ID, Role, Owns, Does not own, Dependency flow)
+- [ ] `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/modules.json`, `catalogs/contracts.json`, `catalogs/grid-health.json` are **NOT** modified
+- [ ] `repos/HoneyDrunk.Prompts/` is **NOT** created
+- [ ] `infrastructure/reference/tech-stack.md` is **NOT** modified
+- [ ] The architecture-doc subsection's "Does not own" list explicitly excludes inference (AI's job), audit storage (Audit's job), and Evals scoring (Evals' job)
+- [ ] The architecture-doc subsection states that the audit payload is **tuple-only** (no body / completion / substituted parameters), and that runtime resolution is **snapshot at deploy time, no hot-reload**
+- [ ] No invariant edit in this packet (invariants land in packet 01)
+- [ ] No ADR status edit in this packet (packet 00 already flipped ADR-0064)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0064 D1 — Storage.** Prompts and personas live in a dedicated public repo `HoneyDrunk.Prompts`, distributed as NuGet, content embedded + small loader runtime. The same pattern `HoneyDrunk.Standards` uses for shared analyzers — one repo, NuGet distribution, every consumer pulls the version they build against.
+
+**ADR-0064 D2 — Persona vs Prompt.** Two kinds, one schema. Persona = stable named identity with `system_prompt` body. Prompt = task-specific template with `parameters` declaration, optionally `extends` a persona.
+
+**ADR-0064 D4 — Runtime resolution.** Snapshot at deploy time, no hot-reload. The prompt set live in production at any moment is the set baked into the deployed Node binary.
+
+**ADR-0064 D5 — Audit emit (tuple-only).** Every LLM call records `(persona_id, persona_version, persona_hash, prompt_id, prompt_version, prompt_hash, bypassed_registry?)` to `IAuditLog`. The payload is tuple-only — no rendered prompt body, no completion text, no substituted parameter values.
+
+**ADR-0064 D11 — Loader location.** `IPromptResolver` in `HoneyDrunk.Prompts.Abstractions`; default impl in `HoneyDrunk.Prompts`. `PersonaId`, `PromptId` are records (no `I` prefix per the naming rule). `PersonaContent`, `PromptContent`, `ResolvedMessages` are records carrying body + hash + version + metadata.
+
+**ADR-0064 D12 — Paired standup ADR.** This ADR commits the policy; a paired standup ADR commits the Node shape (repo creation, solution layout, CI pipeline, scaffold packet, contract-shape canary, content folder, catalog entries). The split exists so the per-Node standup convention is preserved.
+
+**ADR-0058 / ADR-0059 precedent.** The Cache Node was added to `constitution/sectors.md` at ADR-0058's acceptance time even though the Node was not yet stood up. This packet mirrors that pattern for the Prompts Node.
+
+## Constraints
+- **Sectors-table row only — no catalog row.** The AI sector table is a sector-taxonomy artifact, not a Node catalog. Adding the row signals policy-level commitment; the catalog rows land with the paired standup ADR.
+- **Architecture-doc subsection follows the existing shape.** Match the document's per-Node section structure (Node ID, Role, Owns, Does not own, Dependency flow). Do not invent a new shape.
+- **The "Does not own" list is load-bearing.** It separates the prompt-registry layer from inference (AI), audit storage (Audit), and Evals scoring (Evals). Without this clarification, the role of the registry layer relative to its neighbors is unclear.
+- **Tuple-only audit emit must be stated in the subsection.** The architecture document is read by downstream AI-sector Nodes during their own feature work; the tuple-only rule must surface there so emitter Nodes (Agents, Knowledge, Memory, Operator, Lore) write the right payload from day one.
+- **Snapshot-at-deploy resolution must be stated in the subsection.** Without it, the temptation to hot-reload is real (Vault has a hot-reload story); the architecture document needs to record the rejection.
+- **No `relationships.json` edits.** Notify Cloud's consumption pattern (and every AI-sector Node's consumption of `IPromptResolver`) lands with the paired standup ADR's catalog packet, not here.
+- **No `infrastructure/reference/tech-stack.md` edits.** The Prompts Node is not a substrate choice (no Azure service, no third-party library); it is a Node. tech-stack.md is for cross-cutting platform choices.
+
+## Labels
+`feature`, `tier-2`, `ai`, `docs`, `adr-0064`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Add the prompt-registry layer to the AI sector taxonomy (`constitution/sectors.md`) and the AI sector architecture document (`constitution/ai-sector-architecture.md`). No catalog edits, no `repos/*` folder creation, no tech-stack.md edits — those belong to the paired `HoneyDrunk.Prompts` standup ADR per ADR-0064 D12.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the prompt-registry layer visible at the policy-document level so AI-sector standup Nodes reading their own architecture have the layer in front of them.
+- Feature: ADR-0064 Prompt and Persona Registry rollout, Wave 1.
+- ADRs: ADR-0064 D1 / D2 / D4 / D5 / D11 / D12 (primary), ADR-0058 / ADR-0059 (precedent for policy/standup pairing).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0064 Accepted before its layer is described in policy docs.
+
+**Constraints:**
+- Sector-table row + architecture-doc subsection only. No catalog files modified. No `repos/*` folder created. No tech-stack.md entry.
+- The architecture-doc subsection's "Does not own" list separates Prompts from AI / Audit / Evals.
+- Tuple-only audit emit and snapshot-at-deploy resolution must surface in the architecture-doc subsection.
+
+**Key Files:**
+- `constitution/sectors.md` — AI sector table, new Prompts row.
+- `constitution/ai-sector-architecture.md` — new subsection.
+
+**Contracts:** None changed. Catalog-level contract surfaces are registered with the paired standup ADR's catalog packet.

--- a/generated/issue-packets/active/adr-0064-prompt-registry/03-audit-llm-call-prompt-tuple-emit.md
+++ b/generated/issue-packets/active/adr-0064-prompt-registry/03-audit-llm-call-prompt-tuple-emit.md
@@ -1,0 +1,195 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Audit
+labels: ["feature", "tier-2", "ai", "docs", "adr-0064", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0064"]
+wave: 2
+initiative: adr-0064-prompt-registry
+node: honeydrunk-audit
+---
+
+# Document the LLM-call prompt-tuple audit emit shape in HoneyDrunk.Audit
+
+## Summary
+Confirm and document the canonical metadata-key shape ADR-0064 D5 commits for every LLM-call audit emit — `persona_id`, `persona_version`, `persona_hash`, `prompt_id`, `prompt_version`, `prompt_hash`, `bypassed_registry` — in `HoneyDrunk.Audit`'s docs. **The emit rides existing `AuditCategory.AgentAction` (agent-originated calls) or `AuditCategory.Integration` (system / non-agent-originated calls) — no new `AuditCategory` enum value is introduced.** The payload is **tuple-only**: never the rendered prompt body, never the completion text, never the substituted parameter values. Docs-only packet; no contract change, no code change. The two ride the existing `AuditEntry.EventName` free-string field and the existing `Metadata` dictionary; this packet pins the canonical event-name, the category-selection rule, and the metadata-key shape so the AI-sector Nodes that emit these events (Agents, Operator, Memory, Knowledge, Evals, Lore — and any future Node that makes LLM calls) follow one canonical shape and forensic queries find them.
+
+## Context
+ADR-0064 D5 commits the per-LLM-call audit emit (full text):
+
+> Every `IChatClient` and `IEmbeddingGenerator` call records to `IAuditLog` (per the audit substrate) the following tuple as part of the audit entry's structured payload: `persona_id`, `persona_version`, `persona_hash`, `prompt_id`, `prompt_version`, `prompt_hash`. Calls that bypass the registry record `persona_id: null`, `prompt_id: null`, and a flag `bypassed_registry: true`. This tuple is required on every LLM-call audit emit. Bypassed-registry calls are operationally legitimate; the goal of the registry is that every production LLM call goes through it; the audit query "how many inline-prompt calls happened" measures progress toward 100% coverage.
+
+The Audit substrate per ADR-0030 ships `IAuditLog`, `IAuditQuery`, the `AuditEntry` record, and a six-value `AuditCategory` enum (`Security`, `UserActivity`, `DataChange`, `SystemAction`, `AgentAction`, `Integration`). The LLM-call audit emit fits cleanly into the existing categories:
+
+- **`AgentAction`** (`AuditCategory.AgentAction = 4`) — defined as "Agent activity such as delegated work, tool execution, or handoffs." When an agent (per ADR-0020) makes an LLM call as part of its execution, the emit is an agent action; the category captures it.
+- **`Integration`** (`AuditCategory.Integration = 5`) — defined as "External integration ingress or egress activity." When a non-agent system component makes an LLM call (e.g., a wiki-ingest skill, a one-off operator diagnostic call, a Notify Cloud rendering step), the call is an outbound integration call to an external provider (OpenAI, Anthropic, Azure OpenAI); the category captures it.
+
+The **two-category split** is structurally meaningful: queries against `AuditCategory.AgentAction` find agent-driven LLM activity; queries against `AuditCategory.Integration` find system-driven LLM activity. Mixing both into a single new "Inference" category would lose this discriminator. **Per the refine-pass clarification: do not invent a new `AuditCategory` value for LLM calls.** Use the existing categories with the prompt-tuple metadata keys to discriminate; the metadata is the discriminator, not the category.
+
+This packet documents the canonical event-name + category-selection rule + metadata-field shape in `HoneyDrunk.Audit`'s docs (`README.md` or a new `docs/event-catalog.md`) so:
+
+- AI-sector emitter Nodes (Agents at GA; Operator, Memory, Knowledge, Evals, Lore as they ship) emit the right `EventName` verbatim, pick the right category, and emit the canonical metadata-key shape.
+- Forensic queries against the audit substrate find LLM-call entries by `EventName` and the prompt-tuple metadata keys.
+- The pattern is single-sourced in the Audit Node's repo — not duplicated across the emitter Nodes' READMEs.
+
+This packet **does not** add code, does not change `IAuditLog` / `AuditEntry` / `AuditCategory`, and does not introduce a new abstraction. The pattern mirrors how ADR-0067 packet 03 documented `RateLimitRejected` and `QuotaOverageBilled` against the existing `AuditEntry.EventName` free-string field — same shape, same kind of registration, different event names.
+
+`HoneyDrunk.Audit` is a docs-only target here — no `.csproj` edits unless the repo's convention requires a PATCH for docs. The repo's existing CHANGELOG convention takes priority; do **not** introduce an `[Unreleased]` section per the user's standing memory note.
+
+## Scope
+- `HoneyDrunk.Audit/README.md` (or `HoneyDrunk.Audit/docs/event-catalog.md` if the executor judges the README is the wrong home) — extend with an `## LLM-Call Audit Catalog` section documenting the canonical event-name, the category-selection rule (`AgentAction` vs `Integration`), the metadata-key shape, the tuple-only payload rule, and the no-secret-values guarantee.
+- `HoneyDrunk.Audit/CHANGELOG.md` — record the documentation addition under a dated version section (either appended to the most recent dated entry as a `## Documentation` subsection if the convention allows, or a new dated PATCH-bumped entry). **No `[Unreleased]`.**
+- No `.csproj` edits. No code change. No `AuditCategory` enum addition. No new abstraction.
+
+## Proposed Implementation
+1. Open `HoneyDrunk.Audit/README.md` (or the repo's documentation home for event catalogs — if a `docs/event-catalog.md` exists from packet 03 of `adr-0067-rate-limiting` or any other prior catalog addition, append there; otherwise add to README as a new top-level `## LLM-Call Audit Catalog` section).
+2. Add the canonical catalog (substance-verbatim — preserve the event-name, the category-selection rule, the metadata-key names, the tuple-only constraint, and the no-secret-values guarantee exactly so future Audit-repo readers find one canonical source):
+
+   ```
+   ## LLM-Call Audit Catalog
+
+   The Grid emits one canonical audit event-type from every LLM call across every Node that consumes `IChatClient` or `IEmbeddingGenerator` (the AI-sector emitter Nodes: Agents, Operator, Memory, Knowledge, Evals, Lore; plus any future Node that makes LLM calls). The event rides the existing `AuditEntry.EventName` free-string field; no new contract is required and no new `AuditCategory` value is introduced — the call site selects from the existing `AgentAction` or `Integration` categories per the rule below.
+
+   ### `LlmCall`
+
+   Emitted on every `IChatClient` or `IEmbeddingGenerator` invocation. The call site captures the prompt-tuple metadata regardless of whether the call composed a registered prompt or bypassed the registry — the emit itself is **never optional**.
+
+   - **Category selection rule:**
+     - `AuditCategory.AgentAction` — when the LLM call is part of an **agent execution** (the call originates from inside an agent's `IAgentExecutionContext` per the Agents Node). The agent's identity is recoverable from the audit entry's `Actor` field.
+     - `AuditCategory.Integration` — when the LLM call is **not** part of an agent execution (a wiki-ingest skill, a one-off operator diagnostic call, a Notify Cloud rendering step, a non-agent system component). The integration is the outbound call to the external LLM provider.
+   - **Outcome:** `AuditOutcome.Succeeded` for completed calls; `AuditOutcome.Failed` if the provider returned an error or the call was canceled. **Do not** set outcome based on whether the registry was bypassed — bypassed-registry calls that succeeded are `Succeeded`; the `bypassed_registry` field in the metadata is the bypass signal, not the outcome.
+   - **Actor:** the agent identifier (for `AgentAction`) or the calling Node / service identifier (for `Integration`). Never an end-user identifier raw — per the data-classification regime, only pseudonymous tokens are acceptable in audit Actor fields.
+   - **Target:** the **registered prompt id** if one was composed (e.g., `prompts/honeydrunk-knowledge/query-rewrite`); the literal string `"inline-prompt"` if the call bypassed the registry. `Target` is **not** the LLM provider — that is a metadata field. `Target` is the prompt content the call was *about*.
+   - **TenantId:** the resolved `TenantId` from the operation context. `TenantId.Internal` for Grid-internal calls (e.g., the Lore wiki-ingest skill running on a scheduled job).
+   - **Metadata fields** (in the `Metadata` dictionary, lower-case snake_case keys, all string-valued — `Metadata` is `IReadOnlyDictionary<string, string>`):
+     - `persona_id` — the persona's `id` from the prompt-registry frontmatter (e.g., `"honeyclaw-bear-keeper"`, `"evals-judge"`, `"operator-safety-filter"`). Absent (key not present) if the call composed no persona.
+     - `persona_version` — the semver version of `HoneyDrunk.Prompts` that supplied the persona (e.g., `"1.3.0"`). Absent if `persona_id` is absent.
+     - `persona_hash` — the SHA-256 content hash of the persona file at that version, lower-case hex, no `sha256:` prefix (e.g., `"a3f2c1…"`, 64 hex chars). Absent if `persona_id` is absent.
+     - `prompt_id` — the prompt's `id` from the prompt-registry frontmatter. Absent if the call composed no template (raw user message only) — i.e., a fully bypassed call.
+     - `prompt_version` — the semver version of `HoneyDrunk.Prompts` that supplied the prompt. Absent if `prompt_id` is absent.
+     - `prompt_hash` — the SHA-256 content hash of the prompt file at that version. Absent if `prompt_id` is absent.
+     - `bypassed_registry` — `"true"` if the call composed an inline raw system message or skipped the registry entirely; absent or `"false"` otherwise. **The bypassed_registry flag is the only metadata field present on every emit** — it is the discriminator between registered and inline calls.
+     - `model_id` — the model identifier per ADR-0041's model registry (e.g., `"gpt-4o-2026-03-15"`). Non-secret operator-visible string.
+     - `provider` — the provider key (e.g., `"openai"`, `"anthropic"`, `"azure-openai"`). Non-secret.
+     - `correlation_id` — the request-correlation identifier from `IGridContext.CorrelationId`. Required.
+
+   ### Payload constraints (load-bearing)
+
+   The audit payload for `LlmCall` is **tuple-only**:
+
+   - **Never** the rendered prompt body (i.e., the prompt text after parameter substitution).
+   - **Never** the completion text (i.e., the LLM's response).
+   - **Never** the substituted parameter values (i.e., the actual values that were substituted into `{{ placeholder }}` slots at render time — these may carry PII per the prompt-registry's PII-via-parameters rule).
+   - The prompt-tuple metadata fields (`persona_id`, `prompt_id`, etc.) carry only the **identifiers, versions, and hashes** — they are non-secret references to the prompt-registry contents.
+
+   The reason: prompt bodies can be multi-kilobyte; completion text can be too; substituted parameter values may carry PII (`Restricted` or `Confidential` tier per the data-classification taxonomy). The audit substrate's append-only-by-interface stance does not enable redaction-after-the-fact; the right discipline is to never let the bodies / completions / substituted values into the payload in the first place. Forensic reconstruction of what text the model saw is achieved by resolving `(prompt_id, prompt_version, prompt_hash)` against the `HoneyDrunk.Prompts` repo at the indicated version, then re-rendering with the same parameters from the request log (the request log carries parameters in the Node's *application* logs, not in the audit channel, and is subject to the Node's own retention / classification).
+
+   No secret value is recorded. Provider API keys, signing secrets, and any other secret material per the secrets-in-Vault rule never appear in any field.
+
+   ## Cross-references
+
+   - **ADR-0064 D5** — LLM-call audit emit contract.
+   - **ADR-0030** — audit substrate, append-only-by-interface stance, durable channel.
+   - **ADR-0049** — data classification taxonomy; the tuple-only rule exists because substituted parameter values may carry Restricted-tier content.
+   - **ADR-0041** — model registry (`model_id` metadata field).
+   - **Invariant 8** — secret values never appear in logs, traces, exceptions, or telemetry; extended to audit entries here.
+   - **Invariant `{N1}` (ADR-0064)** — every LLM call emits this audit entry; the emit is never optional even on bypassed-registry calls.
+   ```
+
+   Adjust prose to match the repo's existing tone if the README's style differs noticeably; preserve the canonical event-name string `LlmCall`, the metadata-key names, the category-selection rule, and the tuple-only / no-secret-values constraints verbatim.
+3. Update `HoneyDrunk.Audit/CHANGELOG.md`. Two options per the repo's convention:
+   - **Option A** — if doc-only additions are acceptable as an additive `## Documentation` note on the most recent dated version entry, append a note to that entry recording "Added LLM-Call Audit Catalog documenting the `LlmCall` event-name and the prompt-tuple metadata-key shape per ADR-0064 D5."
+   - **Option B** — create a new dated PATCH-bumped entry (e.g., `[0.1.1] - 2026-MM-DD`) with the same note. If a PATCH-bump is chosen, every non-test `.csproj` in the solution is updated to the same new PATCH version in a single commit (invariant 27).
+   - Do **not** use `[Unreleased]`. State the chosen option in the PR.
+4. Update repo-level `README.md` if needed to link to the new section (the existing README is short enough that the section appears in the same file; if the section is lifted to `docs/event-catalog.md`, add a `## Documentation` link in the README).
+
+## Affected Files
+- `HoneyDrunk.Audit/README.md` (the canonical LLM-call event-catalog section appended), or `HoneyDrunk.Audit/docs/event-catalog.md` (if the executor lifts the section out of README; preferred if a `docs/event-catalog.md` already exists).
+- `HoneyDrunk.Audit/CHANGELOG.md` (the documentation note under a dated version section).
+- Optionally every non-test `.csproj` in the solution if Option B is chosen for the CHANGELOG bump.
+
+## NuGet Dependencies
+None. This packet touches only Markdown documentation and possibly a single PATCH `<Version>` bump.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Audit`. Routing rule "audit, AuditLog, audit substrate → HoneyDrunk.Audit" maps exactly.
+- [x] No contract change to `IAuditLog` / `IAuditQuery` / `AuditEntry` / `AuditCategory` — the LLM-call event-type rides the existing `EventName` free-string field and uses existing `AgentAction` / `Integration` categories.
+- [x] **No new `AuditCategory` enum value.** Per the refine-pass clarification: do not invent an `Inference` category. The existing two-category split (`AgentAction` for agent-originated, `Integration` for non-agent-originated) is the discriminator, with the prompt-tuple metadata as the per-call detail.
+- [x] No new abstraction. No new code. Documentation-only registration of the canonical event-name + metadata-key shape per ADR-0064 D5.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Audit/README.md` (or `docs/event-catalog.md`) carries an `LLM-Call Audit Catalog` section
+- [ ] `LlmCall` is documented as the canonical event-name string
+- [ ] The category-selection rule is documented: `AgentAction` for agent-execution-originated calls; `Integration` for non-agent-originated calls. **No new `AuditCategory` value is introduced.**
+- [ ] The metadata-key set is documented exactly: `persona_id`, `persona_version`, `persona_hash`, `prompt_id`, `prompt_version`, `prompt_hash`, `bypassed_registry`, `model_id`, `provider`, `correlation_id` — with absence semantics and the all-string-valued constraint
+- [ ] The **tuple-only payload rule** is documented as a load-bearing constraint: the payload never contains the rendered prompt body, the completion text, or the substituted parameter values
+- [ ] The rationale for the tuple-only rule is documented: forensic reconstruction is achieved by resolving `(prompt_id, prompt_version, prompt_hash)` against the `HoneyDrunk.Prompts` repo at the indicated version, not by carrying the body in the audit payload
+- [ ] Cross-references to ADR-0064 D5, ADR-0030, ADR-0049, ADR-0041, invariant 8, and the new invariant `{N1}` from packet 01 are present
+- [ ] `HoneyDrunk.Audit/CHANGELOG.md` records the documentation addition under a dated version section; `[Unreleased]` is NOT used
+- [ ] No code change in any `.cs` file
+- [ ] No `IAuditLog` / `AuditEntry` / `AuditCategory` contract change
+- [ ] `Directory.Build.props` / `<Version>` is bumped only if Option B is chosen and only by PATCH (e.g., 0.1.0 → 0.1.1), with every non-test `.csproj` in the solution updated in a single commit per invariant 27
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0064 D5 — Audit emit (tuple-only, full text):**
+
+> Every `IChatClient` and `IEmbeddingGenerator` call records to `IAuditLog` the tuple: `persona_id` (null if no persona), `persona_version` (null if no persona), `persona_hash` (null if no persona), `prompt_id` (null if raw user message only), `prompt_version`, `prompt_hash`. Calls that bypass the registry record `persona_id: null`, `prompt_id: null`, and `bypassed_registry: true`. The audit emit itself is never optional. The audit query "how many inline-prompt calls happened" lets the studio measure progress toward registry-coverage = 100%.
+
+**Refine-pass clarification (load-bearing):**
+- The audit emit is **tuple-only** — never the rendered prompt body, never the completion text, never the substituted parameter values. The audit payload carries identifiers, versions, and hashes; the bodies live in the `HoneyDrunk.Prompts` repo at the indicated version (forensic reconstruction resolves there).
+- **No new `AuditCategory` enum value.** Use the existing `AgentAction` (agent-originated calls) and `Integration` (non-agent-originated calls) categories with the prompt-tuple metadata as the per-call detail.
+
+**ADR-0030 (referenced) — Audit substrate.** Phase-1 stance is append-only-by-interface; the `IAuditLog.AppendAsync(AuditEntry)` contract is the durable channel. Event-name discipline is enforced by documentation in Phase 1 (no typed registry).
+
+**ADR-0049 (referenced) — Data classification taxonomy.** Substituted parameter values may carry `Restricted` or `Confidential` tier content; that is the reason the tuple-only rule exists.
+
+**Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** Extended here to audit entries: provider API keys, signing secrets, and any other secret material per the secrets-in-Vault rule never appear in any field of an `LlmCall` audit entry. Non-secret operator-visible strings (`model_id`, `provider`) are acceptable.
+
+**Invariant `{N1}` (ADR-0064, landed by packet 01)** — full text:
+> Every `IChatClient` and `IEmbeddingGenerator` call records to `IAuditLog` (per the audit substrate) a structured payload containing `(persona_id, persona_version, persona_hash, prompt_id, prompt_version, prompt_hash, bypassed_registry?)`. … The payload contains only the tuple — never the rendered prompt body, never the completion text, never the substituted parameter values.
+
+## Constraints
+- **No code change.** This packet only documents canonical event-name + category-selection rule + metadata-key shape; no contract or runtime change.
+- **No `AuditCategory` enum modification.** The two-category split (`AgentAction` / `Integration`) is the discriminator. Do not invent an `Inference` category — the refine-pass call-out is explicit.
+- **Tuple-only payload is non-negotiable.** No rendered body, no completion, no substituted parameter values in the audit payload. The rule is in the invariant text from packet 01; reiterate it in the catalog section verbatim.
+- **No `[Unreleased]` CHANGELOG.** Per the user's standing convention, move directly to a dated version section. PATCH-bump or append-to-most-recent-dated-entry per the repo's existing convention.
+- **No secret values in any field.** Invariant 8 applies; the catalog explicitly states this.
+- **No emit-side code lands here.** This packet documents the shape; the AI-sector emitter Nodes (Agents at GA; Operator, Memory, Knowledge, Evals, Lore as they ship) are the first Nodes that actually emit `LlmCall` events. The emitter-side wiring lands with each Node's first registry-aware feature packet, not in this initiative.
+
+## Labels
+`feature`, `tier-2`, `ai`, `docs`, `adr-0064`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Document the canonical shape of the `LlmCall` audit event in the `HoneyDrunk.Audit` repo — event-name, category-selection rule (`AgentAction` vs `Integration`, no new category), metadata-key shape, and the tuple-only payload rule — so AI-sector emitter Nodes emit the right entries.
+
+**Target:** `HoneyDrunk.Audit`, branch from `main`.
+
+**Context:**
+- Goal: Pin the canonical event-name + category-selection rule + metadata-key shape for the ADR-0064 D5 LLM-call audit emit. No code change; documentation-only registration in the Audit repo.
+- Feature: ADR-0064 Prompt and Persona Registry rollout, Wave 2.
+- ADRs: ADR-0064 D5 (primary), ADR-0030 (audit substrate, referenced), ADR-0049 (data classification, referenced — the reason for tuple-only payload), ADR-0041 (model registry, referenced — the `model_id` metadata field).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0064 Accepted.
+- `packet:01` — invariant `{N1}` live in `constitution/invariants.md` before the Audit catalog quotes it as a canonical rule.
+
+**Constraints:**
+- No code change. **No new `AuditCategory` value** — use the existing `AgentAction` and `Integration` categories. The refine-pass call-out is explicit on this point.
+- The audit payload is **tuple-only** — never the rendered prompt body, never the completion text, never the substituted parameter values. Reiterate this in the catalog section.
+- `[Unreleased]` is forbidden in `CHANGELOG.md`; use a dated version section.
+- No secret material in any documented field; invariant 8 applies.
+- Emitter-side code is not in this packet — AI-sector Nodes wire `LlmCall` emits in their own first registry-aware feature packets.
+
+**Key Files:**
+- `HoneyDrunk.Audit/README.md` (or `docs/event-catalog.md`) — the new `LLM-Call Audit Catalog` section.
+- `HoneyDrunk.Audit/CHANGELOG.md` — documentation entry under a dated version.
+
+**Contracts:** None changed. `IAuditLog` / `IAuditQuery` / `AuditEntry` / `AuditCategory` are unchanged.

--- a/generated/issue-packets/active/adr-0064-prompt-registry/04-architecture-scope-review-prompt-registry-checklist.md
+++ b/generated/issue-packets/active/adr-0064-prompt-registry/04-architecture-scope-review-prompt-registry-checklist.md
@@ -1,0 +1,149 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "ai", "docs", "adr-0064", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0064"]
+wave: 2
+initiative: adr-0064-prompt-registry
+node: honeydrunk-architecture
+---
+
+# Update scope.md and review.md with the ADR-0064 prompt-registry checklist
+
+## Summary
+Per ADR-0064's "Follow-up Work" obligations on the scope agent and the review agent: update `.claude/agents/scope.md` and `.claude/agents/review.md` so both agents check four things whenever a packet introduces (or modifies) an LLM call or a prompt-registry artifact — (a) the call resolves through `IPromptResolver` rather than inlining a body string; (b) the `LlmCall` audit emit is wired with the tuple-only payload; (c) any new prompt file declares `classification` other than `Restricted` and contains no PII / no secrets; (d) any new prompt file's body `{{ parameter }}` placeholders match the declared `parameters` frontmatter list. Coupled context-loading per invariant 33 — both files updated in the same packet so they do not drift. Docs-only packet against the Architecture repo's agent definitions.
+
+## Context
+ADR-0064 §Follow-up Work explicitly calls out two agent-checklist obligations:
+
+> Update `.claude/agents/review.md` per the cloud-code-review ADR — new PR-review checklist items for `HoneyDrunk.Prompts` PRs: classification field present and not `Restricted`, no inlined PII, parameter declarations cover every placeholder in the body, body change triggers minor bump.
+>
+> Update `.claude/agents/scope.md` — packets that introduce LLM calls must declare which persona/prompt id they consume from `HoneyDrunk.Prompts`; absent declaration is grounds to amend the packet before filing.
+
+Invariant 33 ("Review-agent and scope-agent context-loading contracts are coupled") makes this a single-packet, both-files update — they must move together so neither agent has a class of prompt-registry-related defect the other cannot see.
+
+The four checks the agents gain (consolidated and reorganized for ergonomic review-time scanning):
+
+1. **Resolver-not-inline (N3 from packet 01)** — if a packet introduces or modifies an LLM call, the call must resolve through `IPromptResolver` rather than inlining a body string. One-off bypasses are permitted but record `bypassed_registry: true` in the `LlmCall` audit emit. The packet declares the consumed `persona_id` / `prompt_id` in its body so the reviewer can verify.
+2. **LlmCall audit emit (N1 from packet 01)** — if a packet introduces an LLM call, the call site emits an `LlmCall` audit entry with the tuple-only payload (`persona_id`, `persona_version`, `persona_hash`, `prompt_id`, `prompt_version`, `prompt_hash`, `bypassed_registry`, plus `model_id` / `provider` / `correlation_id`). Per the documented Audit catalog (packet 03 of this initiative), the category is `AgentAction` for agent-execution-originated calls, `Integration` for non-agent-originated calls. The payload never carries the rendered prompt body, the completion text, or the substituted parameter values.
+3. **Classification + secret-scan (N2 from packet 01)** — if a packet adds or modifies a prompt or persona file in `HoneyDrunk.Prompts`, the file's `classification` frontmatter is one of `Public`, `Internal`, or `Confidential` (never `Restricted`); no PII inline; no secret values inline. PII enters via parameters at render time; secrets stay in Vault.
+4. **Placeholder-parameter parity (N4 / D9)** — if a packet adds or modifies a prompt file in `HoneyDrunk.Prompts`, every `{{ parameter_name }}` placeholder in the body has a matching entry in the file's `parameters` frontmatter list (and vice versa — unused declared parameters are flagged). The double-brace `{{ }}` form is required (single-brace `{ }` is uncapturable distinction per D9; see the Constraints).
+
+This is a docs/agent-config packet. No code, no .NET project.
+
+## Scope
+- `.claude/agents/scope.md` — extend the agent's quality-check / packet-authoring section with the four prompt-registry checks, placed where the existing checklist items live (likely under "Quality Checklist" or a similar section — verify at edit time).
+- `.claude/agents/review.md` — extend the agent's review-category checklist with the same four checks, placed in the appropriate review-category sections (likely the AI / Security / Data-Classification / Boundary categories the file uses).
+
+## Proposed Implementation
+1. **`.claude/agents/scope.md`** — locate the file's checklist or quality-check section (matching the "Quality Checklist" pattern visible in the agent's reference text). Add four new checklist items, each phrased as a positive obligation:
+   - "If a packet introduces or modifies an LLM call (a call to `IChatClient` or `IEmbeddingGenerator` or any composition thereof), the packet body declares which `persona_id` and/or `prompt_id` the call consumes from `HoneyDrunk.Prompts`. A packet that introduces an LLM call without a declared id (or without explicit acknowledgement that the call bypasses the registry) is amended before filing per ADR-0064 §Follow-up Work."
+   - "If a packet introduces an LLM call, the packet body confirms the call site emits an `LlmCall` audit entry with the tuple-only payload (`persona_id`, `persona_version`, `persona_hash`, `prompt_id`, `prompt_version`, `prompt_hash`, `bypassed_registry`, plus `model_id` / `provider` / `correlation_id`). The payload **never** carries the rendered prompt body, the completion text, or the substituted parameter values."
+   - "If a packet adds or modifies a prompt or persona file in `HoneyDrunk.Prompts`, the packet body confirms the file's `classification` frontmatter is `Public`, `Internal`, or `Confidential` — never `Restricted`. No PII inline; no secret values inline. PII enters via parameters at render time per ADR-0064 D10."
+   - "If a packet adds or modifies a prompt file in `HoneyDrunk.Prompts`, the packet body confirms every `{{ parameter_name }}` placeholder in the body has a matching entry in the `parameters` frontmatter list, and every declared parameter is referenced by at least one placeholder. Double-brace `{{ }}` is required; single-brace `{ }` is forbidden per ADR-0064 D9."
+
+2. **`.claude/agents/review.md`** — locate the review-category structure (matching the review-rubric pattern). Add four new check items into the appropriate categories:
+   - **Resolver-not-inline check** — under the AI / boundary-preservation category. Phrasing: "When a PR introduces an LLM call (any call to `IChatClient` / `IEmbeddingGenerator`), verify the call resolves through `IPromptResolver`. An inlined prompt body as a string literal is a violation of invariant N3 (ADR-0064) unless the call is an explicit one-off and emits `bypassed_registry: true` to audit."
+   - **LlmCall audit emit check** — under the AI / Audit category. Phrasing: "When a PR introduces an LLM call, verify the call site emits an `LlmCall` audit entry with the documented tuple (`persona_id`, `persona_version`, `persona_hash`, `prompt_id`, `prompt_version`, `prompt_hash`, `bypassed_registry`, `model_id`, `provider`, `correlation_id`). The payload must not carry the rendered prompt body, the completion text, or the substituted parameter values — those carry PII and exceed audit retention's classification posture. Category selection: `AgentAction` for agent-execution calls, `Integration` for non-agent-originated calls; no new `AuditCategory` value."
+   - **Prompt-file classification + secret-scan check** — under the Security / Data-Classification category. Phrasing: "When a PR adds or modifies a prompt or persona file in `HoneyDrunk.Prompts`, verify the file's `classification` frontmatter is not `Restricted` (per ADR-0064 D10 — `HoneyDrunk.Prompts` is a public repo, Restricted-tier content has no place there). Verify no inlined values look tenant-scoped, PII-bearing, or secret. The CI gate in `HoneyDrunk.Prompts` enforces this, but reviewer eyes catch the subtle cases CI does not."
+   - **Placeholder-parameter parity check** — under the Schema / Contract category. Phrasing: "When a PR adds or modifies a prompt file in `HoneyDrunk.Prompts`, verify every `{{ parameter_name }}` placeholder in the body has a matching entry in the `parameters` frontmatter list, and every declared parameter is referenced by at least one placeholder. Verify the double-brace `{{ }}` form is used (single-brace `{ }` is forbidden per D9 — single-brace placeholders are accidentally captured by C# interpolation, Python f-strings, and other formatters that may sit between authoring and the LLM call site). The content-shape canary per invariant N4 (ADR-0064) enforces this in CI; reviewer is the second line."
+3. **Cite the source.** Each new check item should reference ADR-0064 D5 / D9 / D10 / D11 by D-letter (not by ADR-number-in-prose for public-facing docs; agent files are internal architecture artifacts where ADR citation by ID is acceptable and matches the surrounding convention; verify by scanning the file's existing references).
+4. **Both files updated in the same commit / PR.** Invariant 33's coupling rule means scope.md and review.md must not diverge — one without the other is the anti-pattern the invariant exists to prevent.
+
+## Affected Files
+- `.claude/agents/scope.md`
+- `.claude/agents/review.md`
+
+## NuGet Dependencies
+None. Markdown / agent-config packet.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture` (`.claude/agents/` is the canonical home for the Grid's agent definitions).
+- [x] No code change in any other repo.
+- [x] Both agents updated in the same PR per invariant 33.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/scope.md` carries four new checklist items: resolver-not-inline (N3 / D11), `LlmCall` audit emit tuple-only (N1 / D5), prompt-file classification + no PII (N2 / D10), placeholder-parameter parity (N4 / D9)
+- [ ] `.claude/agents/review.md` carries four matching check items, placed in the appropriate review-category sections (AI / Audit / Security / Schema or equivalent)
+- [ ] Both files' new items reference ADR-0064 D5 / D9 / D10 / D11 by D-letter
+- [ ] Both files explicitly state the `LlmCall` audit category selection rule: `AgentAction` for agent-execution calls, `Integration` for non-agent calls; **no new `AuditCategory` value is introduced**
+- [ ] Both files explicitly state the tuple-only payload rule: the payload never carries the rendered prompt body, the completion text, or the substituted parameter values
+- [ ] Both files explicitly state the `classification: Restricted` forbidden rule for `HoneyDrunk.Prompts` files
+- [ ] Both files explicitly state the double-brace `{{ }}` placeholder requirement (single-brace `{ }` forbidden per D9)
+- [ ] Both files are updated in the same commit / PR (invariant 33 — coupled context-loading contracts)
+- [ ] No existing checklist items are removed or renumbered
+- [ ] No ADR status edit in this packet
+
+## Human Prerequisites
+None.
+
+> Note: after this packet merges, the user should restart Claude Code so the updated agent files re-register with the running session — this is a runtime hygiene step the user owns, not a packet acceptance criterion. The same caveat appears in sibling packets that touch `.claude/agents/`.
+
+## Referenced ADR Decisions
+**ADR-0064 D5 — Audit emit.** Every LLM call records `(persona_id, persona_version, persona_hash, prompt_id, prompt_version, prompt_hash, bypassed_registry?)` to `IAuditLog`. Tuple-only payload (no body, no completion, no substituted parameter values per the refine-pass clarification).
+
+**ADR-0064 D9 — On-disk schema.** Placeholders use double-brace `{{ parameter_name }}` Mustache-style — distinct from C# string interpolation `{name}`, distinct from f-string `{name}`, distinct from `%(name)s`, to avoid accidental capture by any of those interpolation systems passing through the text. The `parameters` frontmatter list declares each placeholder; the content-shape canary per N4 enforces parity.
+
+**ADR-0064 D10 — PII and sensitive content.** Prompts and personas are **public-or-internal text artifacts** per ADR-0049. No `Restricted`-tier or PII-bearing value inline. Per the data-classification taxonomy, tier names are `Public / Internal / Confidential / Restricted`. PII enters via parameters at render time.
+
+**ADR-0064 D11 — Loader location.** `IPromptResolver` in `HoneyDrunk.Prompts.Abstractions`; consumers compose at the call site. The reviewer agent rule per ADR-0044 covers prompt-file PRs.
+
+**ADR-0064 §Follow-up Work — agent-checklist obligations.** Explicit on both scope.md and review.md updates: scope.md gains the "packets introducing LLM calls declare which persona/prompt id they consume" item; review.md gains the "classification field present and not Restricted, no inlined PII, parameter declarations cover every placeholder, body change triggers minor bump" item set.
+
+**Invariant 33 — Review-agent and scope-agent context-loading contracts are coupled (full text):**
+> The set of files loaded by the review agent (per `.claude/agents/review.md`) must be a superset of the set loaded by the scope agent (per `.claude/agents/scope.md`). Divergence is an anti-pattern; updates to either agent's context-loading section must be mirrored in the other. The coupling exists so there is no class of defect the scope agent could introduce at packet-authoring time that the review agent cannot catch at PR time for lack of information.
+
+**Invariant `{N1}` (ADR-0064, landed by packet 01).** Every `IChatClient` / `IEmbeddingGenerator` call emits the prompt tuple; the emit is never optional; the payload is tuple-only.
+
+**Invariant `{N2}` (ADR-0064, landed by packet 01).** No PII, no `Restricted`-tier content, no secret values inline in `HoneyDrunk.Prompts` files; CI gate enforces.
+
+**Invariant `{N3}` (ADR-0064, landed by packet 01).** Application code must never inline a persona's or prompt's body text as a string literal when the registry has an entry for it; new code paths resolve through `IPromptResolver`.
+
+**Invariant `{N4}` (ADR-0064, landed by packet 01).** `HoneyDrunk.Prompts` CI must include a contract-shape canary on `IPromptResolver` and a content-shape canary asserting frontmatter parses and body placeholders match declared parameters.
+
+## Constraints
+- **Both files updated in the same PR (invariant 33).** Do NOT land scope.md and review.md in separate PRs — the coupling rule forbids divergence even temporarily.
+- **Positive obligations, not "if you remember."** Phrase the new items as obligations that fail review if absent, not as soft "consider checking" prompts.
+- **Cite by D-letter only.** ADR-0064 D5 / D9 / D10 / D11 — not "ADR-0064" alone. The D-letters anchor the specific decisions.
+- **State the no-new-AuditCategory rule explicitly.** Both agents must enforce that LLM-call emits use the existing `AgentAction` (agent-originated) or `Integration` (non-agent-originated) categories — never an invented `Inference` category. The refine-pass call-out from the initiative is load-bearing.
+- **State the tuple-only payload rule explicitly.** Both agents must enforce that the `LlmCall` audit payload never carries the rendered prompt body, the completion text, or the substituted parameter values. This is the load-bearing constraint that protects audit retention from PII contamination.
+- **State the double-brace `{{ }}` placeholder requirement.** Single-brace `{ }` is forbidden per D9; both agents flag single-brace placeholders in prompt-file PRs.
+- **State the `classification: Restricted` forbidden rule for `HoneyDrunk.Prompts`.** Per D10, files in that repo are Public, Internal, or Confidential only; reviewer agent flags `Restricted` in frontmatter.
+- **No ADR status flip.**
+
+## Labels
+`feature`, `tier-2`, `ai`, `docs`, `adr-0064`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Add four new prompt-registry checklist items (D5 audit emit tuple-only, D9 placeholder parity, D10 classification + no PII, D11 resolver not inline) to both `.claude/agents/scope.md` and `.claude/agents/review.md` in a single PR per invariant 33.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Ensure both scope-time packet authoring and PR-time review catch missing prompt-registry resolution, missing audit-emit, files inline PII / Restricted classification, and placeholder-parameter mismatch on any new LLM-call or prompt-file packet.
+- Feature: ADR-0064 Prompt and Persona Registry rollout, Wave 2.
+- ADRs: ADR-0064 D5 / D9 / D10 / D11 (primary), ADR-0049 (classification regime), ADR-0030 (audit substrate), ADR-0044 (review rubric for review.md placement).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — initiative registered.
+- `packet:01` — invariants `{N1}/{N2}/{N3}/{N4}` live in `constitution/invariants.md` before the agents reference them as canonical prompt-registry rules.
+
+**Constraints:**
+- Both files updated in the same PR (invariant 33). Do NOT split.
+- Positive obligations; the review agent fails review if a packet introduces an LLM call without naming the consumed persona/prompt id.
+- Cite by D-letter (D5 / D9 / D10 / D11) so the rules are unambiguous.
+- State the no-new-`AuditCategory`-value rule explicitly (existing `AgentAction` / `Integration` categories only).
+- State the tuple-only payload rule explicitly (no body, no completion, no substituted parameter values).
+- State the double-brace `{{ }}` placeholder requirement and the `classification: Restricted` forbidden rule for `HoneyDrunk.Prompts` files.
+
+**Key Files:**
+- `.claude/agents/scope.md`
+- `.claude/agents/review.md`
+
+**Contracts:** None changed. Agent configuration only.

--- a/generated/issue-packets/active/adr-0064-prompt-registry/05-architecture-prompts-standup-adr-handoff-spec.md
+++ b/generated/issue-packets/active/adr-0064-prompt-registry/05-architecture-prompts-standup-adr-handoff-spec.md
@@ -1,0 +1,226 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ai", "docs", "adr-0064", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0064"]
+wave: 2
+initiative: adr-0064-prompt-registry
+node: honeydrunk-architecture
+---
+
+# Author the paired HoneyDrunk.Prompts standup ADR handoff specification
+
+## Summary
+Author the handoff specification at `infrastructure/walkthroughs/honeydrunk-prompts-standup-spec.md` (or equivalent doc location matching the existing walkthrough convention) that the paired `HoneyDrunk.Prompts` standup ADR's adr-composer agent reads as input. The specification captures everything ADR-0064 D12 defers to the standup ADR — repo layout, solution structure, the three planned packages, CI pipeline (including the contract-shape and content-shape canaries per invariant `{N4}` from packet 01), HoneyDrunk.Standards wiring, sector placement, the catalog rows that need to land with the standup, the seed migration packet (Honeyclaw + Lore extraction), and the Honeyclaw OpenClaw export workflow. **This packet does not file the standup ADR itself** — that is a separate adr-composer invocation per Required Decision 2 in packet 00. This packet authors the spec the adr-composer reads.
+
+## Context
+ADR-0064 D12 commits the paired-standup-ADR pattern explicitly:
+
+> This ADR commits the policy — what gets stored, how it versions, how runtime resolution works, the audit emit, the schema, the loader shape. The Node shape — repo layout, solution structure, CI pipeline, contract-shape canary, scaffold packet contents — is a separate paired standup ADR following the precedent set by the ADR-0058 / ADR-0059 pair.
+
+The standup ADR has not been drafted at the time this packet executes (per Required Decision 2 in packet 00 — both Posture A "file now" and Posture B "defer" are acceptable; the recommendation is Posture B). This packet's job is to author the *specification* the adr-composer agent reads as input when it drafts the standup ADR — whether that draft happens in this initiative's filing window (Posture A) or after this initiative completes (Posture B), the spec is the same.
+
+The pattern mirrors ADR-0067's packet 05 (the Notify Cloud rate-limit policy specification authored as a handoff to the future Notify Cloud follow-up packet, filed after the Notify Cloud standup completes). The shape is: a Markdown document under `infrastructure/walkthroughs/` (or equivalent) that captures the full design intent in one place; the future drafter reads it and turns it into an ADR or a packet set without re-deriving the design.
+
+This is a docs / specification packet. No code, no .NET project, no ADR file created.
+
+## Scope
+- `infrastructure/walkthroughs/honeydrunk-prompts-standup-spec.md` (or equivalent path matching the repo's walkthrough convention — verify the existing folder name at edit time; if the convention is `infrastructure/walkthroughs/` add there; if it is `docs/walkthroughs/` add there; if neither, default to `infrastructure/walkthroughs/`) — author the specification document.
+- `initiatives/active-initiatives.md` — update the `adr-0064-prompt-registry` initiative entry's exit criteria to reference this spec as the handoff artifact for the paired standup ADR.
+- No ADR file created in this packet — that is the adr-composer agent's separate invocation per Required Decision 2.
+
+## Proposed Implementation
+1. **Confirm the walkthrough folder location.** Scan the repo to find the existing walkthrough document location (`infrastructure/walkthroughs/`, `docs/walkthroughs/`, or another convention). If multiple exist, prefer the one with the most recent sibling spec (e.g., ADR-0067's `notify-cloud-rate-limit-policy.md` should give the canonical location). If no walkthrough folder exists yet, create `infrastructure/walkthroughs/` and place the file there.
+
+2. **Author the specification.** The spec document has the following sections:
+
+   ### Section: Overview
+
+   - **Purpose:** This document is the specification the paired `HoneyDrunk.Prompts` standup ADR's adr-composer agent reads as input. The policy ADR (ADR-0064) commits *what* the registry is and *what rules* it follows; this spec captures *what the Node looks like* — repo layout, solution structure, CI pipeline, contract-shape canary, scaffold packet contents.
+   - **Out of scope of this spec:** the policy decisions themselves (those live in ADR-0064). Hot-reload, per-prompt semver, App-Configuration-as-storage, and database-backed prompts are all explicitly rejected in ADR-0064 and are not re-litigated here.
+   - **Precedent:** ADR-0058 / ADR-0059 (the Cache policy / standup pair). The Cache standup ADR is the closest analog in shape; reading ADR-0059 alongside this spec gives the adr-composer the right template.
+
+   ### Section: Repo creation
+
+   - **Repo name:** `HoneyDrunkStudios/HoneyDrunk.Prompts`.
+   - **Visibility:** **Public** (per the user's "repos public by default" memory and ADR-0064 D10's rationale — Restricted-tier content is forbidden, secret-scan is enforced; nothing in the repo justifies private visibility).
+   - **License:** matches the rest of the Grid's public repos (Apache 2.0 or MIT — verify at standup-ADR time; do not pin here).
+   - **Branch protection:** standard Grid posture per ADR-0011 (tier-1 gate required on every PR, no force-push to main).
+
+   ### Section: Solution layout
+
+   The standup ADR's scaffold packet creates three .NET projects in one solution:
+
+   - **`HoneyDrunk.Prompts.Abstractions`** — the contract layer. Contains `IPromptResolver` interface and the supporting record types (`PersonaId`, `PromptId`, `PersonaContent`, `PromptContent`, `ResolvedMessages`). Zero runtime dependencies on other Grid packages — only `Microsoft.Extensions.*` abstractions per the abstractions-package invariant.
+   - **`HoneyDrunk.Prompts`** — the default `IPromptResolver` implementation. Depends on `HoneyDrunk.Prompts.Abstractions` and Kernel primitives (`Microsoft.Extensions.*` for DI/options/logging). Embeds the prompt and persona content files (`personas/*.persona.md`, `prompts/{owner-node}/*.prompt.md`) as compile-time content in the package output.
+   - **`HoneyDrunk.Prompts.Tests.Fakes`** — the test-time fake. Provides `InMemoryPromptResolver` for consumer tests that need to stub the registry without including the full prompts package. Test-time only per the convention established by ADR-0019 (Communications).
+
+   All three projects share one solution version per invariant 27. The repo-level `CHANGELOG.md` is the source of truth for releases.
+
+   ### Section: HoneyDrunk.Standards wiring
+
+   Every `.csproj` references `HoneyDrunk.Standards` with `PrivateAssets: all` per invariant 26 (StyleCop + EditorConfig analyzers).
+
+   ### Section: CI pipeline
+
+   The standup ADR's CI packet wires the standard reusable workflows from `HoneyDrunk.Actions`:
+
+   - **`pr-core.yml`** — build, unit tests, analyzers, vulnerability scan, secret scan per ADR-0011 D2. Required branch-protection check.
+   - **`job-api-compatibility.yml`** — scoped to `HoneyDrunk.Prompts.Abstractions`. Fails the build on shape drift to `IPromptResolver` or the supporting record types without a paired version bump. **This is the contract-shape canary** required by invariant `{N4}` (ADR-0064) — full text: "the `HoneyDrunk.Prompts` package's CI must include (a) a contract-shape canary on `IPromptResolver` that fails the build on shape drift … without a corresponding version bump."
+   - **A new content-shape canary** (filed as a separate step in `pr-core.yml`-equivalent or as a dedicated workflow) — asserts every `.persona.md` and `.prompt.md` file's frontmatter parses cleanly (YAML), and for every prompt file, every `{{ parameter_name }}` placeholder in the body has a matching entry in the file's `parameters` frontmatter list (and vice versa). **This is the content-shape canary** required by invariant `{N4}` (ADR-0064). The implementation may be a small custom check (a build-time C# tool that reads the content files and the frontmatter, parses placeholders, and asserts parity) — the obligation is to keep the gate, not to use any specific implementation.
+   - **A classification gate** — fails the build if any file's frontmatter declares `classification: Restricted` (forbidden per ADR-0064 D10 / invariant `{N2}`). The secret-scan in `pr-core.yml` covers the secret-values rule from the same invariant.
+
+   ### Section: Sector placement
+
+   - **Sector:** AI (per the `constitution/sectors.md` row added in packet 02 of this initiative).
+   - **Cluster:** `cognition` or a new `identity-substrate` cluster — the standup ADR picks. AI's existing clusters in `catalogs/nodes.json` should be reviewed at standup time; if `cognition` is the only cluster, use that.
+
+   ### Section: Catalog rows the standup ADR's catalog packet adds
+
+   The standup ADR's catalog packet adds the following rows (these are the rows ADR-0064 §Catalog and Reference Updates Required enumerates — repeated here for the adr-composer's convenience):
+
+   - **`catalogs/nodes.json`** — `honeydrunk-prompts` entry: name `HoneyDrunk.Prompts`, sector `AI`, signal `Seed`, public visibility, short description "Prompt and persona registry — versioned content, audit-anchored tuple emit, snapshot-at-deploy."
+   - **`catalogs/relationships.json`** — `honeydrunk-prompts` with `consumes: ["honeydrunk-kernel"]` (the loader runtime uses Kernel primitives for lifecycle and DI); `consumed_by_planned: ["honeydrunk-ai", "honeydrunk-agents", "honeydrunk-operator", "honeydrunk-memory", "honeydrunk-knowledge", "honeydrunk-evals", "honeydrunk-lore"]`; `exposes.contracts: ["IPromptResolver", "PersonaId", "PromptId", "PersonaContent", "PromptContent", "ResolvedMessages"]`; `exposes.packages: ["HoneyDrunk.Prompts.Abstractions", "HoneyDrunk.Prompts", "HoneyDrunk.Prompts.Tests.Fakes"]`.
+   - **`catalogs/grid-health.json`** — Node row for `honeydrunk-prompts`.
+   - **`catalogs/modules.json`** — Node entry with the three planned packages.
+   - **`catalogs/contracts.json`** — `IPromptResolver` (kind: interface), `PersonaId` / `PromptId` / `PersonaContent` / `PromptContent` / `ResolvedMessages` (kind: record), each with a one-line description matching the existing entry shape.
+   - **`infrastructure/reference/tech-stack.md`** — add `HoneyDrunk.Prompts` to the current Nodes table once the standup ADR ships.
+   - **`repos/HoneyDrunk.Prompts/`** — folder with `overview.md`, `boundaries.md`, `invariants.md`. The standup ADR's docs packet authors these.
+
+   The naming-rule discipline (memory `project_naming_rule_records`): `IPromptResolver` retains the `I` prefix (interface); `PersonaId`, `PromptId`, `PersonaContent`, `PromptContent`, `ResolvedMessages` drop the `I` (records).
+
+   ### Section: Seed migration packet (Honeyclaw + Lore)
+
+   The standup ADR includes a migration packet that seeds the registry with the personas and prompts already running in production:
+
+   - **`personas/honeyclaw-bear-keeper.persona.md`** — extracted from OpenClaw config. The bear-keeper persona is in production today (memory `project_honeyclaw_bot`); it lives in OpenClaw's third-party gateway config; this migration brings the source of truth to the Grid per ADR-0064 D7. Frontmatter: `id: honeyclaw-bear-keeper`, `kind: persona`, `version: 0.1.0`, `owner: honeydrunk-lore` (or a Honeyclaw-specific owner if a Node lands; until then Lore is the closest owner that ships an AI-mediated surface), `classification: Public` (the bear-keeper persona has no PII; it is a public-facing persona definition), `created: <extraction-date>`, `notes: "Extracted from OpenClaw gateway config. Honeyclaw Telegram bot's bear-keeper voice — the user is Oleg, the emoji is 🍯."`. Body: the verbatim system-prompt text from OpenClaw.
+   - **`prompts/honeydrunk-lore/wiki-ingest.prompt.md`** — extracted from the Lore wiki-ingestion skill (memory `project_lore_sourcing_workflow`). Frontmatter per the schema, including a `parameters` list for whatever placeholders the ingest prompt uses today; body: verbatim ingest-prompt text.
+   - **Any other prompts already inlined in seed Nodes** — at file time, no other seed Nodes have shipped feature work (the AI-sector standups are at scaffold stage), so the migration is the two above. The migration packet is small.
+
+   ### Section: Honeyclaw OpenClaw export workflow
+
+   Per ADR-0064 D7, the Grid `HoneyDrunk.Prompts` repo is the source of truth for Honeyclaw's persona even though Honeyclaw runs in third-party OpenClaw infrastructure. The export workflow:
+
+   - Runs on every `HoneyDrunk.Prompts` release (i.e., when a new prompts package version ships).
+   - Reads `personas/honeyclaw-bear-keeper.persona.md` from the just-released package.
+   - Writes it to OpenClaw's configured location — exact mechanism deferred to the standup ADR's decision: (a) a private GitHub gist OpenClaw polls; (b) a Vault-stored OpenClaw config blob the user manually applies via the OpenClaw TUI; (c) a direct OpenClaw API call (if the OpenClaw gateway exposes a config-update endpoint at the time of standup).
+   - **No runtime HTTP call** from OpenClaw into the Grid per D7.
+
+   The workflow may live in `HoneyDrunk.Prompts` itself or in a paired `HoneyDrunk.OpenClaw` integration package; the standup ADR picks. Until the workflow exists, the user manually copies the persona text from the Grid repo to OpenClaw at each release.
+
+   ### Section: PDR-app personas (forward-looking)
+
+   Per ADR-0064 D8, Hearth (the first-build pick per the `project_app_concepts_2026_05_05` memory), Lately, Curiosities, and any future consumer-PDR app registers its persona in `HoneyDrunk.Prompts` at the app's first AI-enabled feature packet. The standup ADR does not author these personas (the apps do not yet exist); but the standup ADR's `repos/HoneyDrunk.Prompts/overview.md` should reference this pattern so future PDR-app authors find the discipline documented.
+
+   ### Section: Forward-looking — Evals release gate
+
+   Per ADR-0064 D6, a future Evals-side ADR may add Evals as a release gate for the prompts package: a major or minor bump cannot publish without all affected suites passing. The standup ADR records this as a deferred follow-up; it does not implement it.
+
+   ### Section: Acceptance gate — what the standup ADR's exit criterion looks like
+
+   The standup ADR's exit criterion is satisfied when:
+
+   - `HoneyDrunk.Prompts` repo exists, is public, has the three projects, the CI pipeline (with the contract-shape canary, the content-shape canary, the classification gate, and the standard `pr-core.yml` gates).
+   - The seed migration has landed: `personas/honeyclaw-bear-keeper.persona.md` and `prompts/honeydrunk-lore/wiki-ingest.prompt.md` are in the repo, the package is published, the catalog rows are in place.
+   - The Honeyclaw OpenClaw export workflow is wired (or the manual-copy interim is documented for the user).
+   - The first downstream Node that consumes `IPromptResolver` (likely `HoneyDrunk.Lore` for the wiki-ingest skill migration, since it has the closest-to-ready dependency) has its first registry-aware feature packet ready to ship.
+
+3. **Update `initiatives/active-initiatives.md`** to reference this spec from the `adr-0064-prompt-registry` initiative entry's exit criteria. Sample wording (adapt to the file's existing style):
+
+   > Exit criteria: ADR-0064 status flip done in packet 00; four invariants live in `constitution/invariants.md`; AI sector table records the Prompts Node placeholder; Audit emit contract documented at canonical metadata-key shape; agent checklists updated; standup handoff spec authored at `infrastructure/walkthroughs/honeydrunk-prompts-standup-spec.md`. The paired `HoneyDrunk.Prompts` standup ADR's drafting and acceptance, and the Node scaffold itself, are out of scope of this initiative and tracked separately per Required Decision 2 in packet 00.
+
+4. **Do NOT file the standup ADR itself.** The adr-composer agent's invocation is a separate human action per Required Decision 2 (Posture A "now" or Posture B "after this initiative"). This packet only authors the spec the adr-composer reads.
+
+## Affected Files
+- `infrastructure/walkthroughs/honeydrunk-prompts-standup-spec.md` (or the equivalent walkthrough-folder path the repo uses) — new specification document.
+- `initiatives/active-initiatives.md` — exit-criteria reference to the spec.
+
+## NuGet Dependencies
+None. Markdown-only packet.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No ADR file created — the standup ADR's drafting is a separate adr-composer invocation.
+- [x] No catalog or `repos/*` edits — those land with the standup ADR's packets, not here.
+
+## Acceptance Criteria
+- [ ] `infrastructure/walkthroughs/honeydrunk-prompts-standup-spec.md` (or the equivalent location in the repo's walkthrough convention) exists and carries the spec sections enumerated in §Proposed Implementation Step 2
+- [ ] The spec records the public-repo visibility decision (per ADR-0064 D10 and the user's repos-public-by-default memory)
+- [ ] The spec records the three-project solution layout (`HoneyDrunk.Prompts.Abstractions`, `HoneyDrunk.Prompts`, `HoneyDrunk.Prompts.Tests.Fakes`) per ADR-0064 D11
+- [ ] The spec records the CI pipeline obligations: `pr-core.yml`, `job-api-compatibility.yml` (contract-shape canary on `IPromptResolver`), a content-shape canary (frontmatter parse + `{{ }}` placeholder ↔ `parameters` parity), and a classification gate (no `classification: Restricted`) per invariants `{N2}` and `{N4}` from packet 01
+- [ ] The spec records the catalog rows the standup ADR's catalog packet must add (nodes.json, relationships.json, grid-health.json, modules.json, contracts.json, tech-stack.md, repos/HoneyDrunk.Prompts/)
+- [ ] The spec records the seed migration packet's contents: `honeyclaw-bear-keeper.persona.md` and `lore-wiki-ingest.prompt.md`, with frontmatter shape per D9
+- [ ] The spec records the Honeyclaw OpenClaw export workflow per D7 (build/release-step, no runtime HTTP)
+- [ ] The spec records the PDR-app pattern forward-look per D8 and the Evals release-gate forward-look per D6
+- [ ] The spec records the standup ADR's exit criteria
+- [ ] The spec's contract names follow the naming rule: `IPromptResolver` keeps `I` (interface); `PersonaId`, `PromptId`, `PersonaContent`, `PromptContent`, `ResolvedMessages` drop `I` (records)
+- [ ] `initiatives/active-initiatives.md` exit criteria references the spec by path
+- [ ] No ADR file is created
+- [ ] No catalog or `repos/*` edits
+
+## Human Prerequisites
+- [ ] Required Decision 2 (paired standup ADR filing posture) resolved in packet 00's PR. Whether Posture A ("file standup ADR now") or Posture B ("defer"), this packet's spec is the same. **If Posture A** — after this packet merges, invoke the adr-composer agent with prompt "Stand up `HoneyDrunk.Prompts` per ADR-0064 D12, reading `infrastructure/walkthroughs/honeydrunk-prompts-standup-spec.md` as input." **If Posture B** — file the same invocation as a follow-up task after the initiative completes.
+
+## Referenced ADR Decisions
+**ADR-0064 D6 — Evals integration.** A future Evals-side ADR may add Evals as a release gate for the prompts package; the spec records this as a deferred follow-up.
+
+**ADR-0064 D7 — Honeyclaw integration.** The Grid registry is the source of truth for Honeyclaw's persona; export via a build/release step, not a runtime HTTP call from OpenClaw into the Grid.
+
+**ADR-0064 D8 — PDR-app personas registered from day one.** The spec records the pattern; PDR apps do not yet exist so no personas are authored at standup time.
+
+**ADR-0064 D9 — On-disk schema.** Path convention `personas/{id}.persona.md` and `prompts/{owner-node}/{id}.prompt.md`; YAML frontmatter; double-brace `{{ parameter_name }}` placeholders.
+
+**ADR-0064 D10 — PII and sensitive content.** Public-or-internal text artifacts only; CI gate forbids `Restricted` classification and runs secret-scan; reviewer-agent rule per ADR-0044.
+
+**ADR-0064 D11 — Loader location.** `IPromptResolver` in `HoneyDrunk.Prompts.Abstractions`; default impl in `HoneyDrunk.Prompts`; test-time fake in `HoneyDrunk.Prompts.Tests.Fakes`.
+
+**ADR-0064 D12 — Paired standup ADR.** Explicit: the standup ADR is a separate ADR following the ADR-0058 / ADR-0059 precedent. Folding the standup into the policy ADR would set the wrong precedent.
+
+**ADR-0058 / ADR-0059 precedent.** ADR-0059 is the standup ADR for the Cache Node (the standup paired to ADR-0058's policy). Reading ADR-0059's text gives the adr-composer the right template for the `HoneyDrunk.Prompts` standup ADR.
+
+**ADR-0067 packet 05 precedent.** The Notify Cloud rate-limit policy specification authored as a handoff to a future follow-up packet. Same shape as this packet — author the spec in the Architecture repo at `infrastructure/walkthroughs/`, the future drafter reads it.
+
+## Constraints
+- **No ADR file created.** The standup ADR's drafting is the adr-composer agent's separate invocation per Required Decision 2 in packet 00.
+- **No catalog or `repos/*` edits.** The catalog rows, the `repos/HoneyDrunk.Prompts/` folder, and the `infrastructure/reference/tech-stack.md` row all land with the standup ADR's packet set, not in this initiative.
+- **Spec captures the design intent, not the implementation.** The adr-composer agent reads the spec and turns it into an ADR; the ADR turns into packets; the packets implement. This spec is the input to that chain.
+- **Public-repo visibility is declared.** The spec records `HoneyDrunkStudios/HoneyDrunk.Prompts` as public per ADR-0064 D10 and the user's repos-public-by-default memory.
+- **The naming rule is observed in the spec.** `IPromptResolver` keeps `I`; the record types drop it.
+- **CI obligations are explicit on the canaries.** The spec records both the contract-shape canary (per invariant `{N4}`) and the content-shape canary (placeholder ↔ parameters parity), and the classification gate (per invariant `{N2}`). Without these in the spec, the standup ADR risks shipping CI that does not satisfy the invariants.
+- **No code change anywhere.** This packet is a Markdown specification; no `.csproj` is touched, no project is created.
+
+## Labels
+`chore`, `tier-3`, `ai`, `docs`, `adr-0064`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author the `HoneyDrunk.Prompts` standup ADR handoff specification at `infrastructure/walkthroughs/honeydrunk-prompts-standup-spec.md` (or the repo's equivalent walkthrough path). The spec captures everything ADR-0064 D12 defers to the standup ADR — repo layout, solution structure, CI pipeline (including both canaries per invariant `{N4}`), catalog rows, seed migration, Honeyclaw export workflow. No ADR file created in this packet; no catalog edits; no `repos/*` folder creation.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Give the future adr-composer invocation (per Required Decision 2 in packet 00) a single document to read as input when it drafts the paired `HoneyDrunk.Prompts` standup ADR.
+- Feature: ADR-0064 Prompt and Persona Registry rollout, Wave 2.
+- ADRs: ADR-0064 D6 / D7 / D8 / D9 / D10 / D11 / D12 (primary), ADR-0058 / ADR-0059 (paired-standup-ADR precedent), ADR-0067 packet 05 (deferred-follow-up-spec precedent).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — initiative registered, Required Decisions surfaced. The spec is the same regardless of which posture (A or B) is chosen for Required Decision 2; the spec can be authored before the human picks.
+
+**Constraints:**
+- No ADR file created. No catalog or `repos/*` edits.
+- Spec captures design intent; the adr-composer turns it into ADR text.
+- Public-repo visibility declared.
+- Naming rule observed (interfaces keep `I`, records drop it).
+- CI obligations explicit on both canaries and the classification gate.
+
+**Key Files:**
+- `infrastructure/walkthroughs/honeydrunk-prompts-standup-spec.md` (or repo's equivalent walkthrough location) — new spec document.
+- `initiatives/active-initiatives.md` — exit-criteria reference to the spec.
+
+**Contracts:** None changed. The spec describes contracts (`IPromptResolver`, the record types) that the standup ADR's contract packet authors in `HoneyDrunk.Prompts.Abstractions` — not in this packet.

--- a/generated/issue-packets/active/adr-0064-prompt-registry/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0064-prompt-registry/dispatch-plan.md
@@ -1,0 +1,165 @@
+# Dispatch Plan — ADR-0064: Prompt and Persona Registry with Versioning
+
+**Initiative:** `adr-0064-prompt-registry`
+**ADR:** ADR-0064 (Proposed → Accepted via packet 00)
+**Sector:** AI / cross-cutting
+**Created:** 2026-05-25
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0064 commits the prompt-and-persona registry **policy** — what gets stored (D1: dedicated public repo `HoneyDrunk.Prompts`, files on disk, NuGet distribution), the persona-vs-prompt distinction (D2), the package-level semver + per-file content-hash versioning (D3), snapshot-at-deploy runtime resolution with no hot-reload (D4), the tuple-only LLM-call audit emit (D5), Evals integration via hash equality key (D6), the Honeyclaw posture with Grid-as-source-of-truth via build-step export (D7), the PDR-app pattern (D8), the on-disk YAML-frontmatter + double-brace-Mustache placeholder schema (D9), the PII-via-parameters / no-Restricted-content rule (D10), the `IPromptResolver` loader contract in `HoneyDrunk.Prompts.Abstractions` (D11), and the paired-standup-ADR pattern (D12).
+
+The **Node shape** (repo creation, solution layout, CI pipeline, scaffolding, catalog rows, `repos/HoneyDrunk.Prompts/` folder) is intentionally deferred to a paired `HoneyDrunk.Prompts` standup ADR per D12, following the ADR-0058 / ADR-0059 precedent. This initiative does not create the Node — it lands the policy, the invariants, the AI-sector taxonomy / architecture-doc update, the Audit emit shape documentation, the agent checklists, and the standup-ADR handoff spec.
+
+This initiative delivers, in **6 packets across 2 waves**, targeting **2 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Audit`):
+
+1. ADR acceptance + reservation row verification + initiative registration + two Required Decisions surfaced for human resolution (Architecture).
+2. Four prompt-registry invariants `{N1}–{N4}` land in `constitution/invariants.md`; the invariant 44 conflict is resolved in the same commit per Required Decision 1 (Architecture).
+3. The AI sector table gains a Prompts row; the AI sector architecture document gains a prompt-registry layer subsection (Architecture).
+4. The Audit Node's docs gain an `LLM-Call Audit Catalog` documenting the canonical `LlmCall` event-name, the category-selection rule (existing `AgentAction` / `Integration` categories — no new `AuditCategory` value), and the tuple-only metadata-key shape (Audit).
+5. `scope.md` + `review.md` gain four new prompt-registry checklist items in a single PR per invariant 33 (Architecture).
+6. A standup-ADR handoff specification is authored as the input the future adr-composer reads when it drafts the paired `HoneyDrunk.Prompts` standup ADR (Architecture).
+
+**6 packets, all `Actor=Agent`, 0 `Actor=Human`.** Two human prerequisites surface in the initiative — both are decision-only (Required Decisions 1 and 2 in packet 00); neither requires portal clicks, deploy actions, or out-of-PR human work *during* the agent's filing window.
+
+## Trigger
+
+ADR-0064 is Proposed. The forcing functions from the ADR's Context: every AI-sector standup ADR (ADR-0016, ADR-0018, ADR-0020, ADR-0021, ADR-0022, ADR-0023) currently has its consumers inlining prompts in feature work because there is no Grid-level registry; the AI-sector standup wave is in flight (ADR-0020, ADR-0021, ADR-0022, ADR-0023 all Proposed); every one of those Nodes' first feature packets will either inline prompts or pull on a registry. Inlining compounds — every Node that inlines now has to migrate later, every Audit emit recorded without a prompt-version field has to be backfilled, every Evals regression discovered after the fact is investigated against drifted text. The cost of doing this later climbs week over week.
+
+ADR-0064 is also the forcing function for Honeyclaw's persona to stop drifting between OpenClaw config and the user's notes (memory `project_honeyclaw_bot`), and for the Lore wiki-ingest skill to source its ingest prompt from a versioned, audit-anchored, hash-equality-keyed registry rather than a code-embedded literal.
+
+## Scope Detection
+
+**Multi-repo (Architecture + Audit), policy-only.** ADR-0064 is a policy ADR; the Node shape lands with the paired standup ADR (D12). This initiative's packets touch only governance documents in `HoneyDrunk.Architecture` and a single docs-only update in `HoneyDrunk.Audit` (the `LLM-Call Audit Catalog`). No code packets; no `HoneyDrunk.AI` / `HoneyDrunk.Agents` / `HoneyDrunk.Operator` / etc. edits.
+
+**No catalog row added in this initiative.** The `honeydrunk-prompts` row in `catalogs/nodes.json` / `relationships.json` / `modules.json` / `contracts.json` / `grid-health.json` lands with the paired standup ADR's catalog packet. This initiative only adds the **sector-taxonomy row** (`constitution/sectors.md` — a sector-level artifact, not a Node catalog) and the **architecture-doc subsection** (`constitution/ai-sector-architecture.md` — a sector-architecture artifact, not a Node catalog). The Cache Node followed the same pattern: ADR-0058 added the row to `sectors.md`; ADR-0059's catalog packet added the catalog rows.
+
+**Four invariants land.** N1 (audit emit tuple), N2 (no PII in files), N3 (no inlined prompt bodies), N4 (canaries). Numbers reserved at `{N1}–{N4}` (currently `74–77` per the reservations file at packet authoring time; resolved against the file at execution time in case of merge races).
+
+**Invariant 44 conflict.** N3 introduces `HoneyDrunk.Prompts.Abstractions` as a new downstream AI-sector dependency. Invariant 44's current text reads as restricting AI-sector runtime dependencies to `HoneyDrunk.AI.Abstractions` only. This is a Required Decision in packet 00 (A — amend by exception; B — restate narrowly, recommended; C — carve out by addition). Packet 01 applies the chosen resolution in the same commit as the four new invariants.
+
+**No new `AuditCategory` enum value.** The refine-pass clarification is load-bearing: the LLM-call audit emit rides existing `AgentAction` (agent-originated calls) and `Integration` (non-agent-originated calls) categories with prompt-tuple metadata as the per-call discriminator. Do NOT invent an `Inference` category.
+
+**Audit payload is tuple-only.** Never the rendered prompt body, never the completion text, never the substituted parameter values. This is stated in invariant N1, in packet 03's audit catalog, and in packet 04's agent checklists. The reason: substituted parameters may carry `Restricted`-tier content per ADR-0049 / N2; the audit substrate's append-only-by-interface stance does not enable redaction-after-the-fact; the right discipline is never let the bodies / completions / substituted values into the payload.
+
+**Paired standup ADR is filed separately.** Required Decision 2 in packet 00: Posture A — file the standup ADR via adr-composer now, in this initiative's filing window; Posture B (recommended) — defer until after this initiative completes. Either is acceptable; the packets here are identical under both postures. Packet 05 authors the spec the adr-composer reads regardless.
+
+## Required Decisions Carried by Packet 00
+
+Both decisions are documented in packet 00's body and surface in the PR description for human resolution before packets 01 and 05 unblock.
+
+### Required Decision 1 — invariant 44 conflict (N3 introduces `HoneyDrunk.Prompts.Abstractions`)
+
+Three resolutions; recommendation: **Resolution B** (restate invariant 44 narrowly so the original "no AI-provider lock-in" intent is preserved without amendment-by-exception). Resolutions A and C are acceptable if the user picks them.
+
+### Required Decision 2 — paired `HoneyDrunk.Prompts` standup ADR filing posture
+
+Two postures; recommendation: **Posture B** (defer standup ADR drafting until after this initiative completes). Posture A is acceptable if the user wants the standup ADR filed in this initiative's filing window.
+
+## Wave Diagram
+
+### Wave 1 (No Dependencies — governance + invariants + sector taxonomy)
+- [ ] **00** — Architecture: Accept ADR-0064 + verify `{N1}–{N4}` reservation row + register initiative + surface Required Decisions 1 and 2. `Actor=Agent`.
+- [ ] **01** — Architecture: Land four prompt-registry invariants `{N1}–{N4}` in `constitution/invariants.md` + apply the chosen resolution of Required Decision 1 (invariant 44 amendment) + move ADR-0064 reservation row to history. `Actor=Agent`. Blocked by: 00.
+- [ ] **02** — Architecture: Add the Prompts row to `constitution/sectors.md` AI sector table + add the prompt-registry layer subsection to `constitution/ai-sector-architecture.md`. `Actor=Agent`. Blocked by: 00.
+
+### Wave 2 (Depends on Wave 1 — Audit catalog + agent checklists + standup handoff)
+- [ ] **03** — Audit: Document the canonical `LlmCall` audit event-shape + the category-selection rule (existing `AgentAction` / `Integration`, no new `AuditCategory` value) + the tuple-only metadata-key shape in `HoneyDrunk.Audit`'s docs. `Actor=Agent`. Blocked by: 00, 01.
+- [ ] **04** — Architecture: Update `.claude/agents/scope.md` + `.claude/agents/review.md` in the same PR with four prompt-registry checklist items per invariant 33. `Actor=Agent`. Blocked by: 00, 01.
+- [ ] **05** — Architecture: Author the standup ADR handoff specification at `infrastructure/walkthroughs/honeydrunk-prompts-standup-spec.md` (the future adr-composer reads it). `Actor=Agent`. Blocked by: 00.
+
+Packets within Wave 1 run sequentially (00 → 01 + 02). Packets 01 and 02 are both blocked by 00 only and could run in parallel; the natural ordering is 01 first (invariants are referenced by 02's prompt-registry-layer subsection) but 02 does not strictly require 01 because the subsection text is independent of the specific invariant numbers — both can execute in parallel without conflict. Within Wave 2, all three packets run in parallel (no shared file conflicts — packet 03 targets the Audit repo; packets 04 and 05 target Architecture but touch different files).
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0064 — initiative + reservation + Required Decisions](./00-architecture-prompt-registry-initiative-and-sector.md) | Architecture | Agent | 1 | — |
+| 01 | [Land four prompt-registry invariants + amend invariant 44](./01-architecture-prompt-registry-invariants.md) | Architecture | Agent | 1 | 00 |
+| 02 | [AI sector table + ai-sector-architecture.md prompt-registry layer](./02-architecture-ai-sector-prompt-registry-layer.md) | Architecture | Agent | 1 | 00 |
+| 03 | [Document `LlmCall` audit event-shape — tuple-only, no new AuditCategory](./03-audit-llm-call-prompt-tuple-emit.md) | Audit | Agent | 2 | 00, 01 |
+| 04 | [scope.md + review.md prompt-registry checklist](./04-architecture-scope-review-prompt-registry-checklist.md) | Architecture | Agent | 2 | 00, 01 |
+| 05 | [HoneyDrunk.Prompts standup ADR handoff specification](./05-architecture-prompts-standup-adr-handoff-spec.md) | Architecture | Agent | 2 | 00 |
+
+## Version Bumps
+
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution; governance/catalog/doc edits across packets 00, 01, 02, 04, 05.
+- **`HoneyDrunk.Audit`** — packet 03 is docs-only. PATCH-bump optional per repo convention (e.g., `0.1.0` → `0.1.1`). If PATCH is chosen, every non-test `.csproj` in the solution moves to the same new version in a single commit per invariant 27. `[Unreleased]` is forbidden per the user's standing convention.
+
+No `HoneyDrunk.Prompts` version-bump in this initiative — the Node does not exist yet. The first version (`0.1.0`) lands with the standup ADR's scaffold packet.
+
+## Cross-Cutting Concerns
+
+### Required Decision 1 — invariant 44 conflict
+
+N3 (no inlined prompt bodies; AI-sector Nodes consume `IPromptResolver` from `HoneyDrunk.Prompts.Abstractions`) introduces a new downstream AI-sector runtime dependency. Invariant 44 in its current text restricts downstream AI-sector dependencies to `HoneyDrunk.AI.Abstractions` only.
+
+Three resolutions:
+- **A** — amend invariant 44 to permit prompt-registry coupling (add an explicit exception).
+- **B (recommended)** — restate invariant 44 narrowly: change "only `HoneyDrunk.AI.Abstractions`" to "on `HoneyDrunk.AI.Abstractions` and no `HoneyDrunk.AI.Providers.*` package directly." Preserves the original ADR-0016 D9 intent ("no AI-provider lock-in at the consumer site") without amendment-by-exception.
+- **C** — carve out by addition (leave invariant 44 alone, add a new invariant at `{N4}+1` permitting `HoneyDrunk.Prompts.Abstractions` as a sibling AI-sector dependency). Heaviest constitution surface.
+
+Packet 00's PR description surfaces this for human resolution. Packet 01 applies the chosen resolution in the same commit as N1–N4 land.
+
+### Required Decision 2 — paired standup ADR filing posture
+
+ADR-0064 D12 commits a paired `HoneyDrunk.Prompts` standup ADR following the ADR-0058 / ADR-0059 precedent. Two postures:
+- **A** — file the standup ADR draft now via adr-composer, in this initiative's filing window. A sibling `adr-{N}-prompts-standup` initiative is created.
+- **B (recommended)** — defer the standup ADR draft until after ADR-0064 reaches Accepted on `main`. Mirrors the ADR-0058 / ADR-0059 cadence (ADR-0058 was Accepted before ADR-0059's standup packets landed). Reduces filing-window surface and the chance of races between the two adr-composer drafts.
+
+Either is acceptable; the packets here are identical. Packet 05 authors the spec the adr-composer reads regardless of posture.
+
+### No new `AuditCategory` enum value
+
+The refine-pass clarification is load-bearing across packets 03 and 04: do NOT invent an `Inference` category. The LLM-call emit uses existing `AgentAction` (agent-execution-originated calls) and `Integration` (non-agent-originated calls — wiki-ingest skill, one-off operator diagnostic, Notify Cloud rendering step). The category is the discriminator between agent and integration LLM activity; the prompt-tuple metadata is the per-call detail.
+
+The reason this matters: introducing a new `AuditCategory` value is a major-breaking-shape change on `HoneyDrunk.Audit.Abstractions` per ADR-0035 strict semver. The category enum is part of the contract surface canary (invariant 49). Adding a value where the existing two-category split works is unnecessary risk.
+
+### Audit payload is tuple-only
+
+Across N1 (invariant), packet 03 (audit catalog), and packet 04 (agent checklists): the LLM-call audit payload never carries the rendered prompt body, the completion text, or the substituted parameter values. The reason: substituted parameters may carry `Restricted`-tier content per ADR-0049 / N2; the audit substrate's append-only-by-interface stance does not enable redaction-after-the-fact; the right discipline is never let the bodies / completions / substituted values into the payload in the first place.
+
+Forensic reconstruction of "what text did the model actually see" is achieved by:
+1. Reading the `(prompt_id, prompt_version, prompt_hash)` from the audit entry.
+2. Resolving the prompt content from the `HoneyDrunk.Prompts` repo at the indicated version (the hash confirms byte-exactness).
+3. Reading the substituted parameter values from the Node's *application* logs (not the audit channel — the application logs are subject to the Node's own retention / classification posture, which may include redaction).
+
+This split keeps the audit channel free of PII while preserving forensic reconstruction capability.
+
+### Tier names per ADR-0049
+
+ADR-0049 D1 commits four classification tiers: `Public`, `Internal`, `Confidential`, `Restricted`. `Sensitive` is a **PII sub-classification** under D2 (a sub-taxonomy of `Restricted`), **not** a top-level tier. Across N2 and packet 04, the rule for `HoneyDrunk.Prompts` files is "Public / Internal / Confidential only, never `Restricted`." Do not say "no Sensitive" — say "no Restricted." Sensitive is a sub-category that does not apply at the file-classification level.
+
+### Paired standup ADR is filed as a separate sibling track
+
+This initiative does not create the `HoneyDrunk.Prompts` repo, does not write the contract code, does not land catalog edges. Packet 05 authors the spec the adr-composer reads when it drafts the paired standup ADR. The standup ADR's own packets (scaffold, contract, runtime, seed migration, catalog rows) land in a sibling initiative folder when the user invokes the adr-composer per Required Decision 2.
+
+This is the same pattern ADR-0067 used for the Notify Cloud rate-limit policy implementation (deferred to ADR-0027's standup completion + a follow-up packet).
+
+### Site sync
+
+No site-sync flag. ADR-0064 is internal AI-sector infrastructure; the Studios website does not change. (Once the `HoneyDrunk.Prompts` Node is stood up via the paired standup ADR, the Studios website's Grid visualization gains the Prompts Node — but that is the standup ADR's site-sync concern, not this initiative's.)
+
+### Deferred follow-ups (explicitly out of scope of this initiative)
+
+- **`HoneyDrunk.Prompts` Node standup** (the paired standup ADR + its packet set). Drafted by adr-composer per Required Decision 2. Includes repo creation, the three .NET projects, CI pipeline (contract-shape canary, content-shape canary, classification gate, `pr-core.yml`), `repos/HoneyDrunk.Prompts/` folder, catalog rows, seed migration (Honeyclaw + Lore), Honeyclaw OpenClaw export workflow.
+- **AI-sector consumer wiring.** Agents (ADR-0020), Operator (ADR-0018), Memory (ADR-0022), Knowledge (ADR-0021), Evals (ADR-0023), Lore — each Node's first registry-aware feature packet wires `IPromptResolver` consumption + the `LlmCall` audit emit. These packets land in each Node's own standup or feature initiative, not here.
+- **Honeyclaw OpenClaw export workflow implementation.** Deferred to the standup ADR's decision (private gist / Vault config blob / OpenClaw API call). Until it lands, the user manually copies the persona text from the Grid repo to OpenClaw at each release.
+- **Evals release-gate ADR.** Per ADR-0064 D6, a future ADR may add Evals as a release gate for the prompts package (major/minor bumps cannot publish without affected suites passing). Out of scope here.
+- **PDR-app persona registration packets.** Per ADR-0064 D8, Hearth (first-build pick), Lately, Curiosities register their personas at their first AI-enabled feature packet — those packets land in each app's initiative, not here.
+
+## Rollback Plan
+
+- **Packets 00–02 (governance):** revert the PR. ADR returns to Proposed; the four invariants disappear from `constitution/invariants.md`; the invariant 44 amendment is reverted; the sectors.md Prompts row is removed; the ai-sector-architecture.md subsection is removed. The ADR-0064 reservation row returns to **Active Reservations** if it had been moved to history. No runtime impact (no code, no Node exists).
+- **Packet 03 (Audit docs):** revert the PR; the LLM-Call Audit Catalog section is removed from `HoneyDrunk.Audit`'s docs. No runtime impact (no code).
+- **Packet 04 (agent checklists):** revert the PR; the four prompt-registry checklist items are removed from `scope.md` and `review.md`. After revert, the user restarts Claude Code so the reverted files re-register. No runtime impact on any deployed Node.
+- **Packet 05 (standup handoff spec):** revert the PR; the spec document is removed. No runtime impact. The paired standup ADR's drafting is unaffected at the runtime level; only the input document for the adr-composer is gone (the adr-composer can still draft the standup ADR by reading ADR-0064 directly, just with more derivation).
+- **Operational escape hatch:** none required at this initiative's stage. The Node does not exist yet; no consumer is wired; no LLM call emits an `LlmCall` audit entry yet (the first emitter ships with the AI-sector consumer wiring in a later initiative). If a defect surfaces in the policy itself post-acceptance, the fix is an amendment to ADR-0064 + a new acceptance packet, not a rollback.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.
+
+The paired `HoneyDrunk.Prompts` standup ADR is **not** filed by this initiative's push. It is filed later, as a separate adr-composer invocation per Required Decision 2 in packet 00 — either as Posture A (in this initiative's filing window, as a sibling initiative folder) or as Posture B (after this initiative completes, as a follow-up task).

--- a/generated/issue-packets/active/adr-0073-notify-providers/00-architecture-adr-0073-acceptance.md
+++ b/generated/issue-packets/active/adr-0073-notify-providers/00-architecture-adr-0073-acceptance.md
@@ -1,0 +1,144 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "docs", "adr-0073", "wave-1"]
+dependencies: []
+adrs: ["ADR-0073"]
+accepts: ["ADR-0073"]
+wave: 1
+initiative: adr-0073-notify-providers
+node: honeydrunk-architecture
+---
+
+# Accept ADR-0073 — amend D3 provider naming and record npm-templates deferral
+
+## Summary
+Flip ADR-0073 (Notify Default Providers — Resend / Twilio / Expo) from Proposed to Accepted: update the ADR header, add the ADR-0073 row to `adrs/README.md`, register the `adr-0073-notify-providers` initiative in `initiatives/active-initiatives.md`, **amend D3** to channel-scoped provider naming (`HoneyDrunk.Notify.Providers.Push.Expo`), and record the `@honeydrunk/notify-templates` npm-templates standup deferral as a Required Decision in the ADR. ADR-0073 adds **no new invariants** (its §Consequences / Invariants section is explicit on that point) — `constitution/invariants.md` is **not** modified.
+
+## Context
+ADR-0073 commits the canonical default providers for HoneyDrunk.Notify's three channels — Resend (email, D1), Twilio (SMS, D2, tentative), Expo Notifications (push, D3) — plus react-email as the templating choice (D4) that pairs with the email default. The provider abstraction (`IEmailSender` / `ISmsSender` / future `IPushSender`) is preserved; per-tenant and per-PDR overrides remain allowed but discouraged (D5).
+
+ADR-0073's decisions:
+
+- **D1 — Resend is the default email provider.** `HoneyDrunk.Notify.Providers.Email.Resend` (the existing package, already shipping at v0.3.0) fills the `IEmailSender` slot. API key in Vault per ADR-0005 (`kv-hd-notify-{env}` namespace), rotated per ADR-0006 Tier 2. Sender-identity discipline per ADR-0038. Webhook-driven deliverability events per ADR-0062.
+- **D2 — Twilio is the default SMS provider (tentative; re-evaluate at first cost-pressure inflection).** `HoneyDrunk.Notify.Providers.Sms.Twilio` (existing) fills the `ISmsSender` slot. Account credentials in Vault. Webhook delivery events per ADR-0062. Re-evaluation trigger: first month with SMS spend > $200, or specific tenant-driven requirement, or a Twilio stewardship event.
+- **D3 — Expo Notifications is the default push provider.** New `HoneyDrunk.Notify.Providers.Push.Expo` package (per **D3 amendment**, see below) implementing `IPushSender`. Expo Push Tokens are the addressable identifier. Expo Access Tokens in Vault. Receipt-driven delivery confirmation via Expo's receipts API.
+- **D4 — Email templating uses react-email.** `@react-email/components` for component authoring. Templates live in `HoneyDrunk.Notify.Templates` (new package — **deferred to a standup ADR**, see below). Per-consumer-PDR templates consume react-email components from the Notify Templates package for consistency. Render at send time (consumer-side); Notify is HTML-in. Tokens and design system from Web.UI per ADR-0071.
+- **D5 — Provider abstraction is held; defaults are not exclusive bindings.** Per-tenant override permitted (Notify Cloud BYO-provider seam). Per-PDR override permitted but discouraged. Node-level default enforced at packet scaffolding.
+- **D6 — Out of scope.** Sender-identity policy (owned by ADR-0038); per-region provider variation; tenant-BYO provider tooling; outbound-rate-limiting; bounce/complaint policy (Communications-side); MMS/RCS; in-app toasts; outbound webhooks.
+
+ADR-0073 §Consequences / Invariants is explicit:
+
+> No new Grid-wide invariants introduced. Conventions enforced at packet authoring and review.
+
+This packet does **not** edit `constitution/invariants.md` and does **not** reserve a number from the pre-allocated batch.
+
+## D3 amendment — channel-scoped provider naming
+
+ADR-0073 D3 names the push package `HoneyDrunk.Notify.Providers.Expo`. The Grid's existing per-channel provider naming (already in the `HoneyDrunk.Notify` repo on disk) uses **channel-scoped** naming:
+
+- `HoneyDrunk.Notify.Providers.Email.Resend` (exists today, v0.3.0)
+- `HoneyDrunk.Notify.Providers.Email.Smtp` (exists today, v0.3.0)
+- `HoneyDrunk.Notify.Providers.Sms.Twilio` (exists today, v0.3.0)
+
+The ADR's D3 wording (`Providers.Expo`) is inconsistent with the established channel-scoped pattern. **This packet amends D3** to `HoneyDrunk.Notify.Providers.Push.Expo` — channel-scoped, parallel to email/sms. The amendment is recorded inline in D3 with a dated note (no full revision history block — the ADR was Proposed when amended, not yet Accepted, so the amendment is an authorship correction).
+
+D1 and D2's descriptive phrasings in the ADR (`Providers.Resend` / `Providers.Twilio`) are similarly informal but the existing packages already ship under their channel-scoped names. **No amendment to D1 or D2 is required** — the shipped code is authoritative; the ADR's descriptive phrasing is informally aligned without an explicit revision line.
+
+## Deferred — `@honeydrunk/notify-templates` npm-templates standup
+
+ADR-0073 D4 commits react-email as the canonical email-templating library and pins the canonical template set's home as `HoneyDrunk.Notify.Templates` (mentioned in §Consequences / Affected Nodes). react-email is a TypeScript/JSX library that lives in the npm ecosystem; `HoneyDrunk.Notify` is a .NET repo. The canonical template set is therefore an **npm package living inside a .NET repo** (a polyglot package: react-email source in `templates/`, rendered HTML output potentially consumed by .NET via a sibling library or via build-time emission).
+
+The packaging shape, build pipeline, publish destination (npmjs.org under `@honeydrunk` scope per ADR-0034 patterns), and consumer-PDR template-extension model are non-trivial decisions warranting their own standup ADR — parallel to how `HoneyDrunk.Cache` got ADR-0059 paired with ADR-0058's contract decision. Per the user's standing convention ("new-Node scaffolding gets its own standup ADR; don't bundle scaffold into feature packets"), **packet 03 in this initiative is deferred** with a placeholder until the standup ADR (provisionally `ADR-0073a-notify-templates-npm-standup`, number to be assigned at draft time) is drafted and accepted.
+
+This packet records the deferral in the ADR's Follow-up Work section so the open question is visible from the ADR text and not hidden in the dispatch plan only.
+
+## Scope
+- `adrs/ADR-0073-notify-default-providers.md` — flip `**Status:** Proposed` → `**Status:** Accepted`. Amend D3 to channel-scoped `Providers.Push.Expo` naming with a dated note. Append a "Deferred — Required Decision: notify-templates npm-package standup" entry under Follow-up Work.
+- `adrs/README.md` — add the ADR-0073 row (Status: Accepted, Date: 2026-05-25, Sector: Ops, with the impact summary).
+- `initiatives/active-initiatives.md` — register the `adr-0073-notify-providers` initiative under `## In Progress` with the packet tracking checklist (10 packets, 4 waves).
+- `constitution/invariants.md` — **NOT modified.** ADR-0073 adds no new invariants.
+
+## Proposed Implementation
+1. **Edit the ADR-0073 header**: `**Status:** Proposed` → `**Status:** Accepted`. Keep the original `**Date:** 2026-05-23` (the original drafting date); add a separate dated note in the D3 amendment block (next step).
+2. **Amend D3** — inside the D3 section, edit the bullet that names the package:
+   - **From:** `**HoneyDrunk.Notify.Providers.Expo** (new package, ships when push lands) — the IPushSender implementation.`
+   - **To:** `**HoneyDrunk.Notify.Providers.Push.Expo** (new package, ships when push lands) — the IPushSender implementation. *(Amended 2026-05-25 from the original "HoneyDrunk.Notify.Providers.Expo" to align with the Grid's channel-scoped provider naming used by HoneyDrunk.Notify.Providers.Email.Resend, HoneyDrunk.Notify.Providers.Email.Smtp, and HoneyDrunk.Notify.Providers.Sms.Twilio.)*`
+3. **Append the deferral entry to §Follow-up Work** — add a new line:
+   - `Deferred — Required Decision: HoneyDrunk.Notify.Templates / @honeydrunk/notify-templates polyglot npm-package standup ADR. The canonical react-email template set named in D4 is a polyglot npm package inside a .NET repo; the packaging shape, build pipeline, npm publish destination, and consumer-PDR template-extension model warrant a standup ADR. Until that ADR lands, react-email is the committed library but the canonical template set does not ship; email sends compose HTML consumer-side however the consuming Node already does (today: Notify's existing template renderer).`
+4. **Add the ADR-0073 row to `adrs/README.md`** — append after the most recent row. Use the same `| ID | Title | Status | Date | Sector | Impact |` shape. Suggested row text:
+   - `| [ADR-0073](ADR-0073-notify-default-providers.md) | Notify Default Providers — Resend (Email), Twilio (SMS), Expo (Push) | Accepted | 2026-05-23 | Ops | Canonical default providers for HoneyDrunk.Notify's three channels: Resend (email, D1), Twilio (SMS, D2, tentative pending first cost-pressure inflection), Expo Notifications (push, D3, channel-scoped Providers.Push.Expo package). react-email as the canonical email-templating library (D4) pairing with the Resend default. Provider abstraction held — per-tenant and per-PDR overrides allowed but discouraged (D5). No new Grid-wide invariants. Sender-identity (ADR-0038), webhook intake (ADR-0062), and Tier-2 rotation (ADR-0006) discipline applied to all three providers from their existing ADRs. HoneyDrunk.Notify.Templates / @honeydrunk/notify-templates npm-package standup deferred to its own follow-up ADR. |`
+5. **Register the initiative in `initiatives/active-initiatives.md`** under `## In Progress` with the wave structure and packet checklist for this folder. Match the existing entry-shape used by sibling initiatives (`adr-0058-caching-strategy`, `adr-0067-rate-limiting`): an `### ADR-0073 Notify Default Providers` heading, Status / Scope / Initiative / Board / Description fields, and a Tracking checklist of the 9 packets in this folder split across 4 waves (per dispatch-plan.md). Use the file naming as the canonical packet references; GitHub issue numbers backfill via `hive-sync` after filing.
+6. **Do NOT modify `constitution/invariants.md`.** ADR-0073 §Consequences / Invariants is explicit: no new Grid-wide invariants. The conventions stated there (email defaults to Resend, SMS to Twilio, push to Expo, react-email-no-raw-HTML, Vault for credentials) are enforced at packet authoring and review — not as numbered invariants.
+
+## Affected Files
+- `adrs/ADR-0073-notify-default-providers.md`
+- `adrs/README.md`
+- `initiatives/active-initiatives.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] ADR-0073 header reads `**Status:** Accepted`
+- [ ] ADR-0073 D3 names the push package `HoneyDrunk.Notify.Providers.Push.Expo` with the dated amendment note inline
+- [ ] ADR-0073 §Follow-up Work contains the `@honeydrunk/notify-templates` standup-deferral line
+- [ ] `adrs/README.md` has a new row for ADR-0073 with Status: Accepted, Sector: Ops, and a one-paragraph impact summary
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0073-notify-providers` initiative under `## In Progress` with the 9-packet tracking checklist split across 4 waves
+- [ ] `constitution/invariants.md` is **NOT** modified
+- [ ] No catalog schema change in this packet (no edits to `catalogs/nodes.json`, `catalogs/relationships.json`, `catalogs/contracts.json`)
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0073 §Consequences / Invariants.** "No new Grid-wide invariants introduced. Conventions enforced at packet authoring and review: Email sends use Resend by default. Alternative providers require justification. SMS sends use Twilio by default. Tentative; re-evaluation triggers per D2. Push sends use Expo Notifications by default. Email templates use react-email; raw HTML email is not authored by hand. Provider credentials live in Vault per ADR-0005."
+
+**ADR-0073 §Follow-up Work.** "Ship `HoneyDrunk.Notify.Providers.Resend` package (Notify-side packet, with Vault wiring and webhook intake). Ship `HoneyDrunk.Notify.Templates` package with the canonical react-email template set. Migrate or retire any legacy SendGrid adapter sketches. Ship `HoneyDrunk.Notify.Providers.Twilio` package when the first SMS-needing PDR pulls on it. Ship `HoneyDrunk.Notify.Providers.Expo` package when the first mobile-PDR push-flow pulls on it. Identity verification-email flow per ADR-0060 Phase 2 lands on Resend. Notify Cloud GA documentation includes the per-tenant provider-override mechanism per D5. Re-evaluation calendar: track Twilio monthly spend; the D2 trigger fires the cost comparison. Watch list: Resend stewardship continues; Twilio pricing curve; Expo's stewardship under its current ownership."
+
+**ADR-0073 D5 — Provider abstraction is held; defaults are not exclusive bindings.** Per-tenant override permitted. Per-PDR override permitted but discouraged. Node-level default enforced at scaffolding.
+
+## Constraints
+- **Acceptance precedes implementation.** ADR-0073 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **No invariant edits.** ADR-0073 §Consequences / Invariants is explicit: no new invariants. Do not append placeholder text to `constitution/invariants.md`. Do not reserve a number for ADR-0073 in the pre-reservation batch.
+- **D3 amendment is the only structural correction.** D1 and D2 phrasings remain as written; the shipped code names (`Providers.Email.Resend`, `Providers.Sms.Twilio`) are authoritative against the ADR's informal descriptions. Only D3 needed correction because the package does not yet exist.
+- **`@honeydrunk/notify-templates` package does not ship in this initiative.** Packet 03 records the deferral; no code work happens until the standup ADR lands. Email sends in this initiative use the existing Notify template renderer.
+- **No constitution row reserved for ADR-0073.** ADR-0073 is excluded from any invariant pre-reservation; if at execution time the user decides ADR-0073 should have a numbered invariant (e.g. "no raw HTML email") that is a separate amendment + new acceptance packet, not a silent append from this packet.
+
+## Labels
+`chore`, `tier-3`, `ops`, `docs`, `adr-0073`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0073 to Accepted, amend D3 to channel-scoped naming, record the npm-templates deferral, and register the initiative. No invariant edits.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0073 so the remaining packets (Resend production hardening, Twilio production hardening, Expo push provider standup, override-policy doc, npm-templates deferral) can reference its decisions as live rules.
+- Feature: ADR-0073 Notify Default Providers rollout, Wave 1.
+- ADRs: ADR-0073 (primary); ADR-0019 (Notify/Communications boundary — provider selection is a Notify concern); ADR-0027 (Notify Cloud — first commercial consumer of the defaults, Proposed); ADR-0038 (sender identity, Proposed — discipline applied to Resend); ADR-0062 (webhook verification — discipline applied to all three providers' delivery callbacks); ADR-0006 (Tier-2 rotation — applied to all three providers' credentials).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+- ADR-0073 stays Proposed until this PR merges.
+- **No invariant edits** — ADR-0073 adds no new Grid-wide invariants. Do not append placeholder text; do not reserve a batch number.
+- **D3 amendment must use the exact channel-scoped name** `HoneyDrunk.Notify.Providers.Push.Expo` (Push capitalized as a channel segment, mirroring `.Email.` and `.Sms.`).
+- The npm-templates deferral entry in §Follow-up Work must be explicit about the open questions: polyglot packaging shape, build pipeline, npm publish destination, consumer-PDR extension model.
+
+**Key Files:**
+- `adrs/ADR-0073-notify-default-providers.md`
+- `adrs/README.md`
+- `initiatives/active-initiatives.md`
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0073-notify-providers/01-notify-resend-production-hardening.md
+++ b/generated/issue-packets/active/adr-0073-notify-providers/01-notify-resend-production-hardening.md
@@ -1,0 +1,174 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["feature", "tier-2", "ops", "adr-0073", "wave-2"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0073", "ADR-0062", "ADR-0006", "ADR-0038", "ADR-0005"]
+wave: 2
+initiative: adr-0073-notify-providers
+node: honeydrunk-notify
+---
+
+# Production-harden the Resend email provider for ADR-0073 D1
+
+## Summary
+Confirm and complete the production-hardening obligations ADR-0073 D1 puts on the canonical Resend email provider: webhook intake for deliverability events per ADR-0062 (bounce / complaint / delivered / opened / clicked), Tier-2 secret rotation registration per ADR-0006, sender-identity discipline cross-reference per ADR-0038, and confirmation that the existing `HoneyDrunk.Notify.Providers.Email.Resend` package (v0.3.0) is the canonical `IEmailSender` slot fill. **First packet on the Notify solution in this initiative — rolls the existing `[Unreleased]` CHANGELOG content into a dated `[0.3.1]` patch-bump section** and bumps every non-test `.csproj` in the solution from `0.3.0` to `0.3.1`.
+
+## Context
+The `HoneyDrunk.Notify.Providers.Email.Resend` package already exists in the Notify repo at version 0.3.0 (per `HoneyDrunk.Notify/HoneyDrunk.Notify.Providers.Email.Resend/HoneyDrunk.Notify.Providers.Email.Resend.csproj`). It already:
+
+- Implements `INotificationSender` against the Resend HTTP API (`ResendNotificationSender.cs`).
+- Registers as the `NotificationChannel.Email` keyed provider via `AddHoneyDrunkNotifyResendProvider` (`DependencyInjection/ResendNotifyServiceCollectionExtensions.cs`).
+- Resolves the API key from `ISecretStore` at send time using the secret name `Resend--ApiKey` (per the v0.2.0 CHANGELOG note).
+- Is named `Providers.Email.Resend` (channel-scoped — the convention this initiative is preserving and extending).
+
+What is **not yet in place** per ADR-0073 D1 + the referenced ADRs:
+
+1. **Webhook intake for deliverability events** per ADR-0062. Resend posts webhook callbacks for bounce, complaint, delivered, opened, and clicked events. ADR-0062's verification model (HMAC signature, replay protection, payload schema validation) must be applied at the intake. The intake handler routes verified events into Notify's existing intake pipeline.
+2. **Tier-2 secret rotation registration** per ADR-0006. The Resend API key sits in `kv-hd-notify-{env}` and rotates per Tier-2 cadence (≤90 days). The rotation calendar registration in `HoneyDrunk.Vault.Rotation` must list Resend as a Tier-2 rotation target with the `Resend--ApiKey` secret-name binding.
+3. **Sender-identity discipline cross-reference** per ADR-0038. The Resend provider's README and the repo's overview should cross-reference ADR-0038's DKIM / SPF / DMARC / From-address governance so an operator looking at the provider knows where the discipline lives. (This packet writes the cross-reference; ADR-0038's full record-creation work is separate from this initiative — see Cross-references below.)
+
+This is **not a new package** — it is hardening of an existing package. The version bump is a **patch** (`0.3.0` → `0.3.1`) because the changes are deliverability/operational hardening with no public API change.
+
+> **CHANGELOG rule (per "no commits under CHANGELOG Unreleased" memory).** The repo-level `CHANGELOG.md` and per-package CHANGELOGs currently carry `[Unreleased]` content (ADR-0044 Grid Review enablement + HoneyDrunk.Standards 0.2.9 refresh, per the file at `HoneyDrunk.Notify/CHANGELOG.md`). This packet is the bumping packet for the Notify solution in this initiative — per invariant 27 it bumps every non-test `.csproj`, and per the standing rule it **rolls the existing `[Unreleased]` content into the new dated `[0.3.1]` section together with the hardening changes from this packet**. After this packet merges, the repo-level `[Unreleased]` section is empty (or absent — match the existing convention in the file).
+
+## Scope
+- **`HoneyDrunk.Notify` (intake / runtime)** — new webhook intake endpoint(s) for Resend deliverability events, applying ADR-0062's verification model. Wired into Notify's existing intake pipeline.
+- **`HoneyDrunk.Notify.Providers.Email.Resend`** — provider package gets:
+  - `README.md` updated with: the ADR-0073 D1 default-provider declaration; the ADR-0038 sender-identity cross-reference; the ADR-0062 webhook verification cross-reference; the ADR-0006 Tier-2 rotation cross-reference.
+  - `CHANGELOG.md` updated with a `[0.3.1]` entry — appending the hardening changes; the package's existing `[Unreleased]` Standards-refresh line is rolled into the `[0.3.1]` section.
+- **`HoneyDrunk.Notify.Hosting.AspNetCore`** (or wherever the existing intake HTTP routes live — confirm against the repo on execution) — register the new Resend webhook route under the existing intake routing convention.
+- **`HoneyDrunk.Notify.Tests`** — unit tests for the Resend webhook intake (verifies ADR-0062 signature; rejects unsigned/replayed payloads; routes verified events into the intake pipeline). **Use the existing test project name** (`HoneyDrunk.Notify.Tests`) — the ADR-0047 `*.Tests.Unit` rename is a separate follow-up tracked under `adr-0047-testing-patterns-and-tooling` and is not gated here.
+- **`HoneyDrunk.Notify.IntegrationTests`** — integration test for the end-to-end webhook intake using `WebApplicationFactory<TStartup>` per ADR-0047 Tier 2a — exercises the route, the signature verification, and the dispatch to the intake pipeline using in-process fakes for any external dependency.
+- **All non-test `.csproj` files in the solution version-bumped to `0.3.1`** in one commit (invariant 27).
+- **Repo-level `CHANGELOG.md`** receives a new `[0.3.1]` dated section that consolidates the existing `[Unreleased]` content (per the standing "no commits under Unreleased" rule) with the changes from this packet.
+
+## Out of Scope
+- The actual DKIM / SPF / DMARC record creation work — owned by ADR-0038 (Proposed) and its future implementation initiative. This packet only adds the **cross-reference** at the Resend provider's README.
+- The Tier-2 rotation runtime in `HoneyDrunk.Vault.Rotation`. That infrastructure already exists (per the `vault-rotation-bring-up` initiative). This packet only ensures Resend is listed in the rotation calendar configuration consumed by Vault.Rotation; if the calendar configuration lives in Vault.Rotation rather than in Notify, the actual edit may land via a Vault.Rotation packet rather than here — confirm at execution time. If the Resend entry is already present (e.g. added during the original Vault.Rotation bring-up), this is a no-op.
+- The Notify Cloud per-tenant override flow (packet 05's responsibility).
+- The legacy SendGrid adapter migration — the Notify repo has no SendGrid adapter on disk; the ADR-0073 §Follow-up Work item is a no-op (see dispatch-plan Cross-Cutting Concerns).
+
+## Proposed Implementation
+1. **Webhook intake — author the Resend webhook endpoint(s).**
+   - Add an HTTP POST endpoint (e.g. at `/internal/webhooks/resend` — confirm path convention against the existing intake routes in `HoneyDrunk.Notify.Hosting.AspNetCore` and `HoneyDrunk.Notify.Functions`).
+   - Apply ADR-0062's verification: read the Resend signature header (Resend uses Svix for webhook signing — confirm header name `svix-signature` at execution time), resolve the signing-secret value from `ISecretStore` (secret name `Resend--WebhookSigningSecret` or similar — confirm with the existing Resend-secret-name convention in `HoneyDrunk.Notify.Providers.Email.Resend`), verify the HMAC, reject any payload that fails verification or whose timestamp falls outside the ADR-0062 replay window with `401 Unauthorized` or `400 Bad Request` per ADR-0062.
+   - On verified payloads, parse the event and route into Notify's existing intake pipeline as a `DeliveryStatusEvent` (or whatever the existing event shape is for delivery callbacks — confirm against the existing intake-event types).
+   - Map Resend event types to internal event shapes: `email.delivered` → delivered; `email.bounced` → bounced (with classification); `email.complained` → complained; `email.opened` → opened; `email.clicked` → clicked. Schema reference: Resend's webhook docs at https://resend.com/docs/dashboard/webhooks/introduction.
+2. **Tier-2 rotation calendar registration.**
+   - Confirm whether `HoneyDrunk.Vault.Rotation`'s rotation calendar already lists `Resend--ApiKey` (likely already in place from the `vault-rotation-bring-up` initiative). If absent, add the registration in the format used by the calendar (configuration file, attribute, or DI binding — confirm at execution time).
+   - If the calendar lives in Vault.Rotation's repo, this step turns into a cross-reference in the Resend provider README only, and the actual rotation-calendar packet is filed against Vault.Rotation separately.
+   - Add `Resend--WebhookSigningSecret` to the rotation calendar at Tier 2 (90-day SLA per invariant 20).
+3. **README cross-references** in `HoneyDrunk.Notify.Providers.Email.Resend/README.md`:
+   - Add a section "ADR-0073 D1 default provider declaration" stating: "Resend is the canonical default email provider for HoneyDrunk.Notify's `IEmailSender` slot per ADR-0073 D1. Per-tenant and per-PDR overrides are permitted per D5 but discouraged."
+   - Add a section "Sender identity (ADR-0038)" stating: "DKIM, SPF, DMARC alignment for every sending domain and per-product From-address governance are owned by ADR-0038. Configure Resend's domain-verification flow per ADR-0038's discipline before sending in `dev` / `staging` / `prod` environments."
+   - Add a section "Webhook intake (ADR-0062)" stating: "Resend deliverability webhooks (bounce, complaint, delivered, opened, clicked) are received and verified per ADR-0062's HMAC-signed inbound discipline. The signing secret is `Resend--WebhookSigningSecret` in `kv-hd-notify-{env}`."
+   - Add a section "Rotation (ADR-0006 Tier 2)" stating: "The Resend API key (`Resend--ApiKey`) and webhook signing secret (`Resend--WebhookSigningSecret`) rotate at Tier 2 cadence (≤90 days) via `HoneyDrunk.Vault.Rotation`."
+4. **Per-package CHANGELOG (`HoneyDrunk.Notify.Providers.Email.Resend/CHANGELOG.md`)** — add a `[0.3.1] - {merge-date}` section. Roll the existing `[Unreleased]` entry (Standards 0.2.9 refresh) into this section. Add the new hardening entries: webhook intake; Tier-2 rotation registration; ADR-0073 D1 default-provider declaration in README.
+5. **Repo-level `CHANGELOG.md`** — add a `[0.3.1] - {merge-date}` section. Roll the existing `[Unreleased]` entries (ADR-0044 Grid Review request enablement; HoneyDrunk.Standards 0.2.9 refresh) into this section. Add the ADR-0073 production-hardening summary line.
+6. **Version bump** — set `<Version>0.3.1</Version>` on every non-test `.csproj` file in the solution in one commit (invariant 27). The test projects (`HoneyDrunk.Notify.Tests`, `HoneyDrunk.Notify.IntegrationTests`) are exempt from the version bump per the existing convention. **Do not add per-package CHANGELOG entries to packages with no functional change** (invariants 12 / 27) — only the repo-level CHANGELOG and the Resend provider's CHANGELOG get entries.
+7. **Unit + integration tests.** Use NSubstitute + AwesomeAssertions per the existing repo test stack (post-ADR-0047 migration is complete in this repo). Tests assert: valid signed payload → 200 + event routed; invalid signature → 401 / 400; expired timestamp → 400; malformed body → 400. Tests contain no `Thread.Sleep` (invariant 51).
+
+## Affected Files
+- `HoneyDrunk.Notify/Intake/` (or equivalent — confirm at execution) — new files for the Resend webhook route handler and the event mapper.
+- `HoneyDrunk.Notify.Hosting.AspNetCore/` — register the route in the existing routing extension if needed.
+- `HoneyDrunk.Notify.Providers.Email.Resend/README.md`, `CHANGELOG.md`.
+- Repo-level `CHANGELOG.md`.
+- All non-test `.csproj` files in the solution — version `0.3.0` → `0.3.1`.
+- `HoneyDrunk.Notify.Tests/` — new tests for the webhook intake.
+- `HoneyDrunk.Notify.IntegrationTests/` — new integration test for the webhook route.
+
+## NuGet Dependencies
+- **`HoneyDrunk.Notify`** — confirm whether ADR-0062's webhook verification helpers ship from `HoneyDrunk.Kernel` or from a Notify-internal helper (likely Notify-internal at this stage). No new third-party `PackageReference` is expected — the HMAC verification uses BCL primitives (`System.Security.Cryptography`). If the existing intake already references a webhook-verification helper (e.g. for a sibling Twilio or Stripe webhook), reuse it.
+- **`HoneyDrunk.Notify.Providers.Email.Resend`** — no new `PackageReference`. The package's existing references (`Resend 0.4.0`, `HoneyDrunk.Vault 0.5.0`, `Microsoft.Extensions.*`, `HoneyDrunk.Standards`) are unchanged.
+- **Test projects** — existing test-stack references (xUnit + NSubstitute + AwesomeAssertions + coverlet per ADR-0047). No new packages.
+
+## Boundary Check
+- [x] All work in `HoneyDrunk.Notify` per the routing rule "notification, email, SMS, SMTP, Resend, Twilio, notify, channel → HoneyDrunk.Notify".
+- [x] Webhook intake is delivery mechanics (Notify owns delivery; Communications owns decision — per Notify's `boundaries.md` "If the concern is how to deliver a structurally valid notification, it belongs in Notify"). Verified deliverability events feed Notify's intake, not Communications.
+- [x] No new cross-Node runtime dependency. ADR-0062 verification is currently a Notify-internal capability (or ships from Kernel — confirm at execution); no new abstraction edge is added.
+- [x] Sender-identity discipline cross-reference does not duplicate ADR-0038's work — it points at ADR-0038, where the work lives.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Notify` exposes an HTTP POST webhook route for Resend deliverability events (path under `/internal/webhooks/` or the existing intake-route convention)
+- [ ] The route applies ADR-0062 HMAC signature verification using `ISecretStore`-resolved `Resend--WebhookSigningSecret` (or the existing Resend webhook-secret name — confirm at execution)
+- [ ] Verified payloads route into Notify's existing intake event pipeline; invalid signatures or expired timestamps return 401/400 without side-effects
+- [ ] Resend event types map to Notify's internal event shapes: `email.delivered`, `email.bounced`, `email.complained`, `email.opened`, `email.clicked`
+- [ ] `Resend--ApiKey` and `Resend--WebhookSigningSecret` are listed in `HoneyDrunk.Vault.Rotation`'s Tier-2 rotation calendar (or, if the calendar config lives in Vault.Rotation's repo, the cross-reference is in the Resend provider README and a parallel packet is open against Vault.Rotation)
+- [ ] `HoneyDrunk.Notify.Providers.Email.Resend/README.md` includes the four cross-reference sections (ADR-0073 D1 declaration, ADR-0038 sender identity, ADR-0062 webhook intake, ADR-0006 Tier-2 rotation)
+- [ ] `HoneyDrunk.Notify.Providers.Email.Resend/CHANGELOG.md` has a `[0.3.1]` entry that rolls the existing `[Unreleased]` Standards-refresh content into the new dated section and adds the hardening changes
+- [ ] Repo-level `CHANGELOG.md` has a `[0.3.1]` entry that rolls the existing `[Unreleased]` content (ADR-0044 Grid Review enablement + Standards 0.2.9 refresh) into the new dated section together with the ADR-0073 hardening summary
+- [ ] The repo-level `CHANGELOG.md` no longer carries any commits under `[Unreleased]` (per the standing "no commits under CHANGELOG Unreleased" rule)
+- [ ] Every non-test `.csproj` file in the solution is at `<Version>0.3.1</Version>` in a single commit (invariant 27)
+- [ ] **Only** packages with actual functional changes get a per-package CHANGELOG entry (`HoneyDrunk.Notify.Providers.Email.Resend` gets one — `HoneyDrunk.Notify` core may also get one if the webhook route lives there). All other packages get version-aligned `.csproj` updates with **no** CHANGELOG noise (invariants 12 / 27)
+- [ ] Unit + integration tests verify: signature-valid → 200 + event routed; signature-invalid → 401/400; replay-window-expired → 400; malformed body → 400; tests contain no `Thread.Sleep` (invariant 51)
+- [ ] The `pr-core.yml` tier-1 gate and any contract-shape canary pass
+
+## Human Prerequisites
+- [ ] **Resend webhook signing secret seeded in `kv-hd-notify-{env}` for each env.** The signing secret is generated in Resend's dashboard when the operator configures the webhook destination; copy that secret into `kv-hd-notify-dev` / `kv-hd-notify-staging` / `kv-hd-notify-prod` as `Resend--WebhookSigningSecret` before the webhook route goes live.
+- [ ] **Resend webhook destination configured in the Resend dashboard** for each environment (dev / staging / prod), pointing at the appropriate `/internal/webhooks/resend` URL.
+- [ ] **Tier-2 rotation calendar updated** if the calendar configuration lives outside this repo. Confirm at execution time whether the calendar lives in `HoneyDrunk.Vault.Rotation`'s repo (likely) or in App Configuration; file a Vault.Rotation packet if necessary.
+- [ ] **After this packet merges, a human pushes the `HoneyDrunk.Notify` `0.3.1` release tag** so the NuGet packages publish. Agents merge code but never tag or publish.
+
+## Referenced ADR Decisions
+**ADR-0073 D1 — Resend is the default email provider.** "`HoneyDrunk.Notify.Providers.Resend` (NuGet package, per the Grid's per-provider-package convention) — the `IEmailSender` implementation. API key in Vault per ADR-0005 — `kv-hd-notify-{env}` namespace, rotated per ADR-0006 Tier 2. Sender identity discipline per ADR-0038 — DKIM, SPF, DMARC alignment for every sending domain; per-product From-address governance. Webhook-driven deliverability events — Resend's webhook callbacks (bounce, complaint, delivered, opened, clicked) deliver into Notify's intake per ADR-0062's verification discipline." (Existing package name on disk is `HoneyDrunk.Notify.Providers.Email.Resend`; the channel-scoped naming is the established convention. The ADR's informal `Providers.Resend` phrasing aligns with the shipped name informally.)
+
+**ADR-0062 §Inbound Webhook Verification** (referenced — this packet consumes the verification discipline ADR-0062 commits; the full ADR text is not inlined here but its rule set is: HMAC signature over body + timestamp header; replay window (typically 5 minutes); fail-closed on missing or invalid signature; per-provider signing-secret resolution via `ISecretStore`).
+
+**ADR-0006 §Tier 2 (third-party rotation)** — "Tier 2 (third-party via rotation Function): ≤ 90 days." (Per invariant 20.) Third-party provider credentials rotate via `HoneyDrunk.Vault.Rotation`'s scheduled Function App, writing new versions into `kv-hd-notify-{env}`. Event Grid cache invalidation propagates the new version per ADR-0005's event-driven invalidation model — applications never pin to a specific secret version per invariant 21.
+
+**ADR-0038 §Outbound Sender Identity and Deliverability** (referenced — discipline applied at Resend's domain-verification flow; this packet does not redefine ADR-0038's rules, it cross-references them in the provider README).
+
+**ADR-0073 §Operational Consequences.** "Local-dev sends never reach real providers. Dev environments use the InMemory implementations per Invariant 15; only `dev`/`staging`/`prod` environments hit Resend / Twilio / Expo."
+
+## Constraints
+- **Invariant 12 — Semantic versioning with CHANGELOG and README.**
+  > Breaking changes bump major. New features bump minor. Fixes bump patch. Changelogs follow Keep a Changelog format. Per-package CHANGELOG.md inside each package directory: updated only when that specific package has functional changes. Do not add noise entries for packages that were version-bumped solely to align with the solution (see invariant 27).
+
+  Only `HoneyDrunk.Notify.Providers.Email.Resend` (and possibly `HoneyDrunk.Notify` itself, if the webhook route adds code there) gets a per-package CHANGELOG entry. Every other package in the solution gets the version bump in its `.csproj` only.
+- **Invariant 15 — Unit tests and in-process integration tests never depend on external services.** The webhook intake tests use in-process fakes for `ISecretStore` and for any HTTP dispatch. No live calls to Resend, no test webhooks fired against the real Resend dashboard.
+- **Invariant 20 — No secret may exceed its tier's rotation SLA without an active exception.** Tier 2 (third-party): ≤ 90 days. The Resend API key and webhook signing secret rotate within 90 days.
+- **Invariant 21 — Applications must never pin to a specific secret version.** The Resend provider reads the latest version of `Resend--ApiKey` and `Resend--WebhookSigningSecret` on every send / verify call; pinning breaks Event Grid cache invalidation per ADR-0006.
+- **Invariant 27 — All projects in a solution share one version and move together.** Every non-test `.csproj` goes to `0.3.1` in one commit. Partial bumps are forbidden. This is the first packet on the Notify solution in this initiative; packets 04 / 06 / 07 / 08 append to (or further bump from) `0.3.1` per the dispatch plan.
+- **Invariant 51 — Test code contains no `Thread.Sleep`.** Async work waits via `await` or polling primitives with explicit timeouts.
+- **No `[Unreleased]` commits left in any CHANGELOG.** Per the standing rule "no commits under CHANGELOG `Unreleased`" — the existing `[Unreleased]` content in the repo-level and per-package CHANGELOGs is rolled into the new `[0.3.1]` dated section in this packet's commit.
+- **Test project naming.** The existing test project name `HoneyDrunk.Notify.Tests` (pre-ADR-0047) is acknowledged. The rename to `HoneyDrunk.Notify.Tests.Unit` is a separate follow-up tracked under `adr-0047-testing-patterns-and-tooling` — not done here. Add tests under the existing project name.
+- **ADR-0073 D5 — Default is not exclusive.** The Resend provider stays composable with the existing keyed-DI shape; other providers (the existing `Providers.Email.Smtp`) remain registerable for `NotificationChannel.Email`. Do not change the resolver to hard-favor Resend.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0073`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Production-harden the Resend email provider per ADR-0073 D1: webhook intake (ADR-0062), Tier-2 rotation registration (ADR-0006), ADR-0038 cross-reference. First packet on the Notify solution in this initiative — bumps from `0.3.0` to `0.3.1` and rolls the existing `[Unreleased]` content into the dated `[0.3.1]` section.
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: Confirm Resend as the canonical default `IEmailSender` and complete the production-hardening obligations ADR-0073 D1 puts on it.
+- Feature: ADR-0073 Notify Default Providers rollout, Wave 2.
+- ADRs: ADR-0073 D1 (primary); ADR-0062 (webhook verification — consumed); ADR-0006 (Tier-2 rotation — consumed); ADR-0038 (sender identity — cross-referenced, not implemented); ADR-0005 (Vault config — already in place); ADR-0019 (Notify is delivery-mechanics layer, Communications is decision layer — webhook intake feeds Notify's intake, not Communications).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0073 is Accepted before any consuming packet runs.
+
+**Constraints:**
+- Bump every non-test `.csproj` to `0.3.1` in one commit (invariant 27). This is the first packet on Notify in this initiative; subsequent packets (04, 06, 07, 08) sequence after.
+- Roll the existing `[Unreleased]` CHANGELOG content into the dated `[0.3.1]` section in the same commit — do not leave anything in `[Unreleased]` (standing rule).
+- Per-package CHANGELOGs only for packages with actual functional change (invariants 12 / 27). The Resend provider gets an entry; everything else is alignment-bump-only with no noise.
+- Webhook intake applies ADR-0062's HMAC verification with `ISecretStore`-resolved signing secret; fail-closed on missing or invalid signature.
+- Test project name stays `HoneyDrunk.Notify.Tests` (pre-ADR-0047). The `.Tests.Unit` rename is tracked under `adr-0047-testing-patterns-and-tooling` separately.
+
+**Key Files:**
+- `HoneyDrunk.Notify/Intake/` (or equivalent existing intake folder) — new webhook route.
+- `HoneyDrunk.Notify.Providers.Email.Resend/README.md` and `CHANGELOG.md`.
+- Repo-level `CHANGELOG.md`.
+- Every non-test `.csproj` file — version `0.3.0` → `0.3.1`.
+- Test projects — new tests under existing folder conventions.
+
+**Contracts:**
+- No public contract change. `IEmailSender` and `INotificationSender` are unchanged. The webhook intake adds an internal event-routing path, not a new abstraction.

--- a/generated/issue-packets/active/adr-0073-notify-providers/02-architecture-sender-identity-cross-reference.md
+++ b/generated/issue-packets/active/adr-0073-notify-providers/02-architecture-sender-identity-cross-reference.md
@@ -1,0 +1,111 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "docs", "adr-0073", "wave-3"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0073", "ADR-0038"]
+wave: 3
+initiative: adr-0073-notify-providers
+node: honeydrunk-architecture
+---
+
+# Cross-reference ADR-0038 sender-identity discipline from Notify's repo overview
+
+## Summary
+Add a one-paragraph cross-reference to ADR-0038 (Outbound Sender Identity and Deliverability) inside `repos/HoneyDrunk.Notify/overview.md` so an operator looking at Notify's architecture context immediately sees where the DKIM / SPF / DMARC / From-address governance lives. **No new policy** — this packet just makes the existing ADR-0038 rules visible at the Notify Node's boundary. The Resend provider README cross-reference is authored in packet 01; this packet is the Architecture-side mirror.
+
+## Context
+ADR-0073 D1 commits Resend as the canonical default email provider but **explicitly defers** sender-identity discipline to ADR-0038:
+
+> Sender identity discipline per ADR-0038 — DKIM, SPF, DMARC alignment for every sending domain; per-product From-address governance.
+
+ADR-0073 D6 also names sender-identity policy as out-of-scope ("owned by ADR-0038"). The discipline is real — every send must respect it — but the rules are not in ADR-0073; they are in ADR-0038. Without a cross-reference at the Notify Node's overview, an operator looking at the Notify boundary doc has no signal that the discipline exists or where to find it.
+
+ADR-0038 is currently **Proposed**. The discipline is committed in the ADR text even though it has not been implemented at the operational level (DKIM record creation, SPF record creation, DMARC policy authoring are the implementation packets that follow ADR-0038's acceptance — those are not gated here). This packet does **not** wait for ADR-0038's acceptance — the cross-reference points at the ADR file and is valid as soon as the file exists, which it does.
+
+## Scope
+- `repos/HoneyDrunk.Notify/overview.md` — add a short "Sender Identity" section near the existing ADR-0019 Boundary Cleanup section, pointing at ADR-0038.
+
+## Out of Scope
+- The Resend provider's own README cross-reference — authored in packet 01 (Notify side).
+- Any actual DKIM / SPF / DMARC record-creation work — owned by ADR-0038's future implementation initiative.
+- Twilio's sender-identity discipline (10DLC, A2P 10DLC) — that is per-PDR consumer-app concern per ADR-0073 D2, not a Notify-side discipline. No cross-reference for SMS sender-identity in this packet.
+
+## Proposed Implementation
+1. Open `repos/HoneyDrunk.Notify/overview.md`.
+2. After the existing `## ADR-0019 Boundary Cleanup` section, add:
+
+   ```markdown
+   ## Sender Identity (ADR-0038)
+
+   Outbound email sender identity — DKIM, SPF, DMARC alignment for every sending domain and per-product From-address governance — is owned by [ADR-0038](../../adrs/ADR-0038-outbound-sender-identity-and-deliverability.md), not by Notify itself. The Notify Node's responsibility is delivery mechanics; the deliverability discipline is the configuration-level posture documented in ADR-0038.
+
+   Every email provider Notify wires (Resend per ADR-0073 D1, the existing SMTP provider, any future BYO-provider) operates inside ADR-0038's discipline. The provider package READMEs cross-reference ADR-0038 at the package boundary so an operator looking at a single provider can find the rules. SMS sender identity (10DLC registration, A2P 10DLC) is a per-PDR consumer-app concern per ADR-0073 D2 and is not enforced at the Notify provider layer.
+   ```
+
+3. Save. That's the whole packet.
+
+## Affected Files
+- `repos/HoneyDrunk.Notify/overview.md`
+
+## NuGet Dependencies
+None. This packet touches only Markdown context files; no .NET project.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any repo.
+- [x] No new abstraction or cross-Node runtime dependency.
+- [x] The cross-reference does not duplicate ADR-0038's content — it points at the ADR file.
+
+## Acceptance Criteria
+- [ ] `repos/HoneyDrunk.Notify/overview.md` has a new `## Sender Identity (ADR-0038)` section
+- [ ] The section explicitly names DKIM, SPF, DMARC, From-address governance, and the per-product discipline
+- [ ] The section explicitly states SMS sender identity (10DLC) is a per-PDR concern per ADR-0073 D2, not enforced at the Notify provider layer
+- [ ] The section links to `adrs/ADR-0038-outbound-sender-identity-and-deliverability.md` via the standard relative-path convention
+- [ ] No edits to `constitution/invariants.md` (ADR-0073 adds no invariants; ADR-0038's invariants — if any are committed when ADR-0038 is Accepted — are handled in ADR-0038's own initiative)
+- [ ] No edits to any `catalogs/` file
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0073 D1.** "Sender identity discipline per ADR-0038 — DKIM, SPF, DMARC alignment for every sending domain; per-product From-address governance. Pairs with ADR-0038."
+
+**ADR-0073 D6 — Out of scope.** "Sender-identity policy — owned by ADR-0038. This ADR commits the provider; ADR-0038 commits the identity discipline (DKIM, SPF, DMARC, From-address governance)."
+
+**ADR-0073 D2 — SMS provider.** "TCPA / SMS-marketing discipline is a per-PDR consumer-app concern; Notify does not enforce it at the provider layer." (Same shape — SMS sender-identity also lives outside the Notify boundary.)
+
+## Constraints
+- **Docs-only, no policy.** This packet adds a cross-reference; it does not author DKIM / SPF / DMARC records, does not pin domain names, does not configure Resend's domain-verification flow. Those are ADR-0038's implementation work.
+- **No invariant text.** ADR-0073 adds no invariants. If ADR-0038's acceptance introduces invariants (e.g. "every outbound sending domain has a valid DMARC policy at staged-strict"), those are added in ADR-0038's acceptance packet, not here.
+- **No relationships.json edit.** ADR-0038 does not introduce new Node-to-Node edges; no catalog update.
+
+## Labels
+`chore`, `tier-3`, `ops`, `docs`, `adr-0073`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Add a one-paragraph ADR-0038 cross-reference to `repos/HoneyDrunk.Notify/overview.md` so the discipline is visible at the Notify Node's architectural boundary.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make ADR-0038 sender-identity discipline visible at the Notify Node's boundary doc.
+- Feature: ADR-0073 Notify Default Providers rollout, Wave 3.
+- ADRs: ADR-0073 D1 / D6 (defer to ADR-0038); ADR-0038 (the discipline, Proposed — referenced not modified).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0073 is Accepted before any consuming packet runs.
+
+**Constraints:**
+- Docs-only. No new policy. Do not edit the ADR text of either ADR-0073 or ADR-0038.
+- Cross-reference uses relative paths (`../../adrs/ADR-0038-...`), matching the existing convention in `repos/HoneyDrunk.Notify/overview.md` for ADR links.
+
+**Key Files:**
+- `repos/HoneyDrunk.Notify/overview.md`
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0073-notify-providers/03-architecture-notify-templates-npm-deferral.md
+++ b/generated/issue-packets/active/adr-0073-notify-providers/03-architecture-notify-templates-npm-deferral.md
@@ -1,0 +1,173 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "docs", "adr-0073", "wave-3", "deferred"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0073"]
+wave: 3
+initiative: adr-0073-notify-providers
+node: honeydrunk-architecture
+---
+
+# DEFERRED — record the @honeydrunk/notify-templates polyglot npm-standup deferral
+
+## Summary
+Record the deferral of the `HoneyDrunk.Notify.Templates` / `@honeydrunk/notify-templates` package standup as a tracked work item on The Hive. ADR-0073 D4 commits **react-email** as the canonical email-templating library and pins the canonical template set's home at `HoneyDrunk.Notify.Templates` — a polyglot npm package living inside a .NET repo. The packaging shape, build pipeline, npm publish destination, and consumer-PDR template-extension model are non-trivial decisions warranting their own standup ADR. **This packet ships no code.** It writes a deferral document at `generated/deferred-work/adr-0073-notify-templates-npm-standup.md` describing the open questions, the rationale, and the expected shape of the future standup ADR. The deferral entry was also added to ADR-0073 §Follow-up Work by packet 00.
+
+## Context
+ADR-0073 D4 — Email templating uses react-email:
+
+- `@react-email/components` for component authoring.
+- Templates live in **`HoneyDrunk.Notify.Templates`** — a per-Notify package that holds the canonical template set (verification email, password reset, account-change confirmation, account-deletion confirmation, generic transactional shapes).
+- Per-consumer-PDR templates live in the consumer-PDR's repo when product-specific. They consume react-email components from the Notify Templates package for consistency.
+- Render at send time — Notify's `IEmailSender` implementation accepts a rendered HTML body; the consumer code calls `render(<MyEmail />)` from react-email and passes the result to `IEmailSender.SendAsync`.
+- Tokens and design system from Web.UI per ADR-0071.
+
+The challenge: **react-email is TypeScript/JSX, living in the npm ecosystem; `HoneyDrunk.Notify` is a .NET repo.** The canonical template set is therefore a **polyglot npm package inside a .NET repo** — react-email source in `templates/` (or a sibling structure), HTML output potentially consumed by .NET via a sibling library or via build-time emission. The packaging shape (npm package only? sibling .NET package wrapping rendered HTML? both?), the build pipeline (Node-side build inside CI; how the .NET CI integrates; how the npm package is published to npmjs.org), the publish destination (npmjs.org under `@honeydrunk` scope per ADR-0034 NuGet-feed patterns extended to npm; or GitHub Packages npm; or both), and the consumer-PDR template-extension model (how Hearth's "welcome to the town" email consumes the canonical `<EmailButton>` and contributes a new `<HearthHero>` component) are non-trivial decisions.
+
+Per the user's standing convention ("new-Node scaffolding gets its own standup ADR; don't bundle scaffold into feature packets"), the `HoneyDrunk.Notify.Templates` / `@honeydrunk/notify-templates` package needs its **own standup ADR**. The same pattern was used for `HoneyDrunk.Cache` — ADR-0059's standup paired with ADR-0058's contract decision; the standup ADR scaffolds the Node / package independently of the consuming-contract ADR.
+
+This packet **does not draft the standup ADR**. It records the deferral so the open question is visible on The Hive board and is not lost in the dispatch plan. The standup ADR (provisionally `ADR-0073a-notify-templates-npm-standup`, number to be assigned at draft time) is a separate, future work item.
+
+**Operational impact during the deferral.** react-email is the **committed** templating library per ADR-0073 D4. Until the standup ADR lands and the package ships:
+
+- The canonical template set does not exist.
+- Email sends compose HTML consumer-side however the consuming Node already does — today that means Notify's existing template-renderer abstractions (`ITemplateRenderer`, `IEmailTemplateRenderer`) and the per-consumer template-string flow that exists pre-react-email.
+- No new email templates should be authored in raw HTML between now and the standup ADR's acceptance (per ADR-0073 D4 negative form: "HTML-string-concatenation is forbidden"). If a consumer needs a new email template before the standup ADR lands, the consumer either waits or temporarily authors with the existing renderer + acknowledges the migration debt; the standup ADR's acceptance forces migration.
+
+## Scope
+- New file: `generated/deferred-work/adr-0073-notify-templates-npm-standup.md` — the deferral document.
+
+## Out of Scope
+- Drafting the standup ADR. That is a separate, future work item (use the `adr-composer` agent when ready to draft).
+- Creating the npm package directory in `HoneyDrunk.Notify`. The standup ADR decides the directory shape; this packet does not pre-empt it.
+- Choosing the publish destination, the build pipeline shape, or the consumer-extension model. The standup ADR's job.
+- Migrating existing email-template usage. There is no migration until the standup ADR is accepted and the canonical template set ships.
+
+## Proposed Implementation
+1. Create the directory `generated/deferred-work/` if it does not exist. (If the directory already exists from a prior deferral document, reuse it.)
+2. Author `generated/deferred-work/adr-0073-notify-templates-npm-standup.md` with the following sections:
+
+   ```markdown
+   # Deferred — @honeydrunk/notify-templates polyglot npm-package standup
+
+   **Source ADR:** [ADR-0073](../../adrs/ADR-0073-notify-default-providers.md) D4 + §Follow-up Work
+   **Recorded:** 2026-05-25
+   **Status:** Deferred — standup ADR not yet drafted
+   **Target ADR (provisional):** ADR-0073a (number to be assigned at draft time)
+   **Target packaging:** `HoneyDrunk.Notify.Templates` (.NET side, if any) + `@honeydrunk/notify-templates` (npm)
+   **Home repo:** `HoneyDrunk.Notify` (polyglot — react-email source lives alongside the .NET solution)
+
+   ## Why deferred
+
+   ADR-0073 D4 commits react-email as the Grid's canonical email-templating library and names `HoneyDrunk.Notify.Templates` as the home for the canonical template set. react-email is a TypeScript/JSX library in the npm ecosystem; HoneyDrunk.Notify is a .NET repo. The package is therefore polyglot — npm source inside a .NET repo. The packaging shape, build pipeline, publish destination, and consumer-PDR template-extension model are non-trivial decisions warranting a standup ADR rather than being bundled into ADR-0073's already-broad scope.
+
+   Per the user's standing convention, new-Node and new-package scaffolding gets its own standup ADR — parallel to how ADR-0059 stood up `HoneyDrunk.Cache` paired with ADR-0058's contract decision.
+
+   ## Open questions the standup ADR must answer
+
+   1. **Packaging shape.** Pure npm package (TypeScript/JSX source + rendered HTML output); or polyglot npm + sibling .NET package (.NET-side HTML strings wrapping the rendered output for .NET consumers that don't want to invoke Node at runtime)? If polyglot, how do the two packages version together — independently, or solution-aligned per invariant 27?
+   2. **Build pipeline.** Node-side build runs in CI alongside .NET build. How does the .NET CI gate against the Node-side build? Does the canonical template set's rendered HTML get committed to the repo, or generated fresh in CI? Reproducibility implications either way.
+   3. **Publish destination.** npmjs.org under `@honeydrunk` scope (parallel to ADR-0034's NuGet-feed conventions extended to npm); or GitHub Packages npm; or both? ADR-0034 should be consulted/amended for an npm policy if one does not exist.
+   4. **Consumer-PDR extension model.** A consumer-PDR (Hearth, Notify Cloud, Identity) writes a product-specific email template. The template should compose the canonical `<EmailButton>` and `<EmailLayout>` from the canonical set, and may contribute new shared components. How does extension work? Workspaces? `peerDependencies`? Plain npm imports with shared design tokens via the Web.UI package per ADR-0071?
+   5. **Web.UI token interop** (ADR-0071). Web.UI is a separate Node (currently being stood up per ADR-0071). The react-email package must consume Web.UI's design tokens. How is the token contract shared — a third sibling package, runtime fetch, build-time copy?
+   6. **InMemory rendering for tests** (invariant 15). Unit tests must not invoke Node to render. Does the canonical set ship pre-rendered fixtures for test consumption, or does the test fixture mock the renderer?
+   7. **Preview tooling.** react-email ships a local preview server. Where does it live in the Notify repo's tooling — a `npm run preview` script at the package root? A CLI in `HoneyDrunk.Notify.Tools`?
+   8. **Versioning and SemVer.** A breaking change to the canonical `<EmailLayout>` is a breaking change for every consumer-PDR template extending it. The same per-package SemVer + cascade rules ADR-0035 applies to .NET Abstractions packages should apply here — but with npm-side mechanics (peerDeps + version-range pinning).
+   9. **Sender-identity integration.** ADR-0038 commits per-product From-address governance. The canonical template set should make From-address misuse hard — every template renders inside an `<EmailLayout>` that pins the product's From-address (consumed from the consumer-PDR's config). The standup ADR pins this contract.
+
+   ## Until the standup ADR lands
+
+   - **No `HoneyDrunk.Notify.Templates` directory is created** in `HoneyDrunk.Notify`. The standup ADR decides the directory shape.
+   - **No new npm package is published.** `@honeydrunk/notify-templates` is reserved on npmjs.org by the operator if reservation is desired; that is a human-only chore, not gated here.
+   - **Email sends route through Notify's existing template-renderer abstractions** (`ITemplateRenderer`, `IEmailTemplateRenderer`). The pre-react-email flow continues to operate.
+   - **No new email templates should be authored in raw HTML.** ADR-0073 D4 negative form forbids "HTML-string-concatenation." Consumers needing a new template either wait for the canonical react-email set to ship, or temporarily extend the existing renderer with the understanding that migration is forced on standup-ADR acceptance.
+
+   ## Trigger to draft the standup ADR
+
+   Draft the standup ADR when **one** of the following fires:
+
+   - **The first consumer-PDR needs to ship a new email template.** Identity's verification-email flow (ADR-0060 Phase 2) is a plausible first trigger — once that work item is queued, the standup ADR is a hard prerequisite.
+   - **Notify Cloud GA wants the canonical tenant-onboarding email** in its onboarding flow. ADR-0027's GA work item is a plausible trigger.
+   - **Operator-discretion.** The standup is independent enough to draft at any time the operator has the context window.
+
+   When drafting, use the `adr-composer` agent. Reference this deferral document as the input.
+
+   ## Related work
+
+   - [ADR-0073 D4](../../adrs/ADR-0073-notify-default-providers.md) — react-email and `HoneyDrunk.Notify.Templates` commitment.
+   - [ADR-0034](../../adrs/ADR-0034-public-package-distribution-and-nuget-policy.md) — public-package distribution policy (NuGet-only at v1; an npm extension is a likely addition for this standup).
+   - [ADR-0035](../../adrs/ADR-0035-abstractions-versioning-and-deprecation-policy.md) — SemVer + deprecation policy (npm-side adaptation needed).
+   - [ADR-0038](../../adrs/ADR-0038-outbound-sender-identity-and-deliverability.md) — sender-identity discipline that the canonical `<EmailLayout>` enforces.
+   - [ADR-0071](../../adrs/ADR-0071-stand-up-honeydrunk-web-ui-node.md) — Web.UI tokens consumed by the canonical template set.
+   - [ADR-0070](../../adrs/ADR-0070-frontend-platform-stack.md) D1 — React posture (the same idiom react-email uses).
+   ```
+
+3. Save.
+
+## Affected Files
+- `generated/deferred-work/adr-0073-notify-templates-npm-standup.md` (new file)
+
+## NuGet Dependencies
+None. This packet touches only Markdown deferral-tracking files.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any repo.
+- [x] No new abstraction. The deferred package's contract surface is left open for the standup ADR to define.
+
+## Acceptance Criteria
+- [ ] `generated/deferred-work/adr-0073-notify-templates-npm-standup.md` exists with the sections listed in Proposed Implementation
+- [ ] The document explicitly lists at least the 9 open questions stated above
+- [ ] The document explicitly states the until-standup-ADR-lands operational posture (no `HoneyDrunk.Notify.Templates` directory created; no new raw-HTML email templates)
+- [ ] The document explicitly names the triggers that fire the standup ADR draft (Identity verification email, Notify Cloud GA tenant-onboarding, or operator discretion)
+- [ ] The document links to ADR-0073, ADR-0034, ADR-0035, ADR-0038, ADR-0071, ADR-0070 via the standard relative-path convention
+- [ ] **No code work happens.** No directory created in `HoneyDrunk.Notify`. No `.csproj` modified. No npm package created.
+- [ ] **No edit to `adrs/ADR-0073-notify-default-providers.md`** — packet 00 already added the §Follow-up Work entry referencing this deferral. This packet writes the deferral document only.
+
+## Human Prerequisites
+- [ ] (Optional, not gating) **Reserve the `@honeydrunk` npm scope on npmjs.org** if not already reserved. Reserving the scope is a low-cost defensive move that prevents name squatting; reservation itself is a human-only chore on npmjs.org. The standup ADR will commit to a publish destination when drafted.
+
+## Referenced ADR Decisions
+**ADR-0073 D4.** "react-email is the canonical email-templating library for the Grid. Email templates author in JSX, render to HTML at send time, and ship via Resend. Templates live in `HoneyDrunk.Notify.Templates` — a per-Notify package that holds the canonical template set."
+
+**ADR-0073 §Follow-up Work.** "Ship `HoneyDrunk.Notify.Templates` package with the canonical react-email template set." (Deferred to standup ADR per the entry packet 00 appended.)
+
+**Memory: New-Node scaffolding needs its own ADR.** Per the user's standing convention, empty cataloged repos and new package standups get a standup ADR first; don't bundle scaffold into feature packets. The same convention applies to polyglot packages of non-trivial complexity.
+
+## Constraints
+- **No code work in this packet.** This is a tracking-only deferral; the standup ADR is the work item that produces code.
+- **No premature directory creation.** Do not create `HoneyDrunk.Notify/HoneyDrunk.Notify.Templates/` or any sibling — the standup ADR decides the directory shape.
+- **No publish-destination commitment in this packet.** npmjs.org vs GitHub Packages npm is an open question for the standup ADR.
+- **No edit to ADR-0073's text.** Packet 00 already added the §Follow-up Work entry pointing at this deferral. This packet only writes the deferral document.
+
+## Labels
+`chore`, `tier-3`, `ops`, `docs`, `adr-0073`, `wave-3`, `deferred`
+
+## Agent Handoff
+
+**Objective:** Record the `@honeydrunk/notify-templates` polyglot npm-package standup deferral as a tracked work item on The Hive. No code ships.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make the deferral visible on The Hive so the open question isn't lost in the dispatch plan.
+- Feature: ADR-0073 Notify Default Providers rollout, Wave 3.
+- ADRs: ADR-0073 D4 (primary — commits react-email; pins the template-set home; this packet records the standup deferral).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0073 is Accepted before this packet runs (because packet 00 added the §Follow-up Work entry that this document is the long-form referent of).
+
+**Constraints:**
+- Docs-only, no code, no directory creation.
+- The deferral document must enumerate the 9 open questions and the operational-posture-until-standup-ADR-lands rules so a future standup-ADR drafter has a complete starting point.
+- Do not draft the standup ADR in this packet. The deferral document is a placeholder, not a draft.
+
+**Key Files:**
+- `generated/deferred-work/adr-0073-notify-templates-npm-standup.md` (new file)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0073-notify-providers/04-notify-twilio-production-hardening.md
+++ b/generated/issue-packets/active/adr-0073-notify-providers/04-notify-twilio-production-hardening.md
@@ -1,0 +1,172 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["feature", "tier-2", "ops", "adr-0073", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0073", "ADR-0062", "ADR-0006", "ADR-0005"]
+wave: 2
+initiative: adr-0073-notify-providers
+node: honeydrunk-notify
+---
+
+# Production-harden the Twilio SMS provider for ADR-0073 D2 (tentative-commitment note)
+
+## Summary
+Complete the production-hardening obligations ADR-0073 D2 puts on the canonical Twilio SMS provider: webhook intake for delivery events per ADR-0062 (delivered / failed / queued), Tier-2 secret rotation registration per ADR-0006, **tentative-commitment note** recorded in the package README and in `repos/HoneyDrunk.Notify/overview.md` (per ADR-0073 D2's re-evaluation triggers), and confirmation that the existing `HoneyDrunk.Notify.Providers.Sms.Twilio` package (v0.3.0) is the canonical `ISmsSender` slot fill. **Appends to the in-progress `[0.3.1]` CHANGELOG entry created by packet 01** — no version bump.
+
+## Context
+The `HoneyDrunk.Notify.Providers.Sms.Twilio` package already exists in the Notify repo at version 0.3.0 (per `HoneyDrunk.Notify/HoneyDrunk.Notify.Providers.Sms.Twilio/HoneyDrunk.Notify.Providers.Sms.Twilio.csproj`). It already:
+
+- Implements `INotificationSender` against Twilio for `NotificationChannel.Sms` (per `TwilioNotificationSender.cs` and `DependencyInjection/`).
+- Resolves account credentials from `ISecretStore` at send time (the v0.2.0 CHANGELOG note describes the Vault-backed pattern).
+- Is named `Providers.Sms.Twilio` (channel-scoped — the convention this initiative is preserving).
+
+What is **not yet in place** per ADR-0073 D2 + the referenced ADRs:
+
+1. **Webhook intake for delivery events** per ADR-0062. Twilio posts webhook callbacks for `delivered`, `failed`, `queued`, `sent` events on configured `StatusCallback` URLs. ADR-0062's verification model (Twilio uses HTTP signature verification via `X-Twilio-Signature` header + the configured auth token) must be applied at the intake.
+2. **Tier-2 secret rotation registration** per ADR-0006. The Twilio Account SID + Auth Token sit in `kv-hd-notify-{env}` and rotate per Tier-2 cadence (≤90 days). The rotation calendar registration in `HoneyDrunk.Vault.Rotation` must list Twilio.
+3. **Tentative-commitment note** per ADR-0073 D2. The ADR explicitly marks the Twilio commitment as tentative and names the re-evaluation triggers (monthly SMS spend > $200; tenant-driven requirement; Twilio stewardship event). This note belongs in the package README so the next operator looking at the Twilio package sees the tentative posture and the trigger conditions; it also belongs in `repos/HoneyDrunk.Notify/overview.md` so the Notify Node's overview reflects the policy.
+
+This is **not a new package** — it is hardening of an existing package. **No version bump in this packet** — it appends to the `[0.3.1]` entry packet 01 creates.
+
+## Scope
+- **`HoneyDrunk.Notify` (intake / runtime)** — new webhook intake endpoint for Twilio delivery events, applying ADR-0062's verification model (Twilio's `X-Twilio-Signature` HMAC scheme). Wired into Notify's existing intake pipeline.
+- **`HoneyDrunk.Notify.Providers.Sms.Twilio`** — provider package gets:
+  - `README.md` updated with: the ADR-0073 D2 default-provider declaration; the **tentative-commitment note** (re-evaluation triggers verbatim); the ADR-0062 webhook intake cross-reference; the ADR-0006 Tier-2 rotation cross-reference.
+  - `CHANGELOG.md` updated with a `[0.3.1]` entry — the existing `[Unreleased]` line (if any) is rolled into the `[0.3.1]` section together with the hardening changes.
+- **`HoneyDrunk.Notify.Hosting.AspNetCore`** (or the existing intake-route location) — register the Twilio webhook route.
+- **`HoneyDrunk.Notify.Tests`** — unit tests for the Twilio webhook intake (signature verification; rejected-payload semantics; event-routing).
+- **`HoneyDrunk.Notify.IntegrationTests`** — integration test for the webhook end-to-end.
+- **`repos/HoneyDrunk.Notify/overview.md`** (in `HoneyDrunk.Architecture` — see note below) — tentative-commitment note added to the Notify overview so the Node-level architectural context reflects the policy.
+
+> **Cross-repo note.** This packet's scope is primarily `HoneyDrunk.Notify`, but the `repos/HoneyDrunk.Notify/overview.md` update lives in `HoneyDrunk.Architecture`. **Per the issue-authoring rule "one packet = one target repo," the Architecture-side overview update is rolled into this packet's PR only if the execution agent is filing PRs against both repos in one ticket — otherwise, file a tiny follow-up packet against Architecture.** The recommended approach: the agent files the Notify-side PR (code + README), and either (a) opens a separate Architecture PR with the overview edit as a parallel `[1]` step, or (b) defers the overview edit to a quick follow-up packet that the operator files manually. The acceptance criteria below cover both paths and pass either way.
+
+## Out of Scope
+- The actual SMS-marketing / TCPA compliance work — ADR-0073 D2 explicitly names this as a per-PDR consumer-app concern; Notify does not enforce it at the provider layer.
+- Per-region number management — D1 of ADR-0073's D2 names this as Notify-internal but the v1 posture is single-region (US, with the Studios toll-free number per ADR-0038). Multi-region is deferred to a tenant-driven trigger.
+- The D2 cost-trigger re-evaluation itself — that fires when the trigger condition is met (e.g. monthly spend > $200). Not gated here.
+
+## Proposed Implementation
+1. **Webhook intake — author the Twilio webhook endpoint.**
+   - Add an HTTP POST endpoint (e.g. at `/internal/webhooks/twilio` — confirm path convention against the Resend endpoint added in packet 01 and the existing intake routes).
+   - Apply ADR-0062's verification using Twilio's HMAC scheme: read the `X-Twilio-Signature` header, recompute the signature using the Twilio auth token resolved via `ISecretStore` (secret name `Twilio--AuthToken` — confirm against the existing Twilio-secret-name convention in `HoneyDrunk.Notify.Providers.Sms.Twilio`), reject on mismatch with `401 Unauthorized` per ADR-0062.
+   - On verified payloads, parse the event (Twilio's status-callback payload schema — `MessageSid`, `MessageStatus`, `ErrorCode`, etc.) and route into Notify's existing intake pipeline as a `DeliveryStatusEvent` (or the existing event shape used by packet 01's Resend handler — reuse for consistency).
+   - Map Twilio statuses to internal event shapes: `delivered` → delivered; `failed` → failed (with `ErrorCode` as classification); `undelivered` → failed; `sent` → in-flight; `queued` → queued.
+2. **Tier-2 rotation calendar registration.**
+   - Confirm whether `HoneyDrunk.Vault.Rotation`'s rotation calendar already lists `Twilio--AuthToken` and `Twilio--AccountSid` (likely from the `vault-rotation-bring-up` initiative). If absent, register them. Twilio Auth Tokens rotate per Tier-2 cadence (≤90 days). Twilio Account SIDs are typically not rotated (they identify the account); confirm against Twilio's current account-credential model whether SID rotation is even supported. If not, document the exception in the rotation calendar configuration with an inline rationale (per invariant 20 — exceptions must be logged).
+3. **README cross-references** in `HoneyDrunk.Notify.Providers.Sms.Twilio/README.md`:
+   - Add a section "ADR-0073 D2 default provider declaration (tentative)" stating: "Twilio is the canonical default SMS provider for HoneyDrunk.Notify's `ISmsSender` slot per ADR-0073 D2. **The commitment is tentative** — the ADR explicitly names re-evaluation triggers (see below). Per-tenant overrides are permitted per D5."
+   - Add a section "Re-evaluation triggers (ADR-0073 D2)" stating verbatim:
+     - "First month with SMS spend > $200. At that point, run a cost comparison against MessageBird and Plivo for the same workload mix. Switch if the savings justify the migration cost (a one-PR adapter swap behind `ISmsSender`)."
+     - "A specific tenant-driven requirement (regulatory, country-specific) that another provider serves better."
+     - "A Twilio stewardship event (pricing change, hostile policy, API instability) that breaks trust."
+     - "Until a trigger fires, Twilio is the default."
+   - Add a section "Webhook intake (ADR-0062)" stating: "Twilio status-callback webhooks (`delivered`, `failed`, `queued`, `sent`) are received and verified per ADR-0062's HMAC-signed inbound discipline using Twilio's `X-Twilio-Signature` scheme and the auth token resolved from `Twilio--AuthToken` in `kv-hd-notify-{env}`."
+   - Add a section "Rotation (ADR-0006 Tier 2)" stating: "The Twilio Auth Token (`Twilio--AuthToken`) rotates at Tier 2 cadence (≤90 days) via `HoneyDrunk.Vault.Rotation`. The Twilio Account SID (`Twilio--AccountSid`) is the account identifier and is not rotated; if Twilio's account-credential model changes to support SID rotation, this exception is removed."
+   - Add a section "SMS-marketing / TCPA discipline" stating: "TCPA and SMS-marketing compliance is a per-PDR consumer-app concern per ADR-0073 D2. Notify does not enforce it at the provider layer. Consumer-PDRs that send SMS at scale (Notify Cloud, Hearth, Currents) are individually responsible for opt-in records, STOP/HELP handling, time-of-day restrictions, and 10DLC registration."
+4. **Per-package CHANGELOG (`HoneyDrunk.Notify.Providers.Sms.Twilio/CHANGELOG.md`)** — add a `[0.3.1] - {merge-date}` section. Roll any existing `[Unreleased]` line into this section. Add the hardening entries: webhook intake; Tier-2 rotation registration; ADR-0073 D2 default-provider declaration with tentative-commitment note.
+5. **Repo-level `CHANGELOG.md`** — **append** to the `[0.3.1]` entry created by packet 01; do **not** create a new dated section. Add one line for the Twilio production-hardening summary.
+6. **`repos/HoneyDrunk.Notify/overview.md`** (Architecture-side) — see the cross-repo note in Scope. Add the tentative-commitment text under a new `## SMS Provider (ADR-0073 D2 — Tentative)` section: "Twilio is the canonical default SMS provider per ADR-0073 D2. **The commitment is tentative** pending re-evaluation triggers (first month with SMS spend > $200; tenant-driven requirement; Twilio stewardship event). When a trigger fires, the provider swap is bounded — a one-PR adapter swap behind `ISmsSender`."
+7. **Version handling.** Confirm packet 01 has already bumped the solution to `0.3.1`. If yes — this packet leaves the `.csproj` files alone (no version change), and only appends to the repo-level `[0.3.1]` CHANGELOG entry plus adds the Twilio per-package CHANGELOG entry. If no (packet 01 has not yet merged) — this packet does the bump (rolling existing `[Unreleased]` into `[0.3.1]` as packet 01 would have). State the chosen path in the PR.
+
+## Affected Files
+- `HoneyDrunk.Notify/Intake/` (or equivalent) — new file for the Twilio webhook route handler.
+- `HoneyDrunk.Notify.Hosting.AspNetCore/` — register the route if needed.
+- `HoneyDrunk.Notify.Providers.Sms.Twilio/README.md`, `CHANGELOG.md`.
+- Repo-level `CHANGELOG.md` — append to existing `[0.3.1]`.
+- `HoneyDrunk.Notify.Tests/` — new tests.
+- `HoneyDrunk.Notify.IntegrationTests/` — new integration test.
+- `repos/HoneyDrunk.Notify/overview.md` (in `HoneyDrunk.Architecture`) — tentative-commitment section. See Scope's cross-repo note.
+
+## NuGet Dependencies
+- **`HoneyDrunk.Notify`** — no new third-party `PackageReference`. Twilio's signature scheme is verifiable with BCL `System.Security.Cryptography` (or via the existing Twilio SDK already in `Providers.Sms.Twilio` — confirm at execution which path the existing send code uses).
+- **`HoneyDrunk.Notify.Providers.Sms.Twilio`** — no new `PackageReference`. The existing Twilio SDK reference is unchanged.
+- **Test projects** — existing test-stack references.
+
+## Boundary Check
+- [x] All code work in `HoneyDrunk.Notify` per the routing rule.
+- [x] Webhook intake is delivery mechanics per Notify's boundaries.md.
+- [x] No new cross-Node runtime dependency.
+- [x] TCPA / SMS-marketing discipline is correctly placed outside Notify per ADR-0073 D2 (per-PDR concern).
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Notify` exposes an HTTP POST webhook route for Twilio status-callback events
+- [ ] The route applies ADR-0062 HMAC signature verification using Twilio's `X-Twilio-Signature` scheme and `ISecretStore`-resolved `Twilio--AuthToken`
+- [ ] Verified payloads route into Notify's existing intake event pipeline; invalid signatures return 401 without side-effects
+- [ ] Twilio statuses map to Notify's internal event shapes: `delivered`, `failed` (with Twilio `ErrorCode` classification), `sent` (in-flight), `queued`
+- [ ] `Twilio--AuthToken` is listed in `HoneyDrunk.Vault.Rotation`'s Tier-2 rotation calendar; `Twilio--AccountSid` is either listed or its non-rotation exception is documented per invariant 20
+- [ ] `HoneyDrunk.Notify.Providers.Sms.Twilio/README.md` includes the five sections (D2 declaration with tentative note, re-evaluation triggers verbatim, webhook intake, rotation, TCPA/SMS-marketing discipline)
+- [ ] `HoneyDrunk.Notify.Providers.Sms.Twilio/CHANGELOG.md` has a `[0.3.1]` entry with the hardening changes
+- [ ] Repo-level `CHANGELOG.md`'s `[0.3.1]` entry includes a Twilio production-hardening summary line **appended** (not a new dated section)
+- [ ] `repos/HoneyDrunk.Notify/overview.md` has a `## SMS Provider (ADR-0073 D2 — Tentative)` section (or — if the cross-repo split path is chosen — a parallel Architecture-side packet is filed for the overview edit)
+- [ ] No new version bump in this packet — `.csproj` files remain at `0.3.1` from packet 01. If packet 01 has not landed at execution time, this packet bumps in its stead (state the chosen path in the PR)
+- [ ] Unit + integration tests verify signature-valid / signature-invalid / event-routing paths; no `Thread.Sleep`
+- [ ] The `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **Twilio status-callback URL configured** in the Twilio console for each environment's Messaging Service, pointing at the appropriate `/internal/webhooks/twilio` URL.
+- [ ] **`Twilio--AuthToken` and `Twilio--AccountSid` already seeded** in `kv-hd-notify-{env}` from prior Notify operational work; confirm presence before deploying the webhook route.
+- [ ] **Tier-2 rotation calendar updated** if the calendar configuration lives in `HoneyDrunk.Vault.Rotation` rather than this repo — file a parallel Vault.Rotation packet if necessary.
+- [ ] **No NuGet tag is pushed by this packet alone.** This packet appends to the in-progress `0.3.1` release. The tag push happens once all `0.3.1` packets (this one plus packet 01) have landed on `main` — a human pushes the tag at that point.
+
+## Referenced ADR Decisions
+**ADR-0073 D2 — Twilio is the default SMS provider (tentative).** "Twilio is the canonical SMS provider for HoneyDrunk.Notify's `ISmsSender` slot. The commitment is marked **tentative** and is re-evaluated at the first cost-pressure inflection. `HoneyDrunk.Notify.Providers.Twilio` — the `ISmsSender` implementation. Account credentials in Vault per ADR-0005 — same namespace as Resend. Per-region number management is a Notify-internal concern; tenants do not bring their own numbers at MVP. Webhook-driven delivery events (delivered, failed, queued) deliver into Notify's intake per ADR-0062. TCPA / SMS-marketing discipline is a per-PDR consumer-app concern; Notify does not enforce it at the provider layer."
+
+**ADR-0073 D2 — Re-evaluation triggers.**
+- "First month with SMS spend > $200. At that point, run a cost comparison against MessageBird and Plivo for the same workload mix. Switch if the savings justify the migration cost (a one-PR adapter swap behind `ISmsSender`)."
+- "A specific tenant-driven requirement (regulatory, country-specific) that another provider serves better."
+- "A Twilio stewardship event (pricing change, hostile policy, API instability) that breaks trust."
+- "Until a trigger fires, Twilio is the default."
+
+**ADR-0073 §Operational Consequences.** "Twilio cost is workload-dependent. No SMS volume today; the cost grows linearly with send volume. The D2 re-evaluation trigger at $200/mo catches the inflection."
+
+**ADR-0006 §Tier 2.** Third-party provider credentials rotate via `HoneyDrunk.Vault.Rotation` Function App on ≤90-day cadence; new versions land in `kv-hd-notify-{env}`; Event Grid cache invalidation propagates per ADR-0005. Per invariant 21, applications never pin to a specific secret version.
+
+## Constraints
+- **Invariant 12 — Per-package CHANGELOGs are updated only for packages with functional changes.** Only `HoneyDrunk.Notify.Providers.Sms.Twilio` (and the core `HoneyDrunk.Notify` if the webhook route lives there) gets a per-package CHANGELOG entry. Every other package has `.csproj` already aligned by packet 01 and gets no entry.
+- **Invariant 15 — Unit tests and in-process integration tests never depend on external services.** Webhook intake tests use in-process fakes for `ISecretStore` and any HTTP dispatch. No live Twilio calls.
+- **Invariant 20 — Tier 2 ≤ 90 days rotation SLA.** Twilio Auth Token rotates within 90 days. Twilio Account SID's non-rotation is documented as an exception.
+- **Invariant 21 — Applications must never pin to a specific secret version.** The Twilio provider reads the latest version of `Twilio--AuthToken` on every send / verify call.
+- **Invariant 27 — All projects in a solution share one version and move together.** Already at `0.3.1` from packet 01; no further bump in this packet.
+- **Invariant 51 — Test code contains no `Thread.Sleep`.**
+- **D5 — Default is not exclusive.** Per-tenant override seam preserved. Do not change the resolver to hard-favor Twilio.
+- **Tentative-commitment note is verbatim.** The re-evaluation-trigger block in the Twilio README quotes ADR-0073 D2 verbatim so the operator sees the same text the ADR commits — not a paraphrase.
+- **Test project naming.** Same as packet 01 — keep `HoneyDrunk.Notify.Tests` and `HoneyDrunk.Notify.IntegrationTests`; the `.Tests.Unit` rename is a separate ADR-0047 follow-up.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0073`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Production-harden the Twilio SMS provider per ADR-0073 D2: webhook intake (ADR-0062), Tier-2 rotation registration (ADR-0006), tentative-commitment note in package README and Notify overview. Appends to packet 01's `[0.3.1]` CHANGELOG entry; no further version bump.
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: Confirm Twilio as the canonical default `ISmsSender` (tentative) and complete the production-hardening obligations.
+- Feature: ADR-0073 Notify Default Providers rollout, Wave 2.
+- ADRs: ADR-0073 D2 (primary); ADR-0062 (webhook verification); ADR-0006 (Tier-2 rotation); ADR-0005 (Vault config).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0073 is Accepted.
+- `packet:01` — Resend hardening lands the `[0.3.1]` repo-level CHANGELOG entry that this packet appends to.
+
+**Constraints:**
+- No version bump — packet 01 already bumped to `0.3.1`. State the chosen path explicitly if packet 01 has not yet landed at execution time.
+- Append (do not create new section) in repo-level CHANGELOG.
+- Tentative-commitment text in the Twilio README quotes ADR-0073 D2 verbatim.
+- TCPA / SMS-marketing discipline stays outside Notify per ADR-0073 D2 (per-PDR concern).
+- Webhook intake uses Twilio's `X-Twilio-Signature` scheme; fail-closed on missing or invalid signature.
+
+**Key Files:**
+- `HoneyDrunk.Notify/Intake/` — new webhook route.
+- `HoneyDrunk.Notify.Providers.Sms.Twilio/README.md` and `CHANGELOG.md`.
+- Repo-level `CHANGELOG.md` (append).
+- `repos/HoneyDrunk.Notify/overview.md` (cross-repo — see Scope note).
+- Test projects.
+
+**Contracts:** None changed.

--- a/generated/issue-packets/active/adr-0073-notify-providers/05-architecture-notify-cloud-override-policy.md
+++ b/generated/issue-packets/active/adr-0073-notify-providers/05-architecture-notify-cloud-override-policy.md
@@ -1,0 +1,219 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "ops", "docs", "adr-0073", "wave-3"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0073", "ADR-0027"]
+wave: 3
+initiative: adr-0073-notify-providers
+node: honeydrunk-architecture
+---
+
+# Author the Notify Cloud per-tenant provider-override policy specification
+
+## Summary
+Author the canonical per-tenant provider-override policy specification at `business/context/notify-cloud-tenant-override-policy.md`. ADR-0073 D5 commits the seam ("per-tenant override is permitted; per-PDR override is permitted but discouraged"); the mechanics — credential-entry UI, validation flow, fallback semantics — are Notify Cloud-internal per ADR-0073 D6 ("tenant-BYO provider tooling"). This packet writes the specification document that the future Notify Cloud follow-up packet (filed against `HoneyDrunk.Notify.Cloud` after `adr-0027-notify-cloud-standup` packet 06 lands) implements. **No code ships in this packet.**
+
+## Context
+ADR-0073 D5 — Provider abstraction is held; defaults are not exclusive bindings:
+
+> Per-tenant override is permitted. A Notify Cloud tenant with their own SES account, their own Postmark relationship, their own Twilio sub-account can plug into the `IEmailSender` / `ISmsSender` provider slot with a tenant-scoped implementation. The default (Resend / Twilio / Expo) is what Notify uses for tenants who do not override.
+
+ADR-0073 D6 — Out of scope:
+
+> Tenant-BYO provider tooling. The mechanism by which a Notify Cloud tenant brings their own provider (UI for credential entry, validation flow, fallback semantics) is a Notify Cloud-internal concern.
+
+The decision is recorded; the mechanics are not. Without a specification document, the Notify Cloud follow-up packet has no design to consume. This packet authors that specification in the Architecture repo so the follow-up filer (in the future `adr-0027-notify-cloud-standup` initiative or a sibling initiative) has the canonical input.
+
+**Notify Cloud's repo does not yet exist on disk.** ADR-0027 is Proposed; the `HoneyDrunk.Notify.Cloud` repo creation is gated on ADR-0027's standup packets. Per the user's standing convention ("file-packets can't file against repos that don't exist"), the production implementation packet for the tenant-override flow lives in the Notify Cloud standup initiative — not here. This packet's job is to be the design input that initiative consumes.
+
+This packet's location pin is **deliberate**: `business/context/notify-cloud-tenant-override-policy.md` — `business/` is the directory that holds product/business-policy documents that consuming initiatives (Notify Cloud, identity, billing) reference at draft time. Confirm the directory exists or create it; the parallel sibling `business/context/notify-cloud-rate-limit-policy.md` from the `adr-0067-rate-limiting` initiative establishes the convention (or, if that initiative chose `infrastructure/walkthroughs/` as its location, mirror that choice — confirm at execution).
+
+## Scope
+- New file: `business/context/notify-cloud-tenant-override-policy.md` (or the directory matching the `adr-0067-rate-limiting` initiative's choice — confirm at execution).
+
+## Out of Scope
+- The Notify Cloud implementation packet — filed against `HoneyDrunk.Notify.Cloud` after the standup packets land.
+- The Notify-side provider abstraction work — the abstraction already exists in `HoneyDrunk.Notify.Abstractions` (`INotificationSender` keyed by `NotificationChannel`). This packet does not propose changes to the abstraction.
+- Stripe / billing integration for BYO-provider tenants (the tenant pays nothing extra for using their own provider; this is not a billing concern).
+- The actual provider-credential storage in `kv-hd-notify-cloud-{env}` or a tenant-scoped vault namespace — see ADR-0026 for the tenant-scoped secret pattern. This packet documents the choice but the implementation is the follow-up's job.
+
+## Proposed Implementation
+1. Confirm whether the sibling override-policy doc from `adr-0067-rate-limiting` landed at `business/context/` or `infrastructure/walkthroughs/`. Mirror the choice.
+2. Create the file at the confirmed location with the following sections:
+
+   ```markdown
+   # Notify Cloud Per-Tenant Provider Override Policy
+
+   **Source ADR:** [ADR-0073](../../adrs/ADR-0073-notify-default-providers.md) D5 + D6
+   **Target Node:** `HoneyDrunk.Notify.Cloud` (Proposed via [ADR-0027](../../adrs/ADR-0027-stand-up-honeydrunk-notify-cloud-node.md))
+   **Status:** Specification — implementation packet filed under Notify Cloud standup after `adr-0027-notify-cloud-standup` packet 06 lands.
+   **Authored:** 2026-05-25
+
+   ## Why this exists
+
+   ADR-0073 D5 commits the seam: a Notify Cloud tenant may bring their own email / SMS / push provider credentials and route their tenant's sends through their own SES, Postmark, Twilio sub-account, Expo project, etc. The default (Resend / Twilio / Expo) is what Notify uses for tenants who do not override.
+
+   ADR-0073 D6 explicitly names tenant-BYO tooling as Notify Cloud-internal. This document specifies what Notify Cloud builds.
+
+   ## Tenant override scope
+
+   A tenant override consists of three independent decisions, one per channel:
+
+   - **Email provider override.** Tenant supplies credentials for an alternate `IEmailSender`-compatible provider (SES, Postmark, Mailgun, SendGrid, their own Resend account, etc.). When set, all tenant emails route through the override; the platform Resend account is bypassed.
+   - **SMS provider override.** Tenant supplies credentials for an alternate `ISmsSender`-compatible provider (their own Twilio sub-account, MessageBird, Plivo, etc.). When set, all tenant SMS routes through the override; the platform Twilio account is bypassed.
+   - **Push provider override.** Tenant supplies credentials for an alternate `IPushSender`-compatible provider (their own Expo project, OneSignal, direct APNs+FCM). Override is per-platform if needed (iOS-only override is acceptable; the unprovided channel falls back to platform).
+
+   Each channel is independent — a tenant can override Email only, leave SMS on platform Twilio, and have no push needs at all.
+
+   ## Credential storage
+
+   Tenant-scoped credentials follow the [ADR-0026 D5 tenant-scoped secret pattern](../../adrs/ADR-0026-grid-multi-tenant-primitives.md) (invariant 9a): the secret name format is `tenant-{tenantId}-{secretName}` resolved via `TenantScopedSecretResolver`. Examples for a tenant whose `TenantId` ULID resolves to `01J0...`:
+
+   - `tenant-01J0-Resend--ApiKey` (if the tenant overrode to a different Resend account)
+   - `tenant-01J0-Postmark--ServerToken` (if the tenant overrode to Postmark)
+   - `tenant-01J0-Twilio--AuthToken` (if the tenant overrode their Twilio sub-account)
+   - `tenant-01J0-Expo--AccessToken` (if the tenant overrode their Expo project)
+
+   The credential **values** live in the same `kv-hd-notify-cloud-{env}` namespace as the platform credentials. Tenant credentials are never co-located with another tenant's; the secret name's tenant prefix is the isolation seam. Invariant 9a applies — `TenantId.Internal` continues to resolve the un-prefixed platform names.
+
+   ## Per-tenant override resolution
+
+   When dispatching a tenant send, Notify Cloud's runtime composes the provider resolution as follows:
+
+   1. **Identify the tenant** from the inbound send context (typically via `IGridContext.TenantId`).
+   2. **Look up the tenant's override configuration** (a small per-tenant record stored in Notify Cloud's tenant table). The record names which channels are overridden and which alternate provider the override binds.
+   3. **For overridden channels**: resolve credentials via `TenantScopedSecretResolver` using the tenant-prefixed secret name; instantiate the alternate provider's `INotificationSender` implementation; dispatch through it.
+   4. **For non-overridden channels**: dispatch through the platform default (Resend / Twilio / Expo).
+   5. **For overridden channels whose credentials are missing or invalid**: see "Fallback semantics" below.
+
+   The composition happens at dispatch time, not at host registration. The platform default registrations remain in DI (Resend at `NotificationChannel.Email`, Twilio at `NotificationChannel.Sms`, Expo at `NotificationChannel.Push`); the override dispatch replaces the resolved sender per-call when a tenant override applies. The `NotificationSenderResolver` already exists; the override resolution is a pre-dispatch wrapper around it.
+
+   ## Validation flow (BYO-provider onboarding)
+
+   When a Notify Cloud tenant enters override credentials in the Notify Cloud admin UI:
+
+   1. **Schema-validate the credentials** for the named provider (e.g. Resend API keys start with `re_`; Postmark server tokens are UUIDs; Twilio Account SIDs start with `AC`).
+   2. **Live-test the credentials** with a low-risk provider-side call (Resend: GET `/domains`; Postmark: GET `/server`; Twilio: GET account resource; Expo: GET `/push/getReceipts` with empty body) that round-trips a 200 / 401 / 403 with the credentials.
+   3. **Store the credentials in Vault** under the tenant-prefixed name. Audit the credential set per [ADR-0030](../../adrs/ADR-0030-grid-wide-audit-substrate.md) — the audit entry records the tenant ID, the channel, the provider name, and the timestamp. Credential **values** are never audited (invariant 8).
+   4. **Confirm to the tenant** that override is active. The tenant's first send post-confirmation routes through the override.
+
+   Validation is the gate — if the live-test fails, the credentials are not stored and the tenant sees the failure with an actionable error.
+
+   ## Fallback semantics
+
+   At dispatch time, an override may fail for runtime reasons (rotated credential that the tenant did not re-enter; provider outage; account suspension). Two fallback choices:
+
+   - **Fail the send** (strict). The tenant override is the chosen behaviour and a fallback to platform Resend would deliver email under the platform's From-address — a deliverability and brand risk for the tenant. The strict choice respects the override's intent.
+   - **Fall back to platform** (lax). The send goes out via platform Resend; the tenant is alerted via Notify Cloud's tenant notification channel. The lax choice prioritizes delivery over override fidelity.
+
+   **Decision: strict by default.** A tenant who has chosen an override has done so deliberately. Falling back silently to platform is a surprise; the platform-vs-tenant From-address risk is real. The tenant override fails the send with a clear error; the tenant's admin is notified; the next send retries. The lax option is offered as a per-tenant opt-in setting ("fall back to platform if my provider fails — accept that my emails may show the HoneyDrunk From-address temporarily") but defaults off.
+
+   The send-failure audit entry (per ADR-0030) records the override failure with the rotated/missing credential reason — the audit value never includes the credential value itself.
+
+   ## Per-PDR override (out of scope for Notify Cloud)
+
+   ADR-0073 D5 also permits per-PDR override (a consuming Node — Hearth, Currents, etc. — may register an alternate provider at its host composition). This is **not** a Notify Cloud concern; it is a per-PDR composition choice made in the consumer's `AddHoneyDrunk*Provider()` host registration. Notify Cloud's per-tenant override is independent and operates only against tenants of the Notify Cloud Service.
+
+   ## Open questions for the implementation packet
+
+   - **UI surface.** The Notify Cloud admin UI is per ADR-0027's standup; UI mockups, validation-error UX, and credential-rotation reminders are the implementation packet's design work.
+   - **Audit detail.** ADR-0030's `AuditEntry` shape carries the override decision; the implementation packet decides whether per-send override-resolution events emit an audit entry or only the credential-management events do (per-send may be too noisy at scale).
+   - **Tenant tier-gating.** ADR-0027 introduces tiers (Free / Pro / Scale per ADR-0037 reconciled in ADR-0067). Is BYO-provider available on all tiers, or gated to Pro+? Implementation packet decides; default recommendation is "Pro+ only" — BYO-provider is a power-user feature whose support cost is non-trivial.
+   - **Credential-rotation reminder cadence.** A tenant who entered credentials 80 days ago is approaching the typical 90-day rotation window. Notify Cloud should remind them. The cadence and channel (in-app banner? email reminder?) is the implementation packet's design.
+
+   ## Follow-up Notify Cloud packet outline
+
+   The packet that consumes this specification:
+
+   - **Target repo:** `HoneyDrunkStudios/HoneyDrunk.Notify.Cloud`
+   - **Expected wave:** post-standup (Wave 3 or 4 of the `adr-0027-notify-cloud-standup` initiative)
+   - **Blocked by:** `adr-0027-notify-cloud-standup` packet 06 (scaffold)
+   - **Version-bump impact:** Notify Cloud minor (new tenant-facing feature)
+   - **Scope:** tenant-override configuration record + admin UI + credential validation flow + dispatch-time override resolver + audit hooks + strict fallback policy + Pro+ tier-gating
+   - **References:** this specification document, ADR-0073 D5/D6, ADR-0026 D5 (tenant-scoped secrets), ADR-0030 (audit emit), ADR-0027 (Notify Cloud tier shape), ADR-0067 D3 (tier-name reconciliation), invariant 9a (tenant-scoped secrets pattern), invariant 8 (no secret values in logs/traces).
+
+   ## Related work
+
+   - [ADR-0073](../../adrs/ADR-0073-notify-default-providers.md) — the default-provider commitment that this override mechanism is the escape valve for.
+   - [ADR-0027](../../adrs/ADR-0027-stand-up-honeydrunk-notify-cloud-node.md) — Notify Cloud standup (Proposed; the implementing Node).
+   - [ADR-0026](../../adrs/ADR-0026-grid-multi-tenant-primitives.md) — tenant-scoped secret pattern (invariant 9a).
+   - [ADR-0030](../../adrs/ADR-0030-grid-wide-audit-substrate.md) — audit emit for override credential management.
+   - [ADR-0019](../../adrs/ADR-0019-stand-up-honeydrunk-communications-node.md) — Notify is delivery mechanics; the per-tenant override is delivery-side, not Communications decision-side.
+   ```
+
+3. Save.
+
+## Affected Files
+- `business/context/notify-cloud-tenant-override-policy.md` (new file; confirm directory choice against sibling `adr-0067-rate-limiting` packet 05 at execution)
+
+## NuGet Dependencies
+None. This packet touches only Markdown specification files.
+
+## Boundary Check
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule matches.
+- [x] No code change in any repo.
+- [x] The specification respects Notify's boundary (delivery mechanics) and Communications' boundary (decision/preference) — the override decision is a tenant-configuration choice made at the Notify Cloud admin layer, not a per-send decision-logic choice; it operates inside the Notify-delivery boundary.
+
+## Acceptance Criteria
+- [ ] The specification document exists at `business/context/notify-cloud-tenant-override-policy.md` (or the mirror location matching `adr-0067-rate-limiting` packet 05 — state the chosen path in the PR if different)
+- [ ] The document covers: tenant override scope (3 channels independent); credential storage (ADR-0026 D5 tenant-scoped secret pattern); per-tenant override resolution (dispatch-time wrapping the existing `NotificationSenderResolver`); validation flow (schema + live-test + Vault store + audit); fallback semantics (strict by default, lax as per-tenant opt-in); per-PDR override out of scope for Notify Cloud; open questions for the implementation packet; follow-up Notify Cloud packet outline
+- [ ] The document explicitly cites invariants 8 (no secrets in audit) and 9a (tenant-scoped secret pattern)
+- [ ] The document explicitly states the strict-fallback decision with the rationale (override's intent + From-address brand risk)
+- [ ] The document explicitly defers the open questions (UI, audit detail, tier-gating, rotation-reminder cadence) to the implementation packet — none of them are resolved here
+- [ ] **No code work.** No edits to `HoneyDrunk.Notify`, `HoneyDrunk.Vault`, `HoneyDrunk.Vault.Rotation`, or any other code repo.
+- [ ] **No edit to ADR-0073's text** or any other ADR.
+- [ ] **No catalog change.** No edits to any `catalogs/` file.
+
+## Human Prerequisites
+None.
+
+## Referenced ADR Decisions
+**ADR-0073 D5 — Provider abstraction is held; defaults are not exclusive bindings.** "Per-tenant override is permitted. A Notify Cloud tenant with their own SES account, their own Postmark relationship, their own Twilio sub-account can plug into the `IEmailSender` / `ISmsSender` provider slot with a tenant-scoped implementation. The default (Resend / Twilio / Expo) is what Notify uses for tenants who do not override. Per-PDR override is permitted (but discouraged)."
+
+**ADR-0073 D6 — Out of scope.** "Tenant-BYO provider tooling. The mechanism by which a Notify Cloud tenant brings their own provider (UI for credential entry, validation flow, fallback semantics) is a Notify Cloud-internal concern."
+
+**ADR-0026 D5 — Tenant-scoped secrets are a Vault usage pattern, not an `ISecretStore` contract change** (invariant 9a). "Tenant-owned secrets use `tenant-{tenantId}-{secretName}` and resolve through `TenantScopedSecretResolver`; `TenantId.Internal` uses the standard node-level secret path."
+
+**ADR-0030 §IAuditLog emit obligations.** Override credential-management events (entered, validated, rotated, removed) emit `AuditEntry` records via `IAuditLog`. The audit entry records the tenant ID, the channel, the provider name, and the timestamp. Credential **values** never appear in audit (invariant 8).
+
+**ADR-0027 §Tenant tier shape** + **ADR-0067 D3 tier-name reconciliation.** Notify Cloud tiers at GA: Free / Pro / Scale (reconciled from ADR-0027's original Free / Starter / Pro to ADR-0037's Free / Pro / Scale). BYO-provider is a candidate Pro+ gate per the implementation packet.
+
+## Constraints
+- **Docs-only, no code.** This packet writes the specification; the implementation packet is filed against Notify Cloud after the standup lands.
+- **No abstraction change to `HoneyDrunk.Notify`.** The existing `INotificationSender` / `NotificationSenderResolver` already supports per-call provider substitution via keyed DI. The override is a dispatch-time wrapper, not a contract change.
+- **Strict-fallback default is committed.** This document's "strict by default, lax as opt-in" decision binds the implementation packet. Reopening this decision is an amendment to this document, not a silent implementation drift.
+- **Per-PDR override stays out of Notify Cloud's scope.** A consumer-PDR's host-composition override is independent and not Notify Cloud's concern.
+- **Open questions are deferred deliberately.** UI design, audit detail, tier-gating, rotation reminders — those are the implementation packet's design space. Resolving them in this specification would couple to a particular UI framework / audit-emit cadence / tier-naming that the standup ADR has not yet committed.
+
+## Labels
+`chore`, `tier-3`, `ops`, `docs`, `adr-0073`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Author the canonical per-tenant provider-override policy specification at `business/context/notify-cloud-tenant-override-policy.md` as the design input the future Notify Cloud implementation packet consumes. No code ships.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Spec the per-tenant override mechanics so the Notify Cloud follow-up packet (filed against `HoneyDrunk.Notify.Cloud` after its standup lands) has a complete design.
+- Feature: ADR-0073 Notify Default Providers rollout, Wave 3.
+- ADRs: ADR-0073 D5 / D6 (primary); ADR-0027 (Notify Cloud — Proposed, implementing Node); ADR-0026 (tenant-scoped secret pattern); ADR-0030 (audit emit for credential management).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0073 is Accepted.
+
+**Constraints:**
+- Docs-only.
+- Strict-fallback default is committed in the spec; lax is opt-in per-tenant.
+- Open questions (UI, audit detail, tier-gating, rotation cadence) are deferred to the implementation packet — not resolved here.
+- Confirm the directory choice (`business/context/` vs `infrastructure/walkthroughs/`) against the sibling `adr-0067-rate-limiting` packet 05 at execution time; mirror the choice.
+
+**Key Files:**
+- `business/context/notify-cloud-tenant-override-policy.md` (new file)
+
+**Contracts:** None.

--- a/generated/issue-packets/active/adr-0073-notify-providers/06-notify-push-channel-and-contract.md
+++ b/generated/issue-packets/active/adr-0073-notify-providers/06-notify-push-channel-and-contract.md
@@ -1,0 +1,232 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["feature", "tier-2", "ops", "adr-0073", "wave-4"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0073", "ADR-0035"]
+wave: 4
+initiative: adr-0073-notify-providers
+node: honeydrunk-notify
+---
+
+# Add NotificationChannel.Push and IPushSender contract for ADR-0073 D3
+
+## Summary
+Add the push channel to HoneyDrunk.Notify's abstractions: `NotificationChannel.Push = 2` added to the `NotificationChannel` enum, and `IPushSender` abstraction added to `HoneyDrunk.Notify.Abstractions` as the contract the Expo provider (packet 07) implements. **Version-bumping packet for the Notify solution from `0.3.1` → `0.4.0`** (additive new enum value + new public abstraction is a minor bump per ADR-0035 D1). The Expo provider implementation lands in packet 07; the Expo Push Receipts intake seam lands in packet 08.
+
+## Context
+ADR-0073 D3 commits **Expo Notifications** as the canonical push provider for HoneyDrunk.Notify's `IPushSender` slot. The `IPushSender` contract does not yet exist in `HoneyDrunk.Notify.Abstractions`; the `NotificationChannel` enum does not yet carry a `Push` value (per the current file at `HoneyDrunk.Notify/HoneyDrunk.Notify.Abstractions/NotificationChannel.cs`, only `Email = 0` and `Sms = 1` are defined).
+
+This packet ships the **contract + enum** only. The Expo provider implementation lives in packet 07 in the new `HoneyDrunk.Notify.Providers.Push.Expo` package (channel-scoped naming per the D3 amendment in packet 00).
+
+Splitting contract from implementation keeps `HoneyDrunk.Notify.Abstractions` honest: the abstractions package gains a new contract + enum value (additive); the implementation lands in a separate package in a separate packet. Per ADR-0035 D1, an additive new contract on an Abstractions package is a **minor** version bump.
+
+> **Routing flow — no dispatcher change needed.** The existing `NotificationSenderResolver` (at `HoneyDrunk.Notify/Routing/NotificationSenderResolver.cs`) routes via keyed DI on the `NotificationChannel` enum value with a non-keyed fallback. The existing `NotificationDispatcher` (at `HoneyDrunk.Notify/Routing/NotificationDispatcher.cs`) reads `envelope.Channel` and delegates to the resolver — no channel-aware branching anywhere. Adding `NotificationChannel.Push = 2` is a pure additive enum extension; the resolver and dispatcher continue to work without modification. When packet 07 registers the Expo provider via `services.AddKeyedSingleton<INotificationSender>(NotificationChannel.Push, ...)` (or the `TryAddNotificationSender<T>(NotificationChannel.Push)` helper), the dispatch path lights up automatically.
+
+The new contract — `IPushSender` — is the **abstraction-level** name. Per ADR-0073 D3, push providers implement `IPushSender` (consistent with `IEmailSender` / `ISmsSender`). However, the existing email and SMS providers in this repo implement `INotificationSender` (the channel-agnostic interface) directly and rely on keyed DI to route by channel — there is no explicit `IEmailSender` / `ISmsSender` interface in the current Abstractions package. The design choice for the push side:
+
+- **Option A:** Add `IPushSender` as a marker interface inheriting `INotificationSender` (parallel to a hypothetical `IEmailSender` / `ISmsSender` if those existed). Documents intent; allows future per-channel cross-cutting (e.g. push-only telemetry middleware that constrains to `IPushSender`).
+- **Option B:** Do not add `IPushSender`; just register `INotificationSender` against `NotificationChannel.Push` like the existing email/sms providers do.
+
+**Recommendation: Option A**, with `IPushSender : INotificationSender` as the contract. This matches ADR-0073 D3's explicit naming and gives the same shape ADR-0073 D1 and D2 imply for `IEmailSender` / `ISmsSender` (even though the current code does not surface those marker interfaces — adding `IPushSender` now establishes the pattern; backfilling `IEmailSender` / `ISmsSender` is a separate non-gated refactor). If the execution agent finds the existing code has reasons to prefer Option B, state the choice in the PR with a brief rationale; either choice satisfies the ADR.
+
+`HoneyDrunk.Notify.Abstractions` is the package being bumped here; the runtime `HoneyDrunk.Notify` and all 14 other packages in the solution are aligned to `0.4.0` per invariant 27 but get no functional change in this packet.
+
+## Scope
+- **`HoneyDrunk.Notify.Abstractions`**:
+  - Edit `NotificationChannel.cs` — add `Push = 2` enum value with XML documentation.
+  - New file (Option A path): `IPushSender.cs` — marker interface inheriting `INotificationSender`, with XML documentation citing ADR-0073 D3.
+  - Per-package `CHANGELOG.md` entry for the additive changes.
+  - Per-package `README.md` update — document the new enum value and the new interface in the public-API section.
+- **All non-test `.csproj` files in the solution** version-bumped to `0.4.0` (invariant 27) in one commit.
+- **Repo-level `CHANGELOG.md`** receives a new `[0.4.0] - {merge-date}` dated section describing the additive enum + abstraction. No `[Unreleased]` left behind.
+- **Per-package CHANGELOGs for other packages** — **none** (invariants 12 / 27 — alignment-bump-only).
+- **`HoneyDrunk.Notify.Tests`** — add a tiny shape test for the new enum value (`NotificationChannel.Push.Should().Be((NotificationChannel)2)`) and for the new interface (`typeof(IPushSender).Should().Implement<INotificationSender>()` if Option A is chosen).
+
+## Out of Scope
+- The Expo provider package implementation — packet 07.
+- The Expo receipts intake seam — packet 08.
+- A `PushTokenRegistration` record or push-token-store contract — packet 08 ships the minimal seam if needed; this packet does not pre-empt it.
+- Backfilling `IEmailSender` / `ISmsSender` marker interfaces for the existing email/sms providers — separate non-gated refactor, not in scope here.
+- Mobile-side Expo Push Token capture — consumer-PDR concern; not a Notify Node concern.
+
+## Proposed Implementation
+1. **Edit `HoneyDrunk.Notify/HoneyDrunk.Notify.Abstractions/NotificationChannel.cs`** — add the `Push` value:
+
+   ```csharp
+   namespace HoneyDrunk.Notify.Abstractions;
+
+   /// <summary>
+   /// Represents the delivery channel through which a notification is sent.
+   /// </summary>
+   public enum NotificationChannel
+   {
+       /// <summary>
+       /// Email delivery (SMTP, transactional API, etc.).
+       /// </summary>
+       Email = 0,
+
+       /// <summary>
+       /// SMS delivery (Twilio, etc.).
+       /// </summary>
+       Sms = 1,
+
+       /// <summary>
+       /// Push notification delivery (Expo Push API per ADR-0073 D3, fanning out to APNs and FCM).
+       /// </summary>
+       Push = 2,
+   }
+   ```
+
+2. **Add `HoneyDrunk.Notify/HoneyDrunk.Notify.Abstractions/IPushSender.cs`** (Option A path):
+
+   ```csharp
+   namespace HoneyDrunk.Notify.Abstractions;
+
+   /// <summary>
+   /// Marker interface for notification senders that deliver to <see cref="NotificationChannel.Push"/>.
+   /// </summary>
+   /// <remarks>
+   /// <para>
+   /// Inherits <see cref="INotificationSender"/>; push providers (Expo per ADR-0073 D3 — the canonical default;
+   /// alternate providers if registered via D5's per-tenant or per-PDR override) implement this interface and
+   /// register against <see cref="NotificationChannel.Push"/> via keyed DI.
+   /// </para>
+   /// <para>
+   /// The Expo Push API is the canonical send pipeline; Expo Push Receipts are the canonical delivery-confirmation
+   /// pipeline. See ADR-0073 D3 for the default-provider commitment and the vendor-risk mitigation rationale.
+   /// </para>
+   /// </remarks>
+   public interface IPushSender : INotificationSender
+   {
+   }
+   ```
+
+3. **Version bump** — set `<Version>0.4.0</Version>` on every non-test `.csproj` in the solution in one commit (invariant 27).
+4. **Per-package CHANGELOG** for `HoneyDrunk.Notify.Abstractions`:
+
+   ```markdown
+   ## [0.4.0] - {merge-date}
+
+   ### Added
+
+   - `NotificationChannel.Push = 2` enum value for the push notification channel per ADR-0073 D3.
+   - `IPushSender` marker interface inheriting `INotificationSender` for push-channel providers.
+   ```
+
+5. **README** for `HoneyDrunk.Notify.Abstractions` — add `NotificationChannel.Push` and `IPushSender` to the public-API section.
+6. **Repo-level CHANGELOG** — add a new `[0.4.0] - {merge-date}` section:
+
+   ```markdown
+   ## [0.4.0] - {merge-date}
+
+   ### Added
+
+   - Push notification channel — `NotificationChannel.Push = 2` and `IPushSender` interface added to `HoneyDrunk.Notify.Abstractions` per ADR-0073 D3. The Expo provider implementation (`HoneyDrunk.Notify.Providers.Push.Expo`) ships separately.
+
+   ### Changed
+
+   - Aligned package versions to `0.4.0` across the solution per invariant 27.
+   ```
+
+   Confirm no `[Unreleased]` content has accrued since packet 01's `[0.3.1]` close; if it has (e.g. an unrelated maintenance commit landed in between), roll that content into `[0.4.0]` per the standing "no commits under Unreleased" rule.
+7. **Tests** — minimal shape tests in `HoneyDrunk.Notify.Tests`:
+   - `NotificationChannel.Push.Should().Be((NotificationChannel)2);`
+   - `typeof(IPushSender).Should().BeAssignableTo<INotificationSender>();` (Option A only)
+   - No new test categories — these are inline shape assertions.
+
+## Affected Files
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.Abstractions/NotificationChannel.cs` — add `Push = 2`.
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.Abstractions/IPushSender.cs` — new file (Option A).
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.Abstractions/CHANGELOG.md`, `README.md`.
+- Repo-level `CHANGELOG.md`.
+- All non-test `.csproj` files in the solution — version `0.3.1` → `0.4.0`.
+- `HoneyDrunk.Notify.Tests/` — shape tests.
+
+## NuGet Dependencies
+- **`HoneyDrunk.Notify.Abstractions`** — no new `PackageReference`. The new enum value and marker interface use only BCL.
+- **Other packages** — no new `PackageReference`.
+- **Test project** — existing test-stack references.
+
+## Boundary Check
+- [x] Enum + abstraction changes land in `HoneyDrunk.Notify.Abstractions` (the Abstractions layer); no runtime code in this packet.
+- [x] No dependency on any HoneyDrunk runtime package from Abstractions (invariant 1).
+- [x] Notify is the right home — push is a notification delivery channel; Communications (decision/preference) does not need a `Push` enum value at the Communications layer (Communications routes intent to channel via Notify; the channel enum is a Notify concept).
+- [x] The new `IPushSender` (Option A) is a marker for the push slot only — it does not introduce a new contract surface beyond `INotificationSender`.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Notify.Abstractions` exposes `NotificationChannel.Push = 2` with XML documentation citing ADR-0073 D3
+- [ ] `HoneyDrunk.Notify.Abstractions` exposes `IPushSender : INotificationSender` (or, if Option B is chosen with rationale in the PR, no marker interface — the absence is acceptable as long as the rationale is stated)
+- [ ] `HoneyDrunk.Notify.Abstractions` has zero new runtime `PackageReference` (invariant 1)
+- [ ] Every non-test `.csproj` in the solution is at `<Version>0.4.0</Version>` in a single commit (invariant 27)
+- [ ] Repo-level `CHANGELOG.md` has a new `[0.4.0]` dated entry; no `[Unreleased]` content left
+- [ ] `HoneyDrunk.Notify.Abstractions/CHANGELOG.md` has a `[0.4.0]` entry; other per-package CHANGELOGs receive **no** entries (alignment-bump-only per invariants 12 / 27)
+- [ ] `HoneyDrunk.Notify.Abstractions/README.md` documents `NotificationChannel.Push` and `IPushSender` in the public-API section
+- [ ] `NotificationSenderResolver` and `NotificationDispatcher` are **NOT** modified in this packet — they handle the new enum value via the existing keyed-DI routing automatically
+- [ ] Shape tests verify the enum value and (Option A) the interface inheritance
+- [ ] The `pr-core.yml` tier-1 gate passes; no contract-shape canary failure (the changes are additive)
+
+## Human Prerequisites
+- [ ] **After this packet merges, a human pushes the `HoneyDrunk.Notify` `0.4.0` release tag** so the NuGet packages publish for packet 07 to consume. Agents merge code but never tag or publish.
+
+## Referenced ADR Decisions
+**ADR-0073 D3 — Expo Notifications is the default push provider.** "Expo Notifications is the canonical push provider for HoneyDrunk.Notify's `IPushSender` slot. iOS and Android push both route through Expo's push pipeline; Notify does not talk to APNs or FCM directly. `HoneyDrunk.Notify.Providers.Push.Expo` (new package, ships when push lands) — the `IPushSender` implementation. Expo Push Tokens are the addressable identifier. Expo's Push API is the send pipeline. Expo Push Receipts are the delivery-confirmation pipeline. Expo Access Tokens in Vault per ADR-0005."
+
+**ADR-0073 D3 amendment (packet 00).** "HoneyDrunk.Notify.Providers.Push.Expo (channel-scoped naming, parallel to Providers.Email.Resend / Providers.Sms.Twilio)."
+
+**ADR-0035 D1 — Strict SemVer with binary-compat guarantee at minor/patch.** "New public types are additive minor bumps. New enum values on an existing public enum are additive minor bumps; consuming code that exhaustively switches on the enum gets a compiler warning but no break." (The new `Push` enum value + `IPushSender` interface together are a minor bump.)
+
+**ADR-0073 §Operational Consequences.** "Vendor risk is bounded by the wrapping pattern. Each provider is one adapter swap away from replacement. The `IEmailSender` / `ISmsSender` / `IPushSender` contracts are stable; the implementations are swappable."
+
+## Constraints
+- **Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.** Only `Microsoft.Extensions.*` *abstractions* permitted. The enum value and marker interface use only BCL — no new package reference.
+- **Invariant 12 — Per-package CHANGELOGs are updated only for packages with functional changes.** Only `HoneyDrunk.Notify.Abstractions` gets a per-package entry. The other 14 packages get the version alignment via `.csproj` only.
+- **Invariant 13 — All public APIs have XML documentation.** The new enum value and the new interface have XML docs citing ADR-0073 D3.
+- **Invariant 27 — All projects in a solution share one version and move together.** Every non-test `.csproj` to `0.4.0` in one commit. Partial bumps forbidden.
+- **No `[Unreleased]` left behind.** Per the standing rule, the new `[0.4.0]` section captures any accrued content since the close of `[0.3.1]`.
+- **No dispatcher / resolver modification.** The existing routing is enum-agnostic via keyed DI; do not introduce channel-specific branching in `NotificationSenderResolver` or `NotificationDispatcher`.
+- **Push channel routing is keyed DI.** When packet 07 ships the Expo provider, it registers via `services.AddKeyedSingleton<INotificationSender>(NotificationChannel.Push, ...)` (or the existing `TryAddNotificationSender<T>(NotificationChannel.Push)` helper). The push send path lights up at that point — not in this packet.
+- **No premature push-token-store contract.** A `PushTokenRegistration` record + receipts-poll seam may land in packet 08 if the operator decides the Notify-side intake seam belongs there. Do not ship a contract in this packet that packet 08 might want to shape differently.
+- **Test project naming.** Same as the rest of the initiative — `HoneyDrunk.Notify.Tests` stays under its pre-ADR-0047 name; the rename is a separate follow-up.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0073`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Add `NotificationChannel.Push = 2` and `IPushSender` to `HoneyDrunk.Notify.Abstractions` per ADR-0073 D3 (channel-scoped amendment per packet 00). Bump the Notify solution from `0.3.1` to `0.4.0`. Ship contract only — Expo implementation in packet 07.
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: Land the push-channel abstraction so packet 07 can implement Expo against it.
+- Feature: ADR-0073 Notify Default Providers rollout, Wave 4 (the push channel foundation).
+- ADRs: ADR-0073 D3 (primary); ADR-0035 D1 (additive minor-bump policy); ADR-0008 (packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:00` — ADR-0073 Accepted (the D3 amendment to channel-scoped naming is in the ADR text when this packet runs).
+- `packet:01` — Notify solution at `0.3.1` (this packet bumps from there to `0.4.0`).
+
+**Constraints:**
+- Abstractions stay zero-HoneyDrunk-dependency (invariant 1).
+- Add `NotificationChannel.Push = 2` (not 99, not the next available number — exactly 2, parallel to Email=0/Sms=1).
+- `IPushSender` marker interface inherits `INotificationSender` (Option A) unless the execution agent's review finds a reason to prefer Option B — state the choice in the PR with rationale.
+- Bump every non-test `.csproj` to `0.4.0` in one commit. This is the bumping packet for `HoneyDrunk.Notify` `0.4.0`; packets 07 and 08 append.
+- Do not modify `NotificationSenderResolver` or `NotificationDispatcher` — the existing keyed-DI routing handles the new enum value automatically.
+- XML doc on the new enum value and interface cites ADR-0073 D3.
+
+**Key Files:**
+- `HoneyDrunk.Notify.Abstractions/NotificationChannel.cs` (edit).
+- `HoneyDrunk.Notify.Abstractions/IPushSender.cs` (new — Option A).
+- `HoneyDrunk.Notify.Abstractions/CHANGELOG.md`, `README.md`.
+- Repo-level `CHANGELOG.md`.
+- Every non-test `.csproj`.
+- `HoneyDrunk.Notify.Tests/` — shape tests.
+
+**Contracts:**
+- `NotificationChannel.Push = 2` (new enum value).
+- `IPushSender : INotificationSender` (new marker interface, Option A).

--- a/generated/issue-packets/active/adr-0073-notify-providers/07-notify-expo-push-provider.md
+++ b/generated/issue-packets/active/adr-0073-notify-providers/07-notify-expo-push-provider.md
@@ -1,0 +1,230 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["feature", "tier-2", "ops", "adr-0073", "wave-4"]
+dependencies: ["packet:06"]
+adrs: ["ADR-0073", "ADR-0062", "ADR-0006", "ADR-0005"]
+wave: 4
+initiative: adr-0073-notify-providers
+node: honeydrunk-notify
+---
+
+# Ship HoneyDrunk.Notify.Providers.Push.Expo package implementing IPushSender against Expo's Push API
+
+## Summary
+Ship the new `HoneyDrunk.Notify.Providers.Push.Expo` package implementing `IPushSender` against Expo's Push API. Vault-backed Expo Access Token (`Expo--AccessToken` in `kv-hd-notify-{env}`). Registers as the `NotificationChannel.Push` keyed provider via a new `AddHoneyDrunkNotifyExpoPushProvider` extension following the existing `AddHoneyDrunkNotifyResendProvider` pattern. **Appends to the in-progress `[0.4.0]` CHANGELOG entry created by packet 06.** New package — ships with its own `CHANGELOG.md` and `README.md` from the first commit (invariant 12).
+
+## Context
+Packet 06 added `NotificationChannel.Push = 2` and `IPushSender` to `HoneyDrunk.Notify.Abstractions`. This packet ships the concrete Expo provider — the canonical default per ADR-0073 D3.
+
+**Channel-scoped naming.** Per the D3 amendment in packet 00, the package is `HoneyDrunk.Notify.Providers.Push.Expo` (not `HoneyDrunk.Notify.Providers.Expo`), parallel to the existing `HoneyDrunk.Notify.Providers.Email.Resend` and `HoneyDrunk.Notify.Providers.Sms.Twilio`.
+
+ADR-0073 D3 commits:
+
+- **Expo Push Tokens** are the addressable identifier; the mobile app (per ADR-0070 D3 RN+Expo) registers with Expo at app-launch and the token rounds back to the user record (Identity per ADR-0060) via the consumer-PDR's registration flow. **The token-capture flow on the mobile side is a consumer-PDR concern; this packet only sends to a token already in hand.**
+- **Expo's Push API** is the send pipeline — Notify's `IPushSender` calls Expo's REST endpoint at `https://exp.host/--/api/v2/push/send`; Expo fan-outs to APNs and FCM internally.
+- **Expo Push Receipts** are the delivery-confirmation pipeline — Notify polls receipts after send and lands the delivery / failure events into its standard intake. **The receipts-poll worker is packet 08's scope; this packet's send returns the Expo `ticket` IDs that the receipts-poll worker consumes.**
+- **Expo Access Tokens in Vault** per ADR-0005.
+
+The Expo Push API:
+
+- POST `https://exp.host/--/api/v2/push/send` — body is an array of messages; each message has `to` (Expo Push Token), `title`, `body`, `data` (arbitrary payload), `sound`, `priority`, `channelId` (Android channel), etc. Response is an array of `ticket` objects, each with a `status` of `ok` (with a `ticket-id`) or `error` (with an `error-code` and `message`).
+- The Expo Access Token authenticates the request via the `Authorization: Bearer {token}` header. Tokens are managed in the Expo dashboard.
+
+For this packet's scope:
+
+- **Send only.** This packet's `ExpoPushNotificationSender.SendAsync` accepts a `NotificationEnvelope` whose `Channel == NotificationChannel.Push` and whose `Payload` is a `PushEnvelope` (a new record-type parallel to the existing `EmailEnvelope` — confirm at execution whether the existing payload model uses a discriminated union per channel or a generic object; mirror the pattern).
+- **Returns a `DeliveryOutcome`** that captures the Expo `ticket-id` in the outcome's `Provider`-specific data so packet 08's receipts-poll worker can resolve the ticket to a final delivered/failed status.
+- **No receipts-poll worker in this packet.** That is packet 08.
+
+The Expo Access Token rotates at Tier 2 per ADR-0006 (90-day cadence). Registered in `HoneyDrunk.Vault.Rotation`'s calendar in this packet (or, if the calendar lives in Vault.Rotation's repo, cross-referenced in the Expo provider README with a parallel Vault.Rotation packet).
+
+> **Vendor risk per ADR-0073 D3.** Expo is a single vendor. The mitigation is the `IPushSender` abstraction itself — if Expo fails as a vendor, the swap to direct APNs + direct FCM (or to OneSignal) is a one-PR adapter swap behind the same interface. This packet ships the Expo binding; the abstraction it implements is the seam.
+
+## Scope
+- **New package: `HoneyDrunk.Notify.Providers.Push.Expo`**.
+  - `HoneyDrunk.Notify.Providers.Push.Expo.csproj` — channel-scoped naming, version `0.4.0`, follows the structure of the existing `HoneyDrunk.Notify.Providers.Email.Resend.csproj` (PackageId, PackageTags, README/CHANGELOG packaged, HoneyDrunk.Standards reference with `PrivateAssets: all`, ProjectReference to `HoneyDrunk.Notify.Abstractions`, PackageReference to `HoneyDrunk.Vault` for `ISecretStore`, linked compile of the `HoneyDrunk.Notify.ProviderSupport` helpers — confirm against the Resend project at execution).
+  - `ExpoPushNotificationSender.cs` — implements `IPushSender`. Reads `Expo--AccessToken` from `ISecretStore` per call; POSTs to `https://exp.host/--/api/v2/push/send`; maps Expo's response to `DeliveryOutcome`; captures the Expo `ticket-id` in outcome metadata for packet 08's consumption.
+  - `ExpoPushOptions.cs` — options class with the Expo project ID (non-secret; informational), optional defaults (priority, channel ID for Android).
+  - `DependencyInjection/ExpoPushNotifyServiceCollectionExtensions.cs` — `AddHoneyDrunkNotifyExpoPushProvider(this IServiceCollection, Action<ExpoPushOptions>)` extension; follows the `AddHoneyDrunkNotifyResendProvider` shape.
+  - `CHANGELOG.md` — new file with `[0.4.0] - {merge-date}` initial entry (invariant 12).
+  - `README.md` — new file documenting the package purpose, installation, public API, the ADR-0073 D3 default-provider declaration, the ADR-0062 receipts cross-reference (packet 08), the ADR-0006 Tier-2 rotation cross-reference.
+- **Add the new project to the solution (`HoneyDrunk.Notify.slnx`)** so it builds with the rest.
+- **`HoneyDrunk.Notify.Tests`** — unit tests for `ExpoPushNotificationSender` (mocking the HTTP boundary; verifying request shape; verifying the response → `DeliveryOutcome` mapping; verifying secret-resolution).
+- **`HoneyDrunk.Notify.IntegrationTests`** — integration test for the DI registration and the keyed-DI routing (`services.AddHoneyDrunkNotifyExpoPushProvider(...)` → resolve `INotificationSender` keyed by `NotificationChannel.Push` → expect `ExpoPushNotificationSender`).
+- **Repo-level `CHANGELOG.md`** — **append** to the `[0.4.0]` entry created by packet 06 with the Expo provider summary line.
+- **No version bump** — solution is already at `0.4.0` from packet 06.
+
+## Out of Scope
+- **Receipts polling.** Packet 08.
+- **Push-token capture flow** on the mobile side. Consumer-PDR concern.
+- **`PushTokenRegistration` record** for storing tokens against user records. If packet 08 decides a Notify-side intake seam belongs there, the record ships in packet 08. This packet only **sends** to tokens already in hand.
+- **APNs / FCM direct fallback.** ADR-0073 D3 names this as the vendor-risk mitigation, but it does not ship now; only when Expo as a vendor fails does the swap fire.
+- **OneSignal alternative.** Explicitly rejected per ADR-0073 D3 alternatives. Do not provide an OneSignal adapter.
+
+## Proposed Implementation
+1. **Project scaffold.** Copy the structure from `HoneyDrunk.Notify.Providers.Email.Resend/`:
+   - `HoneyDrunk.Notify.Providers.Push.Expo.csproj` — same shape, swapped `PackageId`, `Description`, `PackageTags` (`notify;provider;push;expo;notifications;grid`), and the ProjectReference / PackageReferences. Replace the `Resend 0.4.0` package reference with no third-party push SDK — the Expo Push API is plain HTTPS / JSON and uses `IHttpClientFactory` + `System.Text.Json` (BCL); a third-party Expo .NET SDK is not necessary and would add maintenance surface.
+   - Add the same `<Compile Include="..\HoneyDrunk.Notify.ProviderSupport\..." Link="..." />` items the Resend project uses (`OptionsRegistrationExtensions.cs`, `SecretStoreExtensions.cs`, `ServiceCollectionRegistrationExtensions.cs`) so the DI registration shape matches.
+   - Set `<Version>0.4.0</Version>`.
+2. **`ExpoPushNotificationSender`** — internal sealed partial class implementing `IPushSender` and `INotificationSender`. Constructor injects `IHttpClientFactory`, `ISecretStore`, `IOptions<ExpoPushOptions>`, `ILogger<ExpoPushNotificationSender>`. Constants:
+   - `const string ProviderName = "expo";`
+   - `const string AccessTokenSecretName = "Expo--AccessToken";`
+   - `const string HttpClientName = "HoneyDrunk.Notify.Expo";`
+   - `const string PushEndpoint = "https://exp.host/--/api/v2/push/send";`
+   In `SendAsync`:
+   - Validate the envelope's payload is a `PushEnvelope` (or whatever the existing payload shape for push is — if a `PushEnvelope` record does not exist in `HoneyDrunk.Notify.Abstractions`, add it in this packet alongside the sender. The record carries: `string ExpoPushToken`, `string Title`, `string Body`, `IReadOnlyDictionary<string, object>? Data`, optional priority / channel / sound).
+   - If the payload is wrong-shape, return `DeliveryOutcome.Failed(... FailureKind.Permanent, "Missing or invalid PushEnvelope payload on the notification envelope.")` — same pattern as Resend.
+   - Resolve `Expo--AccessToken` via `ISecretStore.GetRequiredSecretValueAsync(...)`.
+   - Build the Expo Push API request body: `[{ "to": pushToken, "title": ..., "body": ..., "data": ..., "sound": ..., "priority": ... }]` (single-message array; batching is a v2 concern).
+   - POST to `PushEndpoint` via the named `IHttpClient`; set `Authorization: Bearer {accessToken}`.
+   - Parse the response. Expo returns an envelope `{ "data": [{ "status": "ok" | "error", "id"?: string, "details"?: object, "message"?: string }] }`. For a single-message send, the `data` array has one element.
+   - On `status: "ok"` → return `DeliveryOutcome.Succeeded(...)` and **stash the `id` (ticket-id) in the outcome's `Provider`-specific metadata** so packet 08's receipts-poll worker can resolve it. The exact stash mechanism depends on the existing `DeliveryOutcome` shape — if it has a `Metadata: IReadOnlyDictionary<string, string>?` field, use `["expo.ticket_id"] = id`; if not, add a typed Expo-specific outcome detail. State the chosen path in the PR.
+   - On `status: "error"` → classify the failure per Expo's documented error codes. `DeviceNotRegistered` is permanent (the push token is invalid; the consumer-PDR should drop it from the user record); `InvalidCredentials` is permanent (auth-token rotation needed — log + audit); `MessageTooBig` is permanent; `MessageRateExceeded` is transient (retry); HTTP 5xx is transient. Return `DeliveryOutcome.Failed(... FailureKind.Permanent | FailureKind.Transient ...)`.
+   - Handle HTTP-level errors (network, timeout) as transient.
+3. **`ExpoPushOptions`** — options class with: `string? ProjectId` (informational; appears in logs/audit, not the request body), optional `string? DefaultPriority` (e.g. `"high"`), optional `string? DefaultAndroidChannelId`. No `AccessToken` option (the token resolves from Vault at send time per ADR-0005, never from in-process options — same pattern as the Resend `ApiKey` is no longer in `ResendOptions` per the v0.2.0 CHANGELOG note "Bootstrap-time `ApiKey` option usage is obsolete and no longer used for delivery").
+4. **`AddHoneyDrunkNotifyExpoPushProvider`** extension — copy the shape from `AddHoneyDrunkNotifyResendProvider`:
+   - `ArgumentNullException.ThrowIfNull(services); ArgumentNullException.ThrowIfNull(configure);`
+   - `services.ConfigureOptional(configure);`
+   - `services.AddHttpClient("HoneyDrunk.Notify.Expo");`
+   - `return services.TryAddNotificationSender<ExpoPushNotificationSender>(NotificationChannel.Push);`
+5. **Solution file** — add the new project to `HoneyDrunk.Notify.slnx`.
+6. **Vault.Rotation calendar** — register `Expo--AccessToken` at Tier 2 (≤90 days). Same handling as packets 01 and 04 — if the calendar lives in Vault.Rotation's repo, this is a cross-reference + parallel Vault.Rotation packet.
+7. **CHANGELOG entries:**
+   - **New `HoneyDrunk.Notify.Providers.Push.Expo/CHANGELOG.md`** — initial `[0.4.0] - {merge-date}` with `### Added` listing the package's purpose.
+   - **Repo-level `CHANGELOG.md`** — **append** to the `[0.4.0]` entry from packet 06 with a line: "Shipped `HoneyDrunk.Notify.Providers.Push.Expo` package implementing `IPushSender` against Expo's Push API per ADR-0073 D3."
+   - **No other per-package CHANGELOG entries** — alignment-bump-only for unchanged packages (invariants 12 / 27).
+8. **README** for the new package — sections: Overview (Expo provider for HoneyDrunk.Notify's push channel); Installation (`dotnet add package HoneyDrunk.Notify.Providers.Push.Expo`); Quick Start (the `AddHoneyDrunkNotifyExpoPushProvider` usage block); Configuration (`ExpoPushOptions` fields); Vault Secrets (`Expo--AccessToken` in `kv-hd-notify-{env}`); ADR-0073 D3 default-provider declaration; ADR-0062 receipts cross-reference (receipts handled in packet 08); ADR-0006 Tier-2 rotation cross-reference; ADR-0070 D3 mobile-platform alignment note (RN + Expo).
+9. **Tests:**
+   - **Unit tests** in `HoneyDrunk.Notify.Tests` under a new folder `Providers/Expo/`:
+     - `SendAsync_WithValidEnvelope_ReturnsSucceeded` — fakes the HTTP response with `{ "data": [{ "status": "ok", "id": "ticket-123" }] }`; asserts the outcome is `Succeeded` and the ticket-id is captured in outcome metadata.
+     - `SendAsync_WithInvalidPayload_ReturnsPermanentFailure`.
+     - `SendAsync_WithDeviceNotRegistered_ReturnsPermanentFailure`.
+     - `SendAsync_WithMessageRateExceeded_ReturnsTransientFailure`.
+     - `SendAsync_WithHttp500_ReturnsTransientFailure`.
+     - `SendAsync_ResolvesAccessTokenFromSecretStore` — verifies `ISecretStore.GetRequiredSecretValueAsync("Expo--AccessToken", ...)` is called.
+     - `SendAsync_SetsAuthorizationBearerHeader` — verifies the outbound HTTP request carries `Authorization: Bearer {token}`.
+   - **Integration test** in `HoneyDrunk.Notify.IntegrationTests`:
+     - `AddHoneyDrunkNotifyExpoPushProvider_RegistersSenderAgainstPushChannel` — `services.AddHoneyDrunkNotifyExpoPushProvider(...)` → resolve `INotificationSender` keyed by `NotificationChannel.Push` → expect a non-null `ExpoPushNotificationSender`.
+   - **No `Thread.Sleep`** (invariant 51).
+   - **No live Expo calls** (invariant 15) — all HTTP is faked.
+
+## Affected Files
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.Providers.Push.Expo/` — entire new package directory.
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.slnx` — add the new project.
+- Repo-level `CHANGELOG.md` — append to `[0.4.0]`.
+- `HoneyDrunk.Notify.Tests/Providers/Expo/` — new unit tests.
+- `HoneyDrunk.Notify.IntegrationTests/` — new integration test.
+- (Possibly) `HoneyDrunk.Notify/HoneyDrunk.Notify.Abstractions/PushEnvelope.cs` — new payload record if it does not exist (state choice in PR; per-channel envelope records likely exist per the `EmailEnvelope` pattern referenced in `ResendNotificationSender`).
+
+## NuGet Dependencies
+- **`HoneyDrunk.Notify.Providers.Push.Expo`** (new):
+  - `<ProjectReference Include="..\HoneyDrunk.Notify.Abstractions\HoneyDrunk.Notify.Abstractions.csproj" />`
+  - `<PackageReference Include="HoneyDrunk.Standards" Version="0.2.9"><PrivateAssets>all</PrivateAssets><IncludeAssets>...</IncludeAssets></PackageReference>` (StyleCop + EditorConfig analyzers per the existing convention).
+  - `<PackageReference Include="HoneyDrunk.Vault" Version="0.5.0" />` (for `ISecretStore`).
+  - `<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />`
+  - `<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />` (for `IHttpClientFactory`).
+  - `<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />`
+  - `<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />`
+  - `<PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202" />`
+  - The linked `<Compile Include="..\HoneyDrunk.Notify.ProviderSupport\..."` items for shared DI / secret-store helpers.
+  - **No third-party Expo SDK.** Expo's Push API is plain JSON over HTTPS — using `HttpClient` + `System.Text.Json` keeps the dependency surface minimal.
+- **Test projects** — existing test-stack references (xUnit + NSubstitute + AwesomeAssertions + coverlet).
+
+## Boundary Check
+- [x] All code in `HoneyDrunk.Notify` per the routing rule. The new package is a `HoneyDrunk.Notify.Providers.*` sibling.
+- [x] Channel-scoped naming (`Providers.Push.Expo`) matches the established Email/Sms convention and the D3 amendment in packet 00.
+- [x] `IPushSender` is the abstraction the sender implements (added in packet 06); the implementation lives in this packet per the Abstractions / runtime split.
+- [x] Vault secret resolution via `ISecretStore` per invariants 9 / 21 — never pin a version, never log the value (invariant 8).
+- [x] No dependency on `HoneyDrunk.Transport`, `HoneyDrunk.Kernel.Abstractions` beyond what `HoneyDrunk.Notify.Abstractions` already pulls in, or any other Node beyond Vault.
+
+## Acceptance Criteria
+- [ ] New package `HoneyDrunk.Notify.Providers.Push.Expo` builds and ships at version `0.4.0`
+- [ ] `ExpoPushNotificationSender` implements `IPushSender` (and transitively `INotificationSender`)
+- [ ] `AddHoneyDrunkNotifyExpoPushProvider` extension registers the sender against `NotificationChannel.Push` via the existing `TryAddNotificationSender<T>` helper
+- [ ] Expo Access Token resolves from `ISecretStore` using secret name `Expo--AccessToken` on every send (never cached in options, never pinned to a version per invariant 21)
+- [ ] Send POSTs to `https://exp.host/--/api/v2/push/send` with `Authorization: Bearer {token}` header
+- [ ] Successful sends capture the Expo `ticket-id` in the outcome metadata for packet 08 to consume
+- [ ] Expo error codes map correctly: `DeviceNotRegistered` / `InvalidCredentials` / `MessageTooBig` → Permanent; `MessageRateExceeded` / HTTP 5xx / network → Transient
+- [ ] No third-party Expo SDK referenced — pure `HttpClient` + `System.Text.Json`
+- [ ] `HoneyDrunk.Standards` referenced with `PrivateAssets: all` per invariant 26
+- [ ] Package ships with `CHANGELOG.md` and `README.md` from the first commit (invariant 12); both packed in the NuGet output
+- [ ] Repo-level `CHANGELOG.md`'s `[0.4.0]` entry includes the Expo provider summary line (**appended** to packet 06's entry, not a new dated section)
+- [ ] `Expo--AccessToken` is registered in `HoneyDrunk.Vault.Rotation`'s Tier-2 rotation calendar (or, if the calendar lives in Vault.Rotation's repo, cross-referenced in the Expo provider README and a parallel Vault.Rotation packet is filed)
+- [ ] New project added to `HoneyDrunk.Notify.slnx`
+- [ ] Unit + integration tests pass; no `Thread.Sleep` (invariant 51); no live Expo calls (invariant 15)
+- [ ] The `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **Expo project created in the Expo dashboard** for each environment (a single Expo project may serve all three envs via different access tokens, or three separate projects — operator choice). Expo project ID stored in `ExpoPushOptions.ProjectId` (informational, not a secret).
+- [ ] **Expo Access Token seeded in each `kv-hd-notify-{env}` vault** as `Expo--AccessToken` before the Expo provider is composed in any host. The token is generated in the Expo dashboard with push-send permissions.
+- [ ] **Tier-2 rotation calendar updated** for `Expo--AccessToken` — file a Vault.Rotation packet if the calendar lives there.
+- [ ] **No NuGet tag pushed by this packet alone.** This packet appends to the in-progress `0.4.0` release; the tag push happens after packet 08 (or after the operator decides the `0.4.0` set is complete). A human pushes the tag.
+
+## Referenced ADR Decisions
+**ADR-0073 D3 — Expo Notifications is the default push provider.** "`HoneyDrunk.Notify.Providers.Push.Expo` (new package, ships when push lands) — the `IPushSender` implementation. Expo Push Tokens are the addressable identifier. Expo's Push API is the send pipeline — Notify's `IPushSender` implementation calls Expo's Push API; Expo fan-outs to APNs and FCM internally. Expo Push Receipts are the delivery-confirmation pipeline. Expo Access Tokens in Vault per ADR-0005."
+
+**ADR-0073 D3 — Vendor risk mitigation.** "Expo is one company; an Expo failure mode (acquisition, pricing change, shutdown) is real risk. The mitigation: Expo Push Tokens are translatable to native APNs / FCM tokens, and the `IPushSender` abstraction means the migration cost is a one-PR adapter swap. The risk is bounded by the wrapping pattern."
+
+**ADR-0073 §Operational Consequences.** "Expo Notifications cost is effectively zero for the Grid's mobile-app scale. Expo's paid tiers (EAS Build, OTA) are mobile-build concerns, not push concerns."
+
+**ADR-0005 §Vault as the sole source of secrets** (invariant 9). The Expo Access Token resolves through `ISecretStore` on every send — never via environment variables, never via config-file values, never via an in-process options field.
+
+**ADR-0006 §Tier 2 (third-party rotation)** (invariant 20). Third-party provider credentials rotate at ≤90 days via `HoneyDrunk.Vault.Rotation`.
+
+## Constraints
+- **Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.** This packet ships runtime code, not abstractions — invariant 1 is honored at the Abstractions package, not here. (Just noting the boundary: this package depends on `HoneyDrunk.Notify.Abstractions` via ProjectReference, which is fine.)
+- **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The Expo Access Token value never appears in any log, never in any thrown exception's message, never in any audit field. Only the secret name (`Expo--AccessToken`) may appear.
+- **Invariant 9 — Vault is the only source of secrets.** The Expo Access Token resolves through `ISecretStore` per call. No environment-variable fallback. No options-bag fallback.
+- **Invariant 12 — Semantic versioning with CHANGELOG and README.** New package ships with both files from the first commit.
+- **Invariant 13 — All public APIs have XML documentation.** `AddHoneyDrunkNotifyExpoPushProvider`, `ExpoPushOptions`, and `PushEnvelope` (if newly authored) have XML docs.
+- **Invariant 15 — Unit tests and in-process integration tests never depend on external services.** No live Expo calls in any test.
+- **Invariant 20 — Tier 2 rotation SLA ≤ 90 days.** `Expo--AccessToken` rotates on Tier-2 cadence.
+- **Invariant 21 — Applications must never pin to a specific secret version.** Resolve the latest version per call.
+- **Invariant 26 — `HoneyDrunk.Standards` reference with `PrivateAssets: all` on every new .NET project.**
+- **Invariant 27 — All projects in a solution share one version and move together.** New package ships at `0.4.0` aligned with packets 06 / 08.
+- **Invariant 51 — Test code contains no `Thread.Sleep`.**
+- **Channel-scoped naming.** Package name is `HoneyDrunk.Notify.Providers.Push.Expo` — not `HoneyDrunk.Notify.Providers.Expo` (ADR D3 informal description is overridden by the D3 amendment in packet 00).
+- **No third-party Expo SDK.** Expo's Push API is plain JSON over HTTPS; using BCL keeps the dependency surface small and the audit surface minimal.
+- **OneSignal is explicitly rejected** per ADR-0073 D3 alternatives. No OneSignal adapter.
+- **No receipts-poll worker.** That is packet 08's scope. This packet only sends and captures ticket IDs.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0073`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Ship the new `HoneyDrunk.Notify.Providers.Push.Expo` package implementing `IPushSender` against Expo's Push API per ADR-0073 D3. Channel-scoped naming. Vault-backed access token. Captures Expo ticket-IDs for packet 08's receipts poll.
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: Land the canonical default push provider.
+- Feature: ADR-0073 Notify Default Providers rollout, Wave 4.
+- ADRs: ADR-0073 D3 (primary); ADR-0062 (receipts intake — packet 08 scope); ADR-0006 (Tier-2 rotation); ADR-0005 (Vault config); ADR-0070 D3 (mobile platform alignment).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:06` — `IPushSender` + `NotificationChannel.Push = 2` exist in `HoneyDrunk.Notify.Abstractions`; Notify solution at `0.4.0`.
+
+**Constraints:**
+- Channel-scoped package naming.
+- Vault-backed access token (resolve every call; never cache).
+- No third-party Expo SDK; pure `HttpClient` + JSON.
+- No receipts-poll worker — packet 08.
+- Capture Expo ticket-id in outcome metadata for packet 08 to consume.
+- Append to repo-level `[0.4.0]` CHANGELOG entry; new per-package CHANGELOG + README from first commit.
+- No `Thread.Sleep`; no live Expo calls in tests.
+
+**Key Files:**
+- New: `HoneyDrunk.Notify.Providers.Push.Expo/` directory with `.csproj`, `ExpoPushNotificationSender.cs`, `ExpoPushOptions.cs`, `DependencyInjection/ExpoPushNotifyServiceCollectionExtensions.cs`, `README.md`, `CHANGELOG.md`.
+- Edited: `HoneyDrunk.Notify.slnx`, repo-level `CHANGELOG.md`.
+- Possibly new: `HoneyDrunk.Notify.Abstractions/PushEnvelope.cs` (state choice in PR).
+- New tests: `HoneyDrunk.Notify.Tests/Providers/Expo/` and `HoneyDrunk.Notify.IntegrationTests/`.
+
+**Contracts:**
+- Implements `IPushSender` (from `HoneyDrunk.Notify.Abstractions` per packet 06).
+- Possibly new `PushEnvelope` record in `HoneyDrunk.Notify.Abstractions` if no per-channel payload record exists for push yet (mirror the `EmailEnvelope` pattern used by Resend).

--- a/generated/issue-packets/active/adr-0073-notify-providers/08-notify-expo-push-receipts-worker.md
+++ b/generated/issue-packets/active/adr-0073-notify-providers/08-notify-expo-push-receipts-worker.md
@@ -1,0 +1,265 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Notify
+labels: ["feature", "tier-2", "ops", "adr-0073", "wave-4"]
+dependencies: ["packet:06", "packet:07"]
+adrs: ["ADR-0073", "ADR-0062"]
+wave: 4
+initiative: adr-0073-notify-providers
+node: honeydrunk-notify
+---
+
+# Add the Expo Push Receipts intake seam in HoneyDrunk.Notify.Worker
+
+## Summary
+Ship the Expo Push Receipts poll-and-intake seam. After a successful Expo push send (packet 07), Notify holds the Expo `ticket-id` returned by Expo's send API; the receipts API at `https://exp.host/--/api/v2/push/getReceipts` is polled some time later to convert tickets into final delivered/failed delivery events that feed Notify's intake pipeline. Also adds a minimal `PushTokenRegistration` record to `HoneyDrunk.Notify.Abstractions` as the seam consumer-PDRs use to register a mobile user's Expo Push Token against an internal user record. **Appends to the in-progress `[0.4.0]` CHANGELOG entry.** Per-package CHANGELOG entries on `HoneyDrunk.Notify.Abstractions` (for the new record) and `HoneyDrunk.Notify.Worker` (for the new background hook). No version bump.
+
+## Context
+ADR-0073 D3 commits the **Expo Push Receipts** pipeline as the delivery-confirmation seam:
+
+> Expo Push Receipts are the delivery-confirmation pipeline — Notify polls receipts after send and lands the delivery / failure events into its standard intake.
+
+Expo's send API (packet 07) returns immediately with a `ticket-id` indicating the message was accepted into Expo's pipeline — **not** that it was delivered to the device. Final delivery / failure is reported via the receipts API:
+
+- **`POST https://exp.host/--/api/v2/push/getReceipts`** — body is `{ "ids": ["ticket-1", "ticket-2", ...] }`. Response is `{ "data": { "ticket-1": { "status": "ok" | "error", "details"?: {...}, "message"?: string }, ... } }`. Receipts become available approximately 15 minutes after send and persist for ~24 hours. Once read, they may be deleted (Expo does not commit to persistence).
+
+The pattern:
+
+1. Packet 07's `ExpoPushNotificationSender.SendAsync` captures the ticket-id in the `DeliveryOutcome` metadata (e.g. `outcome.Metadata["expo.ticket_id"] = id`).
+2. A background process (this packet) periodically:
+   - Reads recent successful push outcomes whose ticket-id has not yet been resolved (the read store is **Notify's existing intake / outbox / delivery-tracking store** — confirm the existing shape at execution; the receipts poll uses the same store the rest of Notify uses to track in-flight deliveries).
+   - Batches them into a `getReceipts` request.
+   - Parses the response and routes each receipt into Notify's intake pipeline as a `DeliveryStatusEvent` (or the existing event shape for delivery callbacks — same routing the Resend / Twilio webhooks use in packets 01 / 04).
+3. The poll cadence is bounded by Expo's ~15-minute receipt latency and the ~24-hour TTL. A 5-minute interval is a reasonable default (operator-configurable).
+
+This packet **also** adds a minimal `PushTokenRegistration` record to `HoneyDrunk.Notify.Abstractions` so consumer-PDRs have a canonical shape for "this user has an Expo Push Token; here it is." The record is a primitive — the storage and the registration HTTP endpoint live in consumer-PDRs (Identity for the platform-wide case per ADR-0060; or per-PDR for product-specific cases). Notify itself does not store push tokens; it sends to a token the caller supplies.
+
+> **The receipts poller is a background service in `HoneyDrunk.Notify.Worker`** (the existing Worker host that processes the queue). It does not run in `HoneyDrunk.Notify.Functions` — Functions is the queue-triggered intake; the receipts poller is a periodic background, more naturally a Worker concern. If the Functions host needs receipts polling too (e.g. operator chooses to deploy push delivery via Functions only), the poller can be lifted to a shared component; for now it lives in Worker.
+
+## Scope
+- **`HoneyDrunk.Notify.Abstractions`**:
+  - New file: `PushTokenRegistration.cs` — a public record carrying the Expo Push Token + minimal context (per ADR's record-vs-interface naming rule: record drops the `I` prefix). Fields: `string ExpoPushToken`, `string? Platform` (informational: "ios" | "android"), `DateTimeOffset RegisteredAt`. The record is **consumer-input shape only** — Notify does not persist it; the consumer-PDR (Identity / Hearth / etc.) stores it against the user record and supplies the token when sending.
+  - Per-package CHANGELOG entry for the additive record.
+- **`HoneyDrunk.Notify.Worker`** (the existing Worker host):
+  - New background service: `ExpoPushReceiptsPollService` — `BackgroundService` that periodically polls Expo's receipts API for pending tickets.
+  - Options class: `ExpoPushReceiptsPollOptions` — poll interval (default: 5 minutes), batch size (default: 100 — Expo's documented max per receipts call is 100), max ticket-age before giving up (default: 24 hours).
+  - DI registration: `AddHoneyDrunkNotifyExpoPushReceiptsPoll(this IServiceCollection, Action<ExpoPushReceiptsPollOptions>?)` extension. The host opts in. The poll service is **not** wired by `AddHoneyDrunkNotifyExpoPushProvider` (packet 07) — the send-side provider and the receipts-poll background are independent registrations so a host that only sends (and accepts no-confirmation delivery) does not pay for a poller.
+  - Per-package CHANGELOG entry for the additive background service.
+- **Repo-level `CHANGELOG.md`** — **append** to the `[0.4.0]` entry with a one-line summary for the receipts poll + `PushTokenRegistration` record.
+- **`HoneyDrunk.Notify.Tests`** — unit tests for `ExpoPushReceiptsPollService` (mocking HTTP; verifying the batch-request shape; verifying the response → intake-event mapping; verifying empty-batch handling; verifying the access-token resolution).
+- **`HoneyDrunk.Notify.IntegrationTests`** — integration test for the DI registration (`AddHoneyDrunkNotifyExpoPushReceiptsPoll` → background service is in the host).
+- **No version bump** — solution stays at `0.4.0` from packet 06.
+
+## Out of Scope
+- **Push token storage.** `PushTokenRegistration` is the shape consumer-PDRs use to express "this user has this push token." The storage is the consumer-PDR's concern. Notify does not store push tokens.
+- **The receipts persistence store.** The receipts poller reads ticket-ids from Notify's **existing** delivery-tracking store (the same store Resend/Twilio webhooks land into). If the existing store does not have a "pending Expo ticket" shape, the poll service uses an in-memory queue of ticket-ids populated at send time by `ExpoPushNotificationSender` (packet 07) — state the chosen path in the PR. The in-memory approach is acceptable for v1 because Expo's 24-hour receipt TTL is a hard upper bound, and ticket-ids that survive a Worker restart can be re-tried only by Resend/Twilio-style "we'll lose receipts for in-flight tickets across restart" — acceptable initial trade-off; durable storage is a follow-up.
+- **Tenant-specific Expo project handling.** If a Notify Cloud tenant overrides their push provider with their own Expo project (per packet 05's override policy), the receipts poll uses the tenant-scoped access token. The override-resolution wrapping is the Notify Cloud follow-up's job (specified in packet 05); this packet's poller resolves the access token from the same name (`Expo--AccessToken`) the send-side uses, deferring tenant-scoped resolution to the future Notify Cloud override.
+- **Mobile-side push-token capture flow.** Consumer-PDR concern.
+
+## Proposed Implementation
+1. **`PushTokenRegistration` record** in `HoneyDrunk.Notify.Abstractions`:
+
+   ```csharp
+   namespace HoneyDrunk.Notify.Abstractions;
+
+   /// <summary>
+   /// Represents a push token registered by a mobile client for delivery via
+   /// <see cref="NotificationChannel.Push"/>. The token is supplied by the
+   /// consuming Node (Identity, Hearth, etc.) at send time; HoneyDrunk.Notify
+   /// does not persist push tokens — that is a consumer-PDR concern.
+   /// </summary>
+   /// <param name="ExpoPushToken">
+   /// The Expo Push Token (format: <c>ExponentPushToken[...]</c> or <c>ExpoPushToken[...]</c>).
+   /// Generated on the mobile side by the Expo SDK at app launch per ADR-0070 D3.
+   /// </param>
+   /// <param name="Platform">
+   /// Informational platform identifier (<c>ios</c> / <c>android</c>); used only for
+   /// logging and metric tags. Routing is determined by the Expo Push Token, not by
+   /// this field.
+   /// </param>
+   /// <param name="RegisteredAt">
+   /// When the token was registered, in UTC. Used by consumer-PDRs to age tokens
+   /// (e.g. drop tokens older than 30 days that have never been used successfully).
+   /// </param>
+   public sealed record PushTokenRegistration(
+       string ExpoPushToken,
+       string? Platform,
+       DateTimeOffset RegisteredAt);
+   ```
+
+   Naming follows the Grid rule — record drops `I`, interfaces keep `I`. `PushTokenRegistration`, not `IPushTokenRegistration`.
+2. **`ExpoPushReceiptsPollOptions`** in `HoneyDrunk.Notify.Worker`:
+
+   ```csharp
+   public sealed class ExpoPushReceiptsPollOptions
+   {
+       public TimeSpan PollInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+       public int MaxBatchSize { get; set; } = 100; // Expo's documented max per getReceipts call.
+
+       public TimeSpan MaxTicketAge { get; set; } = TimeSpan.FromHours(24); // Expo's documented receipt TTL.
+   }
+   ```
+
+3. **`ExpoPushReceiptsPollService`** — `BackgroundService`:
+   - Constructor injects `IHttpClientFactory`, `ISecretStore`, `IOptions<ExpoPushReceiptsPollOptions>`, `ILogger<ExpoPushReceiptsPollService>`, `TimeProvider`, and the pending-tickets source (see Scope's "in-memory queue" or "existing intake store" choice).
+   - `ExecuteAsync` loop: wait for `PollInterval` via `TimeProvider.CreateTimer` or `Task.Delay(interval, timeProvider, ct)`; pull up to `MaxBatchSize` pending ticket-ids that are within `MaxTicketAge`; if any, POST `https://exp.host/--/api/v2/push/getReceipts` with `{ "ids": [...] }` and `Authorization: Bearer {Expo--AccessToken}` (resolved from `ISecretStore` per call — never cached); parse the response.
+   - For each ticket-id in the response:
+     - `status: "ok"` → routes a delivered `DeliveryStatusEvent` (or the existing event shape) into Notify's intake pipeline.
+     - `status: "error"` → routes a failed event with the Expo-documented error classification (`DeviceNotRegistered` → permanent + the consumer-PDR should drop the token; `MessageRateExceeded` → transient; `MessageTooBig` → permanent; etc.).
+   - Ticket-ids not present in the response are presumed still pending; they remain queued for the next poll until they exceed `MaxTicketAge`, at which point they are marked as "timed out — receipt never arrived" (logged at Warning, audit-emitted per ADR-0030 if the Audit hook is in place; otherwise simply logged).
+   - No `Thread.Sleep` (invariant 51).
+4. **`AddHoneyDrunkNotifyExpoPushReceiptsPoll`** extension in `HoneyDrunk.Notify.Worker`:
+
+   ```csharp
+   public static IServiceCollection AddHoneyDrunkNotifyExpoPushReceiptsPoll(
+       this IServiceCollection services,
+       Action<ExpoPushReceiptsPollOptions>? configure = null)
+   {
+       ArgumentNullException.ThrowIfNull(services);
+
+       if (configure is not null)
+       {
+           services.ConfigureOptional(configure);
+       }
+
+       services.AddHttpClient("HoneyDrunk.Notify.Expo.Receipts");
+       services.AddHostedService<ExpoPushReceiptsPollService>();
+
+       return services;
+   }
+   ```
+
+5. **Wire the captured-ticket-ids from packet 07 into the poll source.** Confirm at execution time:
+   - If `ExpoPushNotificationSender` (packet 07) already writes the ticket-id to Notify's existing delivery-tracking store: the poller reads from that store.
+   - If not: introduce an in-memory `IExpoTicketQueue` shape inside the Worker package (not exposed in Abstractions — purely a Worker-internal seam) that the sender writes to and the poller reads from. State the choice in the PR. The in-memory option requires that the sender and poller live in the same process, which is the existing Worker-host case.
+6. **Per-package CHANGELOG entries:**
+   - `HoneyDrunk.Notify.Abstractions/CHANGELOG.md` — append to the `[0.4.0]` entry: "Added `PushTokenRegistration` record — consumer-input shape for registering an Expo Push Token against an internal user record."
+   - `HoneyDrunk.Notify.Worker/CHANGELOG.md` — new `[0.4.0] - {merge-date}` section (if absent) with: "Added `ExpoPushReceiptsPollService` background service that polls Expo's receipts API and routes delivered/failed events into Notify's intake pipeline per ADR-0073 D3." (The Worker's CHANGELOG may not yet have a `[0.4.0]` entry; create it. Roll any `[Unreleased]` content into the `[0.4.0]` section per the standing rule.)
+7. **Repo-level `CHANGELOG.md`** — append to the `[0.4.0]` entry from packet 06 with a one-line summary of the receipts poller + `PushTokenRegistration` record.
+8. **Tests:**
+   - **Unit tests** in `HoneyDrunk.Notify.Tests/Providers/Expo/` (folder created by packet 07):
+     - `ReceiptsPollService_WithPendingTickets_BatchesAndPolls` — verifies the request shape.
+     - `ReceiptsPollService_WithDeliveredReceipts_RoutesDeliveredEvent`.
+     - `ReceiptsPollService_WithErrorReceipts_RoutesFailedEvent_WithClassification`.
+     - `ReceiptsPollService_WithEmptyPendingQueue_DoesNotCallApi`.
+     - `ReceiptsPollService_WithTicketOlderThanMaxAge_DropsTicket_LogsWarning`.
+     - `ReceiptsPollService_ResolvesAccessTokenFromSecretStore`.
+   - **Integration test** in `HoneyDrunk.Notify.IntegrationTests`:
+     - `AddHoneyDrunkNotifyExpoPushReceiptsPoll_RegistersBackgroundService` — verifies the hosted service is in the DI container after registration.
+   - **No `Thread.Sleep`** (invariant 51); drive the poll interval with `TimeProvider.Advance` (a `FakeTimeProvider` from `Microsoft.Extensions.TimeProvider.Testing` if not already in the test stack — add only if needed and state in PR).
+   - **No live Expo calls** (invariant 15).
+
+## Affected Files
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.Abstractions/PushTokenRegistration.cs` (new).
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.Abstractions/CHANGELOG.md`, `README.md` updates.
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.Worker/Hosting/` (or the existing convention) — new `ExpoPushReceiptsPollService.cs`, `ExpoPushReceiptsPollOptions.cs`, and `DependencyInjection/ExpoPushReceiptsServiceCollectionExtensions.cs`.
+- `HoneyDrunk.Notify/HoneyDrunk.Notify.Worker/CHANGELOG.md`, `README.md` updates.
+- Repo-level `CHANGELOG.md` — append to `[0.4.0]`.
+- `HoneyDrunk.Notify.Tests/Providers/Expo/` — new unit tests.
+- `HoneyDrunk.Notify.IntegrationTests/` — new integration test.
+- Possibly: `HoneyDrunk.Notify.Worker/Internal/IExpoTicketQueue.cs` (and an in-memory implementation) if the chosen path is the in-memory queue rather than the existing delivery-tracking store.
+
+## NuGet Dependencies
+- **`HoneyDrunk.Notify.Worker`** — confirm the existing `PackageReference` set at execution. Likely additions:
+  - `Microsoft.Extensions.Hosting.Abstractions` (for `BackgroundService`) — likely already referenced.
+  - `Microsoft.Extensions.Http` — likely already referenced.
+  - `HoneyDrunk.Vault` — already referenced (per the v0.2.0 ADR-0005 migration).
+  - No new third-party SDK.
+- **`HoneyDrunk.Notify.Abstractions`** — no new `PackageReference` for `PushTokenRegistration` (BCL types only).
+- **Test projects** — possibly `Microsoft.Extensions.TimeProvider.Testing` for `FakeTimeProvider` if not already referenced.
+
+## Boundary Check
+- [x] All code in `HoneyDrunk.Notify` per the routing rule.
+- [x] `PushTokenRegistration` in Abstractions is a primitive (consumer-input shape only); Notify does not persist push tokens — that is consumer-PDR scope.
+- [x] The receipts poll lives in Worker (a Notify-internal host) — not exposed as a public abstraction; only the registration extension is public.
+- [x] The poll service does not introduce a new cross-Node runtime dependency.
+
+## Acceptance Criteria
+- [ ] `HoneyDrunk.Notify.Abstractions` exposes `PushTokenRegistration` record with the three fields and XML documentation
+- [ ] `PushTokenRegistration` follows the Grid record-naming rule (no `I` prefix)
+- [ ] `HoneyDrunk.Notify.Worker` exposes `ExpoPushReceiptsPollService` as a `BackgroundService` and `AddHoneyDrunkNotifyExpoPushReceiptsPoll` as the DI registration extension
+- [ ] The poll service POSTs to `https://exp.host/--/api/v2/push/getReceipts` with batched ticket-ids; resolves `Expo--AccessToken` from `ISecretStore` per call (never cached)
+- [ ] Delivered receipts route a delivered event into Notify's intake pipeline; error receipts route a failed event with Expo-documented classification
+- [ ] Tickets exceeding `MaxTicketAge` (default 24 hours) are dropped with a Warning log
+- [ ] Poll interval defaults to 5 minutes; batch size defaults to 100 (Expo's documented max); both operator-configurable via `ExpoPushReceiptsPollOptions`
+- [ ] The receipts-poll service is **not** auto-wired by `AddHoneyDrunkNotifyExpoPushProvider` (packet 07) — opt-in only via `AddHoneyDrunkNotifyExpoPushReceiptsPoll`
+- [ ] Per-package CHANGELOG entries on `HoneyDrunk.Notify.Abstractions` (the record) and `HoneyDrunk.Notify.Worker` (the background service); no entries on packages with no functional change (invariants 12 / 27)
+- [ ] Repo-level `CHANGELOG.md`'s `[0.4.0]` entry includes the receipts-poller + `PushTokenRegistration` summary **appended** (not a new dated section)
+- [ ] No version bump in this packet — solution stays at `0.4.0` from packet 06
+- [ ] Unit + integration tests verify the request shape, the response → intake-event mapping, the empty-queue path, the timeout path, the access-token resolution
+- [ ] Tests contain no `Thread.Sleep`; poll-interval timing driven via `TimeProvider` (the `FakeTimeProvider` from `Microsoft.Extensions.TimeProvider.Testing` if added; state in PR)
+- [ ] No live Expo calls in any test
+- [ ] The `pr-core.yml` tier-1 gate passes
+
+## Human Prerequisites
+- [ ] **Confirm `Expo--AccessToken` is already in `kv-hd-notify-{env}`** (seeded by packet 07's human prereq).
+- [ ] **After this packet merges, a human pushes the `HoneyDrunk.Notify` `0.4.0` release tag** so the full `0.4.0` (packets 06 + 07 + 08) publishes. Agents merge code but never tag or publish. The tag covers all `0.4.0` packets atomically.
+- [ ] **Decide on the Notify.Worker deployment target.** Per ADR-0015, `HoneyDrunk.Notify.Worker` runs on Azure Container Apps as `ca-hd-notify-worker-{env}`. The receipts poller runs inside the Worker, so the existing Container App revision becomes the host. No new infrastructure is needed; this is informational.
+
+## Referenced ADR Decisions
+**ADR-0073 D3 — Expo Push Receipts are the delivery-confirmation pipeline.** "Expo Push Receipts are the delivery-confirmation pipeline — Notify polls receipts after send and lands the delivery / failure events into its standard intake."
+
+**ADR-0073 §Operational Consequences — Cross-channel intake model.** "Receipt-driven delivery confirmation. Expo's receipt API gives Notify the same delivered/failed events that Resend (for email) and Twilio (for SMS) provide. The cross-channel intake model stays coherent."
+
+**Grid-wide naming rule (memory: records drop I, interfaces keep it).** `PushTokenRegistration` is a record — no `I` prefix.
+
+**ADR-0005 §Vault as the sole source of secrets** (invariant 9). The Expo Access Token resolves through `ISecretStore` on every poll.
+
+**ADR-0021 §Applications must never pin to a specific secret version** (invariant 21). Each poll resolves the latest version.
+
+## Constraints
+- **Invariant 1 — Abstractions packages have zero runtime dependencies on other HoneyDrunk packages.** `PushTokenRegistration` is a pure record over BCL types.
+- **Invariant 8 — Secret values never appear in logs.** The Expo Access Token never appears in any log or audit.
+- **Invariant 9 — Vault is the only source of secrets.** No env-var fallback.
+- **Invariant 12 — Per-package CHANGELOGs are updated only for packages with functional changes.** `HoneyDrunk.Notify.Abstractions` and `HoneyDrunk.Notify.Worker` get entries; nothing else.
+- **Invariant 13 — All public APIs have XML documentation.** `PushTokenRegistration`, `ExpoPushReceiptsPollOptions`, `AddHoneyDrunkNotifyExpoPushReceiptsPoll` all have XML docs.
+- **Invariant 15 — Unit tests and in-process integration tests never depend on external services.** All HTTP fakes; no live Expo calls.
+- **Invariant 20 / 21** — Tier-2 rotation respected; never pin to a version.
+- **Invariant 27 — Solution version alignment.** Already `0.4.0`; no further bump.
+- **Invariant 51 — Test code contains no `Thread.Sleep`.** Drive timing via `TimeProvider`.
+- **Receipts poll is opt-in.** The poll service is not auto-registered by the send-provider extension. A host that doesn't need delivery confirmation does not pay for a poller.
+- **Receipt store is in-memory acceptable for v1.** If the existing delivery-tracking store does not accommodate Expo ticket-ids, use an in-memory queue inside the Worker process. Durable storage is a follow-up if losing in-flight tickets across Worker restart proves operationally problematic.
+- **Naming.** `PushTokenRegistration` is a record (no `I`); `ExpoPushReceiptsPollService` is a class (no `I`); `ExpoPushReceiptsPollOptions` is a class (no `I`). The DI extension `AddHoneyDrunkNotifyExpoPushReceiptsPoll` follows the `AddHoneyDrunkNotify*` pattern.
+
+## Labels
+`feature`, `tier-2`, `ops`, `adr-0073`, `wave-4`
+
+## Agent Handoff
+
+**Objective:** Ship the Expo Push Receipts poll-and-intake seam in `HoneyDrunk.Notify.Worker` and the `PushTokenRegistration` record in `HoneyDrunk.Notify.Abstractions`. Closes ADR-0073 D3's delivery-confirmation obligation.
+
+**Target:** `HoneyDrunk.Notify`, branch from `main`.
+
+**Context:**
+- Goal: Land the receipts pipeline so Expo sends get delivered/failed confirmation routed into Notify's standard intake.
+- Feature: ADR-0073 Notify Default Providers rollout, Wave 4.
+- ADRs: ADR-0073 D3 (primary); ADR-0062 (intake events — using existing patterns); ADR-0005 (Vault for access token); ADR-0015 (Worker hosts on Container Apps — informational).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:06` — `IPushSender` + `NotificationChannel.Push` in Abstractions.
+- `packet:07` — `ExpoPushNotificationSender` captures ticket-ids that this packet's poller consumes.
+
+**Constraints:**
+- Poll service is opt-in via a separate `AddHoneyDrunkNotifyExpoPushReceiptsPoll` extension — not bundled with the send-provider registration.
+- Records drop `I` (Grid naming rule); interfaces keep `I`.
+- Vault-resolved access token per poll; never cached.
+- No `Thread.Sleep` (invariant 51); drive timing via `TimeProvider` (use `FakeTimeProvider` in tests).
+- No live Expo calls in tests.
+- Append to repo-level `[0.4.0]` CHANGELOG — no new dated section, no version bump.
+- Per-package CHANGELOG entries only on packages with actual changes (Abstractions for the record, Worker for the background service).
+
+**Key Files:**
+- `HoneyDrunk.Notify.Abstractions/PushTokenRegistration.cs` (new record).
+- `HoneyDrunk.Notify.Worker/` — new `ExpoPushReceiptsPollService.cs`, `ExpoPushReceiptsPollOptions.cs`, and DI extension.
+- Repo-level `CHANGELOG.md`, per-package CHANGELOGs on Abstractions and Worker.
+- Tests in the existing `HoneyDrunk.Notify.Tests/Providers/Expo/` folder (created by packet 07).
+
+**Contracts:**
+- `PushTokenRegistration` record (new, in Abstractions).
+- `ExpoPushReceiptsPollOptions` class (new, internal to Worker package).
+- `AddHoneyDrunkNotifyExpoPushReceiptsPoll` extension (new, public DI extension on Worker).

--- a/generated/issue-packets/active/adr-0073-notify-providers/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0073-notify-providers/dispatch-plan.md
@@ -1,0 +1,182 @@
+# Dispatch Plan — ADR-0073: Notify Default Providers (Resend / Twilio / Expo)
+
+**Initiative:** `adr-0073-notify-providers`
+**ADR:** ADR-0073 (Proposed → Accepted via packet 00)
+**Sector:** Ops
+**Created:** 2026-05-25
+
+> Per ADR-0008 D7, this dispatch plan is the one exception to packet immutability — it is a living narrative updated at wave boundaries as a historical record.
+
+## Summary
+
+ADR-0073 commits the **canonical default providers** for each of HoneyDrunk.Notify's three channel slots — Resend (email, D1), Twilio (SMS, D2, tentative), Expo Notifications (push, D3) — plus the **react-email templating choice** that pairs with the email default (D4). The provider abstraction (`IEmailSender` / `ISmsSender` / future `IPushSender`) is preserved; per-tenant and per-PDR overrides remain allowed but discouraged (D5). The ADR introduces **no new Grid-wide invariants** (§Consequences / Invariants is explicit on that point — only conventions enforced at packet authoring / review).
+
+The initiative ships, in **9 packets across 4 waves**, targeting **2 repos** (`HoneyDrunk.Architecture`, `HoneyDrunk.Notify`):
+
+1. **Packet 00** — ADR acceptance (status flip, README index row, initiative registration, ADR amendment to D3 — see "Required ADR Amendment" below).
+2. **Packet 01** — Email production hardening of the existing `HoneyDrunk.Notify.Providers.Email.Resend` package (Resend is already the wired Email provider but the ADR-0073 wiring obligations — webhook intake per ADR-0062, DKIM/SPF/DMARC handoff per ADR-0038, Tier-2 rotation per ADR-0006 — are not all in place). **Version-bumping packet for Notify** (rolls existing `[Unreleased]` into `[0.3.1]`).
+3. **Packet 02** — Sender-identity wiring confirmation in Architecture — cross-references ADR-0038's DKIM/SPF/DMARC discipline from `repos/HoneyDrunk.Notify/overview.md` (not duplicating ADR-0038's work; pointing at it).
+4. **Packet 03 — DEFERRED** — `@honeydrunk/notify-templates` polyglot npm-templates standup placeholder. Records the deferral; no code ships. The canonical react-email template set's standup gets its own ADR; this packet creates the deferral document.
+5. **Packet 04** — SMS production hardening of the existing `HoneyDrunk.Notify.Providers.Sms.Twilio` package (D2 wiring obligations parallel to packet 01 — webhook intake, Tier-2 rotation; tentative-commitment note recorded in package README and in repo overview).
+6. **Packet 05** — Notify Cloud per-tenant override policy specification — handoff to ADR-0027 standup (Notify Cloud repo does not yet exist; this initiative authors the spec in Architecture's `business/context/`).
+7. **Packet 06** — Push — `IPushSender` contract in `HoneyDrunk.Notify.Abstractions` + `NotificationChannel.Push = 2` enum addition. **Version-bumping packet to `0.4.0`.** **Provider-package naming uses channel-scoping** (`Providers.Push.Expo`, parallel to the existing `Providers.Email.Resend` / `Providers.Sms.Twilio`) — this reconciles a naming mismatch in ADR-0073 D3. **Packet 00 amends D3 to channel-scoped naming** so the package shipped in packet 07 matches the rest of the Grid.
+8. **Packet 07** — Ship `HoneyDrunk.Notify.Providers.Push.Expo` package implementing `IPushSender` against Expo's Push API. Vault-backed Expo Access Token. Captures Expo ticket-IDs for packet 08's receipts poll.
+9. **Packet 08** — Expo Push Receipts poll-and-intake seam in `HoneyDrunk.Notify.Worker` + minimal `PushTokenRegistration` record in Abstractions for consumer-PDR token registration.
+
+**9 packets total. All `Actor=Agent`, 0 `Actor=Human`.** No `human-only` label. Some packets carry Human Prerequisites (vault secrets for Resend/Twilio/Expo, DKIM record creation, Expo project creation) but the code work itself is delegable.
+
+## Trigger
+
+ADR-0073 is Proposed with no execution scope. Forcing functions from the ADR's Context:
+
+- **Notify Cloud GA (PDR-0002, ADR-0027)** needs a production-grade email provider day one and a production-grade SMS provider when the first tenant requests SMS sends.
+- **Identity verification flows (ADR-0060 Phase 2)** route verification emails through Communications → Notify with Resend underneath.
+- **Consumer-app PDRs (PDR-0003 Lately, PDR-0005 Hearth, PDR-0006 Currents, PDR-0008 Curiosities)** all require push notifications. Per ADR-0070 D3 the mobile platform is React Native + Expo; Expo's push pipeline is the natural alignment.
+- Without canonical defaults, every consumer PDR re-derives the provider choice (the wrong shape per ADR-0019 — provider selection is a Notify concern, not a Communications-consumer concern).
+
+## Scope Detection
+
+**Multi-repo, two repos.** All code work lands in `HoneyDrunk.Notify` (the affected Node per ADR-0073 §Consequences / Affected Nodes). Governance, override-policy doc, npm-templates standup deferral, and ADR amendment land in `HoneyDrunk.Architecture`.
+
+**No new Grid-wide invariants.** ADR-0073 §Consequences / Invariants is explicit:
+
+> No new Grid-wide invariants introduced. Conventions enforced at packet authoring and review.
+
+This initiative does **not** edit `constitution/invariants.md` and does **not** reserve a number from the pre-allocated batch.
+
+**No new Node-to-Node edges in `catalogs/relationships.json`.** Resend, Twilio, Expo are external SaaS vendors, not HoneyDrunk Nodes. Provider packages are additive to Notify's existing `packages` list.
+
+**No new abstractions in `HoneyDrunk.Kernel.Abstractions`.** All contracts (`IEmailSender`, `ISmsSender`, new `IPushSender`) live in `HoneyDrunk.Notify.Abstractions`.
+
+## Required ADR Amendment — D3 provider-package naming
+
+ADR-0073 D3 names the push package `HoneyDrunk.Notify.Providers.Expo`. The Grid's existing per-channel provider naming (already in `HoneyDrunk.Notify/`) uses **channel-scoped** naming:
+
+- `HoneyDrunk.Notify.Providers.Email.Resend` (exists today)
+- `HoneyDrunk.Notify.Providers.Email.Smtp` (exists today)
+- `HoneyDrunk.Notify.Providers.Sms.Twilio` (exists today)
+
+The ADR's D3 phrasing is inconsistent with this established pattern. Packet 00 reconciles by amending D3 to `HoneyDrunk.Notify.Providers.Push.Expo` — channel-scoped, parallel to email/sms. The ADR's D1 (`HoneyDrunk.Notify.Providers.Resend`) and D2 (`HoneyDrunk.Notify.Providers.Twilio`) descriptive phrasings are similarly unscoped, but those packages already ship under their channel-scoped names — the existing names take precedence and the ADR's description is informally aligned without an explicit amendment line.
+
+The amendment to D3 is the only structural correction. Packet 00 lands it during ADR acceptance.
+
+## Required Decision — `@honeydrunk/notify-templates` npm package standup
+
+ADR-0073 D4 commits **react-email** as the canonical email-templating library and pins the canonical template set's home as `HoneyDrunk.Notify.Templates` (mentioned by name in §Consequences / Affected Nodes). The challenge: react-email is a TypeScript/JSX library that lives in the npm ecosystem; `HoneyDrunk.Notify` is a .NET repo. The canonical template set is therefore an **npm package living inside a .NET repo** (a polyglot package — react-email source in `templates/`, rendered HTML output potentially consumed by .NET via a sibling .NET library or via build-time HTML emission).
+
+The packaging shape, build pipeline, publish destination (npmjs.org under `@honeydrunk` scope per ADR-0034 patterns), and consumer-PDR template extension model are **non-trivial decisions** that warrant their own standup ADR — the same way `HoneyDrunk.Cache` got an ADR-0059 standup paired with ADR-0058's contract decision. Per the user's standing convention ("new-Node scaffolding gets its own standup ADR; don't bundle scaffold into feature packets"), packet 03 in this initiative is **deferred** with a placeholder until the standup ADR (provisionally `ADR-0073a-notify-templates-npm-standup`) is drafted and accepted.
+
+Until the standup ADR lands, the canonical react-email template set does not ship. Email sends route through Resend with consumer-side HTML composed however the consuming Node already does it (today: Notify's existing template renderer; the canonical react-email set is a Phase-2 ergonomic improvement, not a runtime prerequisite).
+
+**Packet 03 documents the deferral and the open questions** that the future standup ADR must answer. Packet 03 ships even though it ships no code — its purpose is to record the deferral on The Hive so the work is not lost.
+
+## Wave Diagram
+
+### Wave 1 (Governance — no dependencies)
+- [ ] **00** — Architecture: accept ADR-0073 (status flip + README index row + initiative registration); amend D3 to channel-scoped `Providers.Push.Expo` naming; record the `@honeydrunk/notify-templates` npm-standup deferral as a Required Decision. **No invariant edits.** `Actor=Agent`.
+
+### Wave 2 (Notify production-hardening — code, parallel within wave; runs after governance)
+- [ ] **01** — Notify: Resend email provider production hardening — webhook intake per ADR-0062, Tier-2 rotation registration per ADR-0006, sender-identity README cross-reference to ADR-0038. **First packet on Notify in this initiative — rolls existing `[Unreleased]` content into a dated patch-bump section and bumps from `0.3.0` → `0.3.1`.** `Actor=Agent`. Blocked by: 00.
+- [ ] **04** — Notify: Twilio SMS provider production hardening — webhook intake per ADR-0062, Tier-2 rotation registration per ADR-0006, tentative-commitment note recorded in package README and Notify repo overview (`repos/HoneyDrunk.Notify/overview.md`). `Actor=Agent`. Blocked by: 00, 01.
+
+### Wave 3 (Architecture documentation — runs after governance; parallel within wave)
+- [ ] **02** — Architecture: ADR-0038 sender-identity wiring cross-reference confirmation — verify the discipline is documented on the Notify side; add a one-paragraph cross-reference to `repos/HoneyDrunk.Notify/overview.md` and to the Resend provider README. **No new policy** — this packet just makes the existing ADR-0038 rules visible at the package boundary. `Actor=Agent`. Blocked by: 00.
+- [ ] **03** — Architecture: `@honeydrunk/notify-templates` npm-templates standup deferral — placeholder ADR/standup intent recorded as a packet in this initiative; **no code ships**. Documents the open questions, deferral rationale, and the expected shape of the future standup ADR. `Actor=Agent`. Blocked by: 00. **DEFERRED — does not ship code; serves as the "deferred work" tracker on The Hive.**
+- [ ] **05** — Architecture: Notify Cloud per-tenant provider-override policy specification — author the canonical doc at `business/context/notify-cloud-tenant-override-policy.md` describing the UI + validation + fallback semantics for Notify Cloud tenants who bring their own Resend / Twilio / Expo credentials. `Actor=Agent`. Blocked by: 00. **Handoff to the ADR-0027 (Notify Cloud) standup initiative; no Notify Cloud repo work filed here.**
+
+### Wave 4 (Notify push channel — adds new contract + enum + package; depends on production-hardening waves only via the version sequencing rule)
+- [ ] **06** — Notify: add `NotificationChannel.Push = 2` to the enum + add `IPushSender` contract to `HoneyDrunk.Notify.Abstractions`. **Version-bumping packet for the Notify solution from `0.3.x` → `0.4.0`** (additive new enum value + new public abstraction is a minor bump per ADR-0035 D1). `Actor=Agent`. Blocked by: 00, 01.
+- [ ] **07** — Notify: ship `HoneyDrunk.Notify.Providers.Push.Expo` package implementing `IPushSender` against Expo's Push API + Expo Push Receipts polling for delivery confirmation. Vault-backed Expo Access Token. Appends to the in-progress `[0.4.0]` CHANGELOG entry. `Actor=Agent`. Blocked by: 06.
+- [ ] **08** — Notify: register Expo Push Token capture flow placeholder in `HoneyDrunk.Notify.Abstractions` — minimal `PushTokenRegistration` record + the receipts-poll background-worker hook in `HoneyDrunk.Notify.Worker`. The user-side registration UI lives in consumer-PDRs (out of scope here); this packet ships the Notify-side intake seam only. Appends to the in-progress `[0.4.0]` CHANGELOG. `Actor=Agent`. Blocked by: 06, 07.
+
+Packets within a wave run in parallel where dependencies allow. The exception: Wave 4 packets (06, 07, 08) share the Notify solution and must sequence — 06 is the bumping packet (adds enum + contract); 07 ships the package; 08 ships the receipts-poll seam.
+
+## Packet Links
+
+| # | Packet | Repo | Actor | Wave | Blocked by |
+|---|--------|------|-------|------|-----------|
+| 00 | [Accept ADR-0073 — amend D3 naming + record npm-templates deferral](./00-architecture-adr-0073-acceptance.md) | Architecture | Agent | 1 | — |
+| 01 | [Resend email provider production hardening (0.3.1 bump)](./01-notify-resend-production-hardening.md) | Notify | Agent | 2 | 00 |
+| 02 | [ADR-0038 sender-identity cross-reference in Notify](./02-architecture-sender-identity-cross-reference.md) | Architecture | Agent | 3 | 00 |
+| 03 | [DEFERRED — `@honeydrunk/notify-templates` npm-standup placeholder](./03-architecture-notify-templates-npm-deferral.md) | Architecture | Agent | 3 | 00 |
+| 04 | [Twilio SMS provider production hardening (tentative-commitment note)](./04-notify-twilio-production-hardening.md) | Notify | Agent | 2 | 00, 01 |
+| 05 | [Notify Cloud per-tenant override policy specification](./05-architecture-notify-cloud-override-policy.md) | Architecture | Agent | 3 | 00 |
+| 06 | [Add `NotificationChannel.Push = 2` + `IPushSender` (0.4.0 bump)](./06-notify-push-channel-and-contract.md) | Notify | Agent | 4 | 00, 01 |
+| 07 | [Ship `HoneyDrunk.Notify.Providers.Push.Expo` package](./07-notify-expo-push-provider.md) | Notify | Agent | 4 | 06 |
+| 08 | [Expo Push Receipts intake seam in Notify.Worker](./08-notify-expo-push-receipts-worker.md) | Notify | Agent | 4 | 06, 07 |
+
+## Version Bumps
+
+- **`HoneyDrunk.Notify`** — multi-packet, multi-wave. Per invariant 27, the first packet bumps and subsequent packets append.
+  - **Packet 01 (Resend production hardening)** is the first packet on the Notify solution in this initiative. It must **roll the existing `[Unreleased]` CHANGELOG content into a dated patch-bump section** (per the standing rule "no commits under CHANGELOG `Unreleased`"). The accrued `[Unreleased]` content (per `CHANGELOG.md`: ADR-0044 Grid Review enablement + HoneyDrunk.Standards 0.2.9 refresh) is bundled into a dated `[0.3.1]` section together with the Resend production-hardening changes. Solution bumps from `0.3.0` to `0.3.1` (patch — bugfix/hardening, no new public surface). Per-package CHANGELOG entries only for packages with actual functional change (per invariant 12): repo-level + `HoneyDrunk.Notify.Providers.Email.Resend`. The repo's other 14 packages get the version alignment via their `.csproj` files and get **no** per-package CHANGELOG entries (alignment-bump-only; no noise).
+  - **Packet 04 (Twilio production hardening)** appends to the in-progress `[0.3.1]` repo-level entry; adds a per-package entry to `HoneyDrunk.Notify.Providers.Sms.Twilio` for the production-hardening changes; no version bump (already at `0.3.1`).
+  - **Packet 06 (push channel + contract)** is the bumping packet for the minor bump `0.3.1` → `0.4.0` (additive new enum value + new public `IPushSender` contract is a minor per ADR-0035 D1). Per-package CHANGELOG entry added to `HoneyDrunk.Notify.Abstractions`; alignment bumps on all other packages with no noise.
+  - **Packet 07 (Expo provider)** creates a **new package** `HoneyDrunk.Notify.Providers.Push.Expo` with its own `[0.4.0]` CHANGELOG and README from the first commit (invariant 12). Appends to the in-progress repo-level `[0.4.0]` entry.
+  - **Packet 08 (receipts seam)** appends to the in-progress `[0.4.0]` entry; adds per-package entries to `HoneyDrunk.Notify.Abstractions` (the `PushTokenRegistration` record) and `HoneyDrunk.Notify.Worker` (the receipts-poll hook).
+- **`HoneyDrunk.Architecture`** — not a versioned .NET solution. Governance, doc, and ADR-amendment edits across packets 00, 02, 03, 05.
+
+## Cross-Cutting Concerns
+
+### Pre-existing test project naming — `HoneyDrunk.Notify.Tests` is acknowledged but not renamed here
+
+ADR-0047 D1 / D11 commit the canonical test project naming `*.Tests.Unit` (with `*.Tests.Integration` and `*.Tests.E2E` for the higher tiers). The Notify repo currently has `HoneyDrunk.Notify.Tests` (pre-ADR-0047 naming) and `HoneyDrunk.Notify.IntegrationTests`. Renaming to `*.Tests.Unit` / `*.Tests.Integration` is a **separate ADR-0047 fan-out follow-up** tracked under the existing `adr-0047-testing-patterns-and-tooling` initiative — not gated by this initiative. ADR-0073 packets add tests to the existing project names; the future ADR-0047 fan-out renames them once.
+
+### `NotificationChannel.Push = 2` is the seam
+
+Packet 06 adds `NotificationChannel.Push = 2` to the enum at `HoneyDrunk.Notify.Abstractions/NotificationChannel.cs`. `NotificationSenderResolver` (in `HoneyDrunk.Notify/Routing/NotificationSenderResolver.cs`) routes via keyed DI on the enum value, so no resolver change is needed — registering the Expo provider with `services.AddKeyedSingleton<INotificationSender>(NotificationChannel.Push, ...)` (or, more accurately, via the `TryAddNotificationSender<T>(NotificationChannel.Push)` provider-support helper, parallel to `AddHoneyDrunkNotifyResendProvider`) wires it in. `NotificationDispatcher.DispatchAsync` already reads `envelope.Channel` and delegates to the resolver — no dispatcher change needed.
+
+The new enum value is **additive** at the public surface; existing consumers that exhaustively switch on `NotificationChannel` will get a compiler warning but no break (the enum is not `[Flags]`, and analyzers will surface missing arms). This is a **minor** version bump per ADR-0035 D1.
+
+### Provider naming reconciliation
+
+The ADR D3 text uses `HoneyDrunk.Notify.Providers.Expo`. The Grid's actual code uses **channel-scoped** naming: `Providers.Email.Resend`, `Providers.Sms.Twilio`. Packet 00 amends D3 to `HoneyDrunk.Notify.Providers.Push.Expo` to match. Packet 07 ships under the channel-scoped name. The D1/D2 phrasings in the ADR are similarly informal (`HoneyDrunk.Notify.Providers.Resend`, `HoneyDrunk.Notify.Providers.Twilio`) but the existing packages already ship under their channel-scoped names; the ADR description is not authoritative against shipped code.
+
+### Sender-identity discipline lives in ADR-0038, not here
+
+ADR-0073 D1 / D6 commit Resend as the email provider but **explicitly defer sender identity to ADR-0038**. This initiative does **not** ship DKIM record creation, SPF record creation, DMARC policy authoring, or the subdomain-split work — those are ADR-0038's deliverables. This initiative's packet 02 cross-references ADR-0038 from the Notify side so a future operator finds the discipline; packet 02 ships docs only.
+
+### Webhook intake discipline lives in ADR-0062, not here
+
+ADR-0073 D1 / D2 commit webhook-driven deliverability events from Resend (D1) and Twilio (D2) into Notify's intake **per ADR-0062's verification discipline**. Packets 01 and 04 wire the webhook handlers using ADR-0062's contracts; they do not redefine the verification model.
+
+### Tier-2 secret rotation lives in ADR-0006 + HoneyDrunk.Vault.Rotation
+
+ADR-0073 D1 / D2 mandate rotation per ADR-0006 Tier 2. Packets 01 and 04 register the Resend / Twilio credentials with the Vault.Rotation Function App's rotation calendar (operational config registration — not new code in Vault.Rotation; the rotation infrastructure already exists per the `vault-rotation-bring-up` initiative). Expo Access Token rotation (packet 07) follows the same pattern.
+
+### Notify Cloud per-tenant override is deferred to ADR-0027
+
+ADR-0073 D5 commits the per-tenant override seam but does not ship the UI / validation / fallback semantics — those are Notify Cloud-internal concerns per the ADR's §D6 Out of Scope ("Tenant-BYO provider tooling"). Packet 05 authors the canonical specification at `business/context/notify-cloud-tenant-override-policy.md`; the actual Notify Cloud implementation packet is filed under the `adr-0027-notify-cloud-standup` initiative after Notify Cloud's repo scaffold packet lands.
+
+### Repos public-by-default per the user's standing rule
+
+The `HoneyDrunk.Notify` repo is **public**. No secrets, no env-specific identifiers, no Vault URIs in packet content. Vault secret **names** (e.g. `Resend--ApiKey`, `Twilio--AccountSid`, `Expo--AccessToken`) are non-secret identifiers and may appear in code and docs; the **values** never appear anywhere outside Vault.
+
+### Site sync
+
+No site-sync flag. ADR-0073 is internal Ops infrastructure; the Studios website does not change. The Notify Cloud override-policy doc (packet 05) ships in Architecture's `business/context/`, not on the public website.
+
+### Deferred follow-ups (explicitly out of scope of this initiative)
+
+- **`HoneyDrunk.Notify.Templates` npm package standup ADR** — packet 03 records the deferral. A future standup ADR (provisionally `ADR-0073a` or a numbered sibling) decides the polyglot-package shape, build pipeline, npm publish destination, and consumer-PDR extension model. Until then, react-email is the committed library but the canonical template set does not ship.
+- **Migrating or retiring the legacy SendGrid adapter sketch.** ADR-0073 §Follow-up Work mentions this. No SendGrid adapter ships in `HoneyDrunk.Notify` today (the package directory listing shows `Providers.Email.Smtp` and `Providers.Email.Resend` only — no `Providers.Email.SendGrid`). The follow-up is a no-op; nothing to migrate or retire.
+- **Identity verification-email flow on Resend** (ADR-0060 Phase 2). Filed under the `adr-0060-identity-standup` initiative. This initiative ships the Resend production-hardening that Identity's flow consumes, but the Identity-side flow itself is not here.
+- **Test project rename `Notify.Tests` → `Notify.Tests.Unit`.** Filed under `adr-0047-testing-patterns-and-tooling`. Not gated here.
+- **D2 cost-trigger re-evaluation for Twilio.** Operational follow-up; happens when monthly SMS spend > $200 (or per the other D2 triggers). Tracked outside this initiative.
+- **Per-region provider variation** (D6). Deferred to a future EU-tenant requirement.
+- **Bounce / complaint policy** (D6). Lives in Communications, not Notify; filed under a future Communications initiative.
+
+## Rollback Plan
+
+- **Packet 00 (governance):** revert the PR. ADR returns to Proposed; D3 naming reverts to `HoneyDrunk.Notify.Providers.Expo`; README index row is removed; initiative registration is removed. No runtime impact.
+- **Packet 01 (Resend hardening):** revert the PR. Resend webhook intake reverts; the Tier-2 rotation registration reverts; the existing send path is unchanged (Resend has shipped since 0.1.0). The `[0.3.1]` CHANGELOG entry returns to `[Unreleased]` — note that the standing rule forbids leaving accrued work in `[Unreleased]` long-term, so a follow-up patch-bump must promote the content again.
+- **Packet 02 (sender-identity cross-reference):** revert the PR. The Resend README and Notify overview lose the ADR-0038 callouts. No runtime impact.
+- **Packet 03 (npm-templates deferral):** revert the PR. The deferral document is removed; the open questions return to the dispatch-plan body. No runtime impact.
+- **Packet 04 (Twilio hardening):** revert the PR. Twilio webhook intake and Tier-2 rotation registration revert; tentative-commitment note is removed.
+- **Packet 05 (Notify Cloud override policy):** revert the PR. The specification doc is removed from `business/context/`. The deferred Notify Cloud follow-up is unaffected at the runtime level; only the reference document is gone.
+- **Packet 06 (push channel + contract):** revert the PR. `NotificationChannel.Push = 2` is removed; `IPushSender` is removed. Notify rolls back to `0.3.1`. No consuming Node depends on `Push` at runtime (packet 07 was the first consumer); reverting 06 forces reverting 07 and 08 together.
+- **Packets 07 / 08 (Expo provider + receipts seam):** revert the two PRs. The Expo provider package is unpublished; the receipts-poll hook is removed from the Worker. Mobile apps that have already registered Expo Push Tokens see no sends — the seam is gone — but the Expo Push Tokens themselves are unaffected on Expo's side; a future re-introduction can resume.
+- **Operational escape hatch:** at any point, the operator can drop a provider registration (remove `AddHoneyDrunkNotifyResendProvider()` / `AddHoneyDrunkNotifyTwilioProvider()` / `AddHoneyDrunkNotifyExpoProvider()` from the host composition) to disable that channel. The Notify dispatcher will fail any envelope routed to a disabled channel with a `Permanent` failure ("no provider registered for channel X"), which is the existing behaviour today.
+
+## Filing
+
+Filing is automated. On push to `main`, `file-packets.yml` in `HoneyDrunk.Architecture` files every packet in this folder as a GitHub issue in its `target_repo`, adds it to The Hive (project #4), sets the board fields from frontmatter, and wires `addBlockedBy` edges from the `dependencies:` arrays. No manual `gh issue create`.


### PR DESCRIPTION
## Summary

- Tenth of the staged PRs from the 2026-05-23 ADR batch (re-scoped after the original local packet folders were cleaned). Governance-only — no code lands in any Node.
- Three external-surface ADRs: ADR-0057 (REST + URL-path-prefix versioning + OpenAPI 3.1 substrate + SDK publish for TypeScript/Swift/Kotlin), ADR-0064 (HoneyDrunk.Prompts file-system registry + IPromptResolver contract + prompt-tuple audit emit), ADR-0073 (Resend + Twilio production hardening + Expo Push channel + polyglot npm templates deferred).

## Validation

- Markdown + JSON only; no code changed.
- file-packets.yml will file 30 packet files on merge — verify in The Hive.
- Cross-ADR amendments already in place: ADR-0057 D11/D12/D15 reconciled with ADR-0067 + ADR-0075 in #288.

## Authorship

Authorship: agent-claude-code

## Notes

- This PR is out-of-band per ADR-0011 D9 / invariant 32 — ships packet files but doesn't execute any single packet.
- ADR-0064 uses the Restricted tier name per ADR-0049 D1 (not Sensitive — that's a PII sub-classification). Audit emit is tuple-only (id, version, hash, bypass flag); no rendered prompt body, no completion text.
- ADR-0064 packet 00 surfaces a Required Decision on invariant 44 conflict (HoneyDrunk.Prompts.Abstractions as new AI-sector dependency); resolution narrowed in packet 01.
- ADR-0073 packet 06 adds NotificationChannel.Push = 2 (currently the enum only has Email and Sms). NotificationSenderResolver / NotificationDispatcher verified channel-agnostic — no dispatcher changes needed.
- ADR-0073 packet 03 defers @honeydrunk/notify-templates polyglot npm package to its own standup ADR (Required Decision in packet 00); the deferral document is at generated/deferred-work/.
- ADR-0073 packet 00 carries the D3 naming amendment (HoneyDrunk.Notify.Providers.Push.Expo channel-scoped pattern, not ADR D3's literal text).