### PR TITLE
Scope ADR-0071/0076/0078 backed-by companion ADRs

### DIFF
--- a/generated/issue-packets/active/adr-0071-web-ui-standup/01-architecture-web-ui-catalog-registration.md
+++ b/generated/issue-packets/active/adr-0071-web-ui-standup/01-architecture-web-ui-catalog-registration.md
@@ -1,0 +1,698 @@
+---
+name: Architecture Catalog Registration
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "web-ui", "adr-0071"]
+dependencies: []
+adrs: ["ADR-0071"]
+accepts: ADR-0071
+wave: 1
+initiative: adr-0071-web-ui-standup
+node: honeydrunk-web-ui
+---
+
+# Chore: Register HoneyDrunk.Web.UI's standup decisions in Architecture catalogs
+
+## Summary
+Land the catalog and reference-doc surface for `HoneyDrunk.Web.UI` per ADR-0071's "If Accepted — Required Follow-Up Work" checklist. Add the new Creator-sector Node to every catalog file (`nodes.json`, `relationships.json`, `grid-health.json`, `modules.json`, `contracts.json`), anchor the Creator-sector in `constitution/sectors.md`, add the Q2 2026 roadmap bullet, add an in-progress entry to `initiatives/active-initiatives.md`, capture Studios' informal token inventory into a new context-folder file (`studios-tokens-inventory.md`) for packet 04's reference, and create the `repos/HoneyDrunk.Web.UI/` context folder (`overview.md`, `boundaries.md`, `invariants.md`, `integration-points.md`) matching the template used by `repos/HoneyDrunk.Studios/` and `repos/HoneyDrunk.Audit/`.
+
+ADR-0071 stays at `Status: Proposed` for this packet — the Status flip is a separate post-merge housekeeping step the scope agent handles after the entire initiative completes, per the user's standing ADR acceptance workflow. This packet's body does not edit the ADR header.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+ADR-0071 establishes the `HoneyDrunk.Web.UI` Node's sector and purpose (D1, D2), its anchor role for the empty Creator sector (D2), the Studios-consumes-Web.UI inversion (D3), the per-stack component strategy (D4), the phased shipping plan (D5), the per-stack package layout (D6), the semver discipline (D7), the explicit boundaries (D8), the runtime-dependency posture (D9), the charter sanity check (D10), and the relationships to ADR-0070 / ADR-0027 / ADR-0035 / ADR-0039 (D11). None of that has reached the canonical catalogs yet. Until it does, every downstream consumer (Studios as the first consumer, Notify Cloud's Blazor admin, all four queued consumer-app PDRs Hearth/Lately/Currents/Curiosities) reads stale metadata when scoping its own work, and the scaffold packet (packet 04 of this initiative) has nothing to anchor its `node:` frontmatter or its in-Architecture context-folder cross-references against.
+
+Eight catalog/doc surfaces drift today:
+
+1. **`catalogs/nodes.json`** carries no `honeydrunk-web-ui` entry. The Creator sector currently has zero Nodes; Web.UI is the anchor that gives the sector live identity.
+2. **`catalogs/relationships.json`** has no `honeydrunk-web-ui` block. The new edges (consumes nothing at runtime per D9; `consumed_by_planned` includes Studios, Notify Cloud admin, and the four PDR-driven consumer apps) need to land in lockstep with the Node entry. Also: `honeydrunk-studios.consumes_planned` gains `honeydrunk-web-ui` because Studios is the first named consumer per D3.
+3. **`catalogs/grid-health.json`** has no Web.UI row. Stand-up state is empty (no `0.1.0` yet, no npm packages published, scaffold packet pending) — the row must reflect that honestly.
+4. **`catalogs/modules.json`** has no Web.UI package entries. ADR-0071 D6 commits five packages on the initial surface (`@honeydrunk/web-ui-tokens`, `@honeydrunk/web-ui-css`, `@honeydrunk/web-ui-react`, `HoneyDrunk.Web.UI.Blazor` deferred, `@honeydrunk/web-ui-native` deferred). Two ship at v0.1.0 (tokens + CSS per D5 Phase 1); three are placeholders awaiting Phase 2/3/4 demand. All five need module entries at version 0.0.0 pre-scaffold.
+5. **`catalogs/contracts.json`** has no Web.UI contracts block. The shipped tokens schema (color, spacing, typography, radii, shadows, motion, breakpoints, z-index) plus the primitive-CSS class taxonomy need registration with `status: seed` so downstream Nodes can find the canonical surface.
+6. **`constitution/sectors.md`** Creator-sector text reads "No real Nodes yet. Planned: HoneyDrunk.Signal, Forge." Web.UI must replace that placeholder as the anchor row and update the Creator-sector text accordingly.
+7. **`infrastructure/reference/tech-stack.md`** has no Web.UI entry — but the canonical npm/CSS/React substrate doesn't fit the existing "Backend" / "Azure SDK" sections cleanly. The Frontend section (under `## Frontend` if present, else added under a new section) gains Web.UI rows.
+8. **`initiatives/roadmap.md`** and **`initiatives/active-initiatives.md`** have no Web.UI entries. The Q2 2026 (Apr–Jun) section is where this Node lives, given the Studios-first-consumer driver and the queued PDR-0005 Hearth.
+
+The `repos/HoneyDrunk.Web.UI/` context folder does not exist on disk — confirmed by `ls repos/` showing the sibling folders (`HoneyDrunk.Audit/`, `HoneyDrunk.Studios/`, `HoneyDrunk.Communications/`, etc.) but no `HoneyDrunk.Web.UI/`. This packet creates it with the four standard files matching the Studios template's shape (the closest analog because both are JS-shaped Nodes), plus a fifth file `studios-tokens-inventory.md` that captures the informal tokens Studios uses today so packet 04's scaffolding agent has a concrete starting point for the first `@honeydrunk/web-ui-tokens` release.
+
+The ADR Status flip (Proposed → Accepted) is intentionally **not** in this packet. Per the user's standing ADR acceptance workflow (`feedback_adr_workflow.md`), the scope agent flips Status only after the entire initiative's PRs have merged. This is a separate post-merge housekeeping step that runs after packets 01 / 02 / 03 / 04 are all closed — not a line-edit on this packet.
+
+## Proposed Implementation
+
+### `catalogs/nodes.json` — new `honeydrunk-web-ui` entry
+
+**Anchor semantically, not by line number.** Find the `honeydrunk-studios` block via `rg -n '"id": "honeydrunk-studios"' catalogs/nodes.json` at edit time and insert the new `honeydrunk-web-ui` block adjacent to it (Studios is the closest analog — both Meta/Creator-adjacent, both JS-shaped). Do not rely on the line numbers cited anywhere in this packet; treat them as scoping-time hints only and re-confirm by grep at edit time.
+
+The new block follows the same schema every other Node uses (see `honeydrunk-studios` and `honeydrunk-audit` for shape reference).
+
+**Cluster value note:** Use `cluster: "visualization"` — matches the Studios precedent (Studios is `cluster: "visualization"` in the current `nodes.json`). The allowed cluster values in the existing taxonomy are: `foundation`, `security`, `observability`, `infrastructure`, `orchestration`, `governance`, `visualization`, `cognition`, `quality`, `knowledge`. `frontend` is **not** in the taxonomy and would invent a new cluster. `visualization` is the closest semantic match (design substrate that powers visual surfaces) and aligns with Studios' classification.
+
+```json
+{
+  "id": "honeydrunk-web-ui",
+  "type": "node",
+  "name": "HoneyDrunk.Web.UI",
+  "public_name": "HoneyDrunk.Web.UI",
+  "short": "Cross-stack design system — tokens, primitive CSS, component contracts",
+  "description": "The Creator sector's design substrate Node. Owns design tokens (color, spacing, typography, radii, shadows, motion, breakpoints), primitive CSS (reset, base typography, utility classes), and component contracts (design specifications) shared across React, Blazor, and React Native consumers. Tokens cross-stack; components per-stack. Pure client-side substrate — no runtime dependency on any Grid Node.",
+  "sector": "Creator",
+  "signal": "Seed",
+  "cluster": "visualization",
+  "energy": 0,
+  "priority": 0,
+  "flow": 0,
+  "tags": ["design-system", "tokens", "css", "react", "blazor", "react-native", "frontend-substrate", "creator-sector-anchor"],
+  "links": {
+    "repo": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.UI"
+  },
+  "long_description": {
+    "overview": "HoneyDrunk.Web.UI is the Creator sector's single Node that owns the Grid's design substrate — tokens, primitive CSS, and component contracts consumed by every frontend surface in the Grid. It is the cross-stack reconciliation point for the three-stack split committed by the paired frontend-platform ADR: React for consumer web, Blazor for simple admin, React Native + Expo for mobile. Tokens are shared (one JSON + CSS-variables source consumed identically by every stack); primitive CSS is shared across web stacks (React + Blazor); components ship per-stack (React first-class, Blazor and RN added per surface demand). The boundary is named at standup; the Node ships tokens + primitive CSS at Phase 1 with Studios as the first consumer.",
+    "why_it_exists": "Every consumer surface in the Grid was re-deriving its visual language. Studios had informal tokens; Notify Cloud admin would have invented its own; each of the four queued consumer-app PDRs (Hearth, Lately, Currents, Curiosities) implied a separate per-PDR design tax. Without a shared substrate Node, the design tax compounded with every new surface and brand recognizability degraded per product. Web.UI exists so cross-PDR design coherence becomes the default and every consumer inherits the Grid's visual language without re-deriving it.",
+    "primary_audience": "Every Grid consumer frontend that renders a user-facing surface — HoneyDrunk.Studios (first consumer at Phase 1), HoneyDrunk.Notify.Cloud (Blazor admin at Phase 2; tokens + CSS only), and the four PDR-driven consumer apps (PDR-0003 Lately, PDR-0005 Hearth, PDR-0006 Currents, PDR-0008 Curiosities — each from its first scaffolding packet).",
+    "value_props": [
+      "Single Grid Node owns design tokens — color, spacing, typography, radii, shadows, motion, breakpoints, z-index",
+      "Tokens stack-agnostic (JSON + CSS variables) — consumed identically by React, Blazor, and React Native",
+      "Primitive CSS bundle (reset + base typography + utility classes) shared across web stacks",
+      "Component contracts (design specs) shared; per-stack implementations preserved (React first-class, Blazor and RN per demand)",
+      "Pure client-side substrate — no runtime dependency on any Grid Node, no Kernel coupling",
+      "Studios-consumes-Web.UI inversion — Web.UI is not folded into Studios; substrate is upstream of every product",
+      "Per-PDR CSS-variable overrides permitted — consumers diverge where their brand needs it while inheriting the baseline",
+      "Cross-stack brand coherence compounds — every new consumer surface inherits the Grid's visual language"
+    ],
+    "monetization_signal": "Internal-first design substrate. The investment compounds with every consumer PDR that consumes Web.UI on day one instead of paying its own per-surface design tax. Future open-source surface possible once the token + component pack stabilizes.",
+    "roadmap_focus": "Phase 1 — stand up the monorepo, publish @honeydrunk/web-ui-tokens and @honeydrunk/web-ui-css at 0.1.x with Studios' existing tokens formalized. Phase 2 — ship @honeydrunk/web-ui-react component pack (Button, Input, Label, Card, Modal, Toast, Alert, Spinner, Skeleton) at first non-Studios consumer demand. Phase 3 — HoneyDrunk.Web.UI.Blazor components per Notify Cloud admin demand. Phase 4 — @honeydrunk/web-ui-native at first mobile PDR. Phase 5 — designer-tooling integration (Figma / Penpot) when designer joins.",
+    "grid_relationship": "Does NOT depend on any runtime Grid Node — pure client-side substrate. No Kernel, Vault, Auth, Data, Transport, Audit, or Pulse reference at v1. The dependency direction is one-way: consumer → Web.UI, never the inverse. Consumed (planned) by Studios (first consumer at Phase 1), Notify.Cloud (Blazor admin at Phase 2 with tokens + CSS only), and PDR-driven consumer apps from their first scaffolding packet.",
+    "integration_depth": "shallow",
+    "demo_path": "Open Studios → observe tokens consumed from @honeydrunk/web-ui-tokens (CSS variables on :root) → inspect primitive class names from @honeydrunk/web-ui-css → see consistent button/card/modal shapes across surfaces.",
+    "signal_quote": "The Grid has a face.",
+    "stability_tier": "seed",
+    "impact_vector": "frontend coherence"
+  },
+  "foundational": false,
+  "strategy_base": 12,
+  "tier": "none",
+  "time_pressure": 1,
+  "done": false,
+  "cooldown_days": 14
+},
+```
+
+### `catalogs/relationships.json` — new `honeydrunk-web-ui` block
+
+**Anchor semantically, not by line number.** Add a new entry to the `nodes` array, placed adjacent to the `honeydrunk-studios` entry (closest analog). Find the current position via `rg -n '"id": "honeydrunk-studios"' catalogs/relationships.json` at edit time. Also amend the existing `honeydrunk-studios` entry's `consumes_planned` array to record the new downstream-of-Studios edge per ADR-0071 D3 (Studios consumes Web.UI; Studios is not the host).
+
+- `honeydrunk-studios`: append `"honeydrunk-web-ui"` to `consumes_planned` (Studios migrates to consume Web.UI tokens at Phase 1 per D3). If `consumes_planned` does not exist on the Studios entry, add it.
+- `honeydrunk-notify-cloud` (if present): append `"honeydrunk-web-ui"` to `consumes_planned` (Notify Cloud admin consumes tokens + CSS at Phase 2 per D5). If the entry doesn't exist yet (cloud Node not stood up), skip — the cloud Node's own standup ADR's catalog packet will add the edge bidirectionally.
+
+The new Web.UI entry:
+
+```json
+{
+  "id": "honeydrunk-web-ui",
+  "consumes": [],
+  "consumed_by": [],
+  "consumed_by_planned": ["honeydrunk-studios", "honeydrunk-notify-cloud"],
+  "blocked_by": [],
+  "exposes": {
+    "contracts": ["DesignTokens", "PrimitiveCss", "ComponentContract"],
+    "packages": ["@honeydrunk/web-ui-tokens", "@honeydrunk/web-ui-css", "@honeydrunk/web-ui-react", "HoneyDrunk.Web.UI.Blazor", "@honeydrunk/web-ui-native"]
+  },
+  "consumes_detail": {}
+},
+```
+
+**Note on `consumed_by_planned`:** ADR-0071 names Hearth, Lately, Currents, Curiosities as future consumer-app PDR consumers. None of those Nodes have a stand-up ADR yet (no `honeydrunk-hearth` / `honeydrunk-lately` / `honeydrunk-currents` / `honeydrunk-curiosities` ids exist in `nodes.json` as of 2026-05-25). Listing them as future planned consumers in catalog form would invent Node ids that have not been committed. **Do not list non-existent Node ids in `consumed_by_planned`.** The two entries above (`honeydrunk-studios` and `honeydrunk-notify-cloud`) are the actual existing Nodes (Studios live; Notify.Cloud at standup-pending — verify Notify.Cloud presence in nodes.json at edit time before including it). When each PDR-driven app standup ADR lands, that ADR's own Wave-1 catalog packet adds the bidirectional edge.
+
+**`consumes` array is empty.** Per ADR-0071 D9, Web.UI has no runtime dependency on any Grid Node. This is the load-bearing posture; the empty `consumes` array is correct and not an oversight.
+
+### `catalogs/grid-health.json` — new `honeydrunk-web-ui` row
+
+**Anchor semantically.** Insert a new row into the `nodes` array. Find the position adjacent to the `honeydrunk-studios` row via `rg -n '"id": "honeydrunk-studios"' catalogs/grid-health.json` at edit time. The row reflects empty-stand-up state — no published npm packages yet, no canary baseline.
+
+```json
+{
+  "id": "honeydrunk-web-ui",
+  "name": "HoneyDrunk.Web.UI",
+  "sector": "Creator",
+  "signal": "Seed",
+  "version": "0.0.0",
+  "canary_status": "none",
+  "last_release": null,
+  "active_blockers": [
+    "GitHub repo not yet created (packet 03 of adr-0071-web-ui-standup)",
+    "Scaffold packet (packet 04 of adr-0071-web-ui-standup) not yet executed",
+    "npm scope @honeydrunk not yet verified (packet 03)"
+  ],
+  "notes": "ADR-0071 standup ADR Proposed 2026-05-23 (Status flip to Accepted is a separate post-merge housekeeping step after the initiative completes). Catalog surface registered. Awaiting GitHub repo creation (human-only, packet 03 — also handles npm scope verification and NPM_TOKEN seeding) and scaffold execution: monorepo with pnpm workspaces, @honeydrunk/web-ui-tokens (tokens JSON + CSS variables), @honeydrunk/web-ui-css (primitive CSS bundle), @honeydrunk/web-ui-react (placeholder at standup; first components ship at Phase 2), HoneyDrunk.Web.UI.Blazor (placeholder; ships at Phase 3 per Notify Cloud demand), @honeydrunk/web-ui-native (placeholder; ships at Phase 4 per first mobile PDR), CI with publish-on-tag pipeline. Studios is the first named consumer — migration packet follows after 0.1.0 publishes."
+},
+```
+
+Also update the `summary.blocked_nodes` array at the bottom of the file — append `"honeydrunk-web-ui"` and bump `summary.total_nodes`, `summary.seed`, and `summary.canary_none` each by 1. **Read the actual current values from `summary` at edit time** (find via `rg -n '"summary"' catalogs/grid-health.json`); scoping-time counts may have shifted if other Nodes flipped to Live or were added in the interim.
+
+### `catalogs/modules.json` — five new module entries
+
+Append five entries to the modules array (file is a flat JSON array). All five start at `version: "0.0.0"` reflecting empty pre-scaffold state. After the scaffold packet (packet 04) lands `v0.1.0` for the two shipping packages, a separate post-scaffold catalog reconciliation bumps the tokens + CSS entries to 0.1.0 — that bump is the follow-up packet `05-architecture-web-ui-post-release-version-bump.md` (filed at the same time as this initiative but parked behind `v0.1.0` shipping).
+
+**Anchor semantically.** Insert immediately after the existing `studios` entry — find its position via `rg -n '"nodeId": "honeydrunk-studios"' catalogs/modules.json` at edit time:
+
+```json
+{
+  "id": "web-ui-tokens",
+  "nodeId": "honeydrunk-web-ui",
+  "name": "@honeydrunk/web-ui-tokens",
+  "type": "abstractions",
+  "version": "0.0.0",
+  "description": "Stack-agnostic design tokens — color, spacing, typography, radii, shadows, motion, breakpoints, z-index scale. Shipped as JSON for stack-agnostic consumption and as CSS variables for direct browser consumption. The single source of truth for the Grid's visual language."
+},
+{
+  "id": "web-ui-css",
+  "nodeId": "honeydrunk-web-ui",
+  "name": "@honeydrunk/web-ui-css",
+  "type": "runtime",
+  "version": "0.0.0",
+  "description": "Primitive CSS bundle — reset, base typography, utility classes. Consumed by React and Blazor surfaces. Built on top of @honeydrunk/web-ui-tokens; consumes the CSS variables emitted by the tokens package."
+},
+{
+  "id": "web-ui-react",
+  "nodeId": "honeydrunk-web-ui",
+  "name": "@honeydrunk/web-ui-react",
+  "type": "provider",
+  "version": "0.0.0",
+  "description": "First-class React component implementations (Phase 2 — placeholder at standup; first components Button/Input/Label/Card/Modal/Toast/Alert/Spinner/Skeleton ship at first non-Studios consumer demand). Built on tokens + CSS, may build on headless primitives (Radix UI, shadcn patterns) at the implementation layer."
+},
+{
+  "id": "web-ui-blazor",
+  "nodeId": "honeydrunk-web-ui",
+  "name": "HoneyDrunk.Web.UI.Blazor",
+  "type": "provider",
+  "version": "0.0.0",
+  "description": "Blazor component implementations (Phase 3 — placeholder at standup). Added per admin-surface demand. Most Blazor consumers need only tokens + CSS per ADR-0071 D4."
+},
+{
+  "id": "web-ui-native",
+  "nodeId": "honeydrunk-web-ui",
+  "name": "@honeydrunk/web-ui-native",
+  "type": "provider",
+  "version": "0.0.0",
+  "description": "React Native component implementations (Phase 4 — placeholder at standup). Mobile-specific patterns (TabBar, BottomSheet, etc.) join when first mobile PDR demands them. Web-specific patterns (Tooltip on hover) have no RN equivalent and are documented as web-only."
+}
+```
+
+### `catalogs/contracts.json` — new `honeydrunk-web-ui` block
+
+Append a new entry to the `contracts` array. Schema mirrors every other Node's block — find the `honeydrunk-studios` entry (or the closest neighbor) via `rg -n '"node":' catalogs/contracts.json` at edit time:
+
+```json
+{
+  "node": "honeydrunk-web-ui",
+  "node_name": "HoneyDrunk.Web.UI",
+  "package": "@honeydrunk/web-ui-tokens",
+  "status": "seed",
+  "interfaces": [
+    { "name": "DesignTokens", "kind": "type", "description": "JSON schema covering color (semantic + scale), spacing (4px-based scale), typography (font family, size scale, weight scale, line-height scale), radii (scale), shadows (elevation scale), motion (duration + easing scale), breakpoints (mobile/tablet/desktop), z-index scale. Stack-agnostic." },
+    { "name": "TokensCssVariables", "kind": "type", "description": "Browser-consumable CSS-variables emission of the DesignTokens JSON. Format: --hd-color-* / --hd-space-* / --hd-radius-* / --hd-shadow-* etc. Consumed by primitive CSS and by per-PDR consumer code." },
+    { "name": "PrimitiveCss", "kind": "type", "description": "Primitive CSS bundle exported by @honeydrunk/web-ui-css — reset, base typography (h1-h6, p, ul, ol, etc.), utility class taxonomy (margin / padding / display / flex / grid / text alignment / color). Naming follows the hd- prefix convention to avoid collision with consumer CSS." },
+    { "name": "ComponentContract", "kind": "type", "description": "Design specification for each primitive component (Button, Input, Card, Modal, Toast, Alert, Spinner, Skeleton, ...). Names the variants, the states (hover/focus/active/disabled/loading), the accessibility expectations (keyboard nav, ARIA, focus management). Per-stack implementations target the same contract." }
+  ]
+}
+```
+
+### `constitution/sectors.md` — anchor the Creator sector with Web.UI
+
+The Creator-sector section (find via `rg -n '^## Creator' constitution/sectors.md`) currently reads:
+
+```
+## Creator
+
+Tools that turn imagination into momentum — from marketing automation to creative analytics.
+
+**Color:** `#14B8A6` (chromeTeal)
+
+*No real Nodes yet. Planned: HoneyDrunk.Signal, Forge.*
+```
+
+Replace the placeholder line with a table matching the format of the other live sectors. Update the section to read:
+
+```
+## Creator
+
+Tools that turn imagination into momentum — from design substrate to marketing automation to creative analytics. The Creator sector anchors the Grid's creative-tooling layer for people building consumer surfaces.
+
+**Color:** `#14B8A6` (chromeTeal)
+
+| Node | Signal | Responsibility |
+|------|--------|---------------|
+| **Web.UI** | Seed | Cross-stack design system — tokens (color, spacing, typography, radii, shadows, motion, breakpoints), primitive CSS, component contracts shared across React, Blazor, and React Native consumers |
+
+*Planned: HoneyDrunk.Signal, Forge.*
+```
+
+Also locate the **Dependency Flow (Real Nodes)** code block (find via `rg -n 'Dependency Flow' constitution/sectors.md`). Since Web.UI is not yet "Real" (the repo doesn't exist; scaffold pending; per ADR-0071 D9 Web.UI has no upstream Grid-Node dependencies), do **not** add it to the Real-Nodes flow in this packet. It joins the diagram only after packet 04 lands `0.1.0`. Flagging this here so a future agent doesn't preemptively edit the diagram against an unbuilt Node. (When the diagram does include Web.UI post-release, the edge shape is `Web.UI → (no upstream Grid Node)` — pure client-side substrate.)
+
+### `infrastructure/reference/tech-stack.md` — add Web.UI rows
+
+Multiple table additions. **Anchor semantically** — find existing section headers via `rg -n '^## ' infrastructure/reference/tech-stack.md` at edit time.
+
+**Frontend section table.** If a `## Frontend` section exists, append Web.UI rows. If not, add a new section after the Backend section:
+
+```
+## Frontend
+
+| Stack/Library | Version | Used By |
+|---------------|---------|---------|
+| React | 19.x | Studios, Web.UI (target stack) |
+| Next.js | 16.x | Studios |
+| TypeScript | 5.x | Studios, Web.UI (per ADR-0070 D1) |
+| pnpm | 9.x | Web.UI (monorepo workspace tool) |
+```
+
+Adjust versions to whatever is current at edit time — these are scoping-time references.
+
+**Planned Nodes (no code yet) table.** Find via `rg -n 'Planned Nodes' infrastructure/reference/tech-stack.md`. Web.UI is being stood up (this initiative) — but the scaffold hasn't run, so it's still "no code yet" until packet 04 closes. Add the row:
+
+```
+| Web.UI | Creator | Cross-stack design system — tokens, primitive CSS, component contracts (anchors the Creator sector) |
+```
+
+After packet 04 lands and `0.1.0` ships, a follow-up reconciliation moves Web.UI out of "Planned Nodes (no code yet)" into the live Frontend section. That reconciliation is not in this packet's scope.
+
+### `initiatives/roadmap.md` — add Web.UI entry under Q2 2026
+
+Find the Q2 2026 section via `rg -n 'Q2 2026' initiatives/roadmap.md`. The named first consumer (Studios) is already a live Q2 priority. Add a new bullet under Q2 2026 in the appropriate position (find the closest analog — likely the `HoneyDrunk.Files` line if packet 01 of ADR-0061's initiative has merged by then — and insert nearby):
+
+```
+- [ ] **HoneyDrunk.Web.UI Standup (ADR-0071)** — Cross-stack design system anchoring the Creator sector; tokens + primitive CSS at Phase 1 with Studios as first consumer
+```
+
+### `initiatives/active-initiatives.md` — new "In Progress" entry
+
+Insert a new entry under `## In Progress`, immediately after the most-recent ADR-0061 (HoneyDrunk.Files Standup) block or the closest analog standup block at edit time. Find the section position via `rg -n '## In Progress' initiatives/active-initiatives.md`. The new entry:
+
+```markdown
+### ADR-0071 HoneyDrunk.Web.UI Standup
+**Status:** In Progress
+**Scope:** Architecture (catalog/context-folder registration + invariants) + HoneyDrunk.Web.UI (new repo, scaffold)
+**Initiative:** `adr-0071-web-ui-standup`
+**Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)
+**Description:** Stand up `HoneyDrunk.Web.UI` as the Creator sector's anchor Node per ADR-0071. Owns design tokens (color, spacing, typography, radii, shadows, motion, breakpoints, z-index scale), primitive CSS (reset, base typography, utility classes), and component contracts (design specifications) shared across React, Blazor, and React Native consumers. Tokens cross-stack, components per-stack. Phase 1 ships `@honeydrunk/web-ui-tokens` and `@honeydrunk/web-ui-css` at 0.1.x with Studios' existing informal tokens formalized as the first input. Pure client-side substrate — no runtime dependency on any Grid Node. Four packets: catalog/context-folder registration (Architecture; also captures Studios tokens inventory), three new invariants (token consumption + Studios-not-host + zero Grid-Node runtime dependency), human-only GitHub repo creation + npm scope verification + NPM_TOKEN seeding, scaffold (monorepo with pnpm workspaces, five package placeholders, tokens + CSS shipped first). Anchors the previously-empty Creator sector. Unblocks Studios' tokens migration packet, Notify Cloud admin Blazor consumer, and all four PDR-driven consumer-app scaffolds (Hearth, Lately, Currents, Curiosities).
+
+**Tracking:**
+- [ ] Architecture#NN: Catalog registration + context folder + Studios tokens inventory (packet 01)
+- [ ] Architecture#NN: Add three new Web.UI invariants (packet 02)
+- [ ] Architecture#NN: Create HoneyDrunk.Web.UI GitHub repo + verify @honeydrunk npm scope + seed NPM_TOKEN (human-only — packet 03)
+- [ ] Web.UI#NN: Scaffold HoneyDrunk.Web.UI — monorepo, five packages (tokens + CSS shipped at 0.1.x; React/Blazor/Native placeholders), CI with npm publish-on-tag (packet 04)
+- [ ] Architecture#NN: Post-release catalog version bumps — `modules.json` Web.UI entries `0.0.0` → `0.1.0` (tokens + CSS only; the three placeholders stay at 0.0.0 per ADR-0071 D7's pre-1.0 phasing), `grid-health.json` Web.UI row `version` `0.0.0` → `0.1.0`, clear `active_blockers` (packet 05; parked behind `@honeydrunk/web-ui-tokens 0.1.0` and `@honeydrunk/web-ui-css 0.1.0` shipping to npm)
+
+> **Sync (YYYY-MM-DD):** Initiative scoped today. Packets 01/02 ready to file in Wave 1; packet 03 (human-only repo creation + npm scope + NPM_TOKEN) ready in Wave 2; packet 04 parked on packets 02 + 03 landing — packet 02 because the scaffold body cites assigned invariant numbers, packet 03 because the repo must exist and npm scope must be verified before file-packets.sh can target the repo and scaffold can authenticate to npm.
+```
+
+Replace `YYYY-MM-DD` in the sync line with the date this packet's PR is opened (or merged — the convention is whichever your hive-sync agent normalizes against).
+
+### `repos/HoneyDrunk.Web.UI/` — new context folder (five files)
+
+Create `repos/HoneyDrunk.Web.UI/` with five files. Four match the template used by `repos/HoneyDrunk.Studios/` (the closest JS-shaped analog), plus a fifth `studios-tokens-inventory.md` that captures the informal tokens Studios uses today so packet 04's scaffolding agent has a concrete starting point.
+
+#### `repos/HoneyDrunk.Web.UI/overview.md`
+
+```markdown
+# HoneyDrunk.Web.UI — Overview
+
+**Sector:** Creator
+**Signal:** Seed
+**Version:** 0.0.0 (standup pending)
+**Stack:** TypeScript · React · CSS · Blazor (deferred) · React Native (deferred)
+**Repo:** `HoneyDrunkStudios/HoneyDrunk.Web.UI`
+**Status:** Capability/decision accepted (ADR-0071). Stand-up scaffold pending.
+
+## Purpose
+
+The Creator sector's anchor Node. Owns the Grid's design substrate — tokens, primitive CSS, and component contracts shared across React, Blazor, and React Native consumers. Tokens cross-stack; components per-stack.
+
+It is a substrate Node — the design analog of Kernel for runtime context, Vault for secrets, Audit for the security record. It owns the visual language; the consuming Node owns the product. Pure client-side; no runtime dependency on any Grid Node.
+
+## Key Packages (per ADR-0071 D6)
+
+| Package | Stack | Type | Description |
+|---------|-------|------|-------------|
+| `@honeydrunk/web-ui-tokens` | stack-agnostic (JSON + CSS variables) | Abstractions | Color, spacing, typography, radii, shadows, motion, breakpoints, z-index scale. The canonical source for the Grid's visual language. Ships at 0.1.x in Phase 1. |
+| `@honeydrunk/web-ui-css` | web (React + Blazor) | Runtime | Reset, base typography, utility classes. The primitive CSS bundle. Built on top of tokens. Ships at 0.1.x in Phase 1. |
+| `@honeydrunk/web-ui-react` | React | Provider | First-class React component implementations. Initial component set: Button, Input, Label, Card, Modal, Toast, Alert, Spinner, Skeleton. Placeholder at 0.0.0 until Phase 2 (first non-Studios consumer demand). |
+| `HoneyDrunk.Web.UI.Blazor` (NuGet) | Blazor | Provider | Blazor component implementations. Added per admin surface need. Placeholder at 0.0.0 until Phase 3 (first Blazor consumer that needs components beyond tokens + CSS). |
+| `@honeydrunk/web-ui-native` | React Native | Provider | Mobile-specific component implementations. Placeholder at 0.0.0 until Phase 4 (first mobile PDR). |
+
+## Key Contracts
+
+- `DesignTokens` (JSON schema) — color (semantic + scale), spacing (4px-based scale), typography (font family, size scale, weight scale, line-height scale), radii (scale), shadows (elevation scale), motion (duration + easing scale), breakpoints (mobile/tablet/desktop), z-index scale.
+- `TokensCssVariables` — browser-consumable CSS-variables emission of the tokens JSON. Format: `--hd-color-*` / `--hd-space-*` / `--hd-radius-*` / `--hd-shadow-*` etc.
+- `PrimitiveCss` — primitive CSS bundle exported by `@honeydrunk/web-ui-css` — reset, base typography, utility class taxonomy.
+- `ComponentContract` — design specification for each primitive component. Names the variants, the states, the accessibility expectations. Per-stack implementations target the same contract.
+
+## Design Notes
+
+**Tokens are shared.** One source of truth (a tokens JSON + a CSS variables file), consumed identically by every stack. Color, spacing, typography, radii, shadows, motion, breakpoints, z-index scale. Stack-agnostic by construction.
+
+**Primitive CSS is shared across web stacks.** The reset, the base typography, the utility classes ship as a CSS bundle that React consumers and Blazor consumers both import. The `hd-` prefix avoids collision with consumer CSS.
+
+**Components are per-stack.** React's component model, Blazor's `RenderFragment` model, and React Native's `StyleSheet` model do not converge. A "universal component" abstraction loses to per-stack implementations on every dimension — performance, idiomatic API, ecosystem alignment, AI-assistance accuracy. The shared contract is the **design specification**, not the code.
+
+**Studios is the first consumer.** Studios continues using its current informal tokens until Web.UI's first release is ready. At that release, a Studios follow-up packet migrates Studios to consume the Web.UI tokens package. The migration is bounded (Studios is one product; the cutover is one PR) and the tokens align (Studios' existing tokens are formalized into the first Web.UI release, so the migration is mechanical).
+
+**Phase-1 honest limitation:** the first release ships tokens + primitive CSS only — `@honeydrunk/web-ui-tokens` and `@honeydrunk/web-ui-css` at 0.1.x. The three component packages (`@honeydrunk/web-ui-react`, `HoneyDrunk.Web.UI.Blazor`, `@honeydrunk/web-ui-native`) ship as placeholders at 0.0.0 and gain their first real implementations at Phase 2/3/4 per consumer demand. No designer-tooling integration (Figma / Penpot) at standup — deferred until designer joins.
+```
+
+#### `repos/HoneyDrunk.Web.UI/boundaries.md`
+
+```markdown
+# HoneyDrunk.Web.UI — Boundaries
+
+## What Web.UI Owns
+
+- **Design tokens.** The canonical source for color (semantic + scale), spacing, typography, radii, shadows, motion, breakpoints, z-index scale. Shipped as CSS variables and as a JSON tokens file (stack-agnostic).
+- **Primitive CSS.** Reset, base typography, utility classes. Shipped as a CSS bundle consumable from React, Blazor, and any web-based context.
+- **Component contracts.** The design specification for each primitive (Button, Input, Card, Modal, Toast, Alert, Spinner, Skeleton, etc.). The contract names the variants, the states, the accessibility expectations.
+- **React component implementations.** The first-class implementation of every component contract. The default ships from `@honeydrunk/web-ui-react`.
+- **Blazor component implementations (per-surface).** Added when a specific Blazor admin surface needs a component beyond what tokens + CSS alone provide. Most Blazor consumers need only tokens + CSS at v1.
+- **React Native component implementations.** Mobile-specific implementations, kept visually consistent with the React web components per the per-stack-implementation-shared-contract pattern.
+- **Default light + default dark themes.** Shipped as token sets. Per-PDR custom themes layer on top via the standard CSS-variable cascade.
+- **Accessibility baseline.** Every primitive has a11y baseline (keyboard nav, ARIA, focus management). Per-PDR a11y audits of composed surfaces are the consumer's responsibility.
+- **Opinion on icon set.** Web.UI may opinionate on which icon set the Grid uses (the strong default is a single open-source icon set like Lucide or Phosphor) but does not author icons itself.
+
+## What Web.UI Does NOT Own
+
+- **The Studios website.** Studios is a separate Node and product. Web.UI is **consumed by** Studios; Web.UI does not house Studios. This separation is load-bearing — substrate is upstream of every product.
+- **Per-product page templates, marketing pages, content models.** Those are PDR-side concerns.
+- **State management, routing, data fetching, runtime application concerns.** Web.UI ships visual primitives, not application substrate. No Zustand, no TanStack Query, no React Router, no Apollo, no anything that takes a position on runtime application shape.
+- **Backend integration code.** Web.UI is purely client-side; it does not depend on any Grid Node's runtime contract.
+- **i18n / l10n catalogs.** `HoneyDrunk.Locale` is the future-state home for translation infrastructure. Web.UI's text strings on primitive components are English defaults; localization is the consuming PDR's responsibility for now.
+- **Icon libraries (the icons themselves).** Web.UI re-exports if the Grid commits to a single icon set; it does not author icons.
+- **Designer tooling integration.** Figma / Penpot integration is deferred until designer workflow exists.
+- **Per-PDR token overrides.** Consumers may set CSS-variable overrides locally; Web.UI does not consume those back.
+- **Application-specific composites.** A "BillingDashboard" is a Notify Cloud concern, not a Web.UI concern.
+- **The stack-selection ADR.** Web.UI implements the cross-stack split — ADR-0070 makes the stack-selection decision.
+
+## Boundary Decision Tests
+
+- Is this a **color, spacing, type, radius, shadow, motion, breakpoint, or z-index value the Grid wants to be consistent on**? → Web.UI tokens.
+- Is this a **reset, base typography rule, or utility class**? → Web.UI primitive CSS.
+- Is this a **primitive interactive component (Button, Input, Modal, etc.)**? → Web.UI component contract + per-stack implementation.
+- Is this an **application-specific composite (BillingDashboard, JournalCalendar, MapWithPins)**? → Consuming PDR.
+- Is this **product-specific marketing or content**? → Consuming Node (Studios for HoneyDrunk Studios marketing; per-PDR for product marketing).
+- Is this **runtime state management, routing, or data fetching**? → Consuming PDR (Web.UI does not opinionate).
+- Is this a **translation catalog or l10n surface**? → `HoneyDrunk.Locale` (future) — not Web.UI.
+- Is this **dependent on a Grid Node's runtime contract**? → Boundary violation — Web.UI does not consume Grid Node runtime contracts. The consumer's adapter does the mapping if needed.
+- Is this **a designer tool export pipeline (Figma → tokens)**? → Deferred — when designer joins, this becomes a Web.UI capability.
+```
+
+#### `repos/HoneyDrunk.Web.UI/invariants.md`
+
+```markdown
+# HoneyDrunk.Web.UI — Invariants
+
+Web.UI-specific invariants (supplements `constitution/invariants.md`).
+
+1. **Web.UI is pure client-side substrate — no runtime dependency on any Grid Node.**
+   No Kernel, Vault, Auth, Data, Transport, Audit, Pulse, or Notify reference in any Web.UI package. The dependency direction is consumer → Web.UI, never the inverse. JSON-deserialized values pass through Web.UI primitives the same way arbitrary string values do; if a future consumer needs to render a Grid-canonical value type (e.g., `Money` per ADR-0069, `TenantId` per ADR-0026), the dependency direction is consumer-side (the consuming PDR's adapter, not the Web.UI primitive).
+
+2. **Tokens are stack-agnostic — components are per-stack.**
+   `@honeydrunk/web-ui-tokens` ships JSON + CSS variables consumed identically by every stack. Components ship per-stack: `@honeydrunk/web-ui-react` for React, `HoneyDrunk.Web.UI.Blazor` for Blazor (per-surface), `@honeydrunk/web-ui-native` for React Native. No "universal component abstraction" wrapper; per-stack idioms are preserved.
+
+3. **The shared contract is the design specification, not the code.**
+   What stays shared is the **what** (a Button has primary / secondary / ghost variants; it has hover / focus / active / disabled states; it supports loading; it is keyboard-accessible). The **how** is per-stack. Per-stack implementations target the same `ComponentContract`.
+
+4. **Studios consumes Web.UI — Web.UI does not host Studios.**
+   Studios is a product Node, not the design-system host. Coupling cross-PDR substrate to a single product's deployment cadence, repo lifecycle, and release schedule inverts the substrate's role. The migration shape: Studios consumes Web.UI from the first 0.1.0 release.
+
+5. **Per-PDR overrides flow through standard CSS-variable cascade — Web.UI does not consume them back.**
+   Consumers diverge where their brand needs it (e.g., Hearth's "town" metaphor might want a warmer palette than the Grid default) while still inheriting the Grid baseline. Web.UI does not bidirectionally absorb consumer overrides into the canonical token set.
+
+6. **The npm packages live under `@honeydrunk` scope.**
+   `@honeydrunk/web-ui-tokens`, `@honeydrunk/web-ui-css`, `@honeydrunk/web-ui-react`, `@honeydrunk/web-ui-native`. The NuGet package `HoneyDrunk.Web.UI.Blazor` follows the existing `HoneyDrunk.*` NuGet naming.
+
+7. **Phased shipping — no pre-emptive component surface.**
+   v0.1.0 ships tokens + primitive CSS only. Component packages ship per-consumer-demand, lazily. The Web.UI Node does not pre-ship surface it does not have consumers for.
+
+8. **Default light + default dark themes ship as token sets.**
+   Per-PDR custom themes layer on top via the CSS-variable cascade. Web.UI does not ship arbitrary per-PDR themes — only the two defaults.
+
+9. **Third-party UI library coupling is scoped per-stack and confined to the implementation layer.**
+   React component implementations may build on Radix UI / shadcn patterns; Blazor may use a permissive-licensed Blazor library; RN may use Expo's primitive set. None of those leak into the public component contract or the tokens. A vendor swap is bounded to one package's implementation.
+
+_Constitutional invariants {N1} (Grid frontend surfaces consume design tokens and primitive CSS from `HoneyDrunk.Web.UI`), {N2} (`HoneyDrunk.Web.UI` does not host `HoneyDrunk.Studios` — Web.UI is consumed by Studios), and {N3} (`HoneyDrunk.Web.UI` does not depend on any Grid Node's runtime contracts) in `constitution/invariants.md` are the Grid-level rules this Node exists to enforce. All three are landed by ADR-0071's stand-up initiative (packet 02). The numeric assignments are made at packet 02's edit time via the reservation registry._
+
+## Status
+
+Capability/decision accepted (ADR-0071 Proposed → Accepted flips after this initiative's PRs merge). Standup scaffold (repo, monorepo with pnpm workspaces, five package placeholders with tokens + CSS shipped first, CI with npm publish-on-tag) governed by ADR-0071 itself — a distinct initiative tracked at `generated/issue-packets/active/adr-0071-web-ui-standup/`.
+```
+
+#### `repos/HoneyDrunk.Web.UI/integration-points.md`
+
+```markdown
+# HoneyDrunk.Web.UI — Integration Points
+
+## Upstream Dependencies
+
+**Web.UI has zero upstream Grid-Node dependencies at runtime.** This is the load-bearing posture per ADR-0071 D9.
+
+Web.UI's runtime dependencies are purely on the JavaScript / npm ecosystem and (for Blazor) NuGet — none on any Grid Node.
+
+| Dependency layer | Notes |
+|------------------|-------|
+| `react`, `react-dom` (peer dependencies of `@honeydrunk/web-ui-react`) | Consumer-provided; not bundled |
+| `react-native` (peer dependency of `@honeydrunk/web-ui-native`) | Consumer-provided; not bundled |
+| Headless primitives (Radix UI, shadcn patterns) | Optional implementation-layer dependencies of `@honeydrunk/web-ui-react`; vendor swap is bounded to one package |
+| Build tooling (TypeScript, pnpm, esbuild/Rollup, tsup) | Build-time only; not exposed in published packages |
+
+## Telemetry (no runtime dependency)
+
+Web.UI is pure client-side substrate; it does not emit operational telemetry to Pulse. The consuming PDR's runtime is what gets observed.
+
+## Downstream Consumers (Planned)
+
+| Node | Contract Used | Status |
+|------|---------------|--------|
+| **HoneyDrunk.Studios** | `@honeydrunk/web-ui-tokens` (JSON + CSS variables), `@honeydrunk/web-ui-css` | Studios is the first named consumer. Migration packet follows after `0.1.0` publishes. Studios' existing informal tokens are formalized into the first Web.UI release, so the migration is mechanical. |
+| **HoneyDrunk.Notify.Cloud (admin)** | `@honeydrunk/web-ui-tokens`, `@honeydrunk/web-ui-css` (and `HoneyDrunk.Web.UI.Blazor` if/when admin surface demands components beyond tokens + CSS) | Blazor admin consumes tokens + CSS at Phase 2. Most Blazor admin surfaces need no component package. |
+| **PDR-driven consumer apps (Hearth, Lately, Currents, Curiosities)** | `@honeydrunk/web-ui-tokens`, `@honeydrunk/web-ui-css`, `@honeydrunk/web-ui-react` (when Phase 2 components ship); `@honeydrunk/web-ui-native` (when Phase 4 mobile components ship) | Each PDR-driven app's first scaffolding packet consumes Web.UI. Each PDR's standup ADR will commit its specific edges. |
+
+## Boundary Notes
+
+- Downstream Nodes consume the published npm / NuGet packages only — never the repo source directly, never a workspace symlink in production.
+- Web.UI runs **no host process** at v1. It is a published-package substrate, not a service. No managed identity, no Container App, no Azure Function, no Key Vault. The repo is library-only.
+- The `@honeydrunk` npm scope is org-verified at packet 03 (human-only). All Web.UI npm packages publish under that scope. The NuGet `HoneyDrunk.Web.UI.Blazor` package publishes under the existing Grid NuGet identity (same OIDC federated credential pattern as other Grid NuGet packages).
+- Per-PDR consumer overrides flow one-way through standard CSS-variable cascade. Web.UI does not consume consumer overrides back into the canonical token set.
+
+## Canary Coverage Required
+
+Before any Web.UI code is considered production-ready:
+
+- `web-ui-tokens.test` → exports a `DesignTokens` JSON object that matches the shape contracted in `repos/HoneyDrunk.Web.UI/studios-tokens-inventory.md` (structural assertion that the keys exist; values are intentionally flexible to support future palette rebrands).
+- `web-ui-css.test` → the published `.css` file contains the `hd-` prefixed reset selectors and the documented utility class taxonomy.
+- `web-ui-react.test` (when Phase 2 ships) → each component implements the `ComponentContract` design specification (variant/state/a11y coverage).
+- Cross-PDR brand-coherence canary → manual; each consumer's first scaffolding packet asserts that it consumes Web.UI tokens via the documented CSS-variable names.
+```
+
+#### `repos/HoneyDrunk.Web.UI/studios-tokens-inventory.md` (new)
+
+This file captures Studios' informal tokens as the starting point for `@honeydrunk/web-ui-tokens`'s first release. Studios is the first consumer per ADR-0071 D3, and its existing tokens are formalized into the first Web.UI release. Packet 04 references this file as the source of truth for the initial tokens JSON.
+
+```markdown
+# Studios Informal Tokens Inventory
+
+**Purpose:** Capture the design tokens Studios currently uses informally so packet 04's scaffolding agent has a concrete starting point for `@honeydrunk/web-ui-tokens`'s first release. Once tokens publish, Studios migrates to consume them via a follow-up packet (out of scope here).
+
+**Caveat:** Studios pre-dates Web.UI. The "tokens" below are partly literal CSS variables Studios has declared and partly observable patterns (recurring colors, spacings, type sizes) in Studios' codebase. The scaffolding agent should treat this as the **shape** of what to formalize, not a verbatim copy — equivalent token-name normalization (e.g., Studios' `neonPink` → Web.UI's `--hd-color-accent-pink` with a semantic alias) is expected.
+
+## Sector colors (from `constitution/sectors.md`)
+
+These are already in Studios in some form, and they're load-bearing for the `/grid` WebGL visualization. Web.UI tokens MUST preserve them:
+
+| Sector | Token name (proposed) | Hex value |
+|--------|----------------------|-----------|
+| Core | `--hd-color-sector-core` | `#7B61FF` (violetFlux) |
+| Ops | `--hd-color-sector-ops` | `#FF8C00` (cyberOrange) |
+| Meta | `--hd-color-sector-meta` | `#FFFF00` (neonYellow) |
+| HoneyNet | `--hd-color-sector-honeynet` | `#00FF41` (matrixGreen) |
+| Creator | `--hd-color-sector-creator` | `#14B8A6` (chromeTeal) |
+| Market | `--hd-color-sector-market` | `#F5B700` (aurumGold) |
+| HoneyPlay | `--hd-color-sector-honeyplay` | `#FF2A6D` (neonPink) |
+| Cyberware | `--hd-color-sector-cyberware` | `#00D1FF` (electricBlue) |
+| AI | `--hd-color-sector-ai` | `#D946EF` (synthMagenta) |
+
+Tokens JSON shape:
+
+```json
+{
+  "color": {
+    "sector": {
+      "core": "#7B61FF",
+      "ops": "#FF8C00",
+      "meta": "#FFFF00",
+      "honeynet": "#00FF41",
+      "creator": "#14B8A6",
+      "market": "#F5B700",
+      "honeyplay": "#FF2A6D",
+      "cyberware": "#00D1FF",
+      "ai": "#D946EF"
+    }
+  }
+}
+```
+
+## Other categories Studios uses
+
+Studios' codebase additionally exposes informal patterns for:
+
+- **Neutral palette** — backgrounds, text, surfaces. Likely a 0-900 numeric scale (Tailwind-shaped).
+- **Spacing** — 4px-based scale per the broad Grid convention (4, 8, 12, 16, 24, 32, 48, 64, 96).
+- **Typography** — font family (likely a sans-serif default + monospace), size scale (xs/sm/base/lg/xl/2xl/3xl/4xl/5xl), weight scale (regular/medium/semibold/bold), line-height scale.
+- **Radii** — none / sm / md / lg / full.
+- **Shadows** — sm / md / lg / xl elevation scale.
+- **Motion** — duration tokens (fast/normal/slow) and easing tokens (standard/in/out/inout).
+- **Breakpoints** — mobile / tablet / desktop / wide.
+- **Z-index scale** — base / dropdown / modal / toast / tooltip.
+
+**Action for packet 04's scaffolding agent:** Inspect Studios' codebase at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Studios/` for the actual values currently in use (Tailwind config, CSS custom properties, etc.) and capture them as the v0.1.0 tokens JSON. The sector-color block above is **mandatory** — it must round-trip identically. The other categories are recommended starting shapes; capture actuals where Studios has them and document any synthesized defaults where it does not (the v0.1.0 release is allowed to introduce sensible defaults; a follow-up Studios migration packet reconciles any drift).
+
+## Migration shape (Studios-side follow-up packet)
+
+Out of scope for this initiative. After `@honeydrunk/web-ui-tokens 0.1.0` publishes:
+
+1. Add `@honeydrunk/web-ui-tokens` as a Studios dependency.
+2. Replace Studios' informal CSS-variable declarations with the import from `@honeydrunk/web-ui-tokens/css/variables.css`.
+3. Replace Studios' Tailwind config color-palette block with the import from `@honeydrunk/web-ui-tokens/json/tokens.json` (or the Tailwind preset if one ships).
+4. Verify `/grid` WebGL visualization renders identically (sector colors round-trip).
+5. Ship.
+
+The migration is a single Studios-side PR. It is **not** in this initiative — it lives in a follow-up packet against the Studios repo once Web.UI 0.1.0 publishes.
+```
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the current in-progress dated SemVer section (per memory `feedback_no_unreleased_commits`):
+
+`Architecture: Register HoneyDrunk.Web.UI standup decisions (ADR-0071) in catalogs. Add honeydrunk-web-ui to nodes.json (Creator sector, cluster=visualization, signal=Seed), relationships.json (zero consumes; Studios + Notify.Cloud as consumed_by_planned), grid-health.json (version 0.0.0, three active_blockers), modules.json (five package entries — tokens + CSS + react + blazor + native — all at 0.0.0 pre-scaffold), contracts.json (DesignTokens + TokensCssVariables + PrimitiveCss + ComponentContract). Anchor the Creator sector in constitution/sectors.md (Web.UI as the first row, "No real Nodes yet" placeholder removed). Add tech-stack.md Frontend section + Planned Nodes row. Add Q2 2026 roadmap bullet and active-initiatives In Progress entry. Create repos/HoneyDrunk.Web.UI/ context folder (overview, boundaries, invariants, integration-points) matching the Studios template; also capture Studios' informal tokens as studios-tokens-inventory.md for packet 04's scaffolding reference.`
+
+## Affected Files
+
+- `catalogs/nodes.json` (add `honeydrunk-web-ui` block)
+- `catalogs/relationships.json` (add `honeydrunk-web-ui` block; amend `honeydrunk-studios.consumes_planned` and `honeydrunk-notify-cloud.consumes_planned` if Notify.Cloud Node exists in catalogs at edit time)
+- `catalogs/grid-health.json` (add row, bump `summary` counts)
+- `catalogs/modules.json` (5 new entries — tokens, css, react, blazor, native — all at 0.0.0)
+- `catalogs/contracts.json` (new `honeydrunk-web-ui` block)
+- `constitution/sectors.md` (Creator-sector anchor — table replaces placeholder line)
+- `infrastructure/reference/tech-stack.md` (Frontend section + Planned Nodes row)
+- `initiatives/roadmap.md` (Q2 2026 bullet)
+- `initiatives/active-initiatives.md` (In Progress entry)
+- `repos/HoneyDrunk.Web.UI/overview.md` (new)
+- `repos/HoneyDrunk.Web.UI/boundaries.md` (new)
+- `repos/HoneyDrunk.Web.UI/invariants.md` (new)
+- `repos/HoneyDrunk.Web.UI/integration-points.md` (new)
+- `repos/HoneyDrunk.Web.UI/studios-tokens-inventory.md` (new — references for packet 04)
+- `CHANGELOG.md` (entry under the current dated SemVer-bumped section)
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo — no .NET projects.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture` — correct repo per routing rules.
+- [x] No new design decision — every catalog entry / context file is derived from ADR-0071's decisions and the `## If Accepted` checklist.
+- [x] `cluster: "visualization"` matches existing taxonomy (Studios precedent) — `frontend` is **not** in the allowed cluster values and would invent a new one.
+- [x] `consumes: []` for Web.UI per ADR-0071 D9 (zero runtime dependency on Grid Nodes). This is the load-bearing posture, not an oversight.
+- [x] `consumed_by_planned` lists only existing Node ids — speculative PDR-driven app Nodes (hearth/lately/etc.) are not invented; each PDR-driven app's standup ADR will add its own edge.
+- [x] No edit to ADR-0071's Status header. Status stays Proposed; the flip is post-merge housekeeping.
+
+## Acceptance Criteria
+
+- [ ] `catalogs/nodes.json` carries a new `honeydrunk-web-ui` block with `sector: "Creator"`, `signal: "Seed"`, `cluster: "visualization"` (NOT `"frontend"` — that value is not in the existing cluster taxonomy), full `long_description` per the block above.
+- [ ] `catalogs/relationships.json` carries a new `honeydrunk-web-ui` block with `consumes: []` (empty per ADR-0071 D9), `consumed_by_planned` listing only existing Node ids (Studios; Notify.Cloud if present).
+- [ ] `honeydrunk-studios` block in `catalogs/relationships.json` has `"honeydrunk-web-ui"` appended to its `consumes_planned` (creating the array if it does not already exist).
+- [ ] `catalogs/grid-health.json` carries a new `honeydrunk-web-ui` row at `version: "0.0.0"`, `canary_status: "none"`, three `active_blockers` entries naming packet 03 (repo creation), packet 04 (scaffold), and npm scope verification. `summary.blocked_nodes`, `summary.total_nodes`, `summary.seed`, and `summary.canary_none` bumped by 1.
+- [ ] `catalogs/modules.json` has five new entries: `web-ui-tokens`, `web-ui-css`, `web-ui-react`, `web-ui-blazor`, `web-ui-native` — all at `version: "0.0.0"` pre-scaffold.
+- [ ] `catalogs/contracts.json` carries a new `honeydrunk-web-ui` block with `package: "@honeydrunk/web-ui-tokens"`, `status: "seed"`, and four contract types: `DesignTokens`, `TokensCssVariables`, `PrimitiveCss`, `ComponentContract`.
+- [ ] `constitution/sectors.md` Creator-sector section has its "No real Nodes yet" placeholder replaced with a table containing the Web.UI row at `Signal: Seed`. Section intro paragraph updated to name design substrate as Creator's role.
+- [ ] `infrastructure/reference/tech-stack.md` carries a Frontend section (or extends an existing one) with React/Next.js/TypeScript/pnpm rows naming Web.UI as the consumer.
+- [ ] `infrastructure/reference/tech-stack.md` Planned Nodes (no code yet) table has a Web.UI row.
+- [ ] `initiatives/roadmap.md` Q2 2026 section has a Web.UI Standup bullet.
+- [ ] `initiatives/active-initiatives.md` has a new "ADR-0071 HoneyDrunk.Web.UI Standup" In Progress entry with the five Tracking checkboxes and the dated Sync line.
+- [ ] `repos/HoneyDrunk.Web.UI/` folder created with five files: `overview.md`, `boundaries.md`, `invariants.md`, `integration-points.md`, `studios-tokens-inventory.md` — all per the content blocks above.
+- [ ] `studios-tokens-inventory.md` explicitly lists the 9 sector colors with hex values matching `constitution/sectors.md` exactly. Studios' migration depends on these round-tripping.
+- [ ] `CHANGELOG.md` carries an entry under the current dated SemVer section describing the catalog and context-folder additions (not under `## Unreleased`).
+- [ ] PR body explicitly notes: (1) zero catalog drift introduced by this packet (every cited file was actually edited); (2) `cluster: "visualization"` chosen (matches Studios precedent; `frontend` is not in the taxonomy); (3) Studios tokens inventory captured for packet 04's reference; (4) ADR-0071 Status stays Proposed.
+
+## Human Prerequisites
+
+None. This packet is pure documentation/catalog work — no portal steps, no manual deploy-time actions, no secrets to seed.
+
+## Dependencies
+
+None. This is the leading packet for the initiative — it depends only on ADR-0071 itself being on disk in `Proposed` state (which it is at scoping time).
+
+## Labels
+
+`chore`, `tier-2`, `architecture`, `web-ui`, `adr-0071`
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node (or tightly coupled Node family). Each repo has its own solution, CI pipeline, and versioning. — New Node ⇒ new context-folder entry here; new repo created by packet 03.
+
+> **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. Pre-filing amendments are permitted; post-filing corrections require a new packet. — This packet's content is finalized at filing; the substituted invariant numbers landed by packet 02 do not require edits to this packet (packet 02 handles the cross-reference substitution on `repos/HoneyDrunk.Web.UI/invariants.md`).
+
+## Referenced ADR Decisions
+
+**ADR-0071 D1 (Web.UI is the Creator sector's owner of design tokens, primitive CSS, and component contracts):** This packet registers the Node entry and contracts surface in the catalogs and authors the per-repo context folder reflecting D1's ownership statement.
+
+**ADR-0071 D2 (Sector placement — Creator anchor):** The `constitution/sectors.md` edit replaces the placeholder line with Web.UI as the first Creator-sector row.
+
+**ADR-0071 D3 (Web.UI is consumed by Studios — not folded into Studios):** The relationships entry has `consumed_by_planned: ["honeydrunk-studios", ...]` and Studios' `consumes_planned` gains the Web.UI edge — the inversion is encoded in catalog form.
+
+**ADR-0071 D6 (Package layout):** The five `modules.json` entries reflect the package families per D6 — tokens + CSS at standup; React + Blazor + Native as placeholders for Phase 2/3/4.
+
+**ADR-0071 D9 (Web.UI has no runtime dependency on any Grid Node):** The `consumes: []` empty array in relationships.json encodes the load-bearing posture. This is the substrate property the constitutional invariant in packet 02 enforces.
+
+**Memory `project_repos_public_by_default`:** Web.UI repo is public by default — design substrate is exactly the kind of build-in-public surface the Grid licenses; no carve-out applies. Packet 03 handles the repo-creation step with Visibility = Public.
+
+**Memory `feedback_no_unreleased_commits`:** CHANGELOG entry lands under the current dated SemVer-bumped section, not under `## Unreleased`.
+
+## Agent Handoff
+
+**Objective:** Register `HoneyDrunk.Web.UI` in every catalog file, anchor the Creator sector in `constitution/sectors.md`, add tech-stack/roadmap/active-initiatives entries, create the `repos/HoneyDrunk.Web.UI/` context folder, and capture Studios' informal tokens as a starting reference for packet 04. This is the Wave-1 documentation/catalog landing; the actual code work (npm packages, monorepo, CI) happens in packet 04 against a different repo.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Context:**
+- Goal: Land the catalog and context surface for `HoneyDrunk.Web.UI` so the scaffold packet (packet 04 of this initiative) has its `node:` frontmatter, in-Architecture context-folder cross-references, and tokens-inventory starting point all in place.
+- Feature: ADR-0071 standup initiative — this is the documentation side of Wave 1.
+- ADRs: ADR-0071 (this packet realizes its catalog and context-folder commitments).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None — this is the leading packet in the initiative. ADR-0071 itself is on disk at `Proposed` status; no other prereqs.
+
+**Constraints:**
+
+- **Invariant 11:** One repo per Node (or tightly coupled Node family). Each repo has its own solution, CI pipeline, and versioning. — Web.UI is a new Node, so it gets a new repo (created by packet 03) and a new context-folder entry (created here).
+- **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. Pre-filing amendments are permitted; post-filing corrections require a new packet. — This packet's body is finalized at filing; packet 02 handles cross-reference substitution.
+- **`cluster: "visualization"` not `"frontend"`.** The existing `nodes.json` taxonomy does not include `frontend`. The allowed values are: `foundation`, `security`, `observability`, `infrastructure`, `orchestration`, `governance`, `visualization`, `cognition`, `quality`, `knowledge`. `visualization` matches the Studios precedent and is the closest semantic match for a design-substrate Node. Inventing a new cluster value would be a catalog-shape violation.
+- **`consumes: []` is correct.** Per ADR-0071 D9, Web.UI has no runtime dependency on any Grid Node. The empty array is the load-bearing posture, not an oversight. Do not "fix" this by adding a Kernel reference.
+- **Do not list non-existent Node ids in `consumed_by_planned`.** The four queued consumer-app PDR Nodes (Hearth, Lately, Currents, Curiosities) do not yet exist in `nodes.json` — adding them here would invent ids. Each PDR-driven app's standup ADR adds its own edge bidirectionally.
+- **No edit to ADR-0071 Status.** Status stays Proposed throughout this initiative; the flip is post-merge housekeeping.
+- **Sector-color round-trip is mandatory.** `studios-tokens-inventory.md` lists the 9 sector colors with hex values matching `constitution/sectors.md` exactly. If `sectors.md` is rebranded in the future, the tokens inventory needs corresponding update — but at scoping time the round-trip is exact.
+
+**Key Files:**
+- `catalogs/nodes.json` — append `honeydrunk-web-ui` block
+- `catalogs/relationships.json` — append `honeydrunk-web-ui` block; amend `honeydrunk-studios` (and `honeydrunk-notify-cloud` if present) `consumes_planned`
+- `catalogs/grid-health.json` — append row; bump summary counts
+- `catalogs/modules.json` — append 5 module entries at 0.0.0
+- `catalogs/contracts.json` — append `honeydrunk-web-ui` contracts block
+- `constitution/sectors.md` — Creator-sector anchor (table replaces placeholder)
+- `infrastructure/reference/tech-stack.md` — Frontend section + Planned Nodes row
+- `initiatives/roadmap.md` — Q2 2026 bullet
+- `initiatives/active-initiatives.md` — In Progress entry
+- `repos/HoneyDrunk.Web.UI/` — 5 new files: overview, boundaries, invariants, integration-points, studios-tokens-inventory
+- `CHANGELOG.md` — entry under current dated SemVer section
+
+**Contracts:**
+- This packet does not author any new contracts. It registers ADR-0071's already-decided contracts in the catalog. The actual `DesignTokens` JSON schema, `TokensCssVariables` CSS file, and `PrimitiveCss` bundle are authored in packet 04 (the scaffold).

--- a/generated/issue-packets/active/adr-0071-web-ui-standup/02-architecture-web-ui-invariants.md
+++ b/generated/issue-packets/active/adr-0071-web-ui-standup/02-architecture-web-ui-invariants.md
@@ -1,0 +1,246 @@
+---
+name: Constitution Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "constitution", "web-ui", "adr-0071"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0071"]
+accepts: ADR-0071
+wave: 1
+initiative: adr-0071-web-ui-standup
+node: honeydrunk-web-ui
+---
+
+# Chore: Add ADR-0071's three new invariants to the Grid constitution
+
+## Summary
+Add three new invariants to `constitution/invariants.md` derived from ADR-0071's Consequences §Invariants subsection:
+
+1. **`{N1}`** — Grid frontend surfaces consume design tokens and primitive CSS from `HoneyDrunk.Web.UI`. Per-PDR re-derivation of tokens or primitive CSS is a boundary violation. Per-PDR overrides via standard CSS-variable cascade are permitted.
+2. **`{N2}`** — `HoneyDrunk.Web.UI` does not host `HoneyDrunk.Studios`; Web.UI is consumed by Studios. The Studios website is a product Node, not the design-system host.
+3. **`{N3}`** — `HoneyDrunk.Web.UI` does not depend on any Grid Node's runtime contracts. Web.UI is purely client-side substrate; the dependency direction is consumer→Web.UI, never the inverse.
+
+All three are landed under a new `## Web.UI Invariants` section appended to `constitution/invariants.md`. The numeric assignments (`{N1}`, `{N2}`, `{N3}`) come from the reservation registry — ADR-0071 already holds the block **87–89** per `constitution/invariant-reservations.md`. **Verify at edit time** by re-reading the file; if another ADR's packet 00 landed an interim reservation, shift up by the appropriate offset per the reservation discipline.
+
+This packet also updates ADR-0071's Consequences §Invariants subsection to finalize the numbers (replace the "(this ADR proposes — not commits …)" framing with the assigned numbers) and updates `repos/HoneyDrunk.Web.UI/invariants.md`'s trailing cross-reference paragraph to cite the assigned numbers.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+ADR-0071's §Invariants subsection lists three candidate invariants for promotion at acceptance time:
+
+> - **Invariant proposal: Grid frontend surfaces consume design tokens and primitive CSS from `HoneyDrunk.Web.UI`.** Per-PDR re-derivation of tokens or primitive CSS is a boundary violation. Per-PDR overrides via standard CSS-variable cascade are permitted.
+> - **Invariant proposal: Web.UI does not host Studios; Web.UI is consumed by Studios.** The Studios website is a product Node, not the design-system host. (Codifies D3.)
+> - **Invariant proposal: Web.UI does not depend on any Grid Node's runtime contracts.** Web.UI is purely client-side substrate; the dependency direction is consumer→Web.UI, never the inverse. (Codifies D9.)
+
+All three are definitive — none are conditional on first-feature-packet evidence. This packet promotes all three.
+
+The three invariants need constitutional anchors for three reasons:
+
+- **The downstream-coupling rule does not subsume them.** ADR-0071 D8 commits the boundary text ("Web.UI owns / Web.UI does NOT own") — but the boundary text is design-time documentation. The constitutional invariants are *runtime rules the review agent can cite at PR time*. A future Notify Cloud admin PR that quietly re-derives its own color palette instead of consuming `@honeydrunk/web-ui-tokens` is a boundary violation the review agent must catch — it needs a numbered rule to cite.
+- **The Studios-not-host rule is grep-able and code-reviewable.** "Web.UI is not folded into Studios" is the kind of rule that surfaces only at PR review unless it lives in a numbered constitutional slot the reviewer agent can match against. A future PR that adds a Studios `package.json` export of `studios/design-system` is a boundary violation that needs constitutional standing to reject cleanly.
+- **The zero-Grid-Node-dependency rule is grep-able and code-reviewable.** A future Web.UI PR that quietly adds a `@honeydrunk/kernel-abstractions` dependency to one of the Web.UI packages is the most likely future drift this rule exists to prevent. The contract-shape canary catches abstraction-shape drift; it cannot catch "did this PR introduce an upstream Grid-Node coupling." The constitution is the right home.
+
+## Reservation-Claim Protocol (Hard Gate, Run Before Any Edit)
+
+This packet adds **three** invariants to `constitution/invariants.md`. Per the reservation discipline in `constitution/invariant-reservations.md`, ADR-0071 already holds the block **87–89** for these three invariants.
+
+**Step 1 — verify the reservation block is still 87–89.** Open `constitution/invariant-reservations.md` and read the **Active Reservations** table. As of scoping time (2026-05-25), the ADR-0071 row reads:
+
+```
+| 87–89 | ADR-0071 | Proposed | Web.UI Node standup (`{N1}`–`{N3}`). Packet 02 at `generated/issue-packets/active/adr-0071-web-ui-standup/02-architecture-web-ui-invariants.md`. (N1) Grid frontend surfaces consume design tokens and primitive CSS from `HoneyDrunk.Web.UI` — per-PDR re-derivation is a boundary violation; per-PDR CSS-variable overrides are permitted (D1 / D8). (N2) `HoneyDrunk.Web.UI` does not host `HoneyDrunk.Studios`; Web.UI is consumed by Studios (D3). (N3) `HoneyDrunk.Web.UI` does not depend on any Grid Node's runtime contracts — the dependency direction is one-way consumer → Web.UI (D9). Block claimed at max(invariants.md=53, ADR-0051 reservation=57, ADR-0049 reservation=60, ADR-0054 reservation=63, ADR-0060 reservation=66, ADR-0050 reservation=68, ADR-0063 reservation=73, ADR-0064 reservation=77, ADR-0065 reservation=79, ADR-0066 reservation=82, ADR-0068 reservation=86) + 1.
+```
+
+**At edit time** verify the block is still 87–89. If a packet 00 for an earlier-numbered Proposed ADR has landed in the interim and shifted the block, update the assignment per the reservation discipline (rule 6 — first merge wins; second packet shifts upward).
+
+**Step 2 — cross-check against `invariants.md`.** As defense-in-depth against a missed reservation, also run:
+
+```bash
+rg -n '^[0-9]+\.' constitution/invariants.md | tail -n 20
+```
+
+The numbers `{N1}`, `{N2}`, `{N3}` must be **strictly greater** than every existing number returned by that grep. If `{N1}` is not greater than the accepted high-water in `invariants.md`, the reservation-file lookup was wrong — re-do step 1.
+
+**Step 3 — substitute `{N1}` / `{N2}` / `{N3}` throughout this packet and across cross-reference targets.** Every occurrence of `{N1}`, `{N2}`, `{N3}` in this packet's body and in the cross-reference target files (listed below) is replaced with the assigned numbers in lockstep before commit.
+
+**Step 4 — move the ADR-0071 row from Active Reservations to the Reservation History table.** Per the reservation discipline rule 6 / the History table:
+
+```
+| 87–89 | ADR-0071 | YYYY-MM-DD | Web.UI Node standup invariants — landed in ## Web.UI Invariants section |
+```
+
+(Substitute the actual merge date — typically the date the packet 02 PR merges to `main`.)
+
+**Cross-references to update with the assigned numbers (in lockstep, before commit):**
+
+- `adrs/ADR-0071-stand-up-honeydrunk-web-ui-node.md` — Consequences §Invariants subsection (see implementation block below).
+- `repos/HoneyDrunk.Web.UI/invariants.md` — trailing cross-reference paragraph (placeholder text written by packet 01).
+- `04-web-ui-node-scaffold.md` source file (this initiative's packet 04) — its acceptance criteria, constraints, and Referenced-Invariants sections currently use `{N1}` / `{N2}` / `{N3}` placeholders for the three assigned numbers. Substitute the assigned numbers in place pre-push under invariant 24's pre-filing carve-out. **Packets 02 and 04 cannot be filed in the same push** because packet 04's placeholders depend on packet 02's actual assignment.
+
+**Filing-order rule (hard, enforced by `dependencies:` frontmatter):**
+
+This packet depends on `packet:01` (Architecture catalog registration). Packet 01 must merge first so that `repos/HoneyDrunk.Web.UI/invariants.md` exists on disk for this packet to update (the cross-reference paragraph at the bottom of that file references `{N1}` / `{N2}` / `{N3}` placeholders and needs in-place substitution to the assigned numbers).
+
+## Proposed Implementation
+
+### `constitution/invariants.md` — append a new `## Web.UI Invariants` section
+
+Append at the end of the file (after the most-recent existing section, e.g., `## Files Invariants` if ADR-0061 has landed). The agent must verify that no `## Web.UI Invariants` section already exists (it does not at scoping time; confirm at edit time).
+
+The new section structure — **do not include any "(Proposed)" or "(takes effect when accepted)" qualifier**; land the invariants in their final, active form:
+
+```markdown
+## Web.UI Invariants
+
+{N1}. **Grid frontend surfaces consume design tokens and primitive CSS from `HoneyDrunk.Web.UI`.**
+    Every consumer frontend in the Grid — Studios, Notify Cloud admin (Blazor or React), all PDR-driven consumer apps — sources its design tokens (color, spacing, typography, radii, shadows, motion, breakpoints, z-index) from `@honeydrunk/web-ui-tokens` and its primitive CSS (reset, base typography, utility classes) from `@honeydrunk/web-ui-css`. Per-PDR re-derivation — declaring custom CSS variables for the same semantic concepts or authoring a private reset/utility-class layer — is a boundary violation. Per-PDR overrides via the standard CSS-variable cascade (a consumer setting `--hd-color-accent: var(--my-warmer-accent)` at its root, etc.) are permitted and intentional; the override flows downstream only. The review agent rejects new consumer-frontend packages that introduce a private token/CSS layer instead of consuming Web.UI's. See ADR-0071 D1 / D8.
+
+{N2}. **`HoneyDrunk.Web.UI` does not host `HoneyDrunk.Studios`; Web.UI is consumed by Studios.**
+    Studios is a product Node, not the design-system host. The relationship is one-way: Studios consumes Web.UI's published packages (`@honeydrunk/web-ui-tokens`, `@honeydrunk/web-ui-css`, eventually `@honeydrunk/web-ui-react`) the same way Hearth, Lately, Currents, Curiosities, and Notify Cloud admin will. A PR that adds a `studios/design-system` export to Studios' package surface — or proposes folding Web.UI sources into the Studios repo — is rejected on this invariant. The Studios website is the **first consumer** of Web.UI; it is not the host. See ADR-0071 D3.
+
+{N3}. **`HoneyDrunk.Web.UI` does not depend on any Grid Node's runtime contracts.**
+    No package in the Web.UI repo (`@honeydrunk/web-ui-tokens`, `@honeydrunk/web-ui-css`, `@honeydrunk/web-ui-react`, `HoneyDrunk.Web.UI.Blazor`, `@honeydrunk/web-ui-native`) takes a runtime dependency on `HoneyDrunk.Kernel`, `HoneyDrunk.Vault`, `HoneyDrunk.Auth`, `HoneyDrunk.Data`, `HoneyDrunk.Transport`, `HoneyDrunk.Audit`, `HoneyDrunk.Pulse`, `HoneyDrunk.Notify`, `HoneyDrunk.Communications`, or any other Grid Node. The dependency direction is one-way consumer → Web.UI, never the inverse. If a consumer needs to render a Grid-canonical value type (e.g., `Money` per ADR-0069, `TenantId` per ADR-0026), the dependency direction stays consumer-side — the consuming PDR's adapter, not the Web.UI primitive. Web.UI's package.json `dependencies` and `peerDependencies` arrays contain only third-party libraries (React, React Native, headless primitives at the implementation layer) and the `HoneyDrunk.Web.UI.Blazor` `.csproj` does not reference any `HoneyDrunk.*` NuGet package. The review agent rejects additions of any `HoneyDrunk.*` dependency to any Web.UI package. See ADR-0071 D9.
+```
+
+The agent substitutes the actual assigned numbers (87, 88, 89 — or shifted block if the reservation moved at edit time) at edit time. The Markdown numbering treats these as ordered-list items — the literal numbers must be in the source.
+
+### `adrs/ADR-0071-stand-up-honeydrunk-web-ui-node.md` — finalize the invariant numbers in Consequences
+
+In ADR-0071's Consequences section, the §Invariants subsection currently opens with:
+
+> `This ADR proposes (not commits — invariant numbers and final wording assigned by the scope agent at acceptance):`
+
+Followed by three bullet points (the token-consumption proposal, the Studios-not-host proposal, the zero-runtime-dependency proposal).
+
+Replace the opening sentence so the subsection reads (substitute the actual assigned numbers):
+
+> `Assigned invariant numbers: **{N1}** (Grid frontend surfaces consume design tokens and primitive CSS from HoneyDrunk.Web.UI), **{N2}** (Web.UI does not host Studios; Web.UI is consumed by Studios), and **{N3}** (Web.UI does not depend on any Grid Node's runtime contracts). See \`constitution/invariants.md\`, \`## Web.UI Invariants\`. All three landed by ADR-0071's stand-up initiative (packet 02).`
+
+Leave the three bullet points unchanged.
+
+### `repos/HoneyDrunk.Web.UI/invariants.md` — update the trailing cross-reference
+
+Packet 01 of this initiative writes a trailing cross-reference paragraph using `{N1}` / `{N2}` / `{N3}` placeholders. The exact text (per packet 01's implementation block) is:
+
+> `_Constitutional invariants {N1} (Grid frontend surfaces consume design tokens and primitive CSS from HoneyDrunk.Web.UI), {N2} (HoneyDrunk.Web.UI does not host HoneyDrunk.Studios — Web.UI is consumed by Studios), and {N3} (HoneyDrunk.Web.UI does not depend on any Grid Node's runtime contracts) in \`constitution/invariants.md\` are the Grid-level rules this Node exists to enforce. All three are landed by ADR-0071's stand-up initiative (packet 02). The numeric assignments are made at packet 02's edit time via the reservation registry._`
+
+This packet substitutes the placeholders with the assigned numbers. The replacement text:
+
+> `_Constitutional invariants {assigned-N1} (Grid frontend surfaces consume design tokens and primitive CSS from HoneyDrunk.Web.UI), {assigned-N2} (HoneyDrunk.Web.UI does not host HoneyDrunk.Studios — Web.UI is consumed by Studios), and {assigned-N3} (HoneyDrunk.Web.UI does not depend on any Grid Node's runtime contracts) in \`constitution/invariants.md\` are the Grid-level rules this Node exists to enforce. All three landed by ADR-0071's stand-up initiative (packet 02 — this packet)._`
+
+(Substitute the actual numeric assignments.)
+
+### `constitution/invariant-reservations.md` — move ADR-0071 row from Active to History
+
+Locate the ADR-0071 row in the **Active Reservations** table and remove it. Add a new row to the **Reservation History (for audit)** table at the bottom:
+
+```
+| 87–89 | ADR-0071 | YYYY-MM-DD | Web.UI Node standup invariants — landed in ## Web.UI Invariants section |
+```
+
+Replace `YYYY-MM-DD` with the merge date of this packet's PR (whatever date the file-packets pipeline records).
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the current in-progress dated SemVer section (per memory `feedback_no_unreleased_commits`):
+
+`Architecture: Add new ## Web.UI Invariants section with invariants {N1} (Grid frontend surfaces consume design tokens and primitive CSS from HoneyDrunk.Web.UI — per-PDR re-derivation is a boundary violation; per-PDR CSS-variable overrides permitted), {N2} (HoneyDrunk.Web.UI does not host HoneyDrunk.Studios — Web.UI is consumed by Studios; Studios is a product Node, not the design-system host), and {N3} (HoneyDrunk.Web.UI does not depend on any Grid Node's runtime contracts — pure client-side substrate; dependency direction is one-way consumer → Web.UI) per ADR-0071 §Invariants. Finalizes the invariant numbers in ADR-0071 Consequences (replaces the "This ADR proposes (not commits)…" framing with assigned numbers). Updates repos/HoneyDrunk.Web.UI/invariants.md trailing cross-reference. Moves ADR-0071 reservation row from Active Reservations to Reservation History in constitution/invariant-reservations.md.`
+
+## Affected Files
+
+- `constitution/invariants.md` (append new `## Web.UI Invariants` section with 3 invariants)
+- `constitution/invariant-reservations.md` (move ADR-0071 row from Active Reservations to Reservation History)
+- `adrs/ADR-0071-stand-up-honeydrunk-web-ui-node.md` (Consequences §Invariants subsection — finalize numbers)
+- `repos/HoneyDrunk.Web.UI/invariants.md` (trailing cross-reference paragraph — substitute placeholders with assigned numbers)
+- `CHANGELOG.md` (entry under the current dated SemVer-bumped section)
+
+## NuGet Dependencies
+None. Architecture is a knowledge repo — no .NET projects.
+
+## Boundary Check
+- [x] All edits inside `HoneyDrunk.Architecture` — correct repo per routing rules.
+- [x] No new design decision — invariant text is taken from ADR-0071 §Invariants with light wordsmithing for the constitution's voice.
+- [x] No double-numbering — the agent verifies the reservation block (87–89) at edit time and shifts if any earlier-numbered Proposed ADR's packet 00 landed in the interim.
+- [x] No `(Proposed — takes effect when accepted)` qualifier on the new invariants. Land in their final, active form.
+- [x] No edit to ADR-0071's Status header. Status stays Proposed; the flip is post-merge housekeeping.
+
+## Acceptance Criteria
+
+- [ ] **Reservation check performed at edit time** using both `constitution/invariant-reservations.md` (Active Reservations table) and `rg -n '^[0-9]+\.' constitution/invariants.md | tail -n 20`. The actual assigned numbers are recorded in the PR body and substituted into every cross-reference target. **Block is expected to remain 87–89; use only the reservation-registry assigned numbers at edit time** — if another invariant-numbering packet landed between this scoping and this packet's edit, the assignments shift.
+- [ ] `constitution/invariants.md` carries a new `## Web.UI Invariants` section appended after the most-recent existing section.
+- [ ] The new section carries exactly three invariants at the assigned monotonic numbers: `{N1}` (Grid frontend surfaces consume design tokens and primitive CSS from `HoneyDrunk.Web.UI`), `{N2}` (`HoneyDrunk.Web.UI` does not host `HoneyDrunk.Studios`; Web.UI is consumed by Studios), `{N3}` (`HoneyDrunk.Web.UI` does not depend on any Grid Node's runtime contracts).
+- [ ] **No `(Proposed)` or `(takes effect when ADR-0071 is accepted)` qualifier** appears in the invariant text. The invariants read as fully active from day one.
+- [ ] Invariant `{N1}`'s text names `@honeydrunk/web-ui-tokens` and `@honeydrunk/web-ui-css` as the consumed package surface and names per-PDR CSS-variable overrides as the permitted divergence mechanism.
+- [ ] Invariant `{N2}`'s text explicitly forbids a `studios/design-system` export shape and explicitly forbids folding Web.UI sources into Studios.
+- [ ] Invariant `{N3}`'s text names the five Web.UI packages (`@honeydrunk/web-ui-tokens`, `@honeydrunk/web-ui-css`, `@honeydrunk/web-ui-react`, `HoneyDrunk.Web.UI.Blazor`, `@honeydrunk/web-ui-native`) and explicitly forbids any `HoneyDrunk.*` dependency in any of them. Names the consumer-side adapter as the correct location for any future Grid-canonical-value-type rendering.
+- [ ] **All cross-reference targets updated in lockstep with the assigned numbers:** ADR-0071 Consequences §Invariants subsection, `repos/HoneyDrunk.Web.UI/invariants.md` trailing paragraph, and this initiative's packet 04 source file (pre-filing under invariant 24's carve-out).
+- [ ] `adrs/ADR-0071-stand-up-honeydrunk-web-ui-node.md` Consequences §Invariants subsection has its preamble sentence replaced — "This ADR proposes (not commits…)" → "Assigned invariant numbers: **{N1}**…**{N2}**…**{N3}**…". The three bullet points remain unchanged.
+- [ ] `repos/HoneyDrunk.Web.UI/invariants.md` trailing paragraph is updated to cite the three assigned numbers with brief parenthetical descriptions, naming ADR-0071 as the source.
+- [ ] `constitution/invariant-reservations.md` ADR-0071 row moved from **Active Reservations** to **Reservation History** with the merge date.
+- [ ] `CHANGELOG.md` carries an entry under the current dated SemVer section describing the invariant additions (not under `## Unreleased`).
+- [ ] PR body explicitly notes: (1) three new invariants landed under a new `## Web.UI Invariants` section at block 87–89 (or shifted if reservation moved); (2) ADR-0071 Consequences finalized; (3) `repos/HoneyDrunk.Web.UI/invariants.md` cross-reference updated; (4) packet 04 source file was edited in place pre-filing to substitute the assigned numbers; (5) reservation row moved to History.
+- [ ] Status of ADR-0071 stays `Proposed` in this packet's diff. No edit to the ADR header.
+
+## Human Prerequisites
+
+- [ ] Packet 01 of this initiative merged to `main` before this packet's PR is opened. Without that merge, `repos/HoneyDrunk.Web.UI/invariants.md` does not exist for the trailing-paragraph edit, and `constitution/sectors.md`'s Creator-sector anchor row is not in place for the cross-cite to be coherent.
+- [ ] Confirm the assigned-number text in ADR-0071 Consequences matches the user's understanding of the three candidate invariants — both are mechanical text edits, but ADR Consequences edits warrant a quick eye before merge.
+
+## Referenced Invariants
+
+> **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. Pre-filing amendments are permitted; post-filing corrections require a new packet. — Packet 04 of this initiative cites the three invariant numbers this packet assigns. It must be amended in place pre-filing once this packet's PR merges and the actual assigned numbers are known. **Packets 02 and 04 cannot be filed in the same push.**
+
+## Referenced ADR Decisions
+
+**ADR-0071 §Invariants subsection:** Three candidate invariants nominated for promotion — the token-consumption rule, the Studios-not-host rule, and the zero-runtime-dependency rule. This packet performs the promotion. All three are definitive (none are conditional on first-feature-packet evidence).
+
+**ADR-0071 D1 (Web.UI is the Creator sector's owner of design tokens, primitive CSS, and component contracts):** The token-consumption invariant `{N1}` is the cross-PDR enforcement of D1's ownership statement.
+
+**ADR-0071 D3 (Web.UI is consumed by Studios — not folded into Studios):** The Studios-not-host invariant `{N2}` codifies D3 at the constitutional level.
+
+**ADR-0071 D8 (Boundaries explicit):** The boundary text is design-time documentation; the constitutional invariants are the runtime-enforcement surface the review agent cites at PR time.
+
+**ADR-0071 D9 (Dependencies and Grid-relationship discipline):** The zero-runtime-dependency invariant `{N3}` codifies D9 at the constitutional level. Names all five Web.UI packages and explicitly forbids any `HoneyDrunk.*` dependency in any of them.
+
+## Dependencies
+
+- `packet:01` — Architecture catalog registration. This packet edits `repos/HoneyDrunk.Web.UI/invariants.md` (created by packet 01) and assumes the Web.UI Node is registered in catalogs (so the constitutional invariant has a Node to refer to). Without packet 01 merged, the trailing-paragraph edit has no file to land in.
+
+## Labels
+
+`chore`, `tier-2`, `architecture`, `constitution`, `web-ui`, `adr-0071`
+
+## Agent Handoff
+
+**Objective:** Promote ADR-0071's three candidate invariants to numbered constitutional rules. Append a new `## Web.UI Invariants` section to `constitution/invariants.md` at block 87–89 (per the reservation registry). Substitute the assigned numbers across four cross-reference targets in lockstep. Move the ADR-0071 reservation row from Active to History. No `(Proposed)` qualifier on the new invariants — land them in final active form.
+
+**Target:** HoneyDrunk.Architecture, branch from `main`.
+
+**Context:**
+- Goal: Land the three constitutional invariants ADR-0071 nominates so packet 04 of this initiative (the HoneyDrunk.Web.UI scaffold) can cite them by number, and so the review agent has citable rules for token-consumption enforcement, Studios-not-host enforcement, and zero-Grid-Node-runtime-dependency enforcement at every future PR.
+- Feature: ADR-0071 standup initiative — this is the constitution side of Wave 1.
+- ADRs: ADR-0071 (this packet finalizes its three candidate invariants).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** `packet:01` (Architecture catalog registration) must be merged to `main` before this packet's PR is authored — that packet creates `repos/HoneyDrunk.Web.UI/invariants.md`, registers the Web.UI Node in catalogs, and writes the placeholder text the trailing paragraph update needs.
+
+**Constraints:**
+
+- **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. Pre-filing amendments are permitted; post-filing corrections require a new packet. — Packet 04 cites the three invariant numbers this packet assigns. It must be amended in place pre-filing once this packet's PR merges. **Packets 02 and 04 cannot be filed in the same push.**
+- **The assignment is from the reservation registry — block 87–89 is the expected value.** Verify against `constitution/invariant-reservations.md` at edit time; if an earlier Proposed ADR's packet 00 landed in the interim, the block shifts up per the reservation discipline.
+- **New section header — yes.** This is the first Creator-sector / Web.UI-related invariant set in the constitution, so a new `## Web.UI Invariants` header is required. Place it after the most-recent existing section to follow the file's existing sector-grouped organization.
+- **Three invariants — all promoted.** All three are definitive per the ADR text; none are conditional on first-feature-packet evidence. Promote all three.
+- **No `(Proposed)` or `(takes effect when ADR-0071 is accepted)` qualifier on the new invariants.** ADR-0071 will be Accepted (by post-merge housekeeping) once this initiative completes; the invariants read as fully active from day one. The standup ADR's "Done When" gate carries the qualifier semantics, not the constitutional text. **This is a deliberate departure from earlier drafts that included the qualifier — drop it.**
+
+**Key Files:**
+- `constitution/invariants.md` — append new `## Web.UI Invariants` section with the three new invariants
+- `constitution/invariant-reservations.md` — move ADR-0071 row from Active Reservations to Reservation History
+- `adrs/ADR-0071-stand-up-honeydrunk-web-ui-node.md` — Consequences §Invariants subsection preamble sentence (replace "This ADR proposes (not commits…)" with "Assigned invariant numbers: **{N1}**…**{N2}**…**{N3}**…")
+- `repos/HoneyDrunk.Web.UI/invariants.md` — trailing cross-reference paragraph (substitute placeholders with assigned numbers)
+- `CHANGELOG.md` — append entry under the current dated SemVer section
+
+**Contracts:**
+- This packet does not author any new contracts. It records the three constitutional rules. Authoring of the actual `DesignTokens` JSON schema, `TokensCssVariables` CSS file, and `PrimitiveCss` bundle happens in packet 04 (the scaffold).

--- a/generated/issue-packets/active/adr-0071-web-ui-standup/03-architecture-create-web-ui-repo.md
+++ b/generated/issue-packets/active/adr-0071-web-ui-standup/03-architecture-create-web-ui-repo.md
@@ -1,0 +1,203 @@
+---
+name: Repo Chore
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "meta", "web-ui", "adr-0071", "human-only", "wave-2"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0071"]
+accepts: ADR-0071
+wave: 2
+initiative: adr-0071-web-ui-standup
+node: honeydrunk-web-ui
+actor: human
+---
+
+# Chore: Create `HoneyDrunk.Web.UI` public GitHub repo + npm scope verification + NPM_TOKEN + branch protection + labels + OIDC + clone locally (human-only)
+
+## Summary
+Create the public `HoneyDrunkStudios/HoneyDrunk.Web.UI` GitHub repo, apply the Grid's per-repo standard settings (branch protection, default branch, labels, Actions enabled, security analysis), verify or create the `@honeydrunk` npm scope under the HoneyDrunk Studios npm organization, seed the `NPM_TOKEN` repository (or org-level) secret so the scaffold packet's release workflow can publish `@honeydrunk/web-ui-tokens` and `@honeydrunk/web-ui-css` on first tag-push, wire the OIDC federated credential for tag-driven NuGet publishing of the future `HoneyDrunk.Web.UI.Blazor` package, and clone the repo locally so packet 04's scaffolding agent has a working tree to author into. This is an org-admin + npm-admin / human action that cannot be delegated to an agent — it gates packet 04.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture` (this is where the tracking issue lives; the actual work happens on GitHub at the org level + npmjs.com at the org level + locally on the user's machine)
+
+## Actor
+**`Human`.** Org-admin rights on `HoneyDrunkStudios` (GitHub) and admin rights on the `@honeydrunk` npm organization are required to create the repo, apply branch protection, seed labels, configure the OIDC federated credential, verify/claim the npm scope, and seed `NPM_TOKEN`. Frontmatter sets `actor: human` and labels include `human-only`; the filing pipeline mirrors `Actor=Human` onto The Hive.
+
+## Motivation
+`04-web-ui-node-scaffold.md` defines the monorepo layout, five package families (`@honeydrunk/web-ui-tokens` + `@honeydrunk/web-ui-css` shipped at v0.1.0; `@honeydrunk/web-ui-react`, `HoneyDrunk.Web.UI.Blazor`, `@honeydrunk/web-ui-native` as placeholders), pnpm workspace, build scripts, CI with npm publish-on-tag, etc. — but cannot be executed by the scaffolding agent until:
+
+1. The `HoneyDrunkStudios/HoneyDrunk.Web.UI` GitHub repo exists. As of 2026-05-25 it does not (confirmed pre-scoping — neither the catalog entries nor the local working tree exist).
+2. The local working tree at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Web.UI/` exists. As of 2026-05-25 it does not.
+3. The `@honeydrunk` npm scope is owned by the HoneyDrunk Studios npm organization. **This must be claimed/verified before the first npm publish.** If the scope is already taken by an unrelated user, the package naming has to change — surfacing this here as a hard gate prevents a packet-04 surprise.
+4. The `NPM_TOKEN` secret exists in the `HoneyDrunk.Web.UI` repo (or at the org level, accessible to the repo) so `release.yml` can authenticate to npmjs.com.
+5. Branch protection rules are applied so the scaffolding PR cannot be force-pushed to `main` and `pr-core` is required.
+6. Labels needed for issue filing exist on the repo (`feature`, `chore`, `tier-1`, `tier-2`, `web-ui`, `scaffold`, `adr-0071`, `wave-2`, `wave-3`, `human-only`, `out-of-band`).
+7. The Grid's NuGet publishing OIDC federated credential has `repo:HoneyDrunkStudios/HoneyDrunk.Web.UI:ref:refs/tags/v*` in its subject list so the future `HoneyDrunk.Web.UI.Blazor` package can publish to NuGet at its eventual tag-push (the Blazor package is a 0.0.0 placeholder at v0.1.0, but the credential should be wired now so when the Blazor implementation lands and the version bumps, the publish flow is ready).
+
+Surfacing this as an explicit Wave-2 work item with `Actor=Human` keeps it visible on The Hive board as a human-only blocker on packet 04 instead of an implicit prerequisite buried in the scaffold packet's body. Same shape as `adr-0061-files-standup/03-architecture-create-files-repo.md` and `adr-0031-audit-node-standup/02-architecture-create-audit-repo.md` — create-and-configure, not verify-and-clone. With the extra npm-scope step layered on because Web.UI is the first JS-shaped Node-standup the Grid has done.
+
+## Steps
+
+### Step 1 — Create the public repo (portal)
+
+1. Open https://github.com/organizations/HoneyDrunkStudios/repositories/new
+2. Fill in:
+   - **Repository name:** `HoneyDrunk.Web.UI`
+   - **Description:** `Cross-stack design system for the HoneyDrunk Grid — design tokens, primitive CSS, and component contracts shared across React, Blazor, and React Native consumers. Tokens cross-stack; components per-stack. The Creator sector's anchor Node.`
+   - **Visibility:** **Public** (per memory `project_repos_public_by_default` — design substrate is exactly the build-in-public substrate the Grid licenses; no revenue/compliance/experiment carve-out applies)
+   - **Initialize this repository with:** check `.gitignore` (template: `Node`), check `LICENSE` (template: `MIT` — matches other Grid repos), do **not** add a README (packet 04 will author the README so it lands with the scaffold; if GitHub forces a README at create-time, that initial placeholder is overwritten by packet 04's commit)
+3. Click **Create repository**.
+4. Open https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.UI/settings — confirm:
+   - **Default branch:** `main`
+   - **Visibility:** Public
+   - **Features:** Issues enabled, Actions enabled, Discussions optional (off by default is fine)
+
+### Step 2 — Verify or claim the `@honeydrunk` npm scope
+
+This is the **most important Web.UI-specific step** — the npm scope must be confirmed before the scaffold can publish.
+
+1. Open https://www.npmjs.com/ in a browser and sign in with the HoneyDrunk Studios npm account (or your operator account if it has admin on the HoneyDrunk Studios org).
+2. Navigate to https://www.npmjs.com/settings/honeydrunk (or whatever the HoneyDrunk Studios npm organization slug is — verify at edit time).
+   - **If the organization does not exist:** create it via https://www.npmjs.com/org/create. Name it `honeydrunk` (per ADR-0071 D6: "The npm packages live under the `@honeydrunk` scope"). The scope is `@honeydrunk`. Pick the free plan (public packages only) — paid plan is only needed for private packages, and Web.UI is public per ADR-0039.
+   - **If the organization exists but the user account is not a member:** add the operator account as a member with admin role.
+   - **If the `@honeydrunk` scope is taken by an unrelated user/org:** this is the hard-stop case. Options: (a) negotiate with the current owner to transfer or release the scope; (b) pick a different scope name (e.g., `@honeydrunk-studios`, `@hd-studios`, `@hdgrid`) and update ADR-0071 D6 + this packet + packet 01's catalog entries + packet 04's package.json files in lockstep. The scope name is **load-bearing** for every consumer's PackageReference; do not improvise.
+3. **Verify scope is empty or contains only HoneyDrunk packages.** Run `npm view @honeydrunk/web-ui-tokens` and confirm `npm ERR! 404` (the package does not exist yet — packet 04 publishes it). If the package already exists and is owned by someone else, this is a name collision that needs resolution (most likely never published; this check is cheap insurance).
+4. **Enable 2FA on the npm org** for security if not already on. (Org-level 2FA-required setting.)
+
+### Step 3 — Seed `NPM_TOKEN`
+
+1. On npmjs.com, navigate to https://www.npmjs.com/settings/{your-username}/tokens.
+2. Click **Generate New Token** → **Classic Token** (or Granular Token if preferred; classic is simpler and works fine for org publishing).
+3. Token type: **Automation** (CI-friendly; bypasses 2FA challenges on publish; required for the GitHub Actions publish flow). **Not Publish or Read-Only** — Automation is the correct selection for CI.
+4. Scope: **Restrict to specific scopes** → `@honeydrunk` → **Read and write**.
+5. Copy the token immediately — npm shows it only once.
+6. **Decide the secret scope.** Two options:
+   - **Org-level secret** (preferred for the Grid pattern): Open https://github.com/organizations/HoneyDrunkStudios/settings/secrets/actions and create `NPM_TOKEN` with the token value. Grant access to "Selected repositories" and include `HoneyDrunk.Web.UI` (and any future `@honeydrunk/...`-publishing repo). This matches the org-level `NUGET_API_KEY` pattern.
+   - **Repo-level secret** (if org-level is unavailable for the user's npm pricing tier or other reason): Open https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.UI/settings/secrets/actions and create `NPM_TOKEN`.
+7. Verify the secret name is **exactly** `NPM_TOKEN` (the reusable npm-publish workflow expects this name).
+
+### Step 4 — Branch protection on `main`
+
+Open https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.UI/settings/branches and create a branch protection rule on `main`:
+
+- **Require a pull request before merging:** on
+- **Require approvals:** off (solo developer; matches other Grid repos)
+- **Require status checks to pass before merging:** on
+- **Required status checks:** `pr-core / core` only for now. Any package-publish-canary or contract-shape canary additions are deferred to a **follow-up branch-protection update** after the scaffold lands and the canary first runs cleanly — same first-PR `status: skipped` behavior as the Audit and Files scaffolds.
+- **Allow force pushes:** off
+- **Allow deletions:** off
+- **Require signed commits:** off (matches other Grid repos)
+
+Mirror the settings on `HoneyDrunkStudios/HoneyDrunk.Files` or `HoneyDrunkStudios/HoneyDrunk.Audit` if any field is unclear — those are the most-recent substrate Node standups and are the closest templates.
+
+### Step 5 — Security analysis settings
+
+Open https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.UI/settings/security_analysis and confirm:
+
+- **Dependabot alerts:** Enabled (org default — should already be on)
+- **Dependabot security updates:** **Off** (per memory `project_adr_0009_dependabot_stance` — alerts yes, auto-PRs no; grouped nightly-deps workflow replaces per-package Dependabot PRs)
+- **CodeQL default-setup:** **Off** (per memory `project_github_security_configuration` — the org "HoneyDrunk Grid — public default" config keeps CodeQL default-setup off)
+- **Secret scanning:** Enabled (org default)
+- **Push protection:** Enabled
+
+### Step 6 — Seed labels (CLI)
+
+Run the following from any local directory with `gh` CLI authenticated as the org owner. Color choices follow the existing convention used by other Grid repos. **Per memory `project_windows_crlf_gotcha`, on Windows Git Bash the `gh` and `jq` output is CRLF — when piping through bash, `tr -d '\r'` may be needed. For this loop the labels are inline strings, so CRLF is not a risk; but if a label name appears mangled, that is the cause.**
+
+```bash
+for label in "feature:0E8A16" "chore:CCCCCC" "tier-1:E99695" "tier-2:FBCA04" "web-ui:14B8A6" "scaffold:BFDADC" "adr-0071:1D76DB" "wave-2:FBCA04" "wave-3:FBCA04" "human-only:B60205" "out-of-band:D4C5F9"; do
+  name="${label%:*}"; color="${label#*:}"
+  gh label create "$name" --repo HoneyDrunkStudios/HoneyDrunk.Web.UI --color "$color" 2>/dev/null
+done
+```
+
+If `gh label create` errors with "already exists" for any label, that is fine — it is idempotent for our purposes. The `web-ui` label color `#14B8A6` matches the Creator sector chromeTeal per `constitution/sectors.md`.
+
+### Step 7 — Clone the repo locally
+
+```bash
+cd c:/Users/tatte/source/repos/HoneyDrunkStudios/
+git clone https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.UI.git
+cd HoneyDrunk.Web.UI
+git status
+```
+
+The clone should land at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Web.UI/`. After cloning, confirm the working tree contains `.gitignore`, `LICENSE`, and possibly a placeholder `README.md` from the GitHub create step — and nothing else. Packet 04's scaffolding agent will overwrite the placeholder README and create everything else (`package.json`, `pnpm-workspace.yaml`, `packages/`, `.github/workflows/`, `CHANGELOG.md`, etc.).
+
+### Step 8 — Confirm OIDC federated credential (for future NuGet Blazor publish)
+
+Cross-link: [`infrastructure/walkthroughs/oidc-federated-credentials.md`](../../../../infrastructure/walkthroughs/oidc-federated-credentials.md).
+
+Confirm the Grid's NuGet publishing identity has `repo:HoneyDrunkStudios/HoneyDrunk.Web.UI:ref:refs/tags/v*` in its federated credential subject list. If not, add it via the Azure portal (Microsoft Entra → App registrations → the Grid's NuGet publishing app registration → Certificates & secrets → Federated credentials → Add credential). The `HoneyDrunk.Web.UI.Blazor` package is a 0.0.0 placeholder at v0.1.0 (no implementation), but wiring the credential now means the first feature packet that implements the Blazor component pack can tag-publish without an additional human gate.
+
+### Step 9 — Confirm Architecture-side prereq
+
+Confirm packet 01 (the Architecture catalog registration packet) has merged to `main`. That packet creates the `repos/HoneyDrunk.Web.UI/` context folder, registers `honeydrunk-web-ui` in the catalogs, anchors the Creator sector in `sectors.md`, captures Studios' tokens inventory at `repos/HoneyDrunk.Web.UI/studios-tokens-inventory.md` (which packet 04's scaffolding agent reads as the source for the first tokens release), adds the tech-stack rows, adds the roadmap bullet, and adds the in-progress entry in `active-initiatives.md`. If packet 01 has not merged, this chore can still proceed (the GitHub-side and npm-side actions are independent of Architecture-repo state) — but packet 04 (the scaffold) cannot proceed until packet 01 is in.
+
+## Acceptance Criteria
+
+- [ ] `HoneyDrunkStudios/HoneyDrunk.Web.UI` repo exists on GitHub, is public, has default branch `main`, has Issues + Actions enabled.
+- [ ] Repo initialized with `.gitignore` (Node template) and `LICENSE` (MIT matching other Grid public repos).
+- [ ] **`@honeydrunk` npm scope is verified as owned by the HoneyDrunk Studios npm organization, with the operator account having publish rights.** If the scope was unavailable, the alternative scope chosen is documented in the PR body and ADR-0071 D6 is updated in a separate amendment packet (out of scope here; flag and stop if encountered).
+- [ ] `NPM_TOKEN` secret exists at org-level (or repo-level if org-level is unavailable) with **Automation** classification, scoped to `@honeydrunk` with read+write, and the `HoneyDrunk.Web.UI` repo has access to it.
+- [ ] Branch protection on `main` requires `pr-core / core`, no force-pushes, no deletions, signed commits not required.
+- [ ] Dependabot alerts: Enabled. Dependabot security updates: Off. CodeQL default-setup: Off. Secret scanning + push protection: Enabled.
+- [ ] Labels `feature`, `chore`, `tier-1`, `tier-2`, `web-ui` (color `#14B8A6` — Creator sector chromeTeal), `scaffold`, `adr-0071`, `wave-2`, `wave-3`, `human-only`, `out-of-band` all exist on the repo.
+- [ ] Local working tree at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Web.UI/` exists, is a clean clone, contains `.gitignore` + `LICENSE` + at most a placeholder `README.md`.
+- [ ] OIDC federated credential `repo:HoneyDrunkStudios/HoneyDrunk.Web.UI:ref:refs/tags/v*` exists on the Grid's NuGet publishing identity in Microsoft Entra (for the future `HoneyDrunk.Web.UI.Blazor` package's eventual publish).
+- [ ] Packet 01 of this initiative merged to `main` (confirmation step — not blocked by it for these GitHub/npm-side actions, but packet 04 is).
+- [ ] This chore issue is closed after all checks above are verified.
+- [ ] After this chore is Done **and** packet 02 of this initiative has merged, packet 04 (`04-web-ui-node-scaffold.md`) is fileable.
+
+## Human Prerequisites
+
+- [ ] Org-admin role on `HoneyDrunkStudios` (required to create the repo, set branch protection, and seed labels)
+- [ ] Admin role on the HoneyDrunk Studios npm organization (or ability to create the org if it does not exist)
+- [ ] Browser with GitHub session logged in as the org owner
+- [ ] Browser with npmjs.com session logged in as the user with publish rights
+- [ ] `gh` CLI installed locally and authenticated as the org owner
+- [ ] Azure portal access for the OIDC federated credential check (Microsoft Entra → App registrations → NuGet publishing identity → Certificates & secrets → Federated credentials)
+- [ ] Packet 01 of this initiative merged to `main` — confirms `repos/HoneyDrunk.Web.UI/` context folder is registered and `honeydrunk-web-ui` is in `catalogs/nodes.json`
+
+## Dependencies
+
+- `packet:01` — Architecture catalog registration must have merged to `main` so the Architecture-side registration (catalog, sectors, context folder, tech-stack, roadmap, active-initiatives, Studios tokens inventory) is in place. The GitHub-side and npm-side actions in this chore are technically independent of packet 01's merge, but the scaffold (packet 04) is not — surfacing the dependency here keeps the chain visible on The Hive board.
+
+## Downstream Unblocks
+
+- Packet 04 of this initiative (`04-web-ui-node-scaffold.md`) becomes fileable the moment this chore is Done **and** packet 02 of this initiative has merged.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node (or tightly coupled Node family). Each repo has its own solution, CI pipeline, and versioning. — New Node ⇒ new repo. This chore creates that repo.
+
+> **Invariant 24:** Issue packets are immutable once filed. Pre-filing amendments are permitted; post-filing corrections require a new packet. — This chore packet is filed in Wave 2 alongside the work that packet 02 (Wave 1) is wrapping up; pre-filing amendments to packet 04 (the scaffold) are permitted under invariant 24 if invariant numbers shift in packet 02 or if the npm scope choice changes.
+
+## Referenced ADR Decisions
+
+**ADR-0071 D1 (Web.UI Node ownership):** `HoneyDrunk.Web.UI` is the Creator sector's anchor Node owning design tokens, primitive CSS, and component contracts. New Node ⇒ new repo per invariant 11.
+
+**ADR-0071 D6 (Package layout):** The npm packages live under the `@honeydrunk` scope (per the standard org convention). The NuGet package follows the existing `HoneyDrunk.*` naming. This packet verifies/claims the npm scope (Step 2) and wires both the npm publish credential (Step 3 — `NPM_TOKEN`) and the NuGet publish credential (Step 8 — OIDC federated credential).
+
+**ADR-0071 §If Accepted — Required Follow-Up Work:** "Create `HoneyDrunk.Web.UI` GitHub repo as **public** (Grid default per ADR-0039; design tokens and CSS are the kind of substrate the build-in-public stance covers naturally)." This chore executes that checklist item, plus the npm-scope verification that the ADR's text implies but does not call out explicitly.
+
+**ADR-0009 (Dependabot stance, Accepted):** Dependabot alerts on, auto-PRs off. The grouped nightly-deps workflow replaces per-package Dependabot PRs. This chore configures the security_analysis settings accordingly in Step 5.
+
+**ADR-0039 (Grid open-source license policy):** Web.UI is public per the Grid default; license is MIT or equivalent. Step 1 specifies Visibility = Public and LICENSE template = MIT.
+
+**Org GitHub security configuration (memory `project_github_security_configuration`):** "HoneyDrunk Grid — public default" config; CodeQL default-setup stays off (the Grid uses its own CodeQL invocation pattern, not the default-setup flow). Step 5 reflects this.
+
+## Labels
+
+`chore`, `tier-1`, `meta`, `web-ui`, `adr-0071`, `human-only`, `wave-2`
+
+## Notes for the human executing this chore
+
+- This is a 15-minute task split across GitHub portal + npm portal + CLI + Azure portal (for OIDC) + a single `git clone`. The npm-scope verification is the longest unfamiliar step if this is the first time the Grid has done JS publishing — budget the extra few minutes for navigating npm's org/scope/token UX.
+- The OIDC federated credential step (Step 8) is the only Azure portal step. The Grid has a standard NuGet publishing identity used by every Node; if this is the first new repo since the credential was set up, confirm the subject pattern allows tag-pushes from `HoneyDrunk.Web.UI`.
+- The `NPM_TOKEN` step (Step 3) is the **most consequential security step in this chore.** Use **Automation** classification, restrict scope to `@honeydrunk`, read+write only. If the token is ever exposed, rotate immediately by revoking on npmjs.com and regenerating.
+- If GitHub forces a README at repo creation time, that placeholder is fine — packet 04 will overwrite it with the real scaffold README. Do not waste effort writing a temporary README here.
+- Per memory `project_repos_public_by_default`: design substrate is exactly the kind of build-in-public substrate the Grid licenses — no carve-out applies. Public is the right call — same reasoning as Audit, Capabilities, Files, Communications, Studios.
+- Per memory `feedback_provision_when_needed`: no Azure resources to provision yet. HoneyDrunk.Web.UI is a library Node at standup (published packages only — no runtime host, no Container App, no Function App). Storage Account, CDN, App Configuration, Managed Identity, Key Vault — none apply to Web.UI ever; it is a published-package substrate, not a service. The only "Azure touch" in this chore is the OIDC credential on Microsoft Entra (no resource provisioning).
+- **If the `@honeydrunk` scope is unavailable**, this chore stops at Step 2 and a separate amendment packet to ADR-0071 D6 must rename the scope across (a) ADR-0071 D6, (b) packet 01's catalog entries that reference `@honeydrunk/...` package names, (c) packet 04's scaffolding body, (d) `repos/HoneyDrunk.Web.UI/overview.md` + `invariants.md` + `integration-points.md` from packet 01. This is a non-trivial pivot — flag and stop if encountered.

--- a/generated/issue-packets/active/adr-0071-web-ui-standup/04-web-ui-node-scaffold.md
+++ b/generated/issue-packets/active/adr-0071-web-ui-standup/04-web-ui-node-scaffold.md
@@ -1,0 +1,1152 @@
+---
+name: Repo Scaffold
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Web.UI
+labels: ["feature", "tier-2", "web-ui", "scaffold", "adr-0071"]
+dependencies: ["packet:01", "packet:02", "packet:03"]
+adrs: ["ADR-0071", "ADR-0070", "ADR-0035", "ADR-0039", "ADR-0009"]
+accepts: ADR-0071
+wave: 3
+initiative: adr-0071-web-ui-standup
+node: honeydrunk-web-ui
+---
+
+# Feature: Stand up the HoneyDrunk.Web.UI repo — pnpm monorepo, five packages, tokens + CSS shipped at 0.1.0, CI with npm publish-on-tag
+
+## Summary
+Bring the empty `HoneyDrunk.Web.UI` repo from zero to first-shippable state per ADR-0071 D5 (Phase 1) and D6 (Package layout). Land the pnpm-workspace monorepo, the five package families (`@honeydrunk/web-ui-tokens` + `@honeydrunk/web-ui-css` shipped at 0.1.0 with real content; `@honeydrunk/web-ui-react`, `HoneyDrunk.Web.UI.Blazor`, `@honeydrunk/web-ui-native` as honest 0.0.0 placeholders), the D6 contracts surface inside `@honeydrunk/web-ui-tokens` (color/spacing/typography/radii/shadows/motion/breakpoints/z-index scales), the primitive CSS bundle inside `@honeydrunk/web-ui-css` (reset + base typography + utility classes), Vitest-based unit tests for the tokens shape and the CSS bundle, and the standard CI pipeline (PR core + release with npm publish-on-tag + nightly deps + nightly security).
+
+This is the unblocker for Studios' tokens-migration follow-up packet, Notify Cloud admin's tokens + CSS consumption, and every PDR-driven consumer app's first scaffolding packet. After this packet merges and `v0.1.0` tags, those consumers can take a `@honeydrunk/web-ui-tokens@0.1.0` and `@honeydrunk/web-ui-css@0.1.0` dependency and start wiring their own work in parallel.
+
+**Invariant numbers assigned.** Web.UI constitutional invariants are `{N1}` (Grid frontend surfaces consume design tokens and primitive CSS from `HoneyDrunk.Web.UI`), `{N2}` (`HoneyDrunk.Web.UI` does not host `HoneyDrunk.Studios`; Web.UI is consumed by Studios), and `{N3}` (`HoneyDrunk.Web.UI` does not depend on any Grid Node's runtime contracts). These placeholders are substituted with the actual assigned numbers in place pre-push, after packet 02 of this initiative merges and lands the actual numeric assignments (expected block 87–89 per reservation registry).
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Web.UI`
+
+## Motivation
+ADR-0071 D5 specifies the Phase 1 deliverable: "Repo created; tokens + primitive CSS shipped as `@honeydrunk/web-ui-tokens` and `@honeydrunk/web-ui-css`. No components yet. Studios' existing tokens migrate in as Phase 1's first input. The Studios website becomes the first consumer immediately." Packet 03 created the GitHub repo and cloned the local tree at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Web.UI/` (`.gitignore`, `LICENSE`, placeholder `README.md` only), verified the `@honeydrunk` npm scope, and seeded `NPM_TOKEN`. Catalogs, Web.UI invariants (`{N1}`, `{N2}`, `{N3}`), and the Studios tokens inventory (at `repos/HoneyDrunk.Web.UI/studios-tokens-inventory.md` in the Architecture repo) are already in place. This packet ships the code.
+
+Until this packet ships: every consumer named in ADR-0071 has no `@honeydrunk/web-ui-tokens@0.1.0` or `@honeydrunk/web-ui-css@0.1.0` to reference; Studios' migration is blocked; Notify Cloud admin invents its own colors; every queued consumer-app PDR pays the per-surface design tax independently. ADR-0071 D5 explicitly requires tokens + CSS in the first commit; the three placeholder packages are intentional honest gaps that ship at 0.0.0 and gain real implementations at Phase 2/3/4 per consumer demand.
+
+## Proposed Implementation
+
+### Repository layout
+
+```
+HoneyDrunk.Web.UI/
+├── package.json                      (workspace root — name "@honeydrunk/web-ui-workspace", private:true)
+├── pnpm-workspace.yaml               (lists ./packages/* as workspaces)
+├── pnpm-lock.yaml                    (committed lockfile)
+├── tsconfig.base.json                (shared TypeScript base; per-package tsconfig extends this)
+├── .npmrc                            (npm registry; engine-strict; auto-install-peers if applicable)
+├── CHANGELOG.md                      (repo-level — ## [0.1.0] - YYYY-MM-DD)
+├── README.md
+├── LICENSE                           (placed by packet 03; verify content matches Grid LICENSE)
+├── .editorconfig
+├── .gitignore                        (from packet 03; extend with node_modules, dist, .turbo, .next, etc.)
+├── .github/
+│   └── workflows/
+│       ├── pr-core.yml               (build + test all packages on PR)
+│       ├── release.yml               (on tag v*.*.*, build + npm publish for shipped packages)
+│       ├── nightly-deps.yml          (grouped deps PR per ADR-0009)
+│       └── nightly-security.yml      (security audit; manual close per memory feedback_manual_close_security_issues)
+└── packages/
+    ├── tokens/
+    │   ├── package.json              (name: "@honeydrunk/web-ui-tokens", version: 0.1.0, real content)
+    │   ├── README.md
+    │   ├── CHANGELOG.md              (## [0.1.0])
+    │   ├── tsconfig.json             (extends tsconfig.base.json)
+    │   ├── src/
+    │   │   ├── index.ts              (re-export tokens object + types)
+    │   │   ├── tokens.ts             (the DesignTokens JSON-as-TS const — see content section)
+    │   │   ├── types.ts              (TypeScript type definitions for DesignTokens)
+    │   │   └── build-css.ts          (build-time script: emits dist/css/variables.css from tokens)
+    │   ├── dist/                     (gitignored — built artifacts)
+    │   │   ├── index.js              (CJS)
+    │   │   ├── index.mjs             (ESM)
+    │   │   ├── index.d.ts            (types)
+    │   │   ├── tokens.json           (stack-agnostic JSON for non-TS consumers)
+    │   │   └── css/
+    │   │       └── variables.css     (CSS variables emission of tokens)
+    │   ├── scripts/
+    │   │   └── emit-json-and-css.mjs (build-script entrypoint — produces tokens.json + variables.css)
+    │   └── test/
+    │       └── tokens.test.ts        (Vitest — structural assertion: every sector key from sectors.md is present)
+    ├── css/
+    │   ├── package.json              (name: "@honeydrunk/web-ui-css", version: 0.1.0, real content)
+    │   ├── README.md
+    │   ├── CHANGELOG.md              (## [0.1.0])
+    │   ├── tsconfig.json
+    │   ├── src/
+    │   │   ├── reset.css             (modern CSS reset — sane defaults)
+    │   │   ├── typography.css        (base typography for h1-h6, p, ul, ol, blockquote, code, etc.)
+    │   │   ├── utilities.css         (utility class taxonomy — hd-m-*, hd-p-*, hd-flex, hd-grid, hd-text-*, etc.)
+    │   │   └── index.css             (@imports for reset + typography + utilities; single entrypoint consumers import)
+    │   └── test/
+    │       └── css-bundle.test.ts    (Vitest — assert dist/index.css contains hd- prefixed selectors and known utility classes)
+    ├── react/
+    │   ├── package.json              (name: "@honeydrunk/web-ui-react", version: 0.0.0 PLACEHOLDER)
+    │   ├── README.md                 (states: "Placeholder. Phase 2 — first components ship at first non-Studios consumer demand.")
+    │   ├── CHANGELOG.md              (## [0.0.0] - YYYY-MM-DD — "Placeholder package created.")
+    │   ├── tsconfig.json
+    │   └── src/
+    │       └── index.ts              (export const PLACEHOLDER = true; /* see README */)
+    ├── blazor/
+    │   ├── HoneyDrunk.Web.UI.Blazor.csproj  (placeholder .NET project; targets net10.0; HoneyDrunk.Standards reference)
+    │   ├── README.md                 (states: "Placeholder. Phase 3 — first components ship at first Blazor consumer demand.")
+    │   ├── CHANGELOG.md              (## [0.0.0] - YYYY-MM-DD)
+    │   └── Placeholder.cs            (// Placeholder. No implementation on day one. See README.)
+    └── native/
+        ├── package.json              (name: "@honeydrunk/web-ui-native", version: 0.0.0 PLACEHOLDER)
+        ├── README.md                 (states: "Placeholder. Phase 4 — first components ship at first mobile PDR.")
+        ├── CHANGELOG.md              (## [0.0.0] - YYYY-MM-DD)
+        ├── tsconfig.json
+        └── src/
+            └── index.ts              (export const PLACEHOLDER = true; /* see README */)
+```
+
+**Placeholder discipline (matches the `HoneyDrunk.Files.AzureBlob` pattern from ADR-0061's scaffold packet):** The three placeholder packages (`react`, `blazor`, `native`) ship at version **0.0.0** (not 0.1.0). Their `index.ts` / `Placeholder.cs` files carry only the placeholder comment. Their CHANGELOGs explicitly name them as placeholders. Their READMEs name the phase at which the real implementation lands. This is the honest shape: shipping a stub with `NotImplementedException` or empty components would lie about the package's status and force a churn-PR when the real implementation lands.
+
+Note that this **departs from the standard invariant 27** ("all projects in a solution share one version and move together") — but invariant 27 is .NET-centric and references csproj `<Version>`. The JS monorepo posture is per-package versioning, which is the standard pnpm-workspace pattern; explicitly call this out in the PR body. The shipped packages (`tokens`, `css`) move together at 0.1.0; the placeholders stay at 0.0.0 until their respective Phase ships. **Add `HoneyDrunk.Web.UI.Blazor` to the workspace-versioning posture as a NuGet placeholder at 0.0.0** — it does not version-couple to the npm packages since it ships separately. This is the load-bearing departure from the .NET monorepo precedent.
+
+### Workspace root — `package.json`
+
+```json
+{
+  "name": "@honeydrunk/web-ui-workspace",
+  "version": "0.1.0",
+  "private": true,
+  "description": "HoneyDrunk Grid — cross-stack design system monorepo. Tokens, primitive CSS, component contracts.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.UI.git"
+  },
+  "homepage": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.UI",
+  "engines": {
+    "node": ">=22"
+  },
+  "packageManager": "pnpm@9.0.0",
+  "scripts": {
+    "build": "pnpm -r --filter './packages/tokens' --filter './packages/css' build",
+    "test": "pnpm -r --filter './packages/tokens' --filter './packages/css' test",
+    "lint": "pnpm -r --filter './packages/tokens' --filter './packages/css' lint",
+    "ci": "pnpm run build && pnpm run test"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0",
+    "@types/node": "^22.0.0"
+  }
+}
+```
+
+The `engines.node: ">=22"` field enforces Node 22 minimum — the LTS line at scoping time.
+
+### Workspace declaration — `pnpm-workspace.yaml`
+
+```yaml
+packages:
+  - "packages/tokens"
+  - "packages/css"
+  - "packages/react"
+  - "packages/native"
+```
+
+`packages/blazor` is excluded from the pnpm workspace because it's a .NET project, not an npm package. The Blazor placeholder's `HoneyDrunk.Web.UI.Blazor.csproj` is treated as a sibling .NET project that ships via NuGet, not npm — the CI handles it separately.
+
+### Base TypeScript config — `tsconfig.base.json`
+
+Pinned per the refine-pass guidance:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "isolatedModules": true,
+    "noEmit": false
+  }
+}
+```
+
+Per-package `tsconfig.json` extends this and overrides `outDir` / `rootDir` / `include` as needed.
+
+### Package — `packages/tokens/`
+
+#### `packages/tokens/package.json`
+
+```json
+{
+  "name": "@honeydrunk/web-ui-tokens",
+  "version": "0.1.0",
+  "description": "HoneyDrunk Grid design tokens — color, spacing, typography, radii, shadows, motion, breakpoints, z-index. Stack-agnostic JSON + CSS variables.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.UI.git",
+    "directory": "packages/tokens"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./json": "./dist/tokens.json",
+    "./css/variables.css": "./dist/css/variables.css"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json && node scripts/emit-json-and-css.mjs",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}
+```
+
+#### `packages/tokens/src/tokens.ts`
+
+The tokens object — sector colors from `constitution/sectors.md` are mandatory and round-trip exactly per `repos/HoneyDrunk.Web.UI/studios-tokens-inventory.md` (in the Architecture repo). Other categories are sensible Tailwind-shaped defaults; Studios' migration packet (out of scope) reconciles any drift.
+
+```typescript
+/**
+ * HoneyDrunk Grid design tokens.
+ *
+ * The single source of truth for the Grid's visual language.
+ * Stack-agnostic — consumed by React, Blazor, React Native, and any
+ * other consumer through the JSON export or the CSS-variables emission.
+ *
+ * Sector colors round-trip from constitution/sectors.md exactly.
+ */
+export const tokens = {
+  color: {
+    sector: {
+      core: "#7B61FF",       // violetFlux
+      ops: "#FF8C00",        // cyberOrange
+      meta: "#FFFF00",       // neonYellow
+      honeynet: "#00FF41",   // matrixGreen
+      creator: "#14B8A6",    // chromeTeal
+      market: "#F5B700",     // aurumGold
+      honeyplay: "#FF2A6D",  // neonPink
+      cyberware: "#00D1FF",  // electricBlue
+      ai: "#D946EF",         // synthMagenta
+    },
+    // Neutral palette — Tailwind-shaped 50-950 scale; Studios' migration packet reconciles to actuals.
+    neutral: {
+      50: "#fafafa",
+      100: "#f4f4f5",
+      200: "#e4e4e7",
+      300: "#d4d4d8",
+      400: "#a1a1aa",
+      500: "#71717a",
+      600: "#52525b",
+      700: "#3f3f46",
+      800: "#27272a",
+      900: "#18181b",
+      950: "#09090b",
+    },
+  },
+  space: {
+    0: "0",
+    1: "4px",
+    2: "8px",
+    3: "12px",
+    4: "16px",
+    6: "24px",
+    8: "32px",
+    12: "48px",
+    16: "64px",
+    24: "96px",
+  },
+  typography: {
+    fontFamily: {
+      sans: "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+      mono: "ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace",
+    },
+    fontSize: {
+      xs: "12px",
+      sm: "14px",
+      base: "16px",
+      lg: "18px",
+      xl: "20px",
+      "2xl": "24px",
+      "3xl": "30px",
+      "4xl": "36px",
+      "5xl": "48px",
+    },
+    fontWeight: {
+      regular: 400,
+      medium: 500,
+      semibold: 600,
+      bold: 700,
+    },
+    lineHeight: {
+      tight: 1.2,
+      normal: 1.5,
+      relaxed: 1.75,
+    },
+  },
+  radius: {
+    none: "0",
+    sm: "4px",
+    md: "8px",
+    lg: "12px",
+    xl: "16px",
+    full: "9999px",
+  },
+  shadow: {
+    sm: "0 1px 2px rgba(0,0,0,0.05)",
+    md: "0 4px 6px rgba(0,0,0,0.1)",
+    lg: "0 10px 15px rgba(0,0,0,0.1)",
+    xl: "0 20px 25px rgba(0,0,0,0.1)",
+  },
+  motion: {
+    duration: {
+      fast: "150ms",
+      normal: "250ms",
+      slow: "400ms",
+    },
+    easing: {
+      standard: "cubic-bezier(0.4, 0, 0.2, 1)",
+      in: "cubic-bezier(0.4, 0, 1, 1)",
+      out: "cubic-bezier(0, 0, 0.2, 1)",
+      inOut: "cubic-bezier(0.4, 0, 0.2, 1)",
+    },
+  },
+  breakpoint: {
+    mobile: "640px",
+    tablet: "768px",
+    desktop: "1024px",
+    wide: "1280px",
+  },
+  zIndex: {
+    base: 0,
+    dropdown: 1000,
+    sticky: 1100,
+    modal: 1300,
+    toast: 1400,
+    tooltip: 1500,
+  },
+} as const;
+
+export type Tokens = typeof tokens;
+```
+
+#### `packages/tokens/src/index.ts`
+
+```typescript
+export { tokens } from "./tokens.js";
+export type { Tokens } from "./tokens.js";
+```
+
+#### `packages/tokens/scripts/emit-json-and-css.mjs`
+
+Build-script entry-point. **Uses `fileURLToPath()` for cross-platform path handling — NOT `outPath.pathname.replace(/^\//, '')` which is broken on Windows** (per refine-pass note):
+
+```javascript
+#!/usr/bin/env node
+// Build script: imports the compiled tokens module and emits two artifacts:
+//   1. dist/tokens.json — stack-agnostic JSON for non-TS consumers
+//   2. dist/css/variables.css — CSS-variables emission consumable by primitive CSS and per-PDR consumers
+
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tokens } from "../dist/index.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distDir = join(__dirname, "..", "dist");
+const cssDir = join(distDir, "css");
+
+await mkdir(cssDir, { recursive: true });
+
+// Emit JSON
+await writeFile(join(distDir, "tokens.json"), JSON.stringify(tokens, null, 2), "utf8");
+
+// Emit CSS variables
+function flatten(obj, prefix = "hd") {
+  const lines = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const kebab = key.replace(/([A-Z])/g, "-$1").toLowerCase();
+    const name = `${prefix}-${kebab}`;
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      lines.push(...flatten(value, name));
+    } else {
+      lines.push(`  --${name}: ${value};`);
+    }
+  }
+  return lines;
+}
+
+const cssLines = [":root {", ...flatten(tokens), "}"];
+await writeFile(join(cssDir, "variables.css"), cssLines.join("\n") + "\n", "utf8");
+
+console.log(`Emitted ${join(distDir, "tokens.json")} and ${join(cssDir, "variables.css")}`);
+```
+
+The `fileURLToPath()` import + `dirname()` derivation is the cross-platform pattern that works on both Windows and POSIX. **Do not use `import.meta.url`'s pathname directly** (e.g., `new URL("..", import.meta.url).pathname`) — on Windows that yields a leading slash that breaks `mkdir` and `writeFile`.
+
+#### `packages/tokens/test/tokens.test.ts`
+
+**Structural assertion only — iterates sector keys from a known list, does NOT hex-couple.** Per the refine-pass guidance, the test must remain valid if `constitution/sectors.md` rebrands colors.
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { tokens } from "../src/tokens.js";
+
+describe("@honeydrunk/web-ui-tokens", () => {
+  // Sector keys that constitution/sectors.md defines today.
+  // If sectors.md adds a new sector or renames one, this list must update in lockstep.
+  // Hex values are intentionally NOT asserted here — a palette rebrand should not break this test.
+  const SECTOR_KEYS = [
+    "core",
+    "ops",
+    "meta",
+    "honeynet",
+    "creator",
+    "market",
+    "honeyplay",
+    "cyberware",
+    "ai",
+  ] as const;
+
+  it("exposes a color.sector record covering every sector key", () => {
+    for (const key of SECTOR_KEYS) {
+      expect(tokens.color.sector).toHaveProperty(key);
+      expect(typeof tokens.color.sector[key as keyof typeof tokens.color.sector]).toBe("string");
+      // Sanity: the value looks like a hex color.
+      expect(tokens.color.sector[key as keyof typeof tokens.color.sector]).toMatch(/^#[0-9a-fA-F]{3,8}$/);
+    }
+  });
+
+  it("exposes the canonical token categories", () => {
+    expect(tokens).toHaveProperty("color");
+    expect(tokens).toHaveProperty("space");
+    expect(tokens).toHaveProperty("typography");
+    expect(tokens).toHaveProperty("radius");
+    expect(tokens).toHaveProperty("shadow");
+    expect(tokens).toHaveProperty("motion");
+    expect(tokens).toHaveProperty("breakpoint");
+    expect(tokens).toHaveProperty("zIndex");
+  });
+
+  it("space scale is 4px-based and includes the canonical steps", () => {
+    expect(tokens.space).toHaveProperty("0");
+    expect(tokens.space).toHaveProperty("1");
+    expect(tokens.space).toHaveProperty("4");
+    expect(tokens.space).toHaveProperty("16");
+  });
+
+  it("typography exposes fontFamily / fontSize / fontWeight / lineHeight", () => {
+    expect(tokens.typography).toHaveProperty("fontFamily");
+    expect(tokens.typography).toHaveProperty("fontSize");
+    expect(tokens.typography).toHaveProperty("fontWeight");
+    expect(tokens.typography).toHaveProperty("lineHeight");
+  });
+
+  it("breakpoints cover mobile / tablet / desktop / wide", () => {
+    expect(tokens.breakpoint).toHaveProperty("mobile");
+    expect(tokens.breakpoint).toHaveProperty("tablet");
+    expect(tokens.breakpoint).toHaveProperty("desktop");
+    expect(tokens.breakpoint).toHaveProperty("wide");
+  });
+});
+```
+
+### Package — `packages/css/`
+
+#### `packages/css/package.json`
+
+```json
+{
+  "name": "@honeydrunk/web-ui-css",
+  "version": "0.1.0",
+  "description": "HoneyDrunk Grid primitive CSS — reset, base typography, utility classes. Built on @honeydrunk/web-ui-tokens CSS variables.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.UI.git",
+    "directory": "packages/css"
+  },
+  "main": "./dist/index.css",
+  "exports": {
+    ".": "./dist/index.css",
+    "./reset.css": "./dist/reset.css",
+    "./typography.css": "./dist/typography.css",
+    "./utilities.css": "./dist/utilities.css"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "node scripts/copy-css.mjs",
+    "test": "vitest run",
+    "lint": "echo 'no lint for CSS package'"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@honeydrunk/web-ui-tokens": "^0.1.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}
+```
+
+The peerDependency declaration: consumers of `@honeydrunk/web-ui-css` must also install `@honeydrunk/web-ui-tokens` because the CSS uses the variables emitted by the tokens package. This makes the dependency explicit and consumer-resolved.
+
+#### `packages/css/src/reset.css`
+
+A minimal modern reset. Names follow `hd-` prefix where applicable (for the utility classes; the reset uses universal/type selectors):
+
+```css
+/* HoneyDrunk Web.UI Primitive CSS — Reset */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+* {
+  margin: 0;
+}
+
+html, body {
+  height: 100%;
+}
+
+body {
+  line-height: var(--hd-typography-line-height-normal, 1.5);
+  -webkit-font-smoothing: antialiased;
+}
+
+img, picture, video, canvas, svg {
+  display: block;
+  max-width: 100%;
+}
+
+input, button, textarea, select {
+  font: inherit;
+}
+
+p, h1, h2, h3, h4, h5, h6 {
+  overflow-wrap: break-word;
+}
+```
+
+#### `packages/css/src/typography.css`
+
+```css
+/* HoneyDrunk Web.UI Primitive CSS — Base Typography */
+
+body {
+  font-family: var(--hd-typography-font-family-sans);
+  font-size: var(--hd-typography-font-size-base);
+  font-weight: var(--hd-typography-font-weight-regular);
+  color: var(--hd-color-neutral-900);
+}
+
+h1 { font-size: var(--hd-typography-font-size-5xl); font-weight: var(--hd-typography-font-weight-bold); line-height: var(--hd-typography-line-height-tight); }
+h2 { font-size: var(--hd-typography-font-size-4xl); font-weight: var(--hd-typography-font-weight-bold); line-height: var(--hd-typography-line-height-tight); }
+h3 { font-size: var(--hd-typography-font-size-3xl); font-weight: var(--hd-typography-font-weight-semibold); line-height: var(--hd-typography-line-height-tight); }
+h4 { font-size: var(--hd-typography-font-size-2xl); font-weight: var(--hd-typography-font-weight-semibold); line-height: var(--hd-typography-line-height-normal); }
+h5 { font-size: var(--hd-typography-font-size-xl); font-weight: var(--hd-typography-font-weight-medium); line-height: var(--hd-typography-line-height-normal); }
+h6 { font-size: var(--hd-typography-font-size-lg); font-weight: var(--hd-typography-font-weight-medium); line-height: var(--hd-typography-line-height-normal); }
+
+code, pre {
+  font-family: var(--hd-typography-font-family-mono);
+}
+```
+
+#### `packages/css/src/utilities.css`
+
+A minimal utility taxonomy with the `hd-` prefix:
+
+```css
+/* HoneyDrunk Web.UI Primitive CSS — Utility Classes */
+
+/* Display */
+.hd-block { display: block; }
+.hd-inline-block { display: inline-block; }
+.hd-inline { display: inline; }
+.hd-flex { display: flex; }
+.hd-inline-flex { display: inline-flex; }
+.hd-grid { display: grid; }
+.hd-hidden { display: none; }
+
+/* Flex */
+.hd-flex-row { flex-direction: row; }
+.hd-flex-col { flex-direction: column; }
+.hd-items-center { align-items: center; }
+.hd-items-start { align-items: flex-start; }
+.hd-items-end { align-items: flex-end; }
+.hd-justify-center { justify-content: center; }
+.hd-justify-between { justify-content: space-between; }
+.hd-justify-start { justify-content: flex-start; }
+.hd-justify-end { justify-content: flex-end; }
+.hd-gap-1 { gap: var(--hd-space-1); }
+.hd-gap-2 { gap: var(--hd-space-2); }
+.hd-gap-3 { gap: var(--hd-space-3); }
+.hd-gap-4 { gap: var(--hd-space-4); }
+
+/* Margin */
+.hd-m-0 { margin: var(--hd-space-0); }
+.hd-m-1 { margin: var(--hd-space-1); }
+.hd-m-2 { margin: var(--hd-space-2); }
+.hd-m-4 { margin: var(--hd-space-4); }
+
+/* Padding */
+.hd-p-0 { padding: var(--hd-space-0); }
+.hd-p-1 { padding: var(--hd-space-1); }
+.hd-p-2 { padding: var(--hd-space-2); }
+.hd-p-4 { padding: var(--hd-space-4); }
+
+/* Text */
+.hd-text-left { text-align: left; }
+.hd-text-center { text-align: center; }
+.hd-text-right { text-align: right; }
+
+/* Color (a small starter set; consumers extend via CSS-variable cascade) */
+.hd-text-neutral-900 { color: var(--hd-color-neutral-900); }
+.hd-text-neutral-500 { color: var(--hd-color-neutral-500); }
+.hd-bg-neutral-50 { background-color: var(--hd-color-neutral-50); }
+.hd-bg-neutral-900 { background-color: var(--hd-color-neutral-900); }
+
+/* Border radius */
+.hd-rounded-none { border-radius: var(--hd-radius-none); }
+.hd-rounded-sm { border-radius: var(--hd-radius-sm); }
+.hd-rounded-md { border-radius: var(--hd-radius-md); }
+.hd-rounded-lg { border-radius: var(--hd-radius-lg); }
+.hd-rounded-full { border-radius: var(--hd-radius-full); }
+
+/* Shadow */
+.hd-shadow-sm { box-shadow: var(--hd-shadow-sm); }
+.hd-shadow-md { box-shadow: var(--hd-shadow-md); }
+.hd-shadow-lg { box-shadow: var(--hd-shadow-lg); }
+```
+
+#### `packages/css/src/index.css`
+
+The single entrypoint:
+
+```css
+@import "./reset.css";
+@import "./typography.css";
+@import "./utilities.css";
+```
+
+#### `packages/css/scripts/copy-css.mjs`
+
+Cross-platform CSS copy script using `fileURLToPath()`:
+
+```javascript
+#!/usr/bin/env node
+// Build script: copies src/*.css to dist/ for publishing.
+
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { mkdir, copyFile, readdir } from "node:fs/promises";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const srcDir = join(__dirname, "..", "src");
+const distDir = join(__dirname, "..", "dist");
+
+await mkdir(distDir, { recursive: true });
+
+const files = await readdir(srcDir);
+for (const file of files) {
+  if (file.endsWith(".css")) {
+    await copyFile(join(srcDir, file), join(distDir, file));
+    console.log(`Copied ${file}`);
+  }
+}
+```
+
+#### `packages/css/test/css-bundle.test.ts`
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("@honeydrunk/web-ui-css", () => {
+  it("dist/index.css imports reset, typography, and utilities", async () => {
+    const indexCss = await readFile(join(__dirname, "..", "dist", "index.css"), "utf8");
+    expect(indexCss).toContain("reset.css");
+    expect(indexCss).toContain("typography.css");
+    expect(indexCss).toContain("utilities.css");
+  });
+
+  it("utilities.css uses the hd- prefix on every class", async () => {
+    const utilities = await readFile(join(__dirname, "..", "dist", "utilities.css"), "utf8");
+    // Every class selector in the file should be hd-prefixed.
+    const classMatches = utilities.match(/^\s*\.([a-z][\w-]*)/gm) ?? [];
+    for (const match of classMatches) {
+      const className = match.trim().slice(1);
+      expect(className).toMatch(/^hd-/);
+    }
+  });
+
+  it("reset.css sets box-sizing: border-box on universal selector", async () => {
+    const reset = await readFile(join(__dirname, "..", "dist", "reset.css"), "utf8");
+    expect(reset).toMatch(/box-sizing:\s*border-box/);
+  });
+});
+```
+
+### Placeholder packages — `packages/react/`, `packages/blazor/`, `packages/native/`
+
+Each ships at **version 0.0.0** with a minimal placeholder file, a README that explicitly names the phase at which the real implementation lands, and a CHANGELOG with a `## [0.0.0]` entry.
+
+#### `packages/react/package.json`
+
+```json
+{
+  "name": "@honeydrunk/web-ui-react",
+  "version": "0.0.0",
+  "description": "HoneyDrunk Grid React components — placeholder. Phase 2: first components ship at first non-Studios consumer demand. See README.",
+  "license": "MIT",
+  "private": true,
+  "engines": {
+    "node": ">=22"
+  }
+}
+```
+
+Note **`"private": true`** — the placeholder must NOT publish to npm. Only `tokens` and `css` are published at v0.1.0. The `release.yml` workflow's publish step is filtered to exclude `private` packages.
+
+#### `packages/react/src/index.ts`
+
+```typescript
+// Placeholder. No implementation on day one — see README.
+//
+// Phase 2: the first React component pack (Button, Input, Label, Card,
+// Modal, Toast, Alert, Spinner, Skeleton) ships at first non-Studios
+// consumer demand. At that time this file is replaced with the real
+// implementations and the package version bumps from 0.0.0 to 0.1.0.
+export const PLACEHOLDER = true;
+```
+
+#### `packages/react/README.md`
+
+```markdown
+# @honeydrunk/web-ui-react — Placeholder
+
+**Status:** Placeholder. No implementation on day one.
+
+**Phase 2:** First React component pack (Button, Input, Label, Card, Modal, Toast, Alert, Spinner, Skeleton) ships at first non-Studios consumer demand. The phasing matches consumer demand — the Node does not pre-ship surface it does not have consumers for.
+
+For now, consume `@honeydrunk/web-ui-tokens` and `@honeydrunk/web-ui-css` directly; build product-specific components on top of those primitives.
+```
+
+#### `packages/blazor/HoneyDrunk.Web.UI.Blazor.csproj`
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <Version>0.0.0</Version>
+    <Description>HoneyDrunk Grid Blazor components — placeholder. Phase 3: first components ship at first Blazor consumer demand. See README.</Description>
+    <Authors>HoneyDrunk Studios</Authors>
+    <PackageProjectUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.UI</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Web.UI</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>
+```
+
+`<IsPackable>false</IsPackable>` ensures the placeholder does not publish to NuGet at v0.0.0. The first feature packet that implements Blazor components flips `IsPackable` to `true` and bumps the version. Add `HoneyDrunk.Standards` reference is **deferred** to that future packet — the placeholder doesn't need analyzers since there's nothing to analyze.
+
+#### `packages/blazor/Placeholder.cs`
+
+```csharp
+// Placeholder. No implementation on day one — see README.
+//
+// Phase 3: the first Blazor component or two ships at first Blazor
+// consumer demand. At that time this file is replaced with the real
+// component implementations, IsPackable flips to true, the package
+// version bumps from 0.0.0, and HoneyDrunk.Standards is referenced.
+namespace HoneyDrunk.Web.UI.Blazor;
+
+internal static class Placeholder
+{
+}
+```
+
+#### `packages/native/package.json` and `packages/native/src/index.ts`
+
+Same shape as the React placeholder — `"private": true`, version 0.0.0, placeholder `index.ts`, README naming Phase 4 (first mobile PDR) as the trigger.
+
+### Repo-level `README.md`
+
+```markdown
+# HoneyDrunk.Web.UI
+
+Cross-stack design system for the HoneyDrunk Grid. Owns design tokens, primitive CSS, and component contracts shared across React, Blazor, and React Native consumers. Tokens cross-stack; components per-stack.
+
+## Packages
+
+| Package | Stack | Version | Status |
+|---------|-------|---------|--------|
+| `@honeydrunk/web-ui-tokens` | stack-agnostic | 0.1.0 | Shipping — design tokens (JSON + CSS variables) |
+| `@honeydrunk/web-ui-css` | web (React + Blazor) | 0.1.0 | Shipping — primitive CSS bundle (reset + typography + utilities) |
+| `@honeydrunk/web-ui-react` | React | 0.0.0 | Placeholder — first components ship at first non-Studios consumer demand |
+| `HoneyDrunk.Web.UI.Blazor` (NuGet) | Blazor | 0.0.0 | Placeholder — first components ship at first Blazor consumer demand |
+| `@honeydrunk/web-ui-native` | React Native | 0.0.0 | Placeholder — first components ship at first mobile PDR |
+
+## For downstream consumers — minimal wiring
+
+```bash
+pnpm add @honeydrunk/web-ui-tokens @honeydrunk/web-ui-css
+```
+
+```css
+/* In your global CSS entrypoint */
+@import "@honeydrunk/web-ui-tokens/css/variables.css";
+@import "@honeydrunk/web-ui-css";
+```
+
+```ts
+// In your JS/TS, if you need programmatic access to tokens
+import { tokens } from "@honeydrunk/web-ui-tokens";
+
+console.log(tokens.color.sector.core); // "#7B61FF"
+```
+
+For non-Node consumers (Blazor), import the CSS file directly from the published package or from a CDN unpkg URL.
+
+## Phase-1 honest limitation
+
+This is a Phase-1 release. The following are intentional gaps:
+
+1. **No React, Blazor, or React Native components ship at v0.1.0.** The three component packages (`@honeydrunk/web-ui-react`, `HoneyDrunk.Web.UI.Blazor`, `@honeydrunk/web-ui-native`) ship as placeholders at version 0.0.0. Their READMEs name the phase at which the real implementation lands.
+2. **No designer-tooling integration.** Figma / Penpot integration is deferred indefinitely (lands when designer joins the workflow).
+3. **No icon library.** The Grid will commit to a single icon set in a future release; for now consumers choose their own icons.
+
+## Per-PDR overrides
+
+Per-PDR consumers can override any token via the standard CSS-variable cascade. Set the variable at your application root and every downstream component that reads from it sees the override:
+
+```css
+:root {
+  --hd-color-accent-primary: #ff6600; /* warmer than the default — fine */
+}
+```
+
+The override flows downstream only — the canonical token set is not bidirectionally absorbed.
+
+## License
+
+MIT.
+```
+
+### CHANGELOG (repo-level)
+
+```markdown
+# Changelog
+
+All notable changes to HoneyDrunk.Web.UI are documented here.
+
+## [0.1.0] - YYYY-MM-DD
+
+### Added
+
+- Initial release of HoneyDrunk.Web.UI — the Creator sector's anchor Node.
+- `@honeydrunk/web-ui-tokens` 0.1.0 — design tokens (color, spacing, typography, radii, shadows, motion, breakpoints, z-index). Sector colors round-trip from constitution/sectors.md exactly.
+- `@honeydrunk/web-ui-css` 0.1.0 — primitive CSS bundle (reset, base typography, utility classes with hd- prefix).
+- `@honeydrunk/web-ui-react` 0.0.0 — placeholder package (Phase 2 implementation deferred to first non-Studios consumer demand).
+- `HoneyDrunk.Web.UI.Blazor` 0.0.0 — placeholder package (Phase 3 implementation deferred to first Blazor consumer demand).
+- `@honeydrunk/web-ui-native` 0.0.0 — placeholder package (Phase 4 implementation deferred to first mobile PDR).
+- pnpm-workspace monorepo with TypeScript 5.6, Vitest 2.1.
+- CI: pr-core, release (npm publish-on-tag for non-private packages), nightly-deps, nightly-security.
+```
+
+### CI workflows
+
+#### `.github/workflows/pr-core.yml`
+
+```yaml
+name: PR Core
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  core:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm run test
+      - run: pnpm run lint
+```
+
+#### `.github/workflows/release.yml`
+
+```yaml
+name: Release
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      # Publish only non-private packages. The placeholder packages
+      # (@honeydrunk/web-ui-react, @honeydrunk/web-ui-native) have
+      # "private": true and are skipped naturally by pnpm publish.
+      - name: Publish @honeydrunk/web-ui-tokens
+        working-directory: packages/tokens
+        run: pnpm publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish @honeydrunk/web-ui-css
+        working-directory: packages/css
+        run: pnpm publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # NuGet publish job for HoneyDrunk.Web.UI.Blazor is intentionally
+  # absent at v0.1.0 — the .csproj has IsPackable=false. The first
+  # feature packet that implements Blazor components adds the NuGet
+  # publish job with OIDC federated credential authentication.
+```
+
+#### `.github/workflows/nightly-deps.yml`
+
+Standard grouped-deps PR per ADR-0009 — copies the pattern from `HoneyDrunk.Files` or `HoneyDrunk.Audit` but adapts the package manager from NuGet to pnpm. The agent scaffolds this as a minimal pnpm-aware variant; full ADR-0009 alignment is a follow-up if drift is observed.
+
+#### `.github/workflows/nightly-security.yml`
+
+Standard npm audit + dependency-review per memory `feedback_manual_close_security_issues` (workflow creates/comments on issues; human closes them).
+
+## Affected Files
+Entire repo is created from this packet. Notable new files:
+
+- `package.json`, `pnpm-workspace.yaml`, `pnpm-lock.yaml`, `tsconfig.base.json`, `.npmrc`, `.editorconfig`, `README.md`, `CHANGELOG.md`
+- `packages/tokens/` — `package.json`, `tsconfig.json`, `src/{index.ts, tokens.ts, types.ts, build-css.ts}`, `scripts/emit-json-and-css.mjs`, `test/tokens.test.ts`, `README.md`, `CHANGELOG.md`
+- `packages/css/` — `package.json`, `tsconfig.json`, `src/{reset.css, typography.css, utilities.css, index.css}`, `scripts/copy-css.mjs`, `test/css-bundle.test.ts`, `README.md`, `CHANGELOG.md`
+- `packages/react/` — `package.json`, `tsconfig.json`, `src/index.ts` (placeholder), `README.md`, `CHANGELOG.md`
+- `packages/blazor/` — `HoneyDrunk.Web.UI.Blazor.csproj` (IsPackable=false), `Placeholder.cs`, `README.md`, `CHANGELOG.md`
+- `packages/native/` — `package.json`, `tsconfig.json`, `src/index.ts` (placeholder), `README.md`, `CHANGELOG.md`
+- `.github/workflows/` — `pr-core.yml`, `release.yml`, `nightly-deps.yml`, `nightly-security.yml`
+
+## NuGet Dependencies
+
+The Blazor placeholder (`packages/blazor/HoneyDrunk.Web.UI.Blazor.csproj`) does **NOT** carry a `HoneyDrunk.Standards` PackageReference at v0.0.0 — there is no implementation source to lint, and adding the reference would force the .NET nightly-deps machinery onto a placeholder with no real .NET deps to maintain. The first feature packet that implements Blazor components adds `HoneyDrunk.Standards` (with `PrivateAssets="all"`) and `Microsoft.AspNetCore.Components.Web` as needed.
+
+Per invariant 26, packets for .NET code work include `## NuGet Dependencies`. The Blazor placeholder's deferred-status is documented here as the rationale for the empty section.
+
+| Package | Notes |
+|---|---|
+| (none — placeholder ships with zero NuGet deps at v0.0.0) | First feature packet adds `HoneyDrunk.Standards` (`PrivateAssets="all"`) and `Microsoft.AspNetCore.Components.Web` per actual component needs |
+
+## Boundary Check
+
+- [x] All work inside `HoneyDrunk.Web.UI`. No other Grid repos edited.
+- [x] **Zero `HoneyDrunk.*` dependencies in any Web.UI package** per ADR-0071 D9 / constitutional invariant `{N3}`. No `@honeydrunk/kernel-abstractions` (does not exist; even if a future JS Kernel binding ships, Web.UI does not consume it). No `HoneyDrunk.Kernel`, no `HoneyDrunk.Standards` in the Blazor placeholder (deferred to first feature packet), no anything-Grid-Node-runtime in any package.
+- [x] `tokens` and `css` packages publish to npm under `@honeydrunk` scope. `react`, `native` placeholders carry `"private": true` and do not publish. `HoneyDrunk.Web.UI.Blazor` carries `IsPackable=false` and does not publish to NuGet.
+- [x] Scaffold does NOT include: real React components (Phase 2), real Blazor components (Phase 3), real React Native components (Phase 4), designer tooling (Phase 5), icon library (deferred indefinitely).
+- [x] The three placeholder packages are **honestly named** in their READMEs and CHANGELOGs — no claim of any component shipped at v0.0.0, no language describing them as "production-ready" or "implemented."
+- [x] tsconfig pinned per refine-pass: `target: ES2022`, `module: "ESNext"`, `moduleResolution: "Bundler"`, `resolveJsonModule: true`, `engines.node: ">=22"`.
+- [x] Build scripts use `fileURLToPath()` for cross-platform path handling (not `outPath.pathname.replace(/^\//, '')` which is broken on Windows).
+- [x] `tokens.test.ts` uses structural assertion (iterates sector keys list) — does NOT hex-couple values, so a future palette rebrand does not break the test.
+- [x] Records / interfaces — n/a (TypeScript). The Grid naming convention "records drop I, interfaces keep it" is .NET-specific.
+
+## Acceptance Criteria
+
+- [ ] `pnpm install --frozen-lockfile && pnpm run build && pnpm run test` succeeds from a fresh clone with no errors.
+- [ ] `packages/tokens/package.json` declares `version: "0.1.0"`, name `@honeydrunk/web-ui-tokens`, exports `.`, `./json`, `./css/variables.css`, includes `dist/` in `files`, has `publishConfig.access: "public"`.
+- [ ] `packages/tokens/dist/tokens.json` exists after build and contains the 9 sector colors from `constitution/sectors.md` (`#7B61FF`, `#FF8C00`, `#FFFF00`, `#00FF41`, `#14B8A6`, `#F5B700`, `#FF2A6D`, `#00D1FF`, `#D946EF`) under `color.sector.{core, ops, meta, honeynet, creator, market, honeyplay, cyberware, ai}`.
+- [ ] `packages/tokens/dist/css/variables.css` exists after build and contains `--hd-color-sector-core: #7B61FF;` and the other 8 sector CSS variables under `:root`.
+- [ ] `packages/tokens/test/tokens.test.ts` uses **structural assertion** — iterates a sector-key list and asserts each key exists and the value is a hex string. **Does NOT assert specific hex values** beyond the regex check. A future palette rebrand in `sectors.md` does not break this test.
+- [ ] `packages/tokens/scripts/emit-json-and-css.mjs` uses `fileURLToPath()` for path handling — **not** `import.meta.url`'s `.pathname` (which is broken on Windows). Build runs cleanly on Windows + Linux.
+- [ ] `tsconfig.base.json` declares `target: "ES2022"`, `module: "ESNext"`, `moduleResolution: "Bundler"`, `resolveJsonModule: true`, `strict: true`.
+- [ ] Root `package.json` declares `engines.node: ">=22"` and `packageManager: "pnpm@9.0.0"` (or current pnpm 9.x).
+- [ ] `packages/css/package.json` declares `version: "0.1.0"`, name `@honeydrunk/web-ui-css`, peerDependency on `@honeydrunk/web-ui-tokens`, exports `.` + `./reset.css` + `./typography.css` + `./utilities.css`.
+- [ ] `packages/css/src/utilities.css` uses **`hd-` prefix on every class selector**. `packages/css/test/css-bundle.test.ts` asserts this with a regex over the file content and passes.
+- [ ] `packages/css/src/reset.css` sets `box-sizing: border-box` on the universal selector. Test asserts.
+- [ ] `packages/css/src/index.css` imports reset + typography + utilities. Test asserts.
+- [ ] `packages/react/package.json` declares `version: "0.0.0"`, `"private": true`, and has the placeholder `index.ts` with only the `PLACEHOLDER` constant and the comment block.
+- [ ] `packages/native/package.json` declares `version: "0.0.0"`, `"private": true`, and has the placeholder `index.ts` with only the `PLACEHOLDER` constant and the comment block.
+- [ ] `packages/blazor/HoneyDrunk.Web.UI.Blazor.csproj` declares `<Version>0.0.0</Version>`, `<IsPackable>false</IsPackable>`, no `HoneyDrunk.Standards` PackageReference, no `Microsoft.AspNetCore.Components.Web` PackageReference (both deferred). `Placeholder.cs` contains only the placeholder comment block.
+- [ ] All three placeholder packages' READMEs explicitly state placeholder status and name the Phase at which the real implementation lands. **No claim of "production-ready", "implemented", "component pack", or any language suggesting the placeholder is functional.**
+- [ ] `release.yml` publishes `@honeydrunk/web-ui-tokens` and `@honeydrunk/web-ui-css` to npm on tag `v*.*.*` push, using `NPM_TOKEN` from secrets. Skips placeholder packages via their `"private": true` flag.
+- [ ] `release.yml` does **not** include a NuGet publish step at v0.1.0 (the Blazor placeholder has `IsPackable=false`). A NuGet publish step is added by the first feature packet that implements Blazor components.
+- [ ] `pr-core.yml` runs `pnpm install --frozen-lockfile`, `pnpm run build`, `pnpm run test`, `pnpm run lint` on every PR to `main`.
+- [ ] Repo-level `CHANGELOG.md` has a `## [0.1.0] - YYYY-MM-DD` entry covering the scaffold (per memory `feedback_no_unreleased_commits` — no `## Unreleased` block at commit time).
+- [ ] Per-package `CHANGELOG.md` files each have their own version entry naming what shipped: `tokens` + `css` at `## [0.1.0]`; `react`, `blazor`, `native` at `## [0.0.0]` with explicit "Placeholder package created. No implementation." text.
+- [ ] Repo-level `README.md` and per-package `README.md` files all present.
+- [ ] Repo `README.md` includes a `## For downstream consumers — minimal wiring` section showing copy-pasteable `pnpm add @honeydrunk/web-ui-tokens @honeydrunk/web-ui-css` + the CSS import lines + the JS programmatic-access snippet.
+- [ ] Repo `README.md` includes a `## Phase-1 honest limitation` section that explicitly names: (a) the three placeholder packages and their Phase 2/3/4 deferral; (b) no designer-tooling integration; (c) no icon library.
+- [ ] **The README does NOT cite "ADR-0071" by number in narrative paragraphs.** Per memory `feedback_no_adr_in_docs`. (Runtime metadata references — CHANGELOG, catalog entries elsewhere — are fine; the README is user-facing narrative.)
+- [ ] Test suite runs and passes — minimum coverage: `tokens.test.ts` (sector key structural assertion + canonical category presence + space-scale shape + typography shape + breakpoint shape), `css-bundle.test.ts` (index.css imports, hd- prefix on utilities, reset uses border-box).
+- [ ] Manual confirmation that pushing tag `v0.1.0` triggers `release.yml` and publishes `@honeydrunk/web-ui-tokens@0.1.0` + `@honeydrunk/web-ui-css@0.1.0` to npmjs.com under the `@honeydrunk` scope (do not actually push the tag in this PR — verify the workflow exists and a tag-push trigger is configured).
+- [ ] **No `.github/dependabot.yml` file exists.** Per ADR-0009, dependency-scanning lives in the nightly workflows; no Dependabot config file is committed.
+- [ ] `pnpm-lock.yaml` is committed.
+
+## Human Prerequisites
+
+- [ ] Packet 03 of this initiative complete — `HoneyDrunkStudios/HoneyDrunk.Web.UI` repo exists on GitHub with org-default branch protection, labels seeded, OIDC federated credential wired, `@honeydrunk` npm scope verified, `NPM_TOKEN` seeded, and the local working tree cloned at `c:/Users/tatte/source/repos/HoneyDrunkStudios/HoneyDrunk.Web.UI/`.
+- [ ] Packet 02 of this initiative merged — the three new Web.UI invariants exist in `constitution/invariants.md` so this packet's acceptance criteria reference them by number. **This packet's source file uses `{N1}` / `{N2}` / `{N3}` placeholders** for the three Web.UI-related invariant numbers; substitute the real numbers in place pre-push under invariant 24's pre-filing carve-out, **after** packet 02 merges and the assigned numbers are known. At scoping time (2026-05-25) the expected assignments are 87 / 88 / 89, but the collision-check protocol at packet 02's edit time is authoritative.
+- [ ] After this packet's PR merges, push tag `v0.1.0` from `main` to trigger the first npm publish. Tags are human-pushed.
+- [ ] **`NPM_TOKEN` repository (or org-level) secret is available to the `HoneyDrunk.Web.UI` repo before `v0.1.0` is tagged.** Packet 03 seeds this; verify it's bound to the repo before tagging.
+- [ ] **No Azure resource provisioning required for this packet.** HoneyDrunk.Web.UI is a published-package library Node; no runtime host, no Container App, no Function App, no Storage Account, no CDN, no Key Vault. Ever. The repo is npm/NuGet-only — published packages, not services.
+- [ ] **After this packet's PR merges and `v0.1.0` ships,** file the Studios-side migration packet to add `@honeydrunk/web-ui-tokens` as a Studios dependency and replace Studios' informal CSS-variable declarations with the import. That packet is out of scope here — it lives against the `HoneyDrunk.Studios` repo and references `repos/HoneyDrunk.Web.UI/studios-tokens-inventory.md` as the migration source.
+- [ ] After this packet's PR merges and `v0.1.0` ships, file a small follow-up Architecture packet to bump the two shipped `modules.json` entries (`web-ui-tokens`, `web-ui-css`) from `0.0.0` to `0.1.0` and to flip the `grid-health.json` Web.UI row's `version` from `0.0.0` to `0.1.0`, `signal` from `Seed` to `Live` (if appropriate), and clear the `active_blockers` array. The three placeholder entries (`web-ui-react`, `web-ui-blazor`, `web-ui-native`) stay at `0.0.0`. That follow-up is not in this packet's scope.
+- [ ] After this packet's PR merges, file a SonarCloud onboarding follow-up packet for `HoneyDrunk.Web.UI` modeled on the corresponding ADR-0011 onboarding packet (if SonarCloud is being applied to JS/TS Nodes — verify the current Grid pattern at the time).
+- [ ] After this packet's PR merges, if any future Web.UI consumer (Studios, Notify Cloud admin, or any PDR-driven app) chooses an alternative scope name because the `@honeydrunk` scope has been renamed for any reason, file an amendment packet to ADR-0071 D6 to update the scope name in lockstep across the ADR + catalog + tokens-inventory + this scaffold's package.json files.
+
+## Referenced Invariants
+
+> **Invariant 11:** One repo per Node. Each repo has its own solution, CI pipeline, and versioning. — This packet establishes Web.UI's monorepo + CI.
+
+> **Invariant 12:** Semantic versioning with CHANGELOG and README. New projects must have both files from the first commit. — All five packages ship README + CHANGELOG; repo-level files also.
+
+> **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. Pre-filing amendments are permitted; post-filing corrections require a new packet. — This packet's `{N1}` / `{N2}` / `{N3}` placeholders are substituted in place pre-push after packet 02 merges and assigns the actual numbers.
+
+> **Invariant 26:** Issue packets for .NET code work must include an explicit `## NuGet Dependencies` section. — Section is present above with the deferred-status rationale for the Blazor placeholder.
+
+> **Invariant 27:** All projects in a solution share one version and move together. — **Explicit departure for this packet.** Invariant 27 is .NET-centric and references csproj `<Version>`. The JS monorepo posture is per-package versioning. The two shipped packages (`tokens`, `css`) move together at 0.1.0; the three placeholders stay at 0.0.0 until their respective Phases ship. This departure is documented in the PR body and is consistent with the per-package npm publishing pattern. Future Web.UI version bumps will explicitly call out which packages move and which stay.
+
+> **Invariant `{N1}` (this initiative, packet 02):** Grid frontend surfaces consume design tokens and primitive CSS from `HoneyDrunk.Web.UI`. Per-PDR re-derivation of tokens or primitive CSS is a boundary violation. Per-PDR overrides via standard CSS-variable cascade are permitted. — This packet ships the consumable substrate that enforces this invariant cross-PDR. Studios' migration packet (out of scope) and every consumer's first-scaffolding packet honor this invariant by consuming the published packages.
+
+> **Invariant `{N2}` (this initiative, packet 02):** `HoneyDrunk.Web.UI` does not host `HoneyDrunk.Studios`; Web.UI is consumed by Studios. The Studios website is a product Node, not the design-system host. — Web.UI is published as standalone npm packages that Studios will consume. No Studios sources live in Web.UI; no Web.UI sources live in Studios.
+
+> **Invariant `{N3}` (this initiative, packet 02):** `HoneyDrunk.Web.UI` does not depend on any Grid Node's runtime contracts. Web.UI is purely client-side substrate; the dependency direction is consumer→Web.UI, never the inverse. — Verified by every package's `package.json` (no `HoneyDrunk.*` or `@honeydrunk/kernel-*` dependencies; only third-party libraries and other workspace packages) and by the Blazor placeholder's `HoneyDrunk.Web.UI.Blazor.csproj` (no `HoneyDrunk.*` PackageReferences).
+
+## Referenced ADR Decisions
+
+- **ADR-0071 D1** — Web.UI is the Creator sector's owner of design tokens, primitive CSS, and component contracts. This packet ships the substrate.
+- **ADR-0071 D3** — Web.UI is consumed by Studios — not folded into Studios. The packages are published standalone; Studios consumes them via a follow-up migration packet.
+- **ADR-0071 D4** — Per-stack component strategy: tokens cross-stack, components per-stack. Tokens + CSS ship at standup; component packages are placeholders for Phase 2/3/4.
+- **ADR-0071 D5** — Phased shipping. Phase 1 (this packet): tokens + primitive CSS shipped as `@honeydrunk/web-ui-tokens` and `@honeydrunk/web-ui-css`. No components yet.
+- **ADR-0071 D6** — Package layout. Five packages: tokens (stack-agnostic JSON+CSS), css (web shared), react (per-stack), blazor (per-stack), native (per-stack). npm scope `@honeydrunk`; NuGet `HoneyDrunk.*`.
+- **ADR-0071 D7** — Semantic versioning per ADR-0035 discipline applied to JS/CSS packages. Tokens + CSS start at 0.1.0; placeholders at 0.0.0; pre-1.0 packages do not carry the same compatibility promise.
+- **ADR-0071 D9** — Web.UI has zero runtime dependency on any Grid Node. Verified in every package.
+- **ADR-0070 D1** — React is the default for consumer-facing web. The future `@honeydrunk/web-ui-react` package implements components in React.
+- **ADR-0035** — Semantic versioning discipline. Pre-1.0 packages do not carry the same compatibility promise. Web.UI starts at 0.x and stays there until the cross-PDR consumer base stabilizes.
+- **ADR-0039** — Web.UI is public per the Grid default; license is MIT.
+- **ADR-0009** — No `.github/dependabot.yml`; nightly workflows handle deps.
+
+## Dependencies
+
+- `packet:01` — Architecture catalog registration must be merged so `repos/HoneyDrunk.Web.UI/` context folder, `honeydrunk-web-ui` catalog entries, and `studios-tokens-inventory.md` exist (the scaffolding agent reads the inventory to seed the sector-color block in `tokens.ts`).
+- `packet:02` — the three new Web.UI invariants must exist in `constitution/invariants.md` before this packet's acceptance criteria reference them by number. Substitute the assigned `{N1}` / `{N2}` / `{N3}` numbers in this packet's source file in place pre-push under invariant 24's pre-filing carve-out, **after** packet 02 merges.
+- `packet:03` — the `HoneyDrunk.Web.UI` GitHub repo must exist with branch protection, labels, OIDC, the `@honeydrunk` npm scope verified, `NPM_TOKEN` seeded, and the local working tree cloned. The scaffolding agent has nowhere to author into without packet 03 done.
+
+## Labels
+
+`feature`, `tier-2`, `web-ui`, `scaffold`, `adr-0071`
+
+## Agent Handoff
+
+**Objective:** Take the empty `HoneyDrunk.Web.UI` repo and ship version 0.1.0 with the pnpm-workspace monorepo, the two shipped packages (`@honeydrunk/web-ui-tokens` with tokens JSON + CSS variables; `@honeydrunk/web-ui-css` with reset + typography + utilities), the three honest 0.0.0 placeholder packages (`@honeydrunk/web-ui-react`, `HoneyDrunk.Web.UI.Blazor`, `@honeydrunk/web-ui-native`), the Vitest test suite (structural-assertion-only — no hex coupling), and the full CI pipeline (PR core + release with npm publish-on-tag + nightly deps + nightly security). Sector colors round-trip from `constitution/sectors.md` exactly via the `studios-tokens-inventory.md` reference. The placeholder packages are honestly named — no claim of "production-ready" or "implemented" anywhere in the repo.
+
+**Target:** HoneyDrunk.Web.UI, branch from `main`. (Packet 03 ensures `main` exists with `.gitignore`/`LICENSE` already in place, the `@honeydrunk` npm scope is verified, and `NPM_TOKEN` is seeded.)
+
+**Context:**
+- Goal: Unblock Studios' tokens-migration follow-up packet, Notify Cloud admin's tokens + CSS consumption, every PDR-driven consumer app's first scaffolding packet (Hearth/Lately/Currents/Curiosities). Anchor the Creator sector by shipping its first published artifact.
+- Feature: ADR-0071 standup initiative — this is the substrate scaffold, the fourth packet of the initiative (after Architecture catalog registration, the three new Web.UI invariants `{N1}` / `{N2}` / `{N3}`, and the human-only repo creation + npm scope verification + NPM_TOKEN seeding).
+- ADRs: ADR-0071 (sole governing standup ADR); ADR-0070 (frontend stack — React the default for consumer web); ADR-0035 (semver discipline applied to JS/CSS packages); ADR-0039 (public per Grid default; MIT license); ADR-0009 (no Dependabot config file).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packets 01, 02, and 03 of this initiative must merge / be Done first.
+
+**Constraints:**
+
+- **Invariant 11:** One repo per Node. Each repo has its own solution, CI pipeline, and versioning. — This packet establishes Web.UI's monorepo + CI.
+- **Invariant 12:** Semantic versioning with CHANGELOG and README. New projects must have both files from the first commit. — All five packages ship README + CHANGELOG; repo-level files also.
+- **Invariant 27 departure:** Invariant 27 ("all projects in a solution share one version") is .NET-centric. The JS monorepo posture is per-package versioning. Shipped (`tokens`, `css`) move together at 0.1.0; placeholders (`react`, `blazor`, `native`) stay at 0.0.0. Document the departure in the PR body.
+- **Invariant `{N1}` (Grid frontend surfaces consume design tokens and primitive CSS from `HoneyDrunk.Web.UI`):** This packet ships the consumable substrate. Per-PDR re-derivation is a boundary violation; per-PDR CSS-variable overrides are permitted. The published packages are the single source of truth that every consumer will reference.
+- **Invariant `{N2}` (Web.UI does not host Studios; Web.UI is consumed by Studios):** No Studios sources live in this repo. The repo is standalone; Studios will migrate to consume it via a follow-up packet.
+- **Invariant `{N3}` (Web.UI does not depend on any Grid Node's runtime contracts):** Zero `HoneyDrunk.*` PackageReferences in any package. No `@honeydrunk/kernel-abstractions` (would not exist anyway). Verified by every package.json and the Blazor .csproj.
+- **`cluster: "visualization"`** matches the Studios precedent (packet 01 landed this). Do not invent `frontend` as a cluster value.
+- **`tsconfig.base.json` is pinned:** `target: ES2022`, `module: "ESNext"`, `moduleResolution: "Bundler"`, `resolveJsonModule: true`, `strict: true`. Per-package tsconfig extends and overrides only the project-specific bits.
+- **Root `package.json` declares `engines.node: ">=22"` and `packageManager: "pnpm@9.0.0"`** — Node 22 LTS minimum; pnpm 9.x.
+- **Build scripts use `fileURLToPath()` for cross-platform path handling.** Do not use `import.meta.url`'s `.pathname` directly (broken on Windows due to the leading-slash artifact). This applies to `packages/tokens/scripts/emit-json-and-css.mjs` and `packages/css/scripts/copy-css.mjs`.
+- **`tokens.test.ts` uses structural assertion only.** Iterates a sector-key list and asserts each key exists + the value matches a hex regex. **Does NOT assert specific hex values.** A future palette rebrand in `constitution/sectors.md` does not break this test.
+- **Sector colors round-trip exactly.** The 9 sector colors in `packages/tokens/src/tokens.ts` are the values from `constitution/sectors.md` (cross-referenced in `repos/HoneyDrunk.Web.UI/studios-tokens-inventory.md` from packet 01). Studios' migration depends on these round-tripping. If any sector color in `sectors.md` differs from the values in this scaffold, fix the scaffold to match `sectors.md`.
+- **Placeholder discipline.** `react`, `blazor`, `native` packages ship at version 0.0.0 with `"private": true` (npm) / `<IsPackable>false</IsPackable>` (NuGet). Their `index.ts` / `Placeholder.cs` contains only the placeholder comment + a sentinel constant. **Do not stub out class shapes, prop shapes, or component shells.** Adding stubs would lie about the package's status and force a churn-PR when the real implementation lands. The empty placeholder + explicit README notice is the honest shape.
+- **`HoneyDrunk.Web.UI.Blazor.csproj` does NOT reference `HoneyDrunk.Standards` at v0.0.0.** The placeholder has no implementation to analyze; adding the reference would force the .NET nightly-deps machinery on a placeholder. The first feature packet that implements Blazor components adds `HoneyDrunk.Standards` (with `PrivateAssets="all"`).
+- **`release.yml` publishes only non-private packages.** `tokens` and `css` publish to npm under `@honeydrunk` scope using `NPM_TOKEN`. The three placeholders are skipped automatically (their `"private": true` flag tells pnpm publish to skip them). **No NuGet publish step at v0.1.0** — the Blazor placeholder has `IsPackable=false`.
+- **No `.github/dependabot.yml`** (ADR-0009). Org-default Dependabot security alerts stay enabled.
+- **README does not cite "ADR-0071" by number in narrative paragraphs.** Per memory `feedback_no_adr_in_docs`.
+- **CHANGELOG entries land under dated SemVer-bumped sections, not under `## Unreleased`.** Per memory `feedback_no_unreleased_commits`.
+
+**Key Files:**
+- `package.json` (workspace root), `pnpm-workspace.yaml`, `pnpm-lock.yaml`, `tsconfig.base.json`, `.npmrc`, `.editorconfig`
+- `packages/tokens/` — `package.json`, `src/{index.ts, tokens.ts, types.ts}`, `scripts/emit-json-and-css.mjs`, `test/tokens.test.ts`
+- `packages/css/` — `package.json`, `src/{reset.css, typography.css, utilities.css, index.css}`, `scripts/copy-css.mjs`, `test/css-bundle.test.ts`
+- `packages/react/` — `package.json` (private + 0.0.0), `src/index.ts` (placeholder)
+- `packages/blazor/` — `HoneyDrunk.Web.UI.Blazor.csproj` (IsPackable=false + 0.0.0), `Placeholder.cs`
+- `packages/native/` — `package.json` (private + 0.0.0), `src/index.ts` (placeholder)
+- `.github/workflows/{pr-core, release, nightly-deps, nightly-security}.yml`
+- `README.md`, `CHANGELOG.md` (repo-level), per-package `README.md` and `CHANGELOG.md`
+
+**Contracts:**
+- D6 public surface (`DesignTokens` JSON schema + TS types in `@honeydrunk/web-ui-tokens`; `TokensCssVariables` emitted as `dist/css/variables.css`; `PrimitiveCss` bundle in `@honeydrunk/web-ui-css`) authored fresh in this packet.
+- The shipped tokens/css packages establish the cross-PDR consumable substrate that every future consumer references.

--- a/generated/issue-packets/active/adr-0071-web-ui-standup/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0071-web-ui-standup/dispatch-plan.md
@@ -1,0 +1,194 @@
+# Dispatch Plan — ADR-0071 HoneyDrunk.Web.UI Standup
+
+**Initiative:** `adr-0071-web-ui-standup`
+**Sector:** Creator (anchor)
+**Governing ADR:** [ADR-0071 — Stand Up the HoneyDrunk.Web.UI Node](../../../../adrs/ADR-0071-stand-up-honeydrunk-web-ui-node.md) (Proposed 2026-05-23; stays Proposed across all four packet PRs. Flips to Accepted only after every packet in this initiative is closed, as a separate post-merge housekeeping step the scope agent runs — see "Status-flip handling" below.)
+**Paired ADR:** [ADR-0070 — Frontend Platform Stack](../../../../adrs/ADR-0070-frontend-platform-stack.md) (merged in PR #288; commits React for consumer web, Blazor for simple admin, React Native + Expo for mobile). Web.UI is the cross-stack reconciliation point ADR-0070's three-stack split requires.
+**Trigger:** ADR-0071 in the Proposed queue. Studios needs formal tokens (its existing tokens are informal); Notify Cloud admin needs visual identity from day one; every queued consumer-app PDR (PDR-0003 Lately, PDR-0005 Hearth, PDR-0006 Currents, PDR-0008 Curiosities) is blocked on `@honeydrunk/web-ui-tokens` + `@honeydrunk/web-ui-css` existing. This initiative anchors the Creator sector and ships the cross-PDR design substrate.
+**Type:** Multi-repo (2 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.Web.UI` (new))
+**Site sync required:** No (scaffold-only; no public-API surface change needs site update yet — when `@honeydrunk/web-ui-tokens 0.1.0` and `@honeydrunk/web-ui-css 0.1.0` publish and Studios migrates, a site-sync follow-up may be warranted to publicize the Creator sector going live)
+**Rollback plan:**
+- **Pre-tag rollback** (before `v0.1.0` is pushed in Web.UI): `git revert` of each PR. Packets 01/02/03 are independent reverts (Architecture-side); packet 04 reverts the entire scaffold as a single PR.
+- **Post-tag rollback** (after `v0.1.0` is pushed but before any consumer references the published packages): npm packages are immutable. Either `npm unpublish` within the 72-hour window (npm allows unpublish only for new package versions and only briefly), or fix-forward as `0.1.1`. Practical hard rollback after a tag is messy — prefer fix-forward.
+- **After first consumer (e.g., Studios' migration packet) lands:** rollback of Web.UI tokens is no longer a clean option — Studios has a published-version reference. Treat any defect as forward-only.
+- **`file-packets.yml` lifecycle gotcha:** after this initiative's packets have moved through The Hive, hive-sync may move source packet files from `active/` to `completed/` per invariant 37. A `git revert` only undoes code changes, not packet-file moves. If a revert is needed after lifecycle moves, restore the packet files manually as part of the revert PR.
+
+## Summary
+
+ADR-0071 is the stand-up ADR for `HoneyDrunk.Web.UI`. It decides what the Node owns (D1, D2: the Creator sector's anchor for design substrate — tokens, primitive CSS, component contracts), the per-stack split (D4: tokens cross-stack, components per-stack), the Studios-consumes-Web.UI inversion (D3), the phased shipping plan (D5: tokens + CSS at Phase 1; React/Blazor/RN components per-consumer-demand at Phase 2/3/4), the package layout (D6: five packages — `@honeydrunk/web-ui-tokens`, `@honeydrunk/web-ui-css`, `@honeydrunk/web-ui-react`, `HoneyDrunk.Web.UI.Blazor`, `@honeydrunk/web-ui-native`), the semver discipline (D7), the explicit boundaries (D8), the zero-Grid-Node-runtime-dependency posture (D9), and the charter sanity check (D10). None of that has been built — the `HoneyDrunkStudios/HoneyDrunk.Web.UI` repo does not exist yet.
+
+Four packets land the work:
+
+1. **Architecture catalog registration + context folder + Studios tokens inventory** — register `honeydrunk-web-ui` in every catalog file (`nodes.json`, `relationships.json`, `grid-health.json`, `modules.json`, `contracts.json`), anchor the Creator-sector row in `sectors.md` (replaces the "No real Nodes yet" placeholder), add Frontend section + Planned Nodes row to `tech-stack.md`, add Q2 2026 roadmap bullet, add active-initiatives entry, create `repos/HoneyDrunk.Web.UI/` context folder with `overview.md`, `boundaries.md`, `invariants.md`, `integration-points.md` matching the Studios template, and create a fifth file `studios-tokens-inventory.md` capturing Studios' informal tokens (9 sector colors + recommended categories) as the source of truth for packet 04's first `@honeydrunk/web-ui-tokens` release. Does **not** flip ADR-0071's Status — that is a separate post-merge housekeeping step.
+2. **Constitution invariants** — three new invariants from ADR-0071's §Invariants subsection added to `constitution/invariants.md` under a new `## Web.UI Invariants` section at block 87–89 (per the reservation registry; ADR-0071 already holds this block). `{N1}` = Grid frontend surfaces consume design tokens and primitive CSS from `HoneyDrunk.Web.UI`. `{N2}` = `HoneyDrunk.Web.UI` does not host `HoneyDrunk.Studios`; Web.UI is consumed by Studios. `{N3}` = `HoneyDrunk.Web.UI` does not depend on any Grid Node's runtime contracts. All three are definitive (none are conditional on first-feature-packet evidence). **No `(Proposed)` or `(takes effect when accepted)` qualifier** on the invariants — they land in final active form.
+3. **Create the HoneyDrunk.Web.UI GitHub repo + verify `@honeydrunk` npm scope + seed `NPM_TOKEN` (human-only)** — create the public repo on `HoneyDrunkStudios`, apply branch protection, seed labels, verify or claim the `@honeydrunk` npm scope under the HoneyDrunk Studios npm organization, generate and seed an `NPM_TOKEN` Automation token (org-level or repo-level), configure OIDC federated credential for the future NuGet Blazor publish, clone locally. **The npm scope verification + NPM_TOKEN seeding moves to this human-only packet** (NOT the scaffold) so blockers are caught at Wave 2 instead of mid-scaffold.
+4. **HoneyDrunk.Web.UI scaffold** — empty repo to first-shippable state. pnpm-workspace monorepo with `engines.node: ">=22"`, `tsconfig.base.json` pinned per refine-pass (`target: ES2022`, `module: "ESNext"`, `moduleResolution: "Bundler"`, `resolveJsonModule: true`), five packages (`tokens` + `css` shipped at v0.1.0 with real content; `react` + `blazor` + `native` as honest 0.0.0 placeholders mirroring the `HoneyDrunk.Files.AzureBlob` placeholder discipline), tokens JSON + CSS-variables emission via build script using `fileURLToPath()` (cross-platform), primitive CSS bundle with `hd-` prefix, Vitest tests using **structural assertion only** (iterates sector-key list, does NOT hex-couple — survives palette rebrands), full CI (PR core + release with npm publish-on-tag for non-private packages + nightly deps + nightly security), README with "For downstream consumers — minimal wiring" and "Phase-1 honest limitation" sections.
+
+## Wave Diagram
+
+```
+Wave 1: Architecture catalog + constitution updates
+   ├─ Architecture: 01-architecture-web-ui-catalog-registration   (Agent)
+   └─ Architecture: 02-architecture-web-ui-invariants             (Agent)
+         Blocked by: packet 01 (so repos/HoneyDrunk.Web.UI/invariants.md
+                                 exists for the trailing-paragraph edit)
+
+Wave 2: GitHub repo creation + npm scope + NPM_TOKEN (human-only,
+        sequenced after packet 01 so the catalogs already point at
+        the eventual repo and the npm-scope text exists when packet 03
+        executes)
+   └─ Architecture: 03-architecture-create-web-ui-repo            (Human)
+         Blocked by: packet 01
+
+Wave 3: HoneyDrunk.Web.UI scaffold
+   └─ HoneyDrunk.Web.UI: 04-web-ui-node-scaffold                  (Agent)
+         Blocked by: packet 02 (invariant number placeholders {N1}, {N2},
+                                 {N3} must be substituted pre-push with
+                                 the assigned numbers)
+                     packet 03 (the GitHub repo must exist, the @honeydrunk
+                                 npm scope must be verified, NPM_TOKEN must
+                                 be seeded, and the local working tree must
+                                 be cloned before scaffolding can run)
+```
+
+In practice packets 01 and 02 can be filed in the same push — packet 02's `dependencies: ["packet:01"]` wires the blocking edge automatically. Packet 03 can also travel in the same push (it depends only on packet 01). The strict ordering is just packet 04 — it must wait for packet 02's PR to merge so the invariant numbers actually land, and it must wait for packet 03 to be Done so the target repo exists and npm publishing is configured.
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 01 | [Register HoneyDrunk.Web.UI's standup decisions in Architecture catalogs](./01-architecture-web-ui-catalog-registration.md) | Architecture | 1 | Agent | — |
+| 02 | [Add three new Web.UI invariants (token consumption + Studios-not-host + zero Grid-Node runtime dependency) to the constitution](./02-architecture-web-ui-invariants.md) | Architecture | 1 | Agent | packet:01 |
+| 03 | [Create `HoneyDrunkStudios/HoneyDrunk.Web.UI` public repo, verify @honeydrunk npm scope, seed NPM_TOKEN, branch protection, labels, OIDC, clone locally (human-only)](./03-architecture-create-web-ui-repo.md) | Architecture (tracking issue) | 2 | Human | packet:01 |
+| 04 | [Stand up `HoneyDrunk.Web.UI` — pnpm-workspace monorepo, five packages (tokens + CSS shipped at 0.1.0; React/Blazor/Native placeholders), CI with npm publish-on-tag](./04-web-ui-node-scaffold.md) | HoneyDrunk.Web.UI | 3 | Agent | packet:01, packet:02, packet:03 |
+
+## Phase Mapping (ADR-0071 "If Accepted" checklist → packets)
+
+ADR-0071's "If Accepted — Required Follow-Up Work" checklist, mapped to packets:
+
+| Checklist item | Packet |
+|---|---|
+| Create `HoneyDrunk.Web.UI` GitHub repo as public | packet 03 |
+| Add `honeydrunk-web-ui` Node entry to `catalogs/nodes.json` with Creator sector | packet 01 (`cluster: "visualization"` — `frontend` is not in the existing taxonomy) |
+| Add `honeydrunk-web-ui` entries to `catalogs/relationships.json` | packet 01 |
+| Anchor the Creator sector in `constitution/sectors.md` | packet 01 |
+| Add Web.UI to `catalogs/modules.json` with the per-stack package layout from D6 | packet 01 (5 entries at 0.0.0 pre-scaffold) |
+| Add Web.UI to `catalogs/grid-health.json` reflecting the stood-up package surface | packet 01 (at 0.0.0; flips to 0.1.0 in post-release reconciliation) |
+| Update `constitution/sectors.md` Creator-sector text — Web.UI is the anchor | packet 01 (replaces "No real Nodes yet" placeholder line) |
+| Create `repos/HoneyDrunk.Web.UI/` context folder | packet 01 (5 files: overview, boundaries, invariants, integration-points, studios-tokens-inventory) |
+| File the HoneyDrunk.Web.UI scaffold packet | packet 04 |
+| Confirm the paired ADR-0070 is Accepted | ADR-0070 merged in PR #288 (paired ADR) — already done at scoping time |
+| Scope agent flips Status → Accepted after the first packet declaring this ADR in `accepts:` merges and the tokens package publishes its 0.x release | Separate post-merge housekeeping step — see "Status-flip handling" below |
+
+## What This Initiative Does NOT Deliver
+
+The following are explicitly out of scope for this initiative. Each becomes a separate packet at the appropriate time:
+
+- **The real `@honeydrunk/web-ui-react` component pack.** Per ADR-0071 D5 Phase 2, the React component pack (Button, Input, Label, Card, Modal, Toast, Alert, Spinner, Skeleton) ships at first non-Studios consumer demand. The placeholder package at v0.0.0 is the honest standup state.
+
+- **The real `HoneyDrunk.Web.UI.Blazor` component pack.** Per ADR-0071 D5 Phase 3, Blazor components ship at first Blazor consumer demand (likely Notify Cloud admin if/when its admin surface grows beyond what tokens + CSS alone provide).
+
+- **The real `@honeydrunk/web-ui-native` component pack.** Per ADR-0071 D5 Phase 4, React Native components ship at first mobile PDR.
+
+- **Designer-tooling integration.** Per ADR-0071 D5 Phase 5, Figma / Penpot integration is deferred indefinitely (lands when designer joins the workflow).
+
+- **Icon library / re-export.** Per ADR-0071's What-it-doesn't-own — Web.UI may opinionate on which icon set the Grid uses but does not author icons. The opinion + re-export package (`@honeydrunk/web-ui-icons`) lands later if the Grid commits to a single icon set.
+
+- **Studios' migration packet.** Per ADR-0071 D3 and `repos/HoneyDrunk.Web.UI/studios-tokens-inventory.md` (created by packet 01), Studios consumes Web.UI tokens from the first 0.1.0 release. The migration is a Studios-side follow-up packet (add the `@honeydrunk/web-ui-tokens` dependency, replace Studios' informal CSS-variable declarations with the import, replace Tailwind config color block with the tokens import, verify `/grid` WebGL renders identically, ship). That packet is filed against the `HoneyDrunk.Studios` repo after v0.1.0 publishes — not in this initiative.
+
+- **Notify Cloud admin's tokens + CSS consumption.** Per ADR-0071 D5 Phase 2, Notify Cloud admin consumes tokens + CSS at Phase 2. That wiring lives in the Notify Cloud standup ADR's own initiative (ADR-0027) — Notify Cloud is not yet stood up, so its Web.UI consumption is part of its eventual scaffolding packet.
+
+- **PDR-driven app Node consumption.** Each of the four queued consumer-app PDRs (Hearth, Lately, Currents, Curiosities) consumes Web.UI from its first scaffolding packet. None of those Nodes have a stand-up ADR yet, so their Web.UI consumption is part of each PDR's eventual standup initiative.
+
+- **No Azure resource provisioning.** HoneyDrunk.Web.UI is a published-package library Node — npm + NuGet only. Ever. No runtime host, no Container App, no Function App, no Storage Account, no CDN, no App Configuration, no Key Vault. No Azure walkthrough applies.
+
+- **SonarCloud onboarding for HoneyDrunk.Web.UI.** Follows the pattern from the ADR-0011 code-review-pipeline initiative's per-repo onboarding packets, if SonarCloud is being applied to JS/TS Nodes (verify current Grid pattern at the time). Separate follow-up packet, post-`v0.1.0`. Flagged in packet 04's Human Prerequisites.
+
+- **Grid-health aggregator wiring** for the new repo: if `HoneyDrunk.Actions/.github/workflows/grid-health-aggregator.yml` auto-discovers from `catalogs/nodes.json`, packet 01's edit is sufficient. If not, packet 04's Human Prerequisites flag a small follow-up to add `HoneyDrunk.Web.UI` to the watched-repos list. Confirm which behavior is in place at execution time.
+
+- **Post-v0.1.0 catalog version-bumps.** After packet 04 lands `v0.1.0`, the two shipped `modules.json` entries for Web.UI (`web-ui-tokens`, `web-ui-css`) need to bump to v0.1.0, and the `catalogs/grid-health.json` Web.UI row needs to flip its `version` from `0.0.0` to `0.1.0` and update its `active_blockers` array. The three placeholder entries (`web-ui-react`, `web-ui-blazor`, `web-ui-native`) stay at `0.0.0`. That follow-up is one small Architecture chore packet filed after v0.1.0 ships — not in this initiative.
+
+- **The `@honeydrunk` scope alternative-name pivot.** If packet 03's npm scope verification reveals that `@honeydrunk` is taken by an unrelated user/org and cannot be reclaimed, an ADR-0071 D6 amendment packet is needed to rename the scope across the ADR + packet 01's catalog entries + packet 04's package.json files + the context-folder docs. That pivot is **flagged in packet 03 as a hard-stop** but is not pre-emptively scoped here.
+
+## Cross-ADR Invariant Numbering — Coordination Honored
+
+At scoping time (2026-05-25), the `constitution/invariant-reservations.md` Active Reservations table records ADR-0071 holding block **87–89** for these three invariants. The expected assignments for this initiative's packet 02 are:
+
+- **`{N1}` = 87** — Grid frontend surfaces consume design tokens and primitive CSS from `HoneyDrunk.Web.UI`.
+- **`{N2}` = 88** — `HoneyDrunk.Web.UI` does not host `HoneyDrunk.Studios`; Web.UI is consumed by Studios.
+- **`{N3}` = 89** — `HoneyDrunk.Web.UI` does not depend on any Grid Node's runtime contracts.
+
+The expected numbers will hold unless another in-flight Proposed ADR's packet 00 lands and shifts the block at the reservation-collision rule. Packet 02's reservation-claim protocol is authoritative — the agent re-reads `constitution/invariant-reservations.md` at edit time and uses whatever the actual block ends up being.
+
+**Filing-order rule (hard, enforced by `dependencies:` frontmatter):**
+
+1. Push packets 01 and 02 in the same push (they may travel together — packet 02's `dependencies: ["packet:01"]` wires the blocking edge automatically).
+2. Push packet 03 in the same wave or shortly after (it depends only on packet 01).
+3. Wait for packet 02's PR to merge so the assigned invariant numbers actually land in `constitution/invariants.md` and the reservation row moves to the History table.
+4. Wait for packet 03 to close (the Web.UI repo must exist, the `@honeydrunk` scope must be verified, and NPM_TOKEN must be seeded before packet 04 can be filed against the repo and scaffold can authenticate to npm).
+5. **Substitute the actual assigned numbers** for `{N1}`, `{N2}`, `{N3}` in `04-web-ui-node-scaffold.md` source file in place pre-push (invariant 24's pre-filing carve-out applies; packet 04 has not been filed yet at that point).
+6. Push packet 04.
+
+**Packets 02 and 04 cannot be filed in the same push** because packet 04's placeholders depend on packet 02's actual assignment.
+
+## Asymmetry vs ADR-0061 Files standup (the closest substrate analog)
+
+Five deliberate asymmetries vs Files (which is the most-recent substrate Node standup) are worth recording:
+
+1. **JS/TS monorepo, not .NET solution.** Files is .NET-only — solution file (`.slnx`), MSBuild projects, NuGet packages. Web.UI is the first JS/TS-shaped Node standup the Grid has done — pnpm workspace, `package.json` per package, npm publish via `release.yml`. The five packages do not share a single `.csproj`-style version (per-package versioning is the standard npm-workspace pattern); the .NET-centric invariant 27 ("all projects in a solution share one version") is documented as an explicit departure in packet 04 and the PR body.
+
+2. **Two shipped packages + three placeholders, not one or four shipped.** Files ships Abstractions + runtime + InMemory + AzureBlob (placeholder) at v0.1.0 — four .NET packages at the same version, one of them a placeholder. Web.UI ships tokens + CSS at v0.1.0 (real content) and three placeholders at v0.0.0 (react, blazor, native). The placeholder discipline (no implementation source beyond the sentinel; explicit README + CHANGELOG status) is the same; the count and the version-coupling shape are different.
+
+3. **No Abstractions package — tokens IS the contract.** Files has a dedicated `HoneyDrunk.Files.Abstractions` package for the public contract surface, with a contract-shape canary in CI scoped to that package. Web.UI's "contract" is the tokens JSON shape itself — `@honeydrunk/web-ui-tokens` IS the contract. A contract-shape canary would need to compare the published tokens JSON against the previous version's published JSON — a different mechanism than the .NET `api-compatibility` workflow. This packet does NOT ship the JS-side contract-shape canary; it lands as a follow-up packet once the Grid commits to a tools-choice for JS API diff (e.g., `api-extractor`, `tsd`, or a tokens-specific differ). For v0.1.0 the structural-assertion tests in `packages/tokens/test/tokens.test.ts` provide the test-time floor.
+
+4. **No `HoneyDrunk.Standards` reference at standup.** Web.UI is JS-first; `HoneyDrunk.Standards` is the .NET analyzer / build-tooling package. The Blazor placeholder doesn't reference Standards either (deferred to first feature packet per the placeholder discipline). The JS/TS analyzer / formatter stance is a separate decision — eslint / prettier / tsc-strict are reasonable defaults but no Grid-wide JS analyzer convention exists at scoping time. This packet ships with `tsc --strict` as the type-floor; lint rules are a follow-up if drift is observed.
+
+5. **Three packets-of-context + scope-verification, not two.** Packet 03 carries an extra Wave-2 burden that Files / Audit / Identity didn't have: the npm scope verification + NPM_TOKEN seeding. This is the first JS-publishing Node standup, so the scope claim is a hard one-time gate. Files / Audit / Capabilities / Identity / Audit Communications didn't need this — they ship NuGet, which uses the existing OIDC credential.
+
+## Notes
+
+- **Why packet 03 carries npm scope verification.** ADR-0071 D6 commits to the `@honeydrunk` npm scope. If that scope is taken by an unrelated user/org, the package naming has to pivot — which would force an ADR amendment + cross-packet renames. Catching this at packet 03 (human-only Wave 2) instead of mid-scaffold (Wave 3 agent execution) keeps the surprise at the right wave. **Moving the npm scope step from the scaffold to packet 03 is a deliberate refine-pass decision** so packet 04's agent execution does not surprise-stop on a portal step.
+
+- **Why three honest placeholders, not stubbed-out class shapes.** ADR-0071 D5 explicitly names tokens + CSS as Phase 1 and React/Blazor/Native components as Phase 2/3/4. Stubbing component shapes at standup would (a) lie about the package's status, (b) force a churn-PR when the real implementation lands, and (c) confuse consumers into thinking they can already import a `Button` from the React placeholder. The empty placeholder + explicit README is the honest shape — same pattern as `HoneyDrunk.Files.AzureBlob` in ADR-0061's scaffold packet.
+
+- **Why the `tsconfig.base.json` is pinned to exact values in packet 04.** The refine-pass specifically called out `target: ES2022`, `module: "ESNext"`, `moduleResolution: "Bundler"`, `resolveJsonModule: true`, `engines.node: ">=22"`. These are the modern-2026 minimums for a clean TypeScript publishing setup; any drift (e.g., `target: ES2015` for older-browser support; `module: "CommonJS"` for legacy bundlers; `moduleResolution: "Node10"` for legacy module resolution) would force consumers into older toolchain compatibility modes. The pinned values are the load-bearing choice.
+
+- **Why build scripts use `fileURLToPath()`.** On Windows, `new URL("..", import.meta.url).pathname` returns a leading-slash artifact like `/C:/path/to/file` that breaks `fs.mkdir` and `fs.writeFile`. The `fileURLToPath()` import from `node:url` is the cross-platform-correct way to derive a file system path from an ESM module's URL. The refine-pass specifically flagged the older `outPath.pathname.replace(/^\//, '')` workaround as fragile — `fileURLToPath()` is the right answer.
+
+- **Why `tokens.test.ts` is structural and not hex-coupled.** If the test asserts `tokens.color.sector.core === "#7B61FF"` and `constitution/sectors.md` is later rebranded (a designer joins; the violetFlux gets a refresh), the test breaks even though the code is still correct. The structural assertion (iterates a sector-key list, asserts each key exists with a hex-shaped string value) is the right floor — a palette rebrand still passes. The refine-pass specifically called this out.
+
+- **Why the `(Proposed)` qualifier was dropped on the invariants.** Earlier drafts of constitutional invariants for in-flight ADRs sometimes carried a qualifier like "(Proposed — takes effect when ADR-XXXX is accepted)". The refine-pass landed the editorial decision: drop the qualifier. The invariants land in their final active form. The reasoning: the ADR's "Done When" gate carries the proposed-vs-accepted semantic; the constitutional text should read as immediately-active because that's how the review agent treats it. Carrying the qualifier in invariant text creates ambiguity at review time. Three packets in this initiative honor this — packet 02's invariant text does NOT carry the qualifier.
+
+- **Why Studios tokens inventory is captured in packet 01, not packet 04.** Packet 04 (the scaffold) needs concrete starting values for the tokens JSON's color block. If those values lived in the scaffold packet's body, they would be hard to cross-reference for Studios' migration packet (the agent reads the Architecture repo for context, not the Web.UI repo). Capturing the inventory at packet 01 (in the Architecture repo at `repos/HoneyDrunk.Web.UI/studios-tokens-inventory.md`) means: (a) packet 04's scaffolding agent has a stable reference; (b) Studios' future migration packet has the same reference; (c) the 9 sector colors live in one canonical place (Architecture's catalog domain, not the Web.UI repo where they would feel like product-specific data). The refine-pass landed this layout.
+
+- **Status flip happens after merge, not now.** ADR-0071 stays Proposed for this scoping run. The user's standing workflow says the scope agent flips Status → Accepted after the follow-up PRs merge. None of the four packets here flip ADR-0071's Status — that is a separate housekeeping step the scope agent handles when the initiative completes.
+
+- **`accepts: ADR-0071` frontmatter.** Every packet in this initiative carries `accepts: ADR-0071` so the hive-sync agent's auto-flip mechanic recognizes the initiative as the ADR's acceptance work. Per user constraint, this is mandatory and is checked at filing.
+
+- **Repo is public by default.** Per memory `project_repos_public_by_default`, HoneyDrunk repos are public unless a revenue/compliance/experiment carve-out applies. Design tokens / CSS / component contracts are exactly the build-in-public substrate the Grid licenses — no carve-out applies. Packet 03's portal step specifies Visibility = Public.
+
+- **No ADR numbers in user-facing docs or code comments.** Per memory `feedback_no_adr_in_docs`, the scaffold's README and per-package READMEs do **not** cite "ADR-0071" by number in their narrative — the README explains what the package does. Runtime / packet-data references (catalog entries, frontmatter, this dispatch plan, the CHANGELOG) are fine to cite ADRs by number.
+
+- **No commits under CHANGELOG Unreleased.** Per memory `feedback_no_unreleased_commits`, the scaffold's first commit lands under `## [0.1.0] - YYYY-MM-DD`, not under `## Unreleased`. The tag push happens after merge — but the version section in CHANGELOG is dated and SemVer-bumped before the commit. Packet 04's acceptance criteria call this out.
+
+- **No manual packet filing.** Per memory `feedback_no_manual_packet_filing`, file-packets.yml auto-files on push to main. Do not run `gh issue create` against these packets. Filing happens by pushing the packet files into `generated/issue-packets/active/adr-0071-web-ui-standup/`. The filing-order rule above governs which packets land in which push.
+
+- **Cluster value is `visualization`, not `frontend`.** The existing `nodes.json` taxonomy allows: `foundation`, `security`, `observability`, `infrastructure`, `orchestration`, `governance`, `visualization`, `cognition`, `quality`, `knowledge`. `frontend` is **not** in the taxonomy. `visualization` matches the Studios precedent (Studios is `cluster: "visualization"`) and is the closest semantic match for a design-substrate Node. Packet 01 honors this choice; packet 04 documents it in its Constraints.
+
+## Status-flip handling
+
+ADR-0071 stays at `Status: Proposed` for the duration of this scoping run and across all four packet PRs. Per the user's standing ADR acceptance workflow (`feedback_adr_workflow.md`): new ADRs start Proposed; the scope agent flips Status → Accepted only after the bundle's PRs have merged, never on a first-draft packet.
+
+None of the four packets in this initiative flip ADR-0071's status. That is a separate housekeeping step the scope agent performs once packets 01 / 02 / 03 / 04 are all closed and the scaffold has merged and `v0.1.0` of `@honeydrunk/web-ui-tokens` and `@honeydrunk/web-ui-css` have published to npm. The flip is a one-line edit to `adrs/ADR-0071-stand-up-honeydrunk-web-ui-node.md` line 3 (`**Status:** Proposed` → `**Status:** Accepted`), plus any matching update to `adrs/README.md` if it carries a per-ADR Status entry, plus a CHANGELOG note.
+
+This is the same pattern ADR-0061 Files standup, ADR-0031 Audit standup, ADR-0060 Identity standup, and ADR-0059 Cache standup followed.
+
+## Archival
+
+Per ADR-0008 D10, when every packet in this initiative reaches `Done` on the org Project board AND `@honeydrunk/web-ui-tokens 0.1.0` + `@honeydrunk/web-ui-css 0.1.0` are published to npm, the entire `active/adr-0071-web-ui-standup/` folder moves to `archive/adr-0071-web-ui-standup/` in a single commit. Partial archival is forbidden.
+
+The hive-sync agent moves individual closed packet files from `active/` to `completed/` per invariant 37 — that is per-packet lifecycle. Initiative-level archival is the post-completion sweep that follows after the whole folder reaches `Done` and `v0.1.0` ships.
+
+## Filing
+
+The `file-packets.yml` workflow in `HoneyDrunk.Architecture` triggers automatically on push to `generated/issue-packets/active/**/*.md`. No `gh issue create` commands in this dispatch plan — the pipeline handles filing, project-board addition, field population, and `addBlockedBy` wiring from the `dependencies:` frontmatter on each packet. Verify after push by checking The Hive (org Project #4) for the new items and their blocking edges.

--- a/generated/issue-packets/active/adr-0076-cache-backing-redis/00-architecture-adr-0076-acceptance.md
+++ b/generated/issue-packets/active/adr-0076-cache-backing-redis/00-architecture-adr-0076-acceptance.md
@@ -1,0 +1,148 @@
+---
+name: ADR Acceptance
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "architecture", "adr-0076", "wave-1"]
+dependencies: []
+adrs: ["ADR-0076", "ADR-0058", "ADR-0059"]
+accepts: ADR-0076
+wave: 1
+initiative: adr-0076-cache-backing-redis
+node: honeydrunk-architecture
+---
+
+# Chore: Accept ADR-0076 — Cache Backing: Azure Cache for Redis with Cost-Aware Sizing
+
+## Summary
+Flip ADR-0076's Status from Proposed to Accepted as the bookkeeping step on the dispatch initiative kickoff. The body change is one line on the ADR header plus any matching `adrs/README.md` index update plus a CHANGELOG note. **The flip is held until the initiative's substantive packets (01 through 05) have all merged AND the two upstream paired ADRs (ADR-0058, ADR-0059) are themselves Accepted.** Both upstream gates are already satisfied at this packet's filing time (PR #301 merged ADR-0058; PR #323 merged ADR-0059); the only remaining gate is the rest of this initiative completing.
+
+This packet is the *acceptance container* — it tracks the flip as a discrete work item on The Hive so the initiative has an explicit closing step, but it does not perform the flip eagerly. The agent executing this packet leaves the ADR body untouched and instead documents the gating state in the PR body; the scope agent's post-merge housekeeping performs the actual flip after the other packets land.
+
+## Context
+ADR-0076 was authored as Proposed on 2026-05-23. It fills the first-distributed-cache-backing decision that ADR-0058 D8 explicitly deferred ("The Cache Node's first concrete implementation … is a separate feature packet that lands when the first consumer pulls on it.") and gives the Cache Node stood up by ADR-0059 its first real implementation target.
+
+The ADR commits Azure Cache for Redis as the canonical default distributed-cache backing, with per-environment cost-aware sizing (Basic C0 dev / Standard C1 staging / Standard prod baseline), Redis-protocol-only discipline (no Azure-Redis modules), `allkeys-lru` as the default eviction policy, provider abstraction held (alternate backings permitted per ADR-0058 D5), self-hosted Redis on Container Apps permitted as a cost-pressured per-Node alternative (D7), and explicit handling for Restricted-tier values via application-layer encryption (D6).
+
+Per the user's standing ADR acceptance workflow (`feedback_adr_workflow.md`), the scope agent flips Status → Accepted only after the bundle's PRs have merged, never on a first-draft packet. This packet is the formal "we will flip when ready" marker; the flip itself happens as post-merge housekeeping.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Proposed Implementation
+
+This packet's PR makes **no substantive change to the ADR body**. The agent leaves the ADR header at `**Status:** Proposed` and instead:
+
+1. **Adds a `## Acceptance Tracking` admonition or HTML comment** at the top of `adrs/ADR-0076-cache-backing-azure-cache-for-redis.md` (just below the H1 and the status header line) noting that the acceptance flip is the scope agent's post-merge housekeeping after this initiative's other packets land. Acceptable shapes:
+
+   ```markdown
+   <!-- Acceptance tracking: see generated/issue-packets/active/adr-0076-cache-backing-redis/dispatch-plan.md.
+        The Status flip from Proposed to Accepted is post-merge housekeeping the scope agent performs
+        after packets 01-05 of this initiative have closed. Upstream ADR-0058 and ADR-0059 are already
+        Accepted (PR #301 and PR #323 respectively); the only remaining gate is this initiative completing. -->
+   ```
+
+   The comment is invisible in rendered Markdown but readable in the source for any future scope-agent run that needs to know why the Status header still reads Proposed.
+
+2. **Updates `adrs/README.md`** if it carries a per-ADR Status entry — flip the Proposed badge to "Proposed (acceptance tracked in `adr-0076-cache-backing-redis` initiative)" or equivalent shape matching the existing convention.
+
+3. **Adds a repo-level `CHANGELOG.md` entry** under the in-progress version section (NOT under `## Unreleased` — per memory `feedback_no_unreleased_commits`) noting that the ADR-0076 acceptance initiative has been scoped and the dispatch plan is live. Example shape (under whatever version section the Architecture repo's CHANGELOG is currently building toward):
+
+   ```markdown
+   - Scoped ADR-0076 (Cache Backing: Azure Cache for Redis with Cost-Aware Sizing) acceptance initiative; dispatch plan at `generated/issue-packets/active/adr-0076-cache-backing-redis/dispatch-plan.md`.
+   ```
+
+4. **Does NOT touch:**
+   - The ADR body decisions, alternatives, or consequences — these are correct as-authored.
+   - `catalogs/*.json` — packet 01 handles catalog updates.
+   - `infrastructure/walkthroughs/*` — packet 01 authors the provisioning walkthrough.
+   - `initiatives/active-initiatives.md` — packet 01 handles the initiative tracking entry.
+
+The acceptance flip itself (changing line 3 of `ADR-0076-cache-backing-azure-cache-for-redis.md` from `**Status:** Proposed` to `**Status:** Accepted`) is the scope agent's post-initiative-completion housekeeping. It is NOT in this packet's body. If a future scope-agent run sees all six packets of this initiative closed and ADR-0058 + ADR-0059 both Accepted, it performs the flip on the ADR file directly.
+
+## Affected Files
+- `adrs/ADR-0076-cache-backing-azure-cache-for-redis.md` — add the acceptance-tracking HTML comment just below the H1 + Status header. Do NOT change the Status line itself.
+- `adrs/README.md` — if a Status field exists per ADR, update the ADR-0076 row to reflect the tracking-initiative state.
+- Repo-level `CHANGELOG.md` — entry under the in-progress version section.
+
+## NuGet Dependencies
+None. This packet has no .NET project.
+
+## Boundary Check
+- [x] All work inside `HoneyDrunk.Architecture`. No other Grid repos affected.
+- [x] No ADR Status flip in this packet's PR — the flip is post-merge housekeeping per the user's standing workflow.
+- [x] No catalog updates (packet 01).
+- [x] No walkthrough authoring (packet 01).
+
+## Acceptance Criteria
+- [ ] `adrs/ADR-0076-cache-backing-azure-cache-for-redis.md` carries a new acceptance-tracking HTML comment just below the H1 + Status header explaining that the Status flip is post-merge housekeeping after this initiative's packets close
+- [ ] The ADR's Status line itself is NOT modified — line 3 remains `**Status:** Proposed`
+- [ ] `adrs/README.md` reflects the tracking-initiative state for ADR-0076 if the file carries per-ADR Status entries (no-op if it does not)
+- [ ] Repo-level `CHANGELOG.md` has an entry under the current in-progress version section (NOT `## Unreleased`) noting the initiative has been scoped
+- [ ] No edits to `catalogs/*.json`, `infrastructure/walkthroughs/*`, or `initiatives/active-initiatives.md` in this packet's PR (those are packet 01's territory)
+
+## Human Prerequisites
+
+None for this packet.
+
+The two upstream paired ADRs are already in the desired state at this packet's filing time:
+
+- ADR-0058 (caching strategy) is Accepted — PR #301 merged.
+- ADR-0059 (Cache Node standup) is Accepted — PR #323 merged.
+
+The post-merge housekeeping that performs the actual Status flip is the scope agent's responsibility, not the human's. It runs after every packet in this initiative closes; no portal click or operator action is required.
+
+## Referenced ADR Decisions
+
+**ADR-0076 (full ADR):** This packet does not modify the ADR's decisions; it only adds the acceptance-tracking marker. The ADR text is correct as-authored.
+
+**ADR-0058 D8 (deferred-decision context):** ADR-0076 fills the "first distributed backing" decision that ADR-0058 D8 deferred. This packet does not re-decide; it records that the deferred decision has been made.
+
+**ADR-0059 (Node home for backings):** The Cache Node exists per ADR-0059's standup. Packet 03 of this initiative is the first real package landing in that Node. This packet does not author code.
+
+## Constraints
+
+> **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. Filing is the point of no return. Before a packet is filed, it may be amended to fill in missing operational context without violating this rule. After filing, state lives on the org Project board, never in the packet file. — This packet's PR is small and safe to amend before filing if the scope agent finds the acceptance-tracking comment text needs adjustment.
+
+> **No ADR Status flip on first-draft packet.** Per the user's standing workflow (memory `feedback_adr_workflow`): new ADRs start Proposed; the scope agent flips Status → Accepted after the bundle's PRs have merged, never on a first-draft packet.
+
+- **The Status flip is not in this PR.** It is the scope agent's post-merge housekeeping step.
+- **No `## Unreleased` block in CHANGELOG at commit time.** Per memory `feedback_no_unreleased_commits`. The CHANGELOG entry lands under the current in-progress dated version section.
+
+## Dependencies
+
+None within this initiative. ADR-0076 is the first packet; subsequent packets reference it via `packet:00`.
+
+## Labels
+
+`chore`, `tier-3`, `architecture`, `adr-0076`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Land the ADR-0076 acceptance-tracking marker on the ADR file (HTML comment, no Status-line change), update the `adrs/README.md` index if it carries Status state, and add a CHANGELOG entry. The actual Status flip happens later as scope-agent housekeeping after the initiative's other packets close.
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Track ADR-0076's acceptance as a discrete work item on The Hive so the initiative has an explicit closing step.
+- Feature: ADR-0076 acceptance initiative, Wave 1, Packet 00.
+- ADRs: ADR-0076 (the ADR being accepted), ADR-0058 + ADR-0059 (paired upstream prerequisites, both already Accepted).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None within this initiative.
+
+**Constraints:**
+
+- **No Status-line modification on the ADR.** Line 3 stays `**Status:** Proposed`. The flip is post-merge housekeeping.
+- **No catalog or walkthrough work.** Packet 01 handles those.
+- **No `## Unreleased` block in CHANGELOG.** Entry goes under the current dated version section.
+
+**Key Files:**
+- `adrs/ADR-0076-cache-backing-azure-cache-for-redis.md` — add the HTML comment just below the Status header line
+- `adrs/README.md` — update the ADR-0076 row if Status state lives in this index
+- `CHANGELOG.md` (repo root) — entry under the current in-progress version
+
+**Contracts:**
+
+This packet does not author or modify any contracts. It is governance bookkeeping.

--- a/generated/issue-packets/active/adr-0076-cache-backing-redis/01-architecture-catalogs-and-walkthrough.md
+++ b/generated/issue-packets/active/adr-0076-cache-backing-redis/01-architecture-catalogs-and-walkthrough.md
@@ -1,0 +1,380 @@
+---
+name: Architecture Catalog Registration + Walkthrough
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "architecture", "infrastructure", "cache", "adr-0076", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0076", "ADR-0058", "ADR-0059", "ADR-0053", "ADR-0005"]
+accepts: ADR-0076
+wave: 1
+initiative: adr-0076-cache-backing-redis
+node: honeydrunk-architecture
+---
+
+# Chore: Register Redis backing in catalogs, update tech-stack, author Azure Cache for Redis provisioning walkthrough
+
+## Summary
+Reflect ADR-0076's backing decision in the canonical Architecture catalogs, the tech-stack reference doc, and a new infrastructure walkthrough. Add a `cache-redis` row to `catalogs/modules.json` (Seed, runtime, owned by `honeydrunk-cache`) covering the new `HoneyDrunk.Cache.Redis` package that packet 03 will ship. Add `dev` / `staging` / `prod` Azure Cache for Redis instance entries to `catalogs/grid-health.json` (`dev` as `not-provisioned` for now — flipped to `provisioned` by packet 02; `staging` / `prod` recorded as `not-provisioned-environment-pending` per ADR-0053). Update the contracts catalog if it tracks `ICacheStore<T>` backing implementations (add the Redis backing as a known implementation). Update `infrastructure/reference/tech-stack.md` Redis row from "Future / HoneyDrunk.Cache abstraction" to "Standing up — Azure Cache for Redis adapter in progress (`HoneyDrunk.Cache.Redis`)." Author `infrastructure/walkthroughs/azure-cache-for-redis-provisioning.md` covering per-environment sizing (Basic C0 dev, Standard C1 staging/prod), the `allkeys-lru` eviction-policy default, TLS-only access verification, encryption-in-transit confirmation, the **consumer-Vault** connection-string seeding flow (NOT a `kv-hd-cache-{env}` Vault — Cache is a library Node with no Vault per invariant 17), and the self-hosted-on-Container-Apps alternative path documented per ADR-0076 D7.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0076 commits Azure Cache for Redis as the canonical first distributed-cache backing for `HoneyDrunk.Cache`. None of that has reached the catalogs or the reference docs yet. Until it does:
+
+- `catalogs/modules.json` does not list the `HoneyDrunk.Cache.Redis` package; downstream Notify Cloud / Communications scoping has nothing concrete to point at.
+- `catalogs/grid-health.json` does not show the per-environment Redis instances on the Grid-health readout; cost tracking and provisioning state have no row.
+- `infrastructure/reference/tech-stack.md`'s "Future Backings" Redis row reads as if no decision has been made; the operator-facing reference is stale.
+- No walkthrough document exists for provisioning Azure Cache for Redis in the Azure Portal — packet 02 (the human portal step) has nothing to execute against.
+
+This packet closes those drift items in a single edit:
+
+1. **`catalogs/modules.json`** — add a `cache-redis` row owned by `honeydrunk-cache`, `type: runtime`, signal Seed, naming reflects the package identity. The placeholder `cache-adapters` row (if any was added by the ADR-0059 standup) stays as-is — the Adapters placeholder project continues to exist per invariant 27 alignment.
+2. **`catalogs/grid-health.json`** — add three Azure Cache for Redis instance rows: `redis-hd-dev` (state `not-provisioned`, will flip to `provisioned` after packet 02), `redis-hd-staging` (state `not-provisioned-environment-pending` per ADR-0053), `redis-hd-prod` (same). Also add `honeydrunk-cache` to any module-level state lists where the `HoneyDrunk.Cache.Redis` package's stand-up signal should land.
+3. **`catalogs/contracts.json`** — if the file tracks `ICacheStore<T>` backing implementations (it should, per ADR-0058's acceptance work), add the Azure Cache for Redis backing as a known implementation row under `ICacheStore<T>` with `package: HoneyDrunk.Cache.Redis`, `owner: honeydrunk-cache`, `signal: seed`. If the file does not yet carry per-backing rows, defer this edit — the contracts catalog edit can land in a follow-up if the schema is not yet in place. The packet's acceptance criteria mark this as a conditional edit.
+4. **`infrastructure/reference/tech-stack.md`** — update the Redis row. Pre-state likely reads something like `| Redis / distributed cache | Future | HoneyDrunk.Cache abstraction |`; post-state reads `| Azure Cache for Redis | Standing up | HoneyDrunk.Cache.Redis (StackExchange.Redis) — Basic C0 dev, Standard C1 staging/prod baseline |`.
+5. **`infrastructure/walkthroughs/azure-cache-for-redis-provisioning.md`** — new walkthrough document (see below).
+6. **`initiatives/active-initiatives.md`** — add an `ADR-0076 Cache Backing Azure Cache for Redis` entry under `## In Progress`.
+
+## Proposed Implementation
+
+### `catalogs/modules.json` — new `cache-redis` entry
+
+Add a new entry to the `modules` array (or whatever shape the file uses) owned by `honeydrunk-cache`:
+
+```json
+{
+  "id": "cache-redis",
+  "type": "runtime",
+  "owner": "honeydrunk-cache",
+  "package": "HoneyDrunk.Cache.Redis",
+  "signal": "Seed",
+  "tags": ["cache", "redis", "distributed-cache", "stackexchange-redis"],
+  "description": "Azure Cache for Redis backing implementation of ICacheStore<T> (declared in HoneyDrunk.Kernel.Abstractions). Built on StackExchange.Redis. Standard Redis protocol commands only — no RediSearch, RedisJSON, RedisTimeSeries, or other Azure-Redis modules per ADR-0076 D3."
+}
+```
+
+If the file's existing schema does not include `package` or `tags`, drop those keys and use the equivalent fields the schema does carry. Conform to the file's existing pattern; do not invent new top-level keys.
+
+### `catalogs/grid-health.json` — three new Redis instance entries + module state
+
+Add three entries to whatever section of the file tracks Azure resources by environment. Approximate shape (conform to the file's actual schema at edit time):
+
+```json
+{
+  "id": "redis-hd-dev",
+  "type": "azure-resource",
+  "kind": "azure-cache-for-redis",
+  "tier": "basic-c0",
+  "environment": "dev",
+  "owner": "honeydrunk-cache",
+  "state": "not-provisioned",
+  "estimated_monthly_cost_usd": 16,
+  "notes": "Provisioned by packet 02 of adr-0076-cache-backing-redis initiative. Basic C0 (~$16/mo, 250 MB). Eviction policy allkeys-lru per ADR-0076 D4. TLS-only access. No managed-identity auth on Basic tier — falls back to access keys stored in the FIRST CONSUMER Node's Vault (Notify Cloud's kv-hd-notify-cloud-dev or Communications's kv-hd-comms-dev — whichever lands first), NOT a kv-hd-cache-{env} Vault (Cache is a library Node with no Vault per invariant 17)."
+},
+{
+  "id": "redis-hd-staging",
+  "type": "azure-resource",
+  "kind": "azure-cache-for-redis",
+  "tier": "standard-c1",
+  "environment": "staging",
+  "owner": "honeydrunk-cache",
+  "state": "not-provisioned-environment-pending",
+  "estimated_monthly_cost_usd": 80,
+  "notes": "Provisioned when staging environment stands up (gated on ADR-0053). Standard C1 (~$80/mo, 1 GB, primary/replica). Eviction policy allkeys-lru. Managed-identity auth supported on Standard tier. Connection string lives in the first-consumer's Vault (kv-hd-notify-cloud-staging or kv-hd-comms-staging) when that consumer composes; NOT a Cache-owned Vault."
+},
+{
+  "id": "redis-hd-prod",
+  "type": "azure-resource",
+  "kind": "azure-cache-for-redis",
+  "tier": "standard-c1-or-larger",
+  "environment": "prod",
+  "owner": "honeydrunk-cache",
+  "state": "not-provisioned-environment-pending",
+  "estimated_monthly_cost_usd": 80,
+  "notes": "Provisioned when prod environment stands up (gated on ADR-0053). Starts at Standard C1 (~$80/mo). Scales to C2/C3/C4 per workload data. Premium tier NOT adopted by default — held in reserve per ADR-0076 D2 alternatives. Managed-identity auth via consumer Node. Connection string lives in the first-consumer's prod Vault."
+}
+```
+
+Also add `cache-redis` to the `summary.module_states` section (or equivalent) reflecting the Seed signal for the new module.
+
+### `catalogs/contracts.json` — Redis backing as known `ICacheStore<T>` implementation (conditional)
+
+If the file tracks per-contract implementations under an `ICacheStore<T>` entry (it should, per ADR-0058's acceptance work; verify at edit time), add a row:
+
+```json
+{
+  "implementation_id": "cache-store-redis",
+  "contract": "ICacheStore<T>",
+  "package": "HoneyDrunk.Cache.Redis",
+  "owner": "honeydrunk-cache",
+  "signal": "Seed",
+  "kind": "distributed-backing",
+  "notes": "Azure Cache for Redis backing per ADR-0076. Default distributed backing for Grid Nodes needing cross-replica cache coordination. Per-Node alternatives (Cosmos with TTL, Postgres with TTL, self-hosted Redis on Container Apps) permitted per ADR-0058 D5 / ADR-0076 D5 / D7."
+}
+```
+
+If `contracts.json` does not yet carry per-contract implementation tracking, skip this edit and note it in the PR body — it can land as a follow-up when the contracts catalog gains that schema.
+
+### `infrastructure/reference/tech-stack.md` — Redis row update
+
+Find the row currently describing Redis (likely something like `| Redis / distributed cache | Future | HoneyDrunk.Cache abstraction |` from the ADR-0059 standup). Replace with shape matching the table's existing column layout. Recommended text:
+
+```markdown
+| Azure Cache for Redis | Standing up | HoneyDrunk.Cache.Redis (StackExchange.Redis) — Basic C0 dev, Standard C1 staging/prod baseline; allkeys-lru eviction; Redis-protocol-only (no Azure-Redis modules); managed-identity on Standard+, access-key fallback via consumer-Node Vault. |
+```
+
+If the table has different columns, conform to whatever the existing shape is — the goal is the row reflects the backing decision is made and the implementation is in progress.
+
+### `initiatives/active-initiatives.md` — new entry
+
+Add under `## In Progress`:
+
+```markdown
+- **ADR-0076 Cache Backing: Azure Cache for Redis** — first distributed-cache backing for `HoneyDrunk.Cache`. Six packets: ADR acceptance marker, catalog + walkthrough (this packet), dev portal provisioning, `HoneyDrunk.Cache.Redis` implementation, telemetry + health + error-reporter wiring, classification-aware encrypted-value wrapper. Initiative folder: `generated/issue-packets/active/adr-0076-cache-backing-redis/`.
+```
+
+### `infrastructure/walkthroughs/azure-cache-for-redis-provisioning.md` — new walkthrough
+
+Author a Portal-UI walkthrough modeled on the existing siblings in `infrastructure/walkthroughs/` (`key-vault-creation.md`, `application-insights-provisioning.md`, `container-app-creation.md`). Structure:
+
+```markdown
+# Azure Cache for Redis Provisioning (Azure Portal)
+
+**Applies to:** ADR-0076, ADR-0058, ADR-0059, ADR-0005 (consumer-Vault secret seeding).
+**Related invariants:** 17 (Cache has no Vault — connection strings live in consumer Node Vaults), 19 (naming prefix `hd`), 21 (no version pinning on resolved secrets).
+
+## Goal
+
+Provision a per-environment Azure Cache for Redis instance named `redis-hd-{env}` with:
+- **Basic C0** tier for `dev` (~$16/mo, 250 MB, single instance, no HA, no managed-identity auth — uses access keys).
+- **Standard C1** tier for `staging` (~$80/mo, 1 GB, primary/replica, managed-identity auth supported).
+- **Standard C1** baseline for `prod` (size up to C2/C3/C4 per workload data; Premium tier NOT adopted by default).
+
+Eviction policy `allkeys-lru` (per ADR-0076 D4). Redis-protocol-only commands; no Azure-Redis modules enabled. TLS-only access.
+
+## Portal Breadcrumb
+
+**Azure Portal → Azure Cache for Redis → + Create → Basics / Networking / Advanced / Tags → Review + create**
+
+## Pre-create cost confirmation
+
+Before clicking Create, the Portal shows the estimated monthly cost on the Review + create blade. Confirm the number matches the expected tier:
+- Basic C0: ~$16/mo (dev).
+- Standard C1: ~$80/mo (staging / prod baseline).
+- Premium tier: $300+/mo per instance. NOT adopted by default per ADR-0076 D2 — if the Portal estimate shows a Premium-tier cost, STOP and re-check the tier selection.
+
+(Per the user's standing preference for Portal UI walkthroughs and cheapest-viable Azure tier defaults.)
+
+## Step-by-step
+
+### Basics blade
+
+1. Subscription: choose target subscription.
+2. Resource group: choose the target environment's resource group (`rg-hd-{env}` per the broader Grid convention, or the specific Cache-related RG if one exists).
+3. DNS name: `redis-hd-{env}` (e.g., `redis-hd-dev`).
+4. Region: same as the Container Apps environment that will consume the cache (`East US` for the dev environment unless otherwise specified — colocate for latency).
+5. Cache SKU: per the table above. `dev` → **Basic C0**. `staging` / `prod` → **Standard C1** baseline.
+
+### Networking blade
+
+6. Connectivity method: **Public Endpoint** for dev and staging (no VNet integration on Basic tier; staging/prod can move to Private Endpoint later if compliance pressure justifies — out of scope here per ADR-0076 D8).
+7. TLS settings: **Minimum TLS version 1.2**. Non-SSL port: **Disabled** (no plaintext access).
+
+### Advanced blade
+
+8. Access keys: **Enabled** for dev (Basic tier does not support managed-identity auth). For staging/prod (Standard tier), keep access keys enabled as a fallback but plan to use managed identity on the consumer side.
+9. Microsoft Entra Authentication: **Enabled** on Standard / Premium tiers (skip on Basic — not available). The consumer Node's managed identity gets `Data Contributor` role on the cache resource at the time the consumer Node composes — that is the consumer's Vault / RBAC work, not this packet's.
+10. Eviction policy: confirm or set to **allkeys-lru** (per ADR-0076 D4).
+11. Cluster: **Disabled** (Standard tier does not support clustering; Premium does and is out of scope per ADR-0076 D8).
+12. Redis modules: **None enabled**. Do NOT enable RediSearch, RedisJSON, RedisTimeSeries, RedisGraph, or RedisBloom (per ADR-0076 D3).
+13. Persistence: **Disabled** for dev. For staging/prod (Standard tier), persistence is also disabled — Grid cache values are by-construction ephemeral per ADR-0076 D1; no persistence backing needed.
+
+### Tags blade
+
+14. Add tags:
+    - `env={env}` (e.g. `env=dev`)
+    - `node=honeydrunk-cache`
+    - `purpose=cache-backing`
+    (Per the user's standing lean tag scheme — `env` always; `node` for per-Node; never `initiative`.)
+
+### Review + create
+
+15. Confirm the estimated monthly cost matches expectations.
+16. Click **Create**.
+17. Provisioning takes ~15-20 minutes. Wait for the resource to reach Running state in the portal.
+
+## Post-create verification
+
+1. Open the new cache resource → **Properties**.
+2. Verify Eviction Policy reads `allkeys-lru`. (If it does not — Portal sometimes defaults to `volatile-lru` on Basic tier — set it explicitly via **Advanced settings**.)
+3. Verify **Non-SSL port** is `Disabled` and **Minimum TLS version** is `1.2`.
+4. Open **Access keys** blade. Two keys (Primary / Secondary) are shown. Copy the **Primary connection string** (the full string ending in `,ssl=True,abortConnect=False`). Do not paste it anywhere outside this step.
+
+## Consumer-Vault connection-string seeding
+
+> **Cache is a library Node with no Vault** (invariant 17 — library Nodes such as Kernel, Vault, Transport, Architecture have no Vault). There is no `kv-hd-cache-{env}` Key Vault. The Redis connection string lives in the **first consumer Node's** Vault — whichever Node first composes the Redis backing (most likely `HoneyDrunk.Notify.Cloud` per ADR-0027 multi-replica, or `HoneyDrunk.Communications` per ADR-0019 preference cache).
+
+1. Identify the first consumer's Vault name per its own ADR (`kv-hd-notify-cloud-{env}` or `kv-hd-comms-{env}` — verify the actual ≤13-char service-name token from the consumer's standup ADR).
+2. Open that Vault in the Azure Portal → **Secrets** → **+ Generate/Import**.
+3. Secret name: `redis-connection-string` (or whatever name the consumer Node's overview / runtime convention uses for its cache connection string — defer to the consumer's standup ADR if it specifies one).
+4. Secret value: paste the connection string copied above.
+5. Click **Create**.
+6. Verify the secret exists; do NOT print it back to the terminal or screenshot it (per invariant 8 — secret values never appear in logs, traces, exceptions, or telemetry).
+7. Confirm the consumer Node's host code path resolves the secret via `ISecretStore` per invariant 9, never pinning to a version per invariant 21.
+
+If no consumer is provisioning the Redis instance at this time (e.g., dev provisioning happens before any consumer composes), the connection string is **not seeded** during packet 02; instead the operator notes the access-key value in a secure local note and seeds it into the consumer's Vault at the time the consumer Node's composition packet runs. This avoids creating a transient Cache-owned Vault that would violate invariant 17.
+
+## Self-hosted Redis on Container Apps (alternative per ADR-0076 D7)
+
+Permitted per ADR-0076 D7 as a per-Node alternative when the managed-service premium does not earn its keep. The walkthrough documents the existence of this path but does not detail the steps — that is a separate walkthrough authored at the time a Node actually chooses self-host. The default remains Azure Cache for Redis as documented above.
+
+If a future Node opts for self-host:
+- Container App owns the Redis container lifecycle (Redis version, patches, configuration tuning).
+- No HA unless the Node implements it (single-replica self-host is a single point of failure; consumers must tolerate cache flush on Redis restart).
+- No replication, no failover, no managed backups.
+- Authoring the self-host walkthrough is that Node's packet, not this packet's.
+
+## Per-environment repeat execution
+
+This walkthrough is parameterized on `{env}`. Repeat the steps for `staging` and `prod` when those environments stand up per ADR-0053. The tier selection differs (Basic C0 → Standard C1 → Standard C1+); everything else is identical.
+
+## Cross references
+
+- [ADR-0076](../../adrs/ADR-0076-cache-backing-azure-cache-for-redis.md) — backing decision, sizing rubric, eviction policy, classification handling.
+- [ADR-0058](../../adrs/ADR-0058-grid-wide-caching-strategy.md) — Grid-wide caching strategy; ICacheStore<T> contract.
+- [ADR-0059](../../adrs/ADR-0059-stand-up-honeydrunk-cache-node.md) — Cache Node home.
+- [ADR-0053](../../adrs/ADR-0053-environments-branching-and-release-cadence.md) — per-environment naming; staging/prod environments in flight.
+- [ADR-0005](../../adrs/ADR-0005-configuration-and-secrets-strategy.md) — Vault as only source of secrets; consumer-Vault seeding pattern.
+- [ADR-0049](../../adrs/ADR-0049-data-classification-pii-handling-and-retention-schedule.md) — data classification; Restricted-tier handling for cached values (application-layer encryption per ADR-0076 D6, implemented by packet 05).
+- [Invariants 17, 19, 21](../../constitution/invariants.md).
+- [key-vault-creation.md](./key-vault-creation.md) — sibling walkthrough for the consumer Node's Vault.
+```
+
+## Affected Files
+
+- `catalogs/modules.json` — add `cache-redis` row.
+- `catalogs/grid-health.json` — add three Azure Cache for Redis instance rows (`redis-hd-dev`, `redis-hd-staging`, `redis-hd-prod`) and the module state for `cache-redis`.
+- `catalogs/contracts.json` — conditional row addition for the Redis backing implementation (verify schema at edit time; skip if not yet supported).
+- `infrastructure/reference/tech-stack.md` — Redis row update.
+- `infrastructure/walkthroughs/azure-cache-for-redis-provisioning.md` — new file.
+- `initiatives/active-initiatives.md` — new entry under `## In Progress`.
+- Repo-level `CHANGELOG.md` — entry under the current in-progress version section.
+
+## NuGet Dependencies
+
+None. This packet has no .NET project.
+
+## Boundary Check
+
+- [x] All work inside `HoneyDrunk.Architecture`. No other Grid repos affected.
+- [x] **No `kv-hd-cache-{env}` Vault row anywhere.** Per invariant 17, Cache is a library Node with no Vault. The walkthrough explicitly routes connection-string ownership to consumer Node Vaults.
+- [x] No edit to `catalogs/nodes.json` (the `honeydrunk-cache` Node entry from the ADR-0059 standup is correct — this packet does not modify it).
+- [x] No edit to `catalogs/relationships.json` (the `consumed_by_planned` edges from the ADR-0059 standup are correct; the first real consumer will move the edge to `consumed_by` when it composes).
+- [x] No edit to the ADR file itself (packet 00 handled the acceptance-tracking marker; the Status flip is post-merge housekeeping).
+- [x] No edit to `constitution/invariants.md` (ADR-0076 commits no new invariants).
+
+## Acceptance Criteria
+
+- [ ] `catalogs/modules.json` has a new `cache-redis` row owned by `honeydrunk-cache`, `type: runtime` (or schema equivalent), Seed signal, referencing the `HoneyDrunk.Cache.Redis` package
+- [ ] `catalogs/grid-health.json` has three Azure Cache for Redis instance rows (`redis-hd-dev` with state `not-provisioned`, `redis-hd-staging` with state `not-provisioned-environment-pending`, `redis-hd-prod` with state `not-provisioned-environment-pending`)
+- [ ] **None of the new `grid-health.json` rows reference a `kv-hd-cache-{env}` Vault.** Per invariant 17 — Cache has no Vault. Connection strings live in consumer-Node Vaults; the `notes` fields document this explicitly
+- [ ] `catalogs/contracts.json` Redis backing row added if the file's schema supports per-contract implementations; PR body documents the decision and notes if the edit was skipped pending schema evolution
+- [ ] `infrastructure/reference/tech-stack.md` Redis row updated from `Future` to `Standing up — HoneyDrunk.Cache.Redis (StackExchange.Redis)` shape
+- [ ] `infrastructure/walkthroughs/azure-cache-for-redis-provisioning.md` exists as a step-by-step Azure-Portal UI walkthrough covering per-environment sizing (Basic C0 dev / Standard C1 staging / prod), eviction policy `allkeys-lru`, TLS-only access, Redis modules **disabled**, persistence **disabled**, and the consumer-Vault connection-string seeding flow
+- [ ] The walkthrough explicitly states that Cache has no Vault per invariant 17 and routes connection-string ownership to consumer Node Vaults (Notify Cloud's `kv-hd-notify-cloud-{env}` or Communications's `kv-hd-comms-{env}`)
+- [ ] The walkthrough shows the estimated monthly cost confirmation step before Create (Basic C0 ~$16/mo, Standard C1 ~$80/mo; Premium NOT adopted)
+- [ ] The walkthrough documents the self-hosted-on-Container-Apps alternative path (per ADR-0076 D7) as permitted but not detailed — pointing to a future per-Node walkthrough if/when a Node opts for self-host
+- [ ] The walkthrough covers per-environment repeat execution (parameterized on `{env}`) so future staging/prod provisioning is a re-execution, not a new packet
+- [ ] `initiatives/active-initiatives.md` has an `ADR-0076 Cache Backing Azure Cache for Redis` entry under `## In Progress`
+- [ ] Repo-level `CHANGELOG.md` has an entry under the current in-progress version section (NOT `## Unreleased`) describing the catalog + walkthrough work
+- [ ] No connection string, instrumentation key, or any secret value appears in the walkthrough or anywhere in the repo (invariant 8)
+- [ ] No Azure resource provisioned by this packet — provisioning is packet 02's territory
+
+## Human Prerequisites
+
+- [ ] Packet 00 of this initiative complete — the acceptance-tracking marker is on the ADR file.
+- [ ] No portal action required for this packet (the Azure resource provisioning is packet 02). The walkthrough authored here is what packet 02 executes.
+- [ ] None of this initiative's substantive code work happens until packet 03; this packet is documentation + catalogs only.
+
+## Referenced ADR Decisions
+
+**ADR-0076 D1 — Azure Cache for Redis as default distributed-cache backing:** `HoneyDrunk.Cache.Redis` is the package name (literal text from D1); StackExchange.Redis is the client; Azure-managed Redis is the runtime backing; per-environment instances named `redis-hd-{env}`; managed-identity preferred, access-key fallback through Vault per ADR-0005; same region as the Container Apps environment.
+
+**ADR-0076 D2 — Per-environment sizing rubric:** Basic C0 dev (~$16/mo), Standard C1 staging (~$80/mo, HA-shaped), Standard C1 prod baseline (scales to C2/C3/C4 per workload). Premium tier NOT adopted by default — held in reserve. Walkthrough documents the rubric; packet 02 executes for dev.
+
+**ADR-0076 D3 — Redis-protocol-only; no Azure-Redis modules:** No RediSearch, no RedisJSON, no RedisTimeSeries, no RedisGraph, no RedisBloom. No reliance on Azure-managed Redis persistence. The discipline is the cheap vendor-exit hedge — protocol-portable for future migration to KeyDB / Valkey / Dragonfly / Redis on Container Apps. Walkthrough's Advanced blade explicitly disables modules.
+
+**ADR-0076 D4 — Default eviction policy is `allkeys-lru`:** Cache values are cache-shaped, not state-shaped; eviction under memory pressure is expected; LRU across all keys is the broadly-correct default. Walkthrough records the default; packet 02 verifies/sets the policy on the dev instance.
+
+**ADR-0076 D7 — Self-hosted Redis on Container Apps permitted:** Walkthrough documents the existence of this alternative path; does not detail steps — that is a separate per-Node walkthrough when a Node opts in.
+
+**ADR-0053 — Per-environment branching and release cadence:** Staging and prod environments are in flight; only dev is provisioned at the time this initiative lands. The walkthrough is authored for all three environments as repeat executions.
+
+**ADR-0005 — Vault and Key Vault naming + Vault-as-only-secret-source:** Connection strings live in the consumer Node's Vault (`kv-hd-notify-cloud-{env}` or `kv-hd-comms-{env}` — whichever first composes). Cache has no Vault. Consumer host code resolves via `ISecretStore` per invariant 9, never pinning to a secret version per invariant 21.
+
+## Constraints
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The Redis connection string is a secret. It never enters the repo, the walkthrough body, a config file, or a commit. Only the *fact* of provisioning is recorded.
+
+> **Invariant 9 — Vault is the only source of secrets.** The consumer Node resolves the Redis connection string via `ISecretStore` at the time it composes the Redis backing — never from an environment variable holding the raw string or from a provider SDK default.
+
+> **Invariant 17 — One Key Vault per deployable Node per environment.** Named `kv-hd-{service}-{env}` with Azure RBAC. **Library Nodes (Kernel, Vault, Transport, Architecture) have no Vault.** `HoneyDrunk.Cache` is a library Node per ADR-0059 — no `kv-hd-cache-{env}` Vault exists or is provisioned. The Redis connection string lives in the consumer Node's Vault. This invariant is the load-bearing reason for the walkthrough's consumer-Vault seeding section; the catalog rows reflect it; the ADR text's reference to `kv-hd-cache-{env}` on line 159 is a pre-refine-pass artifact this packet does not reproduce.
+
+> **Invariant 19 — Service names in Azure resource naming must be ≤ 13 characters.** `redis-hd-{env}` uses 9 chars for `redis-hd-` and the separator before `{env}`; the `{env}` token (`dev`, `staging`, `prod`) fits comfortably within Azure's broader naming length limits for cache resources. (Redis cache name limit is 63 characters; this is just for naming-convention consistency with the Grid's `hd-` prefix.)
+
+> **Invariant 21 — Applications must never pin to a specific secret version.** When the consumer Node resolves the Redis connection string, it resolves the latest version via `ISecretStore`. Pinning would break Event Grid cache invalidation if the connection string ever rotates.
+
+- **Per-environment sizing.** Basic C0 for dev, Standard C1 baseline for staging/prod. No Premium tier provisioning. The walkthrough's pre-create cost confirmation step catches any tier-selection error.
+- **`allkeys-lru` eviction policy is the Grid default.** Per ADR-0076 D4.
+- **Portal-only, UI walkthrough.** Per the user's standing preference for Azure Portal over CLI. No Bicep, no ARM, no CLI commands in the walkthrough.
+- **No persistence enabled.** Per ADR-0076 D3 — cache values are by-construction ephemeral; no Redis persistence backing.
+- **No Redis modules enabled.** Per ADR-0076 D3 — protocol-portable.
+
+## Dependencies
+
+- `packet:00` — packet 00's acceptance-tracking marker on the ADR file should land first so this packet's CHANGELOG entry references a consistent state.
+
+## Labels
+
+`chore`, `tier-2`, `architecture`, `infrastructure`, `cache`, `adr-0076`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Land the catalog updates (`modules.json` row, `grid-health.json` three Redis-instance rows, optional `contracts.json` row), the tech-stack reference update (Redis row from Future to Standing up), the new `azure-cache-for-redis-provisioning.md` walkthrough, the active-initiatives entry, and the CHANGELOG entry. **No portal action; no .NET code; no ADR-body changes.**
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make ADR-0076's backing decision visible in the canonical Grid catalogs and reference docs so downstream packets (Notify Cloud composition, Communications composition, future Cosmos backing) can scope against a consistent surface.
+- Feature: ADR-0076 acceptance initiative, Wave 1, Packet 01.
+- ADRs: ADR-0076 (the backing decision being recorded), ADR-0058 + ADR-0059 (paired upstream prerequisites — both Accepted), ADR-0053 (environments in flight — only dev is provisioned by this initiative), ADR-0005 (consumer-Vault secret seeding pattern).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** `packet:00`.
+
+**Constraints:**
+
+- **Invariant 17:** One Key Vault per deployable Node per environment. Library Nodes have no Vault. `HoneyDrunk.Cache` is a library Node — no `kv-hd-cache-{env}` Vault. Connection strings live in the consumer Node's Vault. The walkthrough must route this correctly; the catalog rows must not reference a Cache-owned Vault.
+- **Invariant 19:** Service names ≤ 13 characters in Azure resource naming. `redis-hd-{env}` complies.
+- **Invariant 8 / 9 / 21:** Secret values never in repo/logs/traces; Vault is the only source; never pin to a secret version. The walkthrough text honors all three.
+- **No `## Unreleased` block in CHANGELOG.** Per memory `feedback_no_unreleased_commits`. Entry lands under the current in-progress version section.
+- **Cheapest viable tier.** Basic C0 dev, Standard C1 staging/prod baseline; Premium NOT adopted. The walkthrough's pre-create cost confirmation enforces this.
+- **No portal action in this packet.** That is packet 02. Author the walkthrough; do not execute it.
+- **No `ADR-0076` or `ADR-0058` citation in user-facing prose.** Per memory `feedback_no_adr_in_docs`, the walkthrough body explains what the operator does in plain English. Cross-reference ADRs in the "Cross references" section at the foot of the doc only.
+
+**Key Files:**
+- `catalogs/modules.json` — add `cache-redis` row.
+- `catalogs/grid-health.json` — add three Redis-instance rows; update module state for `cache-redis`.
+- `catalogs/contracts.json` — conditional Redis-backing row (verify schema; skip if not yet supported, document in PR body).
+- `infrastructure/reference/tech-stack.md` — Redis row update.
+- `infrastructure/walkthroughs/azure-cache-for-redis-provisioning.md` — new file (full walkthrough body per the template above).
+- `initiatives/active-initiatives.md` — new entry.
+- `CHANGELOG.md` (repo root) — entry under current in-progress version.
+
+**Contracts:**
+
+This packet does not author or modify any contracts. Catalog metadata and human-facing infrastructure documentation only.

--- a/generated/issue-packets/active/adr-0076-cache-backing-redis/02-architecture-provision-dev-redis.md
+++ b/generated/issue-packets/active/adr-0076-cache-backing-redis/02-architecture-provision-dev-redis.md
@@ -1,0 +1,210 @@
+---
+name: Infrastructure Provisioning
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["feature", "tier-2", "infrastructure", "cache", "human-only", "adr-0076", "wave-1"]
+dependencies: ["packet:01"]
+adrs: ["ADR-0076", "ADR-0053", "ADR-0005"]
+accepts: ADR-0076
+wave: 1
+initiative: adr-0076-cache-backing-redis
+node: honeydrunk-cache
+---
+
+# Provision `dev` Azure Cache for Redis Basic C0 instance (`redis-hd-dev`) — human-only
+
+## Summary
+Execute `infrastructure/walkthroughs/azure-cache-for-redis-provisioning.md` (authored in packet 01) for the `dev` environment. Create the `redis-hd-dev` Basic C0 instance (~$16/mo, 250 MB, single instance, no HA, no managed-identity auth — uses access keys per Basic-tier limitation). Set eviction policy `allkeys-lru`. Verify TLS-only access, non-SSL port disabled, Redis modules disabled, persistence disabled. **Do NOT seed the connection string into a Vault as part of this packet** — Cache has no Vault per invariant 17, and the first-consumer Vault target (Notify Cloud's `kv-hd-notify-cloud-dev` or Communications's `kv-hd-comms-dev`) is not yet known. The connection-string Vault seeding lands in the first consumer composition packet, not here. The operator notes the connection-string value in a secure local note in the meantime.
+
+`Actor=Human` — Azure portal work, no agent path.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Architecture` (tracking issue; the substantive work is in the Azure subscription, not in the repo).
+
+## Motivation
+
+ADR-0076 D2 commits Basic C0 as the dev-environment tier (~$16/mo, sufficient for single-developer scale; no HA needed because dev is single-replica anyway). The forcing function is packet 03's smoke-verification step: a live Redis instance against which the operator can confirm `RedisCacheStore<T>` round-trips a real value end-to-end before the package ships. Unit tests run against an InMemory `IConnectionMultiplexer` fake and pass without a live instance — but the smoke verification needs a real Redis.
+
+Per the user's standing preferences (`feedback_provision_when_needed`, `feedback_default_cheapest_azure_tier`):
+- Provision when first needed (the smoke verification is the trigger).
+- Default cheapest viable tier — Basic C0 covers dev workload without HA cost.
+
+Per ADR-0053, staging and prod environments are still in flight; this packet provisions dev only.
+
+## Proposed Work (human-executed, Azure Portal)
+
+Execute the walkthrough authored in packet 01 (`infrastructure/walkthroughs/azure-cache-for-redis-provisioning.md`) for `{env}=dev`:
+
+1. **Pre-create cost confirmation.** Confirm the Review + create blade shows ~$16/mo for Basic C0. If it shows anything materially higher (e.g., $80+ which would indicate Standard tier was picked, or $300+ which would indicate Premium), STOP and re-select the tier.
+
+2. **Basics blade:**
+   - Subscription: target subscription.
+   - Resource group: `rg-hd-dev` or the equivalent dev RG per the broader Grid convention.
+   - DNS name: `redis-hd-dev`.
+   - Region: `East US` (or whatever region the dev Container Apps environment lives in — colocate for latency).
+   - Cache SKU: **Basic C0**.
+
+3. **Networking blade:**
+   - Connectivity: **Public Endpoint** (Basic tier limitation; VNet integration not available on Basic).
+   - Minimum TLS version: **1.2**.
+   - Non-SSL port: **Disabled**.
+
+4. **Advanced blade:**
+   - Access keys: **Enabled** (Basic tier does not support managed identity — access keys are the only path).
+   - Microsoft Entra Authentication: Not available on Basic — skip.
+   - Eviction policy: **allkeys-lru** (confirm or set per ADR-0076 D4).
+   - Cluster: Disabled (not available on Basic).
+   - Redis modules: **None enabled**. Do NOT enable RediSearch, RedisJSON, RedisTimeSeries, RedisGraph, or RedisBloom.
+   - Persistence: Disabled.
+
+5. **Tags blade:** Add `env=dev`, `node=honeydrunk-cache`, `purpose=cache-backing`.
+
+6. **Review + create:** Confirm cost, click Create. Provisioning takes ~15-20 minutes.
+
+7. **Post-create verification:**
+   - Verify Properties show Eviction Policy `allkeys-lru`.
+   - Verify Non-SSL port `Disabled`, Minimum TLS `1.2`.
+   - Open Access keys blade; copy the Primary connection string (the full string ending in `,ssl=True,abortConnect=False`) into a secure local note. Do NOT paste it into a config file, commit it, screenshot it, or print it to a terminal session that may be captured by clipboard managers / scrollback.
+
+8. **Smoke verification (manual, optional — at the operator's discretion):** Using `redis-cli` or the Azure Portal's Console, run `PING` and verify `PONG`; run `SET test:hello world` then `GET test:hello` and verify the value round-trips. The smoke verification is OPTIONAL — its purpose is operator confidence that the instance is reachable; packet 03's automated smoke step covers the same ground more rigorously.
+
+9. **Update `catalogs/grid-health.json`:** Flip the `redis-hd-dev` row's `state` from `not-provisioned` to `provisioned`. Add the actual resource ID and provisioning date to the row's `notes` field. This is a small repo edit committed alongside this packet's tracking issue close.
+
+## Connection-string handling — deferred to consumer composition
+
+**Do NOT seed the Redis connection string into any Vault as part of this packet.** Per invariant 17, `HoneyDrunk.Cache` has no Vault (it is a library Node). The connection string belongs in the **first consumer Node's Vault** when that consumer composes the Redis backing — either `kv-hd-notify-cloud-dev` (per ADR-0027 multi-replica composition, when that packet runs) or `kv-hd-comms-dev` (per ADR-0019 preference cache composition).
+
+The operator holds the connection-string value in a secure local note (1Password, macOS Keychain, Windows Credential Manager, or equivalent) for the interim period between this packet's completion and the first consumer composition packet's execution. At the time the first consumer composition packet runs, the operator:
+
+1. Opens the consumer Node's Vault in the Azure Portal.
+2. Creates a secret named per the consumer Node's overview convention (likely `redis-connection-string` or similar — defer to that Node's documentation).
+3. Pastes the connection string from the secure local note.
+4. Clears the secure local note (the secret now lives where it belongs).
+
+This avoids creating a transient Cache-owned Vault that would violate invariant 17. The cost is one extra step at the first consumer composition; the benefit is invariant-correctness throughout.
+
+If the operator strongly prefers to seed the secret into a Vault *now* rather than holding it in a local note, the only invariant-correct option is to create the consumer Node's Vault now (if it doesn't already exist) and seed the secret there. **Do NOT create a `kv-hd-cache-{env}` Vault under any circumstances** — invariant 17 forbids it.
+
+## Affected Files
+
+- `catalogs/grid-health.json` — flip the `redis-hd-dev` row's `state` from `not-provisioned` to `provisioned`; add resource ID and provisioning date to `notes`.
+- The Azure subscription — the actual `redis-hd-dev` Basic C0 instance (not a repo artifact).
+- Repo-level `CHANGELOG.md` — entry under the current in-progress version section noting the dev Redis instance was provisioned.
+
+## NuGet Dependencies
+
+None. This packet has no .NET project.
+
+## Boundary Check
+
+- [x] The `grid-health.json` flip lives in `HoneyDrunk.Architecture` — correct home for infra catalog metadata.
+- [x] No code change in any repo.
+- [x] Azure resource lands in the Azure subscription (vendor surface, not a Node).
+- [x] **No `kv-hd-cache-{env}` Vault created.** Per invariant 17. Cache has no Vault. The walkthrough's consumer-Vault routing is honored.
+- [x] No connection-string Vault seeding in this packet — deferred to the first consumer composition packet per the rationale above.
+- [x] No staging or prod provisioning — `dev` only (per ADR-0053 staging/prod are in flight).
+
+## Acceptance Criteria
+
+- [ ] `redis-hd-dev` exists in the Azure subscription, Basic C0 tier, ~$16/mo, in the matching dev resource group
+- [ ] Region matches the dev Container Apps environment's region (colocated for latency)
+- [ ] Minimum TLS version is `1.2`, Non-SSL port is `Disabled`
+- [ ] Eviction Policy is `allkeys-lru` (per ADR-0076 D4)
+- [ ] Cluster mode is `Disabled` (Basic tier limitation; matches default)
+- [ ] Redis modules are NOT enabled — verify the Advanced settings show no modules active (per ADR-0076 D3)
+- [ ] Persistence is `Disabled` (per ADR-0076 D3)
+- [ ] Tags applied: `env=dev`, `node=honeydrunk-cache`, `purpose=cache-backing`
+- [ ] Access keys (Primary connection string) noted by the operator in a secure local mechanism (1Password / Keychain / Credential Manager / equivalent) — NOT in repo, NOT in CHANGELOG, NOT in a config file, NOT in a screenshot (invariant 8)
+- [ ] **`catalogs/grid-health.json` `redis-hd-dev` row flipped to `state: provisioned`** with the actual resource ID and provisioning date added to the `notes` field. Connection string is NOT written to the row — only operational metadata
+- [ ] Repo-level `CHANGELOG.md` has an entry under the current in-progress version section noting that the dev Redis instance was provisioned
+- [ ] **No `kv-hd-cache-{env}` Key Vault created** (per invariant 17 — Cache has no Vault)
+- [ ] **No connection-string secret written to any Vault as part of this packet** — connection-string Vault seeding is deferred to the first consumer composition packet against the consumer Node's own Vault
+
+## Human Prerequisites
+
+This entire packet is `Actor=Human`. Specifically:
+
+- [ ] Packet 01 of this initiative complete — `infrastructure/walkthroughs/azure-cache-for-redis-provisioning.md` exists in the Architecture repo; the operator follows it during portal work.
+- [ ] Azure Portal access to the subscription with rights to create Azure Cache for Redis resources in the `rg-hd-dev` resource group.
+- [ ] The dev resource group (`rg-hd-dev` or equivalent) exists.
+- [ ] Acceptance of the ~$16/mo Azure charge for the Basic C0 instance.
+- [ ] Secure local secret-storage mechanism (1Password, macOS Keychain, Windows Credential Manager, or equivalent) for the interim holding of the Primary connection string until the first consumer composition packet seeds it into the consumer Node's Vault.
+- [ ] **Decision:** Whether to defer connection-string Vault seeding to the first consumer composition packet (recommended — invariant-correct, one extra step at composition time) OR to seed into an already-existing consumer Vault now (if `kv-hd-notify-cloud-dev` or `kv-hd-comms-dev` already exists at this packet's execution time). Document the decision in the PR body. **Do NOT create a `kv-hd-cache-{env}` Vault under any circumstances** — invariant 17 forbids it.
+
+## Referenced ADR Decisions
+
+**ADR-0076 D1 — Azure Cache for Redis as default distributed-cache backing:** Per-environment instance `redis-hd-{env}`. Same region as the Container Apps environment. Access-key auth on Basic tier (managed identity not available; falls back to access keys per ADR-0005).
+
+**ADR-0076 D2 — Per-environment sizing rubric:** Basic C0 for dev (~$16/mo, 250 MB, 1 instance, no HA). Resists over-provisioning. Standard tier is the prod baseline, not the dev tier.
+
+**ADR-0076 D3 — Redis-protocol-only; no Azure-Redis modules:** Modules NOT enabled at provisioning time. Persistence NOT enabled (cache values are by-construction ephemeral).
+
+**ADR-0076 D4 — Default eviction policy is `allkeys-lru`:** Verified or set during the Advanced settings step.
+
+**ADR-0053 — Per-environment branching and release cadence:** Only `dev` is provisioned at this initiative's time. Staging and prod are gated on the environments standing up under ADR-0053.
+
+**ADR-0005 — Vault and Key Vault naming + Vault-as-only-secret-source:** Connection-string Vault seeding happens at the first consumer composition packet's execution against the consumer Node's own Vault (`kv-hd-notify-cloud-dev` or `kv-hd-comms-dev`). The consumer Node resolves it via `ISecretStore` per invariant 9.
+
+## Constraints
+
+> **Invariant 8 — Secret values never appear in logs, traces, exceptions, or telemetry.** The Primary connection string is a secret. It never enters the repo, the CHANGELOG, a config file, a screenshot, or a commit. The operator holds it in a secure local mechanism (1Password / Keychain / Credential Manager).
+
+> **Invariant 9 — Vault is the only source of secrets.** When the first consumer Node composes the Redis backing, it resolves the connection string via `ISecretStore` — never from an environment variable holding the raw string or from a provider SDK default.
+
+> **Invariant 17 — One Key Vault per deployable Node per environment.** Named `kv-hd-{service}-{env}` with Azure RBAC. **Library Nodes have no Vault.** `HoneyDrunk.Cache` is a library Node per ADR-0059 — **no `kv-hd-cache-{env}` Vault is created by this packet.** The connection string belongs in the consumer Node's Vault; if the consumer Vault does not yet exist, the operator holds the connection string in a secure local mechanism until the consumer composition packet seeds it.
+
+> **Invariant 19 — Service names in Azure resource naming must be ≤ 13 characters.** `redis-hd-{env}` complies (the broader Grid convention for resource naming).
+
+> **Invariant 21 — Applications must never pin to a specific secret version.** When the consumer Node resolves the Redis connection string, it resolves the latest version via `ISecretStore`. The operator does NOT pin to a specific version when seeding (the seed creates version 1; future rotations create version 2, 3, etc., and the consumer resolves "latest" by default).
+
+- **Basic C0, not Standard or Premium.** The pre-create cost confirmation catches any tier-selection error. Standard tier is for staging/prod baseline. Premium NOT adopted per ADR-0076 D2 alternatives.
+- **`allkeys-lru` eviction policy.** Per ADR-0076 D4.
+- **Portal-only.** Per the user's standing preference for Azure Portal over CLI.
+- **No Vault seeding in this packet.** Deferred to first consumer composition.
+- **No staging or prod provisioning.** Per ADR-0053 — those environments are in flight.
+- **No `## Unreleased` block in CHANGELOG.** Per memory `feedback_no_unreleased_commits`. Entry lands under the current in-progress dated version section.
+
+## Dependencies
+
+- `packet:01` — the provisioning walkthrough must exist for the operator to execute it.
+
+## Labels
+
+`feature`, `tier-2`, `infrastructure`, `cache`, `human-only`, `adr-0076`, `wave-1`
+
+## Agent Handoff
+
+This packet is `Actor=Human`. The human-executed steps are documented in the Proposed Work section above. After the operator completes the portal work and updates `catalogs/grid-health.json`, they close the tracking issue.
+
+**Objective:** Provision the `dev` Azure Cache for Redis Basic C0 instance per the walkthrough authored in packet 01. Flip the `grid-health.json` row to `provisioned`. Hold the connection string in a secure local mechanism until the first consumer composition packet seeds it into the consumer Node's Vault.
+
+**Target:** Tracked against `HoneyDrunk.Architecture`; the Azure work is human-executed in the Azure Portal. `Actor=Human` — `human-only` label set. The `grid-health.json` flip is a small repo edit committed alongside the issue close.
+
+**Context:**
+- Goal: Stand up the dev Redis instance so packet 03's smoke verification has a real backend to test against.
+- Feature: ADR-0076 acceptance initiative, Wave 1, Packet 02.
+- ADRs: ADR-0076 D1/D2/D3/D4 (the backing decision being executed), ADR-0053 (only dev — staging/prod are in flight), ADR-0005 (consumer-Vault seeding deferred to consumer composition).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:**
+- `packet:01` — the walkthrough must exist.
+
+**Constraints:**
+
+- **Basic C0 for dev.** Not Standard, not Premium. Pre-create cost confirmation catches errors.
+- **`allkeys-lru` eviction.** Verified or set during Advanced settings.
+- **No modules, no persistence.** Per ADR-0076 D3.
+- **No `kv-hd-cache-{env}` Vault.** Per invariant 17. Cache has no Vault.
+- **No connection-string Vault seeding in this packet.** Operator holds in secure local mechanism until first consumer composition.
+- **`grid-health.json` row flipped to `provisioned`** with resource ID + date in `notes`; connection string NEVER written to the row.
+- **Dev only.** No staging or prod work.
+
+**Key Files:**
+- `catalogs/grid-health.json` — flip the `redis-hd-dev` row's `state` from `not-provisioned` to `provisioned`; add resource ID + date to `notes`.
+- `CHANGELOG.md` (repo root) — entry under current in-progress version noting the dev Redis provisioning.
+
+**Contracts:**
+
+This packet does not author or modify any contracts. Azure resource provisioning + small repo edit.

--- a/generated/issue-packets/active/adr-0076-cache-backing-redis/03-cache-redis-implementation.md
+++ b/generated/issue-packets/active/adr-0076-cache-backing-redis/03-cache-redis-implementation.md
@@ -1,0 +1,586 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Cache
+labels: ["feature", "tier-2", "cache", "redis", "adr-0076", "wave-2"]
+dependencies: ["packet:01", "packet:02"]
+adrs: ["ADR-0076", "ADR-0058", "ADR-0059", "ADR-0005"]
+accepts: ADR-0076
+wave: 2
+initiative: adr-0076-cache-backing-redis
+node: honeydrunk-cache
+---
+
+# Feature: Implement `HoneyDrunk.Cache.Redis` — `RedisCacheStore<T>` on StackExchange.Redis + DI registration + tests
+
+## Summary
+First real package in the `HoneyDrunk.Cache` solution. Add `src/HoneyDrunk.Cache.Redis/` project. Implement `RedisCacheStore<T>` against `ICacheStore<T>` from `HoneyDrunk.Kernel.Abstractions` (declared by ADR-0058 D2, in place on `main` via PR #301), backed by `StackExchange.Redis`. Provide `AddHoneyDrunkCacheRedis<T>` extension method on `IServiceCollection` for DI registration with `RedisCacheOptions` configuration. Use System.Text.Json for value serialization. Use standard Redis protocol commands only — no `RediSearch`, `RedisJSON`, `RedisTimeSeries`, `RedisGraph`, or `RedisBloom` module commands per ADR-0076 D3. Implement tag-to-key index using standard Redis sets for `RemoveByTagAsync`. Wire startup-warmup connection probe via `IStartupHook` from `HoneyDrunk.Kernel.Abstractions.Lifecycle` so host startup fails fast on unreachable Redis. Comprehensive unit tests against an InMemory `IConnectionMultiplexer` fake covering Get/Set/Remove/RemoveByTag/TTL/tag-invalidation/serialization-roundtrip/connection-failure semantics. **First/version-bumping packet on the `HoneyDrunk.Cache` solution** (`0.0.1` → `0.1.0`, first feature beyond the empty placeholder).
+
+This is the package that fills ADR-0058 D8's deferred "first distributed backing" decision and gives the Cache Node (stood up empty per ADR-0059) its first real implementation. The placeholder `HoneyDrunk.Cache.Adapters` project from the standup stays as a sibling and receives the alignment-bump version per invariant 27.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Cache`
+
+## Motivation
+
+The empty scaffold landed by ADR-0059's standup is the room with the lighting on; this packet is the first piece of furniture. ADR-0076 D1 commits the literal package name `HoneyDrunk.Cache.Redis` (matching the ADR text exactly; NOT `HoneyDrunk.Cache.Adapters.Redis` or any other naming variant). The package implements the `ICacheStore<T>` contract that ADR-0058 D2 placed in `HoneyDrunk.Kernel.Abstractions` and that PR #301 has merged onto `main`.
+
+The implementation surface is small by design — four method implementations on `ICacheStore<T>` plus a DI registration extension plus a startup hook plus a configuration record. Per ADR-0058 D2 the contract is deliberately minimal at v1 (no `GetOrSetAsync` sugar — consumers compose it themselves). This packet honors that minimalism; it does NOT add convenience helpers, "load if missing" patterns, or refresh-ahead behavior.
+
+`StackExchange.Redis` is the .NET-ecosystem standard Redis client per ADR-0076 D1 ("`StackExchange.Redis` (the .NET-ecosystem standard Redis client)"). The package is widely deployed, AI-assistance-gradient deep, well-documented. No exotic client choice; the boring choice is the right one.
+
+Redis-protocol-only discipline (ADR-0076 D3) means the implementation uses commands every Redis-protocol-compatible server speaks (open Redis, Valkey, KeyDB, Dragonfly, every cloud-managed Redis). The vendor-exit hedge is preserved by code; future migration to a different backing is a managed-service swap, not a code rewrite.
+
+## Scope
+
+- New `src/HoneyDrunk.Cache.Redis/` project with the following surface:
+  - `RedisCacheStore<T>` — implements `ICacheStore<T>` against `IConnectionMultiplexer` from `StackExchange.Redis`.
+  - `RedisCacheOptions` record — configuration (connection string secret name, key prefix, serializer options, command timeout).
+  - `AddHoneyDrunkCacheRedis<T>` — `IServiceCollection` extension for DI registration.
+  - `RedisCacheStartupHook` — implements `IStartupHook` from `HoneyDrunk.Kernel.Abstractions.Lifecycle` for connection-warmup at host startup.
+  - Internal helpers — value serialization via System.Text.Json, key namespacing, tag-to-key index management using standard Redis sets.
+- New `tests/HoneyDrunk.Cache.Redis.Tests.Unit/` project with unit tests against an InMemory `IConnectionMultiplexer` fake.
+- `HoneyDrunk.Cache.slnx` updated to reference the new project(s).
+- Repo-level `Directory.Build.props` version bump `0.0.1` → `0.1.0` (first real feature; alignment-bumps the placeholder Adapters project per invariant 27).
+- Repo-level `CHANGELOG.md` — new `[0.1.0]` dated entry.
+- `src/HoneyDrunk.Cache.Redis/README.md` + `CHANGELOG.md` — new per-package docs.
+- `src/HoneyDrunk.Cache.Adapters/CHANGELOG.md` — receives a one-line alignment-bump entry per invariants 12/27 ("Version bumped to 0.1.0 alongside `HoneyDrunk.Cache.Redis` first release; no functional change to this package.") — explicit no-noise wording per invariant 27 ("Per-package changelogs are updated only for packages with actual changes — do not add alignment-bump noise entries"). On re-reading invariant 27: the alignment-bump-noise prohibition means **do NOT add a CHANGELOG entry to a package that has no real change**. The placeholder Adapters project has no real change — it gets the version bump (silent, per invariant 27's "all projects share one version") but **no CHANGELOG entry**. Acceptance criteria reflect this.
+- `.github/workflows/api-compatibility.yml` — first contract-shape canary for `HoneyDrunk.Cache.Redis` (since the package now ships a public surface — `AddHoneyDrunkCacheRedis<T>`, `RedisCacheOptions`). The ADR-0059 scaffold packet explicitly omitted `api-compatibility.yml` because Cache owned no contracts at stand-up; this packet adds the canary scoped to `HoneyDrunk.Cache.Redis` because there is now a public surface to freeze.
+
+## Proposed Implementation
+
+### `src/HoneyDrunk.Cache.Redis/HoneyDrunk.Cache.Redis.csproj`
+
+Minimal `.csproj`. Per invariant 26, `HoneyDrunk.Standards` is referenced with `PrivateAssets="all"`. The runtime dependencies are `StackExchange.Redis`, `HoneyDrunk.Kernel.Abstractions` (for the contract), and `Microsoft.Extensions.DependencyInjection.Abstractions` (for the `IServiceCollection` extension method).
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Azure Cache for Redis backing implementation of ICacheStore&lt;T&gt; for the HoneyDrunk Grid. Standard Redis protocol commands only; no Azure-Redis modules. System.Text.Json for value serialization. Tag-to-key index for RemoveByTagAsync support.</Description>
+    <PackageTags>cache;redis;distributed-cache;stackexchange-redis;azure-cache-for-redis;honeydrunk</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="HoneyDrunk.Standards" Version="*" PrivateAssets="all" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.8.0" />
+    <PackageReference Include="StackExchange.Redis" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+</Project>
+```
+
+(The exact version pins on `StackExchange.Redis`, `Microsoft.Extensions.*` go to the `Directory.Packages.props` central-version-management file if the repo uses CPM — verify at edit time and use the repo's pattern. Otherwise, pin to the latest stable in the `.csproj` directly. The `HoneyDrunk.Kernel.Abstractions` version is `0.8.0` — the version landed by ADR-0058's packet 04 introducing the contract.)
+
+### `RedisCacheOptions` record
+
+Plain configuration record bound from `IOptions<RedisCacheOptions>`. The connection string is a Vault-resolved secret (NOT a configuration value baked into appsettings); the option carries the *secret name*, not the secret value. The composing host resolves the secret via `ISecretStore` and configures the `IConnectionMultiplexer` accordingly — this packet does NOT take a runtime dependency on `HoneyDrunk.Vault` because Vault composition is host-time. Per the records-naming rule (memory `project_naming_rule_records`): record types drop the `I`, interfaces keep it. `RedisCacheOptions` is a record, no `I` prefix.
+
+```csharp
+namespace HoneyDrunk.Cache.Redis;
+
+/// <summary>
+/// Configuration for the Redis-backed ICacheStore&lt;T&gt; implementation.
+/// </summary>
+public sealed record RedisCacheOptions
+{
+    /// <summary>
+    /// Vault secret name holding the Redis connection string. Default "redis-connection-string".
+    /// The composing host resolves this via ISecretStore and constructs the IConnectionMultiplexer.
+    /// </summary>
+    public string ConnectionStringSecretName { get; init; } = "redis-connection-string";
+
+    /// <summary>
+    /// Optional key prefix applied to every cache operation. Use for per-Node namespacing.
+    /// Example: "notify-cloud:apikeys" so Notify Cloud's keys do not collide with Communications's.
+    /// Per ADR-0058 D5, tenant-keying is the call-site's responsibility — this prefix is Node-level.
+    /// </summary>
+    public string KeyPrefix { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Default command timeout for Redis operations. Default 5 seconds.
+    /// </summary>
+    public TimeSpan CommandTimeout { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// JsonSerializerOptions used to serialize/deserialize values.
+    /// Default: SystemTextJson defaults with PropertyNamingPolicy = CamelCase.
+    /// </summary>
+    public JsonSerializerOptions? SerializerOptions { get; init; }
+}
+```
+
+### `RedisCacheStore<T>` implementation
+
+Implements every method on `ICacheStore<T>` using standard Redis protocol commands.
+
+```csharp
+namespace HoneyDrunk.Cache.Redis;
+
+/// <summary>
+/// Redis-backed ICacheStore&lt;T&gt; implementation. Uses standard Redis protocol commands only —
+/// no RediSearch, RedisJSON, RedisTimeSeries, RedisGraph, or RedisBloom module commands.
+/// Values serialize through System.Text.Json. Tag-to-key index uses Redis sets for RemoveByTagAsync.
+/// </summary>
+public sealed class RedisCacheStore<T> : ICacheStore<T>
+{
+    private readonly IConnectionMultiplexer _multiplexer;
+    private readonly RedisCacheOptions _options;
+    private readonly JsonSerializerOptions _serializerOptions;
+    private readonly ILogger<RedisCacheStore<T>> _logger;
+
+    public RedisCacheStore(
+        IConnectionMultiplexer multiplexer,
+        IOptions<RedisCacheOptions> options,
+        ILogger<RedisCacheStore<T>> logger)
+    {
+        _multiplexer = multiplexer ?? throw new ArgumentNullException(nameof(multiplexer));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _serializerOptions = _options.SerializerOptions ?? new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async ValueTask<T?> GetAsync(string key, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var db = _multiplexer.GetDatabase();
+        var value = await db.StringGetAsync(NamespaceKey(key)).ConfigureAwait(false);
+        if (value.IsNullOrEmpty) return default;
+        return JsonSerializer.Deserialize<T>(value!, _serializerOptions);
+    }
+
+    public async ValueTask SetAsync(
+        string key,
+        T value,
+        TimeSpan? ttl = null,
+        IReadOnlyCollection<string>? tags = null,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var serialized = JsonSerializer.Serialize(value, _serializerOptions);
+        var db = _multiplexer.GetDatabase();
+        var namespacedKey = NamespaceKey(key);
+
+        // Standard Redis protocol: SETEX (or SET with EX/PX) for TTL, SET for no-TTL.
+        await db.StringSetAsync(namespacedKey, serialized, ttl).ConfigureAwait(false);
+
+        // Tag-to-key index using Redis sets — standard SADD per tag, plus a reverse-index
+        // SADD per key listing its tags so RemoveAsync can prune the tag entries cleanly.
+        if (tags is { Count: > 0 })
+        {
+            var tagOps = new List<Task>(tags.Count + 1);
+            foreach (var tag in tags)
+            {
+                tagOps.Add(db.SetAddAsync(NamespaceTagKey(tag), namespacedKey.ToString()));
+            }
+            tagOps.Add(db.SetAddAsync(NamespaceKeyTagsKey(namespacedKey), tags.Select(t => (RedisValue)t).ToArray()));
+            await Task.WhenAll(tagOps).ConfigureAwait(false);
+        }
+    }
+
+    public async ValueTask RemoveAsync(string key, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var db = _multiplexer.GetDatabase();
+        var namespacedKey = NamespaceKey(key);
+
+        // Look up the key's tag set; remove the key from each tag's set; delete the key's tag set;
+        // delete the key. Standard Redis: SMEMBERS, SREM, DEL.
+        var keyTagsKey = NamespaceKeyTagsKey(namespacedKey);
+        var tags = await db.SetMembersAsync(keyTagsKey).ConfigureAwait(false);
+        if (tags.Length > 0)
+        {
+            var pruneOps = new List<Task>(tags.Length + 1);
+            foreach (var tag in tags)
+            {
+                pruneOps.Add(db.SetRemoveAsync(NamespaceTagKey(tag.ToString()), namespacedKey.ToString()));
+            }
+            pruneOps.Add(db.KeyDeleteAsync(keyTagsKey));
+            await Task.WhenAll(pruneOps).ConfigureAwait(false);
+        }
+
+        await db.KeyDeleteAsync(namespacedKey).ConfigureAwait(false);
+    }
+
+    public async ValueTask RemoveByTagAsync(string tag, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var db = _multiplexer.GetDatabase();
+        var tagKey = NamespaceTagKey(tag);
+
+        // Look up every key in the tag's set; delete each; clean up the per-key tag-index entries; delete the tag set.
+        var keys = await db.SetMembersAsync(tagKey).ConfigureAwait(false);
+        if (keys.Length == 0)
+        {
+            await db.KeyDeleteAsync(tagKey).ConfigureAwait(false);
+            return;
+        }
+
+        var deleteOps = new List<Task>(keys.Length * 2 + 1);
+        foreach (var redisKey in keys)
+        {
+            deleteOps.Add(db.KeyDeleteAsync((RedisKey)redisKey.ToString()));
+            deleteOps.Add(db.KeyDeleteAsync(NamespaceKeyTagsKey((RedisKey)redisKey.ToString())));
+        }
+        deleteOps.Add(db.KeyDeleteAsync(tagKey));
+        await Task.WhenAll(deleteOps).ConfigureAwait(false);
+    }
+
+    private RedisKey NamespaceKey(string key) =>
+        string.IsNullOrEmpty(_options.KeyPrefix)
+            ? key
+            : $"{_options.KeyPrefix}:{key}";
+
+    private RedisKey NamespaceTagKey(string tag) =>
+        string.IsNullOrEmpty(_options.KeyPrefix)
+            ? $"__tag:{tag}"
+            : $"{_options.KeyPrefix}:__tag:{tag}";
+
+    private RedisKey NamespaceKeyTagsKey(RedisKey namespacedKey) =>
+        $"{namespacedKey}:__tags";
+}
+```
+
+(The exact code shape — using statements, nullability annotations, sealed/non-sealed decisions, etc. — is the agent's call within the repo's conventions. The above is the intent and the algorithm; conformity to the repo's analyzer set, file-per-type discipline, and StyleCop rules is the agent's responsibility.)
+
+### `RedisCacheStartupHook` — IStartupHook for connection warmup
+
+Implements `IStartupHook` from `HoneyDrunk.Kernel.Abstractions.Lifecycle` (verified at `HoneyDrunk.Kernel.Abstractions/Lifecycle/IStartupHook.cs`). Executes a `PING` against the configured Redis instance during host startup — fails fast if Redis is unreachable, matching the established pattern from Vault's startup-warmup discipline.
+
+```csharp
+namespace HoneyDrunk.Cache.Redis;
+
+/// <summary>
+/// IStartupHook that warms the Redis connection at host startup. Fails fast if Redis is unreachable
+/// so the host does not start up in a degraded state.
+/// </summary>
+public sealed class RedisCacheStartupHook : IStartupHook
+{
+    private readonly IConnectionMultiplexer _multiplexer;
+    private readonly ILogger<RedisCacheStartupHook> _logger;
+
+    public RedisCacheStartupHook(
+        IConnectionMultiplexer multiplexer,
+        ILogger<RedisCacheStartupHook> logger)
+    {
+        _multiplexer = multiplexer ?? throw new ArgumentNullException(nameof(multiplexer));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    // Run after most early hooks but before any business-logic startup that needs cache to be available.
+    public int Priority => 100;
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var db = _multiplexer.GetDatabase();
+        var pong = await db.PingAsync().ConfigureAwait(false);
+        _logger.LogInformation("Redis cache backing reachable; PING latency {LatencyMs}ms", pong.TotalMilliseconds);
+    }
+}
+```
+
+### `AddHoneyDrunkCacheRedis<T>` extension
+
+`IServiceCollection` extension for DI registration. Registers `ICacheStore<T>` → `RedisCacheStore<T>`, the `RedisCacheOptions` binding, the startup hook, and (if not already registered) the `IConnectionMultiplexer` singleton. The `IConnectionMultiplexer` factory takes the Vault-resolved connection string — the registration accepts a `Func<IServiceProvider, string>` for the connection-string factory so the host wires Vault resolution at composition time without forcing this package to take a Vault dependency.
+
+```csharp
+namespace HoneyDrunk.Cache.Redis;
+
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a Redis-backed ICacheStore&lt;T&gt; with the given options and a connection-string
+    /// factory. The factory typically resolves the connection string from ISecretStore (Vault)
+    /// at composition time.
+    /// </summary>
+    public static IServiceCollection AddHoneyDrunkCacheRedis<T>(
+        this IServiceCollection services,
+        Action<RedisCacheOptions>? configureOptions = null,
+        Func<IServiceProvider, string>? connectionStringFactory = null)
+    {
+        if (services is null) throw new ArgumentNullException(nameof(services));
+
+        if (configureOptions is not null)
+        {
+            services.Configure(configureOptions);
+        }
+
+        if (connectionStringFactory is not null)
+        {
+            services.TryAddSingleton<IConnectionMultiplexer>(sp =>
+            {
+                var connectionString = connectionStringFactory(sp);
+                return ConnectionMultiplexer.Connect(connectionString);
+            });
+        }
+
+        services.TryAddSingleton<ICacheStore<T>, RedisCacheStore<T>>();
+        services.AddSingleton<IStartupHook, RedisCacheStartupHook>();
+
+        return services;
+    }
+}
+```
+
+(`TryAddSingleton` for `IConnectionMultiplexer` and `ICacheStore<T>` so multiple calls to `AddHoneyDrunkCacheRedis<T>` for different `T` share one multiplexer and don't double-register the same generic closure.)
+
+### Unit tests — `tests/HoneyDrunk.Cache.Redis.Tests.Unit/`
+
+Test against an InMemory `IConnectionMultiplexer` fake (NSubstitute per the repo's test stack, or a hand-rolled in-process fake — the agent picks per existing convention). Coverage:
+
+- `GetAsync` on a missing key returns `default(T?)`.
+- `SetAsync` then `GetAsync` returns the set value, round-tripped through serialization.
+- `SetAsync` with a `ttl` is reflected in the `StringSetAsync` call's expiry parameter.
+- `SetAsync` with `tags` calls `SetAddAsync` for each tag and for the per-key reverse index.
+- `SetAsync` with an empty `tags` collection behaves the same as `null` (no `SetAddAsync` invocations).
+- `RemoveAsync` calls `KeyDeleteAsync` and prunes the tag indexes the key appeared in.
+- `RemoveByTagAsync` deletes every key in the tag set and the tag set itself; also prunes the per-key tag-index entries.
+- `RemoveByTagAsync` on a non-existent tag is a no-op (no exception).
+- Connection failure during a Get/Set surfaces as the appropriate exception type — no swallowing.
+- Serialization round-trip for a non-trivial type (e.g., a record with nested properties).
+- `KeyPrefix` is applied correctly when non-empty (verify `StringSetAsync` was called with the prefixed key).
+- No `Thread.Sleep` anywhere (invariant 51); TTL tests use the test-fake's clock or skip time-advance verification (TTL is delegated to Redis, not asserted by the test — the test verifies the parameter was passed correctly).
+
+### Solution-level changes
+
+- `HoneyDrunk.Cache.slnx` references the new `src/HoneyDrunk.Cache.Redis/` project and the new `tests/HoneyDrunk.Cache.Redis.Tests.Unit/` project.
+- `Directory.Build.props` `<Version>` bumped `0.0.1` → `0.1.0` (first feature beyond empty placeholder; minor bump for additive feature).
+- `src/HoneyDrunk.Cache.Adapters/HoneyDrunk.Cache.Adapters.csproj` carries the alignment bump silently per invariant 27 — **no per-package CHANGELOG entry** because there is no functional change (invariant 27's no-alignment-noise rule).
+
+### Repo-level + per-package documentation
+
+- Repo-level `CHANGELOG.md` — new `## [0.1.0] - YYYY-MM-DD` entry covering the Redis backing.
+- `src/HoneyDrunk.Cache.Redis/README.md` — per-package README. Includes purpose, installation (`dotnet add package HoneyDrunk.Cache.Redis`), DI registration example, configuration (`RedisCacheOptions`), and the operational shape (Redis-protocol-only, `allkeys-lru` is set on the Azure resource not in the client, tag-to-key index uses Redis sets, value serialization is System.Text.Json). Does NOT cite ADR numbers in narrative paragraphs (per memory `feedback_no_adr_in_docs`).
+- `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` — new per-package CHANGELOG with `## [0.1.0] - YYYY-MM-DD` entry.
+- Repo root `README.md` — update the "For downstream consumers" section to remove the v0.0.1 "no backings shipped" placeholder text and show the Redis backing as the first real available backing. Update the "Phase-1 honest limitation" section to reflect that the first backing has shipped.
+
+### `.github/workflows/api-compatibility.yml` — contract-shape canary scoped to `HoneyDrunk.Cache.Redis`
+
+The ADR-0059 scaffold packet explicitly omitted `api-compatibility.yml` because Cache owned no public surface. This packet adds the canary because `HoneyDrunk.Cache.Redis` now ships a public surface (`AddHoneyDrunkCacheRedis<T>`, `RedisCacheOptions`, `RedisCacheStore<T>`, `RedisCacheStartupHook`). The workflow file is a thin caller of `HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml@main` scoped to `project-path: src/HoneyDrunk.Cache.Redis`. The exact file shape mirrors the same workflow in `HoneyDrunk.Audit`, `HoneyDrunk.AI`, `HoneyDrunk.Capabilities`, and `HoneyDrunk.Communications`.
+
+Branch protection on `main` should be updated to require `api-compatibility` as well as `pr-core / core` — this is a small repo-settings change tracked in the Human Prerequisites section.
+
+## Affected Files
+
+- `src/HoneyDrunk.Cache.Redis/HoneyDrunk.Cache.Redis.csproj` (new)
+- `src/HoneyDrunk.Cache.Redis/RedisCacheStore.cs` (new)
+- `src/HoneyDrunk.Cache.Redis/RedisCacheOptions.cs` (new)
+- `src/HoneyDrunk.Cache.Redis/RedisCacheStartupHook.cs` (new)
+- `src/HoneyDrunk.Cache.Redis/ServiceCollectionExtensions.cs` (new)
+- `src/HoneyDrunk.Cache.Redis/README.md` (new)
+- `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` (new)
+- `tests/HoneyDrunk.Cache.Redis.Tests.Unit/HoneyDrunk.Cache.Redis.Tests.Unit.csproj` (new)
+- `tests/HoneyDrunk.Cache.Redis.Tests.Unit/RedisCacheStoreTests.cs` (new — main test file; agent may decompose further per repo convention)
+- `HoneyDrunk.Cache.slnx` — reference the new projects.
+- `Directory.Build.props` — version bump `0.0.1` → `0.1.0`.
+- `CHANGELOG.md` (repo root) — new `[0.1.0]` entry.
+- `README.md` (repo root) — update "For downstream consumers" and "Phase-1 honest limitation" sections.
+- `src/HoneyDrunk.Cache.Adapters/HoneyDrunk.Cache.Adapters.csproj` — implicit alignment bump via `Directory.Build.props` (no edit needed if the .csproj inherits version).
+- `src/HoneyDrunk.Cache.Adapters/CHANGELOG.md` — **no new entry** (invariant 27 no-alignment-noise rule; the package has no functional change).
+- `.github/workflows/api-compatibility.yml` (new) — contract-shape canary scoped to `HoneyDrunk.Cache.Redis`.
+
+## NuGet Dependencies
+
+### `HoneyDrunk.Cache.Redis.csproj`
+
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` — analyzers + EditorConfig (invariant 26) |
+| `HoneyDrunk.Kernel.Abstractions` | Version `0.8.0` (the version landed by ADR-0058's contract packet; pin to that version or to a wildcard that resolves to `0.8.*` per the repo's central-version-management convention) |
+| `StackExchange.Redis` | Latest stable. The .NET-ecosystem standard Redis client per ADR-0076 D1. |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | For the `IServiceCollection` extension method. |
+| `Microsoft.Extensions.Options` | For `IOptions<RedisCacheOptions>` binding. |
+| `Microsoft.Extensions.Logging.Abstractions` | For `ILogger<T>` injection. |
+
+### `HoneyDrunk.Cache.Redis.Tests.Unit.csproj`
+
+| Package | Notes |
+|---|---|
+| `HoneyDrunk.Standards` | `PrivateAssets="all"` |
+| `Microsoft.NET.Test.Sdk` | Test runner SDK |
+| `xunit` | xUnit framework per ADR-0047 D2 (the shared test stack) |
+| `xunit.runner.visualstudio` | xUnit VS adapter |
+| `NSubstitute` | Mocking per ADR-0047 D2 |
+| `AwesomeAssertions` | Assertion library per ADR-0047 D2 |
+| `coverlet.collector` | Coverage collector per ADR-0047 D3 |
+
+Project reference: `src/HoneyDrunk.Cache.Redis/HoneyDrunk.Cache.Redis.csproj`.
+
+## Boundary Check
+
+- [x] `HoneyDrunk.Cache.Redis` implements `ICacheStore<T>` declared in `HoneyDrunk.Kernel.Abstractions` per ADR-0058 D2 and ADR-0076 D1. Routing rule "context, GridContext, ... → Kernel; cache backings → Cache".
+- [x] **Package name is `HoneyDrunk.Cache.Redis`** (literal text from ADR-0076 D1) — NOT `HoneyDrunk.Cache.Adapters.Redis` or any other naming variant.
+- [x] One-way dependency: Cache → Kernel.Abstractions. No reverse edge.
+- [x] No `HoneyDrunk.Pulse` reference (telemetry is one-way via Kernel's `ITelemetryActivityFactory` — packet 04 wires it). No runtime dependency on Pulse per the Cache → Pulse boundary.
+- [x] No `HoneyDrunk.Vault` reference. Connection-string resolution is host-time composition — the package accepts a `Func<IServiceProvider, string>` factory so the host wires Vault without coupling this package to Vault.
+- [x] **Standard Redis protocol commands only.** Implementation uses `StringSetAsync`, `StringGetAsync`, `KeyDeleteAsync`, `SetAddAsync`, `SetMembersAsync`, `SetRemoveAsync`, `PingAsync` — all Redis-core commands. Verify with grep: no usage of `Module*`, no `FT.*` (RediSearch), no `JSON.*` (RedisJSON), no `TS.*` (RedisTimeSeries), no `GRAPH.*` (RedisGraph), no `BF.*` / `CF.*` / `TDIGEST.*` (RedisBloom) — zero matches expected.
+- [x] System.Text.Json for value serialization. Newtonsoft.Json NOT referenced.
+- [x] Tag-to-key index uses standard Redis sets (`SADD` / `SMEMBERS` / `SREM`). No bespoke pub-sub-on-Redis pattern (ADR-0058 D7's cache-invalidation Lane 2 is Service Bus, not Redis pub/sub).
+- [x] No Azure-Redis-Modules dependency anywhere.
+- [x] No `MultiplexerPool` or other StackExchange.Redis-internal types exposed across the public API.
+- [x] **First/version-bumping packet on the `HoneyDrunk.Cache` solution** per invariant 27. `Directory.Build.props` version bump `0.0.1` → `0.1.0` in this commit.
+- [x] **No `HoneyDrunk.Cache.Adapters/CHANGELOG.md` entry** for the alignment bump (invariant 27 no-alignment-noise rule).
+- [x] No tests run against a live Redis instance — unit tests use an InMemory `IConnectionMultiplexer` fake (invariant 15).
+- [x] No `Thread.Sleep` in test code (invariant 51).
+- [x] No secrets in code, tests, or fixtures (invariant 8).
+
+## Acceptance Criteria
+
+- [ ] `src/HoneyDrunk.Cache.Redis/` exists as a project in the solution; `HoneyDrunk.Cache.slnx` references it
+- [ ] `RedisCacheStore<T>` implements `ICacheStore<T>` from `HoneyDrunk.Kernel.Abstractions` with all four methods (`GetAsync`, `SetAsync`, `RemoveAsync`, `RemoveByTagAsync`)
+- [ ] **No `GetOrSetAsync` helper added** (per ADR-0058 D8 / Alternatives — convenience sugar is deferred until usage justifies it)
+- [ ] `RedisCacheOptions` record exists with `ConnectionStringSecretName`, `KeyPrefix`, `CommandTimeout`, `SerializerOptions` properties
+- [ ] `AddHoneyDrunkCacheRedis<T>` extension exists on `IServiceCollection`; accepts an optional `Action<RedisCacheOptions>` and an optional connection-string factory
+- [ ] `RedisCacheStartupHook` implements `IStartupHook` from `HoneyDrunk.Kernel.Abstractions.Lifecycle`; pings Redis at startup; fails fast if Redis is unreachable
+- [ ] **Implementation uses only standard Redis protocol commands.** Verify with grep across `src/HoneyDrunk.Cache.Redis/`: zero matches for `FT.`, `JSON.`, `TS.`, `GRAPH.`, `BF.`, `CF.`, `TDIGEST.`, `Module` (per ADR-0076 D3)
+- [ ] **Value serialization uses System.Text.Json.** Verify: zero references to `Newtonsoft.Json` in `.csproj` or `.cs` files; the serializer call sites use `JsonSerializer.Serialize` / `JsonSerializer.Deserialize`
+- [ ] Tag-to-key index uses Redis sets (`SetAddAsync`, `SetMembersAsync`, `SetRemoveAsync`); no pub/sub pattern
+- [ ] Unit tests pass: GetAsync-missing, SetAsync→GetAsync round-trip, SetAsync TTL parameter propagation, SetAsync tags → SetAddAsync invocations, SetAsync empty-tags → no SADD, RemoveAsync prunes tag index, RemoveByTagAsync deletes all keys + the tag set, RemoveByTagAsync on missing tag is no-op, connection-failure surfaces exception, KeyPrefix applied correctly, non-trivial-type serialization round-trip
+- [ ] **No live Redis required for unit tests** — tests run against an InMemory `IConnectionMultiplexer` fake (invariant 15)
+- [ ] **No `Thread.Sleep` in any test file** (invariant 51) — verify with grep across `tests/`
+- [ ] `tests/HoneyDrunk.Cache.Redis.Tests.Unit/` project exists; coverlet coverage configured per ADR-0047 D3
+- [ ] `HoneyDrunk.Cache.Redis.csproj` carries the package references listed in the NuGet Dependencies section above; `HoneyDrunk.Kernel.Abstractions` pinned to `0.8.0` (or schema-equivalent per CPM)
+- [ ] **`Directory.Build.props` version is `0.1.0`** (bumped from `0.0.1`); invariant 27 — all non-test `.csproj` files inherit the same version in a single commit
+- [ ] **`src/HoneyDrunk.Cache.Adapters/CHANGELOG.md` has NO new entry** — invariant 27 no-alignment-noise rule (placeholder has no functional change)
+- [ ] Repo-level `CHANGELOG.md` has a new `## [0.1.0] - YYYY-MM-DD` entry covering the Redis backing
+- [ ] `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` (new) has a `## [0.1.0] - YYYY-MM-DD` entry per invariant 12
+- [ ] `src/HoneyDrunk.Cache.Redis/README.md` (new) documents purpose, installation, DI registration example, configuration, operational shape — **without citing "ADR-0076" or "ADR-0058" by number in narrative** (per memory `feedback_no_adr_in_docs`)
+- [ ] Repo-root `README.md` updated to remove the "no backings shipped at v0.0.1" placeholder; reflects that the Redis backing is the first available backing
+- [ ] `.github/workflows/api-compatibility.yml` (new) calls `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-api-compatibility.yml@main` scoped to `project-path: src/HoneyDrunk.Cache.Redis`
+- [ ] `pr-core.yml` and `api-compatibility.yml` both pass on the PR
+- [ ] All public APIs have XML documentation (invariant 13)
+- [ ] No secret values anywhere in code, tests, or fixtures (invariant 8)
+- [ ] No PII or restricted-tier value handling in this package beyond the standard Redis storage — restricted-tier application-layer encryption is packet 05's territory and is not implemented here
+
+## Human Prerequisites
+
+- [ ] Packet 01 of this initiative merged — the `azure-cache-for-redis-provisioning.md` walkthrough exists so the package README can cross-reference it; the catalog rows exist so the module identity is established.
+- [ ] Packet 02 of this initiative complete — the dev Redis instance (`redis-hd-dev`) exists in the Azure subscription. Unit tests do not strictly require this (they use the InMemory fake), but a live instance is required for any post-merge operator smoke verification.
+- [ ] **Upstream ADR-0058 packet 04 merged** — the `ICacheStore<T>` contract exists in `HoneyDrunk.Kernel.Abstractions` at version `0.8.0`. PR #301 confirmed merged at scoping time; the package reference resolves correctly.
+- [ ] **Upstream ADR-0059 packet 03 merged** — the `HoneyDrunk.Cache` repo exists with the placeholder `HoneyDrunk.Cache.Adapters` project, the solution file, and the CI workflows. PR #323 confirmed merged at scoping time.
+- [ ] Branch protection on `main` updated to require `api-compatibility` check after this PR merges (so future PRs don't bypass the canary). The ADR-0059 standup packet noted this would happen "when a future backing introduces its own public surface" — that future is now. The branch-protection update is a small org-admin action; the PR's body should call it out as a post-merge step.
+- [ ] **No `NUGET_API_KEY` activity in this packet.** The version bump to `0.1.0` does NOT trigger a tag push. The first tag push (`v0.1.0`) is human-pushed per invariant 27 after this PR merges and the operator has verified the package on the local feed / test composition. Filing the tag-push as a discrete follow-up note in the PR body is sufficient.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — `HoneyDrunk.Cache.Redis` is a runtime package, not an Abstractions package. It depends on `HoneyDrunk.Kernel.Abstractions` (an Abstractions package — permitted on a runtime package per invariant 2) and on `StackExchange.Redis` (third-party). No Abstractions-on-other-HoneyDrunk-runtime dependency.
+
+> **Invariant 2:** Runtime packages depend on Abstractions, never on other runtime packages at the same layer. — `HoneyDrunk.Cache.Redis` (runtime) depends on `HoneyDrunk.Kernel.Abstractions` (abstractions). Correct.
+
+> **Invariant 4:** No circular dependencies. The dependency graph is a DAG. Kernel is always at the root. — Cache → Kernel.Abstractions is one-way. Kernel does not reference Cache.
+
+> **Invariant 8:** Secret values never appear in logs, traces, exceptions, or telemetry. — The package does not log connection strings, access keys, or any secret value. Telemetry attributes carry cache key names (not values) and operation outcomes; no secret enters the telemetry pipeline.
+
+> **Invariant 9:** Vault is the only source of secrets. — The connection-string factory parameter on `AddHoneyDrunkCacheRedis<T>` is the seam through which the host wires `ISecretStore` resolution. The package itself never resolves a secret; it accepts a factory.
+
+> **Invariant 11:** One repo per Node. — Cache is one repo; the Redis backing is one package within it.
+
+> **Invariant 12:** Every shipped package has a CHANGELOG.md and README.md. New packages and new repos include their creation in acceptance criteria. — Both files are authored for `HoneyDrunk.Cache.Redis`.
+
+> **Invariant 13:** All public APIs have XML documentation. — Every public type, method, parameter, and return value on the Redis backing surface carries XML doc.
+
+> **Invariant 14:** Canary tests validate cross-Node boundaries. — The `api-compatibility.yml` workflow is the contract-shape canary for `HoneyDrunk.Cache.Redis`'s public surface. Future shape drift fails the build unless paired with an intentional version bump.
+
+> **Invariant 15:** Unit tests and in-process integration tests never depend on external services. Use InMemory providers for isolation. — Unit tests use an InMemory `IConnectionMultiplexer` fake. No live Redis dependency.
+
+> **Invariant 17:** One Key Vault per deployable Node per environment. Library-only Nodes have no vault. — `HoneyDrunk.Cache` is a library Node — no `kv-hd-cache-{env}` Vault exists. The connection-string factory parameter on `AddHoneyDrunkCacheRedis<T>` is the seam through which the host wires resolution from the **consumer Node's** Vault.
+
+> **Invariant 21:** Applications must never pin to a specific secret version. — The connection-string factory resolves the latest version via `ISecretStore` (host responsibility). The package does not pin.
+
+> **Invariant 26:** Every project consumes `HoneyDrunk.Standards` via `PackageReference` with `PrivateAssets="all"`. — Applied to both `HoneyDrunk.Cache.Redis.csproj` and `HoneyDrunk.Cache.Redis.Tests.Unit.csproj`.
+
+> **Invariant 27:** All projects in a solution share one version and move together. The first packet to land on a solution in an initiative bumps the version; subsequent packets append to the CHANGELOG only. Per-package changelogs are updated only for packages with actual changes — do not add alignment-bump noise entries. — This packet is the first packet on the `HoneyDrunk.Cache` solution in this initiative; it bumps `0.0.1` → `0.1.0`. The placeholder `HoneyDrunk.Cache.Adapters` alignment-bumps silently (no CHANGELOG noise entry).
+
+> **Invariant 50:** Every Node has a `*.Tests.Unit` project. — `HoneyDrunk.Cache.Redis.Tests.Unit` is added.
+
+> **Invariant 51:** Test code contains no `Thread.Sleep`. Enforced by an analyzer rule. — Tests use the InMemory fake's deterministic shape; no time-advance via `Thread.Sleep`.
+
+## Referenced ADR Decisions
+
+**ADR-0076 D1:** Package name `HoneyDrunk.Cache.Redis` (literal text). StackExchange.Redis client. Azure Cache for Redis as the runtime backing. Per-environment instances `redis-hd-{env}`. Managed-identity auth where supported, access-key fallback via Vault per ADR-0005. Same region as the Container Apps environment.
+
+**ADR-0076 D3:** Redis-protocol-only; no Azure-Redis modules. The implementation uses standard Redis commands (`SET`, `GET`, `DEL`, `SADD`, `SMEMBERS`, `SREM`, `PING`); no `RediSearch`, no `RedisJSON`, no `RedisTimeSeries`, no `RedisGraph`, no `RedisBloom`. No reliance on Azure-managed Redis persistence (cache values are by-construction ephemeral). System.Text.Json for value serialization (the "standard pattern" cited by D3 — Redis stores strings; the serializer materializes typed values at the boundary).
+
+**ADR-0076 D4:** Default eviction policy is `allkeys-lru`. The policy is set on the Azure resource at provisioning time (packet 02) — the client does not configure server-side eviction. The README documents the assumption that the configured backing has `allkeys-lru` set; consumers running against a Redis instance with a different policy may see different invalidation behavior under memory pressure.
+
+**ADR-0076 D5:** Provider abstraction held. The package name `HoneyDrunk.Cache.Redis` reflects the backing identity (Redis), NOT exclusivity (other backings — Cosmos with TTL, Postgres with TTL, self-hosted Redis on Container Apps — are permitted per ADR-0058 D5 + ADR-0076 D5 / D7). The README's "For downstream consumers" section notes the per-Node escape valve.
+
+**ADR-0058 D2:** `ICacheStore<T>` lives in `HoneyDrunk.Kernel.Abstractions`. This packet implements it; it does not re-declare it.
+
+**ADR-0058 D8:** No `GetOrSetAsync` helper at v1. This packet honors the minimalism; convenience sugar waits for usage justification.
+
+**ADR-0005:** Vault as only source of secrets. Connection-string Vault seeding is host-time work at the first consumer composition packet; this package's connection-string-factory parameter is the seam.
+
+## Dependencies
+
+- `packet:01` — the catalog rows and walkthrough must exist before this packet ships (the README cross-references the walkthrough; the catalog rows establish the module identity).
+- `packet:02` — the dev Redis instance must exist (unit tests don't need it, but the post-merge smoke verification does).
+
+## Labels
+
+`feature`, `tier-2`, `cache`, `redis`, `adr-0076`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Implement `HoneyDrunk.Cache.Redis` — the first distributed-cache backing for the Cache Node. `RedisCacheStore<T>` on `StackExchange.Redis`, `RedisCacheOptions`, `AddHoneyDrunkCacheRedis<T>` DI extension, `RedisCacheStartupHook` for connection warmup, comprehensive unit tests, contract-shape canary, version bump `0.0.1` → `0.1.0`. **No live Redis dependency for unit tests; no GetOrSetAsync helper; standard Redis protocol commands only; System.Text.Json for serialization; package name exactly `HoneyDrunk.Cache.Redis` per ADR-0076 D1.**
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Cache`, branch from `main`.
+
+**Context:**
+- Goal: Fill ADR-0058 D8's deferred "first distributed backing" decision and give the Cache Node its first real implementation. The Redis backing is the package that Notify Cloud multi-replica and Communications shared cache will compose at their respective host-time when they pull on distributed caching.
+- Feature: ADR-0076 acceptance initiative, Wave 2, Packet 03.
+- ADRs: ADR-0076 (D1/D3/D4/D5 — the backing decision being implemented), ADR-0058 (D2 — the contract source; D8 — the no-GetOrSetAsync rule), ADR-0059 (the Node home for backings), ADR-0005 (consumer-Vault factory seam).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** `packet:01`, `packet:02`.
+
+**Constraints:**
+
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. — Redis package is runtime, depends on Kernel.Abstractions. Correct.
+- **Invariant 2:** Runtime depends on Abstractions, not other runtimes at the same layer. — Correct.
+- **Invariant 4:** DAG, Kernel at root. — One-way Cache → Kernel.Abstractions.
+- **Invariant 8:** Secret values never in logs/traces/exceptions/telemetry. — The package never logs connection strings or access keys.
+- **Invariant 9:** Vault is the only source of secrets. — Connection-string factory parameter is the seam.
+- **Invariant 11/12/13/14/15/17/21/26/27/50/51:** As inlined in the Referenced Invariants section above. Critical: no live Redis in unit tests (invariant 15); first packet on solution bumps version (invariant 27); no `Thread.Sleep` in tests (invariant 51); Cache has no Vault (invariant 17); placeholder Adapters CHANGELOG gets NO alignment-bump entry (invariant 27 no-alignment-noise rule).
+- **Package name `HoneyDrunk.Cache.Redis`** (literal text from ADR-0076 D1) — NOT `HoneyDrunk.Cache.Adapters.Redis` or any other variant.
+- **Standard Redis protocol commands only** (per ADR-0076 D3) — no `RediSearch`, `RedisJSON`, `RedisTimeSeries`, `RedisGraph`, `RedisBloom`. Verify with grep at acceptance time.
+- **System.Text.Json for value serialization** (per ADR-0076 D3) — no Newtonsoft.Json reference.
+- **No `GetOrSetAsync` helper** (per ADR-0058 D8 / Alternatives) — convenience sugar is deferred.
+- **No `HoneyDrunk.Pulse` reference** — telemetry wires in packet 04 via Kernel's `ITelemetryActivityFactory`, one-way.
+- **No `HoneyDrunk.Vault` reference** — connection-string factory parameter is the seam; the host wires Vault.
+- **`IStartupHook` lives in `HoneyDrunk.Kernel.Abstractions.Lifecycle`** (verified at `Kernel.Abstractions/Lifecycle/IStartupHook.cs`).
+- **First packet on the `HoneyDrunk.Cache` solution in this initiative** — version bump `0.0.1` → `0.1.0` in `Directory.Build.props`. Placeholder Adapters alignment-bumps silently.
+- **No `## Unreleased` block in CHANGELOG.** Per memory `feedback_no_unreleased_commits`. Entry lands under `## [0.1.0] - YYYY-MM-DD`.
+- **README does NOT cite ADR numbers in narrative.** Per memory `feedback_no_adr_in_docs`.
+- **No tag push as part of this packet.** Tags are human-pushed per invariant 27; the first `v0.1.0` tag is a post-merge step the operator performs.
+- **Branch protection update** to require `api-compatibility` is a small post-merge org-admin action; PR body calls it out.
+
+**Key Files:**
+- `src/HoneyDrunk.Cache.Redis/HoneyDrunk.Cache.Redis.csproj` — package references as listed
+- `src/HoneyDrunk.Cache.Redis/RedisCacheStore.cs` — main implementation
+- `src/HoneyDrunk.Cache.Redis/RedisCacheOptions.cs` — configuration record (no `I` prefix per records-naming rule)
+- `src/HoneyDrunk.Cache.Redis/RedisCacheStartupHook.cs` — `IStartupHook` for connection warmup
+- `src/HoneyDrunk.Cache.Redis/ServiceCollectionExtensions.cs` — `AddHoneyDrunkCacheRedis<T>`
+- `src/HoneyDrunk.Cache.Redis/README.md` + `CHANGELOG.md` (new)
+- `tests/HoneyDrunk.Cache.Redis.Tests.Unit/` — full unit-test coverage
+- `HoneyDrunk.Cache.slnx` — reference new projects
+- `Directory.Build.props` — version `0.1.0`
+- `CHANGELOG.md` (repo root) — `[0.1.0]` entry
+- `README.md` (repo root) — update placeholder text
+- `.github/workflows/api-compatibility.yml` (new)
+
+**Contracts:**
+
+This packet implements one contract: `ICacheStore<T>` from `HoneyDrunk.Kernel.Abstractions` (declared by ADR-0058 D2, version `0.8.0`). It introduces public types in `HoneyDrunk.Cache.Redis`:
+
+- `RedisCacheStore<T>` (sealed class, implements `ICacheStore<T>`)
+- `RedisCacheOptions` (sealed record — record naming drops the `I` prefix)
+- `RedisCacheStartupHook` (sealed class, implements `IStartupHook` from `HoneyDrunk.Kernel.Abstractions.Lifecycle`)
+- `ServiceCollectionExtensions` (static class with `AddHoneyDrunkCacheRedis<T>` extension method)
+
+These four public types are the contract surface that the `api-compatibility.yml` canary freezes. Future shape drift on any of them requires an intentional version bump.

--- a/generated/issue-packets/active/adr-0076-cache-backing-redis/04-cache-redis-telemetry-and-health.md
+++ b/generated/issue-packets/active/adr-0076-cache-backing-redis/04-cache-redis-telemetry-and-health.md
@@ -1,0 +1,361 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Cache
+labels: ["feature", "tier-2", "cache", "redis", "telemetry", "adr-0076", "wave-3"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0076", "ADR-0040", "ADR-0045"]
+accepts: ADR-0076
+wave: 3
+initiative: adr-0076-cache-backing-redis
+node: honeydrunk-cache
+---
+
+# Feature: Wire `HoneyDrunk.Cache.Redis` telemetry, health contributor, and `IErrorReporter` failure path
+
+## Summary
+Add operational hooks to the Redis backing landed by packet 03. Wire telemetry (hit count, miss count, eviction count if observable, command latency p50/p95/p99, connection-pool depth) through Kernel's `ITelemetryActivityFactory` per ADR-0040 D6 — telemetry flows one-way to Pulse, no runtime dependency on Pulse. Add an `IHealthContributor` reporting Redis connection state and recent hit/miss ratio for the Kernel-level `/health` and `/ready` endpoints. Wire `IErrorReporter` from `HoneyDrunk.Pulse.Abstractions` per ADR-0045 D3 for connection failures, command timeouts, and deserialization errors — also one-way. **Appends to in-progress `[0.1.0]` from packet 03 — no new version bump.**
+
+This packet hardens the Redis backing's operational shape so the first consumer composition (Notify Cloud multi-replica or Communications shared cache) lands against a production-ready backing with cache-hit-ratio visibility, fail-fast health reporting, and structured error capture in App Insights.
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Cache`
+
+## Motivation
+
+ADR-0076 D6 commits operational discipline: telemetry via the Pulse pipeline (hit rate, miss rate, evictions, latency p50/p95/p99, connection-pool depth) per ADR-0040, error tracking via Azure App Insights per ADR-0045 (connection failures, command timeouts, deserialization errors), cost monitoring per ADR-0052, DR tier 2 per ADR-0036. Packet 03 shipped the bare `RedisCacheStore<T>` and `RedisCacheStartupHook` — neither emits telemetry or reports health. This packet fills the operational gap.
+
+The discipline applies the established Grid pattern: telemetry is one-way from emitting Nodes to Pulse via Kernel's activity factory; error reporting is one-way through `IErrorReporter` (a thin facade over the existing `IErrorSink` Pulse surface per ADR-0045 D3); the Cache package takes no runtime dependency on Pulse. Health reporting plugs into Kernel's `IHealthContributor` contract, which Kernel-hosted endpoints aggregate at `/health` and `/ready`.
+
+## Scope
+
+- `src/HoneyDrunk.Cache.Redis/` updates:
+  - Telemetry instrumentation on every `RedisCacheStore<T>` operation. `Activity` spans for `cache.get`, `cache.set`, `cache.remove`, `cache.remove-by-tag` with attributes for outcome (`hit` / `miss` / `success` / `failure`), key (trace attribute only, NOT a metric dimension per ADR-0040 D6 — invariant 70 equivalent), and latency (recorded as a metric instrument).
+  - Counter metrics: `cache.hits`, `cache.misses`, `cache.errors`. Histogram metrics: `cache.command.duration_ms` (per-operation latency). Tags: `cache.backing=redis`, `cache.value_type=<T>`, `cache.outcome=hit|miss|success|failure`. **No high-cardinality tags** (no key, no tenant id on metrics — those go on traces per ADR-0040 D6).
+  - `RedisHealthContributor` implementing `IHealthContributor` from `HoneyDrunk.Kernel.Abstractions.Health` (verify exact namespace at edit time per repo convention — see existing Vault / Auth health contributors). Reports: connection state (`Healthy` if `IConnectionMultiplexer.IsConnected`; `Unhealthy` otherwise), most recent `PING` latency in ms, recent hit ratio over the last sampling window.
+  - `IErrorReporter`-backed error reporting on connection failures, command timeouts, and deserialization exceptions. The reporter is injected (`IErrorReporter?` — nullable, so the package functions without Pulse composed if a future consumer chooses to skip error reporting). When non-null, every exception path in `RedisCacheStore<T>` calls `_errorReporter.Report(exception, context)` before propagating.
+  - DI registration extension updated: `AddHoneyDrunkCacheRedis<T>` now wires the `IHealthContributor` (singleton) and, if an `IErrorReporter` is already registered in the container, picks it up via constructor injection on `RedisCacheStore<T>`.
+- `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` and repo-level `CHANGELOG.md` — append to in-progress `[0.1.0]` (no new version bump per invariant 27).
+- `src/HoneyDrunk.Cache.Redis/README.md` — update operational-shape section to document the telemetry, health, and error-reporting surfaces.
+- Unit tests:
+  - Telemetry: verify `Activity` is started on each operation; verify counters increment for hits/misses; verify outcome tag is set correctly.
+  - Health: verify Healthy when multiplexer reports connected; Unhealthy when disconnected; recent hit ratio computed correctly.
+  - Error reporting: verify `IErrorReporter.Report` is called on injected exception types (connection failure, timeout, deserialization error); verify the exception still propagates after the report.
+
+## Proposed Implementation
+
+### Telemetry instrumentation
+
+Wrap every `RedisCacheStore<T>` method body in an `Activity` (started via `ITelemetryActivityFactory` from `HoneyDrunk.Kernel.Abstractions.Telemetry` — confirm exact API at edit time per the existing Vault / Auth telemetry patterns).
+
+```csharp
+public async ValueTask<T?> GetAsync(string key, CancellationToken ct = default)
+{
+    ct.ThrowIfCancellationRequested();
+    using var activity = _activityFactory.StartActivity("cache.get", ActivityKind.Client);
+    activity?.SetTag("cache.backing", "redis");
+    activity?.SetTag("cache.value_type", typeof(T).Name);
+    activity?.SetTag("cache.key", key);     // trace attribute, not a metric dimension
+
+    var sw = Stopwatch.StartNew();
+    try
+    {
+        var db = _multiplexer.GetDatabase();
+        var value = await db.StringGetAsync(NamespaceKey(key)).ConfigureAwait(false);
+        var elapsed = sw.Elapsed.TotalMilliseconds;
+        _commandDuration.Record(elapsed, KeyValuePair.Create<string, object?>("cache.operation", "get"));
+
+        if (value.IsNullOrEmpty)
+        {
+            activity?.SetTag("cache.outcome", "miss");
+            _missCounter.Add(1, KeyValuePair.Create<string, object?>("cache.value_type", typeof(T).Name));
+            return default;
+        }
+
+        activity?.SetTag("cache.outcome", "hit");
+        _hitCounter.Add(1, KeyValuePair.Create<string, object?>("cache.value_type", typeof(T).Name));
+        return JsonSerializer.Deserialize<T>(value!, _serializerOptions);
+    }
+    catch (Exception ex)
+    {
+        activity?.SetTag("cache.outcome", "failure");
+        activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+        _errorCounter.Add(1, KeyValuePair.Create<string, object?>("cache.operation", "get"));
+        _errorReporter?.Report(ex, new ErrorReportContext { Operation = "cache.get", Key = key });
+        throw;
+    }
+}
+```
+
+Same pattern for `SetAsync`, `RemoveAsync`, `RemoveByTagAsync`. Counters and histograms are static `Meter` instruments owned by `RedisCacheStore<T>` (or by a sibling `Telemetry.cs` static class — agent's call per repo convention).
+
+### `RedisHealthContributor`
+
+```csharp
+namespace HoneyDrunk.Cache.Redis;
+
+/// <summary>
+/// Health contributor reporting Redis connection state and recent cache hit ratio.
+/// Aggregated by Kernel into the /health and /ready endpoints.
+/// </summary>
+public sealed class RedisHealthContributor : IHealthContributor
+{
+    private readonly IConnectionMultiplexer _multiplexer;
+    private readonly RedisCacheTelemetry _telemetry;
+
+    public RedisHealthContributor(IConnectionMultiplexer multiplexer, RedisCacheTelemetry telemetry)
+    {
+        _multiplexer = multiplexer ?? throw new ArgumentNullException(nameof(multiplexer));
+        _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+    }
+
+    public string Name => "cache.redis";
+
+    public async Task<HealthCheckResult> CheckAsync(CancellationToken cancellationToken)
+    {
+        if (!_multiplexer.IsConnected)
+        {
+            return HealthCheckResult.Unhealthy("Redis multiplexer reports disconnected.");
+        }
+
+        try
+        {
+            var db = _multiplexer.GetDatabase();
+            var pong = await db.PingAsync().ConfigureAwait(false);
+            var hitRatio = _telemetry.RecentHitRatio();
+            var data = new Dictionary<string, object?>
+            {
+                ["ping_ms"] = pong.TotalMilliseconds,
+                ["hit_ratio"] = hitRatio,
+            };
+            return HealthCheckResult.Healthy("Redis reachable.", data);
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("Redis ping failed.", ex);
+        }
+    }
+}
+```
+
+(The exact `IHealthContributor` shape and `HealthCheckResult` type come from `HoneyDrunk.Kernel.Abstractions`. Verify at edit time; the above is the intent. The `RecentHitRatio` helper computes hits / (hits + misses) over a small in-memory rolling window — see existing patterns in Vault's `VaultCacheHealthContributor` if it exists, otherwise a simple `(hits / (hits + misses))` computed against the telemetry counters.)
+
+### `IErrorReporter` wiring
+
+`IErrorReporter` is the thin facade over Pulse's `IErrorSink` per ADR-0045 D3. The interface lives in `HoneyDrunk.Pulse.Abstractions` (verify at edit time — if the interface has not yet shipped in Pulse, the package may take a temporary local interface and bridge to it later; document the decision in the PR body and add a follow-up note to swap to the real interface once Pulse ships it). For the canonical path, `RedisCacheStore<T>` takes `IErrorReporter?` (nullable) in its constructor; the DI registration leaves the binding to whoever composes the host (Notify Cloud, Communications, etc. — each composes Pulse and so the reporter is available).
+
+```csharp
+public RedisCacheStore(
+    IConnectionMultiplexer multiplexer,
+    IOptions<RedisCacheOptions> options,
+    ILogger<RedisCacheStore<T>> logger,
+    ITelemetryActivityFactory activityFactory,
+    RedisCacheTelemetry telemetry,
+    IErrorReporter? errorReporter = null)   // optional — package functions without Pulse composed
+{
+    // ... assignments ...
+    _errorReporter = errorReporter;
+}
+```
+
+Connection failures, command timeouts (`RedisTimeoutException`), and deserialization exceptions (`JsonException`) all route through `_errorReporter?.Report(ex, ...)` in the catch blocks before propagating. The reporter is fire-and-forget from the cache's perspective; Pulse's `IErrorReporter` implementation handles its own delivery semantics.
+
+### DI registration updates
+
+```csharp
+public static IServiceCollection AddHoneyDrunkCacheRedis<T>(
+    this IServiceCollection services,
+    Action<RedisCacheOptions>? configureOptions = null,
+    Func<IServiceProvider, string>? connectionStringFactory = null)
+{
+    // ... existing options + multiplexer + ICacheStore<T> registration ...
+
+    services.TryAddSingleton<RedisCacheTelemetry>();   // counters / histograms / hit-ratio tracker
+    services.AddSingleton<IHealthContributor, RedisHealthContributor>();
+    services.AddSingleton<IStartupHook, RedisCacheStartupHook>();
+
+    // IErrorReporter is NOT registered here — the composing host's Pulse composition handles it.
+    // The constructor parameter is nullable so the package functions without it.
+
+    return services;
+}
+```
+
+### Unit tests
+
+Extend `RedisCacheStoreTests.cs` (or split into a new test file per repo convention) covering:
+
+- **Telemetry-Hit:** `SetAsync` then `GetAsync` records a `cache.hits` counter increment and a `cache.get` activity with `cache.outcome=hit`.
+- **Telemetry-Miss:** `GetAsync` on missing key records `cache.misses` and `cache.outcome=miss`.
+- **Telemetry-CommandDuration:** Each operation records a histogram observation.
+- **Telemetry-Failure:** Injected `RedisException` in the multiplexer fake produces `cache.errors` increment, `cache.outcome=failure`, and `cache.set_status=Error`.
+- **Health-Healthy:** Multiplexer reports `IsConnected=true`, `PingAsync` returns a small TimeSpan → `HealthCheckResult.Healthy` with `ping_ms` and `hit_ratio` in `data`.
+- **Health-Unhealthy-Disconnected:** Multiplexer `IsConnected=false` → `HealthCheckResult.Unhealthy("Redis multiplexer reports disconnected.")`.
+- **Health-Unhealthy-PingFailed:** Multiplexer reports connected but `PingAsync` throws → `HealthCheckResult.Unhealthy("Redis ping failed.", ex)`.
+- **ErrorReporter-Called-OnFailure:** Inject a fake `IErrorReporter`; trigger a connection failure; verify `Report` was called with the expected exception type and context; verify the exception still propagates from `RedisCacheStore<T>`.
+- **ErrorReporter-Optional:** Construct `RedisCacheStore<T>` with `IErrorReporter=null`; trigger a failure; verify no `NullReferenceException`; verify the exception propagates normally.
+- **No high-cardinality on metrics:** Verify the counter / histogram `KeyValuePair` arguments do NOT include the cache key as a tag (only `cache.value_type`, `cache.operation`, `cache.outcome`). Trace attributes DO include the key — separate assertion.
+
+### Documentation updates
+
+- `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` — append to the in-progress `## [0.1.0] - YYYY-MM-DD` section: telemetry instrumentation, health contributor, optional error-reporter wiring.
+- Repo-level `CHANGELOG.md` — append to the in-progress `## [0.1.0]` section the same shape.
+- `src/HoneyDrunk.Cache.Redis/README.md` — update the operational-shape section to document the telemetry counters/histograms/activity spans, the health contributor, and the optional error-reporter wiring. Cite operational concerns in plain English (e.g., "hit ratio and command latency are emitted as counters and histograms; consumer hosts aggregate these via their Pulse composition") without citing ADR numbers (per memory `feedback_no_adr_in_docs`).
+
+## Affected Files
+
+- `src/HoneyDrunk.Cache.Redis/RedisCacheStore.cs` — telemetry instrumentation + `IErrorReporter?` constructor parameter + catch-block reporter calls.
+- `src/HoneyDrunk.Cache.Redis/RedisCacheTelemetry.cs` (new) — Meter/Counter/Histogram instruments + hit-ratio rolling-window helper.
+- `src/HoneyDrunk.Cache.Redis/RedisHealthContributor.cs` (new) — `IHealthContributor` implementation.
+- `src/HoneyDrunk.Cache.Redis/ServiceCollectionExtensions.cs` — register `RedisCacheTelemetry` and `RedisHealthContributor`.
+- `tests/HoneyDrunk.Cache.Redis.Tests.Unit/` — new test cases per the list above.
+- `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` — append to in-progress `[0.1.0]`.
+- `CHANGELOG.md` (repo root) — append to in-progress `[0.1.0]`.
+- `src/HoneyDrunk.Cache.Redis/README.md` — operational-shape section update.
+
+## NuGet Dependencies
+
+### `HoneyDrunk.Cache.Redis.csproj` — additions
+
+| Package | Notes |
+|---|---|
+| `System.Diagnostics.DiagnosticSource` | For `Meter`, `Counter<T>`, `Histogram<T>` types if not already pulled transitively |
+| `HoneyDrunk.Pulse.Abstractions` | For `IErrorReporter` (per ADR-0045 D3). Verify the package exists and the interface ships in it at edit time; if not, document the deferral in the PR body and use a temporary local interface. |
+
+The `ITelemetryActivityFactory` / `IHealthContributor` / `HealthCheckResult` types come from `HoneyDrunk.Kernel.Abstractions` (already referenced by packet 03). No additional Kernel package reference.
+
+### `HoneyDrunk.Cache.Redis.Tests.Unit.csproj` — no new packages
+
+The existing test stack (NSubstitute + AwesomeAssertions + xunit + coverlet) covers the new test cases.
+
+## Boundary Check
+
+- [x] All changes inside `HoneyDrunk.Cache.Redis`. No edits to Kernel, no edits to Pulse.
+- [x] **One-way telemetry to Pulse via Kernel's `ITelemetryActivityFactory`.** No runtime dependency on `HoneyDrunk.Pulse` (the runtime package) — only on `HoneyDrunk.Pulse.Abstractions` (for `IErrorReporter`).
+- [x] **`IErrorReporter` parameter is optional** — package functions without it. Consumer hosts that don't compose Pulse (rare; most do) get a working cache without error reporting.
+- [x] **No high-cardinality identifiers on metrics.** Cache keys and tenant IDs are trace attributes only (per ADR-0040 D6).
+- [x] No new version bump — appends to in-progress `[0.1.0]` from packet 03 (invariant 27).
+- [x] No `Thread.Sleep` in tests (invariant 51).
+- [x] No secrets in code or tests (invariant 8).
+
+## Acceptance Criteria
+
+- [ ] `RedisCacheStore<T>` wraps every operation in an `Activity` via `ITelemetryActivityFactory`; activity names are `cache.get`, `cache.set`, `cache.remove`, `cache.remove-by-tag`
+- [ ] `Activity` attributes include `cache.backing=redis`, `cache.value_type=<T>`, `cache.key=<key>` (key is trace-only, not on metrics), `cache.outcome` (hit/miss/success/failure)
+- [ ] Counter metrics emit: `cache.hits`, `cache.misses`, `cache.errors`. Histogram: `cache.command.duration_ms`. Tags on metrics include `cache.value_type`, `cache.operation`, `cache.outcome` — **NEVER** `cache.key` or `tenant.id` (per ADR-0040 D6 high-cardinality discipline)
+- [ ] `RedisHealthContributor` exists, implements `IHealthContributor`, reports Healthy when multiplexer connected + PING succeeds, Unhealthy when disconnected or PING fails
+- [ ] Health response `data` includes `ping_ms` (most recent PING latency) and `hit_ratio` (recent rolling hit ratio)
+- [ ] `RedisCacheStore<T>` constructor accepts `IErrorReporter?` (nullable); when non-null, every catch block calls `_errorReporter.Report(...)` before propagating
+- [ ] `IErrorReporter` injection is from `HoneyDrunk.Pulse.Abstractions` (or a documented temporary local interface if Pulse has not yet shipped it; PR body explains the decision)
+- [ ] `AddHoneyDrunkCacheRedis<T>` extension registers `RedisCacheTelemetry`, `RedisHealthContributor`, and the existing `RedisCacheStartupHook`; does NOT register `IErrorReporter` (host's responsibility)
+- [ ] Unit tests pass: hit-counter, miss-counter, command-duration histogram, activity-outcome tag, health-healthy, health-unhealthy-disconnected, health-unhealthy-ping-failed, error-reporter-called-on-failure, error-reporter-optional-null, no-key-on-metrics
+- [ ] **`Directory.Build.props` version remains `0.1.0`** — NO version bump in this packet (invariant 27 — appends to the existing in-progress version)
+- [ ] `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` and repo-level `CHANGELOG.md` `[0.1.0]` entries are appended (not replaced; not new version section)
+- [ ] `src/HoneyDrunk.Cache.Redis/README.md` operational-shape section documents telemetry, health, and optional error-reporting surfaces — without citing "ADR-0076" / "ADR-0040" / "ADR-0045" by number in narrative
+- [ ] `pr-core.yml` and `api-compatibility.yml` both pass — the public surface gained `RedisHealthContributor` and `RedisCacheTelemetry` types; the API-compatibility canary reflects an intentional minor-shape addition (the version is still `0.1.0` because this packet appends within the in-progress version per invariant 27)
+- [ ] All public APIs have XML documentation (invariant 13)
+- [ ] No `Thread.Sleep` in test code (invariant 51)
+- [ ] No secret values anywhere (invariant 8)
+
+## Human Prerequisites
+
+- [ ] Packet 03 of this initiative merged — `HoneyDrunk.Cache.Redis` package exists with the bare `RedisCacheStore<T>`, `RedisCacheOptions`, `RedisCacheStartupHook`, and `AddHoneyDrunkCacheRedis<T>` extension.
+- [ ] **Verify `IErrorReporter` interface exists in `HoneyDrunk.Pulse.Abstractions` at edit time.** Per ADR-0045 D3, it is a thin facade over the existing `IErrorSink`. If Pulse has not yet shipped the interface in `Pulse.Abstractions`, document the deferral in the PR body, use a temporary local interface in `HoneyDrunk.Cache.Redis`, and add a follow-up note to swap to the real `IErrorReporter` once Pulse ships it.
+- [ ] **Verify `IHealthContributor` and `HealthCheckResult` namespaces** in `HoneyDrunk.Kernel.Abstractions` at edit time — exact namespace (`Health` vs `Lifecycle.Health` vs other) per repo convention. Match the existing Vault / Auth health-contributor patterns.
+- [ ] **Verify `ITelemetryActivityFactory` is the canonical activity-factory contract** in `HoneyDrunk.Kernel.Abstractions.Telemetry` (or wherever Kernel ships it). Match the existing Vault / Auth telemetry-instrumentation patterns.
+- [ ] After this packet's PR merges, the post-merge tag-push for `v0.1.0` is human-pushed per invariant 27. The tag triggers the release pipeline; `HoneyDrunk.Cache.Redis 0.1.0` (with telemetry + health + error reporting) publishes to NuGet. Confirm `NUGET_API_KEY` is bound to the repo before pushing the tag.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. — `HoneyDrunk.Cache.Redis` is runtime, depends on `HoneyDrunk.Kernel.Abstractions` and `HoneyDrunk.Pulse.Abstractions` — both Abstractions packages. Correct.
+
+> **Invariant 4:** No circular dependencies. — Cache → Kernel.Abstractions and Cache → Pulse.Abstractions are one-way; neither Kernel nor Pulse references Cache.
+
+> **Invariant 8:** Secret values never appear in logs, traces, exceptions, or telemetry. — Telemetry attributes carry the cache key (not value) and operation outcome; no secret enters traces or metrics. The error-reporter context carries exception details but never the connection-string secret.
+
+> **Invariant 13:** All public APIs have XML documentation. — Every new public type and method carries XML doc.
+
+> **Invariant 27:** All projects in a solution share one version and move together. The first packet to land on a solution in an initiative bumps the version; subsequent packets append to the CHANGELOG only. — This packet is the second packet on the `HoneyDrunk.Cache` solution in this initiative (packet 03 was first); it appends to the in-progress `[0.1.0]` CHANGELOG section without bumping.
+
+> **Invariant 50:** Every Node has a `*.Tests.Unit` project. — Existing `HoneyDrunk.Cache.Redis.Tests.Unit` covers the new test cases.
+
+> **Invariant 51:** Test code contains no `Thread.Sleep`. — No `Thread.Sleep` in new tests.
+
+## Referenced ADR Decisions
+
+**ADR-0076 D6 — Operational discipline:**
+> The Redis instances run under standard Grid operational discipline:
+> - **Telemetry** via the Pulse pipeline per [ADR-0040](./ADR-0040-telemetry-backend-and-retention.md) — hit rate, miss rate, evictions, latency p50/p95/p99, connection pool depth.
+> - **Error tracking** via Azure App Insights per [ADR-0045](./ADR-0045-grid-wide-error-tracking.md) — connection failures, command timeouts, deserialization errors.
+> - **Cost monitoring** per ADR-0052 — per-environment Redis spend on the cost-governance dashboard.
+> - **DR posture** per ADR-0036 — cache instances are Tier 2 (operational; loss is non-catastrophic; recovery is automatic on next-cache-warmup). No backup-and-restore discipline needed.
+
+This packet implements the telemetry + error-tracking lines. Cost monitoring is operator-managed via the Azure cost-governance dashboard (separate scoping work, not in this initiative). DR posture requires no code work for Tier 2.
+
+**ADR-0040 D6 — Volume discipline / no high-cardinality on metrics:**
+> `user.id`, `message.id`, `request.id` belong on **traces** (where cardinality drives no extra cost in App Insights, since they're per-event), not duplicated into every log line as redundant context.
+
+Applied here: cache keys and tenant IDs are trace attributes only. Metrics carry only low-cardinality tags (value-type-name, operation, outcome).
+
+**ADR-0045 D3 — Errors flow through Pulse; `IErrorReporter` is a thin facade over the existing `IErrorSink`:**
+> Errors flow through Pulse's existing sink surface via the `IErrorReporter` facade. The facade keeps consumer Nodes from taking a runtime dependency on Pulse's internals; the implementation routes to the App-Insights-backed `IErrorSink` provider.
+
+The Redis backing's catch blocks call `IErrorReporter.Report(...)` (when registered); the package depends only on `HoneyDrunk.Pulse.Abstractions`, never on the Pulse runtime.
+
+## Constraints
+
+- **Invariant 8, 13, 27, 50, 51:** As inlined in Referenced Invariants.
+- **ADR-0040 D6 high-cardinality discipline:** No `cache.key` or `tenant.id` on metric tags. Trace attributes only.
+- **One-way to Pulse.** No runtime dependency on `HoneyDrunk.Pulse`. `IErrorReporter` from `HoneyDrunk.Pulse.Abstractions`; `ITelemetryActivityFactory` from `HoneyDrunk.Kernel.Abstractions`.
+- **`IErrorReporter` parameter is optional.** Package functions without it.
+- **No version bump.** Appends to in-progress `[0.1.0]`.
+- **No `## Unreleased` block in CHANGELOG.** Entries land under `[0.1.0]`.
+- **README does NOT cite ADR numbers in narrative.** Per memory `feedback_no_adr_in_docs`.
+
+## Dependencies
+
+- `packet:03` — the bare `HoneyDrunk.Cache.Redis` package must exist before telemetry/health/error-reporting can be wired into it.
+
+## Labels
+
+`feature`, `tier-2`, `cache`, `redis`, `telemetry`, `adr-0076`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Harden the Redis backing's operational shape per ADR-0076 D6. Wire telemetry (via Kernel's activity factory), a health contributor, and an optional `IErrorReporter` (from `HoneyDrunk.Pulse.Abstractions`). One-way to Pulse — no runtime dependency on the Pulse runtime package. Appends to in-progress `[0.1.0]` from packet 03.
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Cache`, branch from `main`.
+
+**Context:**
+- Goal: Make the Redis backing production-ready for the first consumer composition (Notify Cloud multi-replica or Communications shared cache). Hit-ratio visibility, fail-fast health reporting, structured error capture in App Insights.
+- Feature: ADR-0076 acceptance initiative, Wave 3, Packet 04.
+- ADRs: ADR-0076 D6 (operational discipline), ADR-0040 D6 (no high-cardinality on metrics — keys go on traces), ADR-0045 D3 (`IErrorReporter` thin facade over `IErrorSink`).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** `packet:03`.
+
+**Constraints:**
+
+- **One-way to Pulse.** `HoneyDrunk.Pulse.Abstractions` for `IErrorReporter` only; no runtime Pulse dependency.
+- **`IErrorReporter` parameter is optional** — nullable in the `RedisCacheStore<T>` constructor. Package functions without it.
+- **No high-cardinality on metrics.** Cache key + tenant ID are trace attributes only. Metric tags are `cache.value_type`, `cache.operation`, `cache.outcome`.
+- **No version bump.** This is the second packet on the `HoneyDrunk.Cache` solution in this initiative; appends to `[0.1.0]` per invariant 27.
+- **No `Thread.Sleep` in tests.** Per invariant 51.
+- **No secret values in telemetry, traces, or error-reporter context.** Per invariant 8.
+- **`IErrorReporter` interface verification.** If `HoneyDrunk.Pulse.Abstractions` does not yet ship the interface, document the deferral and use a temporary local interface — add a follow-up note to swap when Pulse ships the canonical interface.
+- **`IHealthContributor` namespace verification.** Match the existing Vault / Auth health-contributor patterns.
+
+**Key Files:**
+- `src/HoneyDrunk.Cache.Redis/RedisCacheStore.cs` — instrumentation + reporter wiring.
+- `src/HoneyDrunk.Cache.Redis/RedisCacheTelemetry.cs` (new) — meter/counter/histogram + hit-ratio.
+- `src/HoneyDrunk.Cache.Redis/RedisHealthContributor.cs` (new) — health contributor.
+- `src/HoneyDrunk.Cache.Redis/ServiceCollectionExtensions.cs` — DI updates.
+- `tests/HoneyDrunk.Cache.Redis.Tests.Unit/` — new test cases.
+- `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` + repo-level `CHANGELOG.md` — append to `[0.1.0]`.
+- `src/HoneyDrunk.Cache.Redis/README.md` — operational-shape update.
+
+**Contracts:**
+
+No new contracts authored. Implements existing contracts (`IHealthContributor`, `IStartupHook`, optionally consumes `IErrorReporter` and `ITelemetryActivityFactory`). The public surface of `HoneyDrunk.Cache.Redis` gains `RedisCacheTelemetry` (new public type) and `RedisHealthContributor` (new public type); these are picked up by the `api-compatibility.yml` canary on the next CI run, and the version is still `0.1.0` because they ship within the in-progress version.

--- a/generated/issue-packets/active/adr-0076-cache-backing-redis/05-cache-redis-classification-encryption.md
+++ b/generated/issue-packets/active/adr-0076-cache-backing-redis/05-cache-redis-classification-encryption.md
@@ -1,0 +1,438 @@
+---
+name: Repo Feature
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Cache
+labels: ["feature", "tier-2", "cache", "redis", "security", "adr-0076", "wave-3"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0076", "ADR-0049", "ADR-0058"]
+accepts: ADR-0076
+wave: 3
+initiative: adr-0076-cache-backing-redis
+node: honeydrunk-cache
+---
+
+# Feature: Add classification-aware encrypted-value wrapper for Restricted-tier values in `HoneyDrunk.Cache.Redis`
+
+## Summary
+Add the application-layer-encryption surface required by ADR-0076 D6 for Restricted-tier values cached in Standard-tier Azure Cache for Redis (Premium tier — which supports encryption at rest — is NOT adopted per ADR-0076 D2 alternatives; Standard tier supports encryption in transit only). Introduce an opt-in `IEncryptedCacheStore<T>` surface (or equivalent — name to be confirmed at edit time per repo convention) that consumers explicitly use when caching values marked Restricted-tier per ADR-0049. Values written through this surface are AES-GCM-encrypted with a Vault-resolved key before being stored in Redis and decrypted on read. The standard `RedisCacheStore<T>` from packet 03 continues to serve Internal-tier and Tenant-tier values unchanged — consumers explicitly opt into encryption when their classification mandates it.
+
+**Appends to in-progress `[0.1.0]` from packet 03 — no new version bump per invariant 27.**
+
+## Target Repo
+`HoneyDrunkStudios/HoneyDrunk.Cache`
+
+## Motivation
+
+ADR-0076 D6's classification carve-out is explicit:
+
+> **No PII / Restricted-tier values in cache without classification-aware handling.** Per ADR-0058 D6 (classification inheritance) and ADR-0049, any cached value carrying Restricted-tier material requires the per-Node encryption-at-rest discipline. Azure Cache for Redis Standard tier supports encryption in transit by default; **encryption at rest is Premium-only at the time of this ADR**. **Restricted-tier values are not stored in Standard-tier Azure Cache for Redis without per-value encryption at the application layer.** Premium-tier instances are considered when a workload requires Restricted-tier caching at scale.
+
+ADR-0076 D2 commits to Standard tier as the prod baseline, not Premium. ADR-0049 defines Restricted as a classification tier carrying the strongest handling requirements. The combination means: if any consumer wants to cache a Restricted-tier value, they need application-layer encryption — the Standard-tier Redis instance can't provide at-rest encryption itself.
+
+Today, no consumer caches Restricted-tier values (Notify Cloud's planned uses are API-key validation results and tenant-tier descriptors, neither of which is Restricted per ADR-0049's tier definitions; Communications's preference cache is Internal-tier). But the discipline must exist before the first consumer with a Restricted-tier cache use lands — otherwise the temptation is to bypass classification awareness, ship the value through `RedisCacheStore<T>`, and absorb the silent compliance break.
+
+This packet ships the encryption surface so Restricted-tier consumers have an in-package, opt-in path. The standard `RedisCacheStore<T>` is untouched for Internal/Tenant-tier consumers; they pay nothing for the encryption surface they don't use.
+
+## Scope
+
+- `src/HoneyDrunk.Cache.Redis/` updates:
+  - `EncryptedRedisCacheStore<T>` — new sibling of `RedisCacheStore<T>` that wraps values in AES-GCM encryption before write and decrypts on read. Implements `ICacheStore<T>` from `HoneyDrunk.Kernel.Abstractions`; consumers compose this implementation instead of (NOT in addition to) the standard `RedisCacheStore<T>` for their Restricted-tier cache use.
+  - `EncryptedRedisCacheOptions` (record, no `I` prefix) — extends `RedisCacheOptions` with `EncryptionKeySecretName` (Vault secret name holding the 256-bit AES key material; the host's `ISecretStore` resolves it at composition time).
+  - `AddHoneyDrunkCacheRedisEncrypted<T>` — `IServiceCollection` extension method for DI registration of the encrypted variant. Accepts an `Action<EncryptedRedisCacheOptions>` and an encryption-key factory parameter `Func<IServiceProvider, byte[]>` (same seam pattern as packet 03's connection-string factory — host resolves from Vault).
+  - Encryption format: AES-GCM with 96-bit nonce + 128-bit auth tag, generating a fresh nonce per write (CSPRNG-sourced). Ciphertext format: `[nonce (12 bytes)][ciphertext][auth_tag (16 bytes)]`. On decrypt, parse the format, verify the auth tag, return the plaintext. Standard AEAD pattern; no bespoke cryptography.
+- `tests/HoneyDrunk.Cache.Redis.Tests.Unit/` — new test cases:
+  - Round-trip: `SetAsync` then `GetAsync` returns the original value (decryption succeeds with same key).
+  - Different nonce per write: setting the same key twice produces different ciphertexts (verify via Redis fake's stored value differing across calls).
+  - Tamper detection: corrupting the stored ciphertext (modifying any byte) causes `GetAsync` to throw (auth-tag verification fails).
+  - Wrong key: constructing two `EncryptedRedisCacheStore<T>` with different keys; one's `SetAsync` value cannot be `GetAsync`-read by the other (auth-tag verification fails).
+  - Tag-based invalidation: `RemoveByTagAsync` works the same as in `RedisCacheStore<T>` — tags are not encrypted (they're routing metadata, not value content), so the tag-to-key index continues to work.
+  - Telemetry: encrypted operations emit the same counters/histograms as `RedisCacheStore<T>` (hit/miss/error, command duration); a separate counter or label distinguishes encrypted-vs-plain operations.
+- Documentation:
+  - `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` and repo-level `CHANGELOG.md` — append to in-progress `[0.1.0]`.
+  - `src/HoneyDrunk.Cache.Redis/README.md` — new "When to use the encrypted variant" section. Plain-English explanation: "If the value being cached carries Restricted-tier material per your Node's data classification, compose `AddHoneyDrunkCacheRedisEncrypted<T>` instead of `AddHoneyDrunkCacheRedis<T>`. Otherwise the standard backing is correct." Does NOT cite ADR numbers in narrative (per memory `feedback_no_adr_in_docs`); cross-link to the data-classification reference doc in the "Cross references" footer if one exists.
+
+## Proposed Implementation
+
+### `EncryptedRedisCacheOptions` record
+
+```csharp
+namespace HoneyDrunk.Cache.Redis;
+
+/// <summary>
+/// Configuration for the encrypted Redis-backed ICacheStore&lt;T&gt; implementation.
+/// Extends RedisCacheOptions with an encryption-key secret reference.
+/// </summary>
+public sealed record EncryptedRedisCacheOptions
+{
+    /// <summary>Connection string secret name (same seam as RedisCacheOptions).</summary>
+    public string ConnectionStringSecretName { get; init; } = "redis-connection-string";
+
+    /// <summary>Key prefix (same as RedisCacheOptions).</summary>
+    public string KeyPrefix { get; init; } = string.Empty;
+
+    /// <summary>Command timeout (same as RedisCacheOptions).</summary>
+    public TimeSpan CommandTimeout { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>JsonSerializerOptions (same as RedisCacheOptions; runs BEFORE encryption).</summary>
+    public JsonSerializerOptions? SerializerOptions { get; init; }
+
+    /// <summary>
+    /// Vault secret name holding the 256-bit AES encryption key. Default "redis-encryption-key".
+    /// The composing host resolves this via ISecretStore and supplies the key bytes through
+    /// the encryption-key factory on AddHoneyDrunkCacheRedisEncrypted&lt;T&gt;.
+    /// </summary>
+    public string EncryptionKeySecretName { get; init; } = "redis-encryption-key";
+}
+```
+
+### `EncryptedRedisCacheStore<T>` implementation
+
+Wraps `RedisCacheStore<T>`'s storage pattern with AES-GCM encryption. The class composes `IConnectionMultiplexer` directly (does NOT call the unencrypted `RedisCacheStore<T>` underneath — it's a sibling implementation, not a decorator, because the serialization-then-encryption order matters and a decorator pattern would double-serialize).
+
+```csharp
+namespace HoneyDrunk.Cache.Redis;
+
+/// <summary>
+/// Encrypted Redis-backed ICacheStore&lt;T&gt; implementation. Values are serialized through
+/// System.Text.Json, then AES-GCM-encrypted with a Vault-resolved key, then stored in Redis.
+/// Tags are NOT encrypted (they are routing metadata, not value content).
+/// Use this variant when the cached value carries Restricted-tier material per data classification.
+/// </summary>
+public sealed class EncryptedRedisCacheStore<T> : ICacheStore<T>
+{
+    private readonly IConnectionMultiplexer _multiplexer;
+    private readonly EncryptedRedisCacheOptions _options;
+    private readonly JsonSerializerOptions _serializerOptions;
+    private readonly byte[] _key;   // 256-bit AES key, resolved at construction time via factory
+    private readonly ILogger<EncryptedRedisCacheStore<T>> _logger;
+
+    public EncryptedRedisCacheStore(
+        IConnectionMultiplexer multiplexer,
+        IOptions<EncryptedRedisCacheOptions> options,
+        byte[] encryptionKey,
+        ILogger<EncryptedRedisCacheStore<T>> logger)
+    {
+        _multiplexer = multiplexer ?? throw new ArgumentNullException(nameof(multiplexer));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _key = encryptionKey ?? throw new ArgumentNullException(nameof(encryptionKey));
+        if (_key.Length != 32)
+        {
+            throw new ArgumentException("Encryption key must be 256 bits (32 bytes).", nameof(encryptionKey));
+        }
+        _serializerOptions = _options.SerializerOptions ?? new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async ValueTask<T?> GetAsync(string key, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var db = _multiplexer.GetDatabase();
+        var ciphertext = await db.StringGetAsync(NamespaceKey(key)).ConfigureAwait(false);
+        if (ciphertext.IsNullOrEmpty) return default;
+
+        var plaintext = Decrypt(ciphertext!);
+        return JsonSerializer.Deserialize<T>(plaintext, _serializerOptions);
+    }
+
+    public async ValueTask SetAsync(
+        string key,
+        T value,
+        TimeSpan? ttl = null,
+        IReadOnlyCollection<string>? tags = null,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var plaintext = JsonSerializer.SerializeToUtf8Bytes(value, _serializerOptions);
+        var ciphertext = Encrypt(plaintext);
+
+        var db = _multiplexer.GetDatabase();
+        var namespacedKey = NamespaceKey(key);
+        await db.StringSetAsync(namespacedKey, ciphertext, ttl).ConfigureAwait(false);
+
+        if (tags is { Count: > 0 })
+        {
+            // Tags are routing metadata; NOT encrypted — same tag-to-key index pattern as RedisCacheStore<T>.
+            var tagOps = new List<Task>(tags.Count + 1);
+            foreach (var tag in tags)
+            {
+                tagOps.Add(db.SetAddAsync(NamespaceTagKey(tag), namespacedKey.ToString()));
+            }
+            tagOps.Add(db.SetAddAsync(NamespaceKeyTagsKey(namespacedKey), tags.Select(t => (RedisValue)t).ToArray()));
+            await Task.WhenAll(tagOps).ConfigureAwait(false);
+        }
+    }
+
+    public ValueTask RemoveAsync(string key, CancellationToken ct = default)
+    {
+        // Identical to RedisCacheStore<T> — no encryption work needed for invalidation.
+        // (Implementation body the same as packet 03's RedisCacheStore<T>.RemoveAsync.)
+    }
+
+    public ValueTask RemoveByTagAsync(string tag, CancellationToken ct = default)
+    {
+        // Identical to RedisCacheStore<T> — tags are not encrypted.
+        // (Implementation body the same as packet 03's RedisCacheStore<T>.RemoveByTagAsync.)
+    }
+
+    private byte[] Encrypt(byte[] plaintext)
+    {
+        Span<byte> nonce = stackalloc byte[12];
+        RandomNumberGenerator.Fill(nonce);
+
+        var ciphertext = new byte[plaintext.Length];
+        Span<byte> tag = stackalloc byte[16];
+
+        using var aes = new AesGcm(_key, tagSizeInBytes: 16);
+        aes.Encrypt(nonce, plaintext, ciphertext, tag);
+
+        // Format: [nonce (12)][ciphertext][tag (16)]
+        var output = new byte[12 + ciphertext.Length + 16];
+        nonce.CopyTo(output.AsSpan(0, 12));
+        ciphertext.AsSpan().CopyTo(output.AsSpan(12, ciphertext.Length));
+        tag.CopyTo(output.AsSpan(12 + ciphertext.Length, 16));
+        return output;
+    }
+
+    private byte[] Decrypt(ReadOnlySpan<byte> ciphertextBlob)
+    {
+        if (ciphertextBlob.Length < 12 + 16)
+        {
+            throw new CryptographicException("Encrypted cache value is malformed (too short).");
+        }
+
+        var nonce = ciphertextBlob[..12];
+        var tag = ciphertextBlob[^16..];
+        var ciphertext = ciphertextBlob[12..^16];
+
+        var plaintext = new byte[ciphertext.Length];
+        using var aes = new AesGcm(_key, tagSizeInBytes: 16);
+        aes.Decrypt(nonce, ciphertext, tag, plaintext);   // throws CryptographicException on auth-tag mismatch
+        return plaintext;
+    }
+
+    // NamespaceKey / NamespaceTagKey / NamespaceKeyTagsKey helpers — same as RedisCacheStore<T>.
+}
+```
+
+(Note: `AesGcm` is the .NET BCL type in `System.Security.Cryptography`. Available on .NET 6+. Verified available on .NET 10.0 — the repo's target framework.)
+
+### DI registration
+
+```csharp
+public static IServiceCollection AddHoneyDrunkCacheRedisEncrypted<T>(
+    this IServiceCollection services,
+    Action<EncryptedRedisCacheOptions>? configureOptions = null,
+    Func<IServiceProvider, string>? connectionStringFactory = null,
+    Func<IServiceProvider, byte[]>? encryptionKeyFactory = null)
+{
+    if (services is null) throw new ArgumentNullException(nameof(services));
+
+    if (configureOptions is not null)
+    {
+        services.Configure(configureOptions);
+    }
+
+    if (connectionStringFactory is not null)
+    {
+        services.TryAddSingleton<IConnectionMultiplexer>(sp =>
+            ConnectionMultiplexer.Connect(connectionStringFactory(sp)));
+    }
+
+    if (encryptionKeyFactory is null)
+    {
+        throw new InvalidOperationException(
+            "AddHoneyDrunkCacheRedisEncrypted<T> requires an encryptionKeyFactory. " +
+            "Resolve the key from ISecretStore (Vault) at composition time.");
+    }
+
+    services.TryAddSingleton<ICacheStore<T>>(sp =>
+        new EncryptedRedisCacheStore<T>(
+            sp.GetRequiredService<IConnectionMultiplexer>(),
+            sp.GetRequiredService<IOptions<EncryptedRedisCacheOptions>>(),
+            encryptionKeyFactory(sp),
+            sp.GetRequiredService<ILogger<EncryptedRedisCacheStore<T>>>()));
+
+    services.AddSingleton<IStartupHook, RedisCacheStartupHook>();
+    services.TryAddSingleton<RedisCacheTelemetry>();
+    services.AddSingleton<IHealthContributor, RedisHealthContributor>();
+
+    return services;
+}
+```
+
+The encryption-key factory parameter is **required** (no default); composing Restricted-tier handling without an explicit key resolution is a misuse. The error message points the host at `ISecretStore` for the resolution path.
+
+### Unit tests
+
+Add to `tests/HoneyDrunk.Cache.Redis.Tests.Unit/EncryptedRedisCacheStoreTests.cs` (new file):
+
+- **RoundTrip:** Set value through encrypted store; get value through encrypted store with same key → original value returned.
+- **DifferentNonceEachWrite:** Set same key twice with same value; verify the stored ciphertext bytes differ between the two writes (different nonce → different ciphertext).
+- **TamperDetection:** Set value; modify any byte of the stored ciphertext in the Redis fake; `GetAsync` throws `CryptographicException` (auth-tag mismatch).
+- **WrongKey:** Two encrypted stores with different keys; one's `SetAsync` value cannot be read by the other (auth-tag mismatch on decrypt → `CryptographicException`).
+- **InvalidKeySize:** Constructing `EncryptedRedisCacheStore<T>` with a 16-byte or 24-byte key throws `ArgumentException` (256-bit key only).
+- **TagsNotEncrypted:** Verify tags passed to `SetAsync` are stored in the tag index as plaintext (verify by `SetMembersAsync` on the tag key returning the original tag values, not ciphertext).
+- **TagInvalidation:** `RemoveByTagAsync` invalidates encrypted values just like the plain backing.
+- **MissingKeyFactory:** Calling `AddHoneyDrunkCacheRedisEncrypted<T>` without an `encryptionKeyFactory` throws `InvalidOperationException` with the helpful error message.
+- **No high-cardinality on metrics:** Verify metric tags on encrypted operations follow the same discipline as packet 04's tests — no key, no tenant id on metrics; trace attributes only.
+
+### Documentation updates
+
+- `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` and repo-level `CHANGELOG.md` — append to `[0.1.0]` describing the encrypted-value wrapper.
+- `src/HoneyDrunk.Cache.Redis/README.md` — new "When to use the encrypted variant" section. Plain-English: "Use `AddHoneyDrunkCacheRedisEncrypted<T>` instead of `AddHoneyDrunkCacheRedis<T>` when the value's data classification requires at-rest encryption. The encryption is AES-GCM with a 256-bit key resolved from your Node's Vault; the standard variant skips the encryption step and is correct for Internal-tier and Tenant-tier values."
+
+## Affected Files
+
+- `src/HoneyDrunk.Cache.Redis/EncryptedRedisCacheStore.cs` (new)
+- `src/HoneyDrunk.Cache.Redis/EncryptedRedisCacheOptions.cs` (new)
+- `src/HoneyDrunk.Cache.Redis/ServiceCollectionExtensions.cs` — add `AddHoneyDrunkCacheRedisEncrypted<T>` extension method.
+- `tests/HoneyDrunk.Cache.Redis.Tests.Unit/EncryptedRedisCacheStoreTests.cs` (new)
+- `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` — append to in-progress `[0.1.0]`.
+- `CHANGELOG.md` (repo root) — append to in-progress `[0.1.0]`.
+- `src/HoneyDrunk.Cache.Redis/README.md` — new "When to use the encrypted variant" section.
+
+## NuGet Dependencies
+
+No new packages. `AesGcm` is in `System.Security.Cryptography` (BCL — available on .NET 6+, .NET 10.0 target framework includes it). `RandomNumberGenerator` is also in the BCL.
+
+## Boundary Check
+
+- [x] All changes inside `HoneyDrunk.Cache.Redis`. No edits to Kernel, no edits to Pulse, no edits to Vault.
+- [x] **Encryption key resolution is host-time** via the `encryptionKeyFactory` parameter. The package does not take a Vault dependency; the host wires `ISecretStore` resolution.
+- [x] **Encryption is opt-in.** Consumers using Internal-tier or Tenant-tier values continue using `RedisCacheStore<T>` from packet 03 unchanged — they pay nothing for the encryption surface.
+- [x] **Standard AEAD cryptography (AES-GCM).** No bespoke cipher constructions. Nonce sourced from `RandomNumberGenerator` (CSPRNG). Auth tag verified on every read. Tamper detection is intrinsic to AES-GCM.
+- [x] **Tags are not encrypted.** Tags are routing metadata, not value content. Tag-to-key index continues to work for invalidation.
+- [x] No new version bump — appends to in-progress `[0.1.0]` from packet 03 (invariant 27).
+- [x] No `Thread.Sleep` in tests (invariant 51).
+- [x] No secret values anywhere — encryption key is byte[] resolved at composition; never logged, never traced, never appears in telemetry or error reports (invariant 8).
+- [x] No reliance on Azure Cache for Redis Premium-tier features (per ADR-0076 D2 alternatives — Premium NOT adopted; this packet's encryption surface is exactly the reason Premium is not needed for Restricted-tier handling).
+
+## Acceptance Criteria
+
+- [ ] `EncryptedRedisCacheStore<T>` implements `ICacheStore<T>` with AES-GCM encryption on `SetAsync` and decryption on `GetAsync`
+- [ ] Ciphertext format is `[nonce (12 bytes)][ciphertext][auth_tag (16 bytes)]`
+- [ ] Nonce is fresh per write (CSPRNG-sourced via `RandomNumberGenerator.Fill`)
+- [ ] Encryption key must be 256 bits (32 bytes); constructor throws `ArgumentException` on other key sizes
+- [ ] Tamper detection: corrupting the stored ciphertext causes `GetAsync` to throw `CryptographicException`
+- [ ] Wrong-key detection: decrypting with a different key throws `CryptographicException`
+- [ ] `EncryptedRedisCacheOptions` record exists with `ConnectionStringSecretName`, `KeyPrefix`, `CommandTimeout`, `SerializerOptions`, `EncryptionKeySecretName` properties
+- [ ] `AddHoneyDrunkCacheRedisEncrypted<T>` extension exists; **requires** an `encryptionKeyFactory` parameter (throws `InvalidOperationException` with helpful message if omitted)
+- [ ] **Tags are stored as plaintext** in the tag-to-key index (NOT encrypted) — verified by unit test inspecting the Redis fake's tag-set contents
+- [ ] `RemoveByTagAsync` invalidates encrypted values correctly (tag invalidation works regardless of value encryption)
+- [ ] Unit tests pass: round-trip, different-nonce-per-write, tamper-detection, wrong-key, invalid-key-size, tags-not-encrypted, tag-invalidation, missing-key-factory, no-high-cardinality-on-metrics
+- [ ] **Standard `RedisCacheStore<T>` is unchanged** by this packet — Internal-tier and Tenant-tier consumers continue using the unencrypted backing unchanged
+- [ ] **`Directory.Build.props` version remains `0.1.0`** — NO version bump in this packet (invariant 27 — appends to existing in-progress version)
+- [ ] `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` and repo-level `CHANGELOG.md` `[0.1.0]` entries appended (not new version section)
+- [ ] `src/HoneyDrunk.Cache.Redis/README.md` "When to use the encrypted variant" section added — without citing "ADR-0076" / "ADR-0049" by number in narrative
+- [ ] No new NuGet packages — `AesGcm` and `RandomNumberGenerator` are BCL types
+- [ ] `pr-core.yml` and `api-compatibility.yml` both pass — the public surface gained `EncryptedRedisCacheStore<T>` and `EncryptedRedisCacheOptions`; the version is still `0.1.0` because they ship within the in-progress version
+- [ ] All public APIs have XML documentation (invariant 13)
+- [ ] No `Thread.Sleep` in test code (invariant 51)
+- [ ] No secret values anywhere (invariant 8) — the encryption key never enters logs, traces, telemetry, or error-reporter context
+
+## Human Prerequisites
+
+- [ ] Packet 03 of this initiative merged — `HoneyDrunk.Cache.Redis` package exists. (Packet 04 — telemetry/health/error-reporter — does NOT need to be merged first; packet 05 can land in parallel with packet 04 against the same `0.1.0` version, both appending to the same CHANGELOG section. The agent merging second should expect to rebase on the first.)
+- [ ] **No consumer is using `EncryptedRedisCacheStore<T>` yet.** This packet ships the surface; the first Restricted-tier cache use lands in a future feature packet against the consuming Node, at which time the operator generates a 256-bit encryption key, seeds it into the consumer Node's Vault, and wires the `encryptionKeyFactory` parameter to resolve from `ISecretStore`.
+- [ ] **No Azure portal action required for this packet.** The encryption key is generated and seeded at the first Restricted-tier consumer composition packet, not now. No `redis-encryption-key` secret exists in any Vault at this packet's merge time.
+- [ ] After this packet's PR merges and the post-merge tag-push for `v0.1.0` ships `HoneyDrunk.Cache.Redis` to NuGet, the package's public surface includes both the standard (`RedisCacheStore<T>`) and encrypted (`EncryptedRedisCacheStore<T>`) variants. Consumers choose at composition time.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. — `HoneyDrunk.Cache.Redis` is runtime; no Abstractions-on-runtime dependency added.
+
+> **Invariant 8:** Secret values never appear in logs, traces, exceptions, or telemetry. — The encryption key (`byte[]`) is held in the `EncryptedRedisCacheStore<T>` instance; never logged, never traced, never written to telemetry attributes or error-reporter context. Key bytes are not serialized or formatted into any string.
+
+> **Invariant 9:** Vault is the only source of secrets. — The `encryptionKeyFactory` parameter is the seam through which the host wires `ISecretStore` resolution. The package never resolves a secret; it accepts a factory.
+
+> **Invariant 13:** All public APIs have XML documentation. — Every new public type and method carries XML doc.
+
+> **Invariant 17:** Library-only Nodes have no Vault. — Cache has no Vault. The encryption key lives in the **consumer Node's** Vault when the first Restricted-tier consumer composes.
+
+> **Invariant 21:** Applications must never pin to a specific secret version. — The `encryptionKeyFactory` resolves the latest version via `ISecretStore` (host responsibility). The package does not pin.
+
+> **Invariant 27:** All projects in a solution share one version and move together. First packet bumps; subsequent packets append. — Second/third packet on the `HoneyDrunk.Cache` solution in this initiative (packet 04 may merge first or second; packet 05 may merge first or second; both append to `[0.1.0]` from packet 03). No version bump.
+
+> **Invariant 51:** Test code contains no `Thread.Sleep`. — Tests use the InMemory fake and synchronous-completion patterns.
+
+## Referenced ADR Decisions
+
+**ADR-0076 D6 — Classification carve-out:** Restricted-tier values are not stored in Standard-tier Azure Cache for Redis without per-value encryption at the application layer. This packet ships exactly that surface — `EncryptedRedisCacheStore<T>` for Restricted-tier consumers; `RedisCacheStore<T>` from packet 03 remains for Internal-tier and Tenant-tier consumers.
+
+**ADR-0076 D2 alternatives — Premium tier NOT adopted:** Premium tier (which supports at-rest encryption natively) is not adopted on cost grounds. The application-layer encryption in this packet is the reason Premium is not needed for Restricted-tier handling at MVP scale; this packet preserves the Standard-tier cost posture while supporting the classification discipline.
+
+**ADR-0049 — Data classification, PII handling, and retention schedule:** Defines the tier system (Public, Internal, Tenant, Restricted) and the handling requirements per tier. Restricted-tier values carry the strongest handling — encryption at rest is one of the disciplines. This packet's encrypted variant satisfies that for cache use.
+
+**ADR-0058 D6 — Classification inheritance:** A cached value inherits its source's classification. If the source value is Restricted-tier, the cached representation is Restricted-tier too. Per this rule, consumers caching Restricted-tier values must compose `AddHoneyDrunkCacheRedisEncrypted<T>` — using `AddHoneyDrunkCacheRedis<T>` for a Restricted-tier value would be a classification-discipline violation.
+
+## Constraints
+
+- **Invariant 1, 8, 9, 13, 17, 21, 27, 51:** As inlined in Referenced Invariants.
+- **AES-GCM with 256-bit key, 96-bit nonce, 128-bit auth tag.** Standard AEAD parameters. No bespoke cipher constructions.
+- **Fresh nonce per write** via `RandomNumberGenerator.Fill` (CSPRNG).
+- **Encryption key never enters logs, traces, telemetry, or error-reporter context.** Per invariant 8.
+- **Tags are NOT encrypted.** They are routing metadata; the tag-to-key index continues to function as in `RedisCacheStore<T>`.
+- **`encryptionKeyFactory` is required.** No default; composing Restricted-tier handling without explicit key resolution is a misuse and throws.
+- **No version bump.** Appends to in-progress `[0.1.0]`. Packet 04 and packet 05 both append; whichever lands second rebases on the first.
+- **No `## Unreleased` block in CHANGELOG.** Entries land under `[0.1.0]`.
+- **README does NOT cite ADR numbers in narrative.** Per memory `feedback_no_adr_in_docs`.
+- **No Azure portal work in this packet.** Encryption key generation and Vault seeding happen at the first Restricted-tier consumer composition packet.
+
+## Dependencies
+
+- `packet:03` — the bare `HoneyDrunk.Cache.Redis` package must exist before the encrypted sibling can be added. (Packet 04 — telemetry/health/error-reporter — is NOT a dependency; packets 04 and 05 are siblings against the in-progress `[0.1.0]`.)
+
+## Labels
+
+`feature`, `tier-2`, `cache`, `redis`, `security`, `adr-0076`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Ship the classification-aware application-layer-encryption surface per ADR-0076 D6. Add `EncryptedRedisCacheStore<T>`, `EncryptedRedisCacheOptions`, `AddHoneyDrunkCacheRedisEncrypted<T>`. AES-GCM with a 256-bit key resolved through a required factory parameter. Tags remain plaintext. Standard `RedisCacheStore<T>` is unchanged. Appends to in-progress `[0.1.0]`.
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Cache`, branch from `main`.
+
+**Context:**
+- Goal: Give Restricted-tier consumers an in-package opt-in encryption path so the Grid does not need to adopt Premium-tier Azure Cache for Redis (which has at-rest encryption native) for the classification discipline. The application-layer surface is the reason Premium is not needed at MVP scale.
+- Feature: ADR-0076 acceptance initiative, Wave 3, Packet 05.
+- ADRs: ADR-0076 D6 (the classification carve-out being implemented), ADR-0076 D2 alternatives (Premium NOT adopted — encryption is application-layer), ADR-0049 (data classification tier definitions), ADR-0058 D6 (classification inheritance — cached values inherit their source's tier).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** `packet:03` only. (Packets 04 and 05 are sibling packets against the same in-progress `[0.1.0]` version; whichever merges second rebases.)
+
+**Constraints:**
+
+- **Invariant 1, 8, 9, 13, 17, 21, 27, 51:** As inlined in Referenced Invariants.
+- **AES-GCM with 256-bit key, 96-bit nonce, 128-bit auth tag.** Standard AEAD. No bespoke cipher constructions.
+- **Fresh nonce per write.** CSPRNG via `RandomNumberGenerator.Fill`.
+- **Encryption key never in logs/traces/telemetry/error-reporter context.** Invariant 8 enforcement.
+- **Tags NOT encrypted.** Routing metadata, plaintext.
+- **`encryptionKeyFactory` is required.** No default; misuse throws.
+- **No version bump.** Appends to `[0.1.0]`.
+- **Standard `RedisCacheStore<T>` unchanged.** This packet adds a sibling implementation, does not modify the existing one.
+- **No Azure portal work.** Key generation + Vault seeding happen at the first Restricted-tier consumer composition.
+- **README does NOT cite ADR numbers in narrative.** Per memory `feedback_no_adr_in_docs`.
+- **No `## Unreleased` block in CHANGELOG.**
+
+**Key Files:**
+- `src/HoneyDrunk.Cache.Redis/EncryptedRedisCacheStore.cs` (new)
+- `src/HoneyDrunk.Cache.Redis/EncryptedRedisCacheOptions.cs` (new — sealed record, no `I` prefix)
+- `src/HoneyDrunk.Cache.Redis/ServiceCollectionExtensions.cs` — add `AddHoneyDrunkCacheRedisEncrypted<T>` extension
+- `tests/HoneyDrunk.Cache.Redis.Tests.Unit/EncryptedRedisCacheStoreTests.cs` (new)
+- `src/HoneyDrunk.Cache.Redis/CHANGELOG.md` + repo-level `CHANGELOG.md` — append to `[0.1.0]`
+- `src/HoneyDrunk.Cache.Redis/README.md` — new "When to use the encrypted variant" section
+
+**Contracts:**
+
+Implements existing `ICacheStore<T>` from `HoneyDrunk.Kernel.Abstractions`. Introduces two new public types in `HoneyDrunk.Cache.Redis`:
+
+- `EncryptedRedisCacheStore<T>` (sealed class, implements `ICacheStore<T>`)
+- `EncryptedRedisCacheOptions` (sealed record — record naming drops the `I` prefix)
+- New static method `AddHoneyDrunkCacheRedisEncrypted<T>` on the existing `ServiceCollectionExtensions` class
+
+These are picked up by the `api-compatibility.yml` canary on the next CI run; the version remains `0.1.0` because they ship within the in-progress version per invariant 27.

--- a/generated/issue-packets/active/adr-0076-cache-backing-redis/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0076-cache-backing-redis/dispatch-plan.md
@@ -1,0 +1,173 @@
+# Dispatch Plan — ADR-0076 Cache Backing: Azure Cache for Redis
+
+**Initiative:** `adr-0076-cache-backing-redis`
+**Sector:** Core / cross-cutting
+**Governing ADR:** [ADR-0076 — Cache Backing: Azure Cache for Redis with Cost-Aware Sizing](../../../../adrs/ADR-0076-cache-backing-azure-cache-for-redis.md) (Proposed 2026-05-23; flips to Accepted only after every packet in this initiative is closed AND the two upstream paired ADRs — ADR-0058 caching strategy and ADR-0059 Cache Node standup — are themselves Accepted. Status-flip is post-merge housekeeping, not a packet action.)
+**Companion ADRs:**
+- [ADR-0058 — Grid-Wide Caching Strategy](../../../../adrs/ADR-0058-grid-wide-caching-strategy.md) (commits the `ICacheStore<T>` contract in `HoneyDrunk.Kernel.Abstractions` and `InMemoryCacheStore<T>` in `HoneyDrunk.Kernel`). Merged into Architecture via PR #301.
+- [ADR-0059 — Stand Up the HoneyDrunk.Cache Node](../../../../adrs/ADR-0059-stand-up-honeydrunk-cache-node.md) (stands up the Cache Node repo and the empty placeholder scaffold). Merged into Architecture via PR #323.
+**Trigger:** ADR-0076 in the Proposed queue. ADR-0058 D8 explicitly deferred the first-distributed-backing decision; ADR-0059 stood up the Node home for that decision; ADR-0076 fills the deferred decision. The first consumer (Notify Cloud's multi-replica horizon per ADR-0027) is the imminent forcing function — without a backing decision, the first consumer's pick becomes the de-facto Grid default by precedent.
+**Type:** Multi-repo (2 repos: `HoneyDrunk.Architecture` + `HoneyDrunk.Cache`)
+**Site sync required:** No (backing-implementation work; no Studios website content depends on a Redis adapter package shipping. The catalogs row updates are internal.)
+**Rollback plan:**
+- **Pre-tag rollback** (before `HoneyDrunk.Cache 0.1.0` is pushed): `git revert` per PR. Architecture-side packets revert cleanly (catalog rows + walkthrough doc). Cache packets 03–05 revert the entire `HoneyDrunk.Cache.Redis` package; the placeholder Adapters project from the standup is unaffected. Packet 02 (human-only Azure provisioning) is undone by deleting the dev Azure Cache for Redis instance in the portal.
+- **Post-tag rollback** (after `HoneyDrunk.Cache 0.1.0` is pushed to NuGet but before any consumer composes it): packages are immutable; prefer fix-forward as `0.1.1`. The cost-bearing Azure resource (the dev Redis instance) remains until manually deleted regardless of NuGet state.
+- **No consumers yet.** Notify Cloud multi-replica and Communications shared cache are both downstream of this initiative; neither has composed `HoneyDrunk.Cache.Redis` at the time these packets land. Rollback at this stage costs only the operator's afternoon of provisioning work.
+- **`file-packets.yml` lifecycle gotcha:** after this initiative's packets have moved through The Hive, hive-sync may move source packet files from `active/` to `completed/` per invariant 37. A `git revert` only undoes code changes, not packet-file moves. If a revert is needed after lifecycle moves, restore the packet files manually as part of the revert PR.
+
+## Sequencing Against Upstream Gates
+
+ADR-0076 sits downstream of two paired upstream ADRs whose acceptance initiatives committed code this ADR depends on. Concretely:
+
+- **ADR-0058 acceptance committed `ICacheStore<T>` to `HoneyDrunk.Kernel.Abstractions`** (PR #301 merged). The Redis backing implements this contract. Without the contract in place, packet 03 has nothing to implement against.
+- **ADR-0059 acceptance committed the `HoneyDrunk.Cache` repo and the placeholder `HoneyDrunk.Cache.Adapters` project** (PR #323 merged). The Redis backing ships as the first real package in this repo. Without the repo and scaffold in place, packet 03 has no Node home to land in.
+
+Both upstream merges are confirmed at scoping time. This initiative inherits a green-light state.
+
+**The `dependencies:` frontmatter in this initiative refers only to packets within this initiative.** Cross-initiative dependencies are not supported by `file-packets.yml` — the Human Prerequisites section on each packet describes the gating upstream state (issue numbers, repo state, package versions) instead. The filing pipeline relies on the packets being filed in dependency order; the human-prerequisite text catches anything that would otherwise be a missing edge.
+
+## Summary
+
+ADR-0076 commits Azure Cache for Redis as the canonical first distributed-cache backing for `HoneyDrunk.Cache`, with per-environment cost-aware sizing (Basic C0 for dev, Standard C1 for staging/prod baseline), Redis-protocol-only discipline (no Azure-Redis modules), `allkeys-lru` as the default eviction policy, provider abstraction held (alternate backings permitted per ADR-0058 D5), self-hosted Redis on Container Apps permitted as a cost-pressured per-Node alternative (D7), and explicit handling for Restricted-tier values that bypass Standard-tier Redis's at-rest-encryption gap via application-layer encryption (D6).
+
+Six packets land the work:
+
+1. **00 — Architecture: Accept ADR-0076** — flip Status from Proposed to Accepted once the initiative's PRs have merged. The Status-flip itself is post-merge housekeeping in this packet's body, mirroring the pattern from prior backing-decision ADRs.
+2. **01 — Architecture: Catalogs + tech-stack updates + provisioning walkthrough** — update `catalogs/contracts.json` (record the `ICacheStore<T>` Redis backing as a planned module), `catalogs/grid-health.json` (add dev/staging/prod Azure Cache for Redis instance rows), `catalogs/modules.json` (add `cache-redis` row for the new `HoneyDrunk.Cache.Redis` package, Seed signal); update `infrastructure/reference/tech-stack.md` Redis row from "Future" to "Stood up; backing implementation in progress"; author `infrastructure/walkthroughs/azure-cache-for-redis-provisioning.md` covering Basic C0 (dev) / Standard C1 (staging/prod) creation, daily ingest cap, connection-string-into-Vault flow, eviction-policy verification, encryption-in-transit confirmation.
+3. **02 — Architecture: Provision `dev` Azure Cache for Redis Basic C0 (human-only)** — execute the walkthrough from packet 01 for `dev`. Create the Basic C0 instance (`redis-hd-dev`); set the eviction policy to `allkeys-lru`; verify TLS-only access; defer connection-string Vault seeding until the first consumer's Vault is the target (Notify Cloud's `kv-hd-notify-cloud-dev` or Communications's `kv-hd-comms-dev` — whichever lands first).
+4. **03 — Cache: Implement `HoneyDrunk.Cache.Redis` (`RedisCacheStore<T>` + DI registration)** — first/version-bumping packet on the `HoneyDrunk.Cache` solution. Add `src/HoneyDrunk.Cache.Redis/` project. Implement `RedisCacheStore<T>` against `ICacheStore<T>` from `HoneyDrunk.Kernel.Abstractions`, backed by `StackExchange.Redis`. `AddHoneyDrunkCacheRedis<T>` extension. Standard Redis protocol commands only (no `RediSearch`, no `RedisJSON`, no `RedisTimeSeries` — D3). System.Text.Json for value serialization (D3). Tag-to-key index using standard Redis sets. Unit tests against an InMemory `IConnectionMultiplexer` fake. Version bump `0.0.1` → `0.1.0` on the `HoneyDrunk.Cache` solution (first real implementation; alignment-bump on the placeholder `HoneyDrunk.Cache.Adapters` per invariant 27).
+5. **04 — Cache: Telemetry + health contributor + error-reporter facade wiring** — add `IHealthContributor` reporting connection state, hit/miss counters, and connection-pool depth via Kernel's telemetry primitives (per ADR-0040 D6 — telemetry flows one-way to Pulse, no runtime dependency on Pulse). Wire `IErrorReporter` (per ADR-0045 D3) for connection failures, command timeouts, deserialization errors. No version bump (appends to in-progress `0.1.0` started by packet 03).
+6. **05 — Cache: Classification-aware encrypted value wrapper for Restricted-tier values** — Per ADR-0076 D6 + ADR-0049: any cached value carrying Restricted-tier material must be application-layer-encrypted when stored in a Standard-tier Redis (Premium is not adopted, so at-rest encryption is the consumer's responsibility). Add `IEncryptedCacheValue` opt-in surface in `HoneyDrunk.Cache.Redis` letting consumers explicitly mark a value as Restricted-tier — the backing then routes the value through AES-GCM with a Vault-resolved key before write and decrypts on read. No version bump (appends to `0.1.0`).
+
+**No invariants packet.** Per the explicit ADR-0076 text ("No new Grid-wide invariants introduced. Conventions enforced at packet authoring and review"), this initiative adds zero rows to `constitution/invariants.md`. The Redis-protocol-only discipline (D3), the `allkeys-lru` default (D4), the per-environment sizing rubric (D2), and the classification-aware caching rule (D6) all live as ADR text + per-packet acceptance criteria, not as Grid-wide invariants. This matches ADR-0059's "None at stand-up" stance and is a deliberate restraint against invariant proliferation for decisions that affect one Node's backing.
+
+## Wave Diagram
+
+```
+Wave 1: Architecture acceptance + catalogs + provisioning walkthrough
+   ├─ Architecture: 00-architecture-adr-0076-acceptance
+   │     No upstream dependencies.
+   ├─ Architecture: 01-architecture-catalogs-and-walkthrough
+   │     Blocked by: packet:00
+   └─ Architecture: 02-architecture-provision-dev-redis  (human-only)
+         Blocked by: packet:01
+
+Wave 2: Cache.Redis implementation
+   └─ Cache: 03-cache-redis-implementation
+         Blocked by: packet:01 (walkthrough must exist for the package README to cross-reference;
+                                catalog rows must be in place so module identity is established)
+                     packet:02 (dev Redis instance must exist for the unit-test composition path
+                                and the eventual smoke verification; NOT strictly required to compile
+                                or pass unit tests since those run against an InMemory IConnectionMultiplexer
+                                fake — but the Human Prerequisites describe why packet 02 should land first)
+
+Wave 3: Cache.Redis hardening (parallel-able)
+   ├─ Cache: 04-cache-redis-telemetry-and-health
+   │     Blocked by: packet:03
+   └─ Cache: 05-cache-redis-classification-encryption
+         Blocked by: packet:03
+```
+
+Packets 04 and 05 modify the same `HoneyDrunk.Cache.Redis` project but in distinct surfaces (health/telemetry vs. encrypted-value wrapper). They are not strictly serialized by file conflict; the agent merging the second of the two should expect to rebase on the first. The dispatch plan does not force a serialization order — whichever wins the file-write race lands first, and the other rebases.
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 00 | [Accept ADR-0076 — Cache Backing Azure Cache for Redis](./00-architecture-adr-0076-acceptance.md) | Architecture | 1 | Agent | — |
+| 01 | [Register Redis backing in catalogs, update tech-stack, author provisioning walkthrough](./01-architecture-catalogs-and-walkthrough.md) | Architecture | 1 | Agent | packet:00 |
+| 02 | [Provision `dev` Azure Cache for Redis Basic C0 instance (human-only)](./02-architecture-provision-dev-redis.md) | Architecture (tracking issue) | 1 | Human | packet:01 |
+| 03 | [Implement `HoneyDrunk.Cache.Redis` — `RedisCacheStore<T>` on StackExchange.Redis + DI extension](./03-cache-redis-implementation.md) | HoneyDrunk.Cache | 2 | Agent | packet:01, packet:02 |
+| 04 | [Wire Redis backing telemetry, health contributor, and IErrorReporter failure path](./04-cache-redis-telemetry-and-health.md) | HoneyDrunk.Cache | 3 | Agent | packet:03 |
+| 05 | [Add classification-aware encrypted-value wrapper for Restricted-tier values](./05-cache-redis-classification-encryption.md) | HoneyDrunk.Cache | 3 | Agent | packet:03 |
+
+## Phase Mapping (ADR-0076 decisions → packets)
+
+| Decision | Packet(s) |
+|---|---|
+| D1 — Azure Cache for Redis as default distributed-cache backing; `HoneyDrunk.Cache.Redis` package; `StackExchange.Redis`; managed-identity preferred / access-key fallback via Vault | 01 (walkthrough), 02 (provision), 03 (package + DI) |
+| D2 — Per-environment sizing rubric (Basic C0 dev / Standard C1 staging / Standard prod baseline; no Premium) | 01 (walkthrough documents rubric), 02 (executes Basic C0 for dev) |
+| D3 — Redis-protocol-only; no RediSearch, RedisJSON, RedisTimeSeries, RedisGraph, RedisBloom; System.Text.Json for serialization | 03 (acceptance criteria forbid module-specific commands; serializer is System.Text.Json) |
+| D4 — Default eviction policy is `allkeys-lru` | 01 (walkthrough records the default), 02 (sets the policy on the dev instance), 03 (README documents the assumption; the backing does not configure server-side eviction — it is set on the Azure resource) |
+| D5 — Provider abstraction held (alternate backings permitted; Azure Cache for Redis is default not only) | 03 (README notes the per-Node escape valve; package name `HoneyDrunk.Cache.Redis` reflects backing identity, not exclusivity) |
+| D6 — Operational discipline: telemetry via Pulse, errors via App Insights, cost monitoring, DR tier 2, classification-aware Restricted-tier handling | 04 (telemetry + health + IErrorReporter), 05 (classification-aware encrypted wrapper) |
+| D7 — Self-hosted Redis on Container Apps permitted for cost-pressured deployments | 01 (walkthrough documents the escape valve as an alternative path; no implementation in this initiative — the default backing is Azure Cache for Redis) |
+| D8 — Out of scope (cache-invalidation lanes, per-Node key conventions, Cosmos-with-TTL, read/write-through patterns, multi-region cache replication, cluster mode) | All packets explicitly note the out-of-scope items in their Boundary Check sections; no follow-up packet here |
+
+## Filing-order rule
+
+Packet 03's body cross-references the walkthrough (`infrastructure/walkthroughs/azure-cache-for-redis-provisioning.md`) and the catalog rows landed by packet 01. Filed packets are immutable (invariant 24). Therefore:
+
+**Packet 01 must be filed, its PR merged, and the walkthrough + catalog rows actually on `main` before packet 03 is filed.**
+
+In practice:
+
+1. Push packets 00, 01, 02 (they may travel together — packet 01's `dependencies: ["packet:00"]` and packet 02's `dependencies: ["packet:01"]` wire the blocking edges automatically).
+2. Wait for packet 01's PR to merge so `infrastructure/walkthroughs/azure-cache-for-redis-provisioning.md` exists and the catalog rows reflect the backing decision.
+3. Wait for packet 02 to close (the dev Azure Cache for Redis instance must exist before packet 03's smoke-verification acceptance criteria can be satisfied; unit tests run against the InMemory fake so they don't strictly need the instance).
+4. Push packets 03, 04, 05 in the same push or staggered — 04 and 05 both depend on `packet:03` only.
+
+**Packets 01 and 03 cannot be filed in the same push.** Packet 03 must reach a state where the walkthrough and catalog rows exist; the file-packets pipeline does not block on prior packet merges within the same push, so the filing order matters.
+
+## Asymmetry vs ADR-0058 and ADR-0059
+
+Three deliberate asymmetries relative to the upstream paired ADRs are worth recording:
+
+1. **No invariants packet.** ADR-0058's acceptance initiative landed three caching invariants (per-Node-opaque caches, tenant-key isolation, classification inheritance). ADR-0059 added zero. ADR-0076 adds zero. The backing-decision ADR enforces its conventions at the packet-acceptance-criteria layer, not at the Grid-wide constitutional invariant layer — the rules apply to one Node's backing, not to every Node.
+
+2. **Vault namespace ownership lives with the consumer, not the Cache Node.** Per invariant 17 ("One Key Vault per deployable Node per environment. Library-only Nodes have no vault. ... `HoneyDrunk.Cache` ... has no vault."), the Cache Node has no `kv-hd-cache-{env}` Key Vault. The Redis connection strings, when used, live in the **consumer Node's** Vault — `kv-hd-notify-cloud-{env}` for Notify Cloud, `kv-hd-comms-{env}` for Communications, etc. The provisioning walkthrough (packet 01) documents this; the dev-provisioning packet (packet 02) defers connection-string Vault seeding until the first consumer's Vault is the target. The ADR text (line 159) references `kv-hd-cache-{env}` but that is an artifact of pre-refine-pass thinking and contradicts invariant 17 — the packets correct it.
+
+3. **Per-environment sizing is mostly walkthrough work, not code work.** Most of the per-environment decision (Basic C0 / Standard C1 / Standard prod baseline) lives in the walkthrough and the human-executed portal step; the .NET code is environment-agnostic — it takes a connection string and behaves correctly. This is the right separation: code does not know its environment; the Vault-stored connection string does.
+
+## What This Initiative Does **NOT** Deliver
+
+- **A staging or prod Azure Cache for Redis instance.** Per ADR-0053 (the environments-standup ADR), staging and prod environments are still in flight. Packet 02 provisions `dev` only. The walkthrough is authored to cover all three environments so future provisioning is a repeat execution, not a new packet.
+- **The first consumer composing the Redis backing.** Notify Cloud multi-replica and Communications shared cache are downstream feature packets against the consuming Node at the time their workload demands a distributed cache. This initiative ships the package; the composition lives in a future Notify Cloud or Communications packet. The connection-string-into-consumer-Vault step happens in that future packet, not in packet 02.
+- **Managed-identity authentication wiring on the .NET side.** Per ADR-0076 D1, managed identity is preferred where Azure Cache for Redis supports it (Standard tier and above). The first consumer composition packet handles the consumer-side `DefaultAzureCredential` / Entra-based connection wiring; the `HoneyDrunk.Cache.Redis` package supports both managed-identity and access-key paths but does not itself wire credentials — that is host-time work at the composing Node.
+- **The Communications consumer composition or Notify Cloud consumer composition.** Each is a separate feature packet against the consuming Node.
+- **Self-hosted Redis on Container Apps.** Permitted per D7 but not implemented. If a future cost-pressured deployment chooses self-host, that is a separate packet against the consuming Node.
+- **Cosmos-with-TTL or Postgres-with-TTL backings.** Permitted per ADR-0058 D5 + ADR-0076 D5 but not implemented. Each is a separate future packet when a workload chooses it.
+- **HTTP / output response caching.** Per ADR-0059 §Unblocks. Likely paired with the Gateway standup. Not in scope here.
+- **Cache invariants.** Per ADR-0076 §"Invariants" ("No new Grid-wide invariants introduced.").
+- **Premium-tier provisioning.** Per ADR-0076 D2 + the alternatives-considered section. Premium tier is held in reserve; this initiative does not provision any Premium-tier instance.
+- **Cost-monitoring dashboard wiring.** Per ADR-0076 D6 references ADR-0052 (cost governance). Wiring lives in a separate cost-governance dashboard packet; this initiative records that Redis spend should appear on it (packet 01 grid-health row), not the dashboard work itself.
+
+## Notes
+
+- **No Azure provisioning beyond the dev instance in this initiative.** Per ADR-0053, staging and prod environments are still standing up. Packet 02 provisions `dev`. Staging/prod follow when those environments exist, as repeat executions of the walkthrough.
+- **Cache repo is public per the standing default.** Per memory `project_repos_public_by_default`, `HoneyDrunk.Cache` is public. The Redis backing is substrate, not commercial product — no revenue carve-out. No PII storage at the Cache layer (cached values are by-construction classified by the consumer); no compliance carve-out beyond the application-layer encryption in packet 05. Public is correct.
+- **No ADR numbers in user-facing docs or code comments.** Per memory `feedback_no_adr_in_docs`. The `HoneyDrunk.Cache.Redis` package README explains what the backing does and what its operational shape is, without citing "ADR-0076" or "ADR-0058" in the narrative. Runtime / packet-data references (catalog entries, frontmatter, this dispatch plan, CHANGELOG entries) cite ADRs by number freely.
+- **No commits under CHANGELOG Unreleased.** Per memory `feedback_no_unreleased_commits`. Packet 03's first commit lands under `## [0.1.0] - YYYY-MM-DD`, not `## Unreleased`. The tag push happens after merge; the version section in CHANGELOG is dated and SemVer-bumped before the commit.
+- **No manual packet filing.** Per memory `feedback_no_manual_packet_filing`. `file-packets.yml` auto-files on push to `main`. Do not run `gh issue create` against these packets.
+- **Cache → Kernel edge direction (one-way, strict).** The Redis backing's `RedisCacheStore<T>` references `HoneyDrunk.Kernel.Abstractions` for `ICacheStore<T>`. Kernel does not reference any `HoneyDrunk.Cache.*` package. This matches ADR-0058 D2 + ADR-0059's leaf-node posture.
+- **`IStartupHook` lives in `HoneyDrunk.Kernel.Abstractions.Lifecycle`.** Verified existing. The Redis backing wires a startup-warmup connection probe via `IStartupHook` to fail fast at host startup if the Redis instance is unreachable — same pattern as Vault's startup warmup per `HoneyDrunk.Vault`'s established discipline.
+- **`IErrorReporter` lives in HoneyDrunk.Pulse per ADR-0045 D3.** A thin facade over the existing `IErrorSink` Pulse surface. Packet 04 references it for connection failures, command timeouts, and deserialization errors. Cache → Pulse is one-way (Cache emits, Pulse consumes); no runtime dependency on Pulse beyond the Abstractions package per the established Cache → Pulse boundary.
+- **Telemetry attributes per ADR-0040 D6.** High-cardinality identifiers (cache keys, tenant ids) go on traces / logs, never on metrics. Hit rate, miss rate, eviction count, latency p50/p95/p99, connection-pool depth are the metric surface; cache keys are trace attributes only.
+- **Data classification per ADR-0049.** Restricted-tier values get the application-layer encryption treatment in packet 05. Internal-tier and Tenant-tier values get standard Redis storage (encryption-in-transit, not at-rest in Standard tier — accepted per ADR-0076 D6).
+- **The Adapters placeholder project stays.** The `HoneyDrunk.Cache.Adapters` placeholder from the ADR-0059 standup is not removed by this initiative. It carries the alignment-bump version with the rest of the solution per invariant 27. If a future initiative removes it as obsolete, that is a separate cleanup packet — not work for this initiative.
+
+## Status-flip handling
+
+ADR-0076 stays at `Status: Proposed` for the duration of packet 00's PR (the acceptance packet does the body work but the Status flip is the post-merge step). The Status flip happens after every packet in this initiative has reached Done **and** the two upstream paired ADRs (ADR-0058, ADR-0059) are themselves Accepted.
+
+**Three gates on the ADR-0076 Status flip:**
+
+1. All six packets in this initiative are Done.
+2. ADR-0058 is Accepted. (Confirmed at scoping time — PR #301 merged.)
+3. ADR-0059 is Accepted. (Confirmed at scoping time — PR #323 merged.)
+
+Gates 2 and 3 are already satisfied. Gate 1 unblocks when the initiative completes.
+
+The flip is a one-line edit to `adrs/ADR-0076-cache-backing-azure-cache-for-redis.md` line 3 (`**Status:** Proposed` → `**Status:** Accepted`), plus any matching update to `adrs/README.md` if it carries a per-ADR Status entry, plus a CHANGELOG note. The hive-sync agent's ADR auto-acceptance loop may also reconcile this on its next run if it is delayed.
+
+## Filing
+
+The `file-packets.yml` workflow in `HoneyDrunk.Architecture` triggers automatically on push to `generated/issue-packets/active/**/*.md`. No `gh issue create` commands in this dispatch plan — the pipeline handles filing, project-board addition, field population, and `addBlockedBy` wiring from the `dependencies:` frontmatter on each packet. Verify after push by checking The Hive (org Project #4) for the new items and their blocking edges.
+
+The exception is packet 02 (the human chore), which is human-executed in the Azure Portal. Its acceptance criteria are satisfied when the dev Redis instance is live and the operator updates `catalogs/grid-health.json` to reflect the provisioned state.
+
+## Archival
+
+Per ADR-0008 D10, when every packet in this initiative reaches `Done` on the org Project board AND `HoneyDrunk.Cache 0.1.0` is published to NuGet AND ADR-0076 has been flipped to Accepted, the entire `active/adr-0076-cache-backing-redis/` folder moves to `archive/adr-0076-cache-backing-redis/` in a single commit. Partial archival is forbidden.
+
+The hive-sync agent moves individual closed packet files from `active/` to `completed/` per invariant 37 — that is per-packet lifecycle. Initiative-level archival is the post-completion sweep that follows after the whole folder reaches `Done`.

--- a/generated/issue-packets/active/adr-0078-entra-external-id/00-architecture-adr-0078-acceptance.md
+++ b/generated/issue-packets/active/adr-0078-entra-external-id/00-architecture-adr-0078-acceptance.md
@@ -1,0 +1,215 @@
+---
+name: Architecture Decision
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "core", "docs", "identity", "adr-0078", "wave-1"]
+dependencies: []
+adrs: ["ADR-0078"]
+accepts: ["ADR-0078"]
+wave: 1
+initiative: adr-0078-entra-external-id
+node: honeydrunk-identity
+---
+
+# Accept ADR-0078 — flip status, claim invariant block 93-94, add the two Entra invariants, register the initiative
+
+## Summary
+
+Flip ADR-0078 (End-User Identity — Microsoft Entra External ID) from Proposed to Accepted: update the ADR header, claim the reserved size-2 invariant block in `constitution/invariant-reservations.md` (default range **93-94** per the existing reservation row), add the two new invariants ADR-0078 commits in its Consequences section to `constitution/invariants.md` under a new `## End-User Identity Invariants` section, and register the `adr-0078-entra-external-id` initiative in `initiatives/active-initiatives.md`. ADR-0078 fills ADR-0060 D2's deferred vendor decision before Hearth's signup packet pulls on Identity.
+
+## Context
+
+ADR-0078 commits **Microsoft Entra External ID** as the identity provider for every end-user authentication surface in the Grid (consumer-app users — Hearth, Lately, Currents, Curiosities — plus Notify Cloud tenant operators). It also commits the **OIDC-standard-claims-only** discipline as the vendor-exit hedge against Entra trajectory changes. The ADR fills [ADR-0060](../../../../adrs/ADR-0060-stand-up-honeydrunk-identity-node.md) D2's deferred vendor decision before the first user-facing app (Hearth per PDR-0005) pulls on Identity.
+
+The ADR decides:
+- **D1** — Microsoft Entra External ID is the end-user IdP. Single Grid-wide Entra External ID tenant; per-application App Registrations; OAuth 2.1 with PKCE over OpenID Connect.
+- **D2** — Azure AD B2C is explicitly not adopted (sunset for new tenants).
+- **D3** — OIDC-standard claims only (`sub`, `iss`, `aud`, `exp`, `iat`, `nbf`, `email`, `email_verified`, `name`, `given_name`, `family_name`, `preferred_username`). Entra-proprietary claims (`oid`, `tid`, etc.) may be logged for diagnostics but are not load-bearing in application logic. This is the cheap vendor-exit hedge wired at the `IExternalIdpClaimMapper` seam.
+- **D4** — `HoneyDrunk.Identity` is the seam; `HoneyDrunk.Identity.Providers.Entra` is the package that implements `IExternalIdpClaimMapper` against Entra External ID. Application code consumes Identity's contracts; never Entra's SDKs directly.
+- **D5** — Token validation stays in `HoneyDrunk.Auth` per Invariant 10. Auth still issues nothing.
+- **D6** — Per-application configuration shape (App Registration ID in App Configuration; tenant-issuer URL; redirect URIs; app-specific branding and user-flow customization).
+- **D7** — Migration path away from Entra is bounded by the wrapping seam and the OIDC-standards-only discipline.
+- **D8** — Free up to 50K MAU; per-MAU pricing thereafter is predictable.
+- **D9** — Alternatives evaluated: B2C (rejected — sunset); Auth0 (rejected on cost); Clerk (strong contender; held for re-evaluation if Entra DX disappoints); Supabase Auth (rejected — self-hosts credentials); self-hosted (held as eventual destination only).
+- **D10** — Out of scope: Identity Node contract surface (owned by ADR-0060), deletion fan-out workflow (owned by ADR-0060), per-app branding details, MFA enforcement policy, social-login provider enablement, tenant-scoped Entra setup details, B2B/enterprise workforce identity, API-key auth for public Grid APIs.
+
+This is a **policy / vendor-confirmation** ADR. The concrete code — the `HoneyDrunk.Identity.Providers.Entra` adapter — lands when the first consumer-app feature packet pulls on Identity (per ADR-0060 D12 Phase 2). The infrastructure provisioning — the Entra External ID tenant, the first App Registration, custom-domain wiring — lands as later packets in this initiative.
+
+This is a docs/governance-only packet. No code, no workflow, no .NET project.
+
+## Scope
+
+- `adrs/ADR-0078-end-user-identity-entra-external-id.md` — flip `**Status:** Proposed` to `**Status:** Accepted`.
+- `constitution/invariant-reservations.md` — confirm the size-2 ADR-0078 reservation row (default **93-94**); move it from Active Reservations to Reservation History with the merge date once the invariants land in `constitution/invariants.md` in this same PR.
+- `constitution/invariants.md` — add the two new invariants under a new `## End-User Identity Invariants` section placed after `## Infrastructure-as-Code Invariants` (the ADR-0077 block; assuming ADR-0077 packet 00 has merged first — if not, anchor against `## Audit Invariants`).
+- `initiatives/active-initiatives.md` — register the `adr-0078-entra-external-id` initiative with the packet checklist for this folder.
+- `initiatives/roadmap.md` — add a Q2-Q3 2026 bullet (Hearth signup is the forcing function; rollout aligns with the consumer-app PDR sequence).
+
+## Proposed Implementation
+
+### Step 1 — Flip ADR-0078 status
+
+Edit `adrs/ADR-0078-end-user-identity-entra-external-id.md`:
+- `**Status:** Proposed` → `**Status:** Accepted`
+
+The ADR README index has not been updated to include rows beyond ADR-0057 at file authoring time; no `adrs/README.md` row update is required here. (If the index has caught up by the time this packet executes, add the ADR-0078 row.)
+
+### Step 2 — Claim the invariant block
+
+Read `constitution/invariant-reservations.md`. ADR-0078's reservation row exists in the Active Reservations table with default range **93-94** (size 2). The reservation framework's "first merge wins" rule means: at edit time, confirm the row's range. If a racing ADR's packet 00 merged first and pushed ADR-0078's block upward, take the new numbers and update every `{N1}` / `{N2}` placeholder in this packet's body in lockstep with `constitution/invariants.md`. At file authoring (2026-05-24) the assignment is **{N1}=93, {N2}=94**.
+
+After the invariants land in `constitution/invariants.md` in this same PR, **move the ADR-0078 row from Active Reservations to Reservation History** with the merge date — per the reservation file's "Reservation History (for audit)" section's documented procedure.
+
+### Step 3 — Add the two new invariants to `constitution/invariants.md`
+
+Introduce a new section `## End-User Identity Invariants` placed **immediately after `## Infrastructure-as-Code Invariants`** (the section ADR-0077 packet 00 adds). If ADR-0077 packet 00 has not merged yet, anchor against `## Audit Invariants` (the section ending around invariant 49 at file authoring time). Substitute `{N1}` / `{N2}` with the actual numbers from the reservation row. Mark each entry with the `(Proposed — this invariant takes effect when ADR-0078 is accepted)` qualifier; the qualifier becomes informationally accurate once ADR-0078's Status flips to Accepted in Step 1 of this same PR.
+
+The two entries:
+
+```markdown
+## End-User Identity Invariants
+
+{N1}. **End-user identity tokens are issued by Microsoft Entra External ID.**
+    Every consumer-app user (Hearth, Lately, Currents, Curiosities, and future consumer PDRs) and every Notify Cloud tenant-operator user authenticates via a single Grid-wide Entra External ID tenant with per-application App Registrations under OAuth 2.1 with PKCE on OpenID Connect. Any other end-user IdP requires an ADR amendment. The Identity Node's `IExternalIdpClaimMapper` seam (per ADR-0060 D4) is the wrapping point; `HoneyDrunk.Identity.Providers.Entra` is the package that implements that seam against Entra. Application code consumes `HoneyDrunk.Identity`'s contracts; never `Microsoft.Identity.Web` or other Entra-specific SDKs directly. See ADR-0078 D1 / D2 (Proposed — this invariant takes effect when ADR-0078 is accepted).
+
+{N2}. **Application code consumes OIDC-standard claims only from Entra-issued tokens.**
+    The allowed claim set: `sub`, `iss`, `aud`, `exp`, `iat`, `nbf`, `email`, `email_verified`, `name`, `given_name`, `family_name`, `preferred_username`. Entra-proprietary claims (`oid`, `tid`, `idp`, `acrs`, and any other non-OIDC-standard claim) may appear in diagnostic logs but are never load-bearing in application logic — they are never branched on, never persisted as the canonical user-identity key, never used in authorization decisions. This is the cheap vendor-exit hedge: code that depends only on OIDC-standard claims migrates cleanly to any other OIDC-compliant IdP; code that depends on Entra-proprietary claims is bound to Entra specifically. The discipline at the consuming end pre-pays the migration cost if Entra's trajectory ever turns hostile (per ADR-0078 D7). See ADR-0078 D3 / D7 (Proposed — this invariant takes effect when ADR-0078 is accepted).
+```
+
+**Note on the dropped third candidate.** ADR-0078's Consequences §Invariants subsection originally proposed a third invariant ("Auth still issues nothing"). That is a restatement of existing invariant 10 ("Auth tokens are validated, never issued. HoneyDrunk.Auth validates JWT Bearer tokens. It is not an identity provider.") per ADR-0078 D5; it is not a new constitutional rule. Block size is therefore 2, not 3, and the reservation row in `invariant-reservations.md` reserves only **93-94**.
+
+### Step 4 — Register the initiative
+
+Append a new entry to `initiatives/active-initiatives.md` under `## In Progress`:
+
+```markdown
+### ADR-0078 End-User Identity — Microsoft Entra External ID
+**Status:** In Progress
+**Scope:** Architecture, Azure portal (Entra External ID tenant + App Registrations), DNS (custom-domain)
+**Initiative:** `adr-0078-entra-external-id`
+**Board:** [The Hive — org Project #4](https://github.com/orgs/HoneyDrunkStudios/projects/4)
+**Description:** Accept ADR-0078, commit Microsoft Entra External ID as the end-user IdP, claim invariant block 93-94, add the two Entra invariants (Entra IdP commitment; OIDC-standards-only claims discipline), document the per-application configuration shape, provision the Entra External ID tenant + first App Registration (Notify Cloud tenant operators + Hearth), verify-or-create the `rg-hd-platform-shared` resource group, wire the `auth.honeydrunkstudios.com` custom domain, and log the active invariant-20 exception for Entra App Registration client-secret rotation cadence.
+
+**Tracking:**
+- [ ] Architecture#NN: Accept ADR-0078, add invariants 93/94, register initiative (packet 00)
+- [ ] Architecture#NN: Catalog updates — IdP provider-slot `notes:` in contracts.json, grid-health entry for `entra-custom-domain-auth-honeydrunkstudios-com`, Identity integration-points amendment naming Entra (packet 01)
+- [ ] Architecture#NN: Document the per-application configuration shape — App Configuration keys, Vault secret naming, `IExternalIdpClaimMapper` Entra-vs-other mapping reference (packet 02)
+- [ ] Architecture#NN: Provision Entra External ID tenant + first App Registration + verify-or-create `rg-hd-platform-shared` + custom-domain prep (packet 03 — human-only)
+- [ ] Architecture#NN: Author Entra App Registration provisioning walkthrough doc (portal-based; Bicep-based provisioning queued under ADR-0077 follow-up) (packet 04)
+- [ ] Architecture#NN: Follow-up — ADR-0006 Tier-2 rotation extension proposal for Entra App Registration client secrets (packet 05 — placeholder for follow-up ADR work)
+```
+
+### Step 5 — Roadmap bullet
+
+Append to the Q2-Q3 2026 section of `initiatives/roadmap.md`:
+
+```markdown
+- [ ] **ADR-0078 End-User Identity — Microsoft Entra External ID — scoped** *(6 packets queued; packets 01/02 reference Identity context files created by ADR-0060 packet 01; packet 03 provisioning blocked on Hearth signup readiness)*
+```
+
+### Step 6 — CHANGELOG entry
+
+Append to the current dated SemVer section of `CHANGELOG.md` (per memory `feedback_no_unreleased_commits` — no `## Unreleased` block; use the existing dated section or create a new one if this commit bumps the version):
+
+> `Architecture: Accept ADR-0078 (End-User Identity — Microsoft Entra External ID). Status flipped to Accepted. Add invariants 93 (end-user identity tokens are issued by Microsoft Entra External ID — D1/D2) and 94 (application code consumes OIDC-standard claims only from Entra-issued tokens; vendor-exit hedge at the IExternalIdpClaimMapper seam — D3/D7) under a new ## End-User Identity Invariants section. Move ADR-0078 reservation from Active Reservations to Reservation History. Register adr-0078-entra-external-id initiative + Q2-Q3 2026 roadmap bullet. Two-invariant block (the third candidate "Auth still issues nothing" is a restatement of existing invariant 10 per D5, not a new invariant).`
+
+## Affected Files
+
+- `adrs/ADR-0078-end-user-identity-entra-external-id.md` (flip Status)
+- `constitution/invariant-reservations.md` (move ADR-0078 row from Active Reservations to Reservation History)
+- `constitution/invariants.md` (add two new invariants under new `## End-User Identity Invariants` section)
+- `initiatives/active-initiatives.md` (new entry)
+- `initiatives/roadmap.md` (new bullet)
+- `CHANGELOG.md` (append under current dated SemVer section)
+
+## NuGet Dependencies
+
+None. This packet touches only Markdown governance files; no .NET project is created or modified.
+
+## Boundary Check
+
+- [x] All edits in `HoneyDrunk.Architecture`. Routing rule "architecture, ADR, invariant, sector, catalog, routing → HoneyDrunk.Architecture" maps exactly.
+- [x] No code change in any other repo.
+- [x] No new cross-Node runtime dependency — IdP vendor decision is policy; the concrete adapter ships from Identity when first consumer-app pulls on it.
+- [x] Block size 2 matches reservation row range 93-94. The third candidate invariant ("Auth still issues nothing") is dropped per ADR-0078 D5 — restatement of invariant 10.
+
+## Acceptance Criteria
+
+- [ ] ADR-0078 header reads `**Status:** Accepted`
+- [ ] `constitution/invariant-reservations.md`'s ADR-0078 row is moved from Active Reservations to Reservation History with the merge date
+- [ ] `constitution/invariants.md` carries the two new End-User Identity invariants (Entra IdP commitment; OIDC-standards-only claims discipline), numbered `{N1}` / `{N2}` (default **93/94**) under a new `## End-User Identity Invariants` section, each citing ADR-0078
+- [ ] Invariant `{N1}` text states: end-user identity tokens are issued by Microsoft Entra External ID; references the single Grid-wide tenant + per-application App Registration model + OAuth 2.1 with PKCE on OIDC; cites ADR-0078 D1 / D2; carries the `(Proposed — this invariant takes effect when ADR-0078 is accepted)` qualifier
+- [ ] Invariant `{N2}` text states: application code consumes OIDC-standard claims only; lists the allowed claim set; names Entra-proprietary claims (`oid`, `tid`, `idp`, `acrs`) as diagnostic-only; cites ADR-0078 D3 / D7; carries the `(Proposed)` qualifier
+- [ ] `initiatives/active-initiatives.md` registers the `adr-0078-entra-external-id` initiative with the six-packet checklist
+- [ ] `initiatives/roadmap.md` has a new Q2-Q3 2026 bullet for the initiative
+- [ ] `CHANGELOG.md` carries an entry under the current dated SemVer section (not under `## Unreleased`)
+- [ ] No catalog schema change in this packet (catalog updates land in packet 01)
+
+## Human Prerequisites
+
+None. ADR-0078 text is already on disk; this packet flips Status and lands the constitutional restatements.
+
+## Referenced Invariants
+
+> **Invariant 10:** Auth tokens are validated, never issued. HoneyDrunk.Auth validates JWT Bearer tokens. **It is not an identity provider.** — Survives ADR-0078 intact. ADR-0078 D5 explicitly preserves this. The Entra-issued tokens and the Identity-issued internal tokens are both validated by Auth's existing JWKS-based `IJwtBearerValidator` path; no new validation primitive lands in Auth. This is why ADR-0078's third candidate invariant ("Auth still issues nothing") is dropped — it is a restatement of invariant 10, not a new rule.
+
+> **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. Before a packet is filed, it may be amended to fill in missing operational context without violating this rule. — Other packets in this initiative cite the invariant numbers this packet assigns. Pre-filing amendments to the other packets in this folder are permitted under invariant 24's carve-out if the assigned numbers shift via the reservation framework's first-merge-wins rule.
+
+## Referenced ADR Decisions
+
+**ADR-0078 D1 — Microsoft Entra External ID is the end-user IdP.** Single Grid-wide Entra External ID tenant; per-application App Registrations (one per consumer-app + one for Notify Cloud tenant operators); OAuth 2.1 with PKCE; OpenID Connect. Restated as invariant `{N1}` by this packet.
+
+**ADR-0078 D2 — Azure AD B2C is explicitly not adopted.** B2C is sunset for new tenants per Microsoft's communicated product direction; Entra External ID is the migration target.
+
+**ADR-0078 D3 — OIDC-standard claims only.** Application code consumes the standard OIDC claim set; Entra-proprietary claims (`oid`, `tid`, etc.) may be logged for diagnostics but are never load-bearing in application logic. The cheap vendor-exit hedge. Restated as invariant `{N2}` by this packet.
+
+**ADR-0078 D5 — Token validation stays in HoneyDrunk.Auth per Invariant 10.** This is why the third candidate invariant ("Auth still issues nothing") is dropped — restatement of invariant 10, not a new constitutional rule.
+
+**ADR-0078 D7 — Migration path away from Entra.** The wrapping seam from ADR-0060 D2 plus the OIDC-standards-only discipline (D3) bound the migration cost. Invariant `{N2}` codifies the discipline-side half of that hedge.
+
+## Constraints
+
+- **Acceptance precedes flip.** ADR-0078 stays Proposed until this packet's PR merges. Do not flip the ADR in any other packet.
+- **Invariant numbers come from the reservation registry.** Read `constitution/invariant-reservations.md` and confirm the ADR-0078 row's range. At file authoring time the row's range is **93-94**. If a racing ADR's packet 00 landed first and shifted the block upward, take the new numbers and update every `{N1}` / `{N2}` placeholder in this packet body together with `constitution/invariants.md`.
+- **New section, not appended to an existing one.** The two End-User Identity invariants are a new cross-cutting topic; create a `## End-User Identity Invariants` section after `## Infrastructure-as-Code Invariants` (or `## Audit Invariants` if 0077 hasn't landed yet) rather than appending to an unrelated section.
+- **Block size is exactly 2.** ADR-0078 adds two new invariants. The "Auth still issues nothing" candidate restates invariant 10 per D5 and is dropped. Do not attempt to claim a size-3 block.
+- **Move the reservation row to history.** The reservation file's documented procedure: once the invariants land in `constitution/invariants.md`, move the ADR-0078 row from Active Reservations to Reservation History with the merge date. Do not leave the row in both tables.
+
+## Labels
+
+`chore`, `tier-3`, `core`, `docs`, `identity`, `adr-0078`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Flip ADR-0078 to Accepted; confirm the size-2 invariant block in `constitution/invariant-reservations.md` (default **93-94**); add the two End-User Identity invariants to `constitution/invariants.md` under a new section; move the reservation row from Active Reservations to Reservation History; register the initiative.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Land ADR-0078 so the remaining packets in this initiative can reference its decisions as live rules, and so downstream consumer-app feature packets (Hearth signup, etc.) have a definite IdP-vendor target.
+- Feature: ADR-0078 End-User Identity — Microsoft Entra External ID rollout, Wave 1, Packet 00.
+- ADRs: ADR-0078 (primary), ADR-0060 (the parent standup ADR; this packet fills D2's deferred vendor decision), ADR-0008 (initiative/packet conventions).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** None. This is the first packet in the initiative.
+
+**Constraints:**
+
+- **Invariant 10:** Auth tokens are validated, never issued. HoneyDrunk.Auth validates JWT Bearer tokens. **It is not an identity provider.** — Survives ADR-0078 intact. This is why the "Auth still issues nothing" candidate is dropped from the constitutional restatement: invariant 10 already says it.
+- **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. Before a packet is filed, it may be amended to fill in missing operational context. — Other packets in this folder cite the assigned invariant numbers; pre-filing amendments are permitted under invariant 24's carve-out if the numbers shift.
+- Acceptance precedes flip — ADR-0078 stays Proposed until this PR merges.
+- Confirm the size-2 block from `constitution/invariant-reservations.md` at PR time; substitute `{N1}` / `{N2}` placeholders against the registry's live numbers. Defaults at scoping are 93/94.
+- Move the reservation row from Active Reservations to Reservation History with the merge date once the invariants land in `constitution/invariants.md` in the same PR.
+- Block size is exactly 2. Do not attempt to claim a size-3 block; the third candidate ("Auth still issues nothing") restates invariant 10.
+
+**Key Files:**
+- `adrs/ADR-0078-end-user-identity-entra-external-id.md`
+- `constitution/invariant-reservations.md`
+- `constitution/invariants.md`
+- `initiatives/active-initiatives.md`
+- `initiatives/roadmap.md`
+- `CHANGELOG.md`
+
+**Contracts:** None changed. This packet is governance-only.

--- a/generated/issue-packets/active/adr-0078-entra-external-id/01-architecture-entra-catalog-updates.md
+++ b/generated/issue-packets/active/adr-0078-entra-external-id/01-architecture-entra-catalog-updates.md
@@ -1,0 +1,206 @@
+---
+name: Architecture Catalog Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "core", "docs", "identity", "adr-0078", "wave-1"]
+dependencies: ["packet:00"]
+adrs: ["ADR-0078", "ADR-0060"]
+accepts: ADR-0078
+wave: 1
+initiative: adr-0078-entra-external-id
+node: honeydrunk-identity
+---
+
+# Chore: Reflect ADR-0078 Entra vendor decision in catalogs, grid-health, and Identity context files
+
+## Summary
+
+Land the catalog-side consequences of ADR-0078: name **Microsoft Entra External ID** as the concrete IdP filling `IExternalIdpClaimMapper`'s provider slot in `catalogs/contracts.json` via a node-block-level `notes:` field (using `notes:` as the field name following the existing precedent in `catalogs/grid-health.json` — do not invent a new field like `provider_slot`). Register the custom-domain auth endpoint `entra-custom-domain-auth-honeydrunkstudios-com` in `catalogs/grid-health.json` so the custom-domain provisioning (landed by packet 03) has a discoverable health surface. Amend `repos/HoneyDrunk.Identity/integration-points.md` to name Entra External ID as the wrapped IdP (the file currently says "external IdP" with no vendor; ADR-0078 makes that concrete). Amend `repos/HoneyDrunk.Identity/overview.md`'s "Design Notes" to reference the OIDC-standards-only discipline (D3) and the wrapping seam (D4). All edits are additive — no contract surface changes; the catalog records the vendor confirmation that ADR-0078 commits.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0060 D2 deferred the IdP vendor decision. ADR-0078 fills that decision. The catalogs still read as if the vendor is undecided:
+
+- `catalogs/contracts.json` `honeydrunk-identity` block describes `IExternalIdpClaimMapper` as "Provider-slot abstraction. Map external IdP claims (Entra, Clerk, etc.) to internal UserPrincipal state." That description treats Entra and Clerk as equivalent candidates. With ADR-0078 Accepted, Entra is no longer a candidate — it is the committed provider. The catalog should record that.
+- `catalogs/grid-health.json` has no entry for the custom-domain auth endpoint. Packet 03 of this initiative provisions `auth.honeydrunkstudios.com` and wires it to the Entra External ID tenant; without a grid-health row, the custom-domain health surface is not discoverable.
+- `repos/HoneyDrunk.Identity/integration-points.md` (authored by ADR-0060 packet 01) says "external IdP" without naming the vendor. The Identity context folder should reflect the Accepted vendor decision so any agent reading the Identity boundary docs sees the concrete provider.
+- `repos/HoneyDrunk.Identity/overview.md`'s "Design Notes" section does not mention the OIDC-standards-only discipline (the vendor-exit hedge) or the per-application App Registration model.
+
+This packet closes those gaps without changing the contract surface and without flipping anything to Accepted (ADR-0078's Status flip happens in packet 00).
+
+## Proposed Implementation
+
+### `catalogs/contracts.json` — add `notes:` field to `honeydrunk-identity` block
+
+The `honeydrunk-identity` block was created by ADR-0060 packet 01. Add a node-block-level `notes:` field (parallel to `node`, `node_name`, `package`, `status`, `interfaces`) recording the IdP vendor commitment. The `notes:` field name follows the existing precedent in `catalogs/grid-health.json` — do **not** invent a `provider_slot` field. The shape:
+
+```json
+{
+  "node": "honeydrunk-identity",
+  "node_name": "HoneyDrunk.Identity",
+  "package": "HoneyDrunk.Identity.Abstractions",
+  "status": "seed",
+  "notes": "IExternalIdpClaimMapper's provider slot is filled by HoneyDrunk.Identity.Providers.Entra against Microsoft Entra External ID per ADR-0078 (D1, D4). Single Grid-wide Entra External ID tenant; per-application App Registrations for each consumer app (Hearth, Lately, Currents, Curiosities) and one for Notify Cloud tenant operators; OAuth 2.1 with PKCE on OpenID Connect. OIDC-standard claims only — Entra-proprietary claims (oid, tid, idp, acrs) are diagnostic-only and never load-bearing in application logic per ADR-0078 D3 (vendor-exit hedge) and invariant 94. Token validation stays in HoneyDrunk.Auth per invariant 10; ADR-0078 D5 explicitly preserves invariant 10.",
+  "interfaces": [
+    // existing entries unchanged
+  ]
+}
+```
+
+The `interfaces` array is **not** modified — `IExternalIdpClaimMapper`'s existing entry (the "Provider-slot abstraction. Map external IdP claims (Entra, Clerk, etc.) to internal UserPrincipal state. ...") stays. The vendor confirmation is recorded at the node-block level via the new `notes:` field, not by editing the interface description. (Rationale: ADR-0060 D2's wrapping-seam architecture intentionally keeps the interface description vendor-agnostic so a future migration target — Clerk, Auth0, self-hosted — can implement the same interface; the vendor commitment is a Grid-policy fact above the interface, recorded at the node-block level.)
+
+### `catalogs/grid-health.json` — add `entra-custom-domain-auth-honeydrunkstudios-com` entry
+
+Append a new entry to `catalogs/grid-health.json` for the custom-domain auth endpoint that packet 03 of this initiative provisions. Mirror the shape of existing infrastructure-surface entries:
+
+```json
+{
+  "id": "entra-custom-domain-auth-honeydrunkstudios-com",
+  "name": "Entra External ID Custom Domain — auth.honeydrunkstudios.com",
+  "sector": "Core",
+  "signal": "Planned",
+  "version": "n/a",
+  "canary_status": "none",
+  "last_release": null,
+  "active_blockers": [
+    "Entra External ID tenant not yet provisioned (packet 03 of adr-0078-entra-external-id is human-only and blocked on Hearth signup readiness)",
+    "Cloudflare CNAME for auth.honeydrunkstudios.com not yet configured (packet 03)"
+  ],
+  "notes": "Custom domain unifies the OAuth experience under the Grid's brand per ADR-0078 D1 / 'Operational Consequences'. Wired to a single Grid-wide Entra External ID tenant with per-application App Registrations (Hearth, Lately, Currents, Curiosities, Notify Cloud tenant operators). DNS managed via Cloudflare per ADR-0029. Provisioning + wiring is human-only (Azure portal + Cloudflare portal) — packet 03 of adr-0078-entra-external-id."
+}
+```
+
+Place the entry after the existing `honeydrunk-identity` row (or at the end of the array if the array is appended-only). The custom-domain entry is a **separate health surface** from the Identity Node — the Identity Node is a library at Phase 1; the custom domain is an Azure-side resource that exists from packet 03 onward.
+
+### `repos/HoneyDrunk.Identity/integration-points.md` — name Entra as the wrapped IdP
+
+The file was authored by ADR-0060 packet 01. Locate the **Consumes** table row that names the external IdP (the row that currently reads something like "External IdP — credential store, sign-in, MFA, passkey, social login — wrapped via IExternalIdpClaimMapper"). Amend the row to name Entra External ID explicitly:
+
+```markdown
+| **Microsoft Entra External ID** (per ADR-0078) | Credential store, sign-in, MFA, passkey enrollment, social login, account lockout, suspicious-login throttling, brute-force protection, geo-IP signal, device fingerprinting — wrapped via `IExternalIdpClaimMapper` (the Entra implementation lives in `HoneyDrunk.Identity.Providers.Entra`; ships with the first consumer-app feature packet that pulls on Identity, per ADR-0060 D12 Phase 2). OIDC-standard claims only consumed in application logic per invariant 94 (Entra-proprietary `oid`, `tid`, etc., are diagnostic-only). |
+```
+
+If the file as authored does not have a dedicated "External IdP" row in the Consumes table (the integration-points template is per-Node and may render this as an Emits or design-notes entry instead), search for "external IdP" and amend the surrounding context to name Entra External ID, citing ADR-0078 D1 / D4. The amendment is additive — do not remove vendor-agnosticism from the interface-description level (that lives in contracts.json and is intentionally vendor-agnostic per the seam architecture).
+
+### `repos/HoneyDrunk.Identity/overview.md` — add Design Notes reference to OIDC-standards-only discipline
+
+The file was authored by ADR-0060 packet 01 with a "Design Notes" section covering the wrapping-seam architecture (ADR-0060 D2), user profile location (D5), and internal-token issuance discipline (D6). Append two new Design Notes entries:
+
+```markdown
+- **Microsoft Entra External ID is the committed end-user IdP** per ADR-0078 D1. Single Grid-wide tenant; per-application App Registrations for each consumer app and one for Notify Cloud tenant operators; OAuth 2.1 with PKCE on OpenID Connect. The wrapping seam (`IExternalIdpClaimMapper`) means a future migration to Clerk / Auth0 / self-hosted OpenIddict is a per-Node adapter swap, not application-code rework — see ADR-0078 D7.
+- **OIDC-standard claims only consumed in application logic** per ADR-0078 D3 and invariant 94. The allowed claim set is `sub`, `iss`, `aud`, `exp`, `iat`, `nbf`, `email`, `email_verified`, `name`, `given_name`, `family_name`, `preferred_username`. Entra-proprietary claims (`oid`, `tid`, `idp`, `acrs`) may appear in diagnostic logs but are never load-bearing in application logic — the cheap vendor-exit hedge wired at the `IExternalIdpClaimMapper` seam.
+```
+
+Do not remove or rewrite the existing Design Notes entries authored by ADR-0060 packet 01. Append only.
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the current dated SemVer section:
+
+> `Architecture: Record ADR-0078 Entra vendor confirmation in catalogs. catalogs/contracts.json honeydrunk-identity block gains a node-block-level notes: field naming Microsoft Entra External ID as the IExternalIdpClaimMapper provider slot (HoneyDrunk.Identity.Providers.Entra). catalogs/grid-health.json gains an entra-custom-domain-auth-honeydrunkstudios-com entry tracking the auth.honeydrunkstudios.com custom domain provisioning (human-only via packet 03). repos/HoneyDrunk.Identity/integration-points.md Consumes row for the external IdP amended to name Entra per ADR-0078 D1/D4. repos/HoneyDrunk.Identity/overview.md Design Notes section gains two entries — Entra vendor commitment (D1) and OIDC-standards-only claims discipline (D3/D7, invariant 94). The IExternalIdpClaimMapper interface description in contracts.json stays vendor-agnostic — the seam architecture intentionally keeps it that way; vendor commitment is recorded at the node-block level.`
+
+## Affected Files
+
+- `catalogs/contracts.json` (add `notes:` field to the `honeydrunk-identity` block)
+- `catalogs/grid-health.json` (append `entra-custom-domain-auth-honeydrunkstudios-com` entry)
+- `repos/HoneyDrunk.Identity/integration-points.md` (name Entra External ID in the Consumes table row for the external IdP)
+- `repos/HoneyDrunk.Identity/overview.md` (append two Design Notes entries)
+- `CHANGELOG.md` (entry under current dated SemVer section)
+
+## NuGet Dependencies
+
+None. Architecture is a knowledge repo — no .NET projects.
+
+## Boundary Check
+
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] No code changes; catalogs + docs only.
+- [x] `IExternalIdpClaimMapper` interface description is **not** modified — the seam architecture per ADR-0060 D2 / D4 intentionally keeps the interface vendor-agnostic. Vendor commitment is recorded at the node-block level via the new `notes:` field.
+- [x] `notes:` field follows the existing `catalogs/grid-health.json` precedent for the field name; no new field like `provider_slot` is invented.
+- [x] Identity context-file amendments are additive — no existing text is removed or rewritten.
+
+## Acceptance Criteria
+
+- [ ] `catalogs/contracts.json` `honeydrunk-identity` block has a node-block-level `notes:` field naming Microsoft Entra External ID as the `IExternalIdpClaimMapper` provider slot, referencing `HoneyDrunk.Identity.Providers.Entra` as the implementing package per ADR-0078 D1 / D4, and naming the OIDC-standards-only discipline per ADR-0078 D3 + invariant 94.
+- [ ] `catalogs/contracts.json` `honeydrunk-identity` block `interfaces` array is unchanged. `IExternalIdpClaimMapper`'s description stays vendor-agnostic per the seam architecture.
+- [ ] `catalogs/grid-health.json` has a new `entra-custom-domain-auth-honeydrunkstudios-com` entry with `signal: "Planned"`, `version: "n/a"`, `canary_status: "none"`, active-blockers naming packet 03's provisioning + Cloudflare CNAME work, and `notes:` describing the custom-domain purpose.
+- [ ] `repos/HoneyDrunk.Identity/integration-points.md` Consumes-table row for the external IdP is amended to name Microsoft Entra External ID and references ADR-0078 D1 / D4 + invariant 94. The amendment is additive — no existing rows or text are removed.
+- [ ] `repos/HoneyDrunk.Identity/overview.md` Design Notes section gains two new entries — Entra vendor commitment (ADR-0078 D1) and OIDC-standards-only claims discipline (ADR-0078 D3 / D7, invariant 94). The existing Design Notes entries authored by ADR-0060 packet 01 are unchanged.
+- [ ] `CHANGELOG.md` carries an entry under the current dated SemVer section describing all four edits (not under `## Unreleased`).
+- [ ] `adrs/ADR-0078-end-user-identity-entra-external-id.md` is **not** modified by this packet. ADR-0078's Status is whatever packet 00 set it to.
+
+## Human Prerequisites
+
+- [ ] **ADR-0060 packet 01 must be merged to `main` before this packet executes.** Packet 01 of the adr-0060-identity-standup initiative creates `repos/HoneyDrunk.Identity/integration-points.md` and `repos/HoneyDrunk.Identity/overview.md`. Without those files, this packet has no Identity context files to amend. Confirmation: `ls repos/HoneyDrunk.Identity/integration-points.md` and `ls repos/HoneyDrunk.Identity/overview.md` should both succeed before this packet's PR is authored.
+- [ ] Packet 00 of this initiative (ADR-0078 acceptance + invariants 93/94) must be merged so the invariant 94 reference in the new contracts.json `notes:` field, the integration-points amendment, and the overview.md Design Notes text are not forward-pointing into a not-yet-landed invariant.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — Reinforces why `HoneyDrunk.Identity.Abstractions` (the package containing `IExternalIdpClaimMapper`) stays vendor-agnostic at the interface level. The Entra-specific implementation lives in a separate runtime package (`HoneyDrunk.Identity.Providers.Entra`); the Abstractions package never references Entra SDKs.
+
+> **Invariant 10:** Auth tokens are validated, never issued. HoneyDrunk.Auth validates JWT Bearer tokens. **It is not an identity provider.** — Survives ADR-0078 intact. The Entra-issued tokens and the Identity-issued internal tokens are both validated by Auth's existing JWKS-based `IJwtBearerValidator` path; the catalog-level vendor commitment in this packet does not weaken invariant 10.
+
+> **Invariant 94 (Proposed — pending ADR-0078 acceptance via packet 00):** Application code consumes OIDC-standard claims only from Entra-issued tokens. The allowed claim set: `sub`, `iss`, `aud`, `exp`, `iat`, `nbf`, `email`, `email_verified`, `name`, `given_name`, `family_name`, `preferred_username`. Entra-proprietary claims (`oid`, `tid`, `idp`, `acrs`) may appear in diagnostic logs but are never load-bearing in application logic. — The cheap vendor-exit hedge codified at the `IExternalIdpClaimMapper` seam. This packet's `notes:` field text in contracts.json and the new Design Notes entries in overview.md restate this invariant inline so any agent reading the Identity context understands the discipline.
+
+## Referenced ADR Decisions
+
+**ADR-0078 D1 — Microsoft Entra External ID is the end-user IdP.** Single Grid-wide tenant; per-application App Registrations; OAuth 2.1 with PKCE; OpenID Connect. Restated in the new `notes:` field in `catalogs/contracts.json` and in the integration-points + overview amendments.
+
+**ADR-0078 D3 — OIDC-standard claims only.** Application code consumes the standard OIDC claim set; Entra-proprietary claims are diagnostic-only. The cheap vendor-exit hedge. Restated as invariant 94 (landed by packet 00) and referenced in the new contracts.json `notes:` field, the integration-points amendment, and the overview.md Design Notes.
+
+**ADR-0078 D4 — HoneyDrunk.Identity is the seam; Entra is the provider.** `HoneyDrunk.Identity.Providers.Entra` is the package that implements `IExternalIdpClaimMapper` against Entra External ID. Application code consumes Identity's contracts; never Entra's SDKs directly. The new `notes:` field names the package explicitly.
+
+**ADR-0078 D5 — Token validation stays in HoneyDrunk.Auth per Invariant 10.** Auth is unchanged. No new validation primitive lands in Auth.
+
+**ADR-0078 D7 — Migration path away from Entra.** The wrapping seam from ADR-0060 D2 plus the OIDC-standards-only discipline (D3) bound the migration cost. The catalog change in this packet does not lock the Grid into Entra at the code level; only at the policy level.
+
+**ADR-0060 D2 — Wrap external IdP, leading candidate Entra External ID.** ADR-0078 fills D2's deferred vendor decision. The wrapping-seam architecture is preserved — `IExternalIdpClaimMapper`'s interface description in contracts.json stays vendor-agnostic.
+
+**ADR-0060 D4 — Exposed contracts.** `IExternalIdpClaimMapper` is one of the six Identity Abstractions interfaces. Vendor confirmation is recorded above the interface (at the node-block level via the new `notes:` field), not inside the interface description.
+
+## Dependencies
+
+- `packet:00` — ADR-0078 acceptance must merge first so invariants 93/94 land and the catalog text can cite invariant 94 by number.
+
+## Labels
+
+`chore`, `tier-2`, `core`, `docs`, `identity`, `adr-0078`, `wave-1`
+
+## Agent Handoff
+
+**Objective:** Record ADR-0078's Entra vendor confirmation in the catalogs and the Identity context files without changing the contract surface. Add a node-block-level `notes:` field to `catalogs/contracts.json`'s `honeydrunk-identity` block naming Entra External ID + `HoneyDrunk.Identity.Providers.Entra`. Add an `entra-custom-domain-auth-honeydrunkstudios-com` entry to `catalogs/grid-health.json`. Amend `repos/HoneyDrunk.Identity/integration-points.md` to name Entra in the external-IdP Consumes-row. Amend `repos/HoneyDrunk.Identity/overview.md` to add two Design Notes entries for the Entra commitment and the OIDC-standards-only discipline.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make ADR-0078's vendor confirmation visible in the catalogs and Identity context, so any agent reading the Identity boundary sees Entra named as the committed provider while the interface description stays vendor-agnostic per the seam architecture.
+- Feature: ADR-0078 End-User Identity — Microsoft Entra External ID rollout, Wave 1, Packet 01.
+- ADRs: ADR-0078 (vendor decision), ADR-0060 (the parent standup ADR that authored the Identity context files this packet amends).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packet 00 of this initiative (acceptance + invariants 93/94).
+
+**Constraints:**
+
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — `IExternalIdpClaimMapper` lives in `HoneyDrunk.Identity.Abstractions`; the Entra-specific implementation must live in a separate runtime/provider package (`HoneyDrunk.Identity.Providers.Entra`). The catalog amendments record that boundary; do not move the vendor name into the Abstractions package's contract surface.
+- **Invariant 10:** Auth tokens are validated, never issued. — Survives ADR-0078 intact; the vendor commitment in this packet does not weaken it.
+- **Invariant 94 (pending packet 00):** Application code consumes OIDC-standard claims only from Entra-issued tokens. — Restated inline in the new `notes:` field and Design Notes entries.
+- `IExternalIdpClaimMapper`'s interface description in `contracts.json` is **not** modified. Vendor commitment is recorded at the node-block level via the new `notes:` field, not at the interface level.
+- The `notes:` field name follows the existing precedent in `catalogs/grid-health.json`. Do NOT invent a new field like `provider_slot`.
+- All Identity context-file amendments are additive. Do not remove or rewrite any existing text in `integration-points.md` or `overview.md`.
+- This packet does not flip any ADR Status. ADR-0078's Status is whatever packet 00 set it to.
+
+**Key Files:**
+- `catalogs/contracts.json` — add `notes:` field to `honeydrunk-identity` block
+- `catalogs/grid-health.json` — append `entra-custom-domain-auth-honeydrunkstudios-com` entry
+- `repos/HoneyDrunk.Identity/integration-points.md` — amend external-IdP Consumes row
+- `repos/HoneyDrunk.Identity/overview.md` — append two Design Notes entries
+- `CHANGELOG.md` — append under current dated SemVer section
+
+**Contracts:** None changed. This packet records the vendor commitment in catalog metadata only.

--- a/generated/issue-packets/active/adr-0078-entra-external-id/02-architecture-per-app-config-shape.md
+++ b/generated/issue-packets/active/adr-0078-entra-external-id/02-architecture-per-app-config-shape.md
@@ -1,0 +1,277 @@
+---
+name: Architecture Docs Update
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "core", "docs", "identity", "adr-0078", "wave-2"]
+dependencies: ["packet:00", "packet:01"]
+adrs: ["ADR-0078", "ADR-0060", "ADR-0005"]
+accepts: ADR-0078
+wave: 2
+initiative: adr-0078-entra-external-id
+node: honeydrunk-identity
+---
+
+# Chore: Document the per-application Entra configuration shape — App Configuration keys, Vault secret naming, claim-mapper reference
+
+## Summary
+
+Author the per-application Entra External ID configuration shape per ADR-0078 D6 as a reference doc that the first consumer-app feature packet (Hearth signup per PDR-0005, then Lately / Currents / Curiosities / Notify Cloud tenant operators) consumes when wiring its OAuth flow. The doc lives at `repos/HoneyDrunk.Identity/entra-configuration.md` and covers: per-application Azure App Configuration key naming (`Identity:Entra:{App}:{Key}`), per-application Vault secret naming (`entra-app-{app}-client-secret` where confidential-client flows are used), the redirect URI pattern, the tenant-issuer URL pattern, the OIDC-standard claim mapping reference for the `IExternalIdpClaimMapper` Entra implementation, and the diagnostic-vs-load-bearing distinction for Entra-proprietary claims per invariant 94.
+
+This is a doc-only packet — no code, no Bicep, no Azure provisioning. The Bicep templates land later (under ADR-0077 follow-up work once Bicep's Entra resource coverage is confirmed); the actual Azure App Configuration / Vault seeding happens in the first consumer-app feature packet that pulls on Identity. This packet writes the *shape* so those later packets have an unambiguous target.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+ADR-0078 D6 names the per-application configuration shape but does not commit specific App Configuration key names, Vault secret names, or redirect URI patterns. Without a documented shape:
+
+- The first consumer-app feature packet (Hearth signup) has to derive the App Configuration key naming from scratch, risking inconsistency with ADR-0005's `Identity:*` namespace pattern.
+- The `HoneyDrunk.Identity.Providers.Entra` package's `IExternalIdpClaimMapper` implementation has no reference for which Entra token claims map to which `UserProfile` / `ExternalSubject` fields and which Entra-proprietary claims to log diagnostically without using them in application logic (invariant 94).
+- The OIDC-standard-claims-only discipline (D3 / invariant 94) is a rule without a positive example — agents may accidentally consume `oid` or `tid` if there's no concrete "use these, log these but don't branch on these" reference.
+
+This packet writes that reference doc. It is the architectural contract every consumer-app feature packet's Entra wiring will read.
+
+## Proposed Implementation
+
+### `repos/HoneyDrunk.Identity/entra-configuration.md` — new reference doc
+
+Create a new file in the Identity context folder. The file is a reference doc consumed by feature packets, not by runtime code. Structure:
+
+```markdown
+# Microsoft Entra External ID — Per-Application Configuration Shape
+
+**ADR:** [ADR-0078](../../adrs/ADR-0078-end-user-identity-entra-external-id.md) (Accepted)
+**Companion ADR:** [ADR-0060](../../adrs/ADR-0060-stand-up-honeydrunk-identity-node.md) (the Identity Node standup)
+**Audience:** Consumer-app feature packets (Hearth signup, Lately signup, Currents signup, Curiosities signup, Notify Cloud tenant-operator sign-in) wiring their first OAuth flow against the Grid's Entra tenant.
+
+## Tenant Topology (Reminder)
+
+- **One** Grid-wide Entra External ID tenant. Tenant identifier finalized at provisioning (packet 03 of adr-0078-entra-external-id).
+- **One App Registration per consumer-app** (Hearth, Lately, Currents, Curiosities) **plus one** for Notify Cloud tenant operators.
+- Each App Registration has its own client ID, redirect URIs, branding, and (if confidential-client) its own client secret.
+- All App Registrations share the same tenant-issuer URL (the Grid tenant's `https://{tenant-id}.ciamlogin.com/{tenant-id}/v2.0` endpoint).
+- Custom domain: `auth.honeydrunkstudios.com` is wired to the tenant per ADR-0078 D1 / "Operational Consequences"; consumer-app OAuth flows redirect through the custom domain, not the raw `*.ciamlogin.com` URL.
+
+## App Configuration Keys (Non-Secret)
+
+Per ADR-0005 (Configuration and Secrets Strategy), non-secret per-application config lives in Azure App Configuration under the `Identity:*` namespace. Per-application keys follow this shape:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `Identity:Entra:TenantId` | string (GUID) | The Grid-wide Entra External ID tenant ID. Shared across all consumer apps. |
+| `Identity:Entra:TenantIssuerUrl` | string (URL) | The OIDC issuer URL for the Grid tenant. Shared across all consumer apps. |
+| `Identity:Entra:CustomDomain` | string (FQDN) | `auth.honeydrunkstudios.com`. Shared. |
+| `Identity:Entra:{App}:ClientId` | string (GUID) | The App Registration's client ID. Per-application (one per consumer app). |
+| `Identity:Entra:{App}:RedirectUri` | string (URL) | The OAuth callback URL for this app. Per-application. |
+| `Identity:Entra:{App}:Scopes` | string (CSV) | The OIDC scopes this app requests. Default: `openid,profile,email`. |
+| `Identity:Entra:{App}:SignUpSignInPolicy` | string | The Entra user-flow name for sign-up + sign-in. Per-application. |
+| `Identity:Entra:{App}:PasswordResetPolicy` | string | The Entra user-flow name for password reset. Per-application. |
+
+`{App}` is the lowercase consumer-app short name: `hearth`, `lately`, `currents`, `curiosities`, `notify-cloud`. Example concrete key: `Identity:Entra:Hearth:ClientId`.
+
+## Vault Secret Names (Confidential-Client Flows Only)
+
+Per [ADR-0005](../../adrs/ADR-0005-configuration-and-secrets-strategy.md), per-application secrets live in `kv-hd-identity-{env}` (Identity's per-Node Key Vault per invariant 17). Per-application client-secret names follow this shape:
+
+| Secret Name | Description |
+|-------------|-------------|
+| `entra-app-{app}-client-secret` | Entra App Registration's client secret. **Only present for confidential-client flows.** Public-client flows (browser-based OAuth 2.1 with PKCE — the default for consumer apps) do not have a client secret and have no entry here. |
+
+`{app}` is the same lowercase consumer-app short name as the App Configuration keys. Example: `entra-app-hearth-client-secret`.
+
+## Redirect URI Pattern
+
+Each consumer app's redirect URI follows this pattern:
+
+```
+https://{app}.honeydrunkstudios.com/auth/callback
+```
+
+Examples (concrete redirect URIs are committed at consumer-app provisioning time; this is the pattern):
+
+- `https://hearth.honeydrunkstudios.com/auth/callback`
+- `https://lately.honeydrunkstudios.com/auth/callback`
+- `https://currents.honeydrunkstudios.com/auth/callback`
+- `https://curiosities.honeydrunkstudios.com/auth/callback`
+- `https://notify-cloud.honeydrunkstudios.com/auth/callback`
+
+For local dev: each consumer app may register a `https://localhost:{port}/auth/callback` URI on its App Registration. The dev redirect URI is registered in addition to the production one.
+
+## OIDC Claim Mapping (Reference for `IExternalIdpClaimMapper` Entra implementation)
+
+The Entra implementation of `IExternalIdpClaimMapper` (the package `HoneyDrunk.Identity.Providers.Entra`) maps the OIDC-standard claims from Entra-issued tokens to internal Identity types. **OIDC-standard claims only are load-bearing in application logic per ADR-0078 D3 and invariant 94.** Entra-proprietary claims are logged diagnostically and never branched on.
+
+### Load-Bearing OIDC-Standard Claims
+
+| Claim | Maps to | Notes |
+|-------|---------|-------|
+| `sub` | `ExternalSubject.Subject` | The IdP subject identifier. Resolved via `IUserDirectory` to `UserId`. |
+| `iss` | `ExternalSubject.Issuer` | The IdP issuer URL. Stored alongside `sub` so two `sub: abc123` from different issuers are distinguishable. |
+| `aud` | (validation only — not stored) | The audience claim. Validated against the App Registration's client ID by `HoneyDrunk.Auth.IJwtBearerValidator` per ADR-0078 D5 and invariant 10. |
+| `exp`, `iat`, `nbf` | (validation only — not stored) | Token lifetime claims. Validated by `HoneyDrunk.Auth.IJwtBearerValidator`. |
+| `email` | `UserProfile.Email` (canonical) | The user's primary email address. Required for `IIdentityDeletionFanout` user-level GDPR Art. 17 lookups. |
+| `email_verified` | `UserRecord.EmailVerified` | Whether Entra has verified the email. Drives the `UserLifecycleStatus` transition from `PendingVerification` to `Active`. |
+| `name` | `UserProfile.DisplayName` (initial value) | Display name; user can edit in-app after signup. |
+| `given_name`, `family_name` | (informational — not stored as canonical) | Available but `UserProfile.DisplayName` is the canonical name field. |
+| `preferred_username` | `UserProfile.PreferredUsername` | Display-name candidate. Per ADR-0060 D5 the profile is mutable post-signup. |
+
+### Diagnostic-Only Entra-Proprietary Claims
+
+Per invariant 94, these claims are logged in diagnostic-tier logs (per ADR-0049 data classification, these are PII / `Sensitive` and never leave the audit boundary) but are **never branched on in application logic**:
+
+| Claim | Why it's diagnostic-only |
+|-------|--------------------------|
+| `oid` | Entra's own object ID for the user. Locks application code to Entra; the canonical user-identity key is `UserId`, resolved from `sub`. |
+| `tid` | Entra tenant ID. The Grid uses a single Entra tenant — `tid` is always the Grid tenant. Logging is fine; branching on `tid` is forbidden. |
+| `idp` | The upstream IdP for federated sign-in (e.g., `google.com` when the user signed in with Google). Useful for support diagnostics; never used in authorization decisions. |
+| `acrs`, `acr` | Authentication context references. Entra-specific format; the Grid does not consume these in policy decisions. MFA enforcement, if added, uses Entra's user-flow policy enforcement, not claim inspection. |
+| Any other non-OIDC-standard claim | Diagnostic-only by default per invariant 94. |
+
+**Code-level enforcement:** the Entra implementation of `IExternalIdpClaimMapper` extracts only the load-bearing OIDC-standard claims into the returned mapping. Diagnostic claims may be passed to `ITraceEnricher` for inclusion in OpenTelemetry spans (subject to ADR-0049 PII-handling rules) but must not appear in the mapper's returned `UserPrincipal` / `UserProfile` shape.
+
+## Vendor-Exit Hedge in Practice
+
+The OIDC-standards-only discipline (D3 / invariant 94) is the cheap vendor-exit hedge. Concretely:
+
+- A future migration to **Clerk** would replace `HoneyDrunk.Identity.Providers.Entra` with `HoneyDrunk.Identity.Providers.Clerk`. The new provider implements the same `IExternalIdpClaimMapper`. Since application code consumes only OIDC-standard claims (which Clerk also emits per the OIDC spec), no application-code rework is needed.
+- A future migration to **self-hosted OpenIddict** would replace the provider package with `HoneyDrunk.Identity.Providers.OpenIddict`. Same `IExternalIdpClaimMapper` contract; same OIDC-standard claims.
+- The migration cost is bounded to: (a) re-keying user credentials (users authenticate against the new IdP at next login); (b) swapping the provider package; (c) updating the App Configuration `Identity:Entra:*` keys to the new provider's equivalents.
+
+The user record (`UserRecord`, `UserProfile`, `IdentityMap`) and the application code stay intact — see ADR-0078 D7.
+
+## What This Doc Does NOT Cover
+
+- **Bicep provisioning templates for Entra App Registrations.** Queued under ADR-0077 follow-up work once Bicep's Entra resource coverage is confirmed. Until then, App Registration provisioning is portal-based (see packet 04 of this initiative for the walkthrough).
+- **The first concrete OAuth flow implementation.** That ships with the first consumer-app feature packet — Hearth signup per PDR-0005 Phase 2.
+- **MFA enforcement policy.** Per ADR-0078 D10, MFA defaults to "optional, user-enrollable" at v1. Per-app policy hardens later.
+- **Social-login provider enablement.** Per ADR-0078 D10, default is "email-only" at v1. Per-app may add Google / Apple / GitHub later.
+- **Tenant-scoped Entra setup for Notify Cloud organizational sign-in.** Notify Cloud-side concern; see ADR-0027 follow-up.
+- **Client-secret rotation cadence.** Tier-2 ≤ 90 days per invariant 20. Operational burden documented as a Constraint on packet 03 of this initiative. The ADR-0006 Tier-2 rotation extension proposal (allowing longer secret lifetimes with documented exception) is packet 05 of this initiative.
+```
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the current dated SemVer section:
+
+> `Architecture: Author repos/HoneyDrunk.Identity/entra-configuration.md — per-application Entra External ID configuration shape per ADR-0078 D6. Documents the Azure App Configuration key namespace (Identity:Entra:{App}:{Key}), Vault secret naming (entra-app-{app}-client-secret in kv-hd-identity-{env} per invariant 17 and ADR-0005), redirect URI pattern (https://{app}.honeydrunkstudios.com/auth/callback), OIDC-standard claim mapping reference for the IExternalIdpClaimMapper Entra implementation, and the diagnostic-only-vs-load-bearing distinction for Entra-proprietary claims per invariant 94. Doc-only — no code, no Bicep, no Azure provisioning.`
+
+## Affected Files
+
+- `repos/HoneyDrunk.Identity/entra-configuration.md` (new)
+- `CHANGELOG.md` (append under current dated SemVer section)
+
+## NuGet Dependencies
+
+None. Architecture is a knowledge repo.
+
+## Boundary Check
+
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] No code changes, no Bicep changes, no Azure provisioning.
+- [x] No contract surface changes — the doc references existing contracts (`IExternalIdpClaimMapper`, `UserRecord`, `UserProfile`, `ExternalSubject`, `IUserDirectory`, `IIdentityDeletionFanout`) from ADR-0060 D4 without adding new ones.
+- [x] App Configuration namespace (`Identity:*`) follows ADR-0005 D3 (per-Node configuration namespaces).
+- [x] Vault secret naming (`kv-hd-identity-{env}` + `entra-app-{app}-client-secret`) follows ADR-0005 D1 (per-Node per-environment Key Vault) and invariant 17.
+
+## Acceptance Criteria
+
+- [ ] `repos/HoneyDrunk.Identity/entra-configuration.md` exists and is structured as described above.
+- [ ] App Configuration key namespace is `Identity:Entra:{App}:{Key}` — never an Entra-proprietary or top-level namespace.
+- [ ] Vault secret name pattern is `entra-app-{app}-client-secret` and explicitly notes that public-client flows (browser-based OAuth 2.1 with PKCE) do not have a client secret.
+- [ ] Redirect URI pattern is `https://{app}.honeydrunkstudios.com/auth/callback` and lists concrete examples for the five consumer-app surfaces (Hearth, Lately, Currents, Curiosities, Notify Cloud).
+- [ ] OIDC claim mapping table lists `sub`, `iss`, `aud`, `exp`, `iat`, `nbf`, `email`, `email_verified`, `name`, `given_name`, `family_name`, `preferred_username` and shows what each maps to inside the Identity contracts.
+- [ ] Diagnostic-only-claims table lists `oid`, `tid`, `idp`, `acrs`, `acr` and explicitly states they are never load-bearing in application logic per invariant 94.
+- [ ] Vendor-exit-hedge section walks through a Clerk migration and a self-hosted OpenIddict migration as concrete examples.
+- [ ] "What This Doc Does NOT Cover" section explicitly defers Bicep provisioning, the first concrete OAuth flow implementation, MFA enforcement policy, social-login enablement, tenant-scoped Entra setup, and client-secret rotation cadence to other packets or future work.
+- [ ] `CHANGELOG.md` carries an entry under the current dated SemVer section.
+- [ ] No code changes, no Bicep changes, no Azure provisioning in this packet.
+
+## Human Prerequisites
+
+- [ ] **ADR-0060 packet 01 must be merged to `main` before this packet executes.** Packet 01 of the adr-0060-identity-standup initiative creates the `repos/HoneyDrunk.Identity/` folder this packet adds a new file to. Confirmation: `ls repos/HoneyDrunk.Identity/` should succeed.
+- [ ] Packet 00 of this initiative (ADR-0078 acceptance + invariants 93/94) must be merged so the doc's references to invariant 94 by number are not forward-pointing.
+- [ ] Packet 01 of this initiative (catalog updates) must be merged so the contracts.json `notes:` field and the Identity context-file amendments referencing Entra are in place — the doc this packet writes cross-links to those.
+
+## Referenced Invariants
+
+> **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. Only `Microsoft.Extensions.*` abstractions are permitted. — `HoneyDrunk.Identity.Abstractions` (containing `IExternalIdpClaimMapper`) stays vendor-agnostic. The Entra-specific implementation lives in `HoneyDrunk.Identity.Providers.Entra` per ADR-0078 D4. This doc records that boundary at the configuration shape level.
+
+> **Invariant 9:** Vault is the only source of secrets. No Node reads secrets directly from environment variables, config files, or provider SDKs. — Client secrets for confidential-client App Registrations live in `kv-hd-identity-{env}` and resolve through `ISecretStore`. This doc documents the secret naming pattern.
+
+> **Invariant 10:** Auth tokens are validated, never issued. HoneyDrunk.Auth validates JWT Bearer tokens. **It is not an identity provider.** — Entra-issued tokens are validated by `HoneyDrunk.Auth.IJwtBearerValidator` against Entra's JWKS. The doc records that the `aud`, `exp`, `iat`, `nbf` claims are validation-only and not stored.
+
+> **Invariant 17:** One Key Vault per deployable Node per environment, named `kv-hd-{service}-{env}`. — The doc names `kv-hd-identity-{env}` as the home for Entra App Registration client secrets.
+
+> **Invariant 18:** Vault URIs and App Configuration endpoints reach Nodes via environment variables. — The doc references the App Configuration namespace `Identity:Entra:*`; the App Configuration endpoint itself reaches Identity via `AZURE_APPCONFIG_ENDPOINT` per ADR-0005.
+
+> **Invariant 21:** Applications must never pin to a specific secret version. — Client secrets in the Vault are read latest-version through `ISecretStore`; no version pinning.
+
+> **Invariant 94 (Proposed — pending ADR-0078 acceptance via packet 00):** Application code consumes OIDC-standard claims only from Entra-issued tokens. — The doc's claim-mapping table is the positive enforcement: only OIDC-standard claims are mapped into application-visible Identity types; Entra-proprietary claims are diagnostic-only.
+
+## Referenced ADR Decisions
+
+**ADR-0078 D1 — Microsoft Entra External ID is the end-user IdP.** Single Grid-wide tenant; per-application App Registrations; OAuth 2.1 with PKCE on OpenID Connect.
+
+**ADR-0078 D3 — OIDC-standard claims only.** Restated as invariant 94. This doc's claim-mapping table is the operational reference.
+
+**ADR-0078 D4 — `HoneyDrunk.Identity` is the seam; Entra is the provider.** `HoneyDrunk.Identity.Providers.Entra` is the package that implements `IExternalIdpClaimMapper` against Entra External ID.
+
+**ADR-0078 D5 — Token validation stays in `HoneyDrunk.Auth` per Invariant 10.** The doc's claim-mapping table records that `aud`, `exp`, `iat`, `nbf` are validation-only (not stored in the mapping result).
+
+**ADR-0078 D6 — Per-application configuration shape.** App Registration ID in App Configuration; tenant-issuer URL; redirect URIs; app-specific branding. This doc commits the specific key names, secret names, and redirect URI patterns.
+
+**ADR-0078 D7 — Migration path away from Entra.** The wrapping seam from ADR-0060 D2 plus the OIDC-standards-only discipline (D3) bound the migration cost. The doc's "Vendor-Exit Hedge in Practice" section walks through concrete migration shapes (Clerk, OpenIddict).
+
+**ADR-0005 D1 — Per-Node per-environment Key Vault.** `kv-hd-identity-{env}` is Identity's Vault.
+
+**ADR-0005 D3 — Per-Node App Configuration namespace.** `Identity:*` is Identity's namespace; `Identity:Entra:*` is the Entra-vendor-specific subspace.
+
+**ADR-0060 D2 — Wrap external IdP.** The vendor-agnostic interface (`IExternalIdpClaimMapper`) stays vendor-agnostic; vendor commitment is at the configuration / package-binding level.
+
+**ADR-0060 D4 — Exposed contracts.** `IExternalIdpClaimMapper`, `UserRecord`, `UserProfile`, `ExternalSubject`, `IUserDirectory`, `IIdentityDeletionFanout` are referenced by this doc but not modified.
+
+## Dependencies
+
+- `packet:00` — ADR-0078 acceptance + invariants 93/94. This doc references invariant 94 by number.
+- `packet:01` — Catalog updates. This doc cross-links to the Identity context-file amendments and the `notes:` field text in `contracts.json`.
+
+## Labels
+
+`chore`, `tier-2`, `core`, `docs`, `identity`, `adr-0078`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author `repos/HoneyDrunk.Identity/entra-configuration.md` — the per-application Entra External ID configuration shape per ADR-0078 D6. The doc is the architectural contract every consumer-app feature packet's Entra wiring reads when implementing its OAuth flow.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Commit the concrete configuration shape so consumer-app feature packets (Hearth signup first) do not re-derive the App Configuration key naming, Vault secret naming, redirect URI pattern, or claim-mapping behavior from scratch.
+- Feature: ADR-0078 End-User Identity rollout, Wave 2, Packet 02.
+- ADRs: ADR-0078 D1 / D3 / D4 / D5 / D6 / D7 (the vendor decision and discipline), ADR-0060 D2 / D4 (the seam architecture and exposed contracts), ADR-0005 D1 / D3 (Vault + App Configuration shape).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packets 00 and 01 of this initiative.
+
+**Constraints:**
+
+- **Invariant 1:** Abstractions packages have zero runtime dependencies on other HoneyDrunk packages. — `IExternalIdpClaimMapper` lives in `HoneyDrunk.Identity.Abstractions`; the Entra implementation is in `HoneyDrunk.Identity.Providers.Entra`. The doc records that split at the package binding level.
+- **Invariant 9:** Vault is the only source of secrets. — Client secrets live in `kv-hd-identity-{env}` only; never in env vars or config files.
+- **Invariant 10:** Auth tokens are validated, never issued. — The doc records that `aud`, `exp`, `iat`, `nbf` claims are validation-only and not part of the mapping result.
+- **Invariant 17:** One Key Vault per deployable Node per environment, named `kv-hd-{service}-{env}`. — Identity's Vault is `kv-hd-identity-{env}`.
+- **Invariant 21:** Applications must never pin to a specific secret version. — Secret reads through `ISecretStore` resolve latest-version automatically.
+- **Invariant 94:** Application code consumes OIDC-standard claims only from Entra-issued tokens. — The doc's claim-mapping table is the positive enforcement reference.
+- The doc must not invent new contracts. It references existing Identity contracts from ADR-0060 D4 (`IExternalIdpClaimMapper`, `UserRecord`, `UserProfile`, `ExternalSubject`, `IUserDirectory`, `IIdentityDeletionFanout`) without adding new ones.
+- The doc must not include Bicep templates or Azure provisioning steps. Those are out of scope (see "What This Doc Does NOT Cover" section).
+- App Configuration key namespace must be `Identity:Entra:{App}:{Key}` — never Entra-proprietary or top-level.
+- Vault secret naming pattern: `entra-app-{app}-client-secret` in `kv-hd-identity-{env}`.
+- Redirect URI pattern: `https://{app}.honeydrunkstudios.com/auth/callback`.
+
+**Key Files:**
+- `repos/HoneyDrunk.Identity/entra-configuration.md` — new
+- `CHANGELOG.md` — append under current dated SemVer section
+
+**Contracts:** None changed. The doc references existing contracts; it does not author new ones.

--- a/generated/issue-packets/active/adr-0078-entra-external-id/03-architecture-provision-entra-tenant.md
+++ b/generated/issue-packets/active/adr-0078-entra-external-id/03-architecture-provision-entra-tenant.md
@@ -1,0 +1,322 @@
+---
+name: Infrastructure Provisioning
+type: chore
+tier: 1
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-1", "core", "infra", "identity", "adr-0078", "human-only", "wave-2"]
+dependencies: ["packet:00", "packet:01", "packet:02"]
+adrs: ["ADR-0078", "ADR-0006", "ADR-0005", "ADR-0029"]
+accepts: ADR-0078
+wave: 2
+initiative: adr-0078-entra-external-id
+node: honeydrunk-identity
+---
+
+# Chore: Provision Entra External ID tenant + first App Registration + verify/create `rg-hd-platform-shared` + custom-domain prep (human-only)
+
+## Summary
+
+Provision the Grid's single Entra External ID tenant per ADR-0078 D1, create the first App Registration (Notify Cloud tenant operators by default, or Hearth if Hearth signup is ready first), verify-or-create the `rg-hd-platform-shared` resource group (the home for Grid-wide shared resources that are not per-Node), wire the custom domain `auth.honeydrunkstudios.com` per ADR-0078 D1 "Operational Consequences" + ADR-0029 (Cloudflare DNS), and **log the active invariant-20 exception** for Entra App Registration client-secret rotation cadence (Entra defaults to 24-month secret expiration, which exceeds invariant 20's Tier-2 ≤ 90-day SLA; the exception is logged in Log Analytics per invariant 20's documented exception clause until the ADR-0006 Tier-2 rotation extension (packet 05 of this initiative) lands).
+
+This is **`Actor=Human`** — every step is portal-based (Azure portal + Cloudflare portal + Microsoft Graph API for tenant creation). No agent can execute portal clicks for the Entra tenant creation, the App Registration setup, the resource-group creation, the custom-domain wiring, or the Cloudflare CNAME record. Frontmatter sets `labels: ["human-only", ...]` per the user's source-of-truth convention.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Architecture` (this is where the tracking issue lives; the actual work happens in the Azure portal + Cloudflare portal + Log Analytics)
+
+## Actor
+
+**`Human`.** Tenant creation, App Registration creation, resource-group creation, custom-domain DNS wiring, and the invariant-20 exception log entry all require portal access. Frontmatter sets `labels: ["human-only", ...]` which is the source-of-truth per the user's convention (the visual `Actor` pill on The Hive defaults to `Agent` unless the `human-only` label is present).
+
+## Motivation
+
+ADR-0078 names Entra External ID as the committed end-user IdP. The infrastructure does not exist yet:
+
+- **No Grid-wide Entra External ID tenant exists.** Microsoft Entra workforce tenants (the standard developer-tenant for HoneyDrunkStudios.com) are separate from External ID tenants. A new External ID tenant must be provisioned via the Azure portal.
+- **No App Registrations exist under the (non-existent) Entra External ID tenant.** The first App Registration commits the tenant to specific consumer apps. Default ordering: Notify Cloud tenant operators first (the operator surface is needed before Hearth ships), or Hearth if Hearth signup is the imminent forcing function — the human decides at provisioning time.
+- **`rg-hd-platform-shared` may or may not exist.** Per memory `feedback_lean_azure_tags` the Grid uses a `purpose=platform-shared` tag for Grid-wide shared resources. The resource group's *existence* should be verified; if absent, create it (per memory `feedback_provision_when_needed` — provision when first needed, do not pre-create). Entra External ID tenants are subscription-bound resources; the tenant lives in this resource group.
+- **The custom domain `auth.honeydrunkstudios.com` is not yet wired.** Per ADR-0078 D1's "Operational Consequences" the custom domain unifies the OAuth experience under the Grid's brand. Wiring requires a Cloudflare CNAME record per ADR-0029 (Cloudflare DNS) plus an Entra-side custom-domain claim.
+- **Invariant 20 exception for the App Registration client secret has not been logged.** Entra App Registration client secrets default to 24-month expiration. Invariant 20 requires Tier-2 (third-party via rotation Function) secrets to rotate ≤ 90 days unless an active exception is logged in Log Analytics. The 90-day rotation cycle is operationally expensive (manual portal step every quarter); the right posture per invariant 20 is to log the exception now, document the operational burden, and resolve via ADR-0006 Tier-2 rotation extension (packet 05 of this initiative) — Option (b) per the scoping refinement.
+
+## Steps
+
+### Step 1 — Verify or create `rg-hd-platform-shared` resource group
+
+Per the user's lean-tag convention (memory `feedback_lean_azure_tags`), the Grid uses a `purpose=platform-shared` tag for resources that are Grid-wide rather than per-Node. The Entra External ID tenant is Grid-wide — there is one tenant for the whole Grid per ADR-0078 D1. The tenant lives in a shared resource group.
+
+1. Open https://portal.azure.com → Resource groups
+2. Search for `rg-hd-platform-shared`.
+3. **If it exists:** verify tags include `env=prod`, `purpose=platform-shared`. If missing, add via the resource group's Tags blade.
+4. **If it does NOT exist:** click **+ Create**.
+   - **Subscription:** the Grid's main subscription (the user's known production subscription; not the per-Node subscriptions per the user's Azure decisions in memory `project_azure_decisions`).
+   - **Resource group:** `rg-hd-platform-shared`
+   - **Region:** Azure US East 2 (per memory `project_azure_decisions` and ADR-0049's data-residency invariant for Restricted data; Entra External ID tenants are global by nature but the resource-group home should match the Grid's standard region).
+   - **Tags:** `env=prod`, `purpose=platform-shared`
+   - Click **Review + create**, then **Create**.
+   - Cost: $0 (resource groups themselves are free).
+
+**Rationale (cross-link to `infrastructure/walkthroughs/azure-provisioning-guide.md` if it exists; otherwise inline):** Per-Node resources live in `rg-hd-{service}-{env}` (e.g., `rg-hd-identity-prod`). Grid-wide shared resources — the Entra External ID tenant, the App Configuration store, the shared ACR — live in `rg-hd-platform-shared`. The Entra tenant is Grid-wide (one tenant for every consumer app + Notify Cloud tenant operators per ADR-0078 D1), so it belongs in the shared resource group.
+
+### Step 2 — Create the Entra External ID tenant
+
+1. Open https://portal.azure.com → search for **"Microsoft Entra External ID"** (not "Entra ID" alone — that is the workforce tenant) → **+ Create tenant**.
+2. **Tenant type:** **External** (the consumer/CIAM variant; **not** the workforce variant).
+3. **Configuration:**
+   - **Organization name:** `HoneyDrunk Studios`
+   - **Initial domain name:** `honeydrunkstudios.onmicrosoft.com` (Azure-assigned default; can be customized per Microsoft's tenant-naming rules — the custom domain `auth.honeydrunkstudios.com` is configured in Step 5 below, not here).
+   - **Region:** Azure US East 2 (matches the Grid's standard region per memory `project_azure_decisions`).
+   - **Subscription:** the Grid's main subscription.
+   - **Resource group:** `rg-hd-platform-shared` (from Step 1).
+4. Click **Review + create**, then **Create**.
+5. Wait for provisioning (~5-10 minutes).
+6. Once created, **record the tenant ID** (a GUID) and the tenant's OIDC issuer URL — these go into App Configuration as `Identity:Entra:TenantId` and `Identity:Entra:TenantIssuerUrl` per the schema documented in packet 02 of this initiative.
+7. Tag the tenant with `env=prod`, `purpose=platform-shared`.
+
+**Cost check (per memory `feedback_default_cheapest_azure_tier`):** Entra External ID is **free up to 50K MAU** per ADR-0078 D8. The Grid's MAU trajectory through Hearth + Lately + Currents + Curiosities + Notify Cloud tenants at low-hundreds is well below 50K. Expected monthly cost: **$0**.
+
+### Step 3 — Create the first App Registration
+
+The first App Registration commits the tenant to a specific consumer-app surface. Choose **one** of:
+
+- **Notify Cloud tenant operators** (`notify-cloud` App Registration) — recommended default if Hearth signup is not yet imminent. Provides a working OAuth flow for the operator surface immediately and exercises the tenant.
+- **Hearth signup** (`hearth` App Registration) — choose this if Hearth signup is the next consumer-app feature packet to land.
+
+Either way:
+
+1. Inside the new Entra External ID tenant: **App registrations → + New registration**.
+2. **Name:** `HoneyDrunk Notify Cloud` (or `HoneyDrunk Hearth`) — human-friendly.
+3. **Supported account types:** Accounts in this organizational directory only (Single tenant — the new External ID tenant).
+4. **Redirect URI:** Platform **Single-page application (SPA)** for public-client PKCE flows, or **Web** for confidential-client flows. URI value per the redirect URI pattern from packet 02's doc: `https://notify-cloud.honeydrunkstudios.com/auth/callback` (or `https://hearth.honeydrunkstudios.com/auth/callback`).
+5. Click **Register**.
+6. **Record the Application (client) ID** — this is the `Identity:Entra:{App}:ClientId` value in App Configuration.
+7. If the flow is confidential-client:
+   - Inside the App Registration: **Certificates & secrets → + New client secret**.
+   - **Description:** `Initial client secret — ADR-0078 packet 03`.
+   - **Expires:** **180 days** (Microsoft's portal default — the minimum is 24 hours, maximum is 24 months; the practical choice given invariant 20 is 90 days). **NOTE: this is the invariant-20 exception trigger — see Step 7 below.**
+   - Click **Add**.
+   - **Copy the secret value immediately** (the portal shows it only once).
+   - Store the secret in `kv-hd-identity-prod` under the secret name `entra-app-notify-cloud-client-secret` (or `entra-app-hearth-client-secret`) per the naming convention in packet 02's doc. Use the Azure portal's Key Vault → Secrets → + Generate/Import flow.
+8. Configure **token configuration**:
+   - **+ Add optional claim** for **ID tokens**: `email`, `family_name`, `given_name`, `preferred_username` (the OIDC-standard claims per invariant 94 / packet 02's mapping table).
+   - Do **not** add Entra-proprietary claims (`oid`, `tid`, etc.) — they're auto-included by Entra; explicitly not configured here.
+9. Configure **API permissions**:
+   - Default: **Microsoft Graph → openid, profile, email** (the OIDC-standard scopes).
+   - Grant admin consent for these scopes.
+
+### Step 4 — Configure the sign-up + sign-in user flow
+
+1. Inside the Entra External ID tenant: **User flows → + New user flow**.
+2. **Type:** Sign-up and sign-in.
+3. **Name:** `b2c_susi_default` (Entra retains the b2c_* prefix in External ID user-flow names for historical compatibility).
+4. **Identity providers:** Email with password (default at v1 per ADR-0078 D10 — social-login providers added per-app at later packets).
+5. **User attributes and token claims:**
+   - **Collect from user during signup:** Email Address, Display Name, Country/Region (per Hearth + Notify Cloud needs).
+   - **Return in token:** Email Addresses, Display Name (only — OIDC-standard claims per invariant 94).
+6. Click **Create**.
+7. Record the user-flow name for the `Identity:Entra:{App}:SignUpSignInPolicy` App Configuration key.
+8. Create a similar **Password reset** flow (`b2c_pwd_reset_default`) — same pattern, type "Password reset".
+
+### Step 5 — Custom domain `auth.honeydrunkstudios.com` (Entra side + Cloudflare side)
+
+Per ADR-0078 D1's "Operational Consequences" and ADR-0029 (Cloudflare DNS).
+
+**Entra side:**
+
+1. Inside the Entra External ID tenant: **Company branding → Custom URL domains → + Custom URL domain**.
+2. **Custom URL domain:** `auth.honeydrunkstudios.com`.
+3. Entra shows the CNAME target the new custom domain should resolve to (a `*.ciamlogin.com` or similar Microsoft-managed hostname). **Record this CNAME target.**
+
+**Cloudflare side (per ADR-0029):**
+
+1. Open https://dash.cloudflare.com → `honeydrunkstudios.com` zone → **DNS → Records → + Add record**.
+2. **Type:** CNAME.
+3. **Name:** `auth`.
+4. **Target:** the CNAME target Entra showed in the previous step.
+5. **Proxy status:** **DNS only** (orange cloud off — Entra needs direct CNAME resolution for the domain-verification flow; the proxy can be re-enabled later if cache/perf reasons emerge, but ADR-0029's stance defaults to DNS-only for IdP-bound names).
+6. **TTL:** Auto.
+7. Click **Save**.
+
+**Back in Entra side:**
+
+1. Return to **Company branding → Custom URL domains** and click **Verify** on the `auth.honeydrunkstudios.com` entry.
+2. Wait for DNS propagation (typically 1-5 minutes; can be up to an hour).
+3. Once verified, Entra shows the domain as **Active**.
+
+### Step 6 — Seed the App Configuration keys (manual; Bicep-deferred)
+
+Per packet 02's per-application configuration shape, seed the following keys in Azure App Configuration (`appcs-hd-platform-shared` — the Grid's shared App Configuration store per ADR-0005). Do this via the portal until the Bicep templates for App Configuration provisioning land (ADR-0077 follow-up).
+
+| Key | Value (source) |
+|-----|----------------|
+| `Identity:Entra:TenantId` | The tenant ID GUID from Step 2 |
+| `Identity:Entra:TenantIssuerUrl` | The OIDC issuer URL from Step 2 |
+| `Identity:Entra:CustomDomain` | `auth.honeydrunkstudios.com` |
+| `Identity:Entra:NotifyCloud:ClientId` (or `Identity:Entra:Hearth:ClientId`) | The Application (client) ID from Step 3 |
+| `Identity:Entra:NotifyCloud:RedirectUri` (or `Identity:Entra:Hearth:RedirectUri`) | The redirect URI from Step 3 |
+| `Identity:Entra:NotifyCloud:Scopes` (or `Identity:Entra:Hearth:Scopes`) | `openid,profile,email` |
+| `Identity:Entra:NotifyCloud:SignUpSignInPolicy` (or equivalent for Hearth) | `b2c_susi_default` |
+| `Identity:Entra:NotifyCloud:PasswordResetPolicy` (or equivalent for Hearth) | `b2c_pwd_reset_default` |
+
+The non-secret values land in App Configuration. The client secret (if confidential-client) is already in `kv-hd-identity-prod` from Step 3.
+
+### Step 7 — Log the invariant-20 exception in Log Analytics
+
+Per invariant 20: *"No secret may exceed its tier's rotation SLA without an active exception. Tier 2 (third-party via rotation Function): ≤ 90 days. ... Exceptions must be logged in Log Analytics."*
+
+Entra App Registration client secrets default to 24-month expiration. 90-day rotation is operationally expensive (manual portal step every quarter; no `IRotator` exists for Entra App Registration secrets yet — that is part of the ADR-0006 Tier-2 rotation extension work in packet 05 of this initiative).
+
+The right posture per invariant 20: **log the exception now, document the operational burden, and resolve via ADR-0006 amendment** (packet 05).
+
+1. Open https://portal.azure.com → Log Analytics workspace `log-hd-platform-shared` (or whichever shared workspace per ADR-0006 / ADR-0040; if no shared workspace exists yet, create one in `rg-hd-platform-shared` per the same cheapest-tier-first principle — Pay-As-You-Go ~$2.30/GB ingested).
+2. Either via a **Custom log** or via a **manual workbook entry**, append a record with:
+   - **Exception type:** `InvariantException`
+   - **Invariant:** `20`
+   - **Secret name:** `entra-app-notify-cloud-client-secret` (or `entra-app-hearth-client-secret`)
+   - **Vault:** `kv-hd-identity-prod`
+   - **Issuer/Vendor:** `Microsoft Entra External ID`
+   - **Current SLA:** Tier-2, ≤ 90 days
+   - **Actual rotation cadence:** Set at 180 days for the initial secret; manual rotation in the Azure portal until the ADR-0006 Tier-2 rotation extension lands.
+   - **Reason:** No `IRotator` implementation for Entra App Registration secrets exists; 90-day manual portal rotation is operationally expensive for a solo-dev shop. Mitigation: Microsoft enforces strong app-secret hygiene (secret values not log-traced; only secret IDs); the consumer-app surface is browser-based PKCE (public client — no secret required for the primary OAuth flow); the client secret is needed only for Microsoft Graph callbacks (account-deletion fan-out per ADR-0060 D8) which are infrequent.
+   - **Follow-up:** Resolved by packet 05 of `adr-0078-entra-external-id` (ADR-0006 Tier-2 rotation extension proposal).
+   - **Logged at:** the current date.
+   - **Logged by:** the user.
+3. If the Log Analytics workspace does not yet have a custom-log table for invariant exceptions, create one (Custom Logs → + Add custom log → schema with the fields above). The schema is small and reusable for future invariant-20 exceptions.
+
+**Alternative for solo-dev shops:** if maintaining a Log Analytics custom-log table is itself overhead, the exception may be logged in `governance/exceptions/invariant-20-entra-app-secret.md` in the Architecture repo (a Markdown record that the review agent and any future audit can read). **Add that file in this same PR** if you go that route — the exception must be discoverable somewhere structured. The Markdown route is acceptable per invariant 20's "logged in Log Analytics" clause being interpreted as "logged in a structured, discoverable, queryable location"; Markdown in the governance folder qualifies.
+
+### Step 8 — Tag everything and confirm
+
+Apply tags `env=prod`, `purpose=platform-shared`, `node=identity` (per memory `feedback_lean_azure_tags` — `node` tag for per-Node resources, but the Entra tenant is Grid-wide so `purpose=platform-shared` is the primary tag) to:
+
+- The Entra External ID tenant (Step 2).
+- The `rg-hd-platform-shared` resource group (Step 1).
+- The Log Analytics workspace (Step 7).
+- (App Configuration keys do not carry Azure tags; the App Configuration store itself is already tagged.)
+
+Take a screenshot of the Entra External ID tenant Overview blade showing tenant ID + Active status, and attach to the closing comment on this chore issue.
+
+## Acceptance Criteria
+
+- [ ] `rg-hd-platform-shared` resource group exists in the Grid's main subscription with tags `env=prod` and `purpose=platform-shared`.
+- [ ] A Microsoft Entra External ID tenant exists, provisioned inside `rg-hd-platform-shared`, tagged `env=prod`, `purpose=platform-shared`. Tenant ID and OIDC issuer URL recorded in the closing comment.
+- [ ] At least one App Registration (Notify Cloud tenant operators or Hearth — the human chose at provisioning time) exists under the new tenant with: SPA or Web platform redirect URI, the OIDC-standard scopes (openid, profile, email), the OIDC-standard optional claims configured (email, family_name, given_name, preferred_username — no Entra-proprietary claims explicitly added), admin consent granted.
+- [ ] If the App Registration uses a confidential-client flow: a client secret exists in `kv-hd-identity-prod` under the secret name `entra-app-{app}-client-secret` (e.g., `entra-app-notify-cloud-client-secret`).
+- [ ] Sign-up + sign-in user flow `b2c_susi_default` exists, configured for email + password (no social-login at v1 per ADR-0078 D10), returning OIDC-standard claims only.
+- [ ] Password reset user flow `b2c_pwd_reset_default` exists.
+- [ ] `auth.honeydrunkstudios.com` custom domain is **Active** on the Entra tenant. Cloudflare CNAME record for `auth` exists in the `honeydrunkstudios.com` zone, set to DNS-only (proxy off).
+- [ ] App Configuration store has the eight `Identity:Entra:*` keys from Step 6 seeded with their concrete values.
+- [ ] **Invariant-20 exception logged** either in Log Analytics workspace `log-hd-platform-shared` as a structured custom-log entry, **or** in `governance/exceptions/invariant-20-entra-app-secret.md` in this repo (committed in this same PR if the Markdown route is chosen).
+- [ ] Closing comment on this chore issue contains: the tenant ID, the OIDC issuer URL, the App Registration client ID, the Vault secret name (no value), the custom-domain verification screenshot, and the path to the invariant-20 exception record.
+- [ ] Cost check confirmed: Entra External ID is free up to 50K MAU per ADR-0078 D8; expected monthly cost is **$0** for the tenant + App Registration + user flows.
+
+## Human Prerequisites
+
+- [ ] Org-admin role on `HoneyDrunkStudios` (required to create the Entra External ID tenant in the Grid's main subscription).
+- [ ] Azure portal access with subscription-Owner role on the Grid's main subscription (required to create the resource group, the tenant, the App Registrations, and the Log Analytics workspace).
+- [ ] Cloudflare portal access on the `honeydrunkstudios.com` zone (required for the custom-domain CNAME record per ADR-0029).
+- [ ] Browser with current sessions for Azure portal + Cloudflare portal.
+- [ ] Packets 00, 01, 02 of this initiative merged to `main` (the contracts.json `notes:` field, the grid-health entry for the custom domain, the per-app configuration shape doc, and the invariants 93/94 must all be in place so this packet's tracking issue references them by number).
+- [ ] **The human decides at provisioning time whether to set up the Notify Cloud or Hearth App Registration first.** This is not a packet-time decision; it depends on which consumer-app surface is the next feature packet to land.
+
+## Dependencies
+
+- `packet:00` — ADR-0078 acceptance + invariants 93/94. This chore's tracking issue references invariant 94 by number.
+- `packet:01` — Catalog updates (the `entra-custom-domain-auth-honeydrunkstudios-com` grid-health entry must exist so the custom-domain provisioning has a discoverable surface to update from `Planned` to active once provisioning completes).
+- `packet:02` — Per-application configuration shape doc (this chore seeds the keys named in that doc; the doc must be on `main` before the human can reference it during provisioning).
+
+## Downstream Unblocks
+
+- The first consumer-app feature packet (Hearth signup per PDR-0005 Phase 2 + `HoneyDrunk.Identity.Providers.Entra` package authoring per ADR-0060 D12 Phase 2) becomes implementable once this chore is Done — the App Registration exists, the App Configuration keys are seeded, the client secret (if any) is in Vault, the custom domain is wired.
+- Packet 04 of this initiative (the Entra App Registration provisioning walkthrough doc) is independent of this chore and can run in parallel — the doc captures the steps for future App Registration provisioning rather than depending on the first tenant existing.
+
+## Referenced Invariants
+
+> **Invariant 8:** Secret values never appear in logs, traces, exceptions, or telemetry. Only secret names/identifiers may be traced. — The closing comment on this chore must record the Vault secret name but **never the secret value**. Microsoft's portal shows the client-secret value once at creation; copy and paste it directly into the Key Vault portal, then do not retain it elsewhere.
+
+> **Invariant 9:** Vault is the only source of secrets. No Node reads secrets directly from environment variables, config files, or provider SDKs. — The Entra App Registration client secret lives in `kv-hd-identity-prod` only. It is read by application code via `ISecretStore` (never inlined in config files or environment variables).
+
+> **Invariant 10:** Auth tokens are validated, never issued. HoneyDrunk.Auth validates JWT Bearer tokens. **It is not an identity provider.** — Survives ADR-0078 intact. The Entra-issued tokens are validated by Auth's existing `IJwtBearerValidator` against Entra's JWKS endpoint.
+
+> **Invariant 17:** One Key Vault per deployable Node per environment, named `kv-hd-{service}-{env}`. — The Entra App Registration client secret lives in `kv-hd-identity-prod` (Identity's per-Node Vault). If that Vault does not exist yet (Identity is still Phase 1 library-only per ADR-0060 D12), the secret can be staged temporarily in `kv-hd-platform-shared` until Identity's Vault is provisioned with the first Identity deployable. Flag this in the closing comment.
+
+> **Invariant 18:** Vault URIs and App Configuration endpoints reach Nodes via environment variables. `AZURE_KEYVAULT_URI` and `AZURE_APPCONFIG_ENDPOINT` are set as App Service config at deploy time. — Not changed by this chore; reflects the future-state once Identity is deployed.
+
+> **Invariant 20:** No secret may exceed its tier's rotation SLA without an active exception. Tier 1 (Azure-native): ≤ 30 days. Tier 2 (third-party via rotation Function): ≤ 90 days. Certificates: auto-renewed 30 days before expiry. Exceptions must be logged in Log Analytics. — The Entra App Registration client secret defaults to 24-month expiration; that exceeds the Tier-2 SLA. **Step 7 of this chore logs the active exception** per invariant 20's exception clause. The exception is resolved long-term by packet 05 of this initiative (ADR-0006 Tier-2 rotation extension proposal).
+
+> **Invariant 21:** Applications must never pin to a specific secret version. All secret reads resolve the latest version via `ISecretStore`. — The Vault entry created in Step 3 carries the latest version; application code reads through `ISecretStore` which resolves latest. Manual rotation in the portal creates a new version; consumers pick it up automatically.
+
+> **Invariant 22:** Every Key Vault must have diagnostic settings routed to the shared Log Analytics workspace. Required for rotation SLA monitoring, unauthorized access alerting, and audit. — `kv-hd-identity-prod` (if it exists) or `kv-hd-platform-shared` (if used as temporary staging) must have diagnostic settings routed. Verify in the closing comment.
+
+> **Invariant 93 (Proposed — pending ADR-0078 acceptance via packet 00):** End-user identity tokens are issued by Microsoft Entra External ID. — This chore provisions the tenant + first App Registration that begin satisfying this invariant.
+
+> **Invariant 94 (Proposed — pending ADR-0078 acceptance via packet 00):** Application code consumes OIDC-standard claims only from Entra-issued tokens. — The App Registration's optional-claim configuration (Step 3) and user-flow token-claim configuration (Step 4) explicitly return only OIDC-standard claims; the chore's portal steps enforce the discipline at the configuration boundary.
+
+## Referenced ADR Decisions
+
+**ADR-0078 D1 — Microsoft Entra External ID is the end-user IdP.** Single Grid-wide tenant; per-application App Registrations; OAuth 2.1 with PKCE on OpenID Connect. This chore provisions the tenant and the first App Registration.
+
+**ADR-0078 D3 — OIDC-standard claims only.** The App Registration's optional-claim configuration in Step 3 includes only `email`, `family_name`, `given_name`, `preferred_username` (the OIDC-standard set per invariant 94 / packet 02's mapping table). No Entra-proprietary claims are configured.
+
+**ADR-0078 D6 — Per-application configuration shape.** Step 6 seeds the App Configuration keys per the schema in packet 02's doc.
+
+**ADR-0078 D8 — Cost posture.** Free up to 50K MAU. Expected monthly cost: $0.
+
+**ADR-0078 D10 — Out of scope:** MFA enforcement policy defaults to "optional, user-enrollable" at v1; social-login defaults to "email-only" at v1; Notify Cloud tenant-operator full setup is a per-ADR-0027 follow-up. The user flow created in Step 4 matches the v1 defaults (email + password, no social-login).
+
+**ADR-0006 (Secret Rotation and Lifecycle):** Step 7's invariant-20 exception logging follows ADR-0006's "Exceptions must be logged in Log Analytics" guidance. Packet 05 of this initiative is the ADR-0006 Tier-2 rotation extension proposal that resolves the exception long-term.
+
+**ADR-0005 D1 — Per-Node per-environment Key Vault.** `kv-hd-identity-prod` is the home for the Entra App Registration client secret (with `kv-hd-platform-shared` as temporary staging if Identity's Vault does not exist yet).
+
+**ADR-0005 D3 — Per-Node App Configuration namespace.** `Identity:Entra:*` is the namespace; seed in Step 6.
+
+**ADR-0029 (Cloudflare DNS):** Custom domain `auth.honeydrunkstudios.com` is wired via Cloudflare CNAME per ADR-0029's DNS-only-by-default stance for IdP-bound names.
+
+**ADR-0060 D2 — Wrap external IdP.** This chore provisions the wrapped IdP (Entra External ID). The Identity Node's `HoneyDrunk.Identity.Providers.Entra` package consumes this provisioning at the first consumer-app feature packet.
+
+**ADR-0049 Data classification:** Tenant + App Registrations + client secrets all sit in `Restricted` / `Sensitive PII` boundary. Step 7's invariant-20 exception record must respect ADR-0049 — the exception text describes the secret name and rotation cadence but never the secret value.
+
+**ADR-0052 Cost governance:** Spend baseline for Entra External ID is $0 through MVP. If the Entra tenant ever exceeds $200/mo a re-evaluation against the alternatives in ADR-0078 D9 happens per ADR-0052's governance hooks.
+
+## Constraints
+
+- **Actor=Human.** This chore is portal-based end-to-end. No agent can execute the Entra tenant creation, the App Registration setup, the Cloudflare CNAME record, the user-flow creation, or the invariant-20 exception logging. Frontmatter sets `labels: ["human-only", ...]` per the user's source-of-truth convention.
+- **Single Grid-wide Entra External ID tenant.** Per ADR-0078 D1. Do not create per-Node or per-environment tenants. Per-app App Registrations under the one tenant accommodate different application contexts.
+- **OIDC-standard claims only at the App Registration level.** Step 3's optional-claim configuration includes only `email`, `family_name`, `given_name`, `preferred_username`. Do not add Entra-proprietary claims (`oid`, `tid`, etc.) — Entra auto-includes those; explicit addition would be a signal that application code intends to consume them, which violates invariant 94.
+- **Custom domain DNS is DNS-only (Cloudflare proxy off).** Per ADR-0029's posture for IdP-bound names. Do not enable the orange-cloud proxy on the `auth` CNAME record; Entra needs direct CNAME resolution.
+- **Invariant-20 exception MUST be logged.** Either in Log Analytics custom log or in `governance/exceptions/invariant-20-entra-app-secret.md`. If the Markdown route is chosen, commit the file in the same PR as the chore-closure comment so the discoverable record exists on `main`.
+- **The invariant-20 exception is temporary** — it is resolved by packet 05 of this initiative (ADR-0006 Tier-2 rotation extension proposal). The exception record must reference packet 05 as the follow-up.
+- **Client secret values never appear in chore comments or PR descriptions.** Per invariant 8. Only the secret *name* (`entra-app-{app}-client-secret`) and the Vault location (`kv-hd-identity-prod`) are mentioned.
+- **Cost confirmation.** Free tier through 50K MAU. The closing comment must state "Cost: $0 (Free tier)" so a future cost review has the baseline recorded.
+- **Tag discipline.** `env=prod`, `purpose=platform-shared` on the resource group + tenant + Log Analytics workspace. `node=identity` is **not** the primary tag for the Entra tenant (the tenant is Grid-wide, not per-Identity-Node) — `purpose=platform-shared` is the primary tag.
+
+## Labels
+
+`chore`, `tier-1`, `core`, `infra`, `identity`, `adr-0078`, `human-only`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Provision the Grid-wide Microsoft Entra External ID tenant; create the first App Registration (Notify Cloud tenant operators or Hearth — human picks at provisioning time); verify-or-create the `rg-hd-platform-shared` resource group; wire the custom domain `auth.honeydrunkstudios.com` via Cloudflare CNAME; seed the App Configuration keys; log the active invariant-20 exception for the Entra App Registration client-secret rotation cadence in Log Analytics or `governance/exceptions/invariant-20-entra-app-secret.md`.
+
+**Target:** `HoneyDrunkStudios/HoneyDrunk.Architecture` (tracking issue lives here; actual work happens in Azure portal + Cloudflare portal + Log Analytics workspace).
+
+**Context:**
+- Goal: Stand up the Entra External ID infrastructure so the first consumer-app feature packet has a working OAuth target and the OpenID Connect surface is reachable via the Grid's brand domain.
+- Feature: ADR-0078 End-User Identity rollout, Wave 2, Packet 03.
+- ADRs: ADR-0078 (Entra commitment), ADR-0006 (secret rotation — invariant-20 exception), ADR-0005 (Vault + App Configuration shape), ADR-0029 (Cloudflare DNS for the custom domain).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packets 00, 01, 02 of this initiative.
+
+**Constraints:** As listed above. Most critically:
+- This is `Actor=Human` (`human-only` label is the source of truth).
+- Single Grid-wide Entra External ID tenant — not per-Node or per-environment.
+- OIDC-standard claims only at the App Registration optional-claim configuration; never explicitly add Entra-proprietary claims.
+- Cloudflare CNAME for `auth` is DNS-only (no proxy).
+- Invariant-20 exception MUST be logged; commit `governance/exceptions/invariant-20-entra-app-secret.md` in the same PR if the Markdown route is chosen.
+- Client secret values never appear in chore comments or PR descriptions (invariant 8).
+
+**Key Files:** (committed if the Markdown exception-record route is chosen)
+- `governance/exceptions/invariant-20-entra-app-secret.md` — new (if used)
+
+**Contracts:** None changed. This is provisioning work; the Identity contract surface from ADR-0060 D4 is not modified.

--- a/generated/issue-packets/active/adr-0078-entra-external-id/04-architecture-entra-app-registration-walkthrough.md
+++ b/generated/issue-packets/active/adr-0078-entra-external-id/04-architecture-entra-app-registration-walkthrough.md
@@ -1,0 +1,309 @@
+---
+name: Infrastructure Walkthrough
+type: cross-repo-change
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "core", "docs", "infra", "identity", "adr-0078", "wave-2"]
+dependencies: ["packet:00", "packet:01", "packet:02"]
+adrs: ["ADR-0078", "ADR-0006", "ADR-0005", "ADR-0029", "ADR-0077"]
+accepts: ADR-0078
+wave: 2
+initiative: adr-0078-entra-external-id
+node: honeydrunk-identity
+---
+
+# Chore: Author `infrastructure/walkthroughs/entra-app-registration.md` — repeatable portal walkthrough for adding consumer-app Entra App Registrations
+
+## Summary
+
+Author a portal-based walkthrough at `infrastructure/walkthroughs/entra-app-registration.md` that future consumer-app feature packets (Hearth signup, Lately signup, Currents signup, Curiosities signup, and any later consumer surfaces) reference when adding a new Entra App Registration under the Grid's single External ID tenant. The walkthrough captures the Steps 3-6 portion of packet 03 (App Registration creation + user flow attachment + App Configuration key seeding + Vault secret storage for confidential-client flows), generalized for repeat use. **Bicep-based provisioning is explicitly out of scope** — queued under ADR-0077 follow-up work once Bicep's Entra resource coverage is confirmed; until then, App Registration provisioning is portal-based per ADR-0078 D6's "via a documented Portal-or-CLI workflow until Bicep's coverage closes the gap" clause.
+
+This is a doc-only packet that runs in parallel with packet 03. Packet 03 provisions the *first* tenant + App Registration; this packet writes the *repeatable* recipe so the second/third/Nth App Registration does not re-derive the steps from scratch.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+Packet 03 of this initiative provisions the tenant + the first App Registration. The four follow-on consumer-app surfaces (Hearth, Lately, Currents, Curiosities) each need their own App Registration. Without a walkthrough doc:
+
+- Each consumer-app feature packet re-derives the App Registration creation steps from scratch, risking drift in scopes, optional-claim configuration, redirect URI patterns, or App Configuration key naming.
+- The OIDC-standards-only claim discipline (invariant 94) is enforced at the App Registration level (Step 3 of packet 03); the walkthrough must restate this so the same enforcement happens consistently for every App Registration.
+- The "no Entra-proprietary claims explicitly added" rule is easy to miss in a portal flow that defaults to including some proprietary claims; the walkthrough surfaces this as a callout.
+- Future App Registrations may be added by a different human (a contractor, a future hire) who has not internalized the per-app configuration shape from packet 02; the walkthrough is the self-contained reference.
+
+This packet writes that walkthrough. It is a sibling to the other docs in `infrastructure/walkthroughs/` (e.g., `oidc-federated-credentials.md`, `key-vault-creation.md`) and follows the same `**Applies to:**` / `**Related invariants:**` / `## Goal` / `## Portal Breadcrumb` / `## Step-by-step` / `## Critical guardrails` structure.
+
+## Proposed Implementation
+
+### `infrastructure/walkthroughs/entra-app-registration.md` — new walkthrough
+
+Create the file following the existing walkthrough template. Structure:
+
+```markdown
+# Entra External ID App Registration (Azure Portal)
+
+**Applies to:** ADR-0078 (End-User Identity — Microsoft Entra External ID), ADR-0060 (Identity Node standup, Phase 2 consumer-app feature packets).
+**Related invariants:** 8, 9, 10, 17, 18, 20, 21, 22, 93, 94.
+**Companion docs:** `repos/HoneyDrunk.Identity/entra-configuration.md` (per-application configuration shape — what keys to seed and where), `infrastructure/walkthroughs/key-vault-creation.md` (if `kv-hd-identity-{env}` does not exist yet), `infrastructure/walkthroughs/app-configuration-provisioning.md` (if the shared App Configuration store does not exist yet).
+**Bicep status:** Not yet supported. Until Bicep's Entra resource coverage closes the gap (queued under ADR-0077 follow-up work), App Registration provisioning is portal-based per ADR-0078 D6.
+
+## Goal
+
+Add a new consumer-app App Registration to the Grid's existing Entra External ID tenant. The App Registration owns its own client ID, redirect URIs, optional-claim configuration, user-flow attachments, and (for confidential-client flows) client secret. After this walkthrough, the consumer app has a working OAuth target ready for its feature packet.
+
+## Portal Breadcrumb
+
+**Azure Portal → Microsoft Entra External ID (the Grid tenant from packet 03 of adr-0078-entra-external-id) → App registrations → + New registration**
+
+## Pre-flight
+
+- The Grid-wide Entra External ID tenant exists (provisioned by packet 03 of `adr-0078-entra-external-id`). If it does not, complete that packet first.
+- `kv-hd-identity-{env}` exists if the new App Registration uses a confidential-client flow. If absent, follow `key-vault-creation.md` first.
+- The shared App Configuration store (`appcs-hd-platform-shared`) exists. If absent, follow `app-configuration-provisioning.md` first.
+- You know the consumer-app short name (`hearth`, `lately`, `currents`, `curiosities`, `notify-cloud`).
+- You know whether the flow is public-client (browser-based OAuth 2.1 with PKCE — the default for consumer apps) or confidential-client (server-side flow that requires a client secret).
+
+## Step-by-step
+
+### 1. Create the App Registration
+
+Inside the Entra External ID tenant: **App registrations → + New registration**.
+
+- **Name:** `HoneyDrunk {AppName}` (e.g., `HoneyDrunk Hearth`).
+- **Supported account types:** Accounts in this organizational directory only.
+- **Redirect URI platform:**
+  - **Single-page application (SPA)** for browser-based OAuth 2.1 with PKCE (the default for consumer apps).
+  - **Web** for server-side confidential-client flows.
+- **Redirect URI value:** Per the redirect URI pattern from `repos/HoneyDrunk.Identity/entra-configuration.md`: `https://{app}.honeydrunkstudios.com/auth/callback`.
+
+Click **Register**. **Record the Application (client) ID** — this goes into App Configuration as `Identity:Entra:{App}:ClientId` in Step 5.
+
+### 2. Configure optional claims — OIDC-standard claims only (invariant 94)
+
+Inside the new App Registration: **Token configuration → + Add optional claim** for **ID tokens**:
+
+- `email`
+- `family_name`
+- `given_name`
+- `preferred_username`
+
+**Do NOT** add Entra-proprietary claims (`oid`, `tid`, `idp`, `acrs`, `acr`, etc.). Per invariant 94, application code consumes OIDC-standard claims only; Entra-proprietary claims appear in token payloads automatically but are diagnostic-only — explicit addition would signal that application code intends to consume them, violating invariant 94.
+
+### 3. Configure API permissions
+
+**API permissions → + Add a permission → Microsoft Graph → Delegated permissions:**
+
+- `openid`
+- `profile`
+- `email`
+
+Click **Add permissions**, then **Grant admin consent for {tenant name}**. The status column should show green checkmarks.
+
+If the App Registration needs to call Microsoft Graph for account-deletion fan-out (per ADR-0060 D8, the `DELETE /users/{id}` call), also add:
+
+- `User.ReadWrite.All` (Application permission, not Delegated — the deletion fan-out is a service-to-service call).
+
+Grant admin consent for `User.ReadWrite.All` as well.
+
+### 4. Add the client secret (confidential-client flows only)
+
+Skip this step for SPA / public-client / PKCE flows — they do not require a client secret.
+
+For Web / confidential-client flows:
+
+Inside the new App Registration: **Certificates & secrets → + New client secret**.
+
+- **Description:** `Initial client secret — {date}` (e.g., `Initial client secret — 2026-05-25`).
+- **Expires:** **180 days** is the portal default; **90 days** is the invariant-20 Tier-2 SLA target. Pick 90 days if your operational schedule supports quarterly rotation; pick 180 days if you accept the documented invariant-20 exception per packet 03 of `adr-0078-entra-external-id` (see "Critical guardrails" below).
+- Click **Add**.
+- **Copy the secret value immediately** (the portal shows it only once).
+
+Open **Key Vault → `kv-hd-identity-{env}` → Secrets → + Generate/Import**:
+
+- **Upload options:** Manual.
+- **Name:** `entra-app-{app}-client-secret` (e.g., `entra-app-hearth-client-secret`).
+- **Secret value:** paste the copied client secret.
+- Click **Create**.
+
+### 5. Attach user flows
+
+Inside the App Registration: **Authentication → User flows** (or via the tenant's User flows blade, select the user flow then add the App Registration as a consumer):
+
+- Attach the sign-up + sign-in flow (`b2c_susi_default` from packet 03, or whichever exists).
+- Attach the password-reset flow (`b2c_pwd_reset_default` from packet 03, or whichever exists).
+
+If you need per-app sign-up form fields (e.g., Hearth wants a "town name" question at signup, Currents wants a "favorite genre" question), create a new user flow specific to this App Registration rather than modifying the shared default flow. Name per-app user flows `b2c_susi_{app}` and `b2c_pwd_reset_{app}`.
+
+### 6. Seed App Configuration keys
+
+Open **App Configuration → `appcs-hd-platform-shared` → Configuration explorer → + Create → Key-value**:
+
+| Key | Value |
+|-----|-------|
+| `Identity:Entra:{App}:ClientId` | The Application (client) ID from Step 1 |
+| `Identity:Entra:{App}:RedirectUri` | The redirect URI from Step 1 |
+| `Identity:Entra:{App}:Scopes` | `openid,profile,email` |
+| `Identity:Entra:{App}:SignUpSignInPolicy` | `b2c_susi_default` (or `b2c_susi_{app}` if per-app) |
+| `Identity:Entra:{App}:PasswordResetPolicy` | `b2c_pwd_reset_default` (or `b2c_pwd_reset_{app}` if per-app) |
+
+`{App}` is the consumer-app short name in lowercase (`hearth`, `lately`, etc.).
+
+Per packet 02's per-application configuration shape, the Grid-wide keys (`Identity:Entra:TenantId`, `Identity:Entra:TenantIssuerUrl`, `Identity:Entra:CustomDomain`) are already seeded by packet 03 of this initiative; do not re-seed them.
+
+### 7. Verify
+
+In the App Registration's **Endpoints** blade, copy the OpenID Connect metadata document URL (`https://{tenant}/.well-known/openid-configuration`). Open it in a browser tab — it should return a JSON document with `issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri`, `userinfo_endpoint`, and supported scopes including `openid profile email`.
+
+If the JSON loads and the issuer matches `Identity:Entra:TenantIssuerUrl` from App Configuration, the App Registration is correctly wired.
+
+## Critical guardrails
+
+- **OIDC-standard claims only at the optional-claim configuration.** Step 2's enumeration is the entire allowed list at the App Registration level. Per invariant 94, application code consumes the OIDC-standard claim set only; Entra-proprietary claims are diagnostic-only. Adding Entra-proprietary claims to the optional-claim configuration is a boundary violation.
+- **Client secret values never appear in chat / PR / chore-issue text.** Per invariant 8, only the secret name (`entra-app-{app}-client-secret`) and the Vault location (`kv-hd-identity-{env}`) are mentioned. The portal shows the value once; copy directly into Key Vault and never paste elsewhere.
+- **Public-client (SPA / PKCE) flows have NO client secret.** Skip Step 4 entirely. The absence of a client secret is the security model — PKCE substitutes for the secret. Trying to add a client secret to a public-client App Registration would either fail or weaken the PKCE flow.
+- **Invariant 20 exception applies if the client-secret expiry exceeds 90 days.** Per invariant 20, Tier-2 secrets ≤ 90 days unless an active exception is logged. Packet 03 of `adr-0078-entra-external-id` logged the first such exception. If you set the secret expiry to 180 days or longer, append a row to the same exception record (Log Analytics custom log or `governance/exceptions/invariant-20-entra-app-secret.md`) naming the new App Registration's secret. The long-term resolution is packet 05 of `adr-0078-entra-external-id` (ADR-0006 Tier-2 rotation extension proposal).
+- **Cloudflare CNAME for `auth.honeydrunkstudios.com`** is set up Grid-wide by packet 03 of this initiative; new App Registrations do **not** add per-app DNS records — they use the same custom-domain endpoint. Per-app subdomains (e.g., `hearth.honeydrunkstudios.com`) are the *redirect target*, not the *Entra endpoint*; the redirect target's DNS is the responsibility of the consumer-app's hosting setup (Container App, Vercel, etc. per the app's own infrastructure).
+- **Diagnostic settings.** If `kv-hd-identity-{env}` does not yet have diagnostic settings routed to the shared Log Analytics workspace, configure them now per invariant 22 (required for rotation SLA monitoring, unauthorized access alerting, and audit).
+- **Tags.** Apply `env={env}`, `node=identity` (the App Registration is per-Identity-Node-application surface) to the App Registration's Notes / Tags blade (Entra App Registrations support a small notes field; longer tagging metadata may need to live in the App Configuration key descriptions instead).
+- **Bicep replacement is coming.** Once Bicep's Entra resource coverage matures and the ADR-0077 follow-up packet for Entra App Registration provisioning lands, this walkthrough may be deprecated in favor of a `bicep deploy` recipe. The walkthrough is the bridge until then.
+
+## Verification checklist (after walkthrough completes)
+
+- [ ] App Registration exists under the Grid Entra tenant with name `HoneyDrunk {AppName}`.
+- [ ] Redirect URI is `https://{app}.honeydrunkstudios.com/auth/callback` (SPA platform for PKCE; Web platform for confidential-client).
+- [ ] Optional claims configured: `email`, `family_name`, `given_name`, `preferred_username`. No Entra-proprietary claims explicitly added.
+- [ ] API permissions: `openid`, `profile`, `email` (Delegated, admin-consented). `User.ReadWrite.All` (Application, admin-consented) if account-deletion fan-out is needed.
+- [ ] Client secret (confidential-client only): stored in `kv-hd-identity-{env}` as `entra-app-{app}-client-secret`. Expiry recorded with associated invariant-20 exception entry if > 90 days.
+- [ ] User flows attached (sign-up + sign-in; password reset).
+- [ ] App Configuration keys seeded under `Identity:Entra:{App}:*`.
+- [ ] OIDC metadata document loads at `https://{tenant}/.well-known/openid-configuration` and matches App Configuration `Identity:Entra:TenantIssuerUrl`.
+- [ ] If client-secret expiry > 90 days: invariant-20 exception record updated.
+- [ ] Diagnostic settings on `kv-hd-identity-{env}` routed to the shared Log Analytics workspace (invariant 22).
+- [ ] Cost check: $0 incremental (the App Registration itself is free under the 50K-MAU tier per ADR-0078 D8).
+```
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the current dated SemVer section:
+
+> `Architecture: Author infrastructure/walkthroughs/entra-app-registration.md — repeatable portal walkthrough for adding consumer-app Entra App Registrations under the Grid's single External ID tenant per ADR-0078 D1 / D6. Captures App Registration creation, optional-claim configuration (OIDC-standard claims only per invariant 94), API permissions, client-secret handling for confidential-client flows (with invariant-20 exception cross-reference to packet 03), user-flow attachment, App Configuration key seeding, and verification via the OIDC metadata document. Bicep-based provisioning explicitly out of scope — queued under ADR-0077 follow-up work; portal-based until Bicep's Entra resource coverage closes the gap per ADR-0078 D6.`
+
+## Affected Files
+
+- `infrastructure/walkthroughs/entra-app-registration.md` (new)
+- `CHANGELOG.md` (entry under current dated SemVer section)
+
+## NuGet Dependencies
+
+None. Architecture is a knowledge repo.
+
+## Boundary Check
+
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] No code changes; doc-only.
+- [x] No new infrastructure provisioning — this packet writes the *recipe*, not the *first instance*; the first instance is packet 03 of this initiative.
+- [x] Walkthrough follows the existing `infrastructure/walkthroughs/` template structure (Applies to / Related invariants / Goal / Portal Breadcrumb / Step-by-step / Critical guardrails).
+- [x] Bicep stance explicitly recorded — portal until Bicep's Entra coverage matures, then ADR-0077 follow-up swaps in `bicep deploy`.
+
+## Acceptance Criteria
+
+- [ ] `infrastructure/walkthroughs/entra-app-registration.md` exists and is structured per the template above.
+- [ ] The walkthrough's **OIDC-standard claims only** section (Step 2) explicitly enumerates the allowed claims (`email`, `family_name`, `given_name`, `preferred_username`) and explicitly forbids adding Entra-proprietary claims (`oid`, `tid`, `idp`, `acrs`, `acr`).
+- [ ] The walkthrough's **client-secret** section (Step 4) covers the public-client-no-secret case explicitly and the confidential-client-with-secret case with Vault storage at `entra-app-{app}-client-secret` in `kv-hd-identity-{env}`.
+- [ ] The walkthrough's **Critical guardrails** section covers: invariant 8 (no secret values in chat/PR/issue text), invariant 94 (OIDC-standard claims only), invariant 20 (client-secret expiry > 90 days triggers exception entry), invariant 22 (Vault diagnostic settings), and the Bicep-replacement note.
+- [ ] The walkthrough's **Verification checklist** is a flat checkbox list capturing every step's success condition.
+- [ ] The walkthrough cross-links to `repos/HoneyDrunk.Identity/entra-configuration.md` (packet 02's per-application configuration shape doc) and to packet 03 of this initiative (for the first tenant + App Registration setup that this walkthrough generalizes from).
+- [ ] The walkthrough cross-links to `infrastructure/walkthroughs/key-vault-creation.md` and `infrastructure/walkthroughs/app-configuration-provisioning.md` as pre-flight dependencies.
+- [ ] Bicep-deferred status is explicitly recorded in the doc preamble (under "Bicep status:").
+- [ ] `CHANGELOG.md` carries an entry under the current dated SemVer section.
+
+## Human Prerequisites
+
+- [ ] Packets 00, 01, 02 of this initiative merged to `main` (the invariants 93/94, the catalog updates, and the per-application configuration shape doc must all be in place — the walkthrough cross-links to them).
+- [ ] Packet 03 of this initiative is **not** a strict prerequisite for *this* doc-authoring packet; the doc can be written in parallel with the provisioning work. (Packet 03 is a strict prerequisite for *using* the walkthrough — you can't add a second App Registration before the first tenant exists.)
+
+## Referenced Invariants
+
+> **Invariant 8:** Secret values never appear in logs, traces, exceptions, or telemetry. Only secret names/identifiers may be traced. — The walkthrough's Critical guardrails section restates this and operationalizes it: copy the client secret from the Entra portal directly into the Key Vault portal; never paste it into chat / PR / issue text.
+
+> **Invariant 9:** Vault is the only source of secrets. — The walkthrough stores client secrets in `kv-hd-identity-{env}` only; application code reads via `ISecretStore` (covered by packet 02's per-application configuration shape doc).
+
+> **Invariant 10:** Auth tokens are validated, never issued. — The walkthrough is provisioning-only; token validation stays in `HoneyDrunk.Auth` per ADR-0078 D5.
+
+> **Invariant 17:** One Key Vault per deployable Node per environment, named `kv-hd-{service}-{env}`. — Client secrets live in `kv-hd-identity-{env}`.
+
+> **Invariant 18:** Vault URIs and App Configuration endpoints reach Nodes via environment variables. — The walkthrough seeds App Configuration keys; the App Configuration endpoint itself reaches Identity via `AZURE_APPCONFIG_ENDPOINT` per ADR-0005.
+
+> **Invariant 20:** No secret may exceed its tier's rotation SLA without an active exception. Tier 2 (third-party via rotation Function): ≤ 90 days. Exceptions must be logged in Log Analytics. — Step 4's secret-expiry guidance cross-references the invariant; the Critical guardrails section explicitly directs the operator to update the invariant-20 exception record if expiry > 90 days.
+
+> **Invariant 21:** Applications must never pin to a specific secret version. — Vault entries are read latest-version through `ISecretStore`; manual rotation creates new versions that consumers pick up automatically.
+
+> **Invariant 22:** Every Key Vault must have diagnostic settings routed to the shared Log Analytics workspace. — The walkthrough's Critical guardrails section reminds the operator to configure diagnostic settings on `kv-hd-identity-{env}` if not yet done.
+
+> **Invariant 93 (pending packet 00):** End-user identity tokens are issued by Microsoft Entra External ID. — Every App Registration this walkthrough creates is under the Grid's single Entra External ID tenant, satisfying the invariant.
+
+> **Invariant 94 (pending packet 00):** Application code consumes OIDC-standard claims only from Entra-issued tokens. — The walkthrough's Step 2 (optional-claim configuration) and Critical guardrails enforce the discipline at the configuration boundary.
+
+## Referenced ADR Decisions
+
+**ADR-0078 D1 — Microsoft Entra External ID is the end-user IdP.** Single Grid-wide tenant; per-application App Registrations. The walkthrough is the recipe for adding the per-application App Registrations.
+
+**ADR-0078 D3 — OIDC-standard claims only.** The walkthrough's Step 2 (optional-claim configuration) enforces this at the App Registration level.
+
+**ADR-0078 D5 — Token validation stays in `HoneyDrunk.Auth` per Invariant 10.** The walkthrough is provisioning-only; no validation logic.
+
+**ADR-0078 D6 — Per-application configuration shape.** The walkthrough's Step 6 (App Configuration key seeding) implements the schema documented in packet 02. The "Bicep-or-Portal until coverage closes the gap" clause is the explicit license for this walkthrough's portal-based approach.
+
+**ADR-0006 (Secret Rotation and Lifecycle):** The walkthrough's Step 4 (client-secret expiry) cross-references invariant 20; long-term resolution is packet 05 of this initiative (ADR-0006 Tier-2 rotation extension proposal).
+
+**ADR-0005 D1 — Per-Node per-environment Key Vault.** `kv-hd-identity-{env}` is the Vault home.
+
+**ADR-0005 D3 — Per-Node App Configuration namespace.** `Identity:Entra:{App}:*` is the namespace.
+
+**ADR-0029 (Cloudflare DNS):** Custom-domain wiring is handled Grid-wide in packet 03; per-App-Registration walkthroughs do not add DNS records.
+
+**ADR-0077 (Infrastructure-as-Code — Bicep):** The walkthrough is portal-based today per ADR-0078 D6's explicit Bicep-or-Portal clause. A future ADR-0077 follow-up packet may add Bicep templates for Entra App Registrations and deprecate this walkthrough in favor of `bicep deploy`.
+
+**ADR-0060 D2 — Wrap external IdP.** The App Registration is the IdP-side concrete; the wrapping seam (`IExternalIdpClaimMapper`) and the runtime adapter (`HoneyDrunk.Identity.Providers.Entra`) consume the App Registration's client ID + secret + scopes via the App Configuration keys this walkthrough seeds.
+
+## Dependencies
+
+- `packet:00` — ADR-0078 acceptance + invariants 93/94. The walkthrough cites invariant 94 by number.
+- `packet:01` — Catalog updates. The walkthrough references the contracts.json `notes:` field text indirectly via the seam architecture description.
+- `packet:02` — Per-application configuration shape doc. The walkthrough cross-links to it as the schema source for the App Configuration keys.
+
+## Labels
+
+`chore`, `tier-2`, `core`, `docs`, `infra`, `identity`, `adr-0078`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Author `infrastructure/walkthroughs/entra-app-registration.md` — the repeatable portal walkthrough for adding consumer-app Entra App Registrations under the Grid's single Entra External ID tenant. Generalizes Steps 3-6 of packet 03 for re-use by every subsequent consumer-app feature packet.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Make App Registration provisioning a repeatable recipe rather than a re-derive-from-scratch effort for every consumer app. Restate the OIDC-standards-only discipline (invariant 94) at the configuration boundary so each App Registration enforces it consistently.
+- Feature: ADR-0078 End-User Identity rollout, Wave 2, Packet 04.
+- ADRs: ADR-0078 D1 / D3 / D5 / D6 (Entra commitment + OIDC-standards discipline + per-app config shape + Portal-or-Bicep clause), ADR-0006 (invariant-20 rotation cadence cross-reference), ADR-0005 (Vault + App Configuration), ADR-0029 (Cloudflare DNS already handled by packet 03), ADR-0077 (Bicep stance — out of scope today, may swap in later).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packets 00, 01, 02 of this initiative.
+
+**Constraints:**
+- The walkthrough must follow the existing `infrastructure/walkthroughs/` template structure (Applies to / Related invariants / Goal / Portal Breadcrumb / Step-by-step / Critical guardrails / Verification checklist).
+- **Invariant 8:** Secret values never appear in logs, traces, exceptions, or telemetry. — Critical guardrails restate this and operationalize it.
+- **Invariant 94 (pending packet 00):** Application code consumes OIDC-standard claims only from Entra-issued tokens. — Step 2 (optional-claim configuration) enforces this at the App Registration boundary and Critical guardrails restate the forbiddance of Entra-proprietary claims.
+- **Invariant 20:** Tier-2 secrets ≤ 90 days unless an active exception is logged in Log Analytics. — Step 4 cross-references the invariant; Critical guardrails direct the operator to update the invariant-20 exception record if expiry > 90 days.
+- Bicep-deferred status must be explicit in the doc preamble — the walkthrough is the bridge until Bicep's Entra coverage matures per ADR-0078 D6.
+- The walkthrough must cross-link to `repos/HoneyDrunk.Identity/entra-configuration.md` (packet 02 of this initiative) and packet 03 of this initiative.
+- Public-client (SPA / PKCE) vs confidential-client (Web + secret) distinction must be explicit; do not let a reader accidentally add a client secret to a public-client App Registration.
+
+**Key Files:**
+- `infrastructure/walkthroughs/entra-app-registration.md` — new
+- `CHANGELOG.md` — append under current dated SemVer section
+
+**Contracts:** None changed. The walkthrough is operational documentation.

--- a/generated/issue-packets/active/adr-0078-entra-external-id/05-architecture-adr-0006-tier2-rotation-extension-proposal.md
+++ b/generated/issue-packets/active/adr-0078-entra-external-id/05-architecture-adr-0006-tier2-rotation-extension-proposal.md
@@ -1,0 +1,193 @@
+---
+name: ADR Drafting
+type: architecture-decision
+tier: 3
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-3", "core", "docs", "identity", "secrets", "adr-0078", "wave-3"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0078", "ADR-0006"]
+wave: 3
+initiative: adr-0078-entra-external-id
+node: honeydrunk-vault-rotation
+---
+
+# Chore: Draft ADR-0006 Tier-2 rotation extension amendment for long-expiry Entra App Registration client secrets (follow-up placeholder)
+
+## Summary
+
+Draft an ADR-0006 amendment that formalizes a long-expiry exception path for Entra App Registration client secrets, so the temporary invariant-20 exception logged by packet 03 of this initiative becomes a documented standing posture rather than an indefinite undocumented one. The amendment either: (a) raises the Tier-2 SLA carve-out for IdP-tenant-bound client secrets (e.g., from 90 days to 365 or 730 days) with documented operational rationale, OR (b) commits to authoring an `IRotator` implementation for Entra App Registration secrets that automates the rotation on the existing 90-day cadence. The ADR records which path the user picks, the operational trade-offs, and the cost shape.
+
+This is the **follow-up packet placeholder** the user named in the scoping refinement — "add follow-up packet placeholder for ADR-0006 Tier-2 rotation extension." The packet is queued in Wave 3 because it depends on packet 03's invariant-20 exception being a known live concern. The actual ADR draft is the work; this packet schedules it.
+
+## Target Repo
+
+`HoneyDrunkStudios/HoneyDrunk.Architecture`
+
+## Motivation
+
+Per packet 03 of this initiative, Step 7 logs an active invariant-20 exception for the Entra App Registration client secret: Entra defaults to 24-month expiration, the Grid has no `IRotator` for Entra App Registration secrets, and the operational burden of 90-day manual portal rotation is non-trivial for a solo-dev shop. The exception is logged in Log Analytics (or `governance/exceptions/invariant-20-entra-app-secret.md`) but it is **not** documented as a standing exception in ADR-0006 itself; the exception record is an operational log entry, not a permanent constitutional carve-out.
+
+Two paths resolve this:
+
+- **(a) Raise the Tier-2 SLA for IdP-tenant-bound secrets.** Amend ADR-0006 to add an IdP-secret tier (e.g., Tier-2a) with a documented longer SLA (365 or 730 days). The amendment records the operational rationale (Microsoft enforces strong app-secret hygiene; secret values are never log-traced; the consumer-app surface is browser-based PKCE so the client secret is not in the primary OAuth flow; the secret is needed only for service-to-service Microsoft Graph calls per ADR-0060 D8) and the security trade-off (longer secret lifetime = larger blast radius if leaked; mitigated by Microsoft's portal-side secret rotation when forced and by manual rotation if a leak is suspected).
+
+- **(b) Ship an `IRotator` for Entra App Registration secrets in `HoneyDrunk.Vault.Rotation`.** Per ADR-0006 D2, Tier-2 secrets rotate via a rotation Function (HoneyDrunk.Vault.Rotation). An `EntraAppRegistrationRotator` would call the Microsoft Graph API to add a new client secret to the App Registration, write the new value to `kv-hd-identity-{env}`, and (after a TTL grace period) delete the old secret. The 90-day cadence is preserved; the operational burden disappears.
+
+Path (b) is the architecturally cleaner option but adds a moderate amount of Vault.Rotation work. Path (a) is the cheaper option but accepts a documented widening of the SLA. The ADR records the user's pick and the trade-off analysis.
+
+This packet schedules the ADR drafting; the ADR itself is the work the user (or the `adr-composer` agent) authors when the packet executes.
+
+## Proposed Implementation
+
+### Step 1 — Open the next available ADR number
+
+Read `adrs/` and pick the next available ADR number above the current high-water mark (which at file authoring is ADR-0080 — see `constitution/invariant-reservations.md` for the highest in-flight Proposed ADR). At the time this packet executes, the high-water mark may have moved; use the actual next-available number.
+
+Create the new ADR file as `adrs/ADR-{NNNN}-tier-2-idp-secret-rotation-cadence.md` (substitute the actual number).
+
+### Step 2 — Author the ADR
+
+The ADR follows the existing ADR template (see e.g., `adrs/ADR-0078-end-user-identity-entra-external-id.md` for a recent example). Required sections:
+
+- **Status:** Proposed
+- **Date:** the date of authoring
+- **Deciders:** HoneyDrunk Studios
+- **Sector:** Core / Infrastructure (the secret-rotation policy is cross-cutting; pick the closer of Core or Infrastructure based on the user's preference at drafting time).
+
+- **Context:** ADR-0006 commits Tier-2 secrets to ≤ 90-day rotation via the HoneyDrunk.Vault.Rotation Function. ADR-0078 commits Microsoft Entra External ID as the end-user IdP; Entra App Registration client secrets default to 24-month expiration. Packet 03 of `adr-0078-entra-external-id` logged an active invariant-20 exception covering the gap. This ADR resolves the gap by either widening the SLA for IdP-tenant-bound secrets or by committing to a rotation Function implementation.
+
+- **Decision (D1):** The chosen path (a or b). Document the trade-offs of the other path.
+  - If path (a): name the new tier (e.g., Tier-2a), commit the new SLA (365 or 730 days), document the operational rationale, document the security trade-off, document the mitigations.
+  - If path (b): commit to an `EntraAppRegistrationRotator` in `HoneyDrunk.Vault.Rotation`, name the Microsoft Graph API calls it makes, name the App Configuration keys it reads, commit to the 90-day cadence, document the TTL grace period for old-secret deletion, document the operational rollout (Function App provisioning, OIDC federated credential setup, etc.).
+
+- **Decision (D2+):** Any sub-decisions that fall out of D1.
+
+- **Consequences:**
+  - Invariant 20 — if path (a): the invariant text may be amended to reference the new Tier-2a; if path (b): the invariant text is unchanged because the 90-day cadence is preserved.
+  - Operational consequences — what changes in the runbook, the on-call posture, the cost shape.
+  - Affected Nodes — at minimum, HoneyDrunk.Vault.Rotation (if path b) or HoneyDrunk.Architecture (if path a, for the invariant text amendment).
+  - Follow-up work — packet sequence for implementation if path (b); invariant-text amendment packet if path (a).
+
+- **Alternatives Considered:**
+  - The unchosen path (a or b).
+  - **Defer indefinitely** — keep the invariant-20 exception record open. Rejected because it accumulates technical debt and the exception record's "Follow-up" field promises a resolution.
+  - **Move to a different IdP** that supports auto-rotating client secrets natively. Rejected per ADR-0078 D7 — the wrapping seam supports migration but the migration cost is real; the rotation policy is the proportionate fix.
+
+- **References:**
+  - ADR-0006 (Secret Rotation and Lifecycle) — the parent ADR being amended.
+  - ADR-0078 (End-User Identity — Microsoft Entra External ID) — the forcing function.
+  - Packet 03 of `adr-0078-entra-external-id` — the live invariant-20 exception record.
+  - `governance/exceptions/invariant-20-entra-app-secret.md` (if used) — the exception record itself.
+  - Invariant 20 — the SLA being amended or preserved.
+
+### Step 3 — Register the ADR
+
+- Add the row to `adrs/README.md` (if the index has caught up to high-number rows by the time this packet executes; if not, no README update needed — the README has been lagging behind per the file-authoring observation).
+- Add the ADR's invariant reservation (if any) to `constitution/invariant-reservations.md`. If path (a) amends invariant 20's text without adding a new invariant, no reservation is needed. If path (b) adds a new invariant codifying the `EntraAppRegistrationRotator` requirement, claim a size-1 block from the registry.
+- Do NOT flip the ADR to Accepted. ADRs start at Proposed per the user's standing workflow (memory `feedback_adr_workflow`); acceptance happens via a subsequent acceptance packet authored by the scope agent.
+
+### Step 4 — Close the invariant-20 exception loop
+
+Once this ADR's acceptance packet (a future packet) merges, the invariant-20 exception record from packet 03 is closed (its "Follow-up" field references this ADR; the record is updated to "Resolved by ADR-{NNNN}").
+
+This packet's scope ends at *drafting* the ADR. The acceptance + invariant-text amendment is a follow-up packet under the newly-drafted ADR's own acceptance initiative.
+
+### `CHANGELOG.md` (Architecture repo)
+
+Append to the current dated SemVer section:
+
+> `Architecture: Draft ADR-{NNNN} (Tier-2 IdP secret rotation cadence) per the follow-up commitment in packet 05 of adr-0078-entra-external-id. Records the chosen resolution path (raise SLA for IdP-tenant-bound secrets OR commit to an EntraAppRegistrationRotator in HoneyDrunk.Vault.Rotation) for the active invariant-20 exception that packet 03 of adr-0078-entra-external-id logged. ADR Status is Proposed; acceptance is a follow-up packet under the new ADR's own acceptance initiative.`
+
+## Affected Files
+
+- `adrs/ADR-{NNNN}-tier-2-idp-secret-rotation-cadence.md` (new — the ADR draft)
+- `adrs/README.md` (new index row IF the README has caught up to recent ADR numbers; otherwise skip)
+- `constitution/invariant-reservations.md` (new reservation IF path (b) is chosen and a new invariant is added)
+- `CHANGELOG.md` (entry under current dated SemVer section)
+
+## NuGet Dependencies
+
+None. Architecture is a knowledge repo.
+
+## Boundary Check
+
+- [x] All edits inside `HoneyDrunk.Architecture`.
+- [x] No code changes; ADR drafting only.
+- [x] No new constitutional invariants land in *this* packet — at most a reservation row in `invariant-reservations.md` is added if path (b) requires a new invariant.
+- [x] The new ADR stays at Status: Proposed per memory `feedback_adr_workflow`. Acceptance is a separate downstream packet.
+- [x] The packet does NOT execute either path (a) or path (b) — it drafts the decision document.
+
+## Acceptance Criteria
+
+- [ ] A new ADR exists at `adrs/ADR-{NNNN}-tier-2-idp-secret-rotation-cadence.md` with Status: Proposed.
+- [ ] The ADR's Context section names packet 03 of `adr-0078-entra-external-id` as the forcing function and references the live invariant-20 exception record.
+- [ ] The ADR's Decision section records the chosen path (a or b) and documents the trade-offs of the other.
+- [ ] The ADR's Consequences section names the affected Nodes (HoneyDrunk.Vault.Rotation if path b; HoneyDrunk.Architecture if path a) and the operational consequences.
+- [ ] The ADR's Alternatives Considered section explicitly names the unchosen path plus "defer indefinitely" and "move to a different IdP" with rejection rationale.
+- [ ] If path (b) is chosen and adds a new invariant: `constitution/invariant-reservations.md` has a new reservation row claimed for the new ADR.
+- [ ] If `adrs/README.md` has caught up to the recent ADR numbers (currently lagging behind): the new ADR row is added to the index.
+- [ ] `CHANGELOG.md` carries an entry under the current dated SemVer section.
+- [ ] The invariant-20 exception record from packet 03 of `adr-0078-entra-external-id` is updated to reference the new ADR in its "Follow-up" field.
+- [ ] The new ADR stays at Status: Proposed. Acceptance is a separate packet authored later.
+
+## Human Prerequisites
+
+- [ ] **Packet 03 of this initiative must be Done before this packet executes.** Without packet 03 having logged the invariant-20 exception, this ADR has no concrete forcing function to reference. The user may push packet 03 and this packet in the same Wave if the Wave-3 dispatch happens after Wave-2 is fully closed.
+- [ ] **The user must pick path (a) or path (b) before the ADR is drafted.** This is an architectural judgment call the user makes; the agent authoring the ADR does not pick the path autonomously. The packet's execution starts with a confirmation: "Which path? (a) raise the SLA for IdP-tenant-bound secrets, or (b) ship an EntraAppRegistrationRotator in HoneyDrunk.Vault.Rotation?"
+- [ ] The user reviews and approves the draft before it merges (per the standard ADR workflow).
+
+## Referenced Invariants
+
+> **Invariant 20:** No secret may exceed its tier's rotation SLA without an active exception. Tier 1 (Azure-native): ≤ 30 days. Tier 2 (third-party via rotation Function): ≤ 90 days. Certificates: auto-renewed 30 days before expiry. Exceptions must be logged in Log Analytics. — The invariant under consideration. The ADR drafted by this packet either amends the invariant text (path a) or preserves it while adding a new rotation Function implementation (path b).
+
+> **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. — This packet's scope is fixed at "draft the ADR"; any change to the path-a-vs-path-b decision happens via the ADR's own follow-up packets after acceptance, not via amending this packet.
+
+## Referenced ADR Decisions
+
+**ADR-0006 (Secret Rotation and Lifecycle):** The parent ADR being amended (path a) or extended by implementation (path b). ADR-0006 D2 commits Tier-2 secrets to ≤ 90-day rotation via the rotation Function.
+
+**ADR-0078 D6 — Per-application configuration shape.** Per-app Entra App Registration client secrets live in `kv-hd-identity-{env}`; this ADR governs how often those secrets rotate.
+
+**ADR-0078 D8 — Cost posture.** The Entra App Registration client secrets carry zero direct cost (free tier); the operational cost of rotation (manual portal vs. Function-automated) is the trade-off this ADR resolves.
+
+## Constraints
+
+- This packet is a **placeholder for follow-up work**. It does not author the ADR's content beyond outlining its required structure. The actual decision (path a or path b), the specific SLA numbers, the specific Microsoft Graph API calls (if path b) are filled in when the packet executes.
+- The new ADR starts at Status: Proposed per the user's standing workflow (memory `feedback_adr_workflow`). Acceptance is a separate downstream packet, not this packet's scope.
+- This packet does NOT execute either path. Path (b) — shipping the `EntraAppRegistrationRotator` — is a future Vault.Rotation feature packet under the new ADR's own initiative. Path (a) — amending invariant 20's text — is a future Architecture invariant-amendment packet under the new ADR's own initiative.
+- The new ADR's number comes from "next available above the current high-water mark." Do NOT pre-claim ADR-0081 or any other specific number in this packet's body — the number is assigned at draft time based on what is live then.
+
+## Labels
+
+`chore`, `tier-3`, `core`, `docs`, `identity`, `secrets`, `adr-0078`, `wave-3`
+
+## Agent Handoff
+
+**Objective:** Draft an ADR amendment to ADR-0006 that resolves the live invariant-20 exception logged by packet 03 of `adr-0078-entra-external-id`. Pick path (a) raise the Tier-2 SLA for IdP-tenant-bound secrets, or path (b) commit to an `EntraAppRegistrationRotator` in `HoneyDrunk.Vault.Rotation`. Document the chosen path, the trade-offs of the unchosen path, and the operational consequences. ADR Status: Proposed.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Context:**
+- Goal: Convert the temporary invariant-20 exception into a permanent documented posture (constitutional carve-out or automated rotation).
+- Feature: ADR-0078 End-User Identity rollout, Wave 3, Packet 05 (the follow-up placeholder).
+- ADRs: ADR-0006 (the parent rotation ADR), ADR-0078 (the forcing function).
+
+**Acceptance Criteria:** As listed above.
+
+**Dependencies:** Packet 03 of this initiative.
+
+**Constraints:**
+- **Invariant 20:** No secret may exceed its tier's rotation SLA without an active exception. — The invariant under amendment or preservation; do not pre-decide which until the user picks the path.
+- **Invariant 24:** Issue packets are immutable once filed as a GitHub Issue. — This packet's scope is "draft the ADR"; any follow-on work is under the new ADR's own initiative, not via amending this packet.
+- ADR starts at Status: Proposed per memory `feedback_adr_workflow`. Acceptance is a separate downstream packet.
+- The path-a-vs-path-b decision is the user's architectural judgment call, not the agent's. The packet's execution starts with confirmation from the user.
+- The new ADR's number is "next available above the current high-water mark," determined at draft time. Do not pre-claim a specific number.
+
+**Key Files:**
+- `adrs/ADR-{NNNN}-tier-2-idp-secret-rotation-cadence.md` — new (the ADR draft)
+- `constitution/invariant-reservations.md` — new reservation row IF path (b) requires a new invariant
+- `adrs/README.md` — new row IF the index has caught up
+- `CHANGELOG.md` — append under current dated SemVer section
+- `governance/exceptions/invariant-20-entra-app-secret.md` — update the "Follow-up" field to point to the new ADR (if the Markdown exception-record route was chosen in packet 03)
+
+**Contracts:** None changed directly. Path (b), if chosen, would later add an `EntraAppRegistrationRotator` to `HoneyDrunk.Vault.Rotation` — that's a follow-up packet under the new ADR's initiative, not this packet's scope.

--- a/generated/issue-packets/active/adr-0078-entra-external-id/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0078-entra-external-id/dispatch-plan.md
@@ -1,0 +1,159 @@
+# Dispatch Plan — ADR-0078 End-User Identity — Microsoft Entra External ID
+
+**Initiative:** `adr-0078-entra-external-id`
+**Sector:** Core
+**Governing ADR:** [ADR-0078 — End-User Identity — Microsoft Entra External ID](../../../../adrs/ADR-0078-end-user-identity-entra-external-id.md) (Proposed 2026-05-23; flips to Accepted via packet 00 of this initiative)
+**Companion ADR:** [ADR-0060 — Stand Up the HoneyDrunk.Identity Node](../../../../adrs/ADR-0060-stand-up-honeydrunk-identity-node.md) (Proposed; merged via PR #323 per the user's scoping context — packets 01 and 02 of *this* initiative reference Identity context files created by ADR-0060 packet 01 and must wait for that to land on `main`)
+**Trigger:** ADR-0060 D2 deferred the IdP-vendor decision until the first user-facing consumer-app feature packet pulled on Identity. ADR-0078 commits Microsoft Entra External ID as the vendor before Hearth (PDR-0005) signup blocks. ADR-0078 also commits the OIDC-standards-only claims discipline as the cheap vendor-exit hedge.
+**Type:** Single-repo (all work lands in `HoneyDrunk.Architecture`; the Entra-side provisioning is portal-based, the tracking issues live in Architecture)
+**Site sync required:** No (no public-API surface change yet — when the first consumer-app feature packet pulls on Identity and ships the `HoneyDrunk.Identity.Providers.Entra` package, a site-sync follow-up may be warranted)
+**Rollback plan:**
+- **Pre-tenant-provisioning rollback** (before packet 03 executes): `git revert` of each PR. Packets 00, 01, 02 are independent reverts. Packet 04 (the walkthrough doc) is an independent revert.
+- **Post-tenant-provisioning rollback** (after packet 03 executes): the Entra External ID tenant exists in Azure; rollback is "manually delete the tenant + App Registrations via the portal" plus revert the catalog/grid-health entries. Practical hard rollback after the tenant is created is expensive (a fresh tenant requires re-verifying the custom domain, re-seeding App Configuration, etc.); prefer fix-forward unless the rollback is for a security incident.
+- **Post-first-App-Registration rollback** (after any consumer-app feature packet wires `HoneyDrunk.Identity.Providers.Entra`): rollback of the App Registration may invalidate consumer-app user sessions. Treat as forward-only past this point; address defects via fix-forward packets.
+- **`file-packets.yml` lifecycle gotcha:** after this initiative's packets have moved through The Hive, hive-sync may move source packet files from `active/` to `completed/` per invariant 37. A `git revert` only undoes code changes, not packet-file moves. If a revert is needed after lifecycle moves, restore the packet files manually as part of the revert PR.
+
+## Summary
+
+ADR-0078 fills ADR-0060 D2's deferred vendor decision: Microsoft Entra External ID is the end-user IdP for every consumer-app surface (Hearth, Lately, Currents, Curiosities) plus Notify Cloud tenant operators. Single Grid-wide tenant; per-application App Registrations; OAuth 2.1 with PKCE on OpenID Connect; OIDC-standard claims only consumed in application logic (vendor-exit hedge at the `IExternalIdpClaimMapper` seam).
+
+Six packets land the work:
+
+1. **Accept ADR-0078** — flip Status to Accepted, claim the size-2 invariant block at **93-94** (the third candidate "Auth still issues nothing" is dropped per D5 — restatement of invariant 10), add the two invariants under a new `## End-User Identity Invariants` section, register the initiative, move the reservation row from Active Reservations to Reservation History.
+2. **Catalog updates** — add a node-block-level `notes:` field to `catalogs/contracts.json`'s `honeydrunk-identity` block naming Entra as the IdP provider-slot (using `notes:` per existing precedent — not a new `provider_slot` field). Add an `entra-custom-domain-auth-honeydrunkstudios-com` entry to `catalogs/grid-health.json`. Amend `repos/HoneyDrunk.Identity/integration-points.md` to name Entra. Amend `repos/HoneyDrunk.Identity/overview.md` Design Notes for the Entra commitment and OIDC-standards-only discipline.
+3. **Per-application configuration shape doc** — author `repos/HoneyDrunk.Identity/entra-configuration.md` covering App Configuration key naming (`Identity:Entra:{App}:{Key}`), Vault secret naming (`entra-app-{app}-client-secret` in `kv-hd-identity-{env}`), redirect URI pattern (`https://{app}.honeydrunkstudios.com/auth/callback`), OIDC-standard claim mapping reference for the `IExternalIdpClaimMapper` Entra implementation, and the diagnostic-vs-load-bearing distinction for Entra-proprietary claims per invariant 94.
+4. **Provision Entra tenant + first App Registration + custom-domain + invariant-20 exception** (human-only) — create the Grid-wide Entra External ID tenant in `rg-hd-platform-shared` (verify or create the resource group), create the first App Registration (Notify Cloud tenant operators or Hearth — human picks at provisioning time), seed App Configuration + Vault, wire the `auth.honeydrunkstudios.com` custom domain via Cloudflare CNAME per ADR-0029, log the active invariant-20 exception for the Entra client-secret rotation cadence.
+5. **Entra App Registration walkthrough doc** — author `infrastructure/walkthroughs/entra-app-registration.md` capturing the repeatable portal walkthrough for adding consumer-app App Registrations (Steps 3-6 of packet 03 generalized for re-use). Bicep-based provisioning explicitly deferred until ADR-0077 follow-up.
+6. **ADR-0006 Tier-2 rotation extension proposal** (follow-up placeholder) — draft an ADR amendment resolving the live invariant-20 exception. Path (a) raise the Tier-2 SLA for IdP-tenant-bound secrets; path (b) ship an `EntraAppRegistrationRotator` in `HoneyDrunk.Vault.Rotation`. User picks path at draft time.
+
+## Wave Diagram
+
+```
+Wave 1: Acceptance + catalogs (sequential — packet 01 depends on packet 00)
+   ├─ Architecture: 00-architecture-adr-0078-acceptance
+   │     Blocked by: none (foundation of the initiative).
+   └─ Architecture: 01-architecture-entra-catalog-updates
+         Blocked by: packet 00 (catalog text cites invariant 94 by number;
+                                packet 00 lands it).
+         Also has cross-init Human Prerequisite: ADR-0060 packet 01 must be
+         merged to main (creates the repos/HoneyDrunk.Identity/ context files
+         this packet amends).
+
+Wave 2: Per-app config shape + provisioning + walkthrough (partial parallelism)
+   ├─ Architecture: 02-architecture-per-app-config-shape
+   │     Blocked by: packet 00 (invariant 94 reference), packet 01 (catalog
+   │                  cross-links).
+   │     Also has cross-init Human Prerequisite: ADR-0060 packet 01 must be
+   │     merged (this packet adds a new file in repos/HoneyDrunk.Identity/).
+   ├─ Architecture: 03-architecture-provision-entra-tenant  (human-only)
+   │     Blocked by: packet 00, packet 01, packet 02.
+   └─ Architecture: 04-architecture-entra-app-registration-walkthrough
+         Blocked by: packet 00, packet 01, packet 02.
+         (Can run in parallel with packet 03 — the walkthrough captures the
+         steps as a recipe; packet 03 executes the first instance.)
+
+Wave 3: Follow-up ADR drafting
+   └─ Architecture: 05-architecture-adr-0006-tier2-rotation-extension-proposal
+         Blocked by: packet 03 (the invariant-20 exception must be a known
+                     live concern before the resolving ADR is drafted).
+```
+
+In practice:
+
+- Wave 1 packets 00 and 01 must land sequentially (packet 01 depends on packet 00).
+- Wave 2 packets 02, 03, 04 can run in parallel after Wave 1 closes (packet 03 is human-only and runs on the user's schedule; packets 02 and 04 are doc-only and can both file in the same push).
+- Wave 3 packet 05 depends on packet 03's human-only provisioning being Done (the invariant-20 exception record must exist before the ADR resolving it is drafted).
+
+## Packet List
+
+| # | Packet | Repo | Wave | Actor | Depends On |
+|---|--------|------|------|-------|------------|
+| 00 | [Accept ADR-0078, claim invariants 93-94, register initiative](./00-architecture-adr-0078-acceptance.md) | Architecture | 1 | Agent | none |
+| 01 | [Catalog updates — contracts.json IdP provider-slot `notes:`, grid-health custom-domain entry, Identity context amendments](./01-architecture-entra-catalog-updates.md) | Architecture | 1 | Agent | 00 |
+| 02 | [Per-application Entra configuration shape doc — App Configuration keys, Vault secret naming, OIDC claim mapping reference](./02-architecture-per-app-config-shape.md) | Architecture | 2 | Agent | 00, 01 |
+| 03 | [Provision Entra tenant + first App Registration + verify/create rg-hd-platform-shared + custom-domain + invariant-20 exception (human-only)](./03-architecture-provision-entra-tenant.md) | Architecture (tracking issue) | 2 | Human | 00, 01, 02 |
+| 04 | [Entra App Registration walkthrough doc (portal-based; Bicep deferred to ADR-0077 follow-up)](./04-architecture-entra-app-registration-walkthrough.md) | Architecture | 2 | Agent | 00, 01, 02 |
+| 05 | [ADR-0006 Tier-2 rotation extension proposal — resolve the invariant-20 exception (follow-up placeholder)](./05-architecture-adr-0006-tier2-rotation-extension-proposal.md) | Architecture | 3 | Agent | 03 |
+
+## Phase Mapping (ADR-0078 "Follow-up Work" → packets)
+
+ADR-0078's Consequences §"Follow-up Work" checklist, mapped to packets:
+
+| Checklist item | Packet |
+|---|---|
+| Provision the Entra External ID tenant | packet 03 |
+| Provision per-application Entra App Registrations (one for Hearth, queued for the other consumer-app PDRs, one for Notify Cloud) | packet 03 (first App Registration) + packet 04 (walkthrough for subsequent App Registrations); ongoing per consumer-app feature packet |
+| Ship `HoneyDrunk.Identity.Providers.Entra` package implementation per ADR-0060 Phase 2 | Not in this initiative; deferred to the first consumer-app feature packet (Hearth signup per PDR-0005 Phase 2) |
+| Wire `auth.honeydrunkstudios.com` custom domain to Entra | packet 03 |
+| Notify Cloud tenant-operator sign-in adopts Entra (ADR-0027 follow-up) | Not in this initiative; queued under ADR-0027 follow-up (packet 03 of *this* initiative may opt to use Notify Cloud as the first App Registration depending on what the human picks at provisioning time) |
+| Bicep templates for Entra App Registration provisioning land in HoneyDrunk.Actions per ADR-0077 | Not in this initiative; queued under ADR-0077 follow-up; packet 04 records the portal-based bridge until then |
+| Per-application branding configuration documented per consumer-app PDR | Not in this initiative; per-PDR concern |
+| Cost-monitoring per ADR-0052 tracks Entra spend against the D8 thresholds | Not a packet in this initiative; cost-monitoring is a standing ADR-0052 governance concern; the cost baseline ($0 through MVP) is recorded in packet 03's closing comment |
+| Scope agent flips Status → Accepted after the first packet declaring this ADR in `accepts:` merges | packet 00 of this initiative |
+
+Every packet 00 carries `accepts: ADR-0078`. Per ADR-0078's "If Accepted" workflow, packet 00's merge triggers the scope agent's auto-flip mechanic for ADR-0078's Status.
+
+## What This Initiative Does NOT Deliver
+
+The following are explicitly out of scope for this initiative. Each becomes a separate packet at the appropriate time:
+
+- **The `HoneyDrunk.Identity.Providers.Entra` package implementation.** Per ADR-0060 D12 Phase 2, the Entra adapter ships with the first user-facing consumer-app feature packet (Hearth signup per PDR-0005). This initiative provisions the infrastructure and writes the configuration shape; the runtime adapter is the consumer-app feature packet's scope.
+
+- **The OAuth 2.1 with PKCE callback HTTP surface.** Per ADR-0060 D12 Phase 2/3, the deployable HTTP surface (`/auth/callback`, `/users/me`, `/.well-known/openid-configuration`) belongs to whichever consumer-app's deployable host composes `HoneyDrunk.Identity`. This initiative provisions the IdP-side endpoint via the Entra tenant; the application-side endpoint is per-consumer-app.
+
+- **The full Identity Node deployable.** Per ADR-0060 D12 Phase 2/3, the Identity Node's Container App (`ca-hd-identity-{env}`), Key Vault (`kv-hd-identity-{env}`), and App Configuration namespace seeding belong with whichever packet first deploys an Identity-composing host. Packet 03 of *this* initiative seeds `kv-hd-platform-shared` (the Grid-wide shared Vault) as a temporary home for the Entra client secret if `kv-hd-identity-{env}` does not yet exist.
+
+- **Bicep templates for Entra App Registration provisioning.** Queued under ADR-0077 follow-up work; packet 04 of this initiative is the portal-based bridge until Bicep's Entra resource coverage closes the gap.
+
+- **MFA enforcement policy.** Per ADR-0078 D10, default at v1 is "optional, user-enrollable." Per-app MFA policy hardens via later per-PDR packets.
+
+- **Social-login provider enablement (Google, Apple, GitHub).** Per ADR-0078 D10, default at v1 is "email-only." Per-app social-login enablement is per-PDR.
+
+- **Per-application branding configuration (logos, color schemes).** Per ADR-0078 D10, per-PDR concern; lands per app at Phase 2.
+
+- **B2B / enterprise workforce identity via Entra.** Per ADR-0078 D10, out of scope. The Grid's identity boundary is consumer / end-user.
+
+- **API-key authentication for the public Grid APIs.** Per ADR-0027, Notify Cloud tenants authenticate API requests with API keys (a different auth surface from end-user identity); out of scope per ADR-0078 D10.
+
+- **Multi-IdP support.** Per ADR-0078 D9's "Adopt multiple IdPs" rejected alternative, one IdP. If a future scenario forces multi-IdP, the wrapping-seam architecture (ADR-0060 D2) supports it via a second `IExternalIdpClaimMapper` implementation, but that work is not scoped here.
+
+## Cross-ADR Dependency — ADR-0060 packet 01
+
+Packets 01 and 02 of this initiative reference Identity context files (`repos/HoneyDrunk.Identity/overview.md`, `boundaries.md`, `integration-points.md`) that **do not yet exist**. They are authored by packet 01 of `adr-0060-identity-standup`. Per the user's scoping refinement:
+
+- Both packets 01 and 02 of this initiative carry explicit Human Prerequisite: "ADR-0060 packet 01 must be merged to main before this packet executes."
+- Without that merge, packet 01 of *this* initiative has no `repos/HoneyDrunk.Identity/integration-points.md` or `overview.md` to amend, and packet 02 has no `repos/HoneyDrunk.Identity/` folder to add `entra-configuration.md` to.
+- The cross-init dependency is *temporal*, not *machine-readable*: there is no `packet:01` cross-folder dependency in the frontmatter (the `dependencies:` schema scopes to same-folder packet references or `{Repo}#N` issue refs). The temporal coordination is handled by the human at filing time per the §Filing-Order Rule below.
+
+## Filing-order rule (hard)
+
+1. Push packet 00 of this initiative. Wait for it to merge so invariants 93-94 land in `constitution/invariants.md` and ADR-0078's Status flips.
+2. Push packet 01 of this initiative. Wait for ADR-0060 packet 01 to also be merged before opening packet 01's PR (cross-init temporal dep; not enforced by the filing pipeline).
+3. Push packets 02 and 04 in the same push (both depend on packets 00 and 01; both are doc-only; they don't conflict). Packet 03 (human-only) can also file in the same push — the chore issue lives on The Hive board and waits on the human's portal session.
+4. Wait for packet 03 (human-only) to be Done — the human completes the portal walkthrough. Cross-link the closing comment to the invariant-20 exception record.
+5. Push packet 05 (the ADR-0006 amendment proposal). The user picks path (a) or path (b) at draft time; the agent authors the ADR accordingly.
+
+## Notes
+
+- **Why packet 03 is its own item.** Entra tenant creation, App Registration setup, App Configuration seeding, Vault secret storage, Cloudflare CNAME wiring, and invariant-20 exception logging are all portal-based and cannot be delegated to an agent. Surfacing as an explicit Wave-2 work item with `Actor=Human` keeps it visible on The Hive board.
+- **Why packet 03 verifies-or-creates `rg-hd-platform-shared`.** Per the scoping refinement, the resource group's existence is verified at provisioning time; if absent, create it (per memory `feedback_provision_when_needed` — provision when first needed, not pre-emptively). The Entra tenant is Grid-wide, so it belongs in a Grid-wide shared resource group, not a per-Node one.
+- **Why packet 03 logs the invariant-20 exception in Log Analytics OR a Markdown file.** Per invariant 20: "Exceptions must be logged in Log Analytics." For a solo-dev shop without an established Log Analytics custom-log table, the Markdown route (`governance/exceptions/invariant-20-entra-app-secret.md`) is an acceptable structured-discoverable equivalent. Either way, the exception is discoverable.
+- **Why the third candidate invariant ("Auth still issues nothing") is dropped.** ADR-0078 D5 explicitly preserves invariant 10. Restating invariant 10 as a new invariant is noise; the user's scoping refinement explicitly called this out: "size 2 — the 'Auth issues nothing' candidate is a restatement of existing invariant 10, not a new invariant."
+- **Why `notes:` is the field name for the IdP provider-slot context.** Per the user's scoping refinement: "use `notes:` field (existing precedent in contracts.json); do NOT invent `provider_slot` field." The `notes:` field name follows the existing precedent in `catalogs/grid-health.json` (where node-level `notes:` is heavily used). Adding a `notes:` field to a node-block in `catalogs/contracts.json` introduces the field there following the same precedent shape; it does not invent a new field name.
+- **Why packet 01 includes the `entra-custom-domain-auth-honeydrunkstudios-com` grid-health entry rather than packet 05.** Per the user's scoping refinement: "Custom-domain grid-health entry: add `entra-custom-domain-auth-honeydrunkstudios-com` to packet 01's scope (not just referenced from packet 05)." The custom-domain entry exists from the moment packet 03's provisioning lands; packet 01 registers the surface so the discovery story is correct from Wave 1.
+- **Why packet 03 explicitly verifies-or-creates `rg-hd-platform-shared` with rationale.** Per the user's scoping refinement: "explicit step in packet 03 (human-only) to verify-or-create with rationale." The packet's Step 1 walks the user through the check and provides the rationale (Grid-wide shared resources live in `rg-hd-platform-shared`; per-Node resources live in `rg-hd-{service}-{env}`).
+- **Why the invariant-20 exception path is option (b) — log the exception now, draft ADR-0006 extension as follow-up.** Per the user's scoping refinement: "Pick (b) and add follow-up packet placeholder for ADR-0006 Tier-2 rotation extension." Path (a) — committing to 90-day rotation — was rejected as operationally too expensive for a solo-dev shop without an `EntraAppRegistrationRotator`. Packet 05 of this initiative is the follow-up.
+- **Repos public by default.** All Architecture-repo changes ship public per memory `project_repos_public_by_default`. The Entra-side credentials (tenant ID, client ID) are non-secret and are seeded in App Configuration; the client secret is in Vault and never appears in any committed file. No revenue/compliance/experiment carve-out applies.
+- **No ADR numbers in docs or code comments.** Per memory `feedback_no_adr_in_docs`, the consumer-app feature packets that consume `HoneyDrunk.Identity.Providers.Entra` should not cite "ADR-0078" by number in their README narratives; the README explains what the package does. Runtime / packet-data references (catalog entries, frontmatter, this dispatch plan, the CHANGELOG, ADR text itself) are fine to cite ADRs by number.
+- **No commits under CHANGELOG Unreleased.** Per memory `feedback_no_unreleased_commits`, every CHANGELOG entry in this initiative lands under the current dated SemVer section, not under `## Unreleased`.
+- **No manual packet filing.** Per memory `feedback_no_manual_packet_filing`, `file-packets.yml` auto-files on push to main. Do not run `gh issue create` against these packets. Filing happens by pushing the packet files into `generated/issue-packets/active/adr-0078-entra-external-id/`. The §Filing-Order Rule above governs which packets land in which push.
+
+## Archival
+
+Per ADR-0008 D10, when every packet in this initiative reaches `Done` on the org Project board AND the first consumer-app feature packet (Hearth signup) ships with the `HoneyDrunk.Identity.Providers.Entra` package wired against the Entra tenant + App Registration provisioned here, the entire `active/adr-0078-entra-external-id/` folder moves to `archive/adr-0078-entra-external-id/` in a single commit. Partial archival is forbidden.
+
+The hive-sync agent moves individual closed packet files from `active/` to `completed/` per invariant 37 — that is per-packet lifecycle. Initiative-level archival is the post-completion sweep that follows after the whole folder reaches `Done`.
+
+## Filing
+
+The `file-packets.yml` workflow in `HoneyDrunk.Architecture` triggers automatically on push to `generated/issue-packets/active/**/*.md`. No `gh issue create` commands in this dispatch plan — the pipeline handles filing, project-board addition, field population, and `addBlockedBy` wiring from the `dependencies:` frontmatter on each packet. Verify after push by checking The Hive (org Project #4) for the new items and their blocking edges.


### PR DESCRIPTION
## Summary

- Eleventh and final of the staged PRs from the 2026-05-23 ADR batch (re-scoped). Governance-only — no code lands in any Node.
- Three backed-by companion ADRs: ADR-0071 (HoneyDrunk.Web.UI monorepo, paired with ADR-0070 in #288), ADR-0076 (HoneyDrunk.Cache.Redis package + AES-GCM wrapper for Restricted-tier, paired with ADR-0058 in #301 and ADR-0059 in #323), ADR-0078 (Entra External ID end-user IdP, paired with ADR-0060 in #323).
- **This PR closes out the 33-ADR batch from 2026-05-23.**

## Validation

- Markdown + JSON only; no code changed.
- file-packets.yml will file 19 packet files on merge — verify in The Hive.
- Each ADR's upstream/paired ADR has already landed in earlier PRs.

## Authorship

Authorship: agent-claude-code

## Notes

- This PR is out-of-band per ADR-0011 D9 / invariant 32 — ships packet files but doesn't execute any single packet.
- ADR-0071 cluster: visualization (matches Studios precedent). npm scope verification + NPM_TOKEN seeding handled in packet 03 (repo-creation), not packet 04 (scaffold) — earlier blocker detection.
- ADR-0076 routes Redis connection-string to consumer Vaults per invariant 17 (Cache is library-only — no kv-hd-cache vault). Package name pinned to HoneyDrunk.Cache.Redis (matches ADR D1).
- ADR-0078 packet 03 uses human-only label as source-of-truth (frontmatter Actor field is display-only). Catalog uses notes: field (existing precedent), no invented provider_slot. 24-month client-secret expiry logged as invariant-20 active exception with packet 05 follow-up for ADR-0006 Tier-2 rotation extension.