### PR TITLE
File ADR-0086 review output contract packet

### DIFF
--- a/generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/12-architecture-review-agent-output-contract.md
+++ b/generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/12-architecture-review-agent-output-contract.md
@@ -3,11 +3,11 @@ name: Infrastructure
 type: repo-feature
 tier: 2
 target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
-labels: ["chore", "tier-2", "meta", "docs", "infrastructure", "adr-0086", "wave-2"]
-dependencies: ["packet:03"]
+labels: ["chore", "tier-2", "meta", "docs", "infrastructure", "adr-0086", "wave-1"]
+dependencies: ["packet:03", "packet:07"]
 adrs: ["ADR-0086", "ADR-0007", "ADR-0044"]
 accepts: []
-wave: 2
+wave: 1
 initiative: adr-0086-pull-based-local-worker-grid-review
 node: honeydrunk-architecture
 ---
@@ -39,6 +39,7 @@ The correction is therefore to make the canonical review agent prompt own the es
 
 ## Dependencies
 - `packet:03` — runner framework and synthesis path.
+- `packet:07` — Architecture local-worker cutover evidence that exposed the PR-facing output-contract mismatch.
 
 ## Referenced ADR Decisions
 
@@ -54,7 +55,7 @@ The correction is therefore to make the canonical review agent prompt own the es
 - Do not mutate filed packets other than adding this follow-on packet.
 
 ## Labels
-`chore`, `tier-2`, `meta`, `docs`, `infrastructure`, `adr-0086`, `wave-2`
+`chore`, `tier-2`, `meta`, `docs`, `infrastructure`, `adr-0086`, `wave-1`
 
 ## Agent Handoff
 

--- a/generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/12-architecture-review-agent-output-contract.md
+++ b/generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/12-architecture-review-agent-output-contract.md
@@ -1,0 +1,71 @@
+---
+name: Infrastructure
+type: repo-feature
+tier: 2
+target_repo: HoneyDrunkStudios/HoneyDrunk.Architecture
+labels: ["chore", "tier-2", "meta", "docs", "infrastructure", "adr-0086", "wave-2"]
+dependencies: ["packet:03"]
+adrs: ["ADR-0086", "ADR-0007", "ADR-0044"]
+accepts: []
+wave: 2
+initiative: adr-0086-pull-based-local-worker-grid-review
+node: honeydrunk-architecture
+---
+
+# Preserve the canonical Grid Review output contract
+
+## Summary
+Clarify the canonical `.claude/agents/review.md` output format so every review surface emits the established Grid Review verdict shape: top metadata (`Risk Level`, `Review Confidence`, `Change Type`, `Blast Radius`, `Operational Sensitivity`, `Requires ADR`), emoji section headers, and the full review-evidence footer.
+
+This is a source-of-truth update, not a runner-local override. Packet 03 builds the ADR-0086 runner substrate and must continue to consume `.claude/agents/review.md` rather than duplicating review instructions. This packet authorizes the prompt contract clarification needed after the runner started synthesizing Codex and Claude outputs into one PR-facing comment.
+
+## Context
+ADR-0086 originally scoped packet 03 as a transport/substrate change and said `.claude/agents/review.md` would not change. During pilot review, the operator confirmed that the runner must preserve the richer Grid Review comment format used by the prior path, including emoji headings and the detailed review categories. A runner-local synthesis prompt is not allowed to become the only source for that format; ADR-0007 makes `.claude/agents/` the source of truth for agent behavior.
+
+The correction is therefore to make the canonical review agent prompt own the established format, then have the runner synthesis prompt mirror that canonical contract.
+
+## Scope
+- Update only the `.claude/agents/review.md` output-format block.
+- Preserve the existing review process, context-loading contract, severity guide, and ADR-0044 D3 rubric.
+- Ensure ADR-0086 runner synthesis mirrors the canonical format and does not post per-agent raw sections.
+- Document that packet 03 remains a runner-substrate packet and does not authorize arbitrary review-agent prompt changes.
+
+## Acceptance Criteria
+- [ ] `.claude/agents/review.md` defines the Grid Review output format with the top metadata fields, `✅ Verdict`, emoji section checklist, and reviewed-scope evidence footer.
+- [ ] The runner synthesis prompt mirrors the canonical format rather than inventing a different PR-facing shape.
+- [ ] Packet 03 is not mutated to retroactively authorize its own scope change.
+- [ ] ADR-0086 text records that this follow-on packet amended the output contract while preserving ADR-0007 source-of-truth discipline.
+- [ ] UTF-8 output from child CLIs is preserved so emoji and punctuation survive in PR comments.
+
+## Dependencies
+- `packet:03` — runner framework and synthesis path.
+
+## Referenced ADR Decisions
+
+**ADR-0007** — `.claude/agents/` is the canonical source of truth for agent definitions. Runner code may invoke and synthesize agent output, but must not fork the review contract into runner-only prompt text.
+
+**ADR-0044 D1/D3** — The Grid Review Runner posts advisory PR comments and the review agent applies the full architecture-aware rubric.
+
+**ADR-0086 D1/D3/D8** — The local worker consumes the canonical review agent file and posts one synthesized PR verdict when multiple independent review passes are required.
+
+## Constraints
+- Do not duplicate the review rubric into runner-only code as the canonical contract.
+- Do not relax the context-loading contract or ADR-0044 D3 review categories.
+- Do not mutate filed packets other than adding this follow-on packet.
+
+## Labels
+`chore`, `tier-2`, `meta`, `docs`, `infrastructure`, `adr-0086`, `wave-2`
+
+## Agent Handoff
+
+**Objective:** Update the canonical review-agent output contract to the established Grid Review format and align ADR-0086 runner synthesis with it.
+
+**Target:** `HoneyDrunk.Architecture`, branch from `main`.
+
+**Acceptance Criteria:** As listed above.
+
+**Key Files:**
+- `.claude/agents/review.md`
+- `infrastructure/workers/grid-agent-runner/lib/Synthesis.psm1`
+- `infrastructure/workers/grid-agent-runner/lib/Agent.psm1`
+- `adrs/ADR-0086-pull-based-local-worker-grid-review-runner.md`

