### PR TITLE
ci: grant file-packets caller read permission

### DIFF
--- a/.github/workflows/file-packets.yml
+++ b/.github/workflows/file-packets.yml
@@ -7,6 +7,9 @@ on:
       - 'generated/issue-packets/active/**/*.md'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   file:
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/file-packets.yml@main


### PR DESCRIPTION
## Summary

- Adds the explicit `contents: read` caller permission required by the reusable `file-packets.yml` workflow.

Out-of-band reason: Follow-up from the ADR-0012 caller-permissions audit; no separate per-repo issue packet was filed before this small caller fix.

## Validation

- `git diff --check HEAD~1..HEAD`

## Authorship

Authorship: agent-codex

## Notes

- Audit source: HoneyDrunk.Architecture `infrastructure/caller-permissions-audit.md` from ADR-0012 packet 08.