### PR TITLE
Keep CodeRabbit summary in the walkthrough, not the PR description

### DIFF
--- a/templates/.coderabbit.yaml
+++ b/templates/.coderabbit.yaml
@@ -46,6 +46,13 @@ reviews:
   request_changes_workflow: false
 
   high_level_summary: true
+  # Keep the summary OUT of the PR description — post it inside the walkthrough
+  # comment instead. CodeRabbit's default writes the summary into the PR body,
+  # which clobbers the Grid's required `Authorship:` / `Packet:` metadata block
+  # that pr-core parses. With this true, CodeRabbit never edits the description;
+  # the body stays exactly as the author wrote it. (ADR-0079 Reviewer 2 is
+  # advisory only — its summary belongs in a comment, not the contract metadata.)
+  high_level_summary_in_walkthrough: true
   review_status: true
   collapse_walkthrough: true
 


### PR DESCRIPTION
CodeRabbit's default writes its high-level summary **into the PR description**, which clobbers the Grid's required `Authorship:` / `Packet:` metadata block that pr-core parses (the recurring "CodeRabbit wiped my PR body" problem).

Setting `reviews.high_level_summary_in_walkthrough: true` relocates the summary into the **walkthrough comment**. CodeRabbit stops editing the description entirely — the body stays exactly as the author wrote it. We keep the summary's value (ADR-0079 Reviewer 2 is advisory); it just lives in a comment, where an advisory reviewer's output belongs, instead of in the contract metadata.

## Note — this is the canonical mirror, not the live config
`templates/.coderabbit.yaml` is the version-controlled master copy. CodeRabbit runs off the **org Global Override** (dashboard), not this file. This change takes effect only once the same line is added to the Override: Organization Settings → Global Overrides → add `high_level_summary_in_walkthrough: true` under `reviews:` → Save. Operator action, tracked separately.

Authorship: agent-claude-code
Out-of-band reason: One-line config-hygiene fix to stop CodeRabbit overwriting pr-core's required PR metadata; not tied to an issue packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)