--- a/generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/dispatch-plan.md
+++ b/generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/dispatch-plan.md
@@ -11,7 +11,7 @@
 
 ADR-0086 keeps the **discipline** of ADR-0044/ADR-0079 intact and changes the **transport** and **execution substrate**. The inbound webhook + Cloudflare Tunnel + OpenClaw-on-the-review-path are removed. A cheap GitHub Action normalizes managed PR labels, then enqueues review requests by labelling and commenting on the PR; a PowerShell scheduled agent runner on the always-on home server polls GitHub on a 60–120 s cadence, claims one PR at a time via a label swap, runs the canonical `.claude/agents/review.md` agent locally under Codex CLI / Claude Code CLI subscription auth, synthesizes independent findings into one verdict when both reviewers run, and posts the verdict back. Reviewer 4 (Claude Code CLI under Max) runs today through the same local runner — the June 15 2026 dependency and the Claude-Code-on-the-web GitHub integration are removed from the Grid Review Runner's design.
 
-This initiative ships **11 packets across 4 waves**, mapped to ADR-0086 D11's phases (A / B / C / D). Phase A is the critical path: build the reusable runner framework, prove the review job on `HoneyDrunk.Architecture` only, and decommission the OpenClaw review-runner role. Phase B widens PR review to the 10 remaining live .NET Nodes (superseding ADR-0044 Architecture#182 which was the same fan-out at the old default). Phase C migrates scheduled agent jobs (`hive-sync`, Lore sourcing, Lore ingest/compile, Lore signal review) to the same runner after smoke tests. Phase D is the narrative-surfacing polish — make runner availability observable through the weekly briefing and hive-sync. Multi-perspective on high-risk Nodes (D8) and post-merge sampling audit (D9) are preserved disciplines whose substrate moves to the local runner — both are wired into the runner by packet 03 ahead of their respective ADR-0044 activation packets (13/14 for D8, 15/16 for D9).
+This initiative ships **12 packets across 4 waves**, mapped to ADR-0086 D11's phases (A / B / C / D). Phase A is the critical path: build the reusable runner framework, prove the review job on `HoneyDrunk.Architecture` only, and decommission the OpenClaw review-runner role. Phase B widens PR review to the 10 remaining live .NET Nodes (superseding ADR-0044 Architecture#182 which was the same fan-out at the old default). Phase C migrates scheduled agent jobs (`hive-sync`, Lore sourcing, Lore ingest/compile, Lore signal review) to the same runner after smoke tests. Phase D is the narrative-surfacing polish — make runner availability observable through the weekly briefing and hive-sync. Multi-perspective on high-risk Nodes (D8) and post-merge sampling audit (D9) are preserved disciplines whose substrate moves to the local runner — both are wired into the runner by packet 03 ahead of their respective ADR-0044 activation packets (13/14 for D8, 15/16 for D9). Packet 12 is a Phase-A follow-on scope correction: it records that the canonical review-agent output contract must own the established Grid Review emoji-section verdict format instead of leaving that contract runner-local.
 
 ## Trigger
 
@@ -43,6 +43,7 @@ Packet 01 first (the acceptance flip). Then 02 (existing App reuse audit) gates 
 - [ ] **05** — Actions: Rewrite `job-review-request.yml` from webhook-emitting to managed-label-normalizing plus label-and-comment enqueue per D2. `Actor=Agent`. Blocked by: 01.
 - [ ] **06** — Actions: Add worker labels and the managed PR-label vocabulary to labels-as-code and fan out Grid-wide. `Actor=Agent`. Blocked by: 01.
 - [ ] **07** — Architecture: Cut `HoneyDrunk.Architecture` over to `runner: local-worker`; update its `pr-review.yml` caller; verify end-to-end on the cutover PR; record Phase-A go/no-go. `Actor=Agent`. Blocked by: 02, 03, 04, 05, 06.
+- [ ] **12** — Architecture: Preserve the canonical Grid Review output contract in `.claude/agents/review.md`; align runner synthesis to that source-of-truth format. `Actor=Agent`. Blocked by: 03, 07.
 
 **Wave 1 exit criterion (Phase A go/no-go):** Per ADR-0086 D11 Phase A — verdict quality at least as useful as the manual local-agent invocation, reliable polling and claim semantics, head-SHA invalidation deterministically handles pushes mid-review, near-zero marginal cost under subscription auth. **If this bar is missed, Wave 2 does not start.**
 
@@ -88,6 +89,7 @@ Packets within a wave run in parallel where their `dependencies:` array permits 
 | 09 | [Enable `runner: local-worker` on 10 Nodes](./09-cross-repo-enable-local-worker-ten-nodes.md) | Cross-repo | Agent | 2 | 07, 08 |
 | 10 | [Runner-health surfacing](./10-architecture-hive-sync-queue-depth-surfacing.md) | Architecture | Agent | 4 | 03, 07, 11 |
 | 11 | [Scheduled agent job migration](./11-architecture-migrate-scheduled-agent-jobs.md) | Architecture | Agent + Human | 3 | 03, 07 |
+| 12 | [Review-agent output contract](./12-architecture-review-agent-output-contract.md) | Architecture | Agent | 1 | 03, 07 |
 
 ## Invariant Numbering
 
@@ -97,9 +99,9 @@ This is a deliberate choice in the ADR and a load-bearing constraint of packet 0
 
 ## Cross-Cutting Concerns
 
-### `.claude/agents/review.md` is unchanged
+### `.claude/agents/review.md` output contract is clarified by packet 12
 
-ADR-0086 D1 and Follow-up Work are explicit: the substrate change is invisible to the prompt. Both the (removed) OpenClaw path and the (new) local-worker path consume the same canonical agent file per ADR-0007. No packet in this initiative edits `.claude/agents/review.md`.
+ADR-0086 D1 and Follow-up Work originally excluded prompt edits because the transport change must not fork agent behavior. Packet 12 is the narrow follow-on correction: `.claude/agents/review.md` remains the canonical source per ADR-0007, and the established Grid Review PR-comment format lives there rather than only in runner synthesis code.
 
 ### ADR-0081 is unchanged
 
@@ -141,12 +143,13 @@ Packet 02 carries portal work (existing GitHub App audit/reuse, permission verif
 - **Packet 08 (decommission):** revert the PR restores the supersession banner removal on the legacy doc. The operator-side work (Cloudflare hostname, secret rotation, OpenClaw process) is more durable — restoring those is operator portal work, recorded in the PR body for traceability.
 - **Packet 09 (Phase B fan-out):** per-repo revert; each of the 10 PRs can be reverted independently. Per-repo `.honeydrunk-review.yaml` flips back to `enabled: false` or removed; the worker stops processing that repo. Per-repo control is the blast-radius mechanism.
 - **Packet 10 (runner-health surfacing):** revert the PR removes the narrative surfacing. No runtime impact.
+- **Packet 12 (review-agent output contract):** revert the PR restores the prior review-agent output block and runner synthesis prompt. The runner still reviews PRs, but output returns to the previous shape until the contract is re-scoped.
 
 **Architectural escape hatch:** at any phase, flipping `.honeydrunk-review.yaml` to `enabled: false` (or removing it) on any repo makes the worker go silent on that repo immediately. The phased rollout (D11) is itself the blast-radius control — each phase is a discrete go/no-go.
 
 ## Out-of-scope items from ADR-0086
 
-- **Editing `.claude/agents/review.md`** — explicitly excluded by ADR-0086 D1 and Follow-up Work. The substrate change is invisible to the prompt.
+- **Broad editing of `.claude/agents/review.md`** — still excluded. Packet 12 is limited to the review-output contract; it does not relax the context-loading contract, severity rules, or ADR-0044 D3 rubric.
 - **Editing `constitution/invariants.md`** — explicitly excluded by ADR-0086's Invariants section. Reconciliation is `hive-sync`'s mandate per ADR-0014.
 - **Editing `adrs/ADR-0081-home-server-for-openclaw-and-local-agent-infrastructure.md` D1 review-webhook-bridge bullet** — explicitly excluded by ADR-0086 Follow-up Work. The edit belongs to ADR-0081's own acceptance/amendment cycle (ADR-0081 is still Proposed).
 - **A cloud queue (Azure Storage Queue / SQS) substitute for the GitHub-native queue** — ADR-0086 Alternatives Considered explicitly rejects this. The GitHub label + comment is sufficient at solo-dev volume; the cloud queue is a follow-up amendment if volume justifies it.

--- a/generated/issue-packets/filed-packets.json
+++ b/generated/issue-packets/filed-packets.json
@@ -499,5 +499,6 @@
   "generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/08-architecture-decommission-openclaw-review-substrate.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/496",
   "generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/09-cross-repo-enable-local-worker-ten-nodes.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/497",
   "generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/10-architecture-hive-sync-queue-depth-surfacing.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/498",
-  "generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/11-architecture-migrate-scheduled-agent-jobs.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/507"
+  "generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/11-architecture-migrate-scheduled-agent-jobs.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/507",
+  "generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/12-architecture-review-agent-output-contract.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/531"
 }

--- a/generated/issue-packets/filed-packets.json
+++ b/generated/issue-packets/filed-packets.json
@@ -499,6 +499,5 @@
   "generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/08-architecture-decommission-openclaw-review-substrate.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/496",
   "generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/09-cross-repo-enable-local-worker-ten-nodes.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/497",
   "generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/10-architecture-hive-sync-queue-depth-surfacing.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/498",
-  "generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/11-architecture-migrate-scheduled-agent-jobs.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/507",
-  "generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/12-architecture-review-agent-output-contract.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/531"
+  "generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/11-architecture-migrate-scheduled-agent-jobs.md": "https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/issues/507"
 }


### PR DESCRIPTION
## Summary
- file ADR-0086 packet 12 for the canonical Grid Review output contract
- update the ADR-0086 dispatch plan so packet 12 is trusted initiative metadata

## Validation
- `Get-Content generated/issue-packets/filed-packets.json -Raw | ConvertFrom-Json`
- `git diff --check`

Authorship: agent-codex
Out-of-band reason: filing a scope packet so ADR-0086 review-output-contract work has trusted base metadata before implementation PR #519 continues